### PR TITLE
Add privacy manifests for App Store compliance

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -44,8 +44,6 @@ post_install do |installer|
     # Enable permission_handler permissions for iOS
     # See: https://pub.dev/packages/permission_handler#setup
     target.build_configurations.each do |config|
-      # Exclude .xcprivacy files from source processing to avoid "no rule to process" warnings
-      config.build_settings['EXCLUDED_SOURCE_FILE_NAMES'] = '$(inherited) *.xcprivacy'
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
         '$(inherited)',
         # Bluetooth permissions (required for dive computer connectivity)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: submersion
 description: An open-source dive logging application for scuba divers.
 publish_to: 'none'
-version: 1.0.0+9
+version: 1.0.0+10
 
 environment:
   sdk: ^3.10.0
@@ -41,13 +41,13 @@ dependencies:
   latlong2: ^0.9.1
   cached_network_image: ^3.4.1
   photo_view: ^0.15.0
-  video_player: ^2.9.2
+  video_player: ^2.9.3
 
   # Networking
   http: ^1.2.2
 
   # Cloud Storage
-  google_sign_in: ^7.2.0
+  google_sign_in: ^7.2.1
   googleapis: ^15.0.0
   extension_google_sign_in_as_googleapis_auth: ^3.0.0
   googleapis_auth: ^2.0.0
@@ -57,12 +57,12 @@ dependencies:
   flutter_blue_plus_winrt: 0.0.10  # Pinned version for stability
   dive_computer: ^0.1.0-dev.2  # libdivecomputer FFI wrapper
   permission_handler: ^12.0.1
-  file_picker: ^10.3.8
-  image_picker: ^1.1.2
-  share_plus: ^12.0.1
-  url_launcher: ^6.3.0
+  file_picker: ^10.3.9
+  image_picker: ^1.1.3
+  share_plus: ^12.0.5
+  url_launcher: ^6.3.1
   flutter_contacts: ^1.1.9+2
-  geolocator: ^14.0.2
+  geolocator: ^14.0.3
   geocoding: ^4.0.0
   photo_manager: ^3.6.0
   native_exif: ^0.6.0
@@ -89,7 +89,7 @@ dependencies:
   gal: ^2.3.2
 
   # Notifications
-  flutter_local_notifications: ^18.0.1
+  flutter_local_notifications: ^18.0.2
   workmanager: ^0.9.0+3
   timezone: ^0.10.0
 


### PR DESCRIPTION
- Remove EXCLUDED_SOURCE_FILE_NAMES setting from Podfile that was stripping .xcprivacy files from the build, causing App Store rejection
- Update Flutter plugins to versions that include privacy manifests:
  - video_player: 2.9.2 -> 2.9.3
  - google_sign_in: 7.2.0 -> 7.2.1
  - file_picker: 10.3.8 -> 10.3.9
  - image_picker: 1.1.2 -> 1.1.3
  - share_plus: 12.0.1 -> 12.0.5
  - url_launcher: 6.3.0 -> 6.3.1
  - geolocator: 14.0.2 -> 14.0.3
  - flutter_local_notifications: 18.0.1 -> 18.0.2
- Bump build number to 10 for new App Store submission

Fixes ITMS-91061 privacy manifest errors for AppAuth, DKImagePickerController, DKPhotoGallery, FBLPromises, GTMAppAuth, GTMSessionFetcher, GoogleSignIn, SDWebImage, SwiftyGif, file_picker, flutter_local_notifications, geolocator_apple, image_picker_ios, package_info_plus, share_plus, sqflite_darwin, url_launcher_ios, and video_player_avfoundation frameworks.

https://claude.ai/code/session_01HewacEgocPthvw4DkMvMub