### PR TITLE
feat: add map style selector (Street, Topo, Satellite)

### DIFF
--- a/lib/core/constants/map_style.dart
+++ b/lib/core/constants/map_style.dart
@@ -1,0 +1,14 @@
+/// Available map tile styles.
+enum MapStyle {
+  openStreetMap,
+  openTopoMap,
+  esriSatellite;
+
+  /// Parse from stored string, defaulting to openStreetMap.
+  static MapStyle fromName(String name) {
+    return MapStyle.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => MapStyle.openStreetMap,
+    );
+  }
+}

--- a/lib/core/constants/map_tile_config.dart
+++ b/lib/core/constants/map_tile_config.dart
@@ -1,0 +1,50 @@
+import 'package:submersion/core/constants/map_style.dart';
+
+/// Centralized configuration for map tile providers.
+class MapTileConfig {
+  MapTileConfig._();
+
+  /// Returns the tile URL template for the given [style].
+  static String urlTemplate(MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap =>
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      MapStyle.openTopoMap =>
+        'https://tile.opentopomap.org/{z}/{x}/{y}.png',
+      MapStyle.esriSatellite =>
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    };
+  }
+
+  /// Returns the maximum zoom level supported by the given [style].
+  static int maxZoom(MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap => 19,
+      MapStyle.openTopoMap => 17,
+      MapStyle.esriSatellite => 18,
+    };
+  }
+
+  /// Returns a concrete tile URL for the given [style], zoom, x, and y indices.
+  static String tileUrl(MapStyle style, int z, int x, int y) {
+    return switch (style) {
+      MapStyle.openStreetMap =>
+        'https://tile.openstreetmap.org/$z/$x/$y.png',
+      MapStyle.openTopoMap =>
+        'https://tile.opentopomap.org/$z/$x/$y.png',
+      MapStyle.esriSatellite =>
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/$z/$y/$x',
+    };
+  }
+
+  /// Returns the attribution string for the given [style].
+  static String attribution(MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap => '\u00a9 OpenStreetMap contributors',
+      MapStyle.openTopoMap =>
+        '\u00a9 OpenStreetMap contributors, SRTM | Style: \u00a9 OpenTopoMap (CC-BY-SA)',
+      MapStyle.esriSatellite =>
+        '\u00a9 Esri, Maxar, Earthstar Geographics',
+    };
+  }
+}

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -672,6 +672,9 @@ class DiverSettings extends Table {
       text().withDefault(const Constant('detailed'))();
   TextColumn get diveCenterListViewMode =>
       text().withDefault(const Constant('detailed'))();
+  // Map style (v64)
+  TextColumn get mapStyle =>
+      text().withDefault(const Constant('openStreetMap'))();
   // Dive profile chart defaults
   TextColumn get defaultRightAxisMetric =>
       text().withDefault(const Constant('temperature'))();
@@ -1307,7 +1310,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 63;
+  static const int currentSchemaVersion = 64;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1374,6 +1377,7 @@ class AppDatabase extends _$AppDatabase {
     61,
     62,
     63,
+    64,
   ];
 
   /// Returns the number of migration steps that will execute when upgrading
@@ -2958,6 +2962,13 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 63) await reportProgress();
+
+        if (from < 64) {
+          await customStatement(
+            "ALTER TABLE diver_settings ADD COLUMN map_style TEXT NOT NULL DEFAULT 'openStreetMap'",
+          );
+        }
+        if (from < 64) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.d
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 
 class DiveCenterDetailPage extends ConsumerStatefulWidget {
   final String centerId;
@@ -603,9 +604,9 @@ class _MapSection extends StatelessWidget {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,
@@ -696,9 +697,9 @@ class _MapSection extends StatelessWidget {
             ),
             children: [
               TileLayer(
-                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
-                maxZoom: 19,
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
                     ? TileCacheService.instance.getTileProvider()
                     : null,

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/dive_centers/presentation/widgets/dive_cente
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
 
 class DiveCenterMapPage extends ConsumerStatefulWidget {
@@ -221,9 +222,9 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -8,6 +8,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
@@ -215,9 +216,9 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/tank_presets.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/core/deco/altitude_calculator.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_card.dart';
 import 'package:submersion/core/services/export/export_service.dart';
@@ -847,10 +848,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   ),
                   children: [
                     TileLayer(
-                      urlTemplate:
-                          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      urlTemplate: ref.watch(mapTileUrlProvider),
                       userAgentPackageName: 'app.submersion',
-                      maxZoom: 19,
+                      maxZoom: ref.watch(mapTileMaxZoomProvider),
                       tileProvider: TileCacheService.instance.isInitialized
                           ? TileCacheService.instance.getTileProvider()
                           : null,

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -7,6 +7,9 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/constants/map_tile_config.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -42,7 +45,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 ///
 /// Converts WGS-84 coordinates to slippy map tile x/y using the standard
 /// Web Mercator projection formula, then returns the OSM raster tile URL.
-String _osmTileUrl(double lat, double lng, int zoom) {
+String _osmTileUrl(double lat, double lng, int zoom, MapStyle style) {
   final n = 1 << zoom; // 2^zoom
   final x = ((lng + 180.0) / 360.0 * n).floor();
   final latRad = lat * math.pi / 180.0;
@@ -51,7 +54,7 @@ String _osmTileUrl(double lat, double lng, int zoom) {
               2.0 *
               n)
           .floor();
-  return 'https://tile.openstreetmap.org/$zoom/$x/$y.png';
+  return MapTileConfig.tileUrl(style, zoom, x, y);
 }
 
 /// Main dive list page with master-detail layout on desktop.
@@ -885,7 +888,7 @@ class DiveListTile extends ConsumerWidget {
 
     // Build the card with or without map background
     if (shouldShowMap) {
-      final tileUrl = _osmTileUrl(siteLatitude!, siteLongitude!, 13);
+      final tileUrl = _osmTileUrl(siteLatitude!, siteLongitude!, 13, ref.watch(settingsProvider).mapStyle);
       return Card(
         margin:
             margin ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 4),

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
@@ -306,9 +307,9 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/site_marine_life_section.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_section.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -383,9 +384,9 @@ class _SiteDetailContent extends ConsumerWidget {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,
@@ -479,9 +480,9 @@ class _SiteDetailContent extends ConsumerWidget {
             ),
             children: [
               TileLayer(
-                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
-                maxZoom: 19,
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
                     ? TileCacheService.instance.getTileProvider()
                     : null,

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
@@ -235,9 +236,9 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -3,8 +3,10 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 
 /// Result from the location picker
 class PickedLocation {
@@ -24,7 +26,7 @@ class PickedLocation {
 }
 
 /// A full-screen map for picking a location
-class LocationPickerMap extends StatefulWidget {
+class LocationPickerMap extends ConsumerStatefulWidget {
   /// Initial location to center the map on (optional)
   final LatLng? initialLocation;
 
@@ -34,7 +36,7 @@ class LocationPickerMap extends StatefulWidget {
   State<LocationPickerMap> createState() => _LocationPickerMapState();
 }
 
-class _LocationPickerMapState extends State<LocationPickerMap> {
+class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
   final MapController _mapController = MapController();
   LatLng? _selectedLocation;
   bool _isGeocoding = false;
@@ -167,9 +169,9 @@ class _LocationPickerMapState extends State<LocationPickerMap> {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/shared/widgets/entity_table/entity_table_view.dart';
@@ -1349,10 +1350,9 @@ class SiteListTile extends ConsumerWidget {
                     ),
                     children: [
                       TileLayer(
-                        urlTemplate:
-                            'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                        urlTemplate: ref.watch(mapTileUrlProvider),
                         userAgentPackageName: 'app.submersion',
-                        maxZoom: 19,
+                        maxZoom: ref.watch(mapTileMaxZoomProvider),
                         tileProvider: TileCacheService.instance.isInitialized
                             ? TileCacheService.instance.getTileProvider()
                             : null,

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
 /// Map content widget for displaying dive sites on a map.
@@ -262,9 +263,9 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -144,7 +144,7 @@ class TileCacheService {
   /// Example:
   /// ```dart
   /// TileLayer(
-  ///   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  ///   urlTemplate: ref.watch(mapTileUrlProvider), // URL from selected map style
   ///   tileProvider: TileCacheService.instance.getTileProvider(),
   /// )
   /// ```

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -18,6 +18,7 @@ import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -270,9 +271,9 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/maps/presentation/providers/map_tile_providers.dart
+++ b/lib/features/maps/presentation/providers/map_tile_providers.dart
@@ -1,0 +1,21 @@
+import 'package:submersion/core/constants/map_tile_config.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Provides the current tile URL template based on the selected map style.
+final mapTileUrlProvider = Provider<String>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return MapTileConfig.urlTemplate(settings.mapStyle);
+});
+
+/// Provides the maximum zoom level for the selected map style.
+final mapTileMaxZoomProvider = Provider<double>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return MapTileConfig.maxZoom(settings.mapStyle).toDouble();
+});
+
+/// Provides the attribution string for the selected map style.
+final mapTileAttributionProvider = Provider<String>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return MapTileConfig.attribution(settings.mapStyle);
+});

--- a/lib/features/maps/presentation/widgets/region_download_dialog.dart
+++ b/lib/features/maps/presentation/widgets/region_download_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/offline_map_providers.dart';
 
 /// Dialog for configuring and starting a region download.
@@ -35,11 +36,11 @@ class _RegionDownloadDialogState extends ConsumerState<RegionDownloadDialog> {
   bool _isLoadingName = false;
   int? _estimatedTiles;
 
-  /// Default tile layer options for OpenStreetMap.
+  /// Default tile layer options using the selected map style.
   TileLayer get _tileLayerOptions => TileLayer(
-    urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    urlTemplate: ref.watch(mapTileUrlProvider),
     userAgentPackageName: 'app.submersion',
-    maxZoom: 19,
+    maxZoom: ref.watch(mapTileMaxZoomProvider),
   );
 
   @override

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
@@ -98,6 +99,7 @@ class DiverSettingsRepository {
               equipmentListViewMode: Value(s.equipmentListViewMode.name),
               buddyListViewMode: Value(s.buddyListViewMode.name),
               diveCenterListViewMode: Value(s.diveCenterListViewMode.name),
+              mapStyle: Value(s.mapStyle.name),
               cardColorGradientPreset: Value(s.cardColorGradientPreset),
               cardColorGradientStart: Value(s.cardColorGradientStart),
               cardColorGradientEnd: Value(s.cardColorGradientEnd),
@@ -229,6 +231,7 @@ class DiverSettingsRepository {
           equipmentListViewMode: Value(settings.equipmentListViewMode.name),
           buddyListViewMode: Value(settings.buddyListViewMode.name),
           diveCenterListViewMode: Value(settings.diveCenterListViewMode.name),
+          mapStyle: Value(settings.mapStyle.name),
           cardColorGradientPreset: Value(settings.cardColorGradientPreset),
           cardColorGradientStart: Value(settings.cardColorGradientStart),
           cardColorGradientEnd: Value(settings.cardColorGradientEnd),
@@ -399,6 +402,7 @@ class DiverSettingsRepository {
       equipmentListViewMode: ListViewMode.fromName(row.equipmentListViewMode),
       buddyListViewMode: ListViewMode.fromName(row.buddyListViewMode),
       diveCenterListViewMode: ListViewMode.fromName(row.diveCenterListViewMode),
+      mapStyle: MapStyle.fromName(row.mapStyle),
       cardColorGradientPreset: row.cardColorGradientPreset,
       cardColorGradientStart: row.cardColorGradientStart,
       cardColorGradientEnd: row.cardColorGradientEnd,

--- a/lib/features/settings/presentation/pages/appearance_page.dart
+++ b/lib/features/settings/presentation/pages/appearance_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_theme_registry.dart';
 import 'package:submersion/features/settings/presentation/pages/language_settings_page.dart';
@@ -68,6 +69,29 @@ class AppearancePage extends ConsumerWidget {
             ),
             trailing: const Icon(Icons.chevron_right),
             onTap: () => context.go('/settings/language'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.map_outlined),
+            title: Text(context.l10n.settings_appearance_mapStyle),
+            subtitle: Text(
+              _getMapStyleDisplayName(context, settings.mapStyle),
+            ),
+            trailing: DropdownButton<MapStyle>(
+              value: settings.mapStyle,
+              underline: const SizedBox.shrink(),
+              onChanged: (style) {
+                if (style != null) {
+                  ref.read(settingsProvider.notifier).setMapStyle(style);
+                }
+              },
+              items: MapStyle.values.map((style) {
+                return DropdownMenuItem(
+                  value: style,
+                  child: Text(_getMapStyleDisplayName(context, style)),
+                );
+              }).toList(),
+            ),
           ),
           const Divider(),
 
@@ -150,6 +174,17 @@ class AppearancePage extends ConsumerWidget {
       case ThemeMode.dark:
         return Icons.dark_mode;
     }
+  }
+
+  String _getMapStyleDisplayName(BuildContext context, MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap =>
+        context.l10n.settings_appearance_mapStyle_openStreetMap,
+      MapStyle.openTopoMap =>
+        context.l10n.settings_appearance_mapStyle_openTopoMap,
+      MapStyle.esriSatellite =>
+        context.l10n.settings_appearance_mapStyle_esriSatellite,
+    };
   }
 
   String _resolveCurrentThemeName(BuildContext context, WidgetRef ref) {

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -3,6 +3,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_theme_preset.dart';
 import 'package:submersion/core/theme/app_theme_registry.dart';
@@ -154,6 +155,9 @@ class AppSettings {
 
   /// Which layout to use for the dive center list
   final ListViewMode diveCenterListViewMode;
+
+  /// Which map tile style to use
+  final MapStyle mapStyle;
 
   /// Name of the selected gradient preset ('ocean', 'thermal', etc.)
   final String cardColorGradientPreset;
@@ -308,6 +312,7 @@ class AppSettings {
     this.equipmentListViewMode = ListViewMode.detailed,
     this.buddyListViewMode = ListViewMode.detailed,
     this.diveCenterListViewMode = ListViewMode.detailed,
+    this.mapStyle = MapStyle.openStreetMap,
     this.cardColorGradientPreset = 'ocean',
     this.cardColorGradientStart,
     this.cardColorGradientEnd,
@@ -430,6 +435,7 @@ class AppSettings {
     ListViewMode? equipmentListViewMode,
     ListViewMode? buddyListViewMode,
     ListViewMode? diveCenterListViewMode,
+    MapStyle? mapStyle,
     String? cardColorGradientPreset,
     int? cardColorGradientStart,
     int? cardColorGradientEnd,
@@ -522,6 +528,7 @@ class AppSettings {
       buddyListViewMode: buddyListViewMode ?? this.buddyListViewMode,
       diveCenterListViewMode:
           diveCenterListViewMode ?? this.diveCenterListViewMode,
+      mapStyle: mapStyle ?? this.mapStyle,
       cardColorGradientPreset:
           cardColorGradientPreset ?? this.cardColorGradientPreset,
       cardColorGradientStart: clearCardColorGradientStart
@@ -935,6 +942,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   Future<void> setDiveCenterListViewMode(ListViewMode mode) async {
     state = state.copyWith(diveCenterListViewMode: mode);
+    await _saveSettings();
+  }
+
+  Future<void> setMapStyle(MapStyle style) async {
+    state = state.copyWith(mapStyle: style);
     await _saveSettings();
   }
 

--- a/lib/features/trips/presentation/widgets/trip_overview_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_overview_tab.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
@@ -196,9 +197,9 @@ class TripOverviewTab extends ConsumerWidget {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,

--- a/lib/features/trips/presentation/widgets/trip_voyage_map.dart
+++ b/lib/features/trips/presentation/widgets/trip_voyage_map.dart
@@ -6,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
 import 'package:submersion/features/trips/presentation/providers/liveaboard_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -62,10 +63,9 @@ class TripVoyageMap extends ConsumerWidget {
                     ),
                     children: [
                       TileLayer(
-                        urlTemplate:
-                            'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                        urlTemplate: ref.watch(mapTileUrlProvider),
                         userAgentPackageName: 'app.submersion',
-                        maxZoom: 19,
+                        maxZoom: ref.watch(mapTileMaxZoomProvider),
                         tileProvider: TileCacheService.instance.isInitialized
                             ? TileCacheService.instance.getTileProvider()
                             : null,

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9625,5 +9625,10 @@
   "settings_appearance_showDetailsPane": "Show Details Pane",
   "settings_appearance_showDetailsPane_subtitle": "Display details pane alongside table",
   "settings_appearance_showProfilePanel": "Show Profile Panel in Table View",
-  "settings_appearance_showProfilePanel_subtitle": "Display dive profile chart above the table by default"
+  "settings_appearance_showProfilePanel_subtitle": "Display dive profile chart above the table by default",
+  "settings_appearance_mapStyle": "Map Style",
+  "settings_appearance_mapStyle_subtitle": "Choose map tile appearance",
+  "settings_appearance_mapStyle_openStreetMap": "Street Map",
+  "settings_appearance_mapStyle_openTopoMap": "Topographic",
+  "settings_appearance_mapStyle_esriSatellite": "Satellite"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -26893,6 +26893,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Display dive profile chart above the table by default'**
   String get settings_appearance_showProfilePanel_subtitle;
+
+  /// No description provided for @settings_appearance_mapStyle.
+  ///
+  /// In en, this message translates to:
+  /// **'Map Style'**
+  String get settings_appearance_mapStyle;
+
+  /// No description provided for @settings_appearance_mapStyle_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose map tile appearance'**
+  String get settings_appearance_mapStyle_subtitle;
+
+  /// No description provided for @settings_appearance_mapStyle_openStreetMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Street Map'**
+  String get settings_appearance_mapStyle_openStreetMap;
+
+  /// No description provided for @settings_appearance_mapStyle_openTopoMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Topographic'**
+  String get settings_appearance_mapStyle_openTopoMap;
+
+  /// No description provided for @settings_appearance_mapStyle_esriSatellite.
+  ///
+  /// In en, this message translates to:
+  /// **'Satellite'**
+  String get settings_appearance_mapStyle_esriSatellite;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15602,4 +15602,20 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'عرض مخطط ملف الغوصة فوق الجدول بشكل افتراضي';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -15898,4 +15898,20 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Tauchprofildiagramm standardmäßig über der Tabelle anzeigen';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15643,4 +15643,20 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Display dive profile chart above the table by default';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -15916,4 +15916,20 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Mostrar gráfico de perfil de inmersión sobre la tabla por defecto';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -15968,4 +15968,20 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Afficher le graphique de profil de plongée au-dessus du tableau par défaut';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15493,4 +15493,20 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'הצג תרשים פרופיל צלילה מעל הטבלה כברירת מחדל';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -15863,4 +15863,20 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Merülési profil diagram megjelenítése a táblázat felett alapértelmezetten';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -15910,4 +15910,20 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Visualizza il grafico del profilo di immersione sopra la tabella per impostazione predefinita';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -15780,4 +15780,20 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Duikprofielgrafiek standaard boven de tabel weergeven';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -15913,4 +15913,20 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Exibir gráfico de perfil de mergulho acima da tabela por padrão';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15141,4 +15141,20 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_appearance_showProfilePanel_subtitle => '默认在表格上方显示潜水剖面图';
+
+  @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
 }


### PR DESCRIPTION
Add MapStyle setting to switch between OpenStreetMap, OpenTopoMap, and Esri Satellite tiles. Centralizes tile URL into a single provider. Adds picker in Settings > Appearance.

Replaces all hardcoded OSM tile URLs across the codebase.

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of key changes -->

-

## Test Plan

- [ ] `flutter test` passes
- [ ] `flutter analyze` passes
- [ ] Manual testing on: <!-- list platforms tested -->

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->
