### PR TITLE
fix: address PR #114 review feedback

### DIFF
--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -804,7 +804,16 @@ class ProfileAnalysisService {
     // Use lastIndexOf so that mid-dive excursions through shallow depths are
     // treated as bottom-phase activity and not counted as safety stops.
     final maxDepthIndex = depths.lastIndexOf(maxDepth);
-    _detectSafetyStops(diveId, depths, timestamps, maxDepthIndex, events, now);
+    if (maxDepthIndex >= 0) {
+      _detectSafetyStops(
+        diveId,
+        depths,
+        timestamps,
+        maxDepthIndex,
+        events,
+        now,
+      );
+    }
 
     // Add ascent rate violation events
     for (final violation in ascentRateViolations) {

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -514,10 +514,10 @@ void main() {
           t++;
         }
 
-        // Hover at 4-6m for 30 minutes with oscillation
+        // Hover at 4-5m for 30 minutes with oscillation
         for (var s = 0; s < 30 * 60; s++) {
           timestamps.add(t);
-          // Oscillate between 3.5m and 5.5m with occasional dips
+          // Oscillate between 4.0m and 5.0m
           const base = 4.5;
           final oscillation =
               1.0 * (s % 120 < 60 ? (s % 60) / 60.0 : 1.0 - (s % 60) / 60.0);


### PR DESCRIPTION
## Summary

- Add defensive guard for `maxDepthIndex < 0` before calling `_detectSafetyStops` (addresses Copilot review)
- Fix inaccurate test comments: depth range is 4.0-5.0m, not 3.5-5.5m (addresses Copilot review)

Follow-up to #114.

## Test plan

- [x] All 16 profile analysis tests pass
- [x] `dart format --set-exit-if-changed` reports 0 changes
- [x] Pre-push hooks pass (format, analyze, test)