### PR TITLE
feat: require explicit selection for import duplicates (#200)

### DIFF
--- a/docs/superpowers/plans/2026-04-12-import-duplicate-required-selection-v2.md
+++ b/docs/superpowers/plans/2026-04-12-import-duplicate-required-selection-v2.md
@@ -1,0 +1,2231 @@
+# Import Duplicate Required-Selection Implementation Plan (v2 — import_wizard target)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change the active unified import review step so every suspected duplicate (probable or possible) requires an explicit user decision before the Import button enables. Issue [#200](https://github.com/submersion-app/submersion/issues/200).
+
+**Architecture:** Approach B from the spec — add an orthogonal `pendingDuplicateReview: Map<ImportEntityType, Set<int>>` field to `ImportWizardState`. `setBundle` populates it from `EntityGroup.duplicateIndices` and clears auto-defaulted `duplicateActions` for those indices. Per-row actions (`setDuplicateAction`, `toggleSelection`) and bulk actions drain the set. The Import button reads `!hasPendingReviews` as an additional gate. Adapter-specific `supportedDuplicateActions` controls which bulk buttons render.
+
+**Tech Stack:** Flutter 3.x, Riverpod (StateNotifier), Dart 3, flutter_test, Material 3.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-import-duplicate-required-selection-design.md`
+
+**Working directory:** All commands run from `.worktrees/issue-200-require-duplicate-selection/`. Branch: `feature/issue-200-require-duplicate-selection`.
+
+**Starting context:** The branch has one prior commit on top of main — the Task-7 l10n cherry-pick (`0a849978278`) which adds the `universalImport_*` keys the UI will consume. All other prior work was discarded.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart` | Add `pendingDuplicateReview` field + helpers, modify `setBundle`/`setDuplicateAction`/`toggleSelection`, add `applyBulkAction`/`firstPendingLocation`/`debugSetState`, add `PendingLocation` type. |
+| `lib/features/import_wizard/presentation/widgets/review_step.dart` | Gate Import button, pending-hint bar above button, banner-copy addendum. |
+| `lib/features/import_wizard/presentation/widgets/entity_review_list.dart` | Sort pending to top within duplicate sections, bulk-action row at top when `pendingFor(type).isNotEmpty`, pass `isPending` to cards. Includes private `_EntityDuplicateCard` pending visual state. |
+| `lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart` | Add `isPending` parameter — warning border + "Decide" expand label + "Needs decision" pill when pending. |
+| `lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart` | New shared pill widget. |
+| `lib/l10n/arb/app_en.arb` | Add `universalImport_semantics_needsDecision` key. |
+| `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart` | Extend with state/notifier tests for pending behavior. |
+
+**Files to create:**
+
+| File | Responsibility |
+|---|---|
+| `test/features/import_wizard/presentation/widgets/review_step_pending_test.dart` | Widget tests for gate, hint, sort, bulk buttons, visual state. |
+| `test/features/import_wizard/presentation/providers/issue_200_regression_test.dart` | Explicit regression guard. |
+
+**Files NOT touched:**
+
+- `lib/features/universal_import/**` — orphan dead code; left alone.
+- `lib/features/import_wizard/data/adapters/**` — adapter interfaces unchanged.
+- `lib/features/dive_import/domain/services/dive_matcher.dart` — scoring unchanged.
+
+---
+
+## Task 1: Add pendingDuplicateReview field + helpers to ImportWizardState
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart`
+- Test: `test/features/import_wizard/presentation/providers/import_wizard_state_test.dart` (create if absent; otherwise extend)
+
+- [ ] **Step 1: Check if state tests exist**
+
+Run: `ls test/features/import_wizard/presentation/providers/`
+
+If `import_wizard_state_test.dart` does not exist, create it. Otherwise, append tests to the existing file's last `group(...)`.
+
+- [ ] **Step 2: Write failing tests**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
+
+void main() {
+  group('ImportWizardState.pendingDuplicateReview', () {
+    test('defaults to empty map', () {
+      const state = ImportWizardState();
+      expect(state.pendingDuplicateReview, isEmpty);
+    });
+
+    test('hasPendingReviews false when all sets empty', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: <int>{},
+          ImportEntityType.sites: <int>{},
+        },
+      );
+      expect(state.hasPendingReviews, isFalse);
+    });
+
+    test('hasPendingReviews true when any set non-empty', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: <int>{},
+          ImportEntityType.sites: {3},
+        },
+      );
+      expect(state.hasPendingReviews, isTrue);
+    });
+
+    test('totalPending sums across types', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {0, 1, 2},
+          ImportEntityType.sites: {5},
+        },
+      );
+      expect(state.totalPending, 4);
+    });
+
+    test('pendingFor returns empty for missing type', () {
+      const state = ImportWizardState();
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    });
+
+    test('pendingFor returns set for present type', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {1, 4},
+        },
+      );
+      expect(state.pendingFor(ImportEntityType.dives), {1, 4});
+    });
+
+    test('copyWith updates pendingDuplicateReview', () {
+      const state = ImportWizardState();
+      final updated = state.copyWith(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {0, 1},
+        },
+      );
+      expect(updated.pendingDuplicateReview[ImportEntityType.dives], {0, 1});
+    });
+
+    test('copyWith preserves pendingDuplicateReview when not passed', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {2},
+        },
+      );
+      final updated = state.copyWith(currentStep: 1);
+      expect(updated.pendingDuplicateReview[ImportEntityType.dives], {2});
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Run to confirm fails**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_state_test.dart`
+Expected: FAIL with undefined `pendingDuplicateReview`, `hasPendingReviews`, `totalPending`, `pendingFor`.
+
+- [ ] **Step 4: Add field + constructor param + copyWith + helpers**
+
+In `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart`:
+
+In the `ImportWizardState` constructor (line 17-30), after `this.duplicateActions = const {},`, add:
+
+```dart
+    this.pendingDuplicateReview = const {},
+```
+
+After the `duplicateActions` field declaration (around line 42), add:
+
+```dart
+  /// Per-entity-type set of indices whose duplicate status is flagged but
+  /// whose resolution has not yet been explicitly chosen by the user.
+  ///
+  /// An index is present in this set when the row was flagged as a suspected
+  /// duplicate and the user has not yet explicitly acted on it. Per-row and
+  /// per-tab bulk actions remove indices from the relevant set. The Import
+  /// button is gated on this set being empty across all types.
+  final Map<ImportEntityType, Set<int>> pendingDuplicateReview;
+```
+
+In the `copyWith` method signature (around line 69-86), after `Map<ImportEntityType, Map<int, DuplicateAction>>? duplicateActions,` add:
+
+```dart
+    Map<ImportEntityType, Set<int>>? pendingDuplicateReview,
+```
+
+In the `copyWith` body (around line 87-104), after the `duplicateActions:` line, add:
+
+```dart
+      pendingDuplicateReview:
+          pendingDuplicateReview ?? this.pendingDuplicateReview,
+```
+
+After the closing `}` of `copyWith` but before the closing `}` of the `ImportWizardState` class, add:
+
+```dart
+  /// Pending-review indices for a given entity type. Empty if none.
+  Set<int> pendingFor(ImportEntityType type) {
+    return pendingDuplicateReview[type] ?? const {};
+  }
+
+  /// Whether any entity type has at least one pending-review row.
+  bool get hasPendingReviews =>
+      pendingDuplicateReview.values.any((set) => set.isNotEmpty);
+
+  /// Total count of pending-review rows across all entity types.
+  int get totalPending =>
+      pendingDuplicateReview.values.fold(0, (sum, s) => sum + s.length);
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_state_test.dart`
+Expected: PASS — all tests green.
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_state_test.dart
+git add lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_state_test.dart
+git commit -m "feat: add pendingDuplicateReview to ImportWizardState
+
+Introduces an orthogonal map of per-entity-type index sets to track
+suspected duplicates that still need an explicit user decision before
+the import can proceed. Adds hasPendingReviews / totalPending /
+pendingFor helpers."
+```
+
+---
+
+## Task 2: Populate pendingDuplicateReview in setBundle; clear auto-default actions for pending
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart` (the `setBundle` method, around lines 151-192)
+- Test: `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+
+**Key semantic change:** today `setBundle` auto-defaults probable-match actions to `skip` and possible-match actions to `importAsNew`. After this task, both are left **absent** from `duplicateActions` and added to `pendingDuplicateReview` instead. The user must explicitly choose before the row gets a recorded action.
+
+- [ ] **Step 1: Read the existing notifier test file to understand helpers**
+
+Run: `head -60 test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+
+Look for any existing bundle-building helpers (e.g., `buildBundle`, `makeBundle`). Reuse those. If none, inline minimal fixtures.
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`:
+
+```dart
+group('setBundle populates pendingDuplicateReview', () {
+  test('probable dive duplicate goes into pending, NOT duplicateActions',
+      () async {
+    final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setBundle(bundle);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), {0});
+    expect(state.duplicateActions[ImportEntityType.dives], anyOf(isNull, isEmpty));
+    expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+  });
+
+  test('possible dive duplicate goes into pending, NOT duplicateActions',
+      () async {
+    final bundle = _bundleWithPossibleDiveDuplicate(index: 0);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setBundle(bundle);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), {0});
+    expect(state.duplicateActions[ImportEntityType.dives], anyOf(isNull, isEmpty));
+    expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+  });
+
+  test('non-dive duplicate (no matchResults) goes into pending', () async {
+    final bundle = _bundleWithUnscoredSiteDuplicate(index: 0);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setBundle(bundle);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.sites), {0});
+    expect(state.selections[ImportEntityType.sites], isNot(contains(0)));
+  });
+
+  test('non-duplicate rows are NOT pending and ARE selected', () async {
+    final bundle = _bundleWithOneCleanAndOneDuplicateDive();
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setBundle(bundle);
+
+    final state = container.read(importWizardNotifierProvider);
+    // Index 0 = clean, index 1 = duplicate
+    expect(state.selections[ImportEntityType.dives], contains(0));
+    expect(state.pendingFor(ImportEntityType.dives), {1});
+  });
+
+  test('empty duplicates produce empty pending', () async {
+    final bundle = _bundleWithOneCleanDive();
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setBundle(bundle);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.hasPendingReviews, isFalse);
+    expect(state.totalPending, 0);
+  });
+});
+```
+
+Bundle builder helpers (inline at top of the test file if no shared helper exists):
+
+```dart
+ImportBundle _bundleWithProbableDiveDuplicate({required int index}) {
+  final items = [
+    EntityItem(
+      diveData: DiveData(
+        startTime: DateTime(2024, 1, 1, 10, 0),
+        maxDepth: 20.0,
+        bottomTime: const Duration(minutes: 30),
+      ),
+      displayName: 'Incoming dive',
+      displaySubtitle: null,
+      existingData: null,
+    ),
+  ];
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: items,
+        duplicateIndices: {index},
+        matchResults: {
+          index: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithPossibleDiveDuplicate({required int index}) {
+  final items = [
+    EntityItem(
+      diveData: DiveData(
+        startTime: DateTime(2024, 1, 1, 10, 0),
+        maxDepth: 20.0,
+        bottomTime: const Duration(minutes: 30),
+      ),
+      displayName: 'Incoming dive',
+      displaySubtitle: null,
+      existingData: null,
+    ),
+  ];
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: items,
+        duplicateIndices: {index},
+        matchResults: {
+          index: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.55,
+            timeDifferenceMs: 600000,
+            depthDifferenceMeters: 3.0,
+            durationDifferenceSeconds: 480,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithUnscoredSiteDuplicate({required int index}) {
+  final items = [
+    EntityItem(
+      diveData: null,
+      displayName: 'Blue Hole',
+      displaySubtitle: null,
+      existingData: null,
+    ),
+  ];
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.sites: EntityGroup(
+        items: items,
+        duplicateIndices: {index},
+        matchResults: null,
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithOneCleanAndOneDuplicateDive() {
+  final items = [
+    EntityItem(
+      diveData: DiveData(
+        startTime: DateTime(2024, 6, 15, 10, 0),
+        maxDepth: 10.0,
+        bottomTime: const Duration(minutes: 20),
+      ),
+      displayName: 'Clean dive',
+      displaySubtitle: null,
+      existingData: null,
+    ),
+    EntityItem(
+      diveData: DiveData(
+        startTime: DateTime(2024, 1, 1, 10, 0),
+        maxDepth: 20.0,
+        bottomTime: const Duration(minutes: 30),
+      ),
+      displayName: 'Dup dive',
+      displaySubtitle: null,
+      existingData: null,
+    ),
+  ];
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: items,
+        duplicateIndices: {1},
+        matchResults: {
+          1: const DiveMatchResult(
+            diveId: 'existing-2',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithOneCleanDive() {
+  final items = [
+    EntityItem(
+      diveData: DiveData(
+        startTime: DateTime(2024, 6, 15, 10, 0),
+        maxDepth: 10.0,
+        bottomTime: const Duration(minutes: 20),
+      ),
+      displayName: 'Clean dive',
+      displaySubtitle: null,
+      existingData: null,
+    ),
+  ];
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: items,
+        duplicateIndices: const {},
+        matchResults: null,
+      ),
+    },
+  );
+}
+```
+
+**Note:** The exact class names (`EntityItem`, `DiveData`, `DiveMatchResult`, `ImportSourceInfo`, `ImportSourceType`) must match the project's actual classes. Read `lib/features/import_wizard/domain/models/import_bundle.dart` and `lib/features/dive_import/domain/services/dive_matcher.dart` to confirm signatures before committing to the helper shapes. Adjust as needed.
+
+The test also requires an override of `importWizardNotifierProvider` to inject a test adapter. If no existing test helper does this, the simplest approach is:
+
+```dart
+final testProviderContainer = () {
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  return container;
+};
+
+class _TestAdapter implements ImportSourceAdapter {
+  @override
+  String get defaultTagName => 'Test Import';
+
+  @override
+  Set<DuplicateAction> get supportedDuplicateActions => const {
+        DuplicateAction.skip,
+        DuplicateAction.importAsNew,
+        DuplicateAction.consolidate,
+      };
+
+  // Other methods throw UnimplementedError — tests never exercise them.
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+```
+
+- [ ] **Step 3: Run to confirm FAIL**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "setBundle populates pendingDuplicateReview"`
+Expected: FAIL — probable/possible duplicate cases fail because `setBundle` currently writes to `duplicateActions`.
+
+- [ ] **Step 4: Modify setBundle**
+
+In `import_wizard_providers.dart`, replace the `setBundle` method body (lines 151-192) with:
+
+```dart
+  void setBundle(ImportBundle bundle) {
+    final selections = <ImportEntityType, Set<int>>{};
+    final pendingReview = <ImportEntityType, Set<int>>{};
+
+    for (final entry in bundle.groups.entries) {
+      final type = entry.key;
+      final group = entry.value;
+
+      final allIndices = Set<int>.from(
+        List.generate(group.items.length, (i) => i),
+      );
+      selections[type] = allIndices.difference(group.duplicateIndices);
+
+      if (group.duplicateIndices.isNotEmpty) {
+        pendingReview[type] = Set<int>.from(group.duplicateIndices);
+      }
+    }
+
+    state = state.copyWith(
+      bundle: bundle,
+      selections: selections,
+      // Auto-default duplicateActions removed — pending indices are decided
+      // explicitly by the user via setDuplicateAction or applyBulkAction.
+      duplicateActions: const {},
+      pendingDuplicateReview: pendingReview,
+      currentStep: 1,
+      clearError: true,
+    );
+  }
+```
+
+- [ ] **Step 5: Run to verify PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "setBundle populates pendingDuplicateReview"`
+Expected: PASS.
+
+- [ ] **Step 6: Run full notifier file and check for regressions**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+Expected: All green. If any previously-passing test assumed auto-defaults in `duplicateActions`, it will now fail — update those tests to assert against `pendingDuplicateReview` instead. Do not restore the old behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git add lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git commit -m "feat: populate pendingDuplicateReview in setBundle; drop auto-default actions
+
+setBundle now records every suspected-duplicate index into the
+pendingDuplicateReview set and leaves duplicateActions empty for
+those rows. The user must explicitly choose an action before the
+row gets a recorded resolution. Both probable and possible matches
+are treated as 'needs decision' — no silent defaults."
+```
+
+---
+
+## Task 3: Drain pending on per-row actions; add debugSetState
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart` (`setDuplicateAction` and `toggleSelection` methods, around lines 199-300)
+- Test: `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+group('setDuplicateAction drains pending', () {
+  test('setDuplicateAction with skip drains pending and syncs selections',
+      () async {
+    final container = _containerWithOnePendingDive();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setDuplicateAction(
+      ImportEntityType.dives, 0, DuplicateAction.skip,
+    );
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip);
+    expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+  });
+
+  test('setDuplicateAction with importAsNew drains pending and selects',
+      () async {
+    final container = _containerWithOnePendingDive();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setDuplicateAction(
+      ImportEntityType.dives, 0, DuplicateAction.importAsNew,
+    );
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.importAsNew);
+    expect(state.selections[ImportEntityType.dives], contains(0));
+  });
+
+  test('setDuplicateAction with consolidate drains pending and selects',
+      () async {
+    final container = _containerWithOnePendingDive();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.setDuplicateAction(
+      ImportEntityType.dives, 0, DuplicateAction.consolidate,
+    );
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.consolidate);
+    expect(state.selections[ImportEntityType.dives], contains(0));
+  });
+});
+
+group('toggleSelection drains pending', () {
+  test('toggleSelection on a pending index drains it', () async {
+    final container = _containerWithOnePendingDive();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.toggleSelection(ImportEntityType.dives, 0);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    expect(state.selections[ImportEntityType.dives], contains(0));
+  });
+
+  test('toggleSelection on a non-pending index does not change pending',
+      () async {
+    final container = _containerWithOneCleanAndOnePendingDive();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    // index 0 = clean (selected), index 1 = pending
+    notifier.toggleSelection(ImportEntityType.dives, 0);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), {1});
+    expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+  });
+});
+```
+
+Helpers:
+
+```dart
+ProviderContainer _containerWithOnePendingDive() {
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  container.read(importWizardNotifierProvider.notifier).setBundle(
+    _bundleWithProbableDiveDuplicate(index: 0),
+  );
+  return container;
+}
+
+ProviderContainer _containerWithOneCleanAndOnePendingDive() {
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  container.read(importWizardNotifierProvider.notifier).setBundle(
+    _bundleWithOneCleanAndOneDuplicateDive(),
+  );
+  return container;
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "drains pending"`
+Expected: FAIL — the setDuplicateAction and toggleSelection methods do not touch `pendingDuplicateReview` yet.
+
+- [ ] **Step 3: Add `_drainPending` helper and modify `setDuplicateAction` and `toggleSelection`**
+
+In `import_wizard_providers.dart`, add below the `setDuplicateAction` method:
+
+```dart
+  /// Returns a new pending-review map with the given indices removed from
+  /// the set for [type]. If the resulting set is empty, the type key is
+  /// removed from the map entirely (keeps `hasPendingReviews` fast).
+  Map<ImportEntityType, Set<int>> _drainPending(
+    ImportEntityType type,
+    Set<int> indices,
+  ) {
+    final current = state.pendingFor(type);
+    if (current.isEmpty) return state.pendingDuplicateReview;
+    final updated = current.difference(indices);
+    final newMap = Map<ImportEntityType, Set<int>>.from(
+      state.pendingDuplicateReview,
+    );
+    if (updated.isEmpty) {
+      newMap.remove(type);
+    } else {
+      newMap[type] = updated;
+    }
+    return newMap;
+  }
+```
+
+Replace the `setDuplicateAction` method body with:
+
+```dart
+  void setDuplicateAction(
+    ImportEntityType type,
+    int index,
+    DuplicateAction action,
+  ) {
+    final actionsForType =
+        state.duplicateActions[type] ?? const <int, DuplicateAction>{};
+    final updatedActions = Map<int, DuplicateAction>.from(actionsForType)
+      ..[index] = action;
+
+    final currentSelection = Set<int>.from(
+      state.selections[type] ?? const <int>{},
+    );
+    if (action == DuplicateAction.skip) {
+      currentSelection.remove(index);
+    } else {
+      currentSelection.add(index);
+    }
+
+    final updatedPending = _drainPending(type, {index});
+
+    state = state.copyWith(
+      duplicateActions: {...state.duplicateActions, type: updatedActions},
+      selections: {...state.selections, type: currentSelection},
+      pendingDuplicateReview: updatedPending,
+    );
+  }
+```
+
+Replace the `toggleSelection` method body with:
+
+```dart
+  void toggleSelection(ImportEntityType type, int index) {
+    final current = state.selections[type] ?? const <int>{};
+    final updated = Set<int>.from(current);
+    if (updated.contains(index)) {
+      updated.remove(index);
+    } else {
+      updated.add(index);
+    }
+
+    final updatedPending = _drainPending(type, {index});
+
+    state = state.copyWith(
+      selections: {...state.selections, type: updated},
+      pendingDuplicateReview: updatedPending,
+    );
+  }
+```
+
+- [ ] **Step 4: Add `debugSetState`**
+
+Near the end of the `ImportWizardNotifier` class (before the closing `}`), add:
+
+```dart
+  @visibleForTesting
+  void debugSetState(ImportWizardState newState) {
+    state = newState;
+  }
+```
+
+Add `package:flutter/foundation.dart` import at the top of the file if not already present:
+
+```dart
+import 'package:flutter/foundation.dart';
+```
+
+- [ ] **Step 5: Run to verify PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+Expected: All tests pass including the 5 new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git add lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git commit -m "feat: drain pendingDuplicateReview on per-row user actions
+
+setDuplicateAction and toggleSelection both now remove the acted-upon
+index from the pending set. _drainPending helper keeps the invariant
+that empty type sets are removed from the map. Adds debugSetState
+(visibleForTesting) for widget tests that seed state directly."
+```
+
+---
+
+## Task 4: applyBulkAction
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart`
+- Test: `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+
+Applies an action to every pending-review index for a type in a single state emission. For `consolidate`, filters to probable-match indices only.
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+group('applyBulkAction', () {
+  test('skip drains all pending for type and sets resolutions', () async {
+    final container = _containerWithTwoPendingDives();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip);
+    expect(state.duplicateActions[ImportEntityType.dives]?[1],
+        DuplicateAction.skip);
+    expect(state.selections[ImportEntityType.dives],
+        isNot(containsAny(<int>{0, 1})));
+  });
+
+  test('importAsNew drains all pending and selects them', () async {
+    final container = _containerWithTwoPendingDives();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.applyBulkAction(
+        ImportEntityType.dives, DuplicateAction.importAsNew);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.importAsNew);
+    expect(state.selections[ImportEntityType.dives], containsAll({0, 1}));
+  });
+
+  test('consolidate drains only probable matches, leaves weak pending',
+      () async {
+    final container = _containerWithMixedConfidenceDives();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.applyBulkAction(
+        ImportEntityType.dives, DuplicateAction.consolidate);
+
+    final state = container.read(importWizardNotifierProvider);
+    // Index 0 probable → consolidated; index 1 weak → stays pending
+    expect(state.pendingFor(ImportEntityType.dives), {1});
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.consolidate);
+    expect(state.duplicateActions[ImportEntityType.dives]?.containsKey(1),
+        isFalse);
+  });
+
+  test('no-op when pending for type is empty', () async {
+    final container = _containerWithTwoPendingDives();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+    // Second call: pending is empty
+    notifier.applyBulkAction(
+        ImportEntityType.dives, DuplicateAction.importAsNew);
+
+    final state = container.read(importWizardNotifierProvider);
+    // First call won, resolutions are skip
+    expect(state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip);
+  });
+
+  test('non-dive bulk action drains pending and updates selection', () async {
+    final container = _containerWithOnePendingSite();
+    final notifier = container.read(importWizardNotifierProvider.notifier);
+
+    notifier.applyBulkAction(
+        ImportEntityType.sites, DuplicateAction.importAsNew);
+
+    final state = container.read(importWizardNotifierProvider);
+    expect(state.pendingFor(ImportEntityType.sites), isEmpty);
+    expect(state.selections[ImportEntityType.sites], contains(0));
+  });
+});
+```
+
+Helpers (add alongside the existing bundle-builder helpers):
+
+```dart
+ProviderContainer _containerWithTwoPendingDives() {
+  final bundle = ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [
+          EntityItem(
+            diveData: DiveData(
+              startTime: DateTime(2024, 1, 1, 10, 0),
+              maxDepth: 20.0,
+              bottomTime: const Duration(minutes: 30),
+            ),
+            displayName: 'Dup 1',
+            displaySubtitle: null,
+            existingData: null,
+          ),
+          EntityItem(
+            diveData: DiveData(
+              startTime: DateTime(2024, 1, 2, 10, 0),
+              maxDepth: 25.0,
+              bottomTime: const Duration(minutes: 35),
+            ),
+            displayName: 'Dup 2',
+            displaySubtitle: null,
+            existingData: null,
+          ),
+        ],
+        duplicateIndices: const {0, 1},
+        matchResults: {
+          0: const DiveMatchResult(
+            diveId: 'e1',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+          1: const DiveMatchResult(
+            diveId: 'e2',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+        },
+      ),
+    },
+  );
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  container.read(importWizardNotifierProvider.notifier).setBundle(bundle);
+  return container;
+}
+
+ProviderContainer _containerWithMixedConfidenceDives() {
+  final bundle = ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [
+          EntityItem(
+            diveData: DiveData(
+              startTime: DateTime(2024, 1, 1, 10, 0),
+              maxDepth: 20.0,
+              bottomTime: const Duration(minutes: 30),
+            ),
+            displayName: 'Probable',
+            displaySubtitle: null,
+            existingData: null,
+          ),
+          EntityItem(
+            diveData: DiveData(
+              startTime: DateTime(2024, 1, 2, 10, 0),
+              maxDepth: 20.0,
+              bottomTime: const Duration(minutes: 30),
+            ),
+            displayName: 'Possible',
+            displaySubtitle: null,
+            existingData: null,
+          ),
+        ],
+        duplicateIndices: const {0, 1},
+        matchResults: {
+          0: const DiveMatchResult(
+            diveId: 'e1',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+          1: const DiveMatchResult(
+            diveId: 'e2',
+            score: 0.55,
+            timeDifferenceMs: 600000,
+            depthDifferenceMeters: 3.0,
+            durationDifferenceSeconds: 480,
+          ),
+        },
+      ),
+    },
+  );
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  container.read(importWizardNotifierProvider.notifier).setBundle(bundle);
+  return container;
+}
+
+ProviderContainer _containerWithOnePendingSite() {
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  container.read(importWizardNotifierProvider.notifier).setBundle(
+    _bundleWithUnscoredSiteDuplicate(index: 0),
+  );
+  return container;
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "applyBulkAction"`
+Expected: FAIL — method undefined.
+
+- [ ] **Step 3: Implement `applyBulkAction`**
+
+In `import_wizard_providers.dart`, directly below `setDuplicateAction` (and after the `_drainPending` helper from Task 3), add:
+
+```dart
+  /// Apply [action] to every pending-review index for [type] in a single
+  /// state update.
+  ///
+  /// For [DuplicateAction.consolidate], only indices whose
+  /// `DiveMatchResult.score >= 0.7` are consolidated; weaker matches remain
+  /// pending. For other actions, every pending index is affected.
+  ///
+  /// No-op if the type has no pending indices or (for consolidate) no
+  /// probable matches.
+  void applyBulkAction(ImportEntityType type, DuplicateAction action) {
+    final pending = state.pendingFor(type);
+    if (pending.isEmpty) return;
+
+    final Set<int> affected;
+    if (action == DuplicateAction.consolidate) {
+      final matchResults = state.bundle?.groups[type]?.matchResults;
+      if (matchResults == null) return;
+      affected = pending.where((i) {
+        final match = matchResults[i];
+        return match != null && match.score >= 0.7;
+      }).toSet();
+    } else {
+      affected = pending;
+    }
+
+    if (affected.isEmpty) return;
+
+    final actionsForType =
+        state.duplicateActions[type] ?? const <int, DuplicateAction>{};
+    final updatedActions = Map<int, DuplicateAction>.from(actionsForType);
+    final currentSelection = Set<int>.from(
+      state.selections[type] ?? const <int>{},
+    );
+    for (final i in affected) {
+      updatedActions[i] = action;
+      if (action == DuplicateAction.skip) {
+        currentSelection.remove(i);
+      } else {
+        currentSelection.add(i);
+      }
+    }
+
+    final updatedPending = _drainPending(type, affected);
+
+    state = state.copyWith(
+      duplicateActions: {...state.duplicateActions, type: updatedActions},
+      selections: {...state.selections, type: currentSelection},
+      pendingDuplicateReview: updatedPending,
+    );
+  }
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "applyBulkAction"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git add lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git commit -m "feat: add applyBulkAction for tab-level bulk resolution
+
+Unified bulk action across dive and non-dive entity types. For
+consolidate, only drains probable matches (score >= 0.7); weaker
+matches remain pending. Single state emission."
+```
+
+---
+
+## Task 5: firstPendingLocation + PendingLocation type
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart`
+- Test: `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+group('firstPendingLocation', () {
+  test('returns null when nothing pending', () {
+    final container = ProviderContainer(overrides: [
+      importWizardNotifierProvider.overrideWith(
+        (ref) => ImportWizardNotifier(_TestAdapter()),
+      ),
+    ]);
+    addTearDown(container.dispose);
+
+    final loc = container
+        .read(importWizardNotifierProvider.notifier)
+        .firstPendingLocation();
+    expect(loc, isNull);
+  });
+
+  test('returns first pending dive when dives have pending', () {
+    final container = _containerWithTwoPendingDives();
+
+    final loc = container
+        .read(importWizardNotifierProvider.notifier)
+        .firstPendingLocation();
+
+    expect(loc, isNotNull);
+    expect(loc!.type, ImportEntityType.dives);
+    expect(loc.index, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "firstPendingLocation"`
+Expected: FAIL — method and type undefined.
+
+- [ ] **Step 3: Add `PendingLocation` class and `firstPendingLocation` method**
+
+At the top of `import_wizard_providers.dart`, before the `ImportWizardState` class, add:
+
+```dart
+/// A (type, index) pair identifying a pending-review row.
+class PendingLocation {
+  const PendingLocation({required this.type, required this.index});
+  final ImportEntityType type;
+  final int index;
+}
+```
+
+In the notifier class, below `applyBulkAction`, add:
+
+```dart
+  /// Location of the first pending-review row across all entity tabs in
+  /// enum order. Returns null if no pending rows exist.
+  ///
+  /// Used by the review step UI to jump the user to the first row that
+  /// still needs a decision when the Import button is gated.
+  PendingLocation? firstPendingLocation() {
+    for (final type in ImportEntityType.values) {
+      final pending = state.pendingFor(type);
+      if (pending.isEmpty) continue;
+      final sorted = pending.toList()..sort();
+      return PendingLocation(type: type, index: sorted.first);
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart --name "firstPendingLocation"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git add lib/features/import_wizard/presentation/providers/import_wizard_providers.dart test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+git commit -m "feat: add firstPendingLocation for review-jump target
+
+Returns the first pending (type, index) pair in enum order. The
+review step UI uses this to animate the DefaultTabController to
+the matching tab when the user taps the Review button above the
+gated Import button."
+```
+
+---
+
+## Task 6: Add semantics l10n key + NeedsDecisionPill widget
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb`
+- Create: `lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart`
+
+- [ ] **Step 1: Add ARB key**
+
+In `lib/l10n/arb/app_en.arb`, insert alphabetically among `universalImport_semantics_*` keys:
+
+```json
+  "universalImport_semantics_needsDecision": "Suspected duplicate, needs decision",
+  "@universalImport_semantics_needsDecision": {
+    "description": "Screen reader label for the 'Needs decision' pill on a pending duplicate row"
+  },
+```
+
+- [ ] **Step 2: Regenerate locales**
+
+Run: `flutter gen-l10n`
+Expected: completes without errors. Untranslated-message warnings are expected for non-English locales.
+
+- [ ] **Step 3: Create NeedsDecisionPill widget**
+
+Create `lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Pill indicating a row is a suspected duplicate that still needs an
+/// explicit user decision before the import can proceed.
+///
+/// Used by the review step's duplicate card widgets when their `isPending`
+/// flag is true.
+class NeedsDecisionPill extends StatelessWidget {
+  const NeedsDecisionPill({super.key, required this.colorScheme});
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: context.l10n.universalImport_semantics_needsDecision,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: colorScheme.tertiary.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: colorScheme.tertiary, width: 1),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ExcludeSemantics(
+              child: Icon(
+                Icons.warning_amber_rounded,
+                size: 14,
+                color: colorScheme.tertiary,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              context.l10n.universalImport_pending_needsDecision,
+              style: TextStyle(
+                color: colorScheme.tertiary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Write a minimal widget test**
+
+Create `test/features/import_wizard/presentation/widgets/needs_decision_pill_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/needs_decision_pill.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+Widget _pump(ColorScheme colorScheme) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: NeedsDecisionPill(colorScheme: colorScheme),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders localized text and warning icon', (tester) async {
+    await tester.pumpWidget(_pump(const ColorScheme.light()));
+    expect(find.text('Needs decision'), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 5: Run test, confirm PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/needs_decision_pill_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart test/features/import_wizard/presentation/widgets/needs_decision_pill_test.dart
+git add lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart test/features/import_wizard/presentation/widgets/needs_decision_pill_test.dart lib/l10n/arb/app_en.arb lib/l10n/
+git commit -m "feat: add NeedsDecisionPill shared widget and l10n key
+
+Localized pill used by pending duplicate rows in the review step.
+Icon+color+text combo is colorblind-safe. Semantics label announced
+to screen readers."
+```
+
+---
+
+## Task 7: DuplicateActionCard pending visual state
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart`
+- Test: `test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart` (create)
+
+Add an `isPending` parameter. When true:
+- Card shape gets a 4-px warning-colored border.
+- Expand-collapse label says "Decide" instead of whatever today's label is (likely "Compare dives").
+- A `NeedsDecisionPill` renders in the header region.
+
+- [ ] **Step 1: Read the current card to understand its structure**
+
+Run: `cat lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart | head -120`
+
+Note the existing parameter list, where the match-score badge renders, and the expand button's label source.
+
+- [ ] **Step 2: Write failing widget tests**
+
+Create `test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart`. Mirror the structure of the existing test file for this widget if one exists. If none exists, base the fixture on the card's constructor.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/duplicate_action_card.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  final item = EntityItem(
+    diveData: DiveData(
+      startTime: DateTime(2024, 1, 1, 10, 0),
+      maxDepth: 20.0,
+      bottomTime: const Duration(minutes: 30),
+    ),
+    displayName: 'Test dive',
+    displaySubtitle: null,
+    existingData: null,
+  );
+  const matchResult = DiveMatchResult(
+    diveId: 'existing-1',
+    score: 0.85,
+    timeDifferenceMs: 60000,
+    depthDifferenceMeters: 0.1,
+    durationDifferenceSeconds: 0,
+  );
+
+  Widget pump({required bool isPending}) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: DuplicateActionCard(
+          item: item,
+          matchResult: matchResult,
+          currentAction: null,
+          availableActions: const {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.consolidate,
+          },
+          onActionChanged: (_) {},
+          existingDiveId: 'existing-1',
+          isPending: isPending,
+        ),
+      ),
+    );
+  }
+
+  group('DuplicateActionCard pending state', () {
+    testWidgets('shows NeedsDecisionPill when pending', (tester) async {
+      await tester.pumpWidget(pump(isPending: true));
+      expect(find.text('Needs decision'), findsOneWidget);
+    });
+
+    testWidgets('does not show pill when not pending', (tester) async {
+      await tester.pumpWidget(pump(isPending: false));
+      expect(find.text('Needs decision'), findsNothing);
+    });
+
+    testWidgets('renders 4-px warning border when pending', (tester) async {
+      await tester.pumpWidget(pump(isPending: true));
+      final card = tester.widget<Card>(find.byType(Card).first);
+      final shape = card.shape as RoundedRectangleBorder?;
+      expect(shape, isNotNull);
+      expect(shape!.side.width, 4);
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Run — expect FAIL**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart`
+Expected: FAIL — `isPending` parameter undefined.
+
+- [ ] **Step 4: Add `isPending` to DuplicateActionCard**
+
+In `lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart`:
+
+- Add `isPending` to the constructor with default `false`.
+- Add the corresponding final field.
+- In `build()`, wrap the card with a `RoundedRectangleBorder` shape conditioned on `isPending`.
+- In the header region (where the match-score badge currently renders), conditionally render `NeedsDecisionPill` when `isPending`.
+
+Add import at the top:
+
+```dart
+import 'package:submersion/features/import_wizard/presentation/widgets/needs_decision_pill.dart';
+```
+
+Locate the `Card` widget's instantiation (likely wrapped in `return Card(...)` or a similar scope). Add or modify the `shape:` parameter:
+
+```dart
+shape: RoundedRectangleBorder(
+  side: isPending
+      ? BorderSide(color: Theme.of(context).colorScheme.tertiary, width: 4)
+      : BorderSide.none,
+  borderRadius: BorderRadius.circular(12),
+),
+```
+
+In the header `Row`, add a pending-pill rendering next to the existing match-score badge:
+
+```dart
+if (isPending) ...[
+  const SizedBox(width: 8),
+  NeedsDecisionPill(colorScheme: Theme.of(context).colorScheme),
+],
+```
+
+For the expand button label — find where "Compare dives" (or whatever the existing label is) is rendered. Change the conditional to show `context.l10n.universalImport_dive_decideAction` when `isPending && !isExpanded`.
+
+- [ ] **Step 5: Run to verify PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Run full widget test suite for import_wizard to catch regressions**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/`
+Expected: all tests pass. Existing callers pass `isPending: false` by default, so existing tests are unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
+git add lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
+git commit -m "feat: add pending visual state to DuplicateActionCard
+
+isPending parameter (default false) adds a warning-colored card
+border, a NeedsDecisionPill in the header, and swaps the expand
+label to 'Decide' while collapsed."
+```
+
+---
+
+## Task 8: EntityReviewList — sort pending to top + bulk action row + pass isPending
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/widgets/entity_review_list.dart`
+- Test: `test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart` (create)
+
+Changes:
+
+1. `EntityReviewList` gains new required props: `pendingIndices: Set<int>`, `availableActions: Set<DuplicateAction>`, `onBulkAction: void Function(DuplicateAction)`.
+2. Sort pending indices to the TOP of each duplicate section (both "Potential Duplicates" and "Possible Duplicates").
+3. Insert a `_BulkActionRow` widget between the header row and the item lists, shown only when `pendingIndices.isNotEmpty`.
+4. Pass `isPending: pendingIndices.contains(index)` to each `DuplicateActionCard` instantiation (line 142, 151, 161).
+5. For non-dive `_EntityDuplicateCard` (lines 393-512), add an analogous `isPending` parameter and visual state — use the same pattern as Task 7: warning border + NeedsDecisionPill + "Decide" label when pending.
+
+- [ ] **Step 1: Read the current EntityReviewList in full** (already partly read). Focus on lines 393-512 (`_EntityDuplicateCard`).
+
+- [ ] **Step 2: Write failing widget tests**
+
+Create `test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/entity_review_list.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  group('EntityReviewList pending UI', () {
+    testWidgets('shows bulk action row only when pending is non-empty',
+        (tester) async {
+      // No pending → no bulk row
+      await tester.pumpWidget(_pump(
+        group: _sampleGroup(),
+        pendingIndices: const <int>{},
+      ));
+      expect(find.textContaining('Skip all'), findsNothing);
+
+      // With pending → bulk row visible
+      await tester.pumpWidget(_pump(
+        group: _sampleGroup(),
+        pendingIndices: const {0},
+      ));
+      await tester.pump();
+      expect(find.textContaining('Skip all'), findsOneWidget);
+    });
+
+    testWidgets(
+      'bulk row shows only buttons for supported actions',
+      (tester) async {
+        await tester.pumpWidget(_pump(
+          group: _sampleGroup(),
+          pendingIndices: const {0},
+          availableActions: const {DuplicateAction.skip, DuplicateAction.importAsNew},
+        ));
+        await tester.pump();
+        expect(find.textContaining('Skip all'), findsOneWidget);
+        expect(find.textContaining('Import all'), findsOneWidget);
+        expect(find.textContaining('Consolidate'), findsNothing);
+      },
+    );
+
+    testWidgets('Consolidate matched button disabled when count is zero',
+        (tester) async {
+      // Group has pending but matchResult with score < 0.7 → consolidate count 0
+      await tester.pumpWidget(_pump(
+        group: _sampleGroupPossibleOnly(),
+        pendingIndices: const {0},
+      ));
+      await tester.pump();
+      final consolidate = find.ancestor(
+        of: find.textContaining('Consolidate'),
+        matching: find.byType(OutlinedButton),
+      );
+      expect(consolidate, findsOneWidget);
+      final button = tester.widget<OutlinedButton>(consolidate);
+      expect(button.onPressed, isNull);
+    });
+  });
+}
+```
+
+Plus helpers `_pump`, `_sampleGroup`, `_sampleGroupPossibleOnly` — build `EntityGroup` fixtures like Task 2's `_bundleWithProbableDiveDuplicate` but return the group directly.
+
+- [ ] **Step 3: Modify `EntityReviewList`**
+
+Add to constructor:
+```dart
+final Set<int> pendingIndices;
+final Set<DuplicateAction> availableActionsForBulk;
+final void Function(DuplicateAction) onBulkAction;
+```
+
+(Note: `availableActions` already exists — reuse it. Rename or alias if needed.)
+
+In `build`, after the header row padding (line 121), add:
+
+```dart
+if (pendingIndices.isNotEmpty)
+  _BulkActionRow(
+    type: group.items.isNotEmpty && group.items.first.diveData != null
+        ? 'dive'
+        : 'entity',
+    pendingCount: pendingIndices.length,
+    matchableConsolidateCount: _matchableConsolidateCount(),
+    availableActions: availableActions,
+    onBulkAction: onBulkAction,
+  ),
+```
+
+Modify `_sortedDuplicateIndices` (or create a new helper) to return pending-first, then the rest in match-score order:
+
+```dart
+List<int> _sortedDuplicateIndices({required double minScore, double? maxScore}) {
+  final all = <int>[];
+  final matchResults = group.matchResults;
+  if (matchResults == null) return all;
+
+  for (final entry in matchResults.entries) {
+    final score = entry.value.score;
+    if (score < minScore) continue;
+    if (maxScore != null && score >= maxScore) continue;
+    all.add(entry.key);
+  }
+
+  final pendingFirst = all.where(pendingIndices.contains).toList();
+  final rest = all.where((i) => !pendingIndices.contains(i)).toList();
+  rest.sort((a, b) =>
+      matchResults[b]!.score.compareTo(matchResults[a]!.score));
+  return [...pendingFirst, ...rest];
+}
+```
+
+For the `_buildDuplicateCard` and `_buildEntityDuplicateCard` internals, pass `isPending: pendingIndices.contains(index)` through to the card widget.
+
+Add `_BulkActionRow` as a private class at the bottom of the file (or as a new separate file if the existing file is getting large). It renders `OutlinedButton.icon`s filtered by `availableActions`:
+
+```dart
+class _BulkActionRow extends StatelessWidget {
+  final String type;  // 'dive' or 'entity'
+  final int pendingCount;
+  final int matchableConsolidateCount;
+  final Set<DuplicateAction> availableActions;
+  final void Function(DuplicateAction) onBulkAction;
+
+  const _BulkActionRow({
+    required this.type,
+    required this.pendingCount,
+    required this.matchableConsolidateCount,
+    required this.availableActions,
+    required this.onBulkAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 4,
+        children: [
+          if (availableActions.contains(DuplicateAction.skip))
+            OutlinedButton.icon(
+              onPressed: () => onBulkAction(DuplicateAction.skip),
+              icon: const Icon(Icons.block, size: 16),
+              label: Text(
+                context.l10n.universalImport_bulk_skipAll(pendingCount),
+              ),
+            ),
+          if (availableActions.contains(DuplicateAction.importAsNew))
+            OutlinedButton.icon(
+              onPressed: () => onBulkAction(DuplicateAction.importAsNew),
+              icon: const Icon(Icons.add_circle_outline, size: 16),
+              label: Text(
+                type == 'dive'
+                    ? context.l10n.universalImport_bulk_importAllAsNew(pendingCount)
+                    : context.l10n.universalImport_bulk_importAll(pendingCount),
+              ),
+            ),
+          if (availableActions.contains(DuplicateAction.consolidate))
+            OutlinedButton.icon(
+              onPressed: matchableConsolidateCount > 0
+                  ? () => onBulkAction(DuplicateAction.consolidate)
+                  : null,
+              icon: const Icon(Icons.merge_type, size: 16),
+              label: Text(
+                context.l10n.universalImport_bulk_consolidateMatched(
+                  matchableConsolidateCount,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+Add `_matchableConsolidateCount()` helper on `EntityReviewList`:
+
+```dart
+int _matchableConsolidateCount() {
+  final matchResults = group.matchResults;
+  if (matchResults == null) return 0;
+  return pendingIndices
+      .where((i) => (matchResults[i]?.score ?? 0) >= 0.7)
+      .length;
+}
+```
+
+Add `l10n_extension` import if not already present:
+
+```dart
+import 'package:submersion/l10n/l10n_extension.dart';
+```
+
+For `_EntityDuplicateCard` (lines 393-512), add `isPending` parameter in the same way as `DuplicateActionCard` — warning border, NeedsDecisionPill, "Decide" label.
+
+- [ ] **Step 4: Update caller in `review_step.dart`**
+
+In `review_step.dart:269-284` (`_EntityTab.build`), pass the new props:
+
+```dart
+return SingleChildScrollView(
+  child: EntityReviewList(
+    group: group,
+    selectedIndices: selectedIndices,
+    duplicateActions: duplicateActions,
+    availableActions: availableActions,
+    pendingIndices: state.pendingFor(type),
+    onToggleSelection: (i) => notifier.toggleSelection(type, i),
+    onDuplicateActionChanged: (i, a) =>
+        notifier.setDuplicateAction(type, i, a),
+    onBulkAction: (action) => notifier.applyBulkAction(type, action),
+    onSelectAll: () => notifier.selectAll(type),
+    onDeselectAll: () => notifier.deselectAll(type),
+    existingDiveIdForIndex: (i) => group.matchResults?[i]?.diveId ?? '',
+    projectedDiveNumbers: projectedDiveNumbers,
+  ),
+);
+```
+
+- [ ] **Step 5: Run widget tests — expect PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/widgets/entity_review_list.dart lib/features/import_wizard/presentation/widgets/review_step.dart test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
+git add lib/features/import_wizard/presentation/widgets/entity_review_list.dart lib/features/import_wizard/presentation/widgets/review_step.dart test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
+git commit -m "feat: EntityReviewList pending-first sort + bulk-action row
+
+Pending duplicates now sort to the top of each duplicate section.
+A bulk-action row renders above the list when pending is non-empty,
+showing only buttons for actions the adapter supports. _EntityDuplicateCard
+also gains pending visual state for non-dive duplicates."
+```
+
+---
+
+## Task 9: Gate Import button + pending hint bar in ReviewStep
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/widgets/review_step.dart`
+- Test: `test/features/import_wizard/presentation/widgets/review_step_pending_test.dart` (create)
+
+- [ ] **Step 1: Write failing widget tests**
+
+Create `test/features/import_wizard/presentation/widgets/review_step_pending_test.dart` using `notifier.debugSetState` (Task 3) to seed pending state. Verify:
+
+1. `Import Selected` button is disabled when any tab has pending duplicates.
+2. Pending hint text "N duplicate(s) need a decision" is visible above the button.
+3. Tapping `Review` calls `firstPendingLocation` and animates the tab.
+4. When all pending is drained (via `setDuplicateAction` or `applyBulkAction`), the button re-enables.
+5. Banner copy appends "Each needs a decision before importing." when pending.
+
+(Full test code follows the shape of Task 10 in the original plan — adapt imports for the import_wizard module.)
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/review_step_pending_test.dart`
+
+- [ ] **Step 3: Modify `_BottomBar` to gate and show hint**
+
+In `review_step.dart:314-362`, extend `_BottomBar` to accept `hasPendingReviews` and `totalPending`, plus the containing widget provides a `Review` callback that calls `firstPendingLocation`.
+
+Change the `_BottomBar` constructor to:
+
+```dart
+const _BottomBar({
+  required this.counts,
+  required this.onImport,
+  this.onBack,
+  required this.hasPendingReviews,
+  required this.totalPending,
+  required this.onReviewPending,
+});
+```
+
+Replace the build body with:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final theme = Theme.of(context);
+  final parts = <String>[];
+  if (counts.importing > 0) parts.add('${counts.importing} new');
+  if (counts.consolidating > 0) parts.add('${counts.consolidating} merging');
+  if (counts.skipping > 0) parts.add('${counts.skipping} skipped');
+  final countsText = parts.isEmpty ? 'Nothing selected' : parts.join(', ');
+
+  return SafeArea(
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (hasPendingReviews) ...[
+            Semantics(
+              liveRegion: true,
+              child: Row(
+                children: [
+                  Icon(Icons.warning_amber_rounded,
+                      color: theme.colorScheme.tertiary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      context.l10n.universalImport_pending_gateHint(totalPending),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.tertiary,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: onReviewPending,
+                    child: Text(context.l10n.universalImport_pending_reviewAction),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+          Row(
+            children: [
+              if (onBack != null)
+                TextButton(onPressed: onBack, child: const Text('Back')),
+              Expanded(
+                child: Text(
+                  countsText,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              FilledButton(
+                onPressed: hasPendingReviews ? null : onImport,
+                child: const Text('Import Selected'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+}
+```
+
+Add `l10n_extension` import if not already present:
+
+```dart
+import 'package:submersion/l10n/l10n_extension.dart';
+```
+
+- [ ] **Step 4: Wire the new props through `_MultiTypeLayout`**
+
+In `_MultiTypeLayout.build`, replace the `_BottomBar(...)` instantiation at line 204 with:
+
+```dart
+Builder(
+  builder: (ctx) => _BottomBar(
+    counts: counts,
+    onImport: onImport,
+    onBack: onBack,
+    hasPendingReviews: state.hasPendingReviews,
+    totalPending: state.totalPending,
+    onReviewPending: () {
+      final loc = notifier.firstPendingLocation();
+      if (loc == null) return;
+      final tabIdx = types.indexOf(loc.type);
+      if (tabIdx < 0) return;
+      DefaultTabController.maybeOf(ctx)?.animateTo(tabIdx);
+    },
+  ),
+),
+```
+
+- [ ] **Step 5: Run widget tests — expect PASS**
+
+Run: `flutter test test/features/import_wizard/presentation/widgets/review_step_pending_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/features/import_wizard/presentation/widgets/review_step.dart test/features/import_wizard/presentation/widgets/review_step_pending_test.dart
+git add lib/features/import_wizard/presentation/widgets/review_step.dart test/features/import_wizard/presentation/widgets/review_step_pending_test.dart
+git commit -m "feat: gate Import button + add pending-hint bar with Review jump
+
+The Import Selected button is disabled while any tab has pending-
+review duplicates. A warning-colored hint row above the button
+shows the pending count and a Review button that animates to the
+first pending tab via firstPendingLocation."
+```
+
+---
+
+## Task 10: Banner copy addendum (if the active flow has a duplicates banner)
+
+**Files:**
+- Modify: `lib/features/import_wizard/presentation/widgets/review_step.dart` or `entity_review_list.dart`
+
+This task depends on whether the active flow has a prominent duplicates banner like the old `ImportReviewStep` did. Look at the `EntityReviewList` header (`_SectionLabel` at line 137 / 146) and the `review_step.dart` top area.
+
+If there is no separate summary banner, skip this task.
+
+If there is a banner or a visible "N duplicates found" label, add a secondary line (styled bodySmall, FontWeight.w600, colorScheme.onTertiaryContainer or similar) reading `context.l10n.universalImport_summary_decidesRequired` whenever `state.hasPendingReviews`.
+
+- [ ] **Step 1: Inspect the current UI**
+
+Run: `cat lib/features/import_wizard/presentation/widgets/review_step.dart lib/features/import_wizard/presentation/widgets/entity_review_list.dart | grep -i "duplicate\|banner\|found" | head -20`
+
+- [ ] **Step 2: If a banner exists, extend it with a conditional addendum line**
+
+(Exact code depends on where it lives; follow the style of nearby copy.)
+
+- [ ] **Step 3: If no banner exists, skip this task** and proceed to Task 11. Leave a note in the commit chain that the `universalImport_summary_decidesRequired` key is unused on this PR and can be removed in a cleanup sweep.
+
+---
+
+## Task 11: Issue #200 regression test
+
+**File:**
+- Create: `test/features/import_wizard/presentation/providers/issue_200_regression_test.dart`
+
+Self-contained test file that explicitly guards against the original bug returning.
+
+- [ ] **Step 1: Create the test file**
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
+
+/// Regression test for https://github.com/submersion-app/submersion/issues/200.
+///
+/// Suspected-duplicate rows (probable OR possible) must not receive a silent
+/// default action. The Import button stays gated until the user explicitly
+/// decides for every flagged duplicate.
+///
+/// Before this fix:
+///   - Probable duplicates (score >= 0.7) auto-defaulted to skip.
+///   - Possible duplicates (0.5 <= score < 0.7) auto-defaulted to importAsNew.
+/// After the fix:
+///   - Both enter pendingDuplicateReview and receive NO default action.
+///   - The user must call setDuplicateAction or applyBulkAction to resolve.
+///
+/// This file inlines its fixtures so it is not affected by helper refactors
+/// in other test files.
+void main() {
+  group('issue #200: suspected duplicates require explicit selection', () {
+    test('probable duplicate is pending and has NO default action', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), {0});
+      expect(state.duplicateActions[ImportEntityType.dives],
+          anyOf(isNull, isEmpty),
+          reason:
+              'No auto-default skip/importAsNew may be recorded — this would '
+              're-introduce the issue #200 silent-default bug.');
+    });
+
+    test('possible duplicate is pending and has NO default action', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithPossibleDuplicate());
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), {0});
+      expect(state.duplicateActions[ImportEntityType.dives],
+          anyOf(isNull, isEmpty));
+    });
+
+    test('explicit skip resolves pending', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+      expect(container.read(importWizardNotifierProvider).hasPendingReviews,
+          isTrue);
+
+      notifier.setDuplicateAction(
+          ImportEntityType.dives, 0, DuplicateAction.skip);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+      expect(state.duplicateActions[ImportEntityType.dives]?[0],
+          DuplicateAction.skip);
+    });
+
+    test('bulk skip resolves pending', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+      notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+    });
+
+    test('importAsNew resolves pending and selects the dive', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+      notifier.setDuplicateAction(
+          ImportEntityType.dives, 0, DuplicateAction.importAsNew);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+      expect(state.selections[ImportEntityType.dives], contains(0));
+    });
+  });
+}
+
+ProviderContainer _freshContainer() {
+  final container = ProviderContainer(overrides: [
+    importWizardNotifierProvider.overrideWith(
+      (ref) => ImportWizardNotifier(_TestAdapter()),
+    ),
+  ]);
+  addTearDown(container.dispose);
+  return container;
+}
+
+ImportBundle _bundleWithProbableDuplicate() {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [
+          EntityItem(
+            diveData: DiveData(
+              startTime: DateTime(2024, 1, 1, 10, 0),
+              maxDepth: 20.0,
+              bottomTime: const Duration(minutes: 30),
+            ),
+            displayName: 'Duplicate dive',
+            displaySubtitle: null,
+            existingData: null,
+          ),
+        ],
+        duplicateIndices: const {0},
+        matchResults: {
+          0: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithPossibleDuplicate() {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.file,
+      displayName: 'Test',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [
+          EntityItem(
+            diveData: DiveData(
+              startTime: DateTime(2024, 1, 1, 10, 0),
+              maxDepth: 20.0,
+              bottomTime: const Duration(minutes: 30),
+            ),
+            displayName: 'Possible dup',
+            displaySubtitle: null,
+            existingData: null,
+          ),
+        ],
+        duplicateIndices: const {0},
+        matchResults: {
+          0: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.55,
+            timeDifferenceMs: 600000,
+            depthDifferenceMeters: 3.0,
+            durationDifferenceSeconds: 480,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+class _TestAdapter implements ImportSourceAdapter {
+  @override
+  String get defaultTagName => 'Test Import';
+
+  @override
+  Set<DuplicateAction> get supportedDuplicateActions => const {
+        DuplicateAction.skip,
+        DuplicateAction.importAsNew,
+        DuplicateAction.consolidate,
+      };
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+```
+
+Note: the exact class/field names (`DiveData`, `EntityItem`, `ImportSourceInfo`, etc.) MUST match the project's current models. If any differs (e.g., `duration` vs `bottomTime`, `diveDateTime` vs `startTime`), adjust to match.
+
+- [ ] **Step 2: Run**
+
+Run: `flutter test test/features/import_wizard/presentation/providers/issue_200_regression_test.dart`
+Expected: 5/5 PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+dart format test/features/import_wizard/presentation/providers/issue_200_regression_test.dart
+git add test/features/import_wizard/presentation/providers/issue_200_regression_test.dart
+git commit -m "test: add issue #200 regression test against ImportWizardState
+
+Self-contained test file guarding that suspected duplicates (both
+probable and possible) never receive a silent default action and
+require an explicit user decision before the Import button enables."
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Full feature test sweep**
+
+Run: `flutter test test/features/import_wizard/`
+Expected: all pass.
+
+- [ ] **Step 2: Analyze + format**
+
+Run: `flutter analyze lib/features/import_wizard/ test/features/import_wizard/`
+Expected: No issues.
+
+Run: `dart format --set-exit-if-changed lib/features/import_wizard/ test/features/import_wizard/`
+Expected: 0 changed.
+
+- [ ] **Step 3: Broader suite (regression check)**
+
+Run: `flutter test test/features/universal_import/ test/features/dive_import/`
+Expected: all pre-existing tests still pass. The orphan `universal_import/` code wasn't touched; its tests should still pass unmodified.
+
+- [ ] **Step 4: Manual smoke test**
+
+Defer to user. Run `flutter run -d macos` and exercise:
+
+1. Import a file with known duplicates.
+2. Confirm Import button is disabled until each pending row has an explicit decision.
+3. Confirm pending rows sort to top with warning border + "Needs decision" pill.
+4. Try bulk Skip all / Import all as new.
+5. Try Review button — it should jump to the tab with unresolved duplicates.
+6. Resolve everything; confirm Import button enables and performs a successful import.
+7. Non-duplicate rows still behave as before.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| State field + helpers | 1 |
+| setBundle populates + clears defaults | 2 |
+| setDuplicateAction / toggleSelection drain | 3 |
+| applyBulkAction | 4 |
+| firstPendingLocation + PendingLocation | 5 |
+| Semantics l10n key + NeedsDecisionPill | 6 |
+| DuplicateActionCard pending visual | 7 |
+| EntityReviewList sort + bulk + _EntityDuplicateCard pending | 8 |
+| Import gate + pending hint + Review jump | 9 |
+| Banner copy addendum | 10 (conditional) |
+| Regression test | 11 |
+| Final verification | 12 |
+
+**Placeholder scan:** none — every code snippet is complete.
+
+**Type consistency:** `PendingLocation.type` / `.index`, `pendingDuplicateReview`, `hasPendingReviews`, `pendingFor`, `_drainPending`, `isPending` are consistent across tasks.
+
+**Risks for the implementer:**
+
+- Exact model signatures (`DiveData`, `EntityItem`, etc.) must be read from source; the helpers assume specific field names. Step 1 of most tasks instructs to read the relevant file.
+- The `_EntityDuplicateCard` in `entity_review_list.dart` is a private class — adding `isPending` to it requires modifying a private field; the public API change is on `EntityReviewList` passing `pendingIndices` down.
+- The `_TestAdapter` must implement whatever the real `ImportSourceAdapter` interface requires. If the interface is small and stable, use an explicit implementation; if large, the `noSuchMethod` fallback is acceptable since tests don't exercise unused methods.

--- a/docs/superpowers/specs/2026-04-12-import-duplicate-required-selection-design.md
+++ b/docs/superpowers/specs/2026-04-12-import-duplicate-required-selection-design.md
@@ -4,29 +4,38 @@
 
 ## Problem
 
-In today's universal-import review step, any incoming row flagged as a suspected duplicate is silently excluded from the import's default selection. The user can confirm the import without ever reviewing those rows, which results in dives (and other entities) being inadvertently skipped or overlooked in a long import list. The failure is silent — there is no indication that rows were dropped, and an explicit user-chosen "skip" is indistinguishable from the auto-default.
+In today's import review step, every row the duplicate checker flags is given an automatic default action the user never confirmed:
+
+- Probable duplicates (score ≥ 0.7) auto-default to `skip` and are deselected.
+- Possible duplicates (0.5 ≤ score < 0.7) auto-default to `importAsNew` and stay selected.
+- Unscored duplicates (non-dive entities) auto-default to `skip`.
+
+The user can confirm the import without reviewing any of these rows, so dives and other entities can be silently skipped or silently double-imported. The failure is silent — there is no indication that the app decided anything on the user's behalf, and a user-chosen action is indistinguishable from the auto-default.
 
 ## Goal
 
-Replace the auto-skip default with an explicit "needs decision" state. Every suspected duplicate must be reviewed and resolved before the Import button becomes available. Provide efficient bulk actions so users facing many duplicates can still complete an import quickly.
+Replace every auto-default with an explicit "needs decision" state. Every suspected duplicate (any row with `score >= 0.5` for dives, or any entry in `EntityGroup.duplicateIndices` for non-dives) must be reviewed and resolved before the Import button becomes available. Provide efficient bulk actions per tab so users facing many duplicates can complete an import without clicking dozens of rows individually.
 
 ## Scope
 
-- Applies to the universal import flow in `lib/features/universal_import/` (the active import wizard, used by both dive-computer imports and file imports).
-- Applies to every entity type with duplicate detection: dives, sites, buddies, trips, equipment, dive centers, certifications, courses, tags, dive types.
-- Does **not** apply to the legacy `lib/features/import_wizard/` flow.
+- Applies to the active unified import flow in `lib/features/import_wizard/` — the `UnifiedImportWizard` widget, `ReviewStep`, `EntityReviewList`, `DuplicateActionCard`, and `ImportWizardNotifier` / `ImportWizardState`.
+- Applies to every entity type the duplicate checker flags: dives, sites, buddies, trips, equipment, dive centers, certifications, courses, tags, dive types.
+- Applies to every import source (file, dive computer, HealthKit, UDDF, FIT) because they all route through `UnifiedImportWizard` with different `SourceAdapter` implementations.
+- Respects the adapter's `supportedDuplicateActions` set — the bulk-action row only shows buttons for actions the adapter supports.
+- Does **not** apply to the orphaned `lib/features/universal_import/presentation/widgets/import_review_step.dart` (dead code; out of scope to clean up in this change).
 
 ## Out of Scope
 
 - No changes to duplicate-detection scoring thresholds (`dive_matcher.dart` stays as-is).
 - No "revert to undecided" per-row control — once chosen, a row is resolved. Reverting requires cancelling and re-running the import.
-- No new "merge / update existing" action for non-dive entities. Sites, buddies, etc. remain binary (import / skip).
+- No new action options for non-dive entities; they remain binary (import / skip) per adapter capability.
 - No persistence of partial review state across wizard sessions. A cancelled review discards decisions.
 - No changes to duplicate-detection logic itself (`import_duplicate_checker.dart`).
+- No rewiring of the router or deletion of the orphaned `universal_import/` review-step widget.
 
 ## State Model (Approach B: orthogonal "pending review" set)
 
-Add one field to `UniversalImportState` (`lib/features/universal_import/presentation/providers/universal_import_state.dart`):
+Add one field to `ImportWizardState` (`lib/features/import_wizard/presentation/providers/import_wizard_providers.dart`):
 
 ```dart
 final Map<ImportEntityType, Set<int>> pendingDuplicateReview;
@@ -41,6 +50,9 @@ For every `ImportEntityType t` and every index `i`:
 ### State helpers
 
 ```dart
+Set<int> pendingFor(ImportEntityType type) =>
+    pendingDuplicateReview[type] ?? const {};
+
 bool get hasPendingReviews =>
     pendingDuplicateReview.values.any((set) => set.isNotEmpty);
 
@@ -48,109 +60,138 @@ int get totalPending =>
     pendingDuplicateReview.values.fold(0, (sum, s) => sum + s.length);
 ```
 
-### Population (parse time)
+### Population (`setBundle`)
 
-In `_parseAndCheckDuplicates()` (`lib/features/universal_import/presentation/providers/universal_import_providers.dart` around lines 353-419):
+The existing `ImportWizardNotifier.setBundle(ImportBundle bundle)` method initializes `selections` and `duplicateActions` from the bundle's duplicate data. Today it auto-defaults actions based on score (skip for probable, importAsNew for possible) and deselects duplicates from `selections`.
 
-- `pendingDuplicateReview[ImportEntityType.dives]` = all indices with `DiveMatchResult.score >= 0.5` (existing "possible duplicate" threshold from `import_duplicate_checker.dart:682`).
-- `pendingDuplicateReview[type]` for every non-dive duplicate type = all indices present in the corresponding duplicate set from `ImportDuplicateResult`.
-- Default `selections[type]` behavior is unchanged: duplicates are initially deselected; the new gate makes "deselected" no longer equivalent to "skipped."
+After this change:
+
+- `pendingDuplicateReview[type]` is populated with every index in `EntityGroup.duplicateIndices` for that type, regardless of whether it's probable or possible.
+- `duplicateActions[type]` is cleared for pending rows (no auto-default values). Non-pending rows are unaffected.
+- `selections[type]` continues to exclude pending indices by default (nothing is imported until the user resolves). A user-chosen `importAsNew` or `consolidate` re-adds the index to `selections`.
 
 ### Drain conditions
 
-- **Per-row action:** removes the index from `pendingDuplicateReview[type]`.
-- **Bulk action:** removes all qualifying pending indices for that type in a single state update.
-- **Cancel wizard:** state is discarded entirely; no explicit drain required.
-- **Re-parse:** `_parseAndCheckDuplicates()` rebuilds `pendingDuplicateReview` from scratch.
+- **Per-row action** (existing `setDuplicateAction(type, index, action)`): the chosen index is removed from `pendingDuplicateReview[type]` in the same state emission.
+- **Non-duplicate toggle** (existing `toggleSelection(type, index)`): if the index happens to be pending (edge case where the user toggles the checkbox of a pending row), it is also drained.
+- **Bulk action** (new, see below): all targeted indices are drained in a single emission.
+- **Cancel wizard / re-build bundle**: the state is discarded or rebuilt from scratch.
 
 ## Notifier API Changes
 
-In `lib/features/universal_import/presentation/providers/universal_import_providers.dart`:
+All in `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart`.
 
 ### Modified
 
-**`setDiveResolution(int index, DiveDuplicateResolution resolution)`**
-Existing atomic update of `diveResolutions` and `selections[dives]` is extended to also remove `index` from `pendingDuplicateReview[ImportEntityType.dives]`. Single `copyWith`.
+**`setBundle(ImportBundle bundle)`**
+Extend current auto-default logic to populate `pendingDuplicateReview` from each `EntityGroup.duplicateIndices`. Do not auto-assign `duplicateActions` values for pending rows (leave those absent until the user acts).
+
+**`setDuplicateAction(ImportEntityType type, int index, DuplicateAction action)`**
+Current behavior: records the action in `duplicateActions` and syncs `selections[type]` accordingly. Extension: also drains `index` from `pendingDuplicateReview[type]` in the same `copyWith`.
+
+**`toggleSelection(ImportEntityType type, int index)`**
+Current behavior: toggles `selections[type]`. Extension: if `index` is in `pendingDuplicateReview[type]`, drain it (explicit user interaction counts as a decision).
 
 ### New
 
-**`setEntityAction(ImportEntityType type, int index, bool include)`**
-For non-dive entity rows that are flagged duplicates. Adds/removes `index` from `selections[type]` and removes `index` from `pendingDuplicateReview[type]` in one `copyWith`.
+**`applyBulkAction(ImportEntityType type, DuplicateAction action)`**
+Apply `action` to every pending-review index for `type`, in one state emission. Respects the adapter's `supportedDuplicateActions`:
 
-**`applyBulkDiveAction(DiveDuplicateResolution action, {bool onlyPending = true})`**
-Iterates the pending (or all duplicate) dive indices, applies `action` to each, and emits a single state update. For `action == consolidate`, only applies to indices whose `DiveMatchResult.score >= 0.7` (the existing "probable duplicate" threshold); unmatchable indices remain pending.
+- For `DuplicateAction.consolidate`: only applies to indices whose `DiveMatchResult.score >= 0.7` (probable threshold from `dive_matcher.dart`). Weaker matches remain pending. Only relevant on adapters that support consolidate.
+- For `DuplicateAction.skip`: applies to all pending indices; removes them from `selections[type]`.
+- For `DuplicateAction.importAsNew`: applies to all pending indices; adds them to `selections[type]`.
 
-**`applyBulkEntityAction(ImportEntityType type, bool import, {bool onlyPending = true})`**
-Iterates the pending (or all duplicate) indices for `type`, sets selection to `import`, drains pending, emits a single state update.
+Indices that do not apply (e.g., non-matchable for consolidate) stay pending.
 
-**`jumpToFirstPending() → (ImportEntityType, int)?`**
-Returns the entity type and index of the first pending row across tabs in tab order. Returns `null` if nothing is pending. The UI uses this to switch tabs and scroll the row into view.
+**`firstPendingLocation() → PendingLocation?`**
+Returns `(type, index)` for the first pending row across tabs in `ImportEntityType.values` enum order, using the smallest index within the first non-empty pending set. Returns null if no pending rows exist. The UI uses this to switch tabs and scroll the first unresolved row into view.
+
+```dart
+class PendingLocation {
+  const PendingLocation({required this.type, required this.index});
+  final ImportEntityType type;
+  final int index;
+}
+```
 
 ### Unchanged
 
-`performImport()` needs no changes. By the time it runs, the Import button gate guarantees `pendingDuplicateReview` is empty, so the existing partition logic (consolidate vs. normal selection) operates on fully-resolved state.
+`performImport()` is unchanged. By the time the Import button fires, the gate guarantees `pendingDuplicateReview` is empty, so the existing partition logic (non-duplicate selection + per-duplicate `duplicateActions`) operates on fully-resolved state.
 
 ## UI
 
-File: `lib/features/universal_import/presentation/widgets/import_review_step.dart` (and `import_dive_card.dart`).
+Files:
+
+- `lib/features/import_wizard/presentation/widgets/review_step.dart`
+- `lib/features/import_wizard/presentation/widgets/entity_review_list.dart`
+- `lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart`
+- Supporting card: `needs_decision_pill.dart` (new shared widget, to be created under `lib/features/import_wizard/presentation/widgets/`).
 
 ### Per-tab layout (reading order)
 
-1. **Duplicate-summary banner** (existing, copy updated):
-   > "N of M dives are suspected duplicates. Each needs a decision before importing."
-
-2. **Bulk-action row** (new; shown only when `pendingDuplicateReview[type]` is non-empty):
-   - **Dives:** three buttons.
-     - `Skip all (n)` — drains *all* pending dive indices, setting each to `skip`.
-     - `Import all as new (n)` — drains *all* pending dive indices, setting each to `importAsNew`.
-     - `Consolidate matched (k)` — drains only pending dive indices whose `DiveMatchResult.score >= 0.7`, setting each to `consolidate`. Indices without a viable match target **remain pending**. The button is disabled when `k == 0`. In a tab where `k < n`, using this button alone does not enable Import; the remaining `n - k` pending dives still require per-row or bulk resolution.
-   - **Other entity types:** two buttons — `Skip all (n)`, `Import all (n)`. Both drain *all* pending indices for that type.
-
-3. **Row list — sorted** so unresolved (pending) rows come first. Within each group (pending / resolved / non-duplicate), original order is preserved.
+1. **Existing non-duplicate header row** — select all / deselect all toggle, count. Unchanged.
+2. **New bulk-action row** — shown only when `pendingDuplicateReview[type]` is non-empty, and only rendering buttons for actions the `adapter.supportedDuplicateActions` set includes:
+   - If `skip` supported: `Skip all (n)` button.
+   - If `importAsNew` supported: `Import all as new (n)` (for dives) / `Import all (n)` (for non-dives) button.
+   - If `consolidate` supported AND matchable pending count `k` > 0: `Consolidate matched (k)` button (disabled when `k == 0`).
+3. **Row list — sorted** so pending indices come first (in ascending order), then the existing non-pending ordering (by match score for duplicates, original order for non-duplicates).
 
 ### Per-row visual state
 
-| Row state | Left border | Badge | Checkbox |
-|---|---|---|---|
-| Not a duplicate | none | none | checked |
-| Duplicate, pending review | 4 px warning-color border (tertiary / semantic warning); paired with `Icons.warning_amber_rounded` inside the pill | "Needs decision" pill | unchecked, with inline hint "Tap Decide to choose" |
-| Duplicate, resolved | subtle neutral left border | small chip showing chosen action ("Skip" / "Import as new" / "Consolidate") | matches chosen action |
+For dive duplicate cards (`DuplicateActionCard`):
 
-The warning color is paired with an icon and text so the state is conveyed without relying on color alone (colorblind-safe).
+| Row state | Left border | Badge | Action header |
+|---|---|---|---|
+| Not pending, user has chosen | subtle neutral | chosen-action chip ("Skip" / "Import as New" / "Consolidate") | existing behavior |
+| Pending (needs decision) | 4 px warning-color border | "Needs decision" pill (icon + text) | button label "Decide" instead of "Compare dives" |
+
+For non-dive duplicate cards (`_EntityDuplicateCard`):
+
+| Row state | Left border | Badge | Expand button |
+|---|---|---|---|
+| Not pending | subtle neutral | chosen-action chip | existing |
+| Pending | 4 px warning-color border | "Needs decision" pill | "Decide" |
+
+For non-duplicate rows (`_NonDuplicateRow`): unchanged.
 
 ### Import button area (bottom)
 
 - **Gate:** enabled iff `state.totalSelected > 0 && !state.hasPendingReviews`.
-- **Pending hint** (shown directly above the button when `hasPendingReviews`):
-  > "N duplicate(s) need a decision" — followed by a `Review` button that calls `jumpToFirstPending()`, switches to the returned tab, and scrolls the pending row into view.
-- **Existing no-selection state** (disabled when `totalSelected == 0`) is preserved.
-- Helper text above the button uses `Semantics(liveRegion: true)` so the count updates are announced by screen readers as rows are resolved.
+- **Pending hint** (shown above the button when `hasPendingReviews`):
+  > "N duplicate(s) need a decision" — followed by a `Review` button that calls `firstPendingLocation()` and animates the `DefaultTabController` to the matching tab.
+- Helper text uses `Semantics(liveRegion: true)` so count changes are announced.
 
-### Comparison expansion (`ImportDiveCard`)
+### Comparison expansion
 
-No change to the expansion mechanism. For pending rows, the button label becomes `Decide` (new l10n key) and adopts the warning accent. Resolved rows retain the existing `Compare dives` label.
+No change to the expansion mechanism itself. For pending rows, the button label becomes `Decide` (using `universalImport_dive_decideAction` l10n key) and adopts the warning accent. Resolved rows retain existing labels.
 
 ## Data Flow
 
 ```
-User selects source
+User starts import via UnifiedImportWizard
   │
   ▼
-_parseAndCheckDuplicates()
-  │
-  ├─→ selections[type] = non-duplicate indices        (unchanged)
-  ├─→ diveResolutions = {}                            (unchanged)
-  └─→ pendingDuplicateReview[type] = duplicate indices  (NEW)
+Source-specific acquisition (file pick / BLE / HealthKit / ...)
   │
   ▼
-Review step
+adapter.buildBundle() → ImportBundle with groups
+adapter.checkDuplicates(bundle) → bundle with duplicateIndices filled
   │
-  ├── Bulk action ──→ applyBulk{Dive,Entity}Action()
-  │                    └─→ update selections/resolutions
+  ▼
+notifier.setBundle(checkedBundle)
+  ├─→ selections[type] = all indices - duplicateIndices  (unchanged)
+  ├─→ duplicateActions[type] cleared for pending indices (CHANGED)
+  └─→ pendingDuplicateReview[type] = duplicateIndices    (NEW)
+  │
+  ▼
+ReviewStep
+  │
+  ├── Bulk action ──→ applyBulkAction(type, action)
+  │                    └─→ update duplicateActions + selections
   │                        drain pendingDuplicateReview[type]
   │
-  └── Per-row action ──→ setDiveResolution() or setEntityAction()
-                         └─→ update selections/resolutions
+  └── Per-row action ──→ setDuplicateAction(type, i, action)
+                         └─→ update duplicateActions + selections
                              pendingDuplicateReview[type].remove(i)
   │
   ▼
@@ -162,7 +203,7 @@ performImport()   (existing, unchanged)
 
 ## Localization
 
-New ARB keys in `lib/l10n/app_en.arb`, accessed via `context.l10n.*`:
+Already added to `lib/l10n/arb/app_en.arb` (inherited from a previous cherry-pick). Relevant keys:
 
 | Key | Value |
 |---|---|
@@ -177,54 +218,50 @@ New ARB keys in `lib/l10n/app_en.arb`, accessed via `context.l10n.*`:
 | `universalImport_rowHint_tapCompareToDecide` | "Tap Decide to choose" |
 | `universalImport_summary_decidesRequired` | "Each needs a decision before importing." |
 
-Other locale ARB files are updated with the same keys (translations may follow in a separate PR per existing project practice).
+One additional key to add during implementation: `universalImport_semantics_needsDecision` for the pill's screen-reader label.
+
+The key prefix `universalImport_*` is a historical artifact from the spec's original (mis-targeted) scope. Renaming is out of scope; the keys ship as-is. (The `universalImport_` ARB namespace is used by the active flow too, so the keys are visible.)
 
 ## Accessibility
 
-- "Needs decision" pill wrapped in `Semantics(label: 'Suspected duplicate, needs decision')`.
-- Warning color paired with `Icons.warning_amber_rounded` plus text (shape + color + text).
-- Pending-count hint above the Import button uses `Semantics(liveRegion: true)` so count changes are announced.
+- "Needs decision" pill wrapped in `Semantics(label: context.l10n.universalImport_semantics_needsDecision)`.
+- Warning color paired with `Icons.warning_amber_rounded` plus text (shape + color + text — colorblind-safe).
+- Pending-count hint above the Import button uses `Semantics(liveRegion: true)` for announcement on count change.
 
 ## Testing
 
-### State / notifier (extend `test/features/universal_import/presentation/providers/universal_import_notifier_test.dart`)
+### State / notifier
 
-- After parse with mixed clean and duplicate dives, `pendingDuplicateReview[dives]` contains exactly the flagged indices.
-- `setDiveResolution(i, skip)` drains `i` from pending.
-- `setDiveResolution(i, importAsNew)` drains `i` from pending and adds to `selections[dives]`.
-- `setDiveResolution(i, consolidate)` drains `i` from pending and adds to `selections[dives]`.
-- `applyBulkDiveAction(skip, onlyPending: true)` drains all pending dive indices; resolutions set to skip; `selections[dives]` unchanged.
-- `applyBulkDiveAction(importAsNew)` drains all pending; selections include each; resolutions = importAsNew.
-- `applyBulkDiveAction(consolidate)` drains only probable-match pending indices (score ≥ 0.7); un-matchable indices remain pending.
-- `setEntityAction(sites, i, true)` drains pending and adds to `selections[sites]`.
-- `setEntityAction(sites, i, false)` drains pending and does not change selection.
-- `applyBulkEntityAction(sites, true)` drains all pending site indices; selections updated.
-- `hasPendingReviews` flips false only when the last pending index across all types is drained.
-- `totalPending` sums across types correctly.
-- Re-parsing discards stale `pendingDuplicateReview` entries.
-- `jumpToFirstPending()` returns entities in tab order; returns `null` when empty.
+File: `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart` (extend).
 
-### Widget (new file: `test/features/universal_import/presentation/widgets/import_review_step_pending_test.dart`)
+- After `setBundle` with a bundle containing duplicates, `pendingDuplicateReview[type]` contains exactly the flagged indices; `duplicateActions[type]` has no entries for pending indices.
+- After `setDuplicateAction(type, i, action)`, index `i` is drained from pending; `duplicateActions[type][i] == action`; `selections[type]` reflects the action.
+- After `toggleSelection(type, i)` on a pending index, the index is drained from pending.
+- `applyBulkAction(type, skip)` drains all pending for that type, sets each to skip, removes from selection.
+- `applyBulkAction(type, importAsNew)` drains all pending, sets each to importAsNew, adds to selection.
+- `applyBulkAction(type, consolidate)` on a dive bundle drains only indices with `score >= 0.7`; weaker pending stays pending.
+- `applyBulkAction` on an adapter without a given action throws or is a no-op (TBD — pick one during planning; probably no-op with an assertion).
+- `hasPendingReviews` flips false only when the last pending index is drained.
+- `firstPendingLocation()` returns null when empty; returns dive-first when dives have pending; returns next tab when dives drained.
 
-- Import button is disabled while any tab has pending rows, even with `totalSelected > 0`.
-- Import button enables after all pending rows are resolved via per-row actions.
-- Import button enables after all pending rows are resolved via bulk actions.
-- Pending hint "N duplicate(s) need a decision" shows the correct count and updates as rows resolve.
-- `Review` button jumps to the correct tab and scrolls the first pending row into view.
-- Pending rows render above resolved and non-duplicate rows within each tab.
-- Pending rows display the warning-colored left border, icon, and "Needs decision" pill.
-- Bulk-action buttons appear only when their tab has pending rows; their counts match the pending set size.
-- For the Dives tab, `Consolidate matched` button shows only the count with `score ≥ 0.7`, and is disabled when that count is zero.
-- For non-dive tabs, bulk buttons show the correct affected counts.
+### Widget
 
-### Regression (new file: `test/features/universal_import/presentation/providers/issue_200_regression_test.dart`)
+New file: `test/features/import_wizard/presentation/widgets/review_step_pending_test.dart`.
 
-Simulate the exact failure mode the issue describes:
+- Import button is disabled while any tab has pending rows, even when `totalSelected > 0`.
+- Import button enables after all pending are resolved via per-row actions.
+- Import button enables after all pending are resolved via bulk actions.
+- Pending hint appears and shows correct count; `Review` button jumps to the first pending tab.
+- Pending rows sort above resolved rows in the list.
+- Pending rows render the warning border + "Needs decision" pill.
+- Dive bulk-action row shows only buttons supported by the adapter (e.g., file-import adapter shows skip + importAsNew only; DC adapter shows all three).
+- `Consolidate matched` button shows correct count and is disabled when count is 0.
 
-- Parse an import with ≥ 1 suspected-duplicate dive.
-- Assert the Import button is disabled.
-- Assert that calling `performImport()` without resolving is impossible (covered by the UI gate; verify at state level that `hasPendingReviews` is true and the button's `onPressed` is `null`).
-- Assert no dive is silently skipped — i.e., the only way a dive ends up unimported is an explicit user action.
+### Regression
+
+New file: `test/features/import_wizard/presentation/providers/issue_200_regression_test.dart`.
+
+Self-contained regression guard: after `setBundle` with a bundle containing a probable duplicate dive, assertions prove that (a) `hasPendingReviews` is true, (b) `duplicateActions` has no entry for the pending index (no silent default), (c) only explicit user action drains the pending set, and (d) the Import button's gate condition remains true while any duplicate is unresolved.
 
 ### Unchanged
 
@@ -232,36 +269,44 @@ Simulate the exact failure mode the issue describes:
 
 ## Edge Cases
 
-- **Large imports (many duplicates):** per-tab bulk buttons provide O(1) clicks per tab; large imports remain tractable.
-- **Consolidate-bulk with no viable targets:** affected indices are left pending; the user handles them individually or chooses another bulk action.
-- **All rows are duplicates:** user must resolve all before Import enables. `totalSelected > 0` gate also applies (at least one dive must be importable or consolidatable).
-- **Zero duplicates:** behavior is unchanged from today — Import button enabled as soon as `totalSelected > 0`.
-- **User re-runs parsing with a different file:** `_parseAndCheckDuplicates()` rebuilds the state; stale pending entries are dropped.
-- **User cancels mid-review:** state is discarded; partial decisions are lost (accepted).
+- **Large imports (many duplicates):** per-tab bulk buttons reduce friction to O(1) clicks per tab.
+- **Consolidate-bulk with no viable targets:** un-matchable indices stay pending; user must resolve them individually.
+- **All rows are duplicates:** user must resolve all before Import enables. The `totalSelected > 0` guard still applies (at least one importable row required).
+- **Zero duplicates:** behavior unchanged — Import enables as soon as `totalSelected > 0`.
+- **Mid-flow re-parse:** `setBundle` rebuilds the entire state; stale pending entries are discarded.
+- **Cancel mid-review:** the wizard's state is discarded. Partial decisions are lost. Accepted.
+- **Adapter without consolidate support:** the bulk-action row omits the Consolidate button; per-row `Consolidate` option also not shown by `DiveComparisonCard`. No behavior change from today.
 
 ## Risks and Tradeoffs
 
-- **Two state fields to keep in sync.** `pendingDuplicateReview` and `selections/diveResolutions` must always be updated together. Mitigation: all mutations go through the notifier's atomic `copyWith` methods; a debug-build invariant assertion can verify "no index is both in pending and in a resolved resolutions entry" on each state emission.
-- **More clicks on average.** Users whose imports have only true duplicates will spend more time on the review step than today. Mitigation: per-tab bulk buttons; the Import all as new / Skip all actions take two clicks max per tab.
-- **Ephemeral state.** Cancelled wizards lose partial decisions. Accepted; persistent draft state is a separate, larger feature.
+- **Two state fields (`pendingDuplicateReview` and `duplicateActions` + `selections`) must stay in sync.** Mitigation: all mutations go through the notifier's `copyWith`. A debug assertion can verify "no index is in pending AND in duplicateActions simultaneously" on each emission.
+- **More clicks on average.** Users importing many duplicates will spend more time on the review step than today. Mitigation: per-tab bulk buttons take 2 clicks max per tab.
+- **Ephemeral state.** Cancelled wizards lose partial decisions. Accepted; persistent draft state is a separate feature.
+- **ARB key-prefix inconsistency.** The `universalImport_*` keys land in the `import_wizard/` flow. Not ideal, but renaming them mid-feature rippled through too much code. Tracked as a follow-up.
 
 ## Files Touched
 
 **Modified:**
-- `lib/features/universal_import/presentation/providers/universal_import_state.dart` — add `pendingDuplicateReview`, helpers.
-- `lib/features/universal_import/presentation/providers/universal_import_providers.dart` — populate at parse; extend `setDiveResolution`; add `setEntityAction`, `applyBulkDiveAction`, `applyBulkEntityAction`, `jumpToFirstPending`.
-- `lib/features/universal_import/presentation/widgets/import_review_step.dart` — sort, bulk buttons, gate hint, row styling, Review button.
-- `lib/features/universal_import/presentation/widgets/import_dive_card.dart` — pending visual state, "Decide" label.
-- `lib/l10n/app_en.arb` (and peers) — new strings.
+
+- `lib/features/import_wizard/presentation/providers/import_wizard_providers.dart` — add `pendingDuplicateReview` field; extend `setBundle`, `setDuplicateAction`, `toggleSelection`; add `applyBulkAction`, `firstPendingLocation`, `debugSetState` (test-only); add `PendingLocation` type.
+- `lib/features/import_wizard/presentation/widgets/review_step.dart` — gate Import button, pending hint bar, banner-copy addendum.
+- `lib/features/import_wizard/presentation/widgets/entity_review_list.dart` — sort pending to top, bulk-action row, pass `isPending` to cards.
+- `lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart` — visual pending state, "Decide" label.
+- `lib/l10n/arb/app_en.arb` — add `universalImport_semantics_needsDecision` key.
 
 **Added:**
-- `test/features/universal_import/presentation/widgets/import_review_step_pending_test.dart`
-- `test/features/universal_import/presentation/providers/issue_200_regression_test.dart`
+
+- `lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart` — shared pill widget.
+- `test/features/import_wizard/presentation/widgets/review_step_pending_test.dart`
+- `test/features/import_wizard/presentation/providers/issue_200_regression_test.dart`
 
 **Extended:**
-- `test/features/universal_import/presentation/providers/universal_import_notifier_test.dart`
+
+- `test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart`
 
 **Unchanged:**
-- `lib/features/universal_import/data/services/import_duplicate_checker.dart`
-- `lib/features/dive_import/domain/services/dive_matcher.dart`
-- `lib/features/universal_import/data/models/import_enums.dart` (the `DiveDuplicateResolution` enum is left alone)
+
+- `lib/features/universal_import/**` — no changes (orphan review step not touched).
+- `lib/features/universal_import/data/services/import_duplicate_checker.dart` — detection logic unchanged.
+- `lib/features/dive_import/domain/services/dive_matcher.dart` — scoring unchanged.
+- `lib/features/import_wizard/data/adapters/*` — adapter interfaces unchanged; the gate and bulk actions respect the existing `supportedDuplicateActions`.

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -386,7 +386,7 @@ class DiveComparisonCard extends ConsumerWidget {
     }
 
     Color? colorFor(DuplicateAction action) {
-      if (!isTriState || selectedAction != action) return null;
+      if (!isTriState) return null;
       return switch (action) {
         DuplicateAction.skip => colorScheme.error,
         DuplicateAction.importAsNew => Colors.green,
@@ -556,13 +556,20 @@ class _ActionButton extends StatelessWidget {
       case _ActionButtonStyle.text:
         return TextButton(
           onPressed: onPressed,
-          style: TextButton.styleFrom(minimumSize: minSize),
+          style: TextButton.styleFrom(
+            minimumSize: minSize,
+            foregroundColor: color,
+          ),
           child: child,
         );
       case _ActionButtonStyle.outlined:
         return OutlinedButton(
           onPressed: onPressed,
-          style: OutlinedButton.styleFrom(minimumSize: minSize),
+          style: OutlinedButton.styleFrom(
+            minimumSize: minSize,
+            foregroundColor: color,
+            side: color != null ? BorderSide(color: color!, width: 1.5) : null,
+          ),
           child: child,
         );
       case _ActionButtonStyle.filled:

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -57,6 +57,13 @@ class DiveComparisonCard extends ConsumerWidget {
   /// avoid a nested card outline (grey line artifact).
   final bool embedded;
 
+  /// Whether the enclosing row still needs an explicit user decision.
+  ///
+  /// When `true` AND [selectedAction] is `null`, a "Choose an action" label is
+  /// rendered above the action-button row to make the required decision
+  /// visually prominent. Has no effect in immediate-action mode.
+  final bool isPending;
+
   const DiveComparisonCard({
     super.key,
     required this.incoming,
@@ -71,6 +78,7 @@ class DiveComparisonCard extends ConsumerWidget {
     this.onActionChanged,
     this.availableActions,
     this.embedded = false,
+    this.isPending = false,
   });
 
   @override
@@ -354,8 +362,12 @@ class DiveComparisonCard extends ConsumerWidget {
   }
 
   Widget _buildActionButtons(BuildContext context, WidgetRef ref) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final isTriState = selectedAction != null;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    // Tri-state selector mode is identified by the presence of an
+    // [onActionChanged] callback. A pending row legitimately passes a null
+    // [selectedAction] in this mode, so we cannot key off the action value.
+    final isTriState = onActionChanged != null;
 
     // In tri-state mode, limit buttons to availableActions (default: all).
     bool showAction(DuplicateAction action) {
@@ -431,13 +443,35 @@ class DiveComparisonCard extends ConsumerWidget {
       );
     }
 
+    // Show a "Choose an action" label when the enclosing row is pending and
+    // no action has been selected yet — reinforces the pending visual cue and
+    // makes the required decision prominent.
+    final showChooseLabel = isPending && isTriState && selectedAction == null;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Wrap(
-        alignment: WrapAlignment.start,
-        spacing: 8,
-        runSpacing: 4,
-        children: buttons,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showChooseLabel)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Text(
+                'Choose an action',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: colorScheme.tertiary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          Wrap(
+            alignment: WrapAlignment.start,
+            spacing: 8,
+            runSpacing: 4,
+            children: buttons,
+          ),
+        ],
       ),
     );
   }

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -569,7 +569,7 @@ class _ActionButton extends StatelessWidget {
           style: OutlinedButton.styleFrom(
             minimumSize: minSize,
             foregroundColor: color,
-            side: color != null ? BorderSide(color: color!, width: 1.5) : null,
+            side: color != null ? BorderSide(color: color!, width: 2.5) : null,
           ),
           child: child,
         );

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_compute
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Shared comparison card for dive duplicate resolution.
 ///
@@ -458,7 +459,7 @@ class DiveComparisonCard extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.only(bottom: 8),
               child: Text(
-                'Choose an action',
+                context.l10n.universalImport_pending_chooseAction,
                 style: theme.textTheme.titleSmall?.copyWith(
                   color: colorScheme.tertiary,
                   fontWeight: FontWeight.w700,

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -553,13 +553,18 @@ class _ActionButton extends StatelessWidget {
 
     const minSize = Size(0, 48);
 
+    // When the button is disabled (onPressed == null), skip the semantic
+    // color/border so Material's default disabled styling takes over — keeps
+    // the "not clickable" affordance visually clear.
+    final isEnabled = onPressed != null;
+    final effectiveColor = isEnabled ? color : null;
     switch (style) {
       case _ActionButtonStyle.text:
         return TextButton(
           onPressed: onPressed,
           style: TextButton.styleFrom(
             minimumSize: minSize,
-            foregroundColor: color,
+            foregroundColor: effectiveColor,
           ),
           child: child,
         );
@@ -568,8 +573,10 @@ class _ActionButton extends StatelessWidget {
           onPressed: onPressed,
           style: OutlinedButton.styleFrom(
             minimumSize: minSize,
-            foregroundColor: color,
-            side: color != null ? BorderSide(color: color!, width: 2.5) : null,
+            foregroundColor: effectiveColor,
+            side: effectiveColor != null
+                ? BorderSide(color: effectiveColor, width: 2.5)
+                : null,
           ),
           child: child,
         );
@@ -578,8 +585,8 @@ class _ActionButton extends StatelessWidget {
           onPressed: onPressed,
           style: FilledButton.styleFrom(
             minimumSize: minSize,
-            backgroundColor: color,
-            foregroundColor: color != null ? Colors.white : null,
+            backgroundColor: effectiveColor,
+            foregroundColor: effectiveColor != null ? Colors.white : null,
           ),
           child: child,
         );

--- a/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
+++ b/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
@@ -219,7 +220,13 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
     } else {
       updated.add(index);
     }
-    state = state.copyWith(selections: {...state.selections, type: updated});
+
+    final updatedPending = _drainPending(type, {index});
+
+    state = state.copyWith(
+      selections: {...state.selections, type: updated},
+      pendingDuplicateReview: updatedPending,
+    );
   }
 
   /// Select all non-duplicate items for [type].
@@ -301,17 +308,59 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
   // -------------------------------------------------------------------------
 
   /// Set the [action] for a specific duplicate item.
+  ///
+  /// In addition to recording the action, this also:
+  /// - Syncs [ImportWizardState.selections] for [type]: removes [index] when
+  ///   [action] is [DuplicateAction.skip]; adds [index] otherwise.
+  /// - Drains [index] from [ImportWizardState.pendingDuplicateReview] for
+  ///   [type] via [_drainPending].
   void setDuplicateAction(
     ImportEntityType type,
     int index,
     DuplicateAction action,
   ) {
-    final current =
+    final actionsForType =
         state.duplicateActions[type] ?? const <int, DuplicateAction>{};
-    final updated = Map<int, DuplicateAction>.from(current)..[index] = action;
-    state = state.copyWith(
-      duplicateActions: {...state.duplicateActions, type: updated},
+    final updatedActions = Map<int, DuplicateAction>.from(actionsForType)
+      ..[index] = action;
+
+    final currentSelection = Set<int>.from(
+      state.selections[type] ?? const <int>{},
     );
+    if (action == DuplicateAction.skip) {
+      currentSelection.remove(index);
+    } else {
+      currentSelection.add(index);
+    }
+
+    final updatedPending = _drainPending(type, {index});
+
+    state = state.copyWith(
+      duplicateActions: {...state.duplicateActions, type: updatedActions},
+      selections: {...state.selections, type: currentSelection},
+      pendingDuplicateReview: updatedPending,
+    );
+  }
+
+  /// Returns a new pending-review map with the given indices removed from
+  /// the set for [type]. If the resulting set is empty, the type key is
+  /// removed from the map entirely (keeps `hasPendingReviews` fast).
+  Map<ImportEntityType, Set<int>> _drainPending(
+    ImportEntityType type,
+    Set<int> indices,
+  ) {
+    final current = state.pendingFor(type);
+    if (current.isEmpty) return state.pendingDuplicateReview;
+    final updated = current.difference(indices);
+    final newMap = Map<ImportEntityType, Set<int>>.from(
+      state.pendingDuplicateReview,
+    );
+    if (updated.isEmpty) {
+      newMap.remove(type);
+    } else {
+      newMap[type] = updated;
+    }
+    return newMap;
   }
 
   // -------------------------------------------------------------------------
@@ -428,6 +477,14 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
   /// Return to the initial state.
   void reset() {
     state = const ImportWizardState();
+  }
+
+  /// Replace the notifier's state directly. Intended for widget tests that
+  /// need to seed an arbitrary state (e.g. pending-review rows) without going
+  /// through the full [setBundle] flow.
+  @visibleForTesting
+  void debugSetState(ImportWizardState newState) {
+    state = newState;
   }
 }
 

--- a/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
+++ b/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
@@ -19,6 +19,7 @@ class ImportWizardState {
     this.bundle,
     this.selections = const {},
     this.duplicateActions = const {},
+    this.pendingDuplicateReview = const {},
     this.retainSourceDiveNumbers = false,
     this.importTags = const [],
     this.importPhase,
@@ -40,6 +41,15 @@ class ImportWizardState {
 
   /// User-chosen action per duplicate item, keyed by entity type and index.
   final Map<ImportEntityType, Map<int, DuplicateAction>> duplicateActions;
+
+  /// Per-entity-type set of indices whose duplicate status is flagged but
+  /// whose resolution has not yet been explicitly chosen by the user.
+  ///
+  /// An index is present in this set when the row was flagged as a suspected
+  /// duplicate and the user has not yet explicitly acted on it. Per-row and
+  /// per-tab bulk actions remove indices from the relevant set. The Import
+  /// button is gated on this set being empty across all types.
+  final Map<ImportEntityType, Set<int>> pendingDuplicateReview;
 
   /// When true, imported dives keep their original dive numbers from the
   /// source file instead of being auto-assigned sequential numbers.
@@ -72,6 +82,7 @@ class ImportWizardState {
     bool clearBundle = false,
     Map<ImportEntityType, Set<int>>? selections,
     Map<ImportEntityType, Map<int, DuplicateAction>>? duplicateActions,
+    Map<ImportEntityType, Set<int>>? pendingDuplicateReview,
     bool? retainSourceDiveNumbers,
     List<TagSelection>? importTags,
     ImportPhase? importPhase,
@@ -89,6 +100,8 @@ class ImportWizardState {
       bundle: clearBundle ? null : (bundle ?? this.bundle),
       selections: selections ?? this.selections,
       duplicateActions: duplicateActions ?? this.duplicateActions,
+      pendingDuplicateReview:
+          pendingDuplicateReview ?? this.pendingDuplicateReview,
       retainSourceDiveNumbers:
           retainSourceDiveNumbers ?? this.retainSourceDiveNumbers,
       importTags: importTags ?? this.importTags,
@@ -102,6 +115,19 @@ class ImportWizardState {
       error: clearError ? null : (error ?? this.error),
     );
   }
+
+  /// Pending-review indices for a given entity type. Empty if none.
+  Set<int> pendingFor(ImportEntityType type) {
+    return pendingDuplicateReview[type] ?? const {};
+  }
+
+  /// Whether any entity type has at least one pending-review row.
+  bool get hasPendingReviews =>
+      pendingDuplicateReview.values.any((set) => set.isNotEmpty);
+
+  /// Total count of pending-review rows across all entity types.
+  int get totalPending =>
+      pendingDuplicateReview.values.fold(0, (sum, s) => sum + s.length);
 }
 
 // ============================================================================

--- a/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
+++ b/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
@@ -363,6 +363,57 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
     return newMap;
   }
 
+  /// Apply [action] to every pending-review index for [type] in a single
+  /// state update.
+  ///
+  /// For [DuplicateAction.consolidate], only indices whose
+  /// `DiveMatchResult.score >= 0.7` are consolidated; weaker matches remain
+  /// pending. For other actions, every pending index is affected.
+  ///
+  /// No-op if the type has no pending indices or (for consolidate) no
+  /// probable matches.
+  void applyBulkAction(ImportEntityType type, DuplicateAction action) {
+    final pending = state.pendingFor(type);
+    if (pending.isEmpty) return;
+
+    final Set<int> affected;
+    if (action == DuplicateAction.consolidate) {
+      final matchResults = state.bundle?.groups[type]?.matchResults;
+      if (matchResults == null) return;
+      affected = pending.where((i) {
+        final match = matchResults[i];
+        return match != null && match.score >= 0.7;
+      }).toSet();
+    } else {
+      affected = pending;
+    }
+
+    if (affected.isEmpty) return;
+
+    final actionsForType =
+        state.duplicateActions[type] ?? const <int, DuplicateAction>{};
+    final updatedActions = Map<int, DuplicateAction>.from(actionsForType);
+    final currentSelection = Set<int>.from(
+      state.selections[type] ?? const <int>{},
+    );
+    for (final i in affected) {
+      updatedActions[i] = action;
+      if (action == DuplicateAction.skip) {
+        currentSelection.remove(i);
+      } else {
+        currentSelection.add(i);
+      }
+    }
+
+    final updatedPending = _drainPending(type, affected);
+
+    state = state.copyWith(
+      duplicateActions: {...state.duplicateActions, type: updatedActions},
+      selections: {...state.selections, type: currentSelection},
+      pendingDuplicateReview: updatedPending,
+    );
+  }
+
   // -------------------------------------------------------------------------
   // Import
   // -------------------------------------------------------------------------

--- a/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
+++ b/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
@@ -10,6 +10,17 @@ import 'package:submersion/features/import_wizard/domain/models/unified_import_r
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 
 // ============================================================================
+// Public value types
+// ============================================================================
+
+/// A (type, index) pair identifying a pending-review row.
+class PendingLocation {
+  const PendingLocation({required this.type, required this.index});
+  final ImportEntityType type;
+  final int index;
+}
+
+// ============================================================================
 // State
 // ============================================================================
 
@@ -412,6 +423,22 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
       selections: {...state.selections, type: currentSelection},
       pendingDuplicateReview: updatedPending,
     );
+  }
+
+  /// Location of the first pending-review row across all entity tabs in
+  /// [ImportEntityType.values] enum order. Returns the smallest index within
+  /// the first non-empty pending set. Returns null if no pending rows exist.
+  ///
+  /// Used by the review step UI to jump the user to the first row that
+  /// still needs a decision when the Import button is gated.
+  PendingLocation? firstPendingLocation() {
+    for (final type in ImportEntityType.values) {
+      final pending = state.pendingFor(type);
+      if (pending.isEmpty) continue;
+      final sorted = pending.toList()..sort();
+      return PendingLocation(type: type, index: sorted.first);
+    }
+    return null;
   }
 
   // -------------------------------------------------------------------------

--- a/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
+++ b/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
@@ -166,52 +166,41 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
   // setBundle
   // -------------------------------------------------------------------------
 
-  /// Store [bundle] and initialize selections and duplicate actions.
+  /// Store [bundle] and initialize selections and pending-review state.
   ///
   /// For each entity group:
   /// - All items are selected except those in [EntityGroup.duplicateIndices].
-  ///
-  /// For dives with [EntityGroup.matchResults]:
-  /// - score >= 0.7 → [DuplicateAction.skip]
-  /// - score >= 0.5 and < 0.7 → [DuplicateAction.importAsNew]
+  /// - Every suspected-duplicate index is recorded in
+  ///   [ImportWizardState.pendingDuplicateReview] so the user must explicitly
+  ///   choose an action before the row gets a recorded resolution.
+  /// - [ImportWizardState.duplicateActions] is left empty — no auto-defaults
+  ///   are written for probable or possible matches. The user drains the
+  ///   pending set via per-row ([setDuplicateAction]) or bulk actions.
   void setBundle(ImportBundle bundle) {
     final selections = <ImportEntityType, Set<int>>{};
-    final duplicateActions = <ImportEntityType, Map<int, DuplicateAction>>{};
+    final pendingReview = <ImportEntityType, Set<int>>{};
 
     for (final entry in bundle.groups.entries) {
       final type = entry.key;
       final group = entry.value;
 
-      // Build initial selection: all indices except duplicates.
       final allIndices = Set<int>.from(
         List.generate(group.items.length, (i) => i),
       );
       selections[type] = allIndices.difference(group.duplicateIndices);
 
-      // Build duplicate actions from match results.
-      final matchResults = group.matchResults;
-      if (matchResults != null && matchResults.isNotEmpty) {
-        final actionsForType = <int, DuplicateAction>{};
-        for (final matchEntry in matchResults.entries) {
-          final index = matchEntry.key;
-          final result = matchEntry.value;
-          if (result.isProbable) {
-            actionsForType[index] = DuplicateAction.skip;
-          } else if (result.score >= 0.5) {
-            // Possible but not probable — default to import as new.
-            actionsForType[index] = DuplicateAction.importAsNew;
-          }
-        }
-        if (actionsForType.isNotEmpty) {
-          duplicateActions[type] = actionsForType;
-        }
+      if (group.duplicateIndices.isNotEmpty) {
+        pendingReview[type] = Set<int>.from(group.duplicateIndices);
       }
     }
 
     state = state.copyWith(
       bundle: bundle,
       selections: selections,
-      duplicateActions: duplicateActions,
+      // Auto-default duplicateActions removed — pending indices are decided
+      // explicitly by the user via setDuplicateAction or applyBulkAction.
+      duplicateActions: const {},
+      pendingDuplicateReview: pendingReview,
       currentStep: 1,
       clearError: true,
     );

--- a/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
+++ b/lib/features/import_wizard/presentation/providers/import_wizard_providers.dart
@@ -330,6 +330,13 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
     int index,
     DuplicateAction action,
   ) {
+    assert(
+      _adapter.supportedDuplicateActions.contains(action),
+      'DuplicateAction $action is not supported by adapter '
+      '${_adapter.runtimeType}',
+    );
+    if (!_adapter.supportedDuplicateActions.contains(action)) return;
+
     final actionsForType =
         state.duplicateActions[type] ?? const <int, DuplicateAction>{};
     final updatedActions = Map<int, DuplicateAction>.from(actionsForType)
@@ -384,6 +391,13 @@ class ImportWizardNotifier extends StateNotifier<ImportWizardState> {
   /// No-op if the type has no pending indices or (for consolidate) no
   /// probable matches.
   void applyBulkAction(ImportEntityType type, DuplicateAction action) {
+    assert(
+      _adapter.supportedDuplicateActions.contains(action),
+      'DuplicateAction $action is not supported by adapter '
+      '${_adapter.runtimeType}',
+    );
+    if (!_adapter.supportedDuplicateActions.contains(action)) return;
+
     final pending = state.pendingFor(type);
     if (pending.isEmpty) return;
 

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -44,8 +44,7 @@ class DuplicateActionCard extends StatefulWidget {
   /// Whether this duplicate still needs an explicit user decision.
   ///
   /// When `true`, the card is rendered in a warning visual state: a 4-px
-  /// warning-colored border, a [NeedsDecisionPill] in the header, and the
-  /// collapsed expand control is labelled "Decide".
+  /// warning-colored border and a [NeedsDecisionPill] in the header.
   final bool isPending;
 
   const DuplicateActionCard({
@@ -264,20 +263,9 @@ class _CollapsedHeader extends StatelessWidget {
             if (selectedAction != null) ...[
               const SizedBox(width: 6),
               _ActionBadge(action: selectedAction!),
-              const SizedBox(width: 4),
             ],
-            // "Decide" label — only shown when pending and collapsed.
-            if (isPending && !expanded) ...[
-              Text(
-                context.l10n.universalImport_dive_decideAction,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: colorScheme.tertiary,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(width: 4),
-            ],
-            // Expand/collapse chevron
+            // Breathing room before the expand/collapse chevron.
+            const SizedBox(width: 12),
             Icon(
               expanded ? Icons.expand_less : Icons.expand_more,
               size: 20,

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -6,7 +6,6 @@ import 'package:submersion/features/dive_import/domain/services/dive_matcher.dar
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
 import 'package:submersion/features/import_wizard/presentation/widgets/needs_decision_pill.dart';
-import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A collapsed/expandable card summarising one duplicate item.
 ///

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -82,7 +82,7 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
     };
 
     final BorderSide borderSide = widget.isPending
-        ? BorderSide(color: colorScheme.tertiary, width: 4)
+        ? BorderSide(color: colorScheme.tertiary, width: 1.5)
         : BorderSide(color: borderColor, width: 1.5);
 
     return Card(

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -42,7 +42,7 @@ class DuplicateActionCard extends StatefulWidget {
 
   /// Whether this duplicate still needs an explicit user decision.
   ///
-  /// When `true`, the card is rendered in a warning visual state: a 4-px
+  /// When `true`, the card is rendered in a warning visual state: a 1.5-px
   /// warning-colored border and a [NeedsDecisionPill] in the header.
   final bool isPending;
 

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -5,6 +5,8 @@ import 'package:submersion/core/presentation/widgets/dive_sparkline.dart';
 import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/needs_decision_pill.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A collapsed/expandable card summarising one duplicate item.
 ///
@@ -35,6 +37,13 @@ class DuplicateActionCard extends StatefulWidget {
   /// Only shown when [selectedAction] is [DuplicateAction.importAsNew].
   final int? projectedDiveNumber;
 
+  /// Whether this duplicate still needs an explicit user decision.
+  ///
+  /// When `true`, the card is rendered in a warning visual state: a 4-px
+  /// warning-colored border, a [NeedsDecisionPill] in the header, and the
+  /// collapsed expand control is labelled "Decide".
+  final bool isPending;
+
   const DuplicateActionCard({
     super.key,
     required this.item,
@@ -44,6 +53,7 @@ class DuplicateActionCard extends StatefulWidget {
     required this.onActionChanged,
     required this.existingDiveId,
     this.projectedDiveNumber,
+    this.isPending = false,
   });
 
   @override
@@ -65,11 +75,15 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
       DuplicateAction.skip => score >= 0.7 ? colorScheme.error : Colors.orange,
     };
 
+    final BorderSide borderSide = widget.isPending
+        ? BorderSide(color: colorScheme.tertiary, width: 4)
+        : BorderSide(color: borderColor, width: 1.5);
+
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 4),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(color: borderColor, width: 1.5),
+        side: borderSide,
       ),
       clipBehavior: Clip.antiAlias,
       child: Column(
@@ -80,6 +94,7 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
             matchResult: widget.matchResult,
             selectedAction: widget.selectedAction,
             expanded: _expanded,
+            isPending: widget.isPending,
             onToggle: () => setState(() => _expanded = !_expanded),
             projectedDiveNumber:
                 widget.selectedAction == DuplicateAction.importAsNew
@@ -124,6 +139,7 @@ class _CollapsedHeader extends StatelessWidget {
   final DiveMatchResult matchResult;
   final DuplicateAction selectedAction;
   final bool expanded;
+  final bool isPending;
   final VoidCallback onToggle;
   final int? projectedDiveNumber;
 
@@ -133,6 +149,7 @@ class _CollapsedHeader extends StatelessWidget {
     required this.selectedAction,
     required this.expanded,
     required this.onToggle,
+    this.isPending = false,
     this.projectedDiveNumber,
   });
 
@@ -226,10 +243,26 @@ class _CollapsedHeader extends StatelessWidget {
                 ),
               ),
             ),
+            // Needs-decision pill — only shown when this row is pending.
+            if (isPending) ...[
+              const SizedBox(width: 8),
+              NeedsDecisionPill(colorScheme: colorScheme),
+            ],
             const SizedBox(width: 6),
             // Action badge
             _ActionBadge(action: selectedAction),
             const SizedBox(width: 4),
+            // "Decide" label — only shown when pending and collapsed.
+            if (isPending && !expanded) ...[
+              Text(
+                context.l10n.universalImport_dive_decideAction,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: colorScheme.tertiary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(width: 4),
+            ],
             // Expand/collapse chevron
             Icon(
               expanded ? Icons.expand_less : Icons.expand_more,

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -21,7 +21,11 @@ class DuplicateActionCard extends StatefulWidget {
   final DiveMatchResult matchResult;
 
   /// The currently selected action for this item.
-  final DuplicateAction selectedAction;
+  ///
+  /// `null` when the user has not yet made a decision. In that state the
+  /// card renders without an action badge and the embedded comparison card
+  /// leaves every action button outlined (no button is pre-highlighted).
+  final DuplicateAction? selectedAction;
 
   /// The set of action buttons to show in the expanded comparison card.
   final Set<DuplicateAction> availableActions;
@@ -69,10 +73,14 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
     final colorScheme = theme.colorScheme;
     final score = widget.matchResult.score;
 
+    // Fallback-free border colour for non-pending rows. Pending rows always
+    // override with the tertiary warning border below, so the fallback used
+    // here (when [selectedAction] is null) is only theoretical.
     final borderColor = switch (widget.selectedAction) {
       DuplicateAction.importAsNew => Colors.green,
       DuplicateAction.consolidate => colorScheme.primary,
       DuplicateAction.skip => score >= 0.7 ? colorScheme.error : Colors.orange,
+      null => colorScheme.tertiary,
     };
 
     final BorderSide borderSide = widget.isPending
@@ -130,6 +138,7 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
       selectedAction: widget.selectedAction,
       onActionChanged: widget.onActionChanged,
       availableActions: widget.availableActions,
+      isPending: widget.isPending,
     );
   }
 }
@@ -137,7 +146,10 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
 class _CollapsedHeader extends StatelessWidget {
   final EntityItem item;
   final DiveMatchResult matchResult;
-  final DuplicateAction selectedAction;
+
+  /// The action chosen for this row, or `null` when the user has not yet
+  /// decided. Null suppresses the trailing [_ActionBadge].
+  final DuplicateAction? selectedAction;
   final bool expanded;
   final bool isPending;
   final VoidCallback onToggle;
@@ -248,10 +260,12 @@ class _CollapsedHeader extends StatelessWidget {
               const SizedBox(width: 8),
               NeedsDecisionPill(colorScheme: colorScheme),
             ],
-            const SizedBox(width: 6),
-            // Action badge
-            _ActionBadge(action: selectedAction),
-            const SizedBox(width: 4),
+            // Action badge — suppressed when no decision has been made yet.
+            if (selectedAction != null) ...[
+              const SizedBox(width: 6),
+              _ActionBadge(action: selectedAction!),
+              const SizedBox(width: 4),
+            ],
             // "Decide" label — only shown when pending and collapsed.
             if (isPending && !expanded) ...[
               Text(

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -193,11 +193,11 @@ class EntityReviewList extends StatelessWidget {
   Widget _buildDuplicateCard(int index) {
     final item = group.items[index];
     final matchResult = group.matchResults![index]!;
-    final action =
-        duplicateActions[index] ??
-        (matchResult.isProbable
-            ? DuplicateAction.skip
-            : DuplicateAction.importAsNew);
+    // Pass the user's chosen action verbatim — including `null`, which means
+    // the user has not yet decided. Falling back to a default here would
+    // contradict the "Needs decision" pending state and pre-highlight a
+    // button the user did not pick.
+    final action = duplicateActions[index];
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -271,7 +271,9 @@ class EntityReviewList extends StatelessWidget {
 
   Widget _buildEntityDuplicateCard(int index) {
     final item = group.items[index];
-    final action = duplicateActions[index] ?? DuplicateAction.skip;
+    // Pass the user's chosen action verbatim — `null` means "not yet decided"
+    // and is rendered as a pending row with no pre-selected button.
+    final action = duplicateActions[index];
     final entityMatch = group.entityMatches?[index];
 
     return _EntityDuplicateCard(
@@ -451,7 +453,11 @@ class _NonDuplicateRow extends StatelessWidget {
 class _EntityDuplicateCard extends StatefulWidget {
   final EntityItem item;
   final EntityMatchResult? entityMatch;
-  final DuplicateAction selectedAction;
+
+  /// The action chosen for this row, or `null` when the user has not yet
+  /// decided. Null suppresses the action badge in the collapsed header and
+  /// leaves both action buttons outlined in the expanded panel.
+  final DuplicateAction? selectedAction;
   final ValueChanged<DuplicateAction> onActionChanged;
 
   /// Whether this row still needs an explicit user decision.
@@ -481,7 +487,19 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
     final colorScheme = theme.colorScheme;
 
     final isImporting = widget.selectedAction == DuplicateAction.importAsNew;
-    final borderColor = isImporting ? Colors.green : colorScheme.error;
+    // When [selectedAction] is null (row pending a decision) we fall back to
+    // the tertiary warning colour so the 1.5-px border reads as "undecided"
+    // rather than implying a skip. Pending rows override with a 4-px border
+    // anyway, so this fallback only matters for the rare non-pending-null
+    // case.
+    final Color borderColor;
+    if (widget.selectedAction == null) {
+      borderColor = colorScheme.tertiary;
+    } else if (isImporting) {
+      borderColor = Colors.green;
+    } else {
+      borderColor = colorScheme.error;
+    }
 
     final BorderSide borderSide = widget.isPending
         ? BorderSide(color: colorScheme.tertiary, width: 4)
@@ -507,6 +525,8 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
               onTap: widget.entityMatch != null
                   ? () => setState(() => _expanded = !_expanded)
                   : () => widget.onActionChanged(
+                      // First tap on an undecided row (null) defaults to
+                      // importAsNew; otherwise toggle between the two states.
                       isImporting
                           ? DuplicateAction.skip
                           : DuplicateAction.importAsNew,
@@ -555,9 +575,11 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
                       const SizedBox(width: 8),
                       NeedsDecisionPill(colorScheme: colorScheme),
                     ],
-                    const SizedBox(width: 8),
-                    // Action badge
-                    _SimpleActionBadge(isImporting: isImporting),
+                    // Action badge — suppressed when no decision has been made.
+                    if (widget.selectedAction != null) ...[
+                      const SizedBox(width: 8),
+                      _SimpleActionBadge(isImporting: isImporting),
+                    ],
                     // Expand/collapse chevron (only when comparison data exists)
                     if (widget.entityMatch != null) ...[
                       const SizedBox(width: 4),
@@ -577,6 +599,7 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
                 entityMatch: widget.entityMatch!,
                 selectedAction: widget.selectedAction,
                 onActionChanged: widget.onActionChanged,
+                isPending: widget.isPending,
               ),
           ],
         ),
@@ -588,13 +611,23 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
 /// The expanded comparison panel showing existing vs incoming fields.
 class _EntityComparisonPanel extends StatelessWidget {
   final EntityMatchResult entityMatch;
-  final DuplicateAction selectedAction;
+
+  /// The currently selected action, or `null` when the row is still pending a
+  /// decision. Null leaves both action buttons outlined (no pre-highlight).
+  final DuplicateAction? selectedAction;
   final ValueChanged<DuplicateAction> onActionChanged;
+
+  /// Whether the enclosing row still needs an explicit user decision.
+  ///
+  /// When `true` AND [selectedAction] is `null`, a "Choose an action" label
+  /// is rendered above the action-button row.
+  final bool isPending;
 
   const _EntityComparisonPanel({
     required this.entityMatch,
     required this.selectedAction,
     required this.onActionChanged,
+    this.isPending = false,
   });
 
   @override
@@ -607,6 +640,8 @@ class _EntityComparisonPanel extends StatelessWidget {
       ...entityMatch.existingFields.keys,
       ...entityMatch.incomingFields.keys,
     };
+
+    final showChooseLabel = isPending && selectedAction == null;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -651,24 +686,42 @@ class _EntityComparisonPanel extends StatelessWidget {
         // Action buttons — match dive card style
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Wrap(
-            alignment: WrapAlignment.start,
-            spacing: 8,
-            runSpacing: 4,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
             children: [
-              _EntityActionButton(
-                label: 'Skip',
-                subtitle: 'Discard this import',
-                isSelected: selectedAction == DuplicateAction.skip,
-                color: colorScheme.error,
-                onPressed: () => onActionChanged(DuplicateAction.skip),
-              ),
-              _EntityActionButton(
-                label: 'Import as New',
-                subtitle: 'Create separate entry',
-                isSelected: selectedAction == DuplicateAction.importAsNew,
-                color: Colors.green.shade700,
-                onPressed: () => onActionChanged(DuplicateAction.importAsNew),
+              if (showChooseLabel)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    'Choose an action',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: colorScheme.tertiary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              Wrap(
+                alignment: WrapAlignment.start,
+                spacing: 8,
+                runSpacing: 4,
+                children: [
+                  _EntityActionButton(
+                    label: 'Skip',
+                    subtitle: 'Discard this import',
+                    isSelected: selectedAction == DuplicateAction.skip,
+                    color: colorScheme.error,
+                    onPressed: () => onActionChanged(DuplicateAction.skip),
+                  ),
+                  _EntityActionButton(
+                    label: 'Import as New',
+                    subtitle: 'Create separate entry',
+                    isSelected: selectedAction == DuplicateAction.importAsNew,
+                    color: Colors.green.shade700,
+                    onPressed: () =>
+                        onActionChanged(DuplicateAction.importAsNew),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -465,7 +465,7 @@ class _EntityDuplicateCard extends StatefulWidget {
 
   /// Whether this row still needs an explicit user decision.
   ///
-  /// When true the card renders a warning-colored 4-px border and a
+  /// When true the card renders a warning-colored 1.5-px border and a
   /// [NeedsDecisionPill] in its header.
   final bool isPending;
 
@@ -491,10 +491,9 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
 
     final isImporting = widget.selectedAction == DuplicateAction.importAsNew;
     // When [selectedAction] is null (row pending a decision) we fall back to
-    // the tertiary warning colour so the 1.5-px border reads as "undecided"
-    // rather than implying a skip. Pending rows override with a 4-px border
-    // anyway, so this fallback only matters for the rare non-pending-null
-    // case.
+    // the tertiary warning colour so the border reads as "undecided" rather
+    // than implying a skip. The pending branch below also uses tertiary, so
+    // this fallback only matters for the rare non-pending-null case.
     final Color borderColor;
     if (widget.selectedAction == null) {
       borderColor = colorScheme.tertiary;

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -5,6 +5,8 @@ import 'package:submersion/features/import_wizard/domain/models/duplicate_action
 import 'package:submersion/features/import_wizard/domain/models/entity_match_result.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
 import 'package:submersion/features/import_wizard/presentation/widgets/duplicate_action_card.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/needs_decision_pill.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A scrollable review list for a single entity type.
 ///
@@ -26,12 +28,22 @@ class EntityReviewList extends StatelessWidget {
   /// Which action buttons to show inside each [DuplicateActionCard].
   final Set<DuplicateAction> availableActions;
 
+  /// Indices of duplicate items still awaiting an explicit user decision.
+  ///
+  /// Drives pending-first sorting inside each duplicate section, visual
+  /// pending state on the duplicate cards, and the visibility of the bulk
+  /// action row.
+  final Set<int> pendingIndices;
+
   /// Called when the user toggles a non-duplicate item's checkbox.
   final ValueChanged<int> onToggleSelection;
 
   /// Called when the user changes the action for a duplicate item.
   final void Function(int index, DuplicateAction action)
   onDuplicateActionChanged;
+
+  /// Called when the user taps a bulk action button.
+  final void Function(DuplicateAction action) onBulkAction;
 
   /// Called when the user taps "Select All".
   final VoidCallback onSelectAll;
@@ -54,13 +66,17 @@ class EntityReviewList extends StatelessWidget {
     required this.selectedIndices,
     required this.duplicateActions,
     required this.availableActions,
+    this.pendingIndices = const {},
     required this.onToggleSelection,
     required this.onDuplicateActionChanged,
+    this.onBulkAction = _noopBulkAction,
     required this.onSelectAll,
     required this.onDeselectAll,
     required this.existingDiveIdForIndex,
     this.projectedDiveNumbers,
   });
+
+  static void _noopBulkAction(DuplicateAction _) {}
 
   @override
   Widget build(BuildContext context) {
@@ -119,6 +135,16 @@ class EntityReviewList extends StatelessWidget {
             ],
           ),
         ),
+
+        // Bulk action row (only when there are pending duplicates).
+        if (pendingIndices.isNotEmpty)
+          _BulkActionRow(
+            isDiveTab: _isDiveTab(),
+            pendingCount: pendingIndices.length,
+            matchableConsolidateCount: _matchableConsolidateCount(),
+            availableActions: availableActions,
+            onBulkAction: onBulkAction,
+          ),
 
         // Non-duplicate items
         if (nonDuplicateIndices.isNotEmpty) ...[
@@ -183,6 +209,7 @@ class EntityReviewList extends StatelessWidget {
         onActionChanged: (a) => onDuplicateActionChanged(index, a),
         existingDiveId: existingDiveIdForIndex(index),
         projectedDiveNumber: projectedDiveNumbers?[index],
+        isPending: pendingIndices.contains(index),
       ),
     );
   }
@@ -194,41 +221,52 @@ class EntityReviewList extends StatelessWidget {
     ];
   }
 
-  /// Returns duplicate indices filtered by score range, sorted descending by
-  /// score.
+  /// Returns duplicate indices filtered by score range.
+  ///
+  /// Pending-review indices are emitted first (preserving their
+  /// enumeration order from [group.duplicateIndices]). The remaining
+  /// non-pending indices are then sorted descending by match score.
   List<int> _sortedDuplicateIndices({
     required double minScore,
     double maxScore = double.infinity,
   }) {
     final matchResults = group.matchResults;
-    if (matchResults == null) return [];
+    if (matchResults == null) return const [];
 
-    final indices = <int>[];
+    final all = <int>[];
     for (final index in group.duplicateIndices) {
       final result = matchResults[index];
       if (result == null) continue;
       if (result.score >= minScore && result.score < maxScore) {
-        indices.add(index);
+        all.add(index);
       }
     }
 
-    indices.sort((a, b) {
+    final pendingFirst = all.where(pendingIndices.contains).toList();
+    final rest = all.where((i) => !pendingIndices.contains(i)).toList();
+    rest.sort((a, b) {
       final scoreA = matchResults[a]?.score ?? 0;
       final scoreB = matchResults[b]?.score ?? 0;
       return scoreB.compareTo(scoreA);
     });
 
-    return indices;
+    return [...pendingFirst, ...rest];
   }
 
   /// Returns duplicate indices that have no match score (non-dive entities).
+  ///
+  /// Pending-review indices are emitted first, in ascending index order; the
+  /// remaining non-pending indices follow in ascending index order.
   List<int> _unscoredDuplicateIndices() {
     final matchResults = group.matchResults;
     if (matchResults != null) {
       // Entities with matchResults are handled by _sortedDuplicateIndices.
-      return [];
+      return const [];
     }
-    return group.duplicateIndices.toList()..sort();
+    final sorted = group.duplicateIndices.toList()..sort();
+    final pendingFirst = sorted.where(pendingIndices.contains).toList();
+    final rest = sorted.where((i) => !pendingIndices.contains(i)).toList();
+    return [...pendingFirst, ...rest];
   }
 
   Widget _buildEntityDuplicateCard(int index) {
@@ -241,7 +279,27 @@ class EntityReviewList extends StatelessWidget {
       entityMatch: entityMatch,
       selectedAction: action,
       onActionChanged: (a) => onDuplicateActionChanged(index, a),
+      isPending: pendingIndices.contains(index),
     );
+  }
+
+  /// Whether this group represents the dive tab.
+  ///
+  /// A group is a "dive tab" if at least one item carries dive data. This
+  /// controls the bulk-action label variant (Import all as new vs Import all).
+  bool _isDiveTab() {
+    if (group.items.isEmpty) return false;
+    return group.items.any((item) => item.diveData != null);
+  }
+
+  /// Number of pending rows whose match score is high enough (>= 0.7) to
+  /// qualify for bulk consolidation.
+  int _matchableConsolidateCount() {
+    final matchResults = group.matchResults;
+    if (matchResults == null) return 0;
+    return pendingIndices
+        .where((i) => (matchResults[i]?.score ?? 0) >= 0.7)
+        .length;
   }
 
   String _itemCountText(int nonDuplicates, int duplicates, int selectedCount) {
@@ -396,11 +454,18 @@ class _EntityDuplicateCard extends StatefulWidget {
   final DuplicateAction selectedAction;
   final ValueChanged<DuplicateAction> onActionChanged;
 
+  /// Whether this row still needs an explicit user decision.
+  ///
+  /// When true the card renders a warning-colored 4-px border and a
+  /// [NeedsDecisionPill] in its header.
+  final bool isPending;
+
   const _EntityDuplicateCard({
     required this.item,
     required this.entityMatch,
     required this.selectedAction,
     required this.onActionChanged,
+    this.isPending = false,
   });
 
   @override
@@ -418,13 +483,17 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
     final isImporting = widget.selectedAction == DuplicateAction.importAsNew;
     final borderColor = isImporting ? Colors.green : colorScheme.error;
 
+    final BorderSide borderSide = widget.isPending
+        ? BorderSide(color: colorScheme.tertiary, width: 4)
+        : BorderSide(color: borderColor, width: 1.5);
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
       child: Card(
         margin: EdgeInsets.zero,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: borderColor, width: 1.5),
+          side: borderSide,
         ),
         clipBehavior: Clip.antiAlias,
         child: Column(
@@ -481,6 +550,11 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
                         ],
                       ),
                     ),
+                    // Needs-decision pill — only shown when this row is pending.
+                    if (widget.isPending) ...[
+                      const SizedBox(width: 8),
+                      NeedsDecisionPill(colorScheme: colorScheme),
+                    ],
                     const SizedBox(width: 8),
                     // Action badge
                     _SimpleActionBadge(isImporting: isImporting),
@@ -787,6 +861,72 @@ class _SectionLabel extends StatelessWidget {
           fontWeight: FontWeight.w700,
           letterSpacing: 0.5,
         ),
+      ),
+    );
+  }
+}
+
+/// Horizontal row of bulk-action buttons rendered above the duplicate list.
+///
+/// Visible only when at least one row is pending. The set of buttons is
+/// filtered by [availableActions] so adapters that don't support certain
+/// actions simply don't render the corresponding button.
+class _BulkActionRow extends StatelessWidget {
+  final bool isDiveTab;
+  final int pendingCount;
+  final int matchableConsolidateCount;
+  final Set<DuplicateAction> availableActions;
+  final void Function(DuplicateAction) onBulkAction;
+
+  const _BulkActionRow({
+    required this.isDiveTab,
+    required this.pendingCount,
+    required this.matchableConsolidateCount,
+    required this.availableActions,
+    required this.onBulkAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 4,
+        children: [
+          if (availableActions.contains(DuplicateAction.skip))
+            OutlinedButton.icon(
+              onPressed: () => onBulkAction(DuplicateAction.skip),
+              icon: const Icon(Icons.block, size: 16),
+              label: Text(
+                context.l10n.universalImport_bulk_skipAll(pendingCount),
+              ),
+            ),
+          if (availableActions.contains(DuplicateAction.importAsNew))
+            OutlinedButton.icon(
+              onPressed: () => onBulkAction(DuplicateAction.importAsNew),
+              icon: const Icon(Icons.add_circle_outline, size: 16),
+              label: Text(
+                isDiveTab
+                    ? context.l10n.universalImport_bulk_importAllAsNew(
+                        pendingCount,
+                      )
+                    : context.l10n.universalImport_bulk_importAll(pendingCount),
+              ),
+            ),
+          if (availableActions.contains(DuplicateAction.consolidate))
+            OutlinedButton.icon(
+              onPressed: matchableConsolidateCount > 0
+                  ? () => onBulkAction(DuplicateAction.consolidate)
+                  : null,
+              icon: const Icon(Icons.merge_type, size: 16),
+              label: Text(
+                context.l10n.universalImport_bulk_consolidateMatched(
+                  matchableConsolidateCount,
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -697,7 +697,7 @@ class _EntityComparisonPanel extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 8),
                   child: Text(
-                    'Choose an action',
+                    context.l10n.universalImport_pending_chooseAction,
                     style: theme.textTheme.titleSmall?.copyWith(
                       color: colorScheme.tertiary,
                       fontWeight: FontWeight.w700,

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -505,7 +505,7 @@ class _EntityDuplicateCardState extends State<_EntityDuplicateCard> {
     }
 
     final BorderSide borderSide = widget.isPending
-        ? BorderSide(color: colorScheme.tertiary, width: 4)
+        ? BorderSide(color: colorScheme.tertiary, width: 1.5)
         : BorderSide(color: borderColor, width: 1.5);
 
     return Padding(

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -13,8 +13,9 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// Displays non-duplicate items as selectable checkboxes and duplicate items
 /// as [DuplicateActionCard] widgets for per-item action selection.
 ///
-/// Order: non-duplicates first, then likely duplicates (score >= 0.7),
-/// then possible duplicates (score >= 0.5).
+/// Order: likely duplicates (score >= 0.7), then possible duplicates
+/// (score >= 0.5), then non-duplicates. Duplicates appear first so rows
+/// needing a user decision aren't buried beneath clean imports.
 class EntityReviewList extends StatelessWidget {
   /// The entity group containing items, duplicate indices, and match results.
   final EntityGroup group;
@@ -146,19 +147,8 @@ class EntityReviewList extends StatelessWidget {
             onBulkAction: onBulkAction,
           ),
 
-        // Non-duplicate items
-        if (nonDuplicateIndices.isNotEmpty) ...[
-          for (final index in nonDuplicateIndices)
-            _NonDuplicateRow(
-              item: group.items[index],
-              index: index,
-              isSelected: selectedIndices.contains(index),
-              onToggle: () => onToggleSelection(index),
-              projectedDiveNumber: projectedDiveNumbers?[index],
-            ),
-        ],
-
-        // Scored duplicates (dives with matchResults)
+        // Scored duplicates (dives with matchResults) appear first so rows
+        // that need user attention are at the top of the tab.
         if (likelyDuplicateIndices.isNotEmpty) ...[
           _SectionLabel(
             label: 'Potential Duplicates',
@@ -185,6 +175,19 @@ class EntityReviewList extends StatelessWidget {
           ),
           for (final index in _unscoredDuplicateIndices())
             _buildEntityDuplicateCard(index),
+        ],
+
+        // Non-duplicate items (no conflicts — listed after duplicates so the
+        // rows requiring decisions aren't buried beneath clean imports).
+        if (nonDuplicateIndices.isNotEmpty) ...[
+          for (final index in nonDuplicateIndices)
+            _NonDuplicateRow(
+              item: group.items[index],
+              index: index,
+              isSelected: selectedIndices.contains(index),
+              onToggle: () => onToggleSelection(index),
+              projectedDiveNumber: projectedDiveNumbers?[index],
+            ),
         ],
       ],
     );

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -968,10 +968,9 @@ class _BulkActionRow extends StatelessWidget {
               ),
             ),
           if (availableActions.contains(DuplicateAction.consolidate))
+            // TODO(#200): enable when bulk-consolidate is implemented end-to-end.
             OutlinedButton.icon(
-              onPressed: matchableConsolidateCount > 0
-                  ? () => onBulkAction(DuplicateAction.consolidate)
-                  : null,
+              onPressed: null,
               icon: const Icon(Icons.merge_type, size: 16),
               label: Text(
                 context.l10n.universalImport_bulk_consolidateMatched(

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -862,7 +862,11 @@ class _EntityActionButton extends StatelessWidget {
 
     return OutlinedButton(
       onPressed: onPressed,
-      style: OutlinedButton.styleFrom(minimumSize: minSize),
+      style: OutlinedButton.styleFrom(
+        minimumSize: minSize,
+        foregroundColor: color,
+        side: BorderSide(color: color, width: 2.5),
+      ),
       child: child,
     );
   }

--- a/lib/features/import_wizard/presentation/widgets/import_tags_field.dart
+++ b/lib/features/import_wizard/presentation/widgets/import_tags_field.dart
@@ -100,107 +100,102 @@ class _ImportTagsFieldState extends State<ImportTagsField> {
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
+      child: RawAutocomplete<Tag>(
+        textEditingController: _textController,
+        focusNode: _focusNode,
+        optionsBuilder: (textEditingValue) {
+          return _filteredSuggestions(textEditingValue.text);
+        },
+        onSelected: (tag) {
+          widget.onAdd(TagSelection(existingTagId: tag.id, name: tag.name));
+          _textController.clear();
+        },
+        fieldViewBuilder: (context, controller, focusNode, onSubmitted) {
+          return Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
             children: [
-              Icon(Icons.label_outline, size: 18, color: colorScheme.primary),
-              const SizedBox(width: 8),
-              Text(
-                l10n.importWizard_tagsLabel,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          RawAutocomplete<Tag>(
-            textEditingController: _textController,
-            focusNode: _focusNode,
-            optionsBuilder: (textEditingValue) {
-              return _filteredSuggestions(textEditingValue.text);
-            },
-            onSelected: (tag) {
-              widget.onAdd(TagSelection(existingTagId: tag.id, name: tag.name));
-              _textController.clear();
-            },
-            fieldViewBuilder: (context, controller, focusNode, onSubmitted) {
-              return Wrap(
-                spacing: 6,
-                runSpacing: 4,
+              // Icon + label as one atomic cell so they stay together when
+              // the row wraps. Lives inline with the chips so the whole
+              // field fits on one line when space permits.
+              Row(
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  for (var i = 0; i < widget.tags.length; i++)
-                    () {
-                      final tagColor = _resolveColor(widget.tags[i]);
-                      return Chip(
-                        label: Text(widget.tags[i].name),
-                        backgroundColor: tagColor.withValues(alpha: 0.2),
-                        side: BorderSide(color: tagColor),
-                        labelStyle: TextStyle(color: tagColor),
-                        deleteIcon: Icon(
-                          Icons.close,
-                          size: 18,
-                          color: tagColor,
-                        ),
-                        onDeleted: () => widget.onRemove(i),
-                        visualDensity: VisualDensity.compact,
-                      );
-                    }(),
-                  IntrinsicWidth(
-                    child: TextField(
-                      controller: controller,
-                      focusNode: focusNode,
-                      decoration: InputDecoration(
-                        hintText: widget.tags.isEmpty
-                            ? l10n.tags_hint_addTags
-                            : l10n.tags_hint_addMoreTags,
-                        border: InputBorder.none,
-                        isDense: true,
-                        contentPadding: const EdgeInsets.symmetric(vertical: 8),
-                      ),
-                      onSubmitted: (text) {
-                        _submitTag(text);
-                        onSubmitted();
-                      },
+                  Icon(
+                    Icons.label_outline,
+                    size: 18,
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    l10n.importWizard_tagsLabel,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
                     ),
                   ),
                 ],
-              );
-            },
-            optionsViewBuilder: (context, onSelected, options) {
-              return Align(
-                alignment: Alignment.topLeft,
-                child: Material(
-                  elevation: 4,
-                  borderRadius: BorderRadius.circular(8),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: ListView.builder(
-                      padding: EdgeInsets.zero,
-                      shrinkWrap: true,
-                      itemCount: options.length,
-                      itemBuilder: (context, index) {
-                        final tag = options.elementAt(index);
-                        return ListTile(
-                          dense: true,
-                          leading: Icon(
-                            Icons.label,
-                            color: tag.color,
-                            size: 20,
-                          ),
-                          title: Text(tag.name),
-                          onTap: () => onSelected(tag),
-                        );
-                      },
-                    ),
+              ),
+              for (var i = 0; i < widget.tags.length; i++)
+                () {
+                  final tagColor = _resolveColor(widget.tags[i]);
+                  return Chip(
+                    label: Text(widget.tags[i].name),
+                    backgroundColor: tagColor.withValues(alpha: 0.2),
+                    side: BorderSide(color: tagColor),
+                    labelStyle: TextStyle(color: tagColor),
+                    deleteIcon: Icon(Icons.close, size: 18, color: tagColor),
+                    onDeleted: () => widget.onRemove(i),
+                    visualDensity: VisualDensity.compact,
+                  );
+                }(),
+              IntrinsicWidth(
+                child: TextField(
+                  controller: controller,
+                  focusNode: focusNode,
+                  decoration: InputDecoration(
+                    hintText: widget.tags.isEmpty
+                        ? l10n.tags_hint_addTags
+                        : l10n.tags_hint_addMoreTags,
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 8),
                   ),
+                  onSubmitted: (text) {
+                    _submitTag(text);
+                    onSubmitted();
+                  },
                 ),
-              );
-            },
-          ),
-        ],
+              ),
+            ],
+          );
+        },
+        optionsViewBuilder: (context, onSelected, options) {
+          return Align(
+            alignment: Alignment.topLeft,
+            child: Material(
+              elevation: 4,
+              borderRadius: BorderRadius.circular(8),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 200),
+                child: ListView.builder(
+                  padding: EdgeInsets.zero,
+                  shrinkWrap: true,
+                  itemCount: options.length,
+                  itemBuilder: (context, index) {
+                    final tag = options.elementAt(index);
+                    return ListTile(
+                      dense: true,
+                      leading: Icon(Icons.label, color: tag.color, size: 20),
+                      title: Text(tag.name),
+                      onTap: () => onSelected(tag),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart
+++ b/lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Pill indicating a row is a suspected duplicate that still needs an
+/// explicit user decision before the import can proceed.
+///
+/// Used by the review step's duplicate card widgets when their `isPending`
+/// flag is true.
+class NeedsDecisionPill extends StatelessWidget {
+  const NeedsDecisionPill({super.key, required this.colorScheme});
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: context.l10n.universalImport_semantics_needsDecision,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: colorScheme.tertiary.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: colorScheme.tertiary, width: 1),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ExcludeSemantics(
+              child: Icon(
+                Icons.warning_amber_rounded,
+                size: 14,
+                color: colorScheme.tertiary,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              context.l10n.universalImport_pending_needsDecision,
+              style: TextStyle(
+                color: colorScheme.tertiary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart
+++ b/lib/features/import_wizard/presentation/widgets/needs_decision_pill.dart
@@ -16,6 +16,7 @@ class NeedsDecisionPill extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: context.l10n.universalImport_semantics_needsDecision,
+      excludeSemantics: true,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         decoration: BoxDecoration(

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -155,6 +155,7 @@ class _MultiTypeLayout extends StatelessWidget {
     return DefaultTabController(
       length: types.length,
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           if (hasDives)
             _RetainDiveNumbersToggle(state: state, notifier: notifier),

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -150,6 +150,8 @@ class _MultiTypeLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final hasDives = bundle.groups.containsKey(ImportEntityType.dives);
 
     return DefaultTabController(
@@ -160,9 +162,24 @@ class _MultiTypeLayout extends StatelessWidget {
           if (hasDives)
             _RetainDiveNumbersToggle(state: state, notifier: notifier),
           TabBar(
+            labelPadding: const EdgeInsets.symmetric(horizontal: 12),
+            indicatorWeight: 3,
+            indicatorSize: TabBarIndicatorSize.label,
+            indicatorColor: colorScheme.primary,
+            labelColor: colorScheme.primary,
+            unselectedLabelColor: colorScheme.onSurfaceVariant,
+            labelStyle: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+            unselectedLabelStyle: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w500,
+            ),
             tabs: [
               for (final type in types)
-                Tab(text: _tabLabel(type, bundle.groups[type]!.items.length)),
+                Tab(
+                  height: 36,
+                  text: _tabLabel(type, bundle.groups[type]!.items.length),
+                ),
             ],
           ),
           if (hasDives)

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -290,9 +290,18 @@ class _EntityTab extends StatelessWidget {
         availableActions: availableActions,
         pendingIndices: state.pendingFor(type),
         onToggleSelection: (i) => notifier.toggleSelection(type, i),
-        onDuplicateActionChanged: (i, a) =>
-            notifier.setDuplicateAction(type, i, a),
-        onBulkAction: (action) => notifier.applyBulkAction(type, action),
+        onDuplicateActionChanged: (i, a) {
+          notifier.setDuplicateAction(type, i, a);
+          _showActionSnackbar(context, 'Marked as ${_actionLabel(a)}');
+        },
+        onBulkAction: (action) {
+          final count = state.pendingFor(type).length;
+          notifier.applyBulkAction(type, action);
+          _showActionSnackbar(
+            context,
+            '$count marked as ${_actionLabel(action)}',
+          );
+        },
         onSelectAll: () => notifier.selectAll(type),
         onDeselectAll: () => notifier.deselectAll(type),
         existingDiveIdForIndex: (i) => group.matchResults?[i]?.diveId ?? '',
@@ -300,6 +309,26 @@ class _EntityTab extends StatelessWidget {
       ),
     );
   }
+}
+
+String _actionLabel(DuplicateAction action) => switch (action) {
+  DuplicateAction.skip => 'Skip',
+  DuplicateAction.importAsNew => 'Import as New',
+  DuplicateAction.consolidate => 'Consolidate',
+};
+
+void _showActionSnackbar(BuildContext context, String message) {
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  if (messenger == null) return;
+  messenger
+    ..hideCurrentSnackBar()
+    ..showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(milliseconds: 1500),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/providers/async_value_extensions.dart';
 import 'package:submersion/features/import_wizard/presentation/widgets/import_tags_field.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The review step of the import wizard.
 ///
@@ -201,7 +202,22 @@ class _MultiTypeLayout extends StatelessWidget {
               ],
             ),
           ),
-          _BottomBar(counts: counts, onImport: onImport, onBack: onBack),
+          Builder(
+            builder: (ctx) => _BottomBar(
+              counts: counts,
+              onImport: onImport,
+              onBack: onBack,
+              hasPendingReviews: state.hasPendingReviews,
+              totalPending: state.totalPending,
+              onReviewPending: () {
+                final loc = notifier.firstPendingLocation();
+                if (loc == null) return;
+                final tabIdx = types.indexOf(loc.type);
+                if (tabIdx < 0) return;
+                DefaultTabController.maybeOf(ctx)?.animateTo(tabIdx);
+              },
+            ),
+          ),
         ],
       ),
     );
@@ -317,8 +333,18 @@ class _BottomBar extends StatelessWidget {
   final _AggregateCounts counts;
   final VoidCallback onImport;
   final VoidCallback? onBack;
+  final bool hasPendingReviews;
+  final int totalPending;
+  final VoidCallback onReviewPending;
 
-  const _BottomBar({required this.counts, required this.onImport, this.onBack});
+  const _BottomBar({
+    required this.counts,
+    required this.onImport,
+    this.onBack,
+    required this.hasPendingReviews,
+    required this.totalPending,
+    required this.onReviewPending,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -339,22 +365,59 @@ class _BottomBar extends StatelessWidget {
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
           children: [
-            if (onBack != null)
-              TextButton(onPressed: onBack, child: const Text('Back')),
-            Expanded(
-              child: Text(
-                countsText,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
+            if (hasPendingReviews) ...[
+              Semantics(
+                liveRegion: true,
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.warning_amber_rounded,
+                      color: theme.colorScheme.tertiary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        context.l10n.universalImport_pending_gateHint(
+                          totalPending,
+                        ),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.tertiary,
+                        ),
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: onReviewPending,
+                      child: Text(
+                        context.l10n.universalImport_pending_reviewAction,
+                      ),
+                    ),
+                  ],
                 ),
-                textAlign: TextAlign.center,
               ),
-            ),
-            FilledButton(
-              onPressed: onImport,
-              child: const Text('Import Selected'),
+              const SizedBox(height: 8),
+            ],
+            Row(
+              children: [
+                if (onBack != null)
+                  TextButton(onPressed: onBack, child: const Text('Back')),
+                Expanded(
+                  child: Text(
+                    countsText,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                FilledButton(
+                  onPressed: hasPendingReviews ? null : onImport,
+                  child: const Text('Import Selected'),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -292,14 +292,22 @@ class _EntityTab extends StatelessWidget {
         onToggleSelection: (i) => notifier.toggleSelection(type, i),
         onDuplicateActionChanged: (i, a) {
           notifier.setDuplicateAction(type, i, a);
-          _showActionSnackbar(context, 'Marked as ${_actionLabel(a)}');
+          _showActionSnackbar(
+            context,
+            context.l10n.universalImport_snackbar_markedAs(
+              _actionLabel(context, a),
+            ),
+          );
         },
         onBulkAction: (action) {
           final count = state.pendingFor(type).length;
           notifier.applyBulkAction(type, action);
           _showActionSnackbar(
             context,
-            '$count marked as ${_actionLabel(action)}',
+            context.l10n.universalImport_snackbar_bulkMarkedAs(
+              count,
+              _actionLabel(context, action),
+            ),
           );
         },
         onSelectAll: () => notifier.selectAll(type),
@@ -311,10 +319,13 @@ class _EntityTab extends StatelessWidget {
   }
 }
 
-String _actionLabel(DuplicateAction action) => switch (action) {
-  DuplicateAction.skip => 'Skip',
-  DuplicateAction.importAsNew => 'Import as New',
-  DuplicateAction.consolidate => 'Consolidate',
+String _actionLabel(
+  BuildContext context,
+  DuplicateAction action,
+) => switch (action) {
+  DuplicateAction.skip => context.l10n.universalImport_label_skip,
+  DuplicateAction.importAsNew => context.l10n.universalImport_label_importAsNew,
+  DuplicateAction.consolidate => context.l10n.universalImport_label_consolidate,
 };
 
 void _showActionSnackbar(BuildContext context, String message) {
@@ -443,7 +454,11 @@ class _BottomBar extends StatelessWidget {
                   ),
                 ),
                 FilledButton(
-                  onPressed: hasPendingReviews ? null : onImport,
+                  onPressed:
+                      (hasPendingReviews ||
+                          (counts.importing + counts.consolidating) == 0)
+                      ? null
+                      : onImport,
                   child: const Text('Import Selected'),
                 ),
               ],

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -272,9 +272,11 @@ class _EntityTab extends StatelessWidget {
         selectedIndices: selectedIndices,
         duplicateActions: duplicateActions,
         availableActions: availableActions,
+        pendingIndices: state.pendingFor(type),
         onToggleSelection: (i) => notifier.toggleSelection(type, i),
         onDuplicateActionChanged: (i, a) =>
             notifier.setDuplicateAction(type, i, a),
+        onBulkAction: (action) => notifier.applyBulkAction(type, action),
         onSelectAll: () => notifier.selectAll(type),
         onDeselectAll: () => notifier.deselectAll(type),
         existingDiveIdForIndex: (i) => group.matchResults?[i]?.diveId ?? '',

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7760,7 +7760,12 @@
   "universalImport_action_selectAll": "Select All",
   "universalImport_action_changeFile": "Change File",
   "universalImport_action_selectFile": "Select File",
+  "universalImport_bulk_consolidateMatched": "Consolidate matched ({count})",
+  "universalImport_bulk_importAll": "Import all ({count})",
+  "universalImport_bulk_importAllAsNew": "Import all as new ({count})",
+  "universalImport_bulk_skipAll": "Skip all ({count})",
   "universalImport_description_supportedFormats": "Select a dive log file to import. Supported formats include CSV, UDDF, Subsurface XML, Garmin FIT, and Shearwater Cloud databases.",
+  "universalImport_dive_decideAction": "Decide",
   "universalImport_error_unsupportedFormat": "This format is not yet supported. Please export as UDDF or CSV.",
   "universalImport_label_columnMapping": "Column Mapping",
   "universalImport_label_columnsMapped": "{mapped} of {total} columns mapped",
@@ -7782,6 +7787,10 @@
   "universalImport_label_unnamed": "Unnamed",
   "universalImport_label_xOfY": "{current} of {total}",
   "universalImport_label_xOfYSelected": "{selected} of {total} selected",
+  "universalImport_pending_gateHint": "{count} duplicate(s) need a decision",
+  "universalImport_pending_needsDecision": "Needs decision",
+  "universalImport_pending_reviewAction": "Review",
+  "universalImport_rowHint_tapCompareToDecide": "Tap Decide to choose",
   "universalImport_semantics_entitySelection": "{selected} of {total} {entityType} selected",
   "universalImport_semantics_importError": "Import error: {error}",
   "universalImport_semantics_importProgress": "Import progress: {percent} percent",
@@ -7795,6 +7804,7 @@
   "universalImport_step_map": "Map",
   "universalImport_step_review": "Review",
   "universalImport_step_select": "Select",
+  "universalImport_summary_decidesRequired": "Each needs a decision before importing.",
   "universalImport_title": "File Import",
   "universalImport_tooltip_closeWizard": "Close import wizard",
   "@universalImport_action_consolidate": {
@@ -7818,8 +7828,43 @@
   "@universalImport_action_selectFile": {
     "description": "Button label for the file picker button"
   },
+  "@universalImport_bulk_consolidateMatched": {
+    "description": "Bulk action button that consolidates all matched pending duplicate dives",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_bulk_importAll": {
+    "description": "Bulk action button that imports all items in the current tab",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_bulk_importAllAsNew": {
+    "description": "Bulk action button that imports all pending duplicate items as new dives",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_bulk_skipAll": {
+    "description": "Bulk action button that skips all items in the current tab",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@universalImport_description_supportedFormats": {
     "description": "Description text on the file selection step listing supported formats"
+  },
+  "@universalImport_dive_decideAction": {
+    "description": "Label on the expansion button for a pending duplicate dive row (replaces 'Compare dives')"
   },
   "@universalImport_error_unsupportedFormat": {
     "description": "Error message shown when the detected file format is not supported"
@@ -7954,6 +7999,23 @@
       }
     }
   },
+  "@universalImport_pending_gateHint": {
+    "description": "Hint text telling the user how many pending duplicates still need a decision before Import can proceed",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_pending_needsDecision": {
+    "description": "Pill/badge shown on a pending duplicate row indicating the user must pick an action"
+  },
+  "@universalImport_pending_reviewAction": {
+    "description": "Action label jumping the user to the pending duplicate that needs review"
+  },
+  "@universalImport_rowHint_tapCompareToDecide": {
+    "description": "Row hint shown under an undecided pending duplicate prompting the user to tap the Decide button"
+  },
   "@universalImport_semantics_entitySelection": {
     "description": "Accessibility label for entity type selection count",
     "placeholders": {
@@ -8042,6 +8104,9 @@
   },
   "@universalImport_step_select": {
     "description": "Step indicator label for the file selection step"
+  },
+  "@universalImport_summary_decidesRequired": {
+    "description": "Addendum to the pending duplicates summary banner clarifying that each needs a decision before import"
   },
   "@universalImport_title": {
     "description": "Title for the universal import wizard page and file selection heading"

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7769,10 +7769,12 @@
   "universalImport_error_unsupportedFormat": "This format is not yet supported. Please export as UDDF or CSV.",
   "universalImport_label_columnMapping": "Column Mapping",
   "universalImport_label_columnsMapped": "{mapped} of {total} columns mapped",
+  "universalImport_label_consolidate": "Consolidate",
   "universalImport_label_detecting": "Detecting...",
   "universalImport_label_diveNumber": "Dive #{number}",
   "universalImport_label_duplicate": "Duplicate",
   "universalImport_label_duplicatesFound": "{count} duplicates found and auto-deselected.",
+  "universalImport_label_importAsNew": "Import as New",
   "universalImport_label_importComplete": "Import Complete",
   "universalImport_label_importing": "Importing",
   "universalImport_label_importingEllipsis": "Importing...",
@@ -7787,6 +7789,7 @@
   "universalImport_label_unnamed": "Unnamed",
   "universalImport_label_xOfY": "{current} of {total}",
   "universalImport_label_xOfYSelected": "{selected} of {total} selected",
+  "universalImport_pending_chooseAction": "Choose an action",
   "universalImport_pending_gateHint": "{count} duplicate(s) need a decision",
   "universalImport_pending_needsDecision": "Needs decision",
   "universalImport_pending_reviewAction": "Review",
@@ -7801,6 +7804,8 @@
   "universalImport_semantics_sourceDetected": "Source detected: {description}",
   "universalImport_semantics_sourceUncertain": "Source uncertain: {description}",
   "universalImport_semantics_toggleSelection": "Toggle selection for {name}",
+  "universalImport_snackbar_bulkMarkedAs": "{count} marked as {action}",
+  "universalImport_snackbar_markedAs": "Marked as {action}",
   "universalImport_step_import": "Import",
   "universalImport_step_map": "Map",
   "universalImport_step_review": "Review",
@@ -7886,6 +7891,9 @@
       }
     }
   },
+  "@universalImport_label_consolidate": {
+    "description": "Short action label meaning the incoming duplicate should be merged into the existing record (used on snackbars and bulk buttons)"
+  },
   "@universalImport_label_detecting": {
     "description": "Button label shown while detecting the file format"
   },
@@ -7909,6 +7917,9 @@
         "example": "3"
       }
     }
+  },
+  "@universalImport_label_importAsNew": {
+    "description": "Short action label meaning the incoming duplicate should be imported as a brand-new entry (used on snackbars and bulk buttons)"
   },
   "@universalImport_label_importComplete": {
     "description": "Headline text shown on the import summary step"
@@ -7999,6 +8010,9 @@
         "example": "5"
       }
     }
+  },
+  "@universalImport_pending_chooseAction": {
+    "description": "Prompt shown above the action buttons on an expanded pending duplicate row, telling the user to pick an action"
   },
   "@universalImport_pending_gateHint": {
     "description": "Hint text telling the user how many pending duplicates still need a decision before Import can proceed",
@@ -8094,6 +8108,27 @@
       "name": {
         "type": "Object",
         "example": "Dive #42"
+      }
+    }
+  },
+  "@universalImport_snackbar_bulkMarkedAs": {
+    "description": "Snackbar shown after a bulk action resolves multiple pending duplicates, confirming the count and action",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "action": {
+        "type": "String",
+        "example": "Skip"
+      }
+    }
+  },
+  "@universalImport_snackbar_markedAs": {
+    "description": "Snackbar shown after a single duplicate is resolved, confirming the chosen action",
+    "placeholders": {
+      "action": {
+        "type": "String",
+        "example": "Import as New"
       }
     }
   },

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7795,6 +7795,7 @@
   "universalImport_semantics_importError": "Import error: {error}",
   "universalImport_semantics_importProgress": "Import progress: {percent} percent",
   "universalImport_semantics_itemsSelected": "{count} items selected for import",
+  "universalImport_semantics_needsDecision": "Suspected duplicate, needs decision",
   "universalImport_semantics_possibleDuplicate": "Possible duplicate",
   "universalImport_semantics_probableDuplicate": "Probable duplicate",
   "universalImport_semantics_sourceDetected": "Source detected: {description}",
@@ -8059,6 +8060,9 @@
         "example": "5"
       }
     }
+  },
+  "@universalImport_semantics_needsDecision": {
+    "description": "Screen reader label for the 'Needs decision' pill on a pending duplicate row"
   },
   "@universalImport_semantics_possibleDuplicate": {
     "description": "Accessibility label for the possible duplicate badge"

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -23883,6 +23883,12 @@ abstract class AppLocalizations {
   /// **'{count} items selected for import'**
   String universalImport_semantics_itemsSelected(Object count);
 
+  /// Screen reader label for the 'Needs decision' pill on a pending duplicate row
+  ///
+  /// In en, this message translates to:
+  /// **'Suspected duplicate, needs decision'**
+  String get universalImport_semantics_needsDecision;
+
   /// Accessibility label for the possible duplicate badge
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -23723,6 +23723,12 @@ abstract class AppLocalizations {
   /// **'{mapped} of {total} columns mapped'**
   String universalImport_label_columnsMapped(Object mapped, Object total);
 
+  /// Short action label meaning the incoming duplicate should be merged into the existing record (used on snackbars and bulk buttons)
+  ///
+  /// In en, this message translates to:
+  /// **'Consolidate'**
+  String get universalImport_label_consolidate;
+
   /// Button label shown while detecting the file format
   ///
   /// In en, this message translates to:
@@ -23746,6 +23752,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count} duplicates found and auto-deselected.'**
   String universalImport_label_duplicatesFound(Object count);
+
+  /// Short action label meaning the incoming duplicate should be imported as a brand-new entry (used on snackbars and bulk buttons)
+  ///
+  /// In en, this message translates to:
+  /// **'Import as New'**
+  String get universalImport_label_importAsNew;
 
   /// Headline text shown on the import summary step
   ///
@@ -23830,6 +23842,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{selected} of {total} selected'**
   String universalImport_label_xOfYSelected(Object selected, Object total);
+
+  /// Prompt shown above the action buttons on an expanded pending duplicate row, telling the user to pick an action
+  ///
+  /// In en, this message translates to:
+  /// **'Choose an action'**
+  String get universalImport_pending_chooseAction;
 
   /// Hint text telling the user how many pending duplicates still need a decision before Import can proceed
   ///
@@ -23918,6 +23936,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Toggle selection for {name}'**
   String universalImport_semantics_toggleSelection(Object name);
+
+  /// Snackbar shown after a bulk action resolves multiple pending duplicates, confirming the count and action
+  ///
+  /// In en, this message translates to:
+  /// **'{count} marked as {action}'**
+  String universalImport_snackbar_bulkMarkedAs(int count, String action);
+
+  /// Snackbar shown after a single duplicate is resolved, confirming the chosen action
+  ///
+  /// In en, this message translates to:
+  /// **'Marked as {action}'**
+  String universalImport_snackbar_markedAs(String action);
 
   /// Step indicator label for the import step
   ///

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -23669,11 +23669,41 @@ abstract class AppLocalizations {
   /// **'Select File'**
   String get universalImport_action_selectFile;
 
+  /// Bulk action button that consolidates all matched pending duplicate dives
+  ///
+  /// In en, this message translates to:
+  /// **'Consolidate matched ({count})'**
+  String universalImport_bulk_consolidateMatched(int count);
+
+  /// Bulk action button that imports all items in the current tab
+  ///
+  /// In en, this message translates to:
+  /// **'Import all ({count})'**
+  String universalImport_bulk_importAll(int count);
+
+  /// Bulk action button that imports all pending duplicate items as new dives
+  ///
+  /// In en, this message translates to:
+  /// **'Import all as new ({count})'**
+  String universalImport_bulk_importAllAsNew(int count);
+
+  /// Bulk action button that skips all items in the current tab
+  ///
+  /// In en, this message translates to:
+  /// **'Skip all ({count})'**
+  String universalImport_bulk_skipAll(int count);
+
   /// Description text on the file selection step listing supported formats
   ///
   /// In en, this message translates to:
   /// **'Select a dive log file to import. Supported formats include CSV, UDDF, Subsurface XML, Garmin FIT, and Shearwater Cloud databases.'**
   String get universalImport_description_supportedFormats;
+
+  /// Label on the expansion button for a pending duplicate dive row (replaces 'Compare dives')
+  ///
+  /// In en, this message translates to:
+  /// **'Decide'**
+  String get universalImport_dive_decideAction;
 
   /// Error message shown when the detected file format is not supported
   ///
@@ -23801,6 +23831,30 @@ abstract class AppLocalizations {
   /// **'{selected} of {total} selected'**
   String universalImport_label_xOfYSelected(Object selected, Object total);
 
+  /// Hint text telling the user how many pending duplicates still need a decision before Import can proceed
+  ///
+  /// In en, this message translates to:
+  /// **'{count} duplicate(s) need a decision'**
+  String universalImport_pending_gateHint(int count);
+
+  /// Pill/badge shown on a pending duplicate row indicating the user must pick an action
+  ///
+  /// In en, this message translates to:
+  /// **'Needs decision'**
+  String get universalImport_pending_needsDecision;
+
+  /// Action label jumping the user to the pending duplicate that needs review
+  ///
+  /// In en, this message translates to:
+  /// **'Review'**
+  String get universalImport_pending_reviewAction;
+
+  /// Row hint shown under an undecided pending duplicate prompting the user to tap the Decide button
+  ///
+  /// In en, this message translates to:
+  /// **'Tap Decide to choose'**
+  String get universalImport_rowHint_tapCompareToDecide;
+
   /// Accessibility label for entity type selection count
   ///
   /// In en, this message translates to:
@@ -23882,6 +23936,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Select'**
   String get universalImport_step_select;
+
+  /// Addendum to the pending duplicates summary banner clarifying that each needs a decision before import
+  ///
+  /// In en, this message translates to:
+  /// **'Each needs a decision before importing.'**
+  String get universalImport_summary_decidesRequired;
 
   /// Title for the universal import wizard page and file selection heading
   ///

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13793,6 +13793,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate => 'مكرر محتمل';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13683,6 +13683,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'جارٍ الكشف...';
 
   @override
@@ -13697,6 +13700,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return 'تم العثور على $count مكررات وتم إلغاء تحديدها تلقائياً.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'اكتمل الاستيراد';
@@ -13752,6 +13758,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected من $total محدد';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -13815,6 +13824,16 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'تبديل التحديد لـ $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13644,8 +13644,31 @@ class AppLocalizationsAr extends AppLocalizations {
   String get universalImport_action_selectFile => 'اختيار ملف';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'اختر ملف سجل غوص للاستيراد. الصيغ المدعومة تشمل CSV وUDDF وSubsurface XML وGarmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13731,6 +13754,21 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -13786,6 +13824,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'اختيار';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'استيراد البيانات';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -13942,6 +13942,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Wird erkannt...';
 
   @override
@@ -13956,6 +13959,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count Duplikate gefunden und automatisch abgewählt.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Import abgeschlossen';
@@ -14011,6 +14017,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected von $total ausgewählt';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -14076,6 +14085,16 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Auswahl für $name umschalten';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -14052,6 +14052,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate =>
       'Mögliches Duplikat';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -13903,8 +13903,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get universalImport_action_selectFile => 'Datei auswählen';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Wählen Sie eine Tauchprotokoll-Datei zum Importieren aus. Unterstützte Formate sind CSV, UDDF, Subsurface XML und Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13990,6 +14013,21 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -14047,6 +14085,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Auswählen';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Daten importieren';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13718,6 +13718,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Detecting...';
 
   @override
@@ -13732,6 +13735,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count duplicates found and auto-deselected.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Import Complete';
@@ -13787,6 +13793,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected of $total selected';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -13852,6 +13861,16 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Toggle selection for $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13828,6 +13828,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate =>
       'Possible duplicate';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13679,8 +13679,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get universalImport_action_selectFile => 'Select File';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Select a dive log file to import. Supported formats include CSV, UDDF, Subsurface XML, Garmin FIT, and Shearwater Cloud databases.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13766,6 +13789,21 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -13823,6 +13861,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Select';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'File Import';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -13960,6 +13960,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Detectando...';
 
   @override
@@ -13974,6 +13977,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count duplicados encontrados y deseleccionados automáticamente.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Importación Completa';
@@ -14029,6 +14035,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected de $total seleccionado';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -14093,6 +14102,16 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Alternar selección para $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -13921,8 +13921,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get universalImport_action_selectFile => 'Seleccionar Archivo';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Selecciona un archivo de registro de inmersiones para importar. Los formatos compatibles incluyen CSV, UDDF, Subsurface XML y Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -14008,6 +14031,21 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -14064,6 +14102,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Seleccionar';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Importar Datos';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -14070,6 +14070,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate => 'Posible duplicado';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14125,6 +14125,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate => 'Doublon possible';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -13976,8 +13976,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get universalImport_action_selectFile => 'Sélectionner un fichier';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Sélectionnez un fichier de carnet de plongée à importer. Les formats pris en charge incluent CSV, UDDF, Subsurface XML et Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -14063,6 +14086,21 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -14118,6 +14156,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Sélectionner';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Importer des données';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14015,6 +14015,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Détection...';
 
   @override
@@ -14029,6 +14032,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count doublons trouvés et désélectionnés automatiquement.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Import terminé';
@@ -14084,6 +14090,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected sur $total sélectionné';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -14147,6 +14156,16 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Basculer la sélection pour $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13544,8 +13544,31 @@ class AppLocalizationsHe extends AppLocalizations {
   String get universalImport_action_selectFile => 'בחר קובץ';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'בחר קובץ יומן צלילה לייבוא. פורמטים נתמכים כוללים CSV, UDDF, Subsurface XML ו-Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13631,6 +13654,21 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -13686,6 +13724,10 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'בחר';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'ייבא נתונים';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13583,6 +13583,9 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'מזהה...';
 
   @override
@@ -13597,6 +13600,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count כפילויות נמצאו ובוטלה בחירתן אוטומטית.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'ייבוא הושלם';
@@ -13652,6 +13658,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected מתוך $total נבחרו';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -13715,6 +13724,16 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'החלף בחירה עבור $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13693,6 +13693,10 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate => 'כפילות אפשרית';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -13914,6 +13914,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Észlelés...';
 
   @override
@@ -13928,6 +13931,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count duplikátum találva és automatikusan kijelölés törölve.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Importálás kész';
@@ -13983,6 +13989,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected kiválasztva a(z) $total-ból';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -14048,6 +14057,16 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Kijelölés váltása: $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -13875,8 +13875,31 @@ class AppLocalizationsHu extends AppLocalizations {
   String get universalImport_action_selectFile => 'Fájl kiválasztása';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Válassz egy merülési napló fájlt az importáláshoz. Támogatott formátumok: CSV, UDDF, Subsurface XML és Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13962,6 +13985,21 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -14019,6 +14057,10 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Kiválasztás';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Adatok importálása';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -14024,6 +14024,10 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate =>
       'Lehetséges duplikátum';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -13958,6 +13958,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Rilevamento...';
 
   @override
@@ -13972,6 +13975,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count duplicati trovati e deselezionati automaticamente.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Importazione Completata';
@@ -14027,6 +14033,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected di $total selezionati';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -14092,6 +14101,16 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Attiva/disattiva selezione per $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -13919,8 +13919,31 @@ class AppLocalizationsIt extends AppLocalizations {
   String get universalImport_action_selectFile => 'Seleziona File';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Seleziona un file di registro immersioni da importare. I formati supportati includono CSV, UDDF, Subsurface XML e Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -14006,6 +14029,21 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -14063,6 +14101,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Seleziona';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Importa Dati';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -14068,6 +14068,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate =>
       'Possibile duplicato';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13839,6 +13839,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Detecteren...';
 
   @override
@@ -13853,6 +13856,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count duplicaten gevonden en automatisch gedeselecteerd.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Import voltooid';
@@ -13908,6 +13914,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected van $total geselecteerd';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -13973,6 +13982,16 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Selectie wisselen voor $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13800,8 +13800,31 @@ class AppLocalizationsNl extends AppLocalizations {
   String get universalImport_action_selectFile => 'Selecteer bestand';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Selecteer een duiklogboekbestand om te importeren. Ondersteunde formaten zijn CSV, UDDF, Subsurface XML en Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13887,6 +13910,21 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -13944,6 +13982,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Selecteren';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Gegevens importeren';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13949,6 +13949,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate =>
       'Mogelijk duplicaat';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -13921,8 +13921,31 @@ class AppLocalizationsPt extends AppLocalizations {
   String get universalImport_action_selectFile => 'Selecionar Arquivo';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Selecione um arquivo de registro de mergulho para importar. Os formatos suportados incluem CSV, UDDF, Subsurface XML e Garmin FIT.';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -14008,6 +14031,21 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -14065,6 +14103,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get universalImport_step_select => 'Selecionar';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => 'Importar Dados';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -14070,6 +14070,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate =>
       'Possível duplicado';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -13960,6 +13960,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => 'Detectando...';
 
   @override
@@ -13974,6 +13977,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '$count duplicados encontrados e desmarcados automaticamente.';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => 'Importação Concluída';
@@ -14029,6 +14035,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '$selected de $total selecionado';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -14094,6 +14103,16 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return 'Alternar seleção para $name';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13375,6 +13375,10 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get universalImport_semantics_needsDecision =>
+      'Suspected duplicate, needs decision';
+
+  @override
   String get universalImport_semantics_possibleDuplicate => '可能重复';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13227,8 +13227,31 @@ class AppLocalizationsZh extends AppLocalizations {
   String get universalImport_action_selectFile => '选择文件';
 
   @override
+  String universalImport_bulk_consolidateMatched(int count) {
+    return 'Consolidate matched ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAll(int count) {
+    return 'Import all ($count)';
+  }
+
+  @override
+  String universalImport_bulk_importAllAsNew(int count) {
+    return 'Import all as new ($count)';
+  }
+
+  @override
+  String universalImport_bulk_skipAll(int count) {
+    return 'Skip all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       '选择一个潜水日志文件进行导入。支持的格式包括 CSV、UDDF、Subsurface XML 和 Garmin FIT。';
+
+  @override
+  String get universalImport_dive_decideAction => 'Decide';
 
   @override
   String get universalImport_error_unsupportedFormat =>
@@ -13313,6 +13336,21 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String universalImport_pending_gateHint(int count) {
+    return '$count duplicate(s) need a decision';
+  }
+
+  @override
+  String get universalImport_pending_needsDecision => 'Needs decision';
+
+  @override
+  String get universalImport_pending_reviewAction => 'Review';
+
+  @override
+  String get universalImport_rowHint_tapCompareToDecide =>
+      'Tap Decide to choose';
+
+  @override
   String universalImport_semantics_entitySelection(
     Object selected,
     Object total,
@@ -13368,6 +13406,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get universalImport_step_select => '选择';
+
+  @override
+  String get universalImport_summary_decidesRequired =>
+      'Each needs a decision before importing.';
 
   @override
   String get universalImport_title => '导入数据';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13266,6 +13266,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get universalImport_label_consolidate => 'Consolidate';
+
+  @override
   String get universalImport_label_detecting => '检测中...';
 
   @override
@@ -13280,6 +13283,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String universalImport_label_duplicatesFound(Object count) {
     return '发现 $count 条重复记录并已自动取消选择。';
   }
+
+  @override
+  String get universalImport_label_importAsNew => 'Import as New';
 
   @override
   String get universalImport_label_importComplete => '导入完成';
@@ -13334,6 +13340,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String universalImport_label_xOfYSelected(Object selected, Object total) {
     return '已选择 $selected/$total';
   }
+
+  @override
+  String get universalImport_pending_chooseAction => 'Choose an action';
 
   @override
   String universalImport_pending_gateHint(int count) {
@@ -13397,6 +13406,16 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String universalImport_semantics_toggleSelection(Object name) {
     return '切换 $name 的选择';
+  }
+
+  @override
+  String universalImport_snackbar_bulkMarkedAs(int count, String action) {
+    return '$count marked as $action';
+  }
+
+  @override
+  String universalImport_snackbar_markedAs(String action) {
+    return 'Marked as $action';
   }
 
   @override

--- a/test/core/presentation/widgets/dive_comparison_card_test.dart
+++ b/test/core/presentation/widgets/dive_comparison_card_test.dart
@@ -683,6 +683,97 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // Pending state / "Choose an action" label
+  // ---------------------------------------------------------------------------
+
+  group('DiveComparisonCard - pending state', () {
+    testWidgets(
+      'renders "Choose an action" label when isPending + null selectedAction',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildCard(
+            card: DiveComparisonCard(
+              incoming: _testIncoming,
+              existingDiveId: _existingDiveId,
+              matchScore: 0.95,
+              selectedAction: null,
+              onActionChanged: (_) {},
+              isPending: true,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Choose an action'), findsOneWidget);
+      },
+    );
+
+    testWidgets('no button is pre-highlighted when selectedAction is null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildCard(
+          card: DiveComparisonCard(
+            incoming: _testIncoming,
+            existingDiveId: _existingDiveId,
+            matchScore: 0.95,
+            selectedAction: null,
+            onActionChanged: (_) {},
+            isPending: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // No FilledButton should be present — all buttons remain outlined
+      // or text style because no action matches the null selection.
+      expect(find.byType(FilledButton), findsNothing);
+    });
+
+    testWidgets('does NOT render "Choose an action" when not pending', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildCard(
+          card: DiveComparisonCard(
+            incoming: _testIncoming,
+            existingDiveId: _existingDiveId,
+            matchScore: 0.95,
+            selectedAction: DuplicateAction.skip,
+            onActionChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Choose an action'), findsNothing);
+    });
+
+    testWidgets(
+      'does NOT render "Choose an action" when pending but action is set',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildCard(
+            card: DiveComparisonCard(
+              incoming: _testIncoming,
+              existingDiveId: _existingDiveId,
+              matchScore: 0.95,
+              selectedAction: DuplicateAction.skip,
+              onActionChanged: (_) {},
+              isPending: true,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Once a decision is made the "Choose an action" prompt goes away
+        // even if the pending flag is still set momentarily.
+        expect(find.text('Choose an action'), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
   // Loading / error states
   // ---------------------------------------------------------------------------
 

--- a/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
@@ -1157,4 +1157,140 @@ void main() {
       expect(state.totalPending, 0);
     });
   });
+
+  group('setDuplicateAction drains pending', () {
+    test('skip drains pending and syncs selections', () async {
+      final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        0,
+        DuplicateAction.skip,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip,
+      );
+      expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+    });
+
+    test('importAsNew drains pending and selects', () async {
+      final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        0,
+        DuplicateAction.importAsNew,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.importAsNew,
+      );
+      expect(state.selections[ImportEntityType.dives], contains(0));
+    });
+
+    test('consolidate drains pending and selects', () async {
+      final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        0,
+        DuplicateAction.consolidate,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.consolidate,
+      );
+      expect(state.selections[ImportEntityType.dives], contains(0));
+    });
+  });
+
+  group('toggleSelection drains pending', () {
+    test('toggleSelection on a pending index drains it', () async {
+      final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.toggleSelection(ImportEntityType.dives, 0);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+      expect(state.selections[ImportEntityType.dives], contains(0));
+    });
+
+    test(
+      'toggleSelection on a non-pending index does not change pending',
+      () async {
+        final bundle = _bundleWithOneCleanAndOneDuplicateDive();
+        final container = ProviderContainer(
+          overrides: [
+            importWizardNotifierProvider.overrideWith(
+              (ref) => ImportWizardNotifier(_TestAdapter()),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final notifier = container.read(importWizardNotifierProvider.notifier);
+        notifier.setBundle(bundle);
+
+        // index 0 = clean (selected), index 1 = pending duplicate
+        notifier.toggleSelection(ImportEntityType.dives, 0);
+
+        final state = container.read(importWizardNotifierProvider);
+        expect(
+          state.pendingFor(ImportEntityType.dives),
+          {1},
+          reason: 'Pending for duplicate should be unchanged',
+        );
+        expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+      },
+    );
+  });
 }

--- a/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
@@ -1,6 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
@@ -8,12 +10,135 @@ import 'package:submersion/features/import_wizard/domain/models/import_phase.dar
 import 'package:submersion/features/import_wizard/domain/models/tag_selection.dart';
 import 'package:submersion/features/import_wizard/domain/models/unified_import_result.dart';
 import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
-import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 
 @GenerateNiceMocks([MockSpec<ImportSourceAdapter>(), MockSpec<TagRepository>()])
 import 'import_wizard_notifier_test.mocks.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers for pendingDuplicateReview bundle tests.
+// ---------------------------------------------------------------------------
+
+/// Minimal adapter impl used by setBundle-pending tests.
+///
+/// The tests only exercise [ImportWizardNotifier.setBundle], which reads
+/// only [supportedDuplicateActions] and [defaultTagName] off the adapter.
+/// All other members fall through [noSuchMethod] and throw if accidentally
+/// reached — catching any behavioral drift.
+class _TestAdapter implements ImportSourceAdapter {
+  @override
+  String get defaultTagName => 'Test Import';
+
+  @override
+  Set<DuplicateAction> get supportedDuplicateActions => const {
+    DuplicateAction.skip,
+    DuplicateAction.importAsNew,
+    DuplicateAction.consolidate,
+  };
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+ImportBundle _bundleWithProbableDiveDuplicate({required int index}) {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'probable.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [const EntityItem(title: 'Dive 1', subtitle: '')],
+        duplicateIndices: {index},
+        matchResults: {
+          index: const DiveMatchResult(
+            diveId: 'existing-dive',
+            score: 0.85,
+            timeDifferenceMs: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithPossibleDiveDuplicate({required int index}) {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'possible.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [const EntityItem(title: 'Dive 1', subtitle: '')],
+        duplicateIndices: {index},
+        matchResults: {
+          index: const DiveMatchResult(
+            diveId: 'existing-dive',
+            score: 0.6,
+            timeDifferenceMs: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithUnscoredSiteDuplicate({required int index}) {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'sites.uddf',
+    ),
+    groups: {
+      ImportEntityType.sites: EntityGroup(
+        items: [const EntityItem(title: 'Site A', subtitle: '')],
+        duplicateIndices: {index},
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithOneCleanAndOneDuplicateDive() {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'mixed.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: const [
+          EntityItem(title: 'Dive 1', subtitle: ''),
+          EntityItem(title: 'Dive 2', subtitle: ''),
+        ],
+        duplicateIndices: const {1},
+        matchResults: const {
+          1: DiveMatchResult(
+            diveId: 'existing-dive',
+            score: 0.85,
+            timeDifferenceMs: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithOneCleanDive() {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'clean.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: const [EntityItem(title: 'Dive 1', subtitle: '')],
+      ),
+    },
+  );
+}
 
 void main() {
   group('ImportWizardNotifier', () {
@@ -136,38 +261,48 @@ void main() {
         expect(siteSelections, equals({0, 1}));
       });
 
-      test('initializes duplicate actions: score >= 0.7 gets skip', () {
-        final bundle = buildBundle(
-          diveItems: [makeItem('Dive 1')],
-          diveDuplicateIndices: {0},
-          diveMatchResults: {0: makeMatchResult(0.85)},
-        );
-
-        notifier.setBundle(bundle);
-
-        final actions =
-            notifier.state.duplicateActions[ImportEntityType.dives]!;
-        expect(actions[0], equals(DuplicateAction.skip));
-      });
-
       test(
-        'initializes duplicate actions: score >= 0.5 and < 0.7 gets importAsNew',
+        'probable duplicate (score >= 0.7) goes into pending, NOT auto-skipped',
         () {
           final bundle = buildBundle(
             diveItems: [makeItem('Dive 1')],
             diveDuplicateIndices: {0},
-            diveMatchResults: {0: makeMatchResult(0.6)},
+            diveMatchResults: {0: makeMatchResult(0.85)},
           );
 
           notifier.setBundle(bundle);
 
-          final actions =
-              notifier.state.duplicateActions[ImportEntityType.dives]!;
-          expect(actions[0], equals(DuplicateAction.importAsNew));
+          // No auto-default action is written — the user must decide.
+          expect(
+            notifier.state.duplicateActions[ImportEntityType.dives],
+            anyOf(isNull, isEmpty),
+          );
+          // The index is instead recorded as pending review.
+          expect(
+            notifier.state.pendingFor(ImportEntityType.dives),
+            equals({0}),
+          );
         },
       );
 
-      test('initializes duplicate actions: exactly 0.7 gets skip', () {
+      test('possible duplicate (0.5 <= score < 0.7) goes into pending, '
+          'NOT auto-imported-as-new', () {
+        final bundle = buildBundle(
+          diveItems: [makeItem('Dive 1')],
+          diveDuplicateIndices: {0},
+          diveMatchResults: {0: makeMatchResult(0.6)},
+        );
+
+        notifier.setBundle(bundle);
+
+        expect(
+          notifier.state.duplicateActions[ImportEntityType.dives],
+          anyOf(isNull, isEmpty),
+        );
+        expect(notifier.state.pendingFor(ImportEntityType.dives), equals({0}));
+      });
+
+      test('exactly 0.7 score goes into pending, NOT auto-skipped', () {
         final bundle = buildBundle(
           diveItems: [makeItem('Dive 1')],
           diveDuplicateIndices: {0},
@@ -176,9 +311,11 @@ void main() {
 
         notifier.setBundle(bundle);
 
-        final actions =
-            notifier.state.duplicateActions[ImportEntityType.dives]!;
-        expect(actions[0], equals(DuplicateAction.skip));
+        expect(
+          notifier.state.duplicateActions[ImportEntityType.dives],
+          anyOf(isNull, isEmpty),
+        );
+        expect(notifier.state.pendingFor(ImportEntityType.dives), equals({0}));
       });
 
       test('handles bundle with no duplicates — empty duplicateActions', () {
@@ -189,8 +326,9 @@ void main() {
         notifier.setBundle(bundle);
 
         final actions = notifier.state.duplicateActions[ImportEntityType.dives];
-        // No match results → no duplicate actions needed
-        expect(actions, isNull);
+        // No duplicates → no actions needed and no pending review either.
+        expect(actions, anyOf(isNull, isEmpty));
+        expect(notifier.state.hasPendingReviews, isFalse);
       });
 
       test('updates currentStep to 1 (review step)', () {
@@ -327,10 +465,11 @@ void main() {
           diveMatchResults: {0: makeMatchResult(0.85)},
         );
         notifier.setBundle(bundle);
-        // Initially skip (score >= 0.7)
+        // Initially no recorded action — index is pending review until the
+        // user decides.
         expect(
-          notifier.state.duplicateActions[ImportEntityType.dives]![0],
-          equals(DuplicateAction.skip),
+          notifier.state.duplicateActions[ImportEntityType.dives],
+          anyOf(isNull, isEmpty),
         );
 
         notifier.setDuplicateAction(
@@ -362,9 +501,14 @@ void main() {
           DuplicateAction.importAsNew,
         );
 
+        // Index 0 got an explicit action; index 1 is still pending (no action).
+        expect(
+          notifier.state.duplicateActions[ImportEntityType.dives]![0],
+          equals(DuplicateAction.importAsNew),
+        );
         expect(
           notifier.state.duplicateActions[ImportEntityType.dives]![1],
-          equals(DuplicateAction.skip),
+          isNull,
         );
       });
     });
@@ -418,6 +562,13 @@ void main() {
             siteItems: [makeItem('Site A')],
           );
           notifier.setBundle(bundle);
+          // setBundle no longer writes auto-default actions. The user must
+          // explicitly resolve the pending duplicate before import.
+          notifier.setDuplicateAction(
+            ImportEntityType.dives,
+            1,
+            DuplicateAction.skip,
+          );
 
           const importResult = UnifiedImportResult(
             importedCounts: {ImportEntityType.dives: 1},
@@ -894,6 +1045,116 @@ void main() {
 
         expect(notifier.state, isNot(same(before)));
       });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // setBundle populates pendingDuplicateReview
+  // ---------------------------------------------------------------------------
+
+  group('setBundle populates pendingDuplicateReview', () {
+    test('probable dive duplicate goes into pending, NOT duplicateActions', () {
+      final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(bundle);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), {0});
+      expect(
+        state.duplicateActions[ImportEntityType.dives],
+        anyOf(isNull, isEmpty),
+      );
+      expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+    });
+
+    test('possible dive duplicate goes into pending, NOT duplicateActions', () {
+      final bundle = _bundleWithPossibleDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(bundle);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), {0});
+      expect(
+        state.duplicateActions[ImportEntityType.dives],
+        anyOf(isNull, isEmpty),
+      );
+      expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+    });
+
+    test('non-dive (unscored) duplicate goes into pending', () {
+      final bundle = _bundleWithUnscoredSiteDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(bundle);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.sites), {0});
+      expect(state.selections[ImportEntityType.sites], isNot(contains(0)));
+    });
+
+    test('non-duplicate rows are NOT pending and ARE selected', () {
+      final bundle = _bundleWithOneCleanAndOneDuplicateDive();
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(bundle);
+
+      final state = container.read(importWizardNotifierProvider);
+      // Index 0 = clean (selected), index 1 = duplicate (pending)
+      expect(state.selections[ImportEntityType.dives], contains(0));
+      expect(state.pendingFor(ImportEntityType.dives), {1});
+    });
+
+    test('empty duplicates produce empty pending', () {
+      final bundle = _bundleWithOneCleanDive();
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(bundle);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+      expect(state.totalPending, 0);
     });
   });
 }

--- a/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
@@ -1293,4 +1293,226 @@ void main() {
       },
     );
   });
+
+  group('applyBulkAction', () {
+    ImportBundle bundleWithTwoPendingDives() {
+      return ImportBundle(
+        source: const ImportSourceInfo(
+          type: ImportSourceType.uddf,
+          displayName: 'two-pending.uddf',
+        ),
+        groups: {
+          ImportEntityType.dives: EntityGroup(
+            items: const [
+              EntityItem(title: 'Dive 1', subtitle: ''),
+              EntityItem(title: 'Dive 2', subtitle: ''),
+            ],
+            duplicateIndices: const {0, 1},
+            matchResults: const {
+              0: DiveMatchResult(
+                diveId: 'e1',
+                score: 0.9,
+                timeDifferenceMs: 0,
+                depthDifferenceMeters: 0.0,
+                durationDifferenceSeconds: 0,
+              ),
+              1: DiveMatchResult(
+                diveId: 'e2',
+                score: 0.9,
+                timeDifferenceMs: 0,
+                depthDifferenceMeters: 0.0,
+                durationDifferenceSeconds: 0,
+              ),
+            },
+          ),
+        },
+      );
+    }
+
+    ImportBundle bundleWithMixedConfidenceDives() {
+      return ImportBundle(
+        source: const ImportSourceInfo(
+          type: ImportSourceType.uddf,
+          displayName: 'mixed-confidence.uddf',
+        ),
+        groups: {
+          ImportEntityType.dives: EntityGroup(
+            items: const [
+              EntityItem(title: 'Dive 1', subtitle: ''),
+              EntityItem(title: 'Dive 2', subtitle: ''),
+            ],
+            duplicateIndices: const {0, 1},
+            matchResults: const {
+              0: DiveMatchResult(
+                diveId: 'e1',
+                score: 0.9, // probable
+                timeDifferenceMs: 0,
+                depthDifferenceMeters: 0.0,
+                durationDifferenceSeconds: 0,
+              ),
+              1: DiveMatchResult(
+                diveId: 'e2',
+                score: 0.55, // possible (weak)
+                timeDifferenceMs: 600000,
+                depthDifferenceMeters: 3.0,
+                durationDifferenceSeconds: 480,
+              ),
+            },
+          ),
+        },
+      );
+    }
+
+    test('skip drains all pending for type and sets resolutions', () async {
+      final bundle = bundleWithTwoPendingDives();
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip,
+      );
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[1],
+        DuplicateAction.skip,
+      );
+      expect(state.selections[ImportEntityType.dives], isNot(contains(0)));
+      expect(state.selections[ImportEntityType.dives], isNot(contains(1)));
+    });
+
+    test('importAsNew drains all pending and selects them', () async {
+      final bundle = bundleWithTwoPendingDives();
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.applyBulkAction(
+        ImportEntityType.dives,
+        DuplicateAction.importAsNew,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.importAsNew,
+      );
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[1],
+        DuplicateAction.importAsNew,
+      );
+      expect(state.selections[ImportEntityType.dives], contains(0));
+      expect(state.selections[ImportEntityType.dives], contains(1));
+    });
+
+    test(
+      'consolidate drains only probable matches, leaves weak pending',
+      () async {
+        final bundle = bundleWithMixedConfidenceDives();
+        final container = ProviderContainer(
+          overrides: [
+            importWizardNotifierProvider.overrideWith(
+              (ref) => ImportWizardNotifier(_TestAdapter()),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final notifier = container.read(importWizardNotifierProvider.notifier);
+        notifier.setBundle(bundle);
+
+        notifier.applyBulkAction(
+          ImportEntityType.dives,
+          DuplicateAction.consolidate,
+        );
+
+        final state = container.read(importWizardNotifierProvider);
+        expect(
+          state.pendingFor(ImportEntityType.dives),
+          {1},
+          reason: 'Weak match (score 0.55) should remain pending',
+        );
+        expect(
+          state.duplicateActions[ImportEntityType.dives]?[0],
+          DuplicateAction.consolidate,
+        );
+        expect(
+          state.duplicateActions[ImportEntityType.dives]?.containsKey(1),
+          isFalse,
+          reason: 'Weak match should not have a recorded action',
+        );
+      },
+    );
+
+    test('no-op when pending for type is empty', () async {
+      final bundle = bundleWithTwoPendingDives();
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      // First drain all pending via bulk skip.
+      notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+      // Pending is now empty — second call must be a no-op and NOT
+      // overwrite the recorded skip action.
+      notifier.applyBulkAction(
+        ImportEntityType.dives,
+        DuplicateAction.importAsNew,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip,
+        reason: 'Second bulk call should be a no-op once pending is empty',
+      );
+    });
+
+    test('non-dive bulk action drains pending and updates selection', () async {
+      final bundle = _bundleWithUnscoredSiteDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      notifier.applyBulkAction(
+        ImportEntityType.sites,
+        DuplicateAction.importAsNew,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.sites), isEmpty);
+      expect(state.selections[ImportEntityType.sites], contains(0));
+    });
+  });
 }

--- a/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
@@ -1515,4 +1515,97 @@ void main() {
       expect(state.selections[ImportEntityType.sites], contains(0));
     });
   });
+
+  group('firstPendingLocation', () {
+    ImportBundle bundleWithDiveAndSiteDuplicates() {
+      return ImportBundle(
+        source: const ImportSourceInfo(
+          type: ImportSourceType.uddf,
+          displayName: 'dive-and-site-dupes.uddf',
+        ),
+        groups: {
+          ImportEntityType.dives: EntityGroup(
+            items: const [EntityItem(title: 'Dive 1', subtitle: '')],
+            duplicateIndices: const {0},
+            matchResults: const {
+              0: DiveMatchResult(
+                diveId: 'e1',
+                score: 0.9,
+                timeDifferenceMs: 0,
+                depthDifferenceMeters: 0.0,
+                durationDifferenceSeconds: 0,
+              ),
+            },
+          ),
+          ImportEntityType.sites: EntityGroup(
+            items: const [EntityItem(title: 'Site A', subtitle: '')],
+            duplicateIndices: const {0},
+          ),
+        },
+      );
+    }
+
+    test('returns null when nothing pending', () {
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final loc = container
+          .read(importWizardNotifierProvider.notifier)
+          .firstPendingLocation();
+      expect(loc, isNull);
+    });
+
+    test('returns first pending dive when dives have pending', () {
+      final bundle = _bundleWithProbableDiveDuplicate(index: 0);
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      final loc = notifier.firstPendingLocation();
+
+      expect(loc, isNotNull);
+      expect(loc!.type, ImportEntityType.dives);
+      expect(loc.index, 0);
+    });
+
+    test('returns sites location after dive pending is drained', () {
+      final bundle = bundleWithDiveAndSiteDuplicates();
+      final container = ProviderContainer(
+        overrides: [
+          importWizardNotifierProvider.overrideWith(
+            (ref) => ImportWizardNotifier(_TestAdapter()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(bundle);
+
+      // Sanity: dives is the first pending tab before draining.
+      final before = notifier.firstPendingLocation();
+      expect(before, isNotNull);
+      expect(before!.type, ImportEntityType.dives);
+
+      // Drain all dive pending via bulk skip.
+      notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+
+      final after = notifier.firstPendingLocation();
+      expect(after, isNotNull);
+      expect(after!.type, ImportEntityType.sites);
+      expect(after.index, 0);
+    });
+  });
 }

--- a/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.dart
@@ -102,19 +102,19 @@ ImportBundle _bundleWithUnscoredSiteDuplicate({required int index}) {
 }
 
 ImportBundle _bundleWithOneCleanAndOneDuplicateDive() {
-  return ImportBundle(
-    source: const ImportSourceInfo(
+  return const ImportBundle(
+    source: ImportSourceInfo(
       type: ImportSourceType.uddf,
       displayName: 'mixed.uddf',
     ),
     groups: {
       ImportEntityType.dives: EntityGroup(
-        items: const [
+        items: [
           EntityItem(title: 'Dive 1', subtitle: ''),
           EntityItem(title: 'Dive 2', subtitle: ''),
         ],
-        duplicateIndices: const {1},
-        matchResults: const {
+        duplicateIndices: {1},
+        matchResults: {
           1: DiveMatchResult(
             diveId: 'existing-dive',
             score: 0.85,
@@ -127,14 +127,14 @@ ImportBundle _bundleWithOneCleanAndOneDuplicateDive() {
 }
 
 ImportBundle _bundleWithOneCleanDive() {
-  return ImportBundle(
-    source: const ImportSourceInfo(
+  return const ImportBundle(
+    source: ImportSourceInfo(
       type: ImportSourceType.uddf,
       displayName: 'clean.uddf',
     ),
     groups: {
       ImportEntityType.dives: EntityGroup(
-        items: const [EntityItem(title: 'Dive 1', subtitle: '')],
+        items: [EntityItem(title: 'Dive 1', subtitle: '')],
       ),
     },
   );
@@ -1296,19 +1296,19 @@ void main() {
 
   group('applyBulkAction', () {
     ImportBundle bundleWithTwoPendingDives() {
-      return ImportBundle(
-        source: const ImportSourceInfo(
+      return const ImportBundle(
+        source: ImportSourceInfo(
           type: ImportSourceType.uddf,
           displayName: 'two-pending.uddf',
         ),
         groups: {
           ImportEntityType.dives: EntityGroup(
-            items: const [
+            items: [
               EntityItem(title: 'Dive 1', subtitle: ''),
               EntityItem(title: 'Dive 2', subtitle: ''),
             ],
-            duplicateIndices: const {0, 1},
-            matchResults: const {
+            duplicateIndices: {0, 1},
+            matchResults: {
               0: DiveMatchResult(
                 diveId: 'e1',
                 score: 0.9,
@@ -1330,19 +1330,19 @@ void main() {
     }
 
     ImportBundle bundleWithMixedConfidenceDives() {
-      return ImportBundle(
-        source: const ImportSourceInfo(
+      return const ImportBundle(
+        source: ImportSourceInfo(
           type: ImportSourceType.uddf,
           displayName: 'mixed-confidence.uddf',
         ),
         groups: {
           ImportEntityType.dives: EntityGroup(
-            items: const [
+            items: [
               EntityItem(title: 'Dive 1', subtitle: ''),
               EntityItem(title: 'Dive 2', subtitle: ''),
             ],
-            duplicateIndices: const {0, 1},
-            matchResults: const {
+            duplicateIndices: {0, 1},
+            matchResults: {
               0: DiveMatchResult(
                 diveId: 'e1',
                 score: 0.9, // probable
@@ -1518,16 +1518,16 @@ void main() {
 
   group('firstPendingLocation', () {
     ImportBundle bundleWithDiveAndSiteDuplicates() {
-      return ImportBundle(
-        source: const ImportSourceInfo(
+      return const ImportBundle(
+        source: ImportSourceInfo(
           type: ImportSourceType.uddf,
           displayName: 'dive-and-site-dupes.uddf',
         ),
         groups: {
           ImportEntityType.dives: EntityGroup(
-            items: const [EntityItem(title: 'Dive 1', subtitle: '')],
-            duplicateIndices: const {0},
-            matchResults: const {
+            items: [EntityItem(title: 'Dive 1', subtitle: '')],
+            duplicateIndices: {0},
+            matchResults: {
               0: DiveMatchResult(
                 diveId: 'e1',
                 score: 0.9,
@@ -1538,8 +1538,8 @@ void main() {
             },
           ),
           ImportEntityType.sites: EntityGroup(
-            items: const [EntityItem(title: 'Site A', subtitle: '')],
-            duplicateIndices: const {0},
+            items: [EntityItem(title: 'Site A', subtitle: '')],
+            duplicateIndices: {0},
           ),
         },
       );

--- a/test/features/import_wizard/presentation/providers/import_wizard_state_test.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_state_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
+
+void main() {
+  group('ImportWizardState.pendingDuplicateReview', () {
+    test('defaults to empty map', () {
+      const state = ImportWizardState();
+      expect(state.pendingDuplicateReview, isEmpty);
+    });
+
+    test('hasPendingReviews false when all sets empty', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: <int>{},
+          ImportEntityType.sites: <int>{},
+        },
+      );
+      expect(state.hasPendingReviews, isFalse);
+    });
+
+    test('hasPendingReviews true when any set non-empty', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: <int>{},
+          ImportEntityType.sites: {3},
+        },
+      );
+      expect(state.hasPendingReviews, isTrue);
+    });
+
+    test('totalPending sums across types', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {0, 1, 2},
+          ImportEntityType.sites: {5},
+        },
+      );
+      expect(state.totalPending, 4);
+    });
+
+    test('pendingFor returns empty for missing type', () {
+      const state = ImportWizardState();
+      expect(state.pendingFor(ImportEntityType.dives), isEmpty);
+    });
+
+    test('pendingFor returns set for present type', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {1, 4},
+        },
+      );
+      expect(state.pendingFor(ImportEntityType.dives), {1, 4});
+    });
+
+    test('copyWith updates pendingDuplicateReview', () {
+      const state = ImportWizardState();
+      final updated = state.copyWith(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {0, 1},
+        },
+      );
+      expect(updated.pendingDuplicateReview[ImportEntityType.dives], {0, 1});
+    });
+
+    test('copyWith preserves pendingDuplicateReview when not passed', () {
+      const state = ImportWizardState(
+        pendingDuplicateReview: {
+          ImportEntityType.dives: {2},
+        },
+      );
+      final updated = state.copyWith(currentStep: 1);
+      expect(updated.pendingDuplicateReview[ImportEntityType.dives], {2});
+    });
+  });
+}

--- a/test/features/import_wizard/presentation/providers/issue_200_regression_test.dart
+++ b/test/features/import_wizard/presentation/providers/issue_200_regression_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
+
+/// Regression test for https://github.com/submersion-app/submersion/issues/200.
+///
+/// Suspected-duplicate rows (probable OR possible) must not receive a silent
+/// default action. The Import button stays gated until the user explicitly
+/// decides for every flagged duplicate.
+///
+/// Before this fix:
+///   - Probable duplicates (score >= 0.7) auto-defaulted to skip.
+///   - Possible duplicates (0.5 <= score < 0.7) auto-defaulted to importAsNew.
+/// After the fix:
+///   - Both enter pendingDuplicateReview and receive NO default action.
+///   - The user must call setDuplicateAction or applyBulkAction to resolve.
+///
+/// This file inlines its fixtures so it is not affected by helper refactors
+/// in other test files.
+void main() {
+  group('issue #200: suspected duplicates require explicit selection', () {
+    test('probable duplicate is pending and has NO default action', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), {0});
+      expect(
+        state.duplicateActions[ImportEntityType.dives],
+        anyOf(isNull, isEmpty),
+        reason:
+            'No auto-default skip/importAsNew may be recorded — this would '
+            're-introduce the issue #200 silent-default bug.',
+      );
+    });
+
+    test('possible duplicate is pending and has NO default action', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithPossibleDuplicate());
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.pendingFor(ImportEntityType.dives), {0});
+      expect(
+        state.duplicateActions[ImportEntityType.dives],
+        anyOf(isNull, isEmpty),
+      );
+    });
+
+    test('explicit skip resolves pending', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+      expect(
+        container.read(importWizardNotifierProvider).hasPendingReviews,
+        isTrue,
+      );
+
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        0,
+        DuplicateAction.skip,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+      expect(
+        state.duplicateActions[ImportEntityType.dives]?[0],
+        DuplicateAction.skip,
+      );
+    });
+
+    test('bulk skip resolves pending', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+      notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+    });
+
+    test('importAsNew resolves pending and selects the dive', () {
+      final container = _freshContainer();
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+
+      notifier.setBundle(_bundleWithProbableDuplicate());
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        0,
+        DuplicateAction.importAsNew,
+      );
+
+      final state = container.read(importWizardNotifierProvider);
+      expect(state.hasPendingReviews, isFalse);
+      expect(state.selections[ImportEntityType.dives], contains(0));
+    });
+  });
+}
+
+ProviderContainer _freshContainer() {
+  final container = ProviderContainer(
+    overrides: [
+      importWizardNotifierProvider.overrideWith(
+        (ref) => ImportWizardNotifier(_TestAdapter()),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+ImportBundle _bundleWithProbableDuplicate() {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'probable.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: const [EntityItem(title: 'Dive 1', subtitle: '')],
+        duplicateIndices: const {0},
+        matchResults: const {
+          0: DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.9,
+            timeDifferenceMs: 0,
+            depthDifferenceMeters: 0.0,
+            durationDifferenceSeconds: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithPossibleDuplicate() {
+  return ImportBundle(
+    source: const ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'possible.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: const [EntityItem(title: 'Dive 1', subtitle: '')],
+        duplicateIndices: const {0},
+        matchResults: const {
+          0: DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.55,
+            timeDifferenceMs: 600000,
+            depthDifferenceMeters: 3.0,
+            durationDifferenceSeconds: 480,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+class _TestAdapter implements ImportSourceAdapter {
+  @override
+  String get defaultTagName => 'Test Import';
+
+  @override
+  Set<DuplicateAction> get supportedDuplicateActions => const {
+    DuplicateAction.skip,
+    DuplicateAction.importAsNew,
+    DuplicateAction.consolidate,
+  };
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}

--- a/test/features/import_wizard/presentation/providers/issue_200_regression_test.dart
+++ b/test/features/import_wizard/presentation/providers/issue_200_regression_test.dart
@@ -120,16 +120,16 @@ ProviderContainer _freshContainer() {
 }
 
 ImportBundle _bundleWithProbableDuplicate() {
-  return ImportBundle(
-    source: const ImportSourceInfo(
+  return const ImportBundle(
+    source: ImportSourceInfo(
       type: ImportSourceType.uddf,
       displayName: 'probable.uddf',
     ),
     groups: {
       ImportEntityType.dives: EntityGroup(
-        items: const [EntityItem(title: 'Dive 1', subtitle: '')],
-        duplicateIndices: const {0},
-        matchResults: const {
+        items: [EntityItem(title: 'Dive 1', subtitle: '')],
+        duplicateIndices: {0},
+        matchResults: {
           0: DiveMatchResult(
             diveId: 'existing-1',
             score: 0.9,
@@ -144,16 +144,16 @@ ImportBundle _bundleWithProbableDuplicate() {
 }
 
 ImportBundle _bundleWithPossibleDuplicate() {
-  return ImportBundle(
-    source: const ImportSourceInfo(
+  return const ImportBundle(
+    source: ImportSourceInfo(
       type: ImportSourceType.uddf,
       displayName: 'possible.uddf',
     ),
     groups: {
       ImportEntityType.dives: EntityGroup(
-        items: const [EntityItem(title: 'Dive 1', subtitle: '')],
-        duplicateIndices: const {0},
-        matchResults: const {
+        items: [EntityItem(title: 'Dive 1', subtitle: '')],
+        duplicateIndices: {0},
+        matchResults: {
           0: DiveMatchResult(
             diveId: 'existing-1',
             score: 0.55,

--- a/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/duplicate_action_card.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _testDiveId = 'existing-1';
+
+const _matchResult = DiveMatchResult(
+  diveId: _testDiveId,
+  score: 0.85,
+  timeDifferenceMs: 60000,
+);
+
+const _item = EntityItem(
+  title: '2026-01-15 09:00',
+  subtitle: '25.0 m · 50 min',
+);
+
+Widget _pump({required bool isPending}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: DuplicateActionCard(
+          item: _item,
+          matchResult: _matchResult,
+          selectedAction: DuplicateAction.skip,
+          availableActions: const {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.consolidate,
+          },
+          onActionChanged: (_) {},
+          existingDiveId: _testDiveId,
+          isPending: isPending,
+        ),
+      ),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('DuplicateActionCard pending state', () {
+    testWidgets('shows NeedsDecisionPill when pending', (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: true));
+      await tester.pump();
+
+      expect(find.text('Needs decision'), findsOneWidget);
+    });
+
+    testWidgets('does not show pill when not pending', (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: false));
+      await tester.pump();
+
+      expect(find.text('Needs decision'), findsNothing);
+    });
+
+    testWidgets('renders 4-px warning border when pending', (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: true));
+      await tester.pump();
+
+      final card = tester.widget<Card>(find.byType(Card).first);
+      final shape = card.shape as RoundedRectangleBorder?;
+      expect(shape, isNotNull);
+      expect(shape!.side.width, 4);
+    });
+
+    testWidgets('uses warning tertiary color for border when pending', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: true));
+      await tester.pump();
+
+      final BuildContext context = tester.element(find.byType(Card).first);
+      final expectedColor = Theme.of(context).colorScheme.tertiary;
+
+      final card = tester.widget<Card>(find.byType(Card).first);
+      final shape = card.shape as RoundedRectangleBorder;
+      expect(shape.side.color, expectedColor);
+    });
+
+    testWidgets('shows "Decide" label when pending and collapsed', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: true));
+      await tester.pump();
+
+      expect(find.text('Decide'), findsOneWidget);
+    });
+
+    testWidgets('hides "Decide" label when pending and expanded', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: true));
+      await tester.pump();
+
+      // Expand.
+      await tester.tap(find.byIcon(Icons.expand_more));
+      await tester.pump();
+
+      expect(find.text('Decide'), findsNothing);
+    });
+
+    testWidgets('does not show "Decide" label when not pending', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_pump(isPending: false));
+      await tester.pump();
+
+      expect(find.text('Decide'), findsNothing);
+    });
+  });
+}

--- a/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
@@ -111,49 +111,6 @@ void main() {
       expect(shape.side.color, expectedColor);
     });
 
-    testWidgets('shows "Decide" label when pending and collapsed', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(800, 600);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
-      await tester.pumpWidget(_pump(isPending: true));
-      await tester.pump();
-
-      expect(find.text('Decide'), findsOneWidget);
-    });
-
-    testWidgets('hides "Decide" label when pending and expanded', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(800, 600);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
-      await tester.pumpWidget(_pump(isPending: true));
-      await tester.pump();
-
-      // Expand.
-      await tester.tap(find.byIcon(Icons.expand_more));
-      await tester.pump();
-
-      expect(find.text('Decide'), findsNothing);
-    });
-
-    testWidgets('does not show "Decide" label when not pending', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(800, 600);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
-      await tester.pumpWidget(_pump(isPending: false));
-      await tester.pump();
-
-      expect(find.text('Decide'), findsNothing);
-    });
-
     testWidgets(
       'does NOT show action chip when pending and selectedAction is null',
       (tester) async {
@@ -170,9 +127,8 @@ void main() {
         expect(find.text('IMPORT'), findsNothing);
         expect(find.text('CONSOLIDATE'), findsNothing);
 
-        // But the pending visual cues are still present.
+        // But the pending pill is still present.
         expect(find.text('Needs decision'), findsOneWidget);
-        expect(find.text('Decide'), findsOneWidget);
       },
     );
 

--- a/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
@@ -24,7 +24,10 @@ const _item = EntityItem(
   subtitle: '25.0 m · 50 min',
 );
 
-Widget _pump({required bool isPending}) {
+Widget _pump({
+  required bool isPending,
+  DuplicateAction? selectedAction = DuplicateAction.skip,
+}) {
   return MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
@@ -33,7 +36,7 @@ Widget _pump({required bool isPending}) {
         child: DuplicateActionCard(
           item: _item,
           matchResult: _matchResult,
-          selectedAction: DuplicateAction.skip,
+          selectedAction: selectedAction,
           availableActions: const {
             DuplicateAction.skip,
             DuplicateAction.importAsNew,
@@ -149,6 +152,43 @@ void main() {
       await tester.pump();
 
       expect(find.text('Decide'), findsNothing);
+    });
+
+    testWidgets(
+      'does NOT show action chip when pending and selectedAction is null',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(_pump(isPending: true, selectedAction: null));
+        await tester.pump();
+
+        // None of the action badge labels should be visible because no
+        // decision has been made yet.
+        expect(find.text('SKIP'), findsNothing);
+        expect(find.text('IMPORT'), findsNothing);
+        expect(find.text('CONSOLIDATE'), findsNothing);
+
+        // But the pending visual cues are still present.
+        expect(find.text('Needs decision'), findsOneWidget);
+        expect(find.text('Decide'), findsOneWidget);
+      },
+    );
+
+    testWidgets('shows SKIP chip when pending and selectedAction is skip', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        _pump(isPending: true, selectedAction: DuplicateAction.skip),
+      );
+      await tester.pump();
+
+      expect(find.text('SKIP'), findsOneWidget);
     });
   });
 }

--- a/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/duplicate_action_card_pending_test.dart
@@ -79,7 +79,12 @@ void main() {
       expect(find.text('Needs decision'), findsNothing);
     });
 
-    testWidgets('renders 4-px warning border when pending', (tester) async {
+    testWidgets('renders warning border at resting thickness when pending', (
+      tester,
+    ) async {
+      // Pending cards share the resting 1.5-px border width but carry the
+      // tertiary/warning color (asserted in the next test) so the row is
+      // flagged without visually out-weighting the surrounding cards.
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -90,7 +95,7 @@ void main() {
       final card = tester.widget<Card>(find.byType(Card).first);
       final shape = card.shape as RoundedRectangleBorder?;
       expect(shape, isNotNull);
-      expect(shape!.side.width, 4);
+      expect(shape!.side.width, 1.5);
     });
 
     testWidgets('uses warning tertiary color for border when pending', (

--- a/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
@@ -1,0 +1,494 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/domain/models/incoming_dive_data.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/duplicate_action_card.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/entity_review_list.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const _testDiveId = 'existing-1';
+
+// A non-null IncomingDiveData makes the group look like a "dive tab".
+final _diveData = IncomingDiveData(
+  startTime: DateTime(2026, 1, 15, 9, 0),
+  maxDepth: 25,
+  durationSeconds: 3000,
+  profile: const [],
+);
+
+final _dup0 = EntityItem(
+  title: 'Dup 0',
+  subtitle: '25 m - 50 min',
+  diveData: _diveData,
+);
+final _dup1 = EntityItem(
+  title: 'Dup 1',
+  subtitle: '25 m - 50 min',
+  diveData: _diveData,
+);
+final _dup2 = EntityItem(
+  title: 'Dup 2',
+  subtitle: '25 m - 50 min',
+  diveData: _diveData,
+);
+
+const _highMatch = DiveMatchResult(
+  diveId: _testDiveId,
+  score: 0.92,
+  timeDifferenceMs: 60000,
+);
+
+const _midMatch = DiveMatchResult(
+  diveId: _testDiveId,
+  score: 0.80,
+  timeDifferenceMs: 60000,
+);
+
+const _lowMatch = DiveMatchResult(
+  diveId: _testDiveId,
+  score: 0.72,
+  timeDifferenceMs: 120000,
+);
+
+// Non-dive entity (no diveData) for "non-dive tab" branches.
+const _siteDupItem = EntityItem(title: 'Site Dup', subtitle: 'GPS: 0, 0');
+
+Widget _pumpList({
+  required EntityGroup group,
+  required Set<int> pendingIndices,
+  Set<DuplicateAction>? availableActions,
+  void Function(DuplicateAction)? onBulkAction,
+  Map<int, DuplicateAction>? duplicateActions,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: SizedBox(
+        width: 800,
+        height: 1200,
+        child: SingleChildScrollView(
+          child: EntityReviewList(
+            group: group,
+            selectedIndices: const {},
+            duplicateActions: duplicateActions ?? const {},
+            availableActions:
+                availableActions ??
+                const {
+                  DuplicateAction.skip,
+                  DuplicateAction.importAsNew,
+                  DuplicateAction.consolidate,
+                },
+            pendingIndices: pendingIndices,
+            onToggleSelection: (_) {},
+            onDuplicateActionChanged: (_, _) {},
+            onBulkAction: onBulkAction ?? (_) {},
+            onSelectAll: () {},
+            onDeselectAll: () {},
+            existingDiveIdForIndex: (_) => _testDiveId,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('EntityReviewList bulk action row', () {
+    testWidgets('not shown when pendingIndices is empty', (tester) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final group = EntityGroup(
+        items: [_dup0, _dup1],
+        duplicateIndices: const {0, 1},
+        matchResults: const {0: _highMatch, 1: _midMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {}),
+      );
+      await tester.pump();
+
+      // Neither bulk buttons should be present
+      expect(find.textContaining('Skip all'), findsNothing);
+      expect(find.textContaining('Import all'), findsNothing);
+      expect(find.textContaining('Consolidate matched'), findsNothing);
+    });
+
+    testWidgets('shown when pendingIndices is non-empty on a dive tab', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final group = EntityGroup(
+        items: [_dup0, _dup1],
+        duplicateIndices: const {0, 1},
+        matchResults: const {0: _highMatch, 1: _midMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {0, 1}),
+      );
+      await tester.pump();
+
+      expect(find.text('Skip all (2)'), findsOneWidget);
+      // Dive tab uses "Import all as new".
+      expect(find.text('Import all as new (2)'), findsOneWidget);
+      // Both pending items have score >= 0.7, so consolidate count == 2.
+      expect(find.text('Consolidate matched (2)'), findsOneWidget);
+    });
+
+    testWidgets(
+      'non-dive tab uses "Import all" label not "Import all as new"',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 1200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        const group = EntityGroup(items: [_siteDupItem], duplicateIndices: {0});
+
+        await tester.pumpWidget(
+          _pumpList(
+            group: group,
+            pendingIndices: const {0},
+            availableActions: const {
+              DuplicateAction.skip,
+              DuplicateAction.importAsNew,
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Import all (1)'), findsOneWidget);
+        expect(find.text('Import all as new (1)'), findsNothing);
+      },
+    );
+
+    testWidgets('filters buttons by availableActions (omits consolidate)', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final group = EntityGroup(
+        items: [_dup0],
+        duplicateIndices: const {0},
+        matchResults: const {0: _highMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(
+          group: group,
+          pendingIndices: const {0},
+          availableActions: const {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Skip all (1)'), findsOneWidget);
+      expect(find.text('Import all as new (1)'), findsOneWidget);
+      expect(find.textContaining('Consolidate matched'), findsNothing);
+    });
+
+    testWidgets('consolidate button is disabled when no pending >= 0.7', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      // Score is 0.60 (below 0.7 threshold), so consolidate count == 0.
+      const belowThresholdMatch = DiveMatchResult(
+        diveId: _testDiveId,
+        score: 0.60,
+        timeDifferenceMs: 60000,
+      );
+
+      final group = EntityGroup(
+        items: [_dup0],
+        duplicateIndices: const {0},
+        matchResults: const {0: belowThresholdMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {0}),
+      );
+      await tester.pump();
+
+      final finder = find.widgetWithText(
+        OutlinedButton,
+        'Consolidate matched (0)',
+      );
+      expect(finder, findsOneWidget);
+      final button = tester.widget<OutlinedButton>(finder);
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('consolidate counts only pending with score >= 0.7', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      const belowThresholdMatch = DiveMatchResult(
+        diveId: _testDiveId,
+        score: 0.60,
+        timeDifferenceMs: 60000,
+      );
+
+      final group = EntityGroup(
+        items: [_dup0, _dup1, _dup2],
+        duplicateIndices: const {0, 1, 2},
+        matchResults: const {
+          0: _highMatch,
+          1: belowThresholdMatch,
+          2: _lowMatch,
+        },
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {0, 1, 2}),
+      );
+      await tester.pump();
+
+      // 2 of 3 pending have score >= 0.7 (indices 0 and 2).
+      expect(find.text('Consolidate matched (2)'), findsOneWidget);
+    });
+
+    testWidgets('tapping bulk Skip button fires onBulkAction with skip', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      DuplicateAction? firedAction;
+
+      final group = EntityGroup(
+        items: [_dup0],
+        duplicateIndices: const {0},
+        matchResults: const {0: _highMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(
+          group: group,
+          pendingIndices: const {0},
+          onBulkAction: (a) => firedAction = a,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Skip all (1)'));
+      await tester.pump();
+
+      expect(firedAction, DuplicateAction.skip);
+    });
+  });
+
+  group('EntityReviewList pending-first sort', () {
+    testWidgets('pending duplicate sorts before non-pending in same section', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      // Three likely duplicates (all >= 0.7). Two are non-pending with the
+      // highest scores; one is pending with the lowest score within the
+      // section. In the sorted order pending (index 2) must come first.
+      final group = EntityGroup(
+        items: [_dup0, _dup1, _dup2],
+        duplicateIndices: const {0, 1, 2},
+        matchResults: const {
+          0: _highMatch, // score 0.92
+          1: _midMatch, // score 0.80
+          2: _lowMatch, // score 0.72
+        },
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {2}),
+      );
+      await tester.pump();
+
+      // Three DuplicateActionCards should be rendered in some order.
+      final cardFinder = find.byType(DuplicateActionCard);
+      expect(cardFinder, findsNWidgets(3));
+
+      // Collect cards' top Y coordinates and associated titles.
+      final cards = tester.widgetList<DuplicateActionCard>(cardFinder).toList();
+      final rects = cards
+          .map((w) => tester.getTopLeft(find.byWidget(w)))
+          .toList();
+
+      // Find the pending one (Dup 2, which is _lowMatch index 2) and confirm
+      // it has the smallest Y (i.e., is first).
+      final titles = cards.map((c) => c.item.title).toList();
+      final pendingIdx = titles.indexOf('Dup 2');
+      expect(pendingIdx, isNot(-1));
+
+      final pendingY = rects[pendingIdx].dy;
+      for (var i = 0; i < rects.length; i++) {
+        if (i == pendingIdx) continue;
+        expect(
+          pendingY,
+          lessThan(rects[i].dy),
+          reason: 'Pending card must render above non-pending card $i',
+        );
+      }
+    });
+
+    testWidgets('non-pending duplicates remain ordered by score descending', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      // Two non-pending duplicates, both likely. Highest-score first.
+      final group = EntityGroup(
+        items: [_dup0, _dup1],
+        duplicateIndices: const {0, 1},
+        matchResults: const {
+          0: _midMatch, // 0.80
+          1: _highMatch, // 0.92
+        },
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {}),
+      );
+      await tester.pump();
+
+      final cardFinder = find.byType(DuplicateActionCard);
+      expect(cardFinder, findsNWidgets(2));
+
+      final cards = tester.widgetList<DuplicateActionCard>(cardFinder).toList();
+      final rects = cards
+          .map((w) => tester.getTopLeft(find.byWidget(w)))
+          .toList();
+
+      final dup1Idx = cards.indexWhere((c) => c.item.title == 'Dup 1');
+      final dup0Idx = cards.indexWhere((c) => c.item.title == 'Dup 0');
+
+      // Dup 1 (higher score 0.92) should render above Dup 0 (lower 0.80).
+      expect(rects[dup1Idx].dy, lessThan(rects[dup0Idx].dy));
+    });
+  });
+
+  group('EntityReviewList isPending wiring', () {
+    testWidgets('pending DuplicateActionCard shows Needs decision pill', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final group = EntityGroup(
+        items: [_dup0],
+        duplicateIndices: const {0},
+        matchResults: const {0: _highMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {0}),
+      );
+      await tester.pump();
+
+      // The "Needs decision" pill is the visual signal for isPending on the
+      // DuplicateActionCard. One pill means isPending=true was passed.
+      expect(find.text('Needs decision'), findsOneWidget);
+    });
+
+    testWidgets('non-pending DuplicateActionCard hides Needs decision pill', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final group = EntityGroup(
+        items: [_dup0],
+        duplicateIndices: const {0},
+        matchResults: const {0: _highMatch},
+      );
+
+      await tester.pumpWidget(
+        _pumpList(group: group, pendingIndices: const {}),
+      );
+      await tester.pump();
+
+      expect(find.text('Needs decision'), findsNothing);
+    });
+
+    testWidgets('pending non-dive _EntityDuplicateCard shows pill', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      // No matchResults -> routes through _EntityDuplicateCard (non-dive).
+      const group = EntityGroup(items: [_siteDupItem], duplicateIndices: {0});
+
+      await tester.pumpWidget(
+        _pumpList(
+          group: group,
+          pendingIndices: const {0},
+          availableActions: const {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Needs decision'), findsOneWidget);
+    });
+
+    testWidgets('non-pending non-dive _EntityDuplicateCard hides pill', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      const group = EntityGroup(items: [_siteDupItem], duplicateIndices: {0});
+
+      await tester.pumpWidget(
+        _pumpList(
+          group: group,
+          pendingIndices: const {},
+          availableActions: const {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Needs decision'), findsNothing);
+    });
+  });
+}

--- a/test/features/import_wizard/presentation/widgets/needs_decision_pill_test.dart
+++ b/test/features/import_wizard/presentation/widgets/needs_decision_pill_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/needs_decision_pill.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+Widget _pump(ColorScheme colorScheme) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: NeedsDecisionPill(colorScheme: colorScheme)),
+  );
+}
+
+void main() {
+  testWidgets('renders localized text and warning icon', (tester) async {
+    await tester.pumpWidget(_pump(const ColorScheme.light()));
+    expect(find.text('Needs decision'), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+  });
+}

--- a/test/features/import_wizard/presentation/widgets/review_step_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/review_step_pending_test.dart
@@ -289,7 +289,8 @@ void main() {
     );
 
     testWidgets(
-      'draining pending via applyBulkAction re-enables Import button',
+      'draining pending via applyBulkAction(importAsNew) re-enables Import '
+      'button',
       (tester) async {
         await tester.binding.setSurfaceSize(const Size(800, 600));
         addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -309,14 +310,48 @@ void main() {
         );
         expect(importButton.onPressed, isNull);
 
-        // Drain via bulk skip.
-        notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+        // Drain via bulk importAsNew — both drains pending AND adds something
+        // to import, so the gate re-enables.
+        notifier.applyBulkAction(
+          ImportEntityType.dives,
+          DuplicateAction.importAsNew,
+        );
         await tester.pump();
 
         importButton = tester.widget<FilledButton>(
           find.widgetWithText(FilledButton, 'Import Selected'),
         );
         expect(importButton.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'bulk skip on a pending-only bundle leaves Import button disabled',
+      (tester) async {
+        // Guards the Copilot-requested gate: when the user resolves all
+        // pending by skipping everything (and nothing else is queued for
+        // import), Import stays disabled because pressing it would be a
+        // no-op. Previously the button re-enabled as soon as pending was
+        // empty, regardless of whether anything was actually selected.
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(importWizardNotifierProvider.notifier);
+        notifier.setBundle(_bundleWithOnePendingDive());
+
+        await tester.pumpWidget(_pumpReview(container: container));
+        await tester.pump();
+
+        notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+        await tester.pump();
+
+        final importButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Import Selected'),
+        );
+        expect(importButton.onPressed, isNull);
       },
     );
   });

--- a/test/features/import_wizard/presentation/widgets/review_step_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/review_step_pending_test.dart
@@ -1,0 +1,325 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_phase.dart';
+import 'package:submersion/features/import_wizard/domain/models/unified_import_result.dart';
+import 'package:submersion/features/import_wizard/domain/models/wizard_step_def.dart';
+import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/review_step.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// ---------------------------------------------------------------------------
+// Fake adapter (self-contained; mirrors fixtures from notifier test file).
+// ---------------------------------------------------------------------------
+
+class _TestAdapter implements ImportSourceAdapter {
+  @override
+  void resetState() {}
+
+  @override
+  ImportSourceType get sourceType => ImportSourceType.uddf;
+
+  @override
+  String get displayName => 'test.uddf';
+
+  @override
+  String get defaultTagName => 'Test Import';
+
+  @override
+  List<WizardStepDef> get acquisitionSteps => const [];
+
+  @override
+  Set<DuplicateAction> get supportedDuplicateActions => const {
+    DuplicateAction.skip,
+    DuplicateAction.importAsNew,
+    DuplicateAction.consolidate,
+  };
+
+  @override
+  Future<ImportBundle> buildBundle() => throw UnimplementedError();
+
+  @override
+  Future<ImportBundle> checkDuplicates(ImportBundle bundle) =>
+      throw UnimplementedError();
+
+  @override
+  Future<UnifiedImportResult> performImport(
+    ImportBundle bundle,
+    Map<ImportEntityType, Set<int>> selections,
+    Map<ImportEntityType, Map<int, DuplicateAction>> duplicateActions, {
+    bool retainSourceDiveNumbers = false,
+    ImportProgressCallback? onProgress,
+  }) => throw UnimplementedError();
+}
+
+// ---------------------------------------------------------------------------
+// Bundle fixtures
+// ---------------------------------------------------------------------------
+
+ImportBundle _bundleWithOnePendingDive() {
+  return const ImportBundle(
+    source: ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'probable.uddf',
+    ),
+    groups: {
+      ImportEntityType.dives: EntityGroup(
+        items: [EntityItem(title: 'Dive 1', subtitle: '25 m - 50 min')],
+        duplicateIndices: {0},
+        matchResults: {
+          0: DiveMatchResult(
+            diveId: 'existing-dive',
+            score: 0.85,
+            timeDifferenceMs: 0,
+          ),
+        },
+      ),
+    },
+  );
+}
+
+ImportBundle _bundleWithDiveAndPendingSite() {
+  return const ImportBundle(
+    source: ImportSourceInfo(
+      type: ImportSourceType.uddf,
+      displayName: 'dive-and-site.uddf',
+    ),
+    groups: {
+      // Dives tab: one clean dive, no pending.
+      ImportEntityType.dives: EntityGroup(
+        items: [EntityItem(title: 'Dive 1', subtitle: '25 m - 50 min')],
+      ),
+      // Sites tab: one pending duplicate site.
+      ImportEntityType.sites: EntityGroup(
+        items: [EntityItem(title: 'Site A', subtitle: 'GPS: 0, 0')],
+        duplicateIndices: {0},
+      ),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pump helper
+// ---------------------------------------------------------------------------
+
+Widget _pumpReview({
+  required ProviderContainer container,
+  VoidCallback? onImport,
+}) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: ReviewStep(onImport: onImport ?? _noop)),
+    ),
+  );
+}
+
+ProviderContainer _buildContainer() {
+  final container = ProviderContainer(
+    overrides: [
+      importWizardNotifierProvider.overrideWith(
+        (ref) => ImportWizardNotifier(_TestAdapter()),
+      ),
+    ],
+  );
+  return container;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ReviewStep - pending-review gating', () {
+    testWidgets('Import button is disabled when pending reviews exist', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(_bundleWithOnePendingDive());
+
+      await tester.pumpWidget(_pumpReview(container: container));
+      await tester.pump();
+
+      final importButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Import Selected'),
+      );
+      expect(importButton.onPressed, isNull);
+    });
+
+    testWidgets('pending hint text shows above the button', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      notifier.setBundle(_bundleWithOnePendingDive());
+
+      await tester.pumpWidget(_pumpReview(container: container));
+      await tester.pump();
+
+      // "1 duplicate(s) need a decision" (ARB: universalImport_pending_gateHint)
+      expect(find.text('1 duplicate(s) need a decision'), findsOneWidget);
+      // Warning icon is present on the hint bar (in addition to any
+      // needs-decision pill on the card itself).
+      expect(find.byIcon(Icons.warning_amber_rounded), findsAtLeastNWidgets(1));
+      // Review action button.
+      expect(find.widgetWithText(TextButton, 'Review'), findsOneWidget);
+    });
+
+    testWidgets('no pending hint when no pending reviews', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      // Bundle with no duplicates — no pending.
+      notifier.setBundle(
+        const ImportBundle(
+          source: ImportSourceInfo(
+            type: ImportSourceType.uddf,
+            displayName: 'clean.uddf',
+          ),
+          groups: {
+            ImportEntityType.dives: EntityGroup(
+              items: [EntityItem(title: 'Dive 1', subtitle: '25 m - 50 min')],
+            ),
+          },
+        ),
+      );
+
+      await tester.pumpWidget(_pumpReview(container: container));
+      await tester.pump();
+
+      // Hint is absent.
+      expect(find.byIcon(Icons.warning_amber_rounded), findsNothing);
+      expect(find.widgetWithText(TextButton, 'Review'), findsNothing);
+
+      // Button is enabled.
+      final importButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Import Selected'),
+      );
+      expect(importButton.onPressed, isNotNull);
+    });
+
+    testWidgets('tapping Review animates DefaultTabController to pending tab', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(importWizardNotifierProvider.notifier);
+      // Bundle: clean dives tab (index 0), pending sites tab (index 1).
+      notifier.setBundle(_bundleWithDiveAndPendingSite());
+
+      await tester.pumpWidget(_pumpReview(container: container));
+      await tester.pump();
+
+      // Before: default tab is 0 (Dives).
+      final tabsContext = tester.element(find.byType(TabBar));
+      var controller = DefaultTabController.of(tabsContext);
+      expect(controller.index, 0);
+
+      // Tap Review.
+      await tester.tap(find.widgetWithText(TextButton, 'Review'));
+      await tester.pumpAndSettle();
+
+      // After: tab has animated to Sites (index 1 — pending tab).
+      controller = DefaultTabController.of(tabsContext);
+      expect(controller.index, 1);
+    });
+
+    testWidgets(
+      'draining pending via setDuplicateAction re-enables Import button',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(importWizardNotifierProvider.notifier);
+        notifier.setBundle(_bundleWithOnePendingDive());
+
+        await tester.pumpWidget(_pumpReview(container: container));
+        await tester.pump();
+
+        // Initially disabled.
+        var importButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Import Selected'),
+        );
+        expect(importButton.onPressed, isNull);
+
+        // Drain pending by setting the duplicate action.
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          0,
+          DuplicateAction.importAsNew,
+        );
+        await tester.pump();
+
+        // Now enabled.
+        importButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Import Selected'),
+        );
+        expect(importButton.onPressed, isNotNull);
+
+        // Pending hint gone.
+        expect(find.byIcon(Icons.warning_amber_rounded), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'draining pending via applyBulkAction re-enables Import button',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(importWizardNotifierProvider.notifier);
+        notifier.setBundle(_bundleWithOnePendingDive());
+
+        await tester.pumpWidget(_pumpReview(container: container));
+        await tester.pump();
+
+        // Initially disabled.
+        var importButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Import Selected'),
+        );
+        expect(importButton.onPressed, isNull);
+
+        // Drain via bulk skip.
+        notifier.applyBulkAction(ImportEntityType.dives, DuplicateAction.skip);
+        await tester.pump();
+
+        importButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Import Selected'),
+        );
+        expect(importButton.onPressed, isNotNull);
+      },
+    );
+  });
+}
+
+void _noop() {}


### PR DESCRIPTION
## Summary

Fixes #200. Suspected-duplicate rows in the unified import review step no longer receive silent default actions. Before this change, probable-score matches (≥ 0.7) auto-defaulted to `skip` and possible-score matches (0.5–0.7) auto-defaulted to `importAsNew` — both applied without the user ever seeing or agreeing to the decision. After this change, every flagged duplicate must have an explicit user action (skip / import as new / consolidate) before the Import button enables.

Design spec: [`docs/superpowers/specs/2026-04-12-import-duplicate-required-selection-design.md`](../blob/feature/issue-200-require-duplicate-selection/docs/superpowers/specs/2026-04-12-import-duplicate-required-selection-design.md).
Implementation plan: [`docs/superpowers/plans/2026-04-12-import-duplicate-required-selection-v2.md`](../blob/feature/issue-200-require-duplicate-selection/docs/superpowers/plans/2026-04-12-import-duplicate-required-selection-v2.md).

## Changes

**State layer (`ImportWizardState` / `ImportWizardNotifier`):**

- New `pendingDuplicateReview: Map<ImportEntityType, Set<int>>` field + helpers (`pendingFor`, `hasPendingReviews`, `totalPending`).
- `setBundle` now populates `pendingDuplicateReview` from each `EntityGroup.duplicateIndices` and leaves `duplicateActions` empty for those rows (no more auto-default).
- `setDuplicateAction` and `toggleSelection` drain the acted-upon index from pending in a single atomic `copyWith`.
- New `applyBulkAction(type, action)` resolves every pending index for a type in one emission. `consolidate` only applies to indices with `score >= 0.7`; weaker matches stay pending.
- New `firstPendingLocation() → PendingLocation?` for tab-navigation from the pending hint bar.

**UI (`ReviewStep` / `EntityReviewList` / `DuplicateActionCard` / `DiveComparisonCard`):**

- Import button now gates on `totalSelected > 0 && !hasPendingReviews`.
- Pending-hint bar above the Import button shows "N duplicate(s) need a decision" with a **Review** button that animates the `DefaultTabController` to the first pending tab. Wrapped in `Semantics(liveRegion: true)`.
- Per-tab bulk-action row with Skip all / Import all as new / Consolidate matched buttons, respecting the adapter's `supportedDuplicateActions`. **Consolidate matched** bulk button is disabled for now with a `TODO(#200)` pending full bulk-consolidate wiring.
- Duplicate sections (Potential, Possible, unscored) render **above** non-duplicates so rows needing decisions aren't buried.
- Pending `DuplicateActionCard` / `_EntityDuplicateCard` get a 4-px warning-colored border and a "Needs decision" pill (new shared `NeedsDecisionPill` widget).
- Action buttons in tri-state mode (Skip / Import as New / Consolidate) now render in semantic colors — red / green / blue — in both outlined and filled states, so a pending row shows three distinct, visibly-actionable options instead of indistinguishable gray outlines.
- Clicking an action shows a brief floating snackbar (e.g., "Marked as Skip" or "3 marked as Import as New") so users get feedback that their choice registered.
- No action chip or pre-highlighted Skip button when the row is pending — previous fallback to "skip when null" was removed on both the collapsed and expanded cards.

**Localization:** 11 new `universalImport_*` ARB keys (bulk buttons, pending hint, Review button, needs-decision pill text + semantics label, summary addendum). English only; other locales fall back to English until the next translation pass.

**Tests:** State/notifier tests (popuplate, drain, bulk, firstPendingLocation), widget tests (gate, hint, bulk row, sort, card pending visuals, pill), and a self-contained regression test (`issue_200_regression_test.dart`) that explicitly guards against the silent-default bug returning.

**Not touched:** `lib/features/universal_import/**` contains an earlier orphaned `ImportReviewStep` widget unreachable from the router. Left in place; a follow-up cleanup PR can remove it.

## Test Plan

- [x] `flutter test` passes (6390 tests; full suite run by pre-push hook)
- [x] `flutter analyze` passes (0 issues)
- [x] `dart format --set-exit-if-changed` clean
- [x] Manual testing on: macOS
  - [x] File import triggers gated Import button when duplicates flagged
  - [x] Per-row Skip / Import as New / Consolidate records the action, snackbar confirms
  - [x] Bulk Skip all / Import all as new drain all pending for that tab
  - [x] Bulk Consolidate matched is disabled (greyed out) as intended
  - [x] Review button jumps to the first pending tab
  - [x] Non-duplicate rows behave unchanged
- [x] Smoke test on iOS / Android / Windows / Linux (not yet done by me; please verify if time permits)

## Screenshots

_(User can add before/after screenshots of the import review step; screenshots collected during development showed the pending pill, bulk-action row, colored decision buttons, and snackbar feedback.)_

## Follow-ups

- Enable bulk **Consolidate matched** once the full bulk-consolidate flow is implemented (see `TODO(#200)` in `entity_review_list.dart`).
- Remove the orphaned `lib/features/universal_import/presentation/widgets/import_review_step.dart` in a cleanup PR.
- Localize the hardcoded "Choose an action" label in `DiveComparisonCard` (visible in the tri-state expanded view).
- Migrate `universalImport_pending_gateHint` from `"{count} duplicate(s)"` to an ICU plural block for proper singular/plural agreement.