### PR TITLE
Issue 78 -- auto-tag imports from dive computer for traceability

### DIFF
--- a/lib/features/dive_computer/data/services/dive_import_service.dart
+++ b/lib/features/dive_computer/data/services/dive_import_service.dart
@@ -1,8 +1,11 @@
+import 'package:intl/intl.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 import 'package:submersion/features/dive_computer/data/services/dive_parser.dart';
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/tags/domain/entities/tag.dart' as domain;
 
 /// Mode for importing dives.
 enum ImportMode {
@@ -181,13 +184,16 @@ class ImportResult {
 class DiveImportService {
   final DiveComputerRepository _repository;
   final DiveRepository? _diveRepository;
+  final TagRepository _tagRepository;
   final DiveParser _parser;
 
   DiveImportService({
     required DiveComputerRepository repository,
+    required TagRepository tagRepository,
     DiveRepository? diveRepository,
     DiveParser? parser,
   }) : _repository = repository,
+       _tagRepository = tagRepository,
        _diveRepository = diveRepository,
        _parser = parser ?? const DiveParser();
 
@@ -211,6 +217,15 @@ class DiveImportService {
     final importedDiveIds = <String>[];
     final importedDives = <DownloadedDive>[];
     final conflicts = <ImportConflict>[];
+
+    // Create a batch tag for this import session
+    domain.Tag? batchTag;
+    if (dives.isNotEmpty) {
+      final now = DateTime.now();
+      final formattedDate = DateFormat('yyyy-MM-dd').format(now);
+      final tagName = '${computer.name} Import $formattedDate';
+      batchTag = await _tagRepository.getOrCreateTag(tagName, diverId: diverId);
+    }
 
     // Sort dives chronologically (oldest first) so that sequential
     // getDiveNumberForDate() calls produce correct numbering.
@@ -247,7 +262,12 @@ class DiveImportService {
               updated++;
             } else {
               // Import as new
-              final diveId = await _importNewDive(dive, computer.id, diverId);
+              final diveId = await _importNewDive(
+                dive,
+                computer.id,
+                diverId,
+                batchTag,
+              );
               importedDiveIds.add(diveId);
               importedDives.add(dive);
               imported++;
@@ -262,14 +282,24 @@ class DiveImportService {
             updated++;
           } else {
             // Low confidence match in 'all' mode - import as new
-            final diveId = await _importNewDive(dive, computer.id, diverId);
+            final diveId = await _importNewDive(
+              dive,
+              computer.id,
+              diverId,
+              batchTag,
+            );
             importedDiveIds.add(diveId);
             importedDives.add(dive);
             imported++;
           }
         } else {
           // No duplicate - import as new
-          final diveId = await _importNewDive(dive, computer.id, diverId);
+          final diveId = await _importNewDive(
+            dive,
+            computer.id,
+            diverId,
+            batchTag,
+          );
           importedDiveIds.add(diveId);
           importedDives.add(dive);
           imported++;
@@ -337,6 +367,7 @@ class DiveImportService {
     DownloadedDive dive,
     String computerId,
     String? diverId,
+    domain.Tag? batchTag,
   ) async {
     // Calculate chronological dive number
     int? diveNumber;
@@ -374,6 +405,9 @@ class DiveImportService {
       events: events,
       diveNumber: diveNumber,
     );
+    if (batchTag != null) {
+      await _tagRepository.addTagToDive(diveId, batchTag.id);
+    }
 
     return diveId;
   }
@@ -416,6 +450,7 @@ class DiveImportService {
     ConflictResolution resolution,
     String computerId, {
     String? diverId,
+    domain.Tag? batchTag,
   }) async {
     conflict.resolution = resolution;
 
@@ -432,7 +467,12 @@ class DiveImportService {
         return conflict.existingDiveId;
 
       case ConflictResolution.importAsNew:
-        return await _importNewDive(conflict.downloaded, computerId, diverId);
+        return await _importNewDive(
+          conflict.downloaded,
+          computerId,
+          diverId,
+          batchTag,
+        );
 
       case ConflictResolution.askUser:
         // This shouldn't be called with askUser

--- a/lib/features/dive_computer/presentation/pages/device_download_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_download_page.dart
@@ -112,7 +112,7 @@ class _DeviceDownloadPageState extends ConsumerState<DeviceDownloadPage> {
           _discoveredDevice = foundDevice;
           _isScanning = false;
         });
-        _startDownload();
+        _startDownload(); // Will be triggered by user action
       } else {
         // Timeout - device not found
         setState(() {
@@ -171,7 +171,9 @@ class _DeviceDownloadPageState extends ConsumerState<DeviceDownloadPage> {
   /// completes. No widget-side import logic needed.
   Future<void> _startDownload() async {
     if (_hasStartedDownload || _discoveredDevice == null) return;
-    _hasStartedDownload = true;
+    setState(() {
+      _hasStartedDownload = true;
+    });
 
     final computer = _computer;
     if (computer == null) return;
@@ -400,6 +402,10 @@ class _DeviceDownloadPageState extends ConsumerState<DeviceDownloadPage> {
           ),
         ),
       );
+    }
+
+    if (_discoveredDevice != null && !_hasStartedDownload) {
+      return _buildDownloadContent(context, downloadState);
     }
 
     // Download in progress or complete

--- a/lib/features/dive_computer/presentation/providers/download_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/download_providers.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/dive_computer/domain/entities/device_model.d
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 import 'package:submersion/features/dive_computer/data/services/fingerprint_utils.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/discovery_providers.dart';
+import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
 
 /// Provider for the dive computer repository.
 final diveComputerRepositoryProvider = Provider<DiveComputerRepository>((ref) {
@@ -23,9 +24,11 @@ final diveComputerRepositoryProvider = Provider<DiveComputerRepository>((ref) {
 final diveImportServiceProvider = Provider<DiveImportService>((ref) {
   final repository = ref.watch(diveComputerRepositoryProvider);
   final diveRepository = ref.watch(diveRepositoryProvider);
+  final tagRepository = ref.watch(tagRepositoryProvider);
   return DiveImportService(
     repository: repository,
     diveRepository: diveRepository,
+    tagRepository: tagRepository,
   );
 });
 

--- a/test/features/dive_computer/data/services/dive_import_service_test.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.dart
@@ -7,12 +7,16 @@ import 'package:submersion/features/dive_log/data/repositories/dive_computer_rep
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 
-@GenerateMocks([DiveComputerRepository, DiveRepository])
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/tags/domain/entities/tag.dart' as domain;
+
+@GenerateMocks([DiveComputerRepository, DiveRepository, TagRepository])
 import 'dive_import_service_test.mocks.dart';
 
 void main() {
   late MockDiveComputerRepository mockComputerRepo;
   late MockDiveRepository mockDiveRepo;
+  late MockTagRepository mockTagRepo;
   late DiveImportService service;
 
   final computer = DiveComputer(
@@ -25,10 +29,12 @@ void main() {
   setUp(() {
     mockComputerRepo = MockDiveComputerRepository();
     mockDiveRepo = MockDiveRepository();
+    mockTagRepo = MockTagRepository();
 
     service = DiveImportService(
       repository: mockComputerRepo,
       diveRepository: mockDiveRepo,
+      tagRepository: mockTagRepo,
     );
 
     // Default: no duplicates found
@@ -41,6 +47,17 @@ void main() {
         fingerprint: anyNamed('fingerprint'),
       ),
     ).thenAnswer((_) async => null);
+
+    when(
+      mockTagRepo.getOrCreateTag(any, diverId: anyNamed('diverId')),
+    ).thenAnswer(
+      (_) async => domain.Tag(
+        id: 'batch-tag',
+        name: 'Batch Tag',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
 
     // Default: importProfile returns a dive id
     when(
@@ -62,6 +79,69 @@ void main() {
         diveNumber: anyNamed('diveNumber'),
       ),
     ).thenAnswer((_) async => 'dive-id');
+  });
+
+  group('DiveImportService tagging', () {
+    test('applies batch tag to imported dives', () async {
+      final dive = DownloadedDive(
+        fingerprint: 'fp1',
+        startTime: DateTime(2026, 3, 23, 10, 0),
+        durationSeconds: 3600,
+        maxDepth: 20.0,
+        profile: const [],
+        tanks: const [],
+        events: const [],
+      );
+      when(
+        mockDiveRepo.getDiveNumberForDate(any, diverId: anyNamed('diverId')),
+      ).thenAnswer((_) async => 1);
+
+      final batchTag = domain.Tag(
+        id: 'tag-1',
+        name: 'Test Computer Import 2026-03-23',
+        createdAt: DateTime(2026, 3, 23),
+        updatedAt: DateTime(2026, 3, 23),
+      );
+
+      when(
+        mockTagRepo.getOrCreateTag(
+          'Test Computer Import 2026-03-23',
+          diverId: anyNamed('diverId'),
+        ),
+      ).thenAnswer((_) async => batchTag);
+      when(
+        mockComputerRepo.importProfile(
+          computerId: anyNamed('computerId'),
+          profileStartTime: anyNamed('profileStartTime'),
+          points: anyNamed('points'),
+          durationSeconds: anyNamed('durationSeconds'),
+          maxDepth: anyNamed('maxDepth'),
+          avgDepth: anyNamed('avgDepth'),
+          isPrimary: anyNamed('isPrimary'),
+          diverId: anyNamed('diverId'),
+          tanks: anyNamed('tanks'),
+          decoAlgorithm: anyNamed('decoAlgorithm'),
+          gfLow: anyNamed('gfLow'),
+          gfHigh: anyNamed('gfHigh'),
+          decoConservatism: anyNamed('decoConservatism'),
+          events: anyNamed('events'),
+          diveNumber: anyNamed('diveNumber'),
+        ),
+      ).thenAnswer((_) async => 'new-dive-id');
+
+      await service.importDives(dives: [dive], computer: computer);
+
+      // Verify a batch tag was created
+      verify(
+        mockTagRepo.getOrCreateTag(
+          'Test Computer Import 2026-03-23',
+          diverId: anyNamed('diverId'),
+        ),
+      ).called(1);
+
+      // Verify the tag was applied to the new dive
+      verify(mockTagRepo.addTagToDive('new-dive-id', 'tag-1')).called(1);
+    });
   });
 
   group('DiveImportService dive numbering', () {

--- a/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
@@ -3,13 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i7;
+import 'dart:async' as _i8;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i9;
-import 'package:submersion/core/constants/sort_options.dart' as _i13;
-import 'package:submersion/core/database/database.dart' as _i8;
-import 'package:submersion/core/models/sort_state.dart' as _i12;
+import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:submersion/core/constants/sort_options.dart' as _i14;
+import 'package:submersion/core/database/database.dart' as _i9;
+import 'package:submersion/core/models/sort_state.dart' as _i13;
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart'
     as _i3;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart'
@@ -18,11 +18,14 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart' as _i4;
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
     as _i2;
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart'
-    as _i10;
+    as _i11;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart'
     as _i6;
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart'
-    as _i11;
+    as _i12;
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart'
+    as _i15;
+import 'package:submersion/features/tags/domain/entities/tag.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -77,6 +80,11 @@ class _FakeDiveNumberingInfo_6 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
+class _FakeTag_7 extends _i1.SmartFake implements _i7.Tag {
+  _FakeTag_7(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [DiveComputerRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -87,108 +95,108 @@ class MockDiveComputerRepository extends _i1.Mock
   }
 
   @override
-  _i7.Future<List<_i2.DiveComputer>> getAllComputers({String? diverId}) =>
+  _i8.Future<List<_i2.DiveComputer>> getAllComputers({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllComputers, [], {#diverId: diverId}),
-            returnValue: _i7.Future<List<_i2.DiveComputer>>.value(
+            returnValue: _i8.Future<List<_i2.DiveComputer>>.value(
               <_i2.DiveComputer>[],
             ),
           )
-          as _i7.Future<List<_i2.DiveComputer>>);
+          as _i8.Future<List<_i2.DiveComputer>>);
 
   @override
-  _i7.Future<_i2.DiveComputer?> getComputerById(String? id) =>
+  _i8.Future<_i2.DiveComputer?> getComputerById(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#getComputerById, [id]),
-            returnValue: _i7.Future<_i2.DiveComputer?>.value(),
+            returnValue: _i8.Future<_i2.DiveComputer?>.value(),
           )
-          as _i7.Future<_i2.DiveComputer?>);
+          as _i8.Future<_i2.DiveComputer?>);
 
   @override
-  _i7.Future<_i2.DiveComputer?> getFavoriteComputer({String? diverId}) =>
+  _i8.Future<_i2.DiveComputer?> getFavoriteComputer({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getFavoriteComputer, [], {#diverId: diverId}),
-            returnValue: _i7.Future<_i2.DiveComputer?>.value(),
+            returnValue: _i8.Future<_i2.DiveComputer?>.value(),
           )
-          as _i7.Future<_i2.DiveComputer?>);
+          as _i8.Future<_i2.DiveComputer?>);
 
   @override
-  _i7.Future<_i2.DiveComputer?> findByBluetoothAddress(String? address) =>
+  _i8.Future<_i2.DiveComputer?> findByBluetoothAddress(String? address) =>
       (super.noSuchMethod(
             Invocation.method(#findByBluetoothAddress, [address]),
-            returnValue: _i7.Future<_i2.DiveComputer?>.value(),
+            returnValue: _i8.Future<_i2.DiveComputer?>.value(),
           )
-          as _i7.Future<_i2.DiveComputer?>);
+          as _i8.Future<_i2.DiveComputer?>);
 
   @override
-  _i7.Future<_i2.DiveComputer> createComputer(_i2.DiveComputer? computer) =>
+  _i8.Future<_i2.DiveComputer> createComputer(_i2.DiveComputer? computer) =>
       (super.noSuchMethod(
             Invocation.method(#createComputer, [computer]),
-            returnValue: _i7.Future<_i2.DiveComputer>.value(
+            returnValue: _i8.Future<_i2.DiveComputer>.value(
               _FakeDiveComputer_0(
                 this,
                 Invocation.method(#createComputer, [computer]),
               ),
             ),
           )
-          as _i7.Future<_i2.DiveComputer>);
+          as _i8.Future<_i2.DiveComputer>);
 
   @override
-  _i7.Future<void> updateComputer(_i2.DiveComputer? computer) =>
+  _i8.Future<void> updateComputer(_i2.DiveComputer? computer) =>
       (super.noSuchMethod(
             Invocation.method(#updateComputer, [computer]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> deleteComputer(String? id) =>
+  _i8.Future<void> deleteComputer(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#deleteComputer, [id]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> setFavoriteComputer(String? id, {String? diverId}) =>
+  _i8.Future<void> setFavoriteComputer(String? id, {String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#setFavoriteComputer, [id], {#diverId: diverId}),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> incrementDiveCount(String? id, {int? by = 1}) =>
+  _i8.Future<void> incrementDiveCount(String? id, {int? by = 1}) =>
       (super.noSuchMethod(
             Invocation.method(#incrementDiveCount, [id], {#by: by}),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> updateLastDownload(String? id) =>
+  _i8.Future<void> updateLastDownload(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#updateLastDownload, [id]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> updateLastFingerprint(String? id, String? fingerprint) =>
+  _i8.Future<void> updateLastFingerprint(String? id, String? fingerprint) =>
       (super.noSuchMethod(
             Invocation.method(#updateLastFingerprint, [id, fingerprint]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<List<_i8.DiveProfile>> getProfilesForDive(
+  _i8.Future<List<_i9.DiveProfile>> getProfilesForDive(
     String? diveId, {
     String? computerId,
   }) =>
@@ -198,49 +206,49 @@ class MockDiveComputerRepository extends _i1.Mock
               [diveId],
               {#computerId: computerId},
             ),
-            returnValue: _i7.Future<List<_i8.DiveProfile>>.value(
-              <_i8.DiveProfile>[],
+            returnValue: _i8.Future<List<_i9.DiveProfile>>.value(
+              <_i9.DiveProfile>[],
             ),
           )
-          as _i7.Future<List<_i8.DiveProfile>>);
+          as _i8.Future<List<_i9.DiveProfile>>);
 
   @override
-  _i7.Future<List<String>> getComputerIdsForDive(String? diveId) =>
+  _i8.Future<List<String>> getComputerIdsForDive(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getComputerIdsForDive, [diveId]),
-            returnValue: _i7.Future<List<String>>.value(<String>[]),
+            returnValue: _i8.Future<List<String>>.value(<String>[]),
           )
-          as _i7.Future<List<String>>);
+          as _i8.Future<List<String>>);
 
   @override
-  _i7.Future<List<_i2.DiveComputer>> getComputersForDive(String? diveId) =>
+  _i8.Future<List<_i2.DiveComputer>> getComputersForDive(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getComputersForDive, [diveId]),
-            returnValue: _i7.Future<List<_i2.DiveComputer>>.value(
+            returnValue: _i8.Future<List<_i2.DiveComputer>>.value(
               <_i2.DiveComputer>[],
             ),
           )
-          as _i7.Future<List<_i2.DiveComputer>>);
+          as _i8.Future<List<_i2.DiveComputer>>);
 
   @override
-  _i7.Future<String?> getPrimaryComputerId(String? diveId) =>
+  _i8.Future<String?> getPrimaryComputerId(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getPrimaryComputerId, [diveId]),
-            returnValue: _i7.Future<String?>.value(),
+            returnValue: _i8.Future<String?>.value(),
           )
-          as _i7.Future<String?>);
+          as _i8.Future<String?>);
 
   @override
-  _i7.Future<void> setPrimaryProfile(String? diveId, String? computerId) =>
+  _i8.Future<void> setPrimaryProfile(String? diveId, String? computerId) =>
       (super.noSuchMethod(
             Invocation.method(#setPrimaryProfile, [diveId, computerId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<String?> findMatchingDive({
+  _i8.Future<String?> findMatchingDive({
     required DateTime? profileStartTime,
     int? toleranceMinutes = 5,
     int? durationSeconds,
@@ -253,12 +261,12 @@ class MockDiveComputerRepository extends _i1.Mock
               #durationSeconds: durationSeconds,
               #maxDepth: maxDepth,
             }),
-            returnValue: _i7.Future<String?>.value(),
+            returnValue: _i8.Future<String?>.value(),
           )
-          as _i7.Future<String?>);
+          as _i8.Future<String?>);
 
   @override
-  _i7.Future<_i3.DiveMatchResult?> findMatchingDiveWithScore({
+  _i8.Future<_i3.DiveMatchResult?> findMatchingDiveWithScore({
     required DateTime? profileStartTime,
     int? toleranceMinutes = 5,
     int? durationSeconds,
@@ -273,25 +281,25 @@ class MockDiveComputerRepository extends _i1.Mock
               #maxDepth: maxDepth,
               #fingerprint: fingerprint,
             }),
-            returnValue: _i7.Future<_i3.DiveMatchResult?>.value(),
+            returnValue: _i8.Future<_i3.DiveMatchResult?>.value(),
           )
-          as _i7.Future<_i3.DiveMatchResult?>);
+          as _i8.Future<_i3.DiveMatchResult?>);
 
   @override
-  _i7.Future<_i3.DiveComputerStats> getComputerStats(String? computerId) =>
+  _i8.Future<_i3.DiveComputerStats> getComputerStats(String? computerId) =>
       (super.noSuchMethod(
             Invocation.method(#getComputerStats, [computerId]),
-            returnValue: _i7.Future<_i3.DiveComputerStats>.value(
+            returnValue: _i8.Future<_i3.DiveComputerStats>.value(
               _FakeDiveComputerStats_1(
                 this,
                 Invocation.method(#getComputerStats, [computerId]),
               ),
             ),
           )
-          as _i7.Future<_i3.DiveComputerStats>);
+          as _i8.Future<_i3.DiveComputerStats>);
 
   @override
-  _i7.Future<List<String>> getDiveIdsForComputer(
+  _i8.Future<List<String>> getDiveIdsForComputer(
     String? computerId, {
     int? limit,
   }) =>
@@ -301,12 +309,12 @@ class MockDiveComputerRepository extends _i1.Mock
               [computerId],
               {#limit: limit},
             ),
-            returnValue: _i7.Future<List<String>>.value(<String>[]),
+            returnValue: _i8.Future<List<String>>.value(<String>[]),
           )
-          as _i7.Future<List<String>>);
+          as _i8.Future<List<String>>);
 
   @override
-  _i7.Future<String> importProfile({
+  _i8.Future<String> importProfile({
     required String? computerId,
     required DateTime? profileStartTime,
     required List<_i3.ProfilePointData>? points,
@@ -341,8 +349,8 @@ class MockDiveComputerRepository extends _i1.Mock
               #events: events,
               #diveNumber: diveNumber,
             }),
-            returnValue: _i7.Future<String>.value(
-              _i9.dummyValue<String>(
+            returnValue: _i8.Future<String>.value(
+              _i10.dummyValue<String>(
                 this,
                 Invocation.method(#importProfile, [], {
                   #computerId: computerId,
@@ -364,10 +372,10 @@ class MockDiveComputerRepository extends _i1.Mock
               ),
             ),
           )
-          as _i7.Future<String>);
+          as _i8.Future<String>);
 
   @override
-  _i7.Future<_i2.DiveComputer> findOrCreateComputer({
+  _i8.Future<_i2.DiveComputer> findOrCreateComputer({
     required String? serialNumber,
     String? diverId,
     String? manufacturer,
@@ -382,7 +390,7 @@ class MockDiveComputerRepository extends _i1.Mock
               #model: model,
               #connectionType: connectionType,
             }),
-            returnValue: _i7.Future<_i2.DiveComputer>.value(
+            returnValue: _i8.Future<_i2.DiveComputer>.value(
               _FakeDiveComputer_0(
                 this,
                 Invocation.method(#findOrCreateComputer, [], {
@@ -395,20 +403,20 @@ class MockDiveComputerRepository extends _i1.Mock
               ),
             ),
           )
-          as _i7.Future<_i2.DiveComputer>);
+          as _i8.Future<_i2.DiveComputer>);
 
   @override
-  _i7.Future<List<_i8.DiveProfileEvent>> getEventsForDive(String? diveId) =>
+  _i8.Future<List<_i9.DiveProfileEvent>> getEventsForDive(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getEventsForDive, [diveId]),
-            returnValue: _i7.Future<List<_i8.DiveProfileEvent>>.value(
-              <_i8.DiveProfileEvent>[],
+            returnValue: _i8.Future<List<_i9.DiveProfileEvent>>.value(
+              <_i9.DiveProfileEvent>[],
             ),
           )
-          as _i7.Future<List<_i8.DiveProfileEvent>>);
+          as _i8.Future<List<_i9.DiveProfileEvent>>);
 
   @override
-  _i7.Future<void> addProfileEvent({
+  _i8.Future<void> addProfileEvent({
     required String? diveId,
     required int? timestamp,
     required String? eventType,
@@ -429,19 +437,19 @@ class MockDiveComputerRepository extends _i1.Mock
               #value: value,
               #tankId: tankId,
             }),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> clearEventsForDive(String? diveId) =>
+  _i8.Future<void> clearEventsForDive(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#clearEventsForDive, [diveId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 }
 
 /// A class which mocks [DiveRepository].
@@ -453,67 +461,67 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
   }
 
   @override
-  _i7.Future<List<_i4.Dive>> getAllDives({String? diverId}) =>
+  _i8.Future<List<_i4.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<_i4.Dive?> getDiveById(String? id) =>
+  _i8.Future<_i4.Dive?> getDiveById(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveById, [id]),
-            returnValue: _i7.Future<_i4.Dive?>.value(),
+            returnValue: _i8.Future<_i4.Dive?>.value(),
           )
-          as _i7.Future<_i4.Dive?>);
+          as _i8.Future<_i4.Dive?>);
 
   @override
-  _i7.Future<List<_i4.DiveProfilePoint>> getDiveProfile(String? diveId) =>
+  _i8.Future<List<_i4.DiveProfilePoint>> getDiveProfile(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveProfile, [diveId]),
-            returnValue: _i7.Future<List<_i4.DiveProfilePoint>>.value(
+            returnValue: _i8.Future<List<_i4.DiveProfilePoint>>.value(
               <_i4.DiveProfilePoint>[],
             ),
           )
-          as _i7.Future<List<_i4.DiveProfilePoint>>);
+          as _i8.Future<List<_i4.DiveProfilePoint>>);
 
   @override
-  _i7.Future<void> saveEditedProfile(
+  _i8.Future<void> saveEditedProfile(
     String? diveId,
     List<_i4.DiveProfilePoint>? editedPoints,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#saveEditedProfile, [diveId, editedPoints]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<Map<String?, List<_i4.DiveProfilePoint>>> getProfilesBySource(
+  _i8.Future<Map<String?, List<_i4.DiveProfilePoint>>> getProfilesBySource(
     String? diveId,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getProfilesBySource, [diveId]),
             returnValue:
-                _i7.Future<Map<String?, List<_i4.DiveProfilePoint>>>.value(
+                _i8.Future<Map<String?, List<_i4.DiveProfilePoint>>>.value(
                   <String?, List<_i4.DiveProfilePoint>>{},
                 ),
           )
-          as _i7.Future<Map<String?, List<_i4.DiveProfilePoint>>>);
+          as _i8.Future<Map<String?, List<_i4.DiveProfilePoint>>>);
 
   @override
-  _i7.Future<void> restoreOriginalProfile(String? diveId) =>
+  _i8.Future<void> restoreOriginalProfile(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#restoreOriginalProfile, [diveId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<Map<String, List<_i4.DiveProfilePoint>>> getBatchProfileSummaries(
+  _i8.Future<Map<String, List<_i4.DiveProfilePoint>>> getBatchProfileSummaries(
     List<String>? diveIds, {
     int? maxSamples = 20,
   }) =>
@@ -524,64 +532,64 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               {#maxSamples: maxSamples},
             ),
             returnValue:
-                _i7.Future<Map<String, List<_i4.DiveProfilePoint>>>.value(
+                _i8.Future<Map<String, List<_i4.DiveProfilePoint>>>.value(
                   <String, List<_i4.DiveProfilePoint>>{},
                 ),
           )
-          as _i7.Future<Map<String, List<_i4.DiveProfilePoint>>>);
+          as _i8.Future<Map<String, List<_i4.DiveProfilePoint>>>);
 
   @override
-  _i7.Future<_i4.Dive> createDive(_i4.Dive? dive) =>
+  _i8.Future<_i4.Dive> createDive(_i4.Dive? dive) =>
       (super.noSuchMethod(
             Invocation.method(#createDive, [dive]),
-            returnValue: _i7.Future<_i4.Dive>.value(
+            returnValue: _i8.Future<_i4.Dive>.value(
               _FakeDive_2(this, Invocation.method(#createDive, [dive])),
             ),
           )
-          as _i7.Future<_i4.Dive>);
+          as _i8.Future<_i4.Dive>);
 
   @override
-  _i7.Future<void> updateDive(_i4.Dive? dive) =>
+  _i8.Future<void> updateDive(_i4.Dive? dive) =>
       (super.noSuchMethod(
             Invocation.method(#updateDive, [dive]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> deleteDive(String? id) =>
+  _i8.Future<void> deleteDive(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#deleteDive, [id]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<List<String>> bulkDeleteDives(List<String>? ids) =>
+  _i8.Future<List<String>> bulkDeleteDives(List<String>? ids) =>
       (super.noSuchMethod(
             Invocation.method(#bulkDeleteDives, [ids]),
-            returnValue: _i7.Future<List<String>>.value(<String>[]),
+            returnValue: _i8.Future<List<String>>.value(<String>[]),
           )
-          as _i7.Future<List<String>>);
+          as _i8.Future<List<String>>);
 
   @override
-  _i7.Future<List<_i4.Dive>> getDivesByIds(List<String>? ids) =>
+  _i8.Future<List<_i4.Dive>> getDivesByIds(List<String>? ids) =>
       (super.noSuchMethod(
             Invocation.method(#getDivesByIds, [ids]),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<List<_i10.DiveSummary>> getDiveSummaries({
+  _i8.Future<List<_i11.DiveSummary>> getDiveSummaries({
     String? diverId,
-    _i11.DiveFilterState? filter = const _i11.DiveFilterState(),
-    _i10.DiveSummaryCursor? cursor,
+    _i12.DiveFilterState? filter = const _i12.DiveFilterState(),
+    _i11.DiveSummaryCursor? cursor,
     int? offset,
     int? limit = 50,
-    _i12.SortState<_i13.DiveSortField>? sort,
+    _i13.SortState<_i14.DiveSortField>? sort,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveSummaries, [], {
@@ -592,44 +600,44 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               #limit: limit,
               #sort: sort,
             }),
-            returnValue: _i7.Future<List<_i10.DiveSummary>>.value(
-              <_i10.DiveSummary>[],
+            returnValue: _i8.Future<List<_i11.DiveSummary>>.value(
+              <_i11.DiveSummary>[],
             ),
           )
-          as _i7.Future<List<_i10.DiveSummary>>);
+          as _i8.Future<List<_i11.DiveSummary>>);
 
   @override
-  _i7.Future<int> getDiveCount({
+  _i8.Future<int> getDiveCount({
     String? diverId,
-    _i11.DiveFilterState? filter = const _i11.DiveFilterState(),
+    _i12.DiveFilterState? filter = const _i12.DiveFilterState(),
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveCount, [], {
               #diverId: diverId,
               #filter: filter,
             }),
-            returnValue: _i7.Future<int>.value(0),
+            returnValue: _i8.Future<int>.value(0),
           )
-          as _i7.Future<int>);
+          as _i8.Future<int>);
 
   @override
-  _i7.Future<List<_i4.Dive>> getDivesForSite(String? siteId) =>
+  _i8.Future<List<_i4.Dive>> getDivesForSite(String? siteId) =>
       (super.noSuchMethod(
             Invocation.method(#getDivesForSite, [siteId]),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<List<_i4.Dive>> getDivesForCourse(String? courseId) =>
+  _i8.Future<List<_i4.Dive>> getDivesForCourse(String? courseId) =>
       (super.noSuchMethod(
             Invocation.method(#getDivesForCourse, [courseId]),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<List<_i4.Dive>> getDivesInRange(
+  _i8.Future<List<_i4.Dive>> getDivesInRange(
     DateTime? start,
     DateTime? end, {
     String? diverId,
@@ -640,20 +648,20 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               [start, end],
               {#diverId: diverId},
             ),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<int> getNextDiveNumber({String? diverId}) =>
+  _i8.Future<int> getNextDiveNumber({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getNextDiveNumber, [], {#diverId: diverId}),
-            returnValue: _i7.Future<int>.value(0),
+            returnValue: _i8.Future<int>.value(0),
           )
-          as _i7.Future<int>);
+          as _i8.Future<int>);
 
   @override
-  _i7.Future<int> getDiveNumberForDate(
+  _i8.Future<int> getDiveNumberForDate(
     DateTime? dateTime, {
     String? diverId,
     int? startFrom = 1,
@@ -664,98 +672,98 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               [dateTime],
               {#diverId: diverId, #startFrom: startFrom},
             ),
-            returnValue: _i7.Future<int>.value(0),
+            returnValue: _i8.Future<int>.value(0),
           )
-          as _i7.Future<int>);
+          as _i8.Future<int>);
 
   @override
-  _i7.Future<List<_i4.Dive>> searchDives(String? query, {String? diverId}) =>
+  _i8.Future<List<_i4.Dive>> searchDives(String? query, {String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#searchDives, [query], {#diverId: diverId}),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<_i5.DiveStatistics> getStatistics({String? diverId}) =>
+  _i8.Future<_i5.DiveStatistics> getStatistics({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getStatistics, [], {#diverId: diverId}),
-            returnValue: _i7.Future<_i5.DiveStatistics>.value(
+            returnValue: _i8.Future<_i5.DiveStatistics>.value(
               _FakeDiveStatistics_3(
                 this,
                 Invocation.method(#getStatistics, [], {#diverId: diverId}),
               ),
             ),
           )
-          as _i7.Future<_i5.DiveStatistics>);
+          as _i8.Future<_i5.DiveStatistics>);
 
   @override
-  _i7.Future<_i5.DiveRecords> getRecords({String? diverId}) =>
+  _i8.Future<_i5.DiveRecords> getRecords({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getRecords, [], {#diverId: diverId}),
-            returnValue: _i7.Future<_i5.DiveRecords>.value(
+            returnValue: _i8.Future<_i5.DiveRecords>.value(
               _FakeDiveRecords_4(
                 this,
                 Invocation.method(#getRecords, [], {#diverId: diverId}),
               ),
             ),
           )
-          as _i7.Future<_i5.DiveRecords>);
+          as _i8.Future<_i5.DiveRecords>);
 
   @override
-  _i7.Future<Set<String>> getWearableIds({String? diverId}) =>
+  _i8.Future<Set<String>> getWearableIds({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getWearableIds, [], {#diverId: diverId}),
-            returnValue: _i7.Future<Set<String>>.value(<String>{}),
+            returnValue: _i8.Future<Set<String>>.value(<String>{}),
           )
-          as _i7.Future<Set<String>>);
+          as _i8.Future<Set<String>>);
 
   @override
-  _i7.Future<void> toggleFavorite(String? diveId) =>
+  _i8.Future<void> toggleFavorite(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#toggleFavorite, [diveId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> setFavorite(String? diveId, bool? isFavorite) =>
+  _i8.Future<void> setFavorite(String? diveId, bool? isFavorite) =>
       (super.noSuchMethod(
             Invocation.method(#setFavorite, [diveId, isFavorite]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<List<_i4.Dive>> getFavoriteDives({String? diverId}) =>
+  _i8.Future<List<_i4.Dive>> getFavoriteDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getFavoriteDives, [], {#diverId: diverId}),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<List<_i4.Dive>> getPlannedDives({String? diverId}) =>
+  _i8.Future<List<_i4.Dive>> getPlannedDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getPlannedDives, [], {#diverId: diverId}),
-            returnValue: _i7.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
+            returnValue: _i8.Future<List<_i4.Dive>>.value(<_i4.Dive>[]),
           )
-          as _i7.Future<List<_i4.Dive>>);
+          as _i8.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<_i4.Dive> createPlannedDive(_i4.Dive? plan) =>
+  _i8.Future<_i4.Dive> createPlannedDive(_i4.Dive? plan) =>
       (super.noSuchMethod(
             Invocation.method(#createPlannedDive, [plan]),
-            returnValue: _i7.Future<_i4.Dive>.value(
+            returnValue: _i8.Future<_i4.Dive>.value(
               _FakeDive_2(this, Invocation.method(#createPlannedDive, [plan])),
             ),
           )
-          as _i7.Future<_i4.Dive>);
+          as _i8.Future<_i4.Dive>);
 
   @override
-  _i7.Future<String> convertPlanToActualDive(
+  _i8.Future<String> convertPlanToActualDive(
     String? planId, {
     DateTime? actualDateTime,
   }) =>
@@ -765,8 +773,8 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               [planId],
               {#actualDateTime: actualDateTime},
             ),
-            returnValue: _i7.Future<String>.value(
-              _i9.dummyValue<String>(
+            returnValue: _i8.Future<String>.value(
+              _i10.dummyValue<String>(
                 this,
                 Invocation.method(
                   #convertPlanToActualDive,
@@ -776,90 +784,90 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               ),
             ),
           )
-          as _i7.Future<String>);
+          as _i8.Future<String>);
 
   @override
-  _i7.Future<void> deletePlannedDive(String? planId) =>
+  _i8.Future<void> deletePlannedDive(String? planId) =>
       (super.noSuchMethod(
             Invocation.method(#deletePlannedDive, [planId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<List<_i6.GasSwitchWithTank>> getGasSwitchesForDive(
+  _i8.Future<List<_i6.GasSwitchWithTank>> getGasSwitchesForDive(
     String? diveId,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getGasSwitchesForDive, [diveId]),
-            returnValue: _i7.Future<List<_i6.GasSwitchWithTank>>.value(
+            returnValue: _i8.Future<List<_i6.GasSwitchWithTank>>.value(
               <_i6.GasSwitchWithTank>[],
             ),
           )
-          as _i7.Future<List<_i6.GasSwitchWithTank>>);
+          as _i8.Future<List<_i6.GasSwitchWithTank>>);
 
   @override
-  _i7.Future<_i6.GasSwitch> createGasSwitch(_i6.GasSwitch? gasSwitch) =>
+  _i8.Future<_i6.GasSwitch> createGasSwitch(_i6.GasSwitch? gasSwitch) =>
       (super.noSuchMethod(
             Invocation.method(#createGasSwitch, [gasSwitch]),
-            returnValue: _i7.Future<_i6.GasSwitch>.value(
+            returnValue: _i8.Future<_i6.GasSwitch>.value(
               _FakeGasSwitch_5(
                 this,
                 Invocation.method(#createGasSwitch, [gasSwitch]),
               ),
             ),
           )
-          as _i7.Future<_i6.GasSwitch>);
+          as _i8.Future<_i6.GasSwitch>);
 
   @override
-  _i7.Future<void> deleteGasSwitch(String? id) =>
+  _i8.Future<void> deleteGasSwitch(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#deleteGasSwitch, [id]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> deleteGasSwitchesForDive(String? diveId) =>
+  _i8.Future<void> deleteGasSwitchesForDive(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#deleteGasSwitchesForDive, [diveId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> insertGasSwitches(List<_i6.GasSwitch>? switches) =>
+  _i8.Future<void> insertGasSwitches(List<_i6.GasSwitch>? switches) =>
       (super.noSuchMethod(
             Invocation.method(#insertGasSwitches, [switches]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<_i4.Dive?> getPreviousDive(String? diveId) =>
+  _i8.Future<_i4.Dive?> getPreviousDive(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getPreviousDive, [diveId]),
-            returnValue: _i7.Future<_i4.Dive?>.value(),
+            returnValue: _i8.Future<_i4.Dive?>.value(),
           )
-          as _i7.Future<_i4.Dive?>);
+          as _i8.Future<_i4.Dive?>);
 
   @override
-  _i7.Future<Duration?> getSurfaceInterval(String? diveId) =>
+  _i8.Future<Duration?> getSurfaceInterval(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getSurfaceInterval, [diveId]),
-            returnValue: _i7.Future<Duration?>.value(),
+            returnValue: _i8.Future<Duration?>.value(),
           )
-          as _i7.Future<Duration?>);
+          as _i8.Future<Duration?>);
 
   @override
-  _i7.Future<_i5.DiveNumberingInfo> getDiveNumberingInfo({String? diverId}) =>
+  _i8.Future<_i5.DiveNumberingInfo> getDiveNumberingInfo({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveNumberingInfo, [], {#diverId: diverId}),
-            returnValue: _i7.Future<_i5.DiveNumberingInfo>.value(
+            returnValue: _i8.Future<_i5.DiveNumberingInfo>.value(
               _FakeDiveNumberingInfo_6(
                 this,
                 Invocation.method(#getDiveNumberingInfo, [], {
@@ -868,53 +876,239 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               ),
             ),
           )
-          as _i7.Future<_i5.DiveNumberingInfo>);
+          as _i8.Future<_i5.DiveNumberingInfo>);
 
   @override
-  _i7.Future<void> renumberAllDives({int? startFrom = 1}) =>
+  _i8.Future<void> renumberAllDives({int? startFrom = 1}) =>
       (super.noSuchMethod(
             Invocation.method(#renumberAllDives, [], {#startFrom: startFrom}),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> assignMissingDiveNumbers() =>
+  _i8.Future<void> assignMissingDiveNumbers() =>
       (super.noSuchMethod(
             Invocation.method(#assignMissingDiveNumbers, []),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> bulkUpdateTrip(List<String>? diveIds, String? tripId) =>
+  _i8.Future<void> bulkUpdateTrip(List<String>? diveIds, String? tripId) =>
       (super.noSuchMethod(
             Invocation.method(#bulkUpdateTrip, [diveIds, tripId]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> bulkAddTags(List<String>? diveIds, List<String>? tagIds) =>
+  _i8.Future<void> bulkAddTags(List<String>? diveIds, List<String>? tagIds) =>
       (super.noSuchMethod(
             Invocation.method(#bulkAddTags, [diveIds, tagIds]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
 
   @override
-  _i7.Future<void> bulkRemoveTags(
+  _i8.Future<void> bulkRemoveTags(
     List<String>? diveIds,
     List<String>? tagIds,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#bulkRemoveTags, [diveIds, tagIds]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i8.Future<void>);
+}
+
+/// A class which mocks [TagRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockTagRepository extends _i1.Mock implements _i15.TagRepository {
+  MockTagRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i8.Future<List<_i7.Tag>> getAllTags({String? diverId}) =>
+      (super.noSuchMethod(
+            Invocation.method(#getAllTags, [], {#diverId: diverId}),
+            returnValue: _i8.Future<List<_i7.Tag>>.value(<_i7.Tag>[]),
+          )
+          as _i8.Future<List<_i7.Tag>>);
+
+  @override
+  _i8.Future<_i7.Tag?> getTagById(String? id) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTagById, [id]),
+            returnValue: _i8.Future<_i7.Tag?>.value(),
+          )
+          as _i8.Future<_i7.Tag?>);
+
+  @override
+  _i8.Future<_i7.Tag?> getTagByName(String? name, {String? diverId}) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTagByName, [name], {#diverId: diverId}),
+            returnValue: _i8.Future<_i7.Tag?>.value(),
+          )
+          as _i8.Future<_i7.Tag?>);
+
+  @override
+  _i8.Future<_i7.Tag> createTag(_i7.Tag? tag) =>
+      (super.noSuchMethod(
+            Invocation.method(#createTag, [tag]),
+            returnValue: _i8.Future<_i7.Tag>.value(
+              _FakeTag_7(this, Invocation.method(#createTag, [tag])),
+            ),
+          )
+          as _i8.Future<_i7.Tag>);
+
+  @override
+  _i8.Future<_i7.Tag> getOrCreateTag(
+    String? name, {
+    String? colorHex,
+    String? diverId,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #getOrCreateTag,
+              [name],
+              {#colorHex: colorHex, #diverId: diverId},
+            ),
+            returnValue: _i8.Future<_i7.Tag>.value(
+              _FakeTag_7(
+                this,
+                Invocation.method(
+                  #getOrCreateTag,
+                  [name],
+                  {#colorHex: colorHex, #diverId: diverId},
+                ),
+              ),
+            ),
+          )
+          as _i8.Future<_i7.Tag>);
+
+  @override
+  _i8.Future<void> updateTag(_i7.Tag? tag) =>
+      (super.noSuchMethod(
+            Invocation.method(#updateTag, [tag]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> deleteTag(String? id) =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteTag, [id]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<List<_i7.Tag>> getTagsForDive(String? diveId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTagsForDive, [diveId]),
+            returnValue: _i8.Future<List<_i7.Tag>>.value(<_i7.Tag>[]),
+          )
+          as _i8.Future<List<_i7.Tag>>);
+
+  @override
+  _i8.Future<Map<String, List<_i7.Tag>>> getTagsForDives(
+    List<String>? diveIds,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTagsForDives, [diveIds]),
+            returnValue: _i8.Future<Map<String, List<_i7.Tag>>>.value(
+              <String, List<_i7.Tag>>{},
+            ),
+          )
+          as _i8.Future<Map<String, List<_i7.Tag>>>);
+
+  @override
+  _i8.Future<void> setTagsForDive(String? diveId, List<_i7.Tag>? tags) =>
+      (super.noSuchMethod(
+            Invocation.method(#setTagsForDive, [diveId, tags]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> addTagToDive(String? diveId, String? tagId) =>
+      (super.noSuchMethod(
+            Invocation.method(#addTagToDive, [diveId, tagId]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> removeTagFromDive(String? diveId, String? tagId) =>
+      (super.noSuchMethod(
+            Invocation.method(#removeTagFromDive, [diveId, tagId]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<List<_i15.TagStatistic>> getTagStatistics({String? diverId}) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTagStatistics, [], {#diverId: diverId}),
+            returnValue: _i8.Future<List<_i15.TagStatistic>>.value(
+              <_i15.TagStatistic>[],
+            ),
+          )
+          as _i8.Future<List<_i15.TagStatistic>>);
+
+  @override
+  _i8.Future<int> getTagUsageCount(String? tagId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTagUsageCount, [tagId]),
+            returnValue: _i8.Future<int>.value(0),
+          )
+          as _i8.Future<int>);
+
+  @override
+  _i8.Future<int> getMergedDiveCount(List<String>? tagIds) =>
+      (super.noSuchMethod(
+            Invocation.method(#getMergedDiveCount, [tagIds]),
+            returnValue: _i8.Future<int>.value(0),
+          )
+          as _i8.Future<int>);
+
+  @override
+  _i8.Future<List<_i7.Tag>> searchTags(String? query, {String? diverId}) =>
+      (super.noSuchMethod(
+            Invocation.method(#searchTags, [query], {#diverId: diverId}),
+            returnValue: _i8.Future<List<_i7.Tag>>.value(<_i7.Tag>[]),
+          )
+          as _i8.Future<List<_i7.Tag>>);
+
+  @override
+  _i8.Future<void> mergeTags({
+    required List<String>? sourceTagIds,
+    required String? survivingTagId,
+    required String? name,
+    required String? colorHex,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#mergeTags, [], {
+              #sourceTagIds: sourceTagIds,
+              #survivingTagId: survivingTagId,
+              #name: name,
+              #colorHex: colorHex,
+            }),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
 }

--- a/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.mocks.dart
+++ b/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.mocks.dart
@@ -5,20 +5,23 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
 
-import 'package:libdivecomputer_plugin/src/dive_computer_service.dart' as _i9;
+import 'package:libdivecomputer_plugin/src/dive_computer_service.dart' as _i11;
 import 'package:libdivecomputer_plugin/src/generated/dive_computer_api.g.dart'
-    as _i10;
+    as _i12;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i7;
+import 'package:mockito/src/dummies.dart' as _i8;
 import 'package:submersion/core/database/database.dart' as _i6;
 import 'package:submersion/features/dive_computer/data/services/dive_import_service.dart'
     as _i4;
+import 'package:submersion/features/dive_computer/data/services/dive_parser.dart'
+    as _i7;
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart'
-    as _i8;
+    as _i9;
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart'
     as _i3;
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
     as _i2;
+import 'package:submersion/features/tags/domain/entities/tag.dart' as _i10;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -295,12 +298,12 @@ class MockDiveComputerRepository extends _i1.Mock
     double? avgDepth,
     bool? isPrimary = false,
     String? diverId,
-    List<_i3.TankData>? tanks,
+    List<_i7.TankData>? tanks,
     String? decoAlgorithm,
     int? gfLow,
     int? gfHigh,
     int? decoConservatism,
-    List<_i3.EventData>? events,
+    List<_i7.EventData>? events,
     int? diveNumber,
   }) =>
       (super.noSuchMethod(
@@ -322,7 +325,7 @@ class MockDiveComputerRepository extends _i1.Mock
               #diveNumber: diveNumber,
             }),
             returnValue: _i5.Future<String>.value(
-              _i7.dummyValue<String>(
+              _i8.dummyValue<String>(
                 this,
                 Invocation.method(#importProfile, [], {
                   #computerId: computerId,
@@ -434,11 +437,12 @@ class MockDiveImportService extends _i1.Mock implements _i4.DiveImportService {
 
   @override
   _i5.Future<_i4.ImportResult> importDives({
-    required List<_i8.DownloadedDive>? dives,
+    required List<_i9.DownloadedDive>? dives,
     required _i2.DiveComputer? computer,
     _i4.ImportMode? mode = _i4.ImportMode.newOnly,
     _i4.ConflictResolution? defaultResolution = _i4.ConflictResolution.skip,
     String? diverId,
+    List<String>? tags = const [],
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importDives, [], {
@@ -447,6 +451,7 @@ class MockDiveImportService extends _i1.Mock implements _i4.DiveImportService {
               #mode: mode,
               #defaultResolution: defaultResolution,
               #diverId: diverId,
+              #tags: tags,
             }),
             returnValue: _i5.Future<_i4.ImportResult>.value(
               _FakeImportResult_2(
@@ -457,6 +462,7 @@ class MockDiveImportService extends _i1.Mock implements _i4.DiveImportService {
                   #mode: mode,
                   #defaultResolution: defaultResolution,
                   #diverId: diverId,
+                  #tags: tags,
                 }),
               ),
             ),
@@ -465,7 +471,7 @@ class MockDiveImportService extends _i1.Mock implements _i4.DiveImportService {
 
   @override
   _i5.Future<_i4.DuplicateResult> detectDuplicate(
-    _i8.DownloadedDive? dive, {
+    _i9.DownloadedDive? dive, {
     double? timeTolerance = 5.0,
     double? depthTolerance = 0.5,
   }) =>
@@ -497,12 +503,13 @@ class MockDiveImportService extends _i1.Mock implements _i4.DiveImportService {
     _i4.ConflictResolution? resolution,
     String? computerId, {
     String? diverId,
+    _i10.Tag? batchTag,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
               #resolveConflict,
               [conflict, resolution, computerId],
-              {#diverId: diverId},
+              {#diverId: diverId, #batchTag: batchTag},
             ),
             returnValue: _i5.Future<String?>.value(),
           )
@@ -513,18 +520,18 @@ class MockDiveImportService extends _i1.Mock implements _i4.DiveImportService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveComputerService extends _i1.Mock
-    implements _i9.DiveComputerService {
+    implements _i11.DiveComputerService {
   MockDiveComputerService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Stream<_i10.DiscoveredDevice> get discoveredDevices =>
+  _i5.Stream<_i12.DiscoveredDevice> get discoveredDevices =>
       (super.noSuchMethod(
             Invocation.getter(#discoveredDevices),
-            returnValue: _i5.Stream<_i10.DiscoveredDevice>.empty(),
+            returnValue: _i5.Stream<_i12.DiscoveredDevice>.empty(),
           )
-          as _i5.Stream<_i10.DiscoveredDevice>);
+          as _i5.Stream<_i12.DiscoveredDevice>);
 
   @override
   _i5.Stream<void> get discoveryComplete =>
@@ -535,35 +542,35 @@ class MockDiveComputerService extends _i1.Mock
           as _i5.Stream<void>);
 
   @override
-  _i5.Stream<_i9.DownloadEvent> get downloadEvents =>
+  _i5.Stream<_i11.DownloadEvent> get downloadEvents =>
       (super.noSuchMethod(
             Invocation.getter(#downloadEvents),
-            returnValue: _i5.Stream<_i9.DownloadEvent>.empty(),
+            returnValue: _i5.Stream<_i11.DownloadEvent>.empty(),
           )
-          as _i5.Stream<_i9.DownloadEvent>);
+          as _i5.Stream<_i11.DownloadEvent>);
 
   @override
-  _i5.Future<List<_i10.DeviceDescriptor>> getDeviceDescriptors() =>
+  _i5.Future<List<_i12.DeviceDescriptor>> getDeviceDescriptors() =>
       (super.noSuchMethod(
             Invocation.method(#getDeviceDescriptors, []),
-            returnValue: _i5.Future<List<_i10.DeviceDescriptor>>.value(
-              <_i10.DeviceDescriptor>[],
+            returnValue: _i5.Future<List<_i12.DeviceDescriptor>>.value(
+              <_i12.DeviceDescriptor>[],
             ),
           )
-          as _i5.Future<List<_i10.DeviceDescriptor>>);
+          as _i5.Future<List<_i12.DeviceDescriptor>>);
 
   @override
   _i5.Future<String> getVersion() =>
       (super.noSuchMethod(
             Invocation.method(#getVersion, []),
             returnValue: _i5.Future<String>.value(
-              _i7.dummyValue<String>(this, Invocation.method(#getVersion, [])),
+              _i8.dummyValue<String>(this, Invocation.method(#getVersion, [])),
             ),
           )
           as _i5.Future<String>);
 
   @override
-  _i5.Future<void> startDiscovery(_i10.TransportType? transport) =>
+  _i5.Future<void> startDiscovery(_i12.TransportType? transport) =>
       (super.noSuchMethod(
             Invocation.method(#startDiscovery, [transport]),
             returnValue: _i5.Future<void>.value(),
@@ -582,7 +589,7 @@ class MockDiveComputerService extends _i1.Mock
 
   @override
   _i5.Future<void> startDownload(
-    _i10.DiscoveredDevice? device, {
+    _i12.DiscoveredDevice? device, {
     String? fingerprint,
   }) =>
       (super.noSuchMethod(
@@ -615,7 +622,7 @@ class MockDiveComputerService extends _i1.Mock
           as _i5.Future<void>);
 
   @override
-  void onDeviceDiscovered(_i10.DiscoveredDevice? device) => super.noSuchMethod(
+  void onDeviceDiscovered(_i12.DiscoveredDevice? device) => super.noSuchMethod(
     Invocation.method(#onDeviceDiscovered, [device]),
     returnValueForMissingStub: null,
   );
@@ -627,14 +634,14 @@ class MockDiveComputerService extends _i1.Mock
   );
 
   @override
-  void onDownloadProgress(_i10.DownloadProgress? progress) =>
+  void onDownloadProgress(_i12.DownloadProgress? progress) =>
       super.noSuchMethod(
         Invocation.method(#onDownloadProgress, [progress]),
         returnValueForMissingStub: null,
       );
 
   @override
-  void onDiveDownloaded(_i10.ParsedDive? dive) => super.noSuchMethod(
+  void onDiveDownloaded(_i12.ParsedDive? dive) => super.noSuchMethod(
     Invocation.method(#onDiveDownloaded, [dive]),
     returnValueForMissingStub: null,
   );
@@ -654,7 +661,7 @@ class MockDiveComputerService extends _i1.Mock
   );
 
   @override
-  void onError(_i10.DiveComputerError? error) => super.noSuchMethod(
+  void onError(_i12.DiveComputerError? error) => super.noSuchMethod(
     Invocation.method(#onError, [error]),
     returnValueForMissingStub: null,
   );

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.mocks.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.mocks.dart
@@ -6,42 +6,44 @@
 import 'dart:async' as _i17;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i31;
+import 'package:mockito/src/dummies.dart' as _i32;
 import 'package:submersion/core/constants/enums.dart' as _i20;
-import 'package:submersion/core/constants/sort_options.dart' as _i30;
-import 'package:submersion/core/models/sort_state.dart' as _i29;
+import 'package:submersion/core/constants/sort_options.dart' as _i31;
+import 'package:submersion/core/models/sort_state.dart' as _i30;
+import 'package:submersion/features/buddies/data/repositories/buddy_merge_repository.dart'
+    as _i22;
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart'
     as _i6;
 import 'package:submersion/features/buddies/domain/entities/buddy.dart' as _i5;
 import 'package:submersion/features/certifications/data/repositories/certification_repository.dart'
-    as _i23;
+    as _i24;
 import 'package:submersion/features/certifications/domain/entities/certification.dart'
     as _i8;
 import 'package:submersion/features/courses/data/repositories/course_repository.dart'
-    as _i33;
+    as _i34;
 import 'package:submersion/features/courses/domain/entities/course.dart'
     as _i15;
 import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart'
-    as _i22;
+    as _i23;
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart'
     as _i7;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart'
     as _i13;
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart'
-    as _i32;
+    as _i33;
 import 'package:submersion/features/dive_log/domain/entities/dive.dart' as _i12;
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart'
-    as _i27;
+    as _i28;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart'
     as _i14;
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart'
-    as _i28;
+    as _i29;
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart'
-    as _i26;
+    as _i27;
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     as _i11;
 import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart'
-    as _i25;
+    as _i26;
 import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart'
     as _i10;
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart'
@@ -53,7 +55,7 @@ import 'package:submersion/features/equipment/domain/entities/equipment_item.dar
 import 'package:submersion/features/equipment/domain/entities/equipment_set.dart'
     as _i4;
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart'
-    as _i24;
+    as _i25;
 import 'package:submersion/features/tags/domain/entities/tag.dart' as _i9;
 import 'package:submersion/features/trips/data/repositories/trip_repository.dart'
     as _i16;
@@ -770,7 +772,7 @@ class MockBuddyRepository extends _i1.Mock implements _i6.BuddyRepository {
           as _i17.Future<_i6.BuddyStats>);
 
   @override
-  _i17.Future<_i6.BuddyMergeResult?> mergeBuddies({
+  _i17.Future<_i22.BuddyMergeResult?> mergeBuddies({
     required _i5.Buddy? mergedBuddy,
     required List<String>? buddyIds,
   }) =>
@@ -779,12 +781,12 @@ class MockBuddyRepository extends _i1.Mock implements _i6.BuddyRepository {
               #mergedBuddy: mergedBuddy,
               #buddyIds: buddyIds,
             }),
-            returnValue: _i17.Future<_i6.BuddyMergeResult?>.value(),
+            returnValue: _i17.Future<_i22.BuddyMergeResult?>.value(),
           )
-          as _i17.Future<_i6.BuddyMergeResult?>);
+          as _i17.Future<_i22.BuddyMergeResult?>);
 
   @override
-  _i17.Future<void> undoMerge(_i6.BuddyMergeSnapshot? snapshot) =>
+  _i17.Future<void> undoMerge(_i22.BuddyMergeSnapshot? snapshot) =>
       (super.noSuchMethod(
             Invocation.method(#undoMerge, [snapshot]),
             returnValue: _i17.Future<void>.value(),
@@ -806,7 +808,7 @@ class MockBuddyRepository extends _i1.Mock implements _i6.BuddyRepository {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveCenterRepository extends _i1.Mock
-    implements _i22.DiveCenterRepository {
+    implements _i23.DiveCenterRepository {
   MockDiveCenterRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -925,7 +927,7 @@ class MockDiveCenterRepository extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCertificationRepository extends _i1.Mock
-    implements _i23.CertificationRepository {
+    implements _i24.CertificationRepository {
   MockCertificationRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -1045,7 +1047,7 @@ class MockCertificationRepository extends _i1.Mock
 /// A class which mocks [TagRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTagRepository extends _i1.Mock implements _i24.TagRepository {
+class MockTagRepository extends _i1.Mock implements _i25.TagRepository {
   MockTagRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -1175,14 +1177,14 @@ class MockTagRepository extends _i1.Mock implements _i24.TagRepository {
           as _i17.Future<void>);
 
   @override
-  _i17.Future<List<_i24.TagStatistic>> getTagStatistics({String? diverId}) =>
+  _i17.Future<List<_i25.TagStatistic>> getTagStatistics({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getTagStatistics, [], {#diverId: diverId}),
-            returnValue: _i17.Future<List<_i24.TagStatistic>>.value(
-              <_i24.TagStatistic>[],
+            returnValue: _i17.Future<List<_i25.TagStatistic>>.value(
+              <_i25.TagStatistic>[],
             ),
           )
-          as _i17.Future<List<_i24.TagStatistic>>);
+          as _i17.Future<List<_i25.TagStatistic>>);
 
   @override
   _i17.Future<int> getTagUsageCount(String? tagId) =>
@@ -1232,7 +1234,7 @@ class MockTagRepository extends _i1.Mock implements _i24.TagRepository {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveTypeRepository extends _i1.Mock
-    implements _i25.DiveTypeRepository {
+    implements _i26.DiveTypeRepository {
   MockDiveTypeRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -1319,16 +1321,16 @@ class MockDiveTypeRepository extends _i1.Mock
           as _i17.Future<void>);
 
   @override
-  _i17.Future<List<_i25.DiveTypeStatistic>> getDiveTypeStatistics({
+  _i17.Future<List<_i26.DiveTypeStatistic>> getDiveTypeStatistics({
     String? diverId,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveTypeStatistics, [], {#diverId: diverId}),
-            returnValue: _i17.Future<List<_i25.DiveTypeStatistic>>.value(
-              <_i25.DiveTypeStatistic>[],
+            returnValue: _i17.Future<List<_i26.DiveTypeStatistic>>.value(
+              <_i26.DiveTypeStatistic>[],
             ),
           )
-          as _i17.Future<List<_i25.DiveTypeStatistic>>);
+          as _i17.Future<List<_i26.DiveTypeStatistic>>);
 
   @override
   _i17.Future<bool> isDiveTypeInUse(String? id) =>
@@ -1342,7 +1344,7 @@ class MockDiveTypeRepository extends _i1.Mock
 /// A class which mocks [SiteRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSiteRepository extends _i1.Mock implements _i26.SiteRepository {
+class MockSiteRepository extends _i1.Mock implements _i27.SiteRepository {
   MockSiteRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -1413,7 +1415,7 @@ class MockSiteRepository extends _i1.Mock implements _i26.SiteRepository {
           as _i17.Future<void>);
 
   @override
-  _i17.Future<_i26.MergeSnapshot?> mergeSites({
+  _i17.Future<_i27.MergeSnapshot?> mergeSites({
     required _i11.DiveSite? mergedSite,
     required List<String>? siteIds,
   }) =>
@@ -1422,12 +1424,12 @@ class MockSiteRepository extends _i1.Mock implements _i26.SiteRepository {
               #mergedSite: mergedSite,
               #siteIds: siteIds,
             }),
-            returnValue: _i17.Future<_i26.MergeSnapshot?>.value(),
+            returnValue: _i17.Future<_i27.MergeSnapshot?>.value(),
           )
-          as _i17.Future<_i26.MergeSnapshot?>);
+          as _i17.Future<_i27.MergeSnapshot?>);
 
   @override
-  _i17.Future<void> undoMerge(_i26.MergeSnapshot? snapshot) =>
+  _i17.Future<void> undoMerge(_i27.MergeSnapshot? snapshot) =>
       (super.noSuchMethod(
             Invocation.method(#undoMerge, [snapshot]),
             returnValue: _i17.Future<void>.value(),
@@ -1457,16 +1459,16 @@ class MockSiteRepository extends _i1.Mock implements _i26.SiteRepository {
           as _i17.Future<Map<String, int>>);
 
   @override
-  _i17.Future<List<_i26.SiteWithDiveCount>> getSitesWithDiveCounts({
+  _i17.Future<List<_i27.SiteWithDiveCount>> getSitesWithDiveCounts({
     String? diverId,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getSitesWithDiveCounts, [], {#diverId: diverId}),
-            returnValue: _i17.Future<List<_i26.SiteWithDiveCount>>.value(
-              <_i26.SiteWithDiveCount>[],
+            returnValue: _i17.Future<List<_i27.SiteWithDiveCount>>.value(
+              <_i27.SiteWithDiveCount>[],
             ),
           )
-          as _i17.Future<List<_i26.SiteWithDiveCount>>);
+          as _i17.Future<List<_i27.SiteWithDiveCount>>);
 }
 
 /// A class which mocks [DiveRepository].
@@ -1598,13 +1600,13 @@ class MockDiveRepository extends _i1.Mock implements _i13.DiveRepository {
           as _i17.Future<List<_i12.Dive>>);
 
   @override
-  _i17.Future<List<_i27.DiveSummary>> getDiveSummaries({
+  _i17.Future<List<_i28.DiveSummary>> getDiveSummaries({
     String? diverId,
-    _i28.DiveFilterState? filter = const _i28.DiveFilterState(),
-    _i27.DiveSummaryCursor? cursor,
+    _i29.DiveFilterState? filter = const _i29.DiveFilterState(),
+    _i28.DiveSummaryCursor? cursor,
     int? offset,
     int? limit = 50,
-    _i29.SortState<_i30.DiveSortField>? sort,
+    _i30.SortState<_i31.DiveSortField>? sort,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveSummaries, [], {
@@ -1615,16 +1617,16 @@ class MockDiveRepository extends _i1.Mock implements _i13.DiveRepository {
               #limit: limit,
               #sort: sort,
             }),
-            returnValue: _i17.Future<List<_i27.DiveSummary>>.value(
-              <_i27.DiveSummary>[],
+            returnValue: _i17.Future<List<_i28.DiveSummary>>.value(
+              <_i28.DiveSummary>[],
             ),
           )
-          as _i17.Future<List<_i27.DiveSummary>>);
+          as _i17.Future<List<_i28.DiveSummary>>);
 
   @override
   _i17.Future<int> getDiveCount({
     String? diverId,
-    _i28.DiveFilterState? filter = const _i28.DiveFilterState(),
+    _i29.DiveFilterState? filter = const _i29.DiveFilterState(),
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveCount, [], {
@@ -1789,7 +1791,7 @@ class MockDiveRepository extends _i1.Mock implements _i13.DiveRepository {
               {#actualDateTime: actualDateTime},
             ),
             returnValue: _i17.Future<String>.value(
-              _i31.dummyValue<String>(
+              _i32.dummyValue<String>(
                 this,
                 Invocation.method(
                   #convertPlanToActualDive,
@@ -1946,7 +1948,7 @@ class MockDiveRepository extends _i1.Mock implements _i13.DiveRepository {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTankPressureRepository extends _i1.Mock
-    implements _i32.TankPressureRepository {
+    implements _i33.TankPressureRepository {
   MockTankPressureRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -2021,7 +2023,7 @@ class MockTankPressureRepository extends _i1.Mock
 /// A class which mocks [CourseRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCourseRepository extends _i1.Mock implements _i33.CourseRepository {
+class MockCourseRepository extends _i1.Mock implements _i34.CourseRepository {
   MockCourseRepository() {
     _i1.throwOnMissingStub(this);
   }


### PR DESCRIPTION
## Summary

### Feature: Add Automatic Batch Tagging for Dive Imports
This pull request introduces automatic batch tagging for dives imported from a dive computer. When a user imports dives, a single, descriptive tag is automatically created and applied to all new dives from that session, improving organization.

The tag uses the format: {Computer Name} Import {YYYY-MM-DD}.

## Changes

- Dive Import Service: The DiveImportService now generates the batch tag and applies it to each newly imported dive during the import process.
- Test Updates: Unit tests for DiveImportService have been updated to verify the correct creation and application of the automatic batch tag.

## Test Plan

- [X] `flutter test` passes
- [X] `flutter analyze` passes
- [X] Manual testing on: windows

## Screenshots

<img width="1328" height="583" alt="image" src="https://github.com/user-attachments/assets/0f6e5a28-b4c4-41ab-b568-58dec3aae1b9" />
