### PR TITLE
chore: upgrade 7 major dependencies with API migrations

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -66,6 +66,6 @@ flutter {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     implementation("androidx.exifinterface:exifinterface:1.3.7")
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -271,8 +271,8 @@ SPEC CHECKSUMS:
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_contacts: 5383945387e7ca37cf963d4be57c21f2fc15ca9f
-  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
+  flutter_contacts: 2ec1d6b62ca2869c3bbb3871bd74d4e3ef157135
+  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   gal: baecd024ebfd13c441269ca7404792a7152fde89
   geocoding_ios: 33776c9ebb98d037b5e025bb0e7537f6dd19646e

--- a/lib/core/services/database_location_service.dart
+++ b/lib/core/services/database_location_service.dart
@@ -139,7 +139,7 @@ class DatabaseLocationService {
 
     // On other platforms, use file_picker
     try {
-      final result = await FilePicker.platform.getDirectoryPath(
+      final result = await FilePicker.getDirectoryPath(
         dialogTitle: 'Choose Database Storage Location',
         lockParentWindow: true,
       );

--- a/lib/core/services/export/csv/csv_export_service.dart
+++ b/lib/core/services/export/csv/csv_export_service.dart
@@ -280,7 +280,7 @@ class CsvExportService {
     final dateStr = _dateFormat.format(DateTime.now());
     final fileName = 'dives_export_$dateStr.csv';
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: 'Save Dives CSV',
       fileName: fileName,
       type: FileType.custom,
@@ -304,7 +304,7 @@ class CsvExportService {
     final dateStr = _dateFormat.format(DateTime.now());
     final fileName = 'sites_export_$dateStr.csv';
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: 'Save Sites CSV',
       fileName: fileName,
       type: FileType.custom,
@@ -328,7 +328,7 @@ class CsvExportService {
     final dateStr = _dateFormat.format(DateTime.now());
     final fileName = 'equipment_export_$dateStr.csv';
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: 'Save Equipment CSV',
       fileName: fileName,
       type: FileType.custom,

--- a/lib/core/services/export/excel/excel_export_service.dart
+++ b/lib/core/services/export/excel/excel_export_service.dart
@@ -124,7 +124,7 @@ class ExcelExportService {
     final dateStr = _dateFormat.format(DateTime.now());
     final fileName = 'submersion_export_$dateStr.xlsx';
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: 'Save Excel File',
       fileName: fileName,
       type: FileType.custom,

--- a/lib/core/services/export/kml/kml_export_service.dart
+++ b/lib/core/services/export/kml/kml_export_service.dart
@@ -79,7 +79,7 @@ class KmlExportService {
     final dateStr = _dateFormat.format(DateTime.now());
     final fileName = 'submersion_sites_$dateStr.kml';
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: 'Save KML File',
       fileName: fileName,
       type: FileType.custom,

--- a/lib/core/services/export/pdf/pdf_export_service.dart
+++ b/lib/core/services/export/pdf/pdf_export_service.dart
@@ -198,7 +198,7 @@ class PdfExportService {
       allSightings: allSightings,
     );
 
-    final saveResult = await FilePicker.platform.saveFile(
+    final saveResult = await FilePicker.saveFile(
       dialogTitle: 'Save PDF File',
       fileName: result.fileName,
       type: FileType.custom,

--- a/lib/core/services/export/shared/file_export_utils.dart
+++ b/lib/core/services/export/shared/file_export_utils.dart
@@ -83,7 +83,7 @@ Future<String> saveImageToPhotos(List<int> pngBytes, String fileName) async {
 /// Opens a file picker dialog allowing the user to choose where to save.
 /// Returns the saved file path, or null if the user cancelled.
 Future<String?> saveImageToFile(List<int> pngBytes, String fileName) async {
-  final result = await FilePicker.platform.saveFile(
+  final result = await FilePicker.saveFile(
     dialogTitle: 'Save Profile Image',
     fileName: fileName,
     type: FileType.image,
@@ -111,7 +111,7 @@ Future<String> sharePdfBytes(List<int> pdfBytes, String fileName) async {
 /// Opens a file picker dialog allowing the user to choose where to save.
 /// Returns the saved file path, or null if the user cancelled.
 Future<String?> savePdfToFile(List<int> pdfBytes, String fileName) async {
-  final result = await FilePicker.platform.saveFile(
+  final result = await FilePicker.saveFile(
     dialogTitle: 'Save PDF',
     fileName: fileName,
     type: FileType.custom,

--- a/lib/core/services/export/uddf/uddf_full_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_export_service.dart
@@ -532,7 +532,7 @@ class UddfFullExportService {
     final fileName =
         'submersion_backup_${_dateFormat.format(DateTime.now())}.uddf';
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: 'Save UDDF File',
       fileName: fileName,
       type: FileType.custom,

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -64,7 +64,7 @@ class NotificationService {
     );
 
     await _plugin.initialize(
-      initSettings,
+      settings: initSettings,
       onDidReceiveNotificationResponse: _onNotificationTapped,
     );
 
@@ -166,15 +166,13 @@ class NotificationService {
     final scheduledTz = tz.TZDateTime.from(scheduledDate, tz.local);
 
     await _plugin.zonedSchedule(
-      notificationId,
-      title,
-      body,
-      scheduledTz,
-      details,
+      id: notificationId,
+      title: title,
+      body: body,
+      scheduledDate: scheduledTz,
+      notificationDetails: details,
       payload: equipmentId,
       androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
-      uiLocalNotificationDateInterpretation:
-          UILocalNotificationDateInterpretation.absoluteTime,
     );
 
     _log.info(
@@ -222,7 +220,12 @@ class NotificationService {
     // Use a fixed ID so repeated backup notifications replace each other
     const backupNotificationId = 99000;
 
-    await _plugin.show(backupNotificationId, title, body, details);
+    await _plugin.show(
+      id: backupNotificationId,
+      title: title,
+      body: body,
+      notificationDetails: details,
+    );
 
     _log.info('Showed backup notification (success: $success)');
   }
@@ -230,7 +233,7 @@ class NotificationService {
   /// Cancel a specific notification
   Future<void> cancelNotification(int notificationId) async {
     if (!_isMobilePlatform) return;
-    await _plugin.cancel(notificationId);
+    await _plugin.cancel(id: notificationId);
     _log.info('Cancelled notification $notificationId');
   }
 

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -167,7 +167,7 @@ class BackupSettingsPage extends ConsumerWidget {
     ExportBottomSheet.show(
       context,
       onSaveToFile: () async {
-        final result = await FilePicker.platform.saveFile(
+        final result = await FilePicker.saveFile(
           dialogTitle: context.l10n.backup_export_title,
           fileName: _generateDefaultFilename(),
           allowedExtensions: ['db', 'sqlite'],
@@ -204,7 +204,7 @@ class BackupSettingsPage extends ConsumerWidget {
   Future<void> _handleImport(BuildContext context, WidgetRef ref) async {
     final FilePickerResult? result;
     try {
-      result = await FilePicker.platform.pickFiles(type: FileType.any);
+      result = await FilePicker.pickFiles(type: FileType.any);
     } on Exception catch (e) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -431,7 +431,7 @@ class BackupSettingsPage extends ConsumerWidget {
           ),
           trailing: TextButton(
             onPressed: () async {
-              final path = await FilePicker.platform.getDirectoryPath(
+              final path = await FilePicker.getDirectoryPath(
                 dialogTitle: context.l10n.backup_location_title,
               );
               if (path != null) {

--- a/lib/features/buddies/presentation/widgets/buddy_list_content.dart
+++ b/lib/features/buddies/presentation/widgets/buddy_list_content.dart
@@ -299,23 +299,26 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
     }
 
     try {
-      if (!await FlutterContacts.requestPermission(readonly: true)) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                context.l10n.buddies_message_contactPermissionRequired,
+      if (!await FlutterContacts.permissions.has(PermissionType.read)) {
+        await FlutterContacts.permissions.request(PermissionType.read);
+        if (!await FlutterContacts.permissions.has(PermissionType.read)) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  context.l10n.buddies_message_contactPermissionRequired,
+                ),
               ),
-            ),
-          );
+            );
+          }
+          return;
         }
-        return;
       }
 
-      final contact = await FlutterContacts.openExternalPick();
-      if (contact == null) return;
+      final contactId = await FlutterContacts.native.showPicker();
+      if (contactId == null) return;
 
-      final fullContact = await FlutterContacts.getContact(contact.id);
+      final fullContact = await FlutterContacts.get(contactId);
       if (fullContact == null) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/dive_import/presentation/providers/uddf_import_providers.dart
+++ b/lib/features/dive_import/presentation/providers/uddf_import_providers.dart
@@ -241,7 +241,7 @@ class UddfImportNotifier extends StateNotifier<UddfImportState> {
     try {
       // Use FileType.any on iOS/macOS since custom extensions don't work
       // reliably in sandboxed apps.
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.any,
         allowMultiple: false,
       );

--- a/lib/features/settings/presentation/providers/debug_log_providers.dart
+++ b/lib/features/settings/presentation/providers/debug_log_providers.dart
@@ -147,7 +147,7 @@ Future<String?> saveLogFile(LogFileService service) async {
   if (!file.existsSync()) return null;
 
   final bytes = await file.readAsBytes();
-  final result = await FilePicker.platform.saveFile(
+  final result = await FilePicker.saveFile(
     dialogTitle: 'Save Debug Logs',
     fileName: 'submersion-debug-logs.txt',
     type: FileType.custom,

--- a/lib/features/settings/presentation/providers/export_providers.dart
+++ b/lib/features/settings/presentation/providers/export_providers.dart
@@ -1037,7 +1037,7 @@ class ExportNotifier extends StateNotifier<ExportState> {
       await DatabaseService.instance.backup(tempBackupPath);
 
       // Let user choose where to save the file
-      final savePath = await FilePicker.platform.saveFile(
+      final savePath = await FilePicker.saveFile(
         dialogTitle: 'Save Backup',
         fileName: fileName,
         type: FileType.any,
@@ -1085,7 +1085,7 @@ class ExportNotifier extends StateNotifier<ExportState> {
     try {
       // Use FileType.any on iOS/macOS since custom extensions don't work reliably
       final useAnyType = Platform.isIOS || Platform.isMacOS;
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: useAnyType ? FileType.any : FileType.custom,
         allowedExtensions: useAnyType ? null : ['db'],
         allowMultiple: false,

--- a/lib/features/universal_import/presentation/providers/universal_import_providers.dart
+++ b/lib/features/universal_import/presentation/providers/universal_import_providers.dart
@@ -157,7 +157,7 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
     );
 
     try {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.any,
         allowMultiple: false,
       );
@@ -286,7 +286,7 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
     state = state.copyWith(isLoading: true, clearError: true);
 
     try {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.any,
         allowMultiple: false,
       );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import desktop_drop
 import device_info_plus
 import file_picker
 import file_selector_macos
+import flutter_contacts
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import gal
@@ -33,6 +34,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -20,6 +20,8 @@ PODS:
     - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
+  - flutter_contacts (0.0.1):
+    - FlutterMacOS
   - flutter_local_notifications (0.0.1):
     - FlutterMacOS
   - flutter_secure_storage_darwin (10.0.0):
@@ -119,6 +121,7 @@ DEPENDENCIES:
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - flutter_contacts (from `Flutter/ephemeral/.symlinks/plugins/flutter_contacts/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -161,6 +164,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  flutter_contacts:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_contacts/macos
   flutter_local_notifications:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   flutter_secure_storage_darwin:
@@ -200,11 +205,12 @@ SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
-  desktop_drop: e0b672a7d84c0a6cbc378595e82cdb15f2970a43
+  desktop_drop: 10a3e6a7fa9dbe350541f2574092fecfa345a07b
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
-  flutter_local_notifications: 13862b132e32eb858dea558a86d45d08daeacfe7
+  flutter_contacts: 6f45cdf49f4fb2241793263546f823f7e812668e
+  flutter_local_notifications: 1fc7ffb10a83d6a2eeeeddb152d43f1944b0aad0
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   gal: baecd024ebfd13c441269ca7404792a7152fde89

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: desktop_drop
-      sha256: d55a010fe46c8e8fcff4ea4b451a9ff84a162217bdb3b2a0aa1479776205e15d
+      sha256: e70b46b2d61f1af7a81a40d1f79b43c28a879e30a4ef31e87e9c27bea4d784e8
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.4"
+    version: "0.7.0"
   device_info_plus:
     dependency: "direct overridden"
     description:
@@ -452,10 +452,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.2"
   file_selector_linux:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      sha256: be8e6de65fa7ae4332c812bcd4e8b90c0d74093fbda972ce3ca2f9f34f65e93c
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.9+2"
+    version: "2.0.2"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -566,26 +566,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -906,10 +914,10 @@ packages:
     dependency: "direct main"
     description:
       name: googleapis
-      sha256: "692fb9e90c321b61a7a2123de0353ec8a20691cd979db2553d8d732f710f6535"
+      sha256: "62b5988f228b774448ebd99b53fe8069becb55840f1b28948bb84160373dc0b6"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "16.0.0"
   googleapis_auth:
     dependency: "direct main"
     description:
@@ -1246,10 +1254,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_exif
-      sha256: "0d37444c1ed00cbcada69b7510aba1d505fed75d3b6ef3ea3c8c2c970040e4f1"
+      sha256: "044276caf22c14695f97833b3e9cec941a7bf2403f422749436797381fceb857"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.7.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -1923,10 +1931,10 @@ packages:
     dependency: "direct main"
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:
@@ -1943,6 +1951,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  universal_platform:
+    dependency: transitive
+    description:
+      name: universal_platform
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -372,10 +372,10 @@ packages:
     dependency: "direct overridden"
     description:
       name: device_info_plus
-      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -372,10 +372,10 @@ packages:
     dependency: "direct overridden"
     description:
       name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.0"
+    version: "12.3.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1499,7 +1499,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
 
   # Cloud Storage
   google_sign_in: ^7.2.0
-  googleapis: ^15.0.0
+  googleapis: ^16.0.0
   extension_google_sign_in_as_googleapis_auth: ^3.0.0
   googleapis_auth: ^2.0.0
 
@@ -59,17 +59,17 @@ dependencies:
   libdivecomputer_plugin:
     path: packages/libdivecomputer_plugin
   permission_handler: ^12.0.1
-  file_picker: ^10.3.9
+  file_picker: ^11.0.2
   image_picker: ^1.1.2
   share_plus: ^12.0.1
-  desktop_drop: ^0.4.4
+  desktop_drop: ^0.7.0
   receive_sharing_intent: ^1.8.1
   url_launcher: ^6.3.1
-  flutter_contacts: ^1.1.9+2
+  flutter_contacts: ^2.0.2
   geolocator: ^14.0.2
   geocoding: ^4.0.0
   photo_manager: ^3.6.0
-  native_exif: ^0.6.0
+  native_exif: ^0.7.0
   health: ^13.3.0  # Cross-platform health data (HealthKit, Health Connect)
 
   # Storage
@@ -98,9 +98,9 @@ dependencies:
   package_info_plus: ^8.0.0
 
   # Notifications
-  flutter_local_notifications: ^18.0.1
+  flutter_local_notifications: ^21.0.0
   workmanager: ^0.9.0+3
-  timezone: ^0.10.0
+  timezone: ^0.11.0
   google_fonts: ^8.0.2
   linked_scroll_controller: ^0.2.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -119,6 +119,7 @@ dev_dependencies:
   json_serializable: ^6.11.2
   riverpod_generator: ^4.0.0+1
   mockito: ^5.6.1
+  plugin_platform_interface: ^2.1.8
 
 dependency_overrides:
   # Pin to 9.4.5 to avoid CNAuthorizationStatusLimited compile error

--- a/test/core/services/export/csv/csv_export_service_test.dart
+++ b/test/core/services/export/csv/csv_export_service_test.dart
@@ -1,6 +1,11 @@
+import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+
+import '../../../../helpers/mock_file_picker_platform.dart';
 
 void main() {
   late CsvExportService service;
@@ -67,6 +72,39 @@ void main() {
       // Pressures exported with 1 decimal for round-trip fidelity
       expect(csv, contains('206.8'));
       expect(csv, contains('50.5'));
+    });
+  });
+
+  group('save to file', () {
+    late MockFilePickerPlatform mockPicker;
+    late FilePickerPlatform originalPicker;
+
+    setUp(() {
+      originalPicker = FilePickerPlatform.instance;
+      mockPicker = MockFilePickerPlatform();
+      FilePickerPlatform.instance = mockPicker;
+    });
+
+    tearDown(() {
+      FilePickerPlatform.instance = originalPicker;
+    });
+
+    test('saveDivesCsvToFile returns null when user cancels', () async {
+      mockPicker.saveFileResult = null;
+      final result = await service.saveDivesCsvToFile([]);
+      expect(result, isNull);
+    });
+
+    test('saveSitesCsvToFile returns null when user cancels', () async {
+      mockPicker.saveFileResult = null;
+      final result = await service.saveSitesCsvToFile(<DiveSite>[]);
+      expect(result, isNull);
+    });
+
+    test('saveEquipmentCsvToFile returns null when user cancels', () async {
+      mockPicker.saveFileResult = null;
+      final result = await service.saveEquipmentCsvToFile(<EquipmentItem>[]);
+      expect(result, isNull);
     });
   });
 }

--- a/test/core/services/export/csv/csv_export_service_test.dart
+++ b/test/core/services/export/csv/csv_export_service_test.dart
@@ -1,4 +1,3 @@
-import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';

--- a/test/core/services/export/file_picker_save_test.dart
+++ b/test/core/services/export/file_picker_save_test.dart
@@ -1,4 +1,3 @@
-import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/core/services/export/excel/excel_export_service.dart';

--- a/test/core/services/export/file_picker_save_test.dart
+++ b/test/core/services/export/file_picker_save_test.dart
@@ -1,0 +1,107 @@
+import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/csv/csv_export_service.dart';
+import 'package:submersion/core/services/export/excel/excel_export_service.dart';
+import 'package:submersion/core/services/export/kml/kml_export_service.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/core/constants/units.dart';
+
+import '../../../helpers/mock_file_picker_platform.dart';
+
+/// Tests that all export service save-to-file methods correctly delegate to
+/// [FilePicker.saveFile] and return null when the user cancels.
+///
+/// These tests cover the FilePicker.platform -> FilePicker static API migration
+/// from file_picker 10.x to 11.x.
+void main() {
+  late MockFilePickerPlatform mockPicker;
+  late FilePickerPlatform originalPicker;
+
+  setUp(() {
+    originalPicker = FilePickerPlatform.instance;
+    mockPicker = MockFilePickerPlatform();
+    FilePickerPlatform.instance = mockPicker;
+  });
+
+  tearDown(() {
+    FilePickerPlatform.instance = originalPicker;
+  });
+
+  group('CsvExportService save to file', () {
+    late CsvExportService service;
+    setUp(() => service = CsvExportService());
+
+    test('saveDivesCsvToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(await service.saveDivesCsvToFile([]), isNull);
+    });
+
+    test('saveSitesCsvToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(await service.saveSitesCsvToFile(<DiveSite>[]), isNull);
+    });
+
+    test('saveEquipmentCsvToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(await service.saveEquipmentCsvToFile(<EquipmentItem>[]), isNull);
+    });
+  });
+
+  group('ExcelExportService save to file', () {
+    late ExcelExportService service;
+    setUp(() => service = ExcelExportService());
+
+    test('saveExcelToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(
+        await service.saveExcelToFile(
+          dives: <Dive>[],
+          sites: <DiveSite>[],
+          equipment: <EquipmentItem>[],
+          depthUnit: DepthUnit.meters,
+          temperatureUnit: TemperatureUnit.celsius,
+          pressureUnit: PressureUnit.bar,
+          volumeUnit: VolumeUnit.liters,
+          dateFormat: DateFormatPreference.yyyymmdd,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('KmlExportService save to file', () {
+    late KmlExportService service;
+    setUp(() => service = KmlExportService());
+
+    test('saveKmlToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      const site = DiveSite(
+        id: 's1',
+        name: 'Test Site',
+        location: GeoPoint(28.5, -80.6),
+      );
+      final (path, _) = await service.saveKmlToFile(
+        sites: [site],
+        dives: <Dive>[],
+        depthUnit: DepthUnit.meters,
+        dateFormat: DateFormatPreference.yyyymmdd,
+      );
+      expect(path, isNull);
+    });
+  });
+
+  group('file_export_utils', () {
+    test('saveImageToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(await saveImageToFile([1, 2, 3], 'test.png'), isNull);
+    });
+
+    test('savePdfToFile returns null when cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(await savePdfToFile([1, 2, 3], 'test.pdf'), isNull);
+    });
+  });
+}

--- a/test/helpers/mock_file_picker_platform.dart
+++ b/test/helpers/mock_file_picker_platform.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// A mock [FilePickerPlatform] that returns pre-configured results
+/// without invoking real platform channels.
+class MockFilePickerPlatform extends FilePickerPlatform
+    implements MockPlatformInterfaceMixin {
+  String? saveFileResult;
+  FilePickerResult? pickFilesResult;
+  String? directoryPathResult;
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) async => saveFileResult;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+  }) async => pickFilesResult;
+
+  @override
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    bool lockParentWindow = false,
+    String? initialDirectory,
+  }) async => directoryPathResult;
+}

--- a/test/helpers/mock_file_picker_platform.dart
+++ b/test/helpers/mock_file_picker_platform.dart
@@ -1,7 +1,11 @@
 import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
+// FilePickerPlatform is not publicly exported; centralise the src/ import here
+// so test files only depend on this helper.
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+export 'package:file_picker/src/platform/file_picker_platform_interface.dart'
+    show FilePickerPlatform;
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 /// A mock [FilePickerPlatform] that returns pre-configured results

--- a/test/shared/widgets/global_drop_target_test.dart
+++ b/test/shared/widgets/global_drop_target_test.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -60,10 +59,10 @@ Future<void> _triggerDrop(WidgetTester tester, DropDoneDetails details) async {
 
 /// Create an [XFile] with pre-loaded [bytes] that avoids real file I/O.
 ///
-/// On dart:io platforms [XFile.fromData] stores the bytes in memory so
-/// [readAsBytes] returns them directly (unlike [XFile()] which ignores bytes).
-XFile _xFileFromBytes(Uint8List bytes, String name) =>
-    XFile.fromData(bytes, path: name);
+/// On dart:io platforms [DropItemFile.fromData] stores the bytes in memory so
+/// [readAsBytes] returns them directly (unlike [DropItemFile()] which ignores bytes).
+DropItemFile _xFileFromBytes(Uint8List bytes, String name) =>
+    DropItemFile.fromData(bytes, path: name);
 
 /// UDDF XML content recognised by the format detector.
 final _uddfBytes = Uint8List.fromList(
@@ -248,7 +247,7 @@ void main() {
           final dropTarget = tester.widget<DropTarget>(find.byType(DropTarget));
           dropTarget.onDragDone?.call(
             DropDoneDetails(
-              files: [XFile('/nonexistent/path/file.uddf')],
+              files: [DropItemFile('/nonexistent/path/file.uddf')],
               localPosition: Offset.zero,
               globalPosition: Offset.zero,
             ),

--- a/test/shared/widgets/global_drop_target_test.dart
+++ b/test/shared/widgets/global_drop_target_test.dart
@@ -57,11 +57,11 @@ Future<void> _triggerDrop(WidgetTester tester, DropDoneDetails details) async {
   }
 }
 
-/// Create an [XFile] with pre-loaded [bytes] that avoids real file I/O.
+/// Create a [DropItemFile] with pre-loaded [bytes] that avoids real file I/O.
 ///
 /// On dart:io platforms [DropItemFile.fromData] stores the bytes in memory so
 /// [readAsBytes] returns them directly (unlike [DropItemFile()] which ignores bytes).
-DropItemFile _xFileFromBytes(Uint8List bytes, String name) =>
+DropItemFile _dropItemFromBytes(Uint8List bytes, String name) =>
     DropItemFile.fromData(bytes, path: name);
 
 /// UDDF XML content recognised by the format detector.
@@ -224,7 +224,7 @@ void main() {
         await _triggerDrop(
           tester,
           DropDoneDetails(
-            files: [_xFileFromBytes(_uddfBytes, 'test.uddf')],
+            files: [_dropItemFromBytes(_uddfBytes, 'test.uddf')],
             localPosition: Offset.zero,
             globalPosition: Offset.zero,
           ),
@@ -270,7 +270,7 @@ void main() {
         await _triggerDrop(
           tester,
           DropDoneDetails(
-            files: [_xFileFromBytes(_pngBytes, 'photo.png')],
+            files: [_dropItemFromBytes(_pngBytes, 'photo.png')],
             localPosition: Offset.zero,
             globalPosition: Offset.zero,
           ),
@@ -290,7 +290,7 @@ void main() {
         await _triggerDrop(
           tester,
           DropDoneDetails(
-            files: [_xFileFromBytes(_uddfBytes, 'dive.uddf')],
+            files: [_dropItemFromBytes(_uddfBytes, 'dive.uddf')],
             localPosition: Offset.zero,
             globalPosition: Offset.zero,
           ),
@@ -310,7 +310,7 @@ void main() {
         await _triggerDrop(
           tester,
           DropDoneDetails(
-            files: [_xFileFromBytes(_csvBytes, 'dives.csv')],
+            files: [_dropItemFromBytes(_csvBytes, 'dives.csv')],
             localPosition: Offset.zero,
             globalPosition: Offset.zero,
           ),
@@ -329,7 +329,7 @@ void main() {
       await _triggerDrop(
         tester,
         DropDoneDetails(
-          files: [_xFileFromBytes(_fitBytes, 'dive.fit')],
+          files: [_dropItemFromBytes(_fitBytes, 'dive.fit')],
           localPosition: Offset.zero,
           globalPosition: Offset.zero,
         ),
@@ -348,8 +348,8 @@ void main() {
         tester,
         DropDoneDetails(
           files: [
-            _xFileFromBytes(_uddfBytes, 'dive.uddf'),
-            _xFileFromBytes(_pngBytes, 'photo.png'),
+            _dropItemFromBytes(_uddfBytes, 'dive.uddf'),
+            _dropItemFromBytes(_pngBytes, 'photo.png'),
           ],
           localPosition: Offset.zero,
           globalPosition: Offset.zero,

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -19,6 +19,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
   jni
 )
 


### PR DESCRIPTION
## Summary

Upgrade 7 direct dependencies with major version bumps, migrating all breaking API changes. Pins `device_info_plus` to 12.3.0 to work around an Xcode 16.2 compile error.

Follows up on #192 which upgraded 66 packages within existing constraints.

## Changes

- `file_picker` 10.x -> 11.x: `FilePicker.platform.method()` -> `FilePicker.method()` (static API)
- `flutter_local_notifications` 18.x -> 21.x: positional -> named parameters for `show`, `zonedSchedule`, `cancel`, `initialize`
- `flutter_contacts` 1.x -> 2.x: monolithic API -> sub-API pattern (`permissions`, `native`)
- `desktop_drop` 0.4.x -> 0.7.x: `XFile` -> `DropItem` type in tests
- `googleapis` 15.x -> 16.x (no API changes)
- `native_exif` 0.6.x -> 0.7.x (no API changes)
- `timezone` 0.10.x -> 0.11.x (no API changes)
- Pinned `device_info_plus` to 12.3.0 via `dependency_overrides` (v12.4.0 calls `NSProcessInfo.isiOSAppOnVision` which is unavailable in Xcode 16.2)

## Test Plan

- [x] `flutter test` passes (6,286 tests, 0 failures)
- [x] `flutter analyze` passes (0 issues)
- [x] CI passes on all 5 platforms (iOS, macOS, Android, Linux, Windows)
- [x] Manual testing on: macOS

## Screenshots

N/A - no UI changes