### PR TITLE
fix: replace propane tank icon with scuba tank icon

### DIFF
--- a/lib/core/constants/enums.dart
+++ b/lib/core/constants/enums.dart
@@ -380,7 +380,7 @@ enum ProfileEventType {
       case ProfileEventType.missedStop:
         return 'dangerous';
       case ProfileEventType.lowGas:
-        return 'propane_tank';
+        return 'diving_scuba_tank';
       case ProfileEventType.cnsWarning:
       case ProfileEventType.cnsCritical:
         return 'air';

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:intl/intl.dart' show DateFormat;
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
@@ -1882,7 +1883,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     return CollapsibleCardSection(
       title: context.l10n.diveLog_detail_section_sacByCylinder,
-      icon: Icons.propane_tank,
+      icon: MdiIcons.divingScubaTank,
       collapsedSubtitle: context.l10n.diveLog_detail_tankCount(
         cylinderSacs.length,
       ),
@@ -1909,7 +1910,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Icon(
-                      Icons.propane_tank,
+                      MdiIcons.divingScubaTank,
                       size: 16,
                       color: colorScheme.primary,
                     ),
@@ -3747,7 +3748,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               }
               return ListTile(
                 contentPadding: EdgeInsets.zero,
-                leading: const Icon(Icons.propane_tank),
+                leading: Icon(MdiIcons.divingScubaTank),
                 title: Text('$tankTitle (${tank.gasMix.name})'),
                 subtitle: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -3896,7 +3897,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       case EquipmentType.computer:
         return Icons.watch;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.light:

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart' hide Visibility;
 import 'package:flutter/services.dart';
-import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:submersion/core/providers/provider.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/constants/enums.dart';
@@ -2138,7 +2139,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       case EquipmentType.hood:
         return Icons.face;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.computer:
@@ -4664,7 +4665,7 @@ class _EquipmentPickerSheet extends ConsumerWidget {
       case EquipmentType.hood:
         return Icons.face;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.computer:

--- a/lib/features/dive_log/presentation/pages/dive_search_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_search_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -196,7 +197,7 @@ class _DiveSearchPageState extends ConsumerState<DiveSearchPage> {
           _buildSection(
             key: 'gas',
             title: context.l10n.diveLog_search_section_gasEquipment,
-            icon: Icons.propane_tank,
+            icon: MdiIcons.divingScubaTank,
             child: _buildGasEquipmentContent(),
           ),
 

--- a/lib/features/dive_log/presentation/widgets/cylinder_sac_card.dart
+++ b/lib/features/dive_log/presentation/widgets/cylinder_sac_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 import 'package:submersion/core/accessibility/semantic_helpers.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -64,7 +65,7 @@ class CylinderSacCard extends StatelessWidget {
                     // Tank icon
                     ExcludeSemantics(
                       child: Icon(
-                        Icons.propane_tank,
+                        MdiIcons.divingScubaTank,
                         size: 18,
                         color: colorScheme.primary,
                       ),

--- a/lib/features/dive_planner/presentation/widgets/gas_results_panel.dart
+++ b/lib/features/dive_planner/presentation/widgets/gas_results_panel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -35,7 +36,7 @@ class GasResultsPanel extends ConsumerWidget {
               children: [
                 ExcludeSemantics(
                   child: Icon(
-                    Icons.propane_tank,
+                    MdiIcons.divingScubaTank,
                     color: theme.colorScheme.primary,
                   ),
                 ),

--- a/lib/features/dive_planner/presentation/widgets/plan_tank_list.dart
+++ b/lib/features/dive_planner/presentation/widgets/plan_tank_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/constants/enums.dart';
@@ -33,7 +34,7 @@ class PlanTankList extends ConsumerWidget {
               children: [
                 ExcludeSemantics(
                   child: Icon(
-                    Icons.propane_tank,
+                    MdiIcons.divingScubaTank,
                     color: theme.colorScheme.primary,
                   ),
                 ),

--- a/lib/features/equipment/presentation/pages/equipment_detail_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
@@ -864,7 +865,7 @@ class _EquipmentDetailContent extends ConsumerWidget {
       case EquipmentType.computer:
         return Icons.watch;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.light:

--- a/lib/features/equipment/presentation/pages/equipment_set_detail_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_set_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
@@ -277,7 +278,7 @@ class EquipmentSetDetailPage extends ConsumerWidget {
       case EquipmentType.computer:
         return Icons.watch;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.light:

--- a/lib/features/equipment/presentation/pages/equipment_set_edit_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_set_edit_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
@@ -365,7 +366,7 @@ class _EquipmentSetEditPageState extends ConsumerState<EquipmentSetEditPage> {
       case EquipmentType.computer:
         return Icons.watch;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.light:

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -554,7 +555,7 @@ class EquipmentListTile extends StatelessWidget {
       case EquipmentType.computer:
         return Icons.watch;
       case EquipmentType.tank:
-        return Icons.propane_tank;
+        return MdiIcons.divingScubaTank;
       case EquipmentType.weights:
         return Icons.fitness_center;
       case EquipmentType.light:

--- a/lib/features/settings/presentation/pages/appearance_page.dart
+++ b/lib/features/settings/presentation/pages/appearance_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/constants/card_color.dart';
@@ -310,7 +311,7 @@ class AppearancePage extends ConsumerWidget {
                   .l10n
                   .settings_appearance_pressureThresholdMarkers_subtitleFull,
             ),
-            secondary: const Icon(Icons.propane_tank),
+            secondary: Icon(MdiIcons.divingScubaTank),
             value: settings.showPressureThresholdMarkers,
             onChanged: (value) {
               ref

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -1450,7 +1451,7 @@ class _AppearanceSectionContentState
                         .l10n
                         .settings_appearance_pressureThresholdMarkers_subtitle,
                   ),
-                  secondary: const Icon(Icons.propane_tank),
+                  secondary: Icon(MdiIcons.divingScubaTank),
                   value: settings.showPressureThresholdMarkers,
                   onChanged: (value) {
                     ref
@@ -1913,7 +1914,7 @@ class _ManageSectionContent extends StatelessWidget {
                 ),
                 const Divider(height: 1),
                 ListTile(
-                  leading: const Icon(Icons.propane_tank),
+                  leading: Icon(MdiIcons.divingScubaTank),
                   title: Text(context.l10n.settings_manage_tankPresets),
                   subtitle: Text(
                     context.l10n.settings_manage_tankPresets_subtitle,

--- a/lib/features/statistics/presentation/pages/statistics_gas_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_gas_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/accessibility/semantic_helpers.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -154,7 +155,7 @@ class StatisticsGasPage extends ConsumerWidget {
         data: (data) {
           if (data.isEmpty) {
             return StatEmptyState(
-              icon: Icons.propane_tank,
+              icon: MdiIcons.divingScubaTank,
               message: context.l10n.statistics_gas_sacByRole_empty,
             );
           }
@@ -178,7 +179,7 @@ class StatisticsGasPage extends ConsumerWidget {
                     children: [
                       ExcludeSemantics(
                         child: Icon(
-                          Icons.propane_tank,
+                          MdiIcons.divingScubaTank,
                           size: 20,
                           color: Theme.of(context).colorScheme.primary,
                         ),

--- a/lib/features/tank_presets/presentation/pages/tank_presets_page.dart
+++ b/lib/features/tank_presets/presentation/pages/tank_presets_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -142,7 +143,7 @@ class TankPresetsPage extends ConsumerWidget {
 
     return ListTile(
       leading: Icon(
-        canEdit ? Icons.propane_tank_outlined : Icons.propane_tank,
+        MdiIcons.divingScubaTank,
         color: canEdit
             ? Theme.of(context).colorScheme.secondary
             : Theme.of(context).colorScheme.primary,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1154,6 +1154,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_design_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: material_design_icons_flutter
+      sha256: "6f986b7a51f3ad4c00e33c5c84e8de1bdd140489bbcdc8b66fc1283dad4dea5a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.7296"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
 
   # Core
   cupertino_icons: ^1.0.8
+  material_design_icons_flutter: ^7.0.7296
 
   # State Management
   flutter_riverpod: ^3.1.0

--- a/test/features/dive_log/presentation/widgets/collapsible_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/collapsible_section_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/collapsible_section.dart';
 
 import '../../../../helpers/test_app.dart';
@@ -243,7 +244,7 @@ void main() {
           child: SingleChildScrollView(
             child: CollapsibleCardSection(
               title: 'Tanks',
-              icon: Icons.propane_tank,
+              icon: MdiIcons.divingScubaTank,
               collapsedTrailing: const Icon(Icons.check_circle),
               isExpanded: false,
               onToggle: (_) {},
@@ -263,7 +264,7 @@ void main() {
           child: SingleChildScrollView(
             child: CollapsibleCardSection(
               title: 'Tanks',
-              icon: Icons.propane_tank,
+              icon: MdiIcons.divingScubaTank,
               collapsedTrailing: const Icon(Icons.check_circle),
               isExpanded: true,
               onToggle: (_) {},


### PR DESCRIPTION
## Summary

- Replaces `Icons.propane_tank` (BBQ-style icon) with `MdiIcons.divingScubaTank` (actual scuba tank) across all 15 source files and 1 test file
- Adds `material_design_icons_flutter` package dependency
- Updates profile event icon string for consistency

Closes #109

## Test plan

- [x] All 3595 existing tests pass
- [x] `flutter analyze` clean (no new issues)
- [x] `dart format` clean (0 changes)
- [x] Visual verification: tank icon appears correctly in equipment list, dive detail, tank presets, dive planner, statistics, settings, and search pages