### PR TITLE
Issue-87 gas mixes floating point numbers not rounded for display

### DIFF
--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -92,7 +92,7 @@ class UddfFullImportService {
       for (final mixElement in gasDefsElement.findElements('mix')) {
         final mixId = mixElement.getAttribute('id');
         if (mixId != null) {
-          gasMixes[mixId] = _parseUddfGasMix(mixElement);
+          gasMixes[mixId] = UddfImportParsers.parseGasMix(mixElement);
         }
       }
     }
@@ -460,17 +460,6 @@ class UddfFullImportService {
     );
 
     return site;
-  }
-
-  GasMix _parseUddfGasMix(XmlElement mixElement) {
-    final o2Text = UddfImportParsers.getElementText(mixElement, 'o2');
-    final heText = UddfImportParsers.getElementText(mixElement, 'he');
-
-    // UDDF stores as fractions (0.21 for 21%)
-    final o2 = o2Text != null ? (double.tryParse(o2Text) ?? 0.21) * 100 : 21.0;
-    final he = heText != null ? (double.tryParse(heText) ?? 0.0) * 100 : 0.0;
-
-    return GasMix(o2: o2, he: he);
   }
 
   Map<String, dynamic> _parseFullDive(

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -1,6 +1,7 @@
 import 'package:xml/xml.dart';
 
 import 'package:submersion/core/constants/enums.dart' as enums;
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 /// Static parser methods for UDDF entity elements.
 ///
@@ -24,6 +25,17 @@ class UddfImportParsers {
     return element?.innerText.trim().isEmpty == true
         ? null
         : element?.innerText.trim();
+  }
+
+  static GasMix parseGasMix(XmlElement mixElement) {
+    final o2Text = getElementText(mixElement, 'o2');
+    final heText = getElementText(mixElement, 'he');
+
+    // UDDF stores gas values as fractions (0.21 for 21%).
+    final o2 = o2Text != null ? (double.tryParse(o2Text) ?? 0.21) * 100 : 21.0;
+    final he = heText != null ? (double.tryParse(heText) ?? 0.0) * 100 : 0.0;
+
+    return GasMix(o2: o2, he: he);
   }
 
   /// Parse a UDDF datetime string using the wall-clock-as-UTC convention.

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -72,7 +72,7 @@ class UddfImportService {
       for (final mixElement in gasDefsElement.findElements('mix')) {
         final mixId = mixElement.getAttribute('id');
         if (mixId != null) {
-          gasMixes[mixId] = _parseUddfGasMix(mixElement);
+          gasMixes[mixId] = UddfImportParsers.parseGasMix(mixElement);
         }
       }
     }
@@ -191,17 +191,6 @@ class UddfImportService {
     site['description'] = _getElementText(siteElement, 'notes');
 
     return site;
-  }
-
-  GasMix _parseUddfGasMix(XmlElement mixElement) {
-    final o2Text = _getElementText(mixElement, 'o2');
-    final heText = _getElementText(mixElement, 'he');
-
-    // UDDF stores as fractions (0.21 for 21%)
-    final o2 = o2Text != null ? (double.tryParse(o2Text) ?? 0.21) * 100 : 21.0;
-    final he = heText != null ? (double.tryParse(heText) ?? 0.0) * 100 : 0.0;
-
-    return GasMix(o2: o2, he: he);
   }
 
   Map<String, dynamic> _parseUddfDive(

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2757,10 +2757,7 @@ class DiveRepository {
 
   /// Format gas mix as a readable name (e.g., "Air", "EAN32", "Tx 21/35")
   String _formatGasMixName(double o2, double he) {
-    if (he > 0) return 'Tx ${o2.toInt()}/${he.toInt()}';
-    if (o2 > 22) return 'EAN${o2.toInt()}';
-    if (o2 >= 20 && o2 <= 22) return 'Air';
-    return '${o2.toInt()}% O2';
+    return domain.GasMix(o2: o2, he: he).name;
   }
 
   /// Create a gas switch record

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -899,6 +899,8 @@ class GasMix extends Equatable {
   const GasMix({this.o2 = 21.0, this.he = 0.0});
 
   double get n2 => 100.0 - o2 - he;
+  int get roundedO2 => o2.round();
+  int get roundedHe => he.round();
 
   bool get isAir => o2 >= 20 && o2 <= 22 && he == 0;
   bool get isNitrox => o2 > 22 && he == 0;
@@ -906,9 +908,9 @@ class GasMix extends Equatable {
 
   String get name {
     if (isAir) return 'Air';
-    if (isTrimix) return 'Tx ${o2.toInt()}/${he.toInt()}';
-    if (isNitrox) return 'EAN${o2.toInt()}';
-    return '${o2.toInt()}% O2';
+    if (isTrimix) return 'Tx $roundedO2/$roundedHe';
+    if (isNitrox) return 'EAN$roundedO2';
+    return '$roundedO2% O2';
   }
 
   /// Maximum Operating Depth (MOD) at given ppO2

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -1,8 +1,66 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
 
+const _uddfEan29 = '''<uddf version="3.2.1">
+  <gasdefinitions>
+    <mix id="mix(29/0)">
+      <name>EANx 29</name>
+      <o2>0.29</o2>
+      <he>0.00</he>
+    </mix>
+  </gasdefinitions>
+  <profiledata>
+    <repetitiongroup id="id4">
+      <dive id="id4">
+        <informationbeforedive>
+          <divenumber>107</divenumber>
+          <datetime>2025-03-19T08:19:54</datetime>
+          <equipmentused>
+            <leadquantity>5</leadquantity>
+          </equipmentused>
+        </informationbeforedive>
+        <tankdata>
+          <link ref="mix(29/0)"/>
+          <tankvolume>24.0</tankvolume>
+          <tankpressurebegin>20500000</tankpressurebegin>
+          <tankpressureend>11000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <depth>1.7</depth>
+            <divetime>2</divetime>
+            <switchmix ref="mix(29/0)"/>
+            <temperature>290.15</temperature>
+          </waypoint>
+          <waypoint>
+            <depth>2</depth>
+            <divetime>4</divetime>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>''';
+
 void main() {
   group('UddfFullImportService', () {
+    late UddfFullImportService service;
+
+    setUp(() {
+      service = UddfFullImportService();
+    });
+
+    test('keeps a 0.29 UDDF mix labeled as EAN29', () async {
+      final result = await service.importAllDataFromUddf(_uddfEan29);
+      final dive = result.dives.first;
+      final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+      final gasMix = tanks.first['gasMix'] as dynamic;
+
+      expect(gasMix, isNotNull);
+      expect(gasMix.o2, closeTo(29.0, 0.000001));
+      expect(gasMix.name, 'EAN29');
+    });
+
     test(
       'maps tankpressure refs by tank order when tankdata entries omit ids',
       () async {
@@ -36,8 +94,6 @@ void main() {
   </profiledata>
 </uddf>
 ''';
-
-        final service = UddfFullImportService();
 
         final result = await service.importAllDataFromUddf(uddfContent);
         expect(result.dives, hasLength(1));
@@ -94,8 +150,6 @@ void main() {
 </uddf>
 ''';
 
-        final service = UddfFullImportService();
-
         final result = await service.importAllDataFromUddf(uddfContent);
         expect(result.dives, hasLength(1));
 
@@ -146,8 +200,6 @@ void main() {
   </profiledata>
 </uddf>
 ''';
-
-      final service = UddfFullImportService();
 
       final result = await service.importAllDataFromUddf(uddfContent);
       final dive = result.dives.first;

--- a/test/features/dive_log/domain/entities/gas_mix_test.dart
+++ b/test/features/dive_log/domain/entities/gas_mix_test.dart
@@ -2,6 +2,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 void main() {
+  group('GasMix.name', () {
+    test('rounds near-integer nitrox percentages for display', () {
+      const ean29 = GasMix(o2: 28.999999999, he: 0.0);
+      expect(ean29.name, 'EAN29');
+    });
+
+    test('rounds near-integer trimix percentages for display', () {
+      const tx2135 = GasMix(o2: 20.999999999, he: 34.999999999);
+      expect(tx2135.name, 'Tx 21/35');
+    });
+  });
+
   group('GasMix.mnd', () {
     test('air with O2 narcotic returns depth equal to END limit', () {
       const air = GasMix(o2: 21.0, he: 0.0);


### PR DESCRIPTION
## Summary

fix: round imported gas labels and share UDDF gas parsing (one issue in Issue-78)

## Changes

- round gas mix display percentages instead of truncating near-integer
  imported values (28.999999) like EAN29 instead of EAN28
- centralize UDDF gas parsing in UddfImportParsers so both import paths
  use the same logic
- remove duplicated gas mix parsing from the standard and full UDDF
  import services
- add regression coverage for near-integer gas labels and a UDDF import
  using a 0.29 mix with switchmix references
- verify with focused UDDF import and gas mix tests

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: Windows

## Screenshots
before:
<img width="719" height="165" alt="image" src="https://github.com/user-attachments/assets/34f155a0-1f19-4b1a-beb9-ef6449a4a714" />

after:
<img width="602" height="180" alt="image" src="https://github.com/user-attachments/assets/b3684231-d48c-4aa4-9794-2a747257905b" />

