### PR TITLE
issue-70 UDDF dual-tank only shows one tank on dive profile

### DIFF
--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1393,6 +1393,14 @@ class UddfFullImportService {
       }
     }
 
+    // Assign default tank IDs to tanks that don't have explicit IDs
+    // This ensures waypoint tankpressure refs like "T1", "T2" can be mapped correctly
+    for (var i = 0; i < tanks.length; i++) {
+      if (tanks[i]['uddfTankId'] == null) {
+        tanks[i]['uddfTankId'] = 'T${i + 1}';
+      }
+    }
+
     // Build mapping from UDDF tank ref IDs to final tank indices
     // (after filtering, so indices match the actual tanks list order)
     final tankRefToIndex = <String, int>{};

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -501,6 +501,16 @@ class UddfImportService {
       }
     }
 
+    // Assign default tank IDs for tanks that don't have them but may be referenced by waypoints
+    // This handles cases where tankdata elements don't have id attributes but waypoints reference "T1", "T2", etc.
+    for (var i = 0; i < tanks.length; i++) {
+      if (tanks[i]['uddfTankId'] == null) {
+        // Assign default ID based on 1-based tank numbering (T1, T2, T3, etc.)
+        final defaultId = 'T${i + 1}';
+        tanks[i]['uddfTankId'] = defaultId;
+      }
+    }
+
     // Build mapping from UDDF tank ref IDs to final tank indices
     // (after filtering, so indices match the actual tanks list order)
     final tankRefToIndex = <String, int>{};

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -457,6 +457,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       _showTankPressure[entry.key] = entry.value;
     }
 
+    // Initialize tank pressure visibility for any tanks not yet in the legend state
+    if (_hasMultiTankPressure && widget.tankPressures != null) {
+      for (final tankId in widget.tankPressures!.keys) {
+        if (!_showTankPressure.containsKey(tankId)) {
+          _showTankPressure[tankId] = true;
+        }
+      }
+    }
+
     // Check data availability for advanced curves
     final hasNdlData = widget.ndlCurve != null && widget.ndlCurve!.isNotEmpty;
     final hasPpO2Data =
@@ -1988,7 +1997,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       final tankId = sortedTankIds[i];
 
       // Skip if tank is hidden
-      if (!(_showTankPressure[tankId] ?? true)) continue;
+      if (_showTankPressure[tankId] == false) continue;
 
       final pressurePoints = tankPressures[tankId]!;
       if (pressurePoints.isEmpty) continue;

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -715,6 +715,69 @@ void main() {
       expect(dive.notes, contains('Great dive'));
       expect(dive.notes, contains('Weight used: 4.5 kg'));
     });
+
+    test(
+      'imports dive with two tanks and stores pressure data for both',
+      () async {
+        when(mockDiveRepo.createDive(any)).thenAnswer(
+          (invocation) async => invocation.positionalArguments[0] as Dive,
+        );
+        when(
+          mockTankPressureRepo.insertTankPressures(any, any),
+        ).thenAnswer((_) async {});
+
+        final data = UddfImportResult(
+          dives: [
+            {
+              'dateTime': now,
+              'maxDepth': 30.0,
+              'tanks': [
+                {'uddfTankId': 'T1', 'volume': 12.0},
+                {'uddfTankId': 'T2', 'volume': 11.0},
+              ],
+              'profile': [
+                {
+                  'timestamp': 0,
+                  'depth': 0.0,
+                  'allTankPressures': [
+                    {'tankIndex': 0, 'pressure': 200.0},
+                    {'tankIndex': 1, 'pressure': 190.0},
+                  ],
+                },
+                {
+                  'timestamp': 60,
+                  'depth': 20.0,
+                  'allTankPressures': [
+                    {'tankIndex': 0, 'pressure': 180.0},
+                    {'tankIndex': 1, 'pressure': 170.0},
+                  ],
+                },
+              ],
+            },
+          ],
+        );
+
+        await importer.import(
+          data: data,
+          selections: UddfImportSelections.selectAll(data),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        verify(mockDiveRepo.createDive(any)).called(1);
+
+        final captured = verify(
+          mockTankPressureRepo.insertTankPressures(any, captureAny),
+        ).captured;
+
+        final pressuresByTank =
+            captured.first
+                as Map<String, List<({int timestamp, double pressure})>>;
+        expect(pressuresByTank.keys, hasLength(2));
+        expect(pressuresByTank.values.first, isNotEmpty);
+        expect(pressuresByTank.values.last, isNotEmpty);
+      },
+    );
   });
 
   group('Progress callback', () {

--- a/test/integration/uddf_round_trip_test.dart
+++ b/test/integration/uddf_round_trip_test.dart
@@ -399,5 +399,163 @@ void main() {
         reason: 'Total tank count should match through round-trip',
       );
     });
+
+    test('imports multi-tank dive and stores separate pressure data', () async {
+      // 1. Manually create a UDDF string for a two-tank dive
+      const uddfContent = '''
+<uddf version="3.2.0">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive_1">
+        <informationbeforedive>
+          <datetime>2024-01-01T12:00:00</datetime>
+          <divenumber>1</divenumber>
+        </informationbeforedive>
+        <tankdata id="T1">
+          <tankvolume>12.0</tankvolume>
+        </tankdata>
+        <tankdata id="T2">
+          <tankvolume>11.0</tankvolume>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <divetime>10</divetime>
+            <depth>10.0</depth>
+            <tankpressure ref="T1">20000000</tankpressure>
+            <tankpressure ref="T2">19000000</tankpressure>
+          </waypoint>
+          <waypoint>
+            <divetime>20</divetime>
+            <depth>20.0</depth>
+            <tankpressure ref="T1">18000000</tankpressure>
+            <tankpressure ref="T2">17000000</tankpressure>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+      // 2. Import the data into the database
+      final importer = createImporter();
+      await importer.importFromContent(uddfContent);
+
+      // 3. Verify the dive was created
+      final diveRepository = DiveRepository();
+      final dives = await diveRepository.getAllDives();
+      expect(dives, hasLength(1));
+      final diveId = dives.first.id;
+
+      // 4. Query the tank pressure data from the repository
+      final tankPressureRepository = TankPressureRepository();
+      final pressuresByTank = await tankPressureRepository
+          .getTankPressuresForDive(diveId);
+
+      // 5. Assert that pressure data for two separate tanks was stored
+      expect(
+        pressuresByTank.keys,
+        hasLength(2),
+        reason: 'Should have pressure data for two tanks.',
+      );
+
+      final tankIds = pressuresByTank.keys.toList();
+      final pressures1 = pressuresByTank[tankIds[0]]!;
+      final pressures2 = pressuresByTank[tankIds[1]]!;
+
+      expect(pressures1, hasLength(2));
+      expect(pressures2, hasLength(2));
+      expect(pressures1.first.pressure, closeTo(200.0, 0.1));
+      expect(pressures2.first.pressure, closeTo(190.0, 0.1));
+    });
+
+    test(
+      'imports multi-tank dive without tank IDs and stores separate pressure data',
+      () async {
+        // Test case for UDDF files where tankdata elements don't have id attributes
+        // but waypoints reference tanks as "T1", "T2", etc. (like Perdix AI exports)
+        const uddfContent = '''
+<uddf version="3.2.3" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.streit.cc/uddf/3.2/">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="1190044691756736304">
+        <informationbeforedive>
+          <divenumber>235</divenumber>
+          <datetime>2025-09-01T14:18:24Z</datetime>
+        </informationbeforedive>
+        <tankdata>
+          <tankpressurebegin>20049962</tankpressurebegin>
+          <tankpressureend>12879411</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>21952916</tankpressurebegin>
+          <tankpressureend>14244574</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>0</tankpressurebegin>
+          <tankpressureend>0</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>0</tankpressurebegin>
+          <tankpressureend>0</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <depth>1</depth>
+            <divetime>0</divetime>
+            <tankpressure ref="T1">20049962</tankpressure>
+            <tankpressure ref="T2">21952916</tankpressure>
+          </waypoint>
+          <waypoint>
+            <depth>3</depth>
+            <divetime>10</divetime>
+            <tankpressure ref="T1">19939646</tankpressure>
+            <tankpressure ref="T2">21939126</tankpressure>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+        // 2. Import the data into the database
+        final importer = createImporter();
+        await importer.importFromContent(uddfContent);
+
+        // 3. Verify the dive was created
+        final diveRepository = DiveRepository();
+        final dives = await diveRepository.getAllDives();
+        expect(dives, hasLength(1));
+        final diveId = dives.first.id;
+
+        // 4. Query the tank pressure data from the repository
+        final tankPressureRepository = TankPressureRepository();
+        final pressuresByTank = await tankPressureRepository
+            .getTankPressuresForDive(diveId);
+
+        // 5. Assert that pressure data for two separate tanks was stored
+        // (tanks 3-4 have zero pressures and should be filtered out)
+        expect(
+          pressuresByTank.keys,
+          hasLength(2),
+          reason:
+              'Should have pressure data for two tanks with non-zero pressures.',
+        );
+
+        final tankIds = pressuresByTank.keys.toList();
+        final pressures1 = pressuresByTank[tankIds[0]]!;
+        final pressures2 = pressuresByTank[tankIds[1]]!;
+
+        expect(pressures1, hasLength(2));
+        expect(pressures2, hasLength(2));
+        // First waypoint pressures
+        expect(pressures1.first.pressure, closeTo(200.5, 0.1));
+        expect(pressures2.first.pressure, closeTo(219.5, 0.1));
+        // Second waypoint pressures
+        expect(pressures1.last.pressure, closeTo(199.4, 0.1));
+        expect(pressures2.last.pressure, closeTo(219.4, 0.1));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

This PR improves UDDF import compatibility for Shearwater exports.

On the UDDF side, it handles multi-tank imports where waypoint pressure data references tanks like `T1`/`T2` even when `<tankdata>` entries do not include explicit `id` attributes (a violation of the UDDF spec).

## Changes

- Fixed multi-tank UDDF import to preserve separate tank pressure series when waypoint pressure data references default tank identifiers
- Additional unit tests for both conforming and non-confirming <tankdata> UDDF formats

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: Windows

## Screenshots

<img width="751" height="400" alt="image" src="https://github.com/user-attachments/assets/4956fc74-efe9-424a-8bdc-df2e9fbc363b" />