### PR TITLE
Issue-71 UDDF handle switchmix switching without explicit tank reference

### DIFF
--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1428,6 +1428,7 @@ class UddfFullImportService {
     if (samplesElement != null) {
       final profile = <Map<String, dynamic>>[];
       GasMix? currentMix;
+      GasMix? pendingSwitchMix;
 
       for (final waypoint in samplesElement.findElements('waypoint')) {
         final point = <String, dynamic>{};
@@ -1453,6 +1454,24 @@ class UddfFullImportService {
             // Validate reasonable water temperature range (-2C to 40C)
             if (celsius >= -2 && celsius <= 40) {
               point['temperature'] = celsius;
+            }
+          }
+        }
+
+        final switchMix = waypoint.findElements('switchmix').firstOrNull;
+        if (switchMix != null) {
+          final mixRef = switchMix.getAttribute('ref');
+          if (mixRef != null && gasMixes.containsKey(mixRef)) {
+            currentMix = gasMixes[mixRef];
+            pendingSwitchMix = currentMix;
+
+            if (tanks.length == 1) {
+              UddfImportParsers.assignGasMixToTankIfMissing(
+                tanks: tanks,
+                tankIndex: 0,
+                gasMix: currentMix!,
+              );
+              pendingSwitchMix = null;
             }
           }
         }
@@ -1498,6 +1517,15 @@ class UddfFullImportService {
               tankIdx = 0;
             }
 
+            if (pendingSwitchMix != null) {
+              UddfImportParsers.assignGasMixToTankIfMissing(
+                tanks: tanks,
+                tankIndex: tankIdx,
+                gasMix: pendingSwitchMix,
+              );
+              pendingSwitchMix = null;
+            }
+
             allTankPressures.add({'pressure': pressure, 'tankIndex': tankIdx});
 
             // Store first tank's pressure in legacy fields for backward compatibility
@@ -1520,15 +1548,6 @@ class UddfFullImportService {
         );
         if (heartRateText != null) {
           point['heartRate'] = int.tryParse(heartRateText);
-        }
-
-        // Check for gas switch
-        final switchMix = waypoint.findElements('switchmix').firstOrNull;
-        if (switchMix != null) {
-          final mixRef = switchMix.getAttribute('ref');
-          if (mixRef != null && gasMixes.containsKey(mixRef)) {
-            currentMix = gasMixes[mixRef];
-          }
         }
 
         if (point.containsKey('timestamp') && point.containsKey('depth')) {

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -1,6 +1,7 @@
 import 'package:xml/xml.dart';
 
 import 'package:submersion/core/constants/enums.dart' as enums;
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 /// Static parser methods for UDDF entity elements.
 ///
@@ -8,6 +9,18 @@ import 'package:submersion/core/constants/enums.dart' as enums;
 /// from UDDF XML elements into maps.
 class UddfImportParsers {
   UddfImportParsers._();
+
+  static void assignGasMixToTankIfMissing({
+    required List<Map<String, dynamic>> tanks,
+    required int tankIndex,
+    required GasMix gasMix,
+  }) {
+    if (tankIndex < 0 || tankIndex >= tanks.length) {
+      return;
+    }
+
+    tanks[tankIndex].putIfAbsent('gasMix', () => gasMix);
+  }
 
   static T? parseEnumValue<T extends Enum>(String value, List<T> values) {
     final lowerValue = value.toLowerCase();

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -536,6 +536,7 @@ class UddfImportService {
     if (samplesElement != null) {
       final profile = <Map<String, dynamic>>[];
       GasMix? currentMix;
+      GasMix? pendingSwitchMix;
 
       for (final waypoint in samplesElement.findElements('waypoint')) {
         final point = <String, dynamic>{};
@@ -558,6 +559,24 @@ class UddfImportService {
             // Validate reasonable water temperature range (-2C to 40C)
             if (celsius >= -2 && celsius <= 40) {
               point['temperature'] = celsius;
+            }
+          }
+        }
+
+        final switchMix = waypoint.findElements('switchmix').firstOrNull;
+        if (switchMix != null) {
+          final mixRef = switchMix.getAttribute('ref');
+          if (mixRef != null && gasMixes.containsKey(mixRef)) {
+            currentMix = gasMixes[mixRef];
+            pendingSwitchMix = currentMix;
+
+            if (tanks.length == 1) {
+              UddfImportParsers.assignGasMixToTankIfMissing(
+                tanks: tanks,
+                tankIndex: 0,
+                gasMix: currentMix!,
+              );
+              pendingSwitchMix = null;
             }
           }
         }
@@ -603,6 +622,15 @@ class UddfImportService {
               tankIdx = 0;
             }
 
+            if (pendingSwitchMix != null) {
+              UddfImportParsers.assignGasMixToTankIfMissing(
+                tanks: tanks,
+                tankIndex: tankIdx,
+                gasMix: pendingSwitchMix,
+              );
+              pendingSwitchMix = null;
+            }
+
             allTankPressures.add({'pressure': pressure, 'tankIndex': tankIdx});
 
             // Store first tank's pressure in legacy fields for backward compatibility
@@ -622,15 +650,6 @@ class UddfImportService {
         final heartRateText = _getElementText(waypoint, 'heartrate');
         if (heartRateText != null) {
           point['heartRate'] = int.tryParse(heartRateText);
-        }
-
-        // Check for gas switch
-        final switchMix = waypoint.findElements('switchmix').firstOrNull;
-        if (switchMix != null) {
-          final mixRef = switchMix.getAttribute('ref');
-          if (mixRef != null && gasMixes.containsKey(mixRef)) {
-            currentMix = gasMixes[mixRef];
-          }
         }
 
         if (point.containsKey('timestamp') && point.containsKey('depth')) {

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 void main() {
   group('UddfFullImportService', () {
@@ -159,5 +160,124 @@ void main() {
       expect(firstPointPressures[0]['tankIndex'], 0);
       expect(firstPointPressures[1]['tankIndex'], 1);
     });
+
+    test(
+      'keeps the Shearwater tank gas mix from gasdefinitions instead of defaulting to air',
+      () async {
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <gasdefinitions>
+    <mix id="OC1:30/00">
+      <name>OC1</name>
+      <o2>0.3</o2>
+      <he>0</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+  </gasdefinitions>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-12-30T14:18:24Z</datetime>
+          <divenumber>267</divenumber>
+        </informationbeforedive>
+        <tankdata>
+          <tankpressurebegin>20000000</tankpressurebegin>
+          <tankpressureend>5000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <batterychargecondition>1.51</batterychargecondition>
+            <calculatedpo2>0.359999985</calculatedpo2>
+            <depth>2</depth>
+            <divetime>0</divetime>
+            <switchmix ref="OC1:30/00" />
+            <temperature>298.15</temperature>
+            <divemode type="opencircuit" />
+            <gradientfactor>0</gradientfactor>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+        final service = UddfFullImportService();
+
+        final result = await service.importAllDataFromUddf(uddfContent);
+        expect(result.dives, hasLength(1));
+
+        final dive = result.dives.first;
+        final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+        final gasMix = tanks.first['gasMix'] as GasMix;
+
+        expect(tanks, hasLength(1));
+        expect(gasMix.isAir, isFalse);
+        expect(gasMix.o2, closeTo(30.0, 0.001));
+        expect(gasMix.he, closeTo(0.0, 0.001));
+        expect(gasMix.name, 'EAN30');
+      },
+    );
+
+    test(
+      'applies switchmix to the tank referenced by the active pressure data',
+      () async {
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <gasdefinitions>
+    <mix id="backgas">
+      <o2>0.21</o2>
+      <he>0</he>
+    </mix>
+    <mix id="deco50">
+      <o2>0.5</o2>
+      <he>0</he>
+    </mix>
+  </gasdefinitions>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-12-30T14:18:24Z</datetime>
+          <divenumber>267</divenumber>
+        </informationbeforedive>
+        <tankdata id="back-tank">
+          <tankpressurebegin>20000000</tankpressurebegin>
+          <tankpressureend>12000000</tankpressureend>
+        </tankdata>
+        <tankdata id="deco-tank">
+          <tankpressurebegin>18000000</tankpressurebegin>
+          <tankpressureend>9000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <depth>6</depth>
+            <divetime>1200</divetime>
+            <switchmix ref="deco50" />
+            <tankpressure ref="deco-tank">18000000</tankpressure>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+        final service = UddfFullImportService();
+
+        final result = await service.importAllDataFromUddf(uddfContent);
+        final dive = result.dives.first;
+        final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+
+        expect(tanks, hasLength(2));
+        expect(tanks[0]['gasMix'], isNull);
+
+        final gasMix = tanks[1]['gasMix'] as GasMix;
+        expect(gasMix.o2, closeTo(50.0, 0.001));
+        expect(gasMix.he, closeTo(0.0, 0.001));
+        expect(gasMix.name, 'EAN50');
+      },
+    );
   });
 }

--- a/test/core/services/export/uddf/uddf_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_import_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/uddf/uddf_import_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 void main() {
   group('UddfImportService', () {
@@ -234,5 +235,125 @@ void main() {
       expect(firstPointPressures[0]['tankIndex'], 0);
       expect(firstPointPressures[1]['tankIndex'], 1);
     });
+
+    test(
+      'keeps the Shearwater tank gas mix from gasdefinitions instead of defaulting to air',
+      () async {
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <gasdefinitions>
+    <mix id="OC1:30/00">
+      <name>OC1</name>
+      <o2>0.3</o2>
+      <he>0</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+  </gasdefinitions>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-12-30T14:18:24Z</datetime>
+          <divenumber>267</divenumber>
+        </informationbeforedive>
+        <tankdata>
+          <tankpressurebegin>20000000</tankpressurebegin>
+          <tankpressureend>5000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <batterychargecondition>1.51</batterychargecondition>
+            <calculatedpo2>0.359999985</calculatedpo2>
+            <depth>2</depth>
+            <divetime>0</divetime>
+            <switchmix ref="OC1:30/00" />
+            <temperature>298.15</temperature>
+            <divemode type="opencircuit" />
+            <gradientfactor>0</gradientfactor>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+        final service = UddfImportService();
+
+        final result = await service.importDivesFromUddf(uddfContent);
+        final dives = result['dives']!;
+        expect(dives, hasLength(1));
+
+        final dive = dives.first;
+        final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+        final gasMix = tanks.first['gasMix'] as GasMix;
+
+        expect(tanks, hasLength(1));
+        expect(gasMix.isAir, isFalse);
+        expect(gasMix.o2, closeTo(30.0, 0.001));
+        expect(gasMix.he, closeTo(0.0, 0.001));
+        expect(gasMix.name, 'EAN30');
+      },
+    );
+
+    test(
+      'applies switchmix to the tank referenced by the active pressure data',
+      () async {
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <gasdefinitions>
+    <mix id="backgas">
+      <o2>0.21</o2>
+      <he>0</he>
+    </mix>
+    <mix id="deco50">
+      <o2>0.5</o2>
+      <he>0</he>
+    </mix>
+  </gasdefinitions>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-12-30T14:18:24Z</datetime>
+          <divenumber>267</divenumber>
+        </informationbeforedive>
+        <tankdata id="back-tank">
+          <tankpressurebegin>20000000</tankpressurebegin>
+          <tankpressureend>12000000</tankpressureend>
+        </tankdata>
+        <tankdata id="deco-tank">
+          <tankpressurebegin>18000000</tankpressurebegin>
+          <tankpressureend>9000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <depth>6</depth>
+            <divetime>1200</divetime>
+            <switchmix ref="deco50" />
+            <tankpressure ref="deco-tank">18000000</tankpressure>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+        final service = UddfImportService();
+
+        final result = await service.importDivesFromUddf(uddfContent);
+        final dive = result['dives']!.first;
+        final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+
+        expect(tanks, hasLength(2));
+        expect(tanks[0]['gasMix'], isNull);
+
+        final gasMix = tanks[1]['gasMix'] as GasMix;
+        expect(gasMix.o2, closeTo(50.0, 0.001));
+        expect(gasMix.he, closeTo(0.0, 0.001));
+        expect(gasMix.name, 'EAN50');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
Fixes UDDF import for Shearwater-style files where tankdata contains only pressure values and the active gas appears only in samples > switchmix. Before this change, those dives could keep the tank but leave its gas mix unset. Now the importer carries the pending switchmix forward and assigns it to the correct tank once the active tank is known.

## Changes

- Update UddfImportService to apply a pending switchmix gas to the resolved tank index from waypoint pressure data
- Update UddfFullImportService with the same behavior so both import paths stay aligned
- Add a shared helper in UddfImportParsers to assign a gas mix onto a tank only when that tank does not already have one
- Add a regression test for the real Shearwater UDDF shape from issue #71 where tankdata has pressures only and switchmix provides the gas
- Add a multi-tank regression test proving switchmix is assigned to the tank referenced by the active tankpressure

## Test Plan
[X] flutter test passes
[X] flutter analyze passes
[X] Manual testing on: Windows

Screenshots
before:
<img width="764" height="215" alt="image" src="https://github.com/user-attachments/assets/9904e8be-8948-4a9c-b07a-87c7b29fd2ed" />

after:
<img width="777" height="230" alt="image" src="https://github.com/user-attachments/assets/b4940d73-f769-42e5-8664-d6555038fd41" />

