### PR TITLE
feat: pre-migration database backup

### DIFF
--- a/docs/superpowers/plans/2026-04-12-db-backup-before-migration.md
+++ b/docs/superpowers/plans/2026-04-12-db-backup-before-migration.md
@@ -1,0 +1,2629 @@
+# Pre-Migration Database Backup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically back up `submersion.db` at app startup whenever a Drift schema migration is pending, hard-fail startup if backup fails, surface pre-migration backups in the existing backup list with pin-to-retain support.
+
+**Architecture:** A new `PreMigrationBackupService` performs a file-level copy of the closed DB before Drift opens it, registering the copy via the existing `BackupPreferences` registry. The existing `BackupRecord` entity gains nullable `type` / `appVersion` / `fromSchemaVersion` / `toSchemaVersion` / `pinned` fields so pre-migration and manual backups share one listing/restore surface. `StartupPage` gets new `backingUp` / `backupFailed` states.
+
+**Tech Stack:** Flutter 3.x, Drift 2.30, sqlite3 FFI, Riverpod, SharedPreferences via `BackupPreferences`, existing `BackupService`. Tests use `flutter_test`, `test`, and in-memory Drift (`NativeDatabase.memory`).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-12-db-backup-before-migration-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+
+- `lib/features/backup/domain/entities/backup_type.dart` — `BackupType` enum (`manual`, `preMigration`).
+- `lib/features/backup/domain/exceptions/backup_failed_exception.dart` — `BackupFailedException` + `BackupFailureCause` enum.
+- `lib/features/backup/data/services/pre_migration_backup_service.dart` — the service.
+- `test/features/backup/data/services/pre_migration_backup_service_test.dart` — unit tests.
+- `test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart` — dialog compat branching.
+- `test/core/presentation/pages/startup_page_backup_flow_test.dart` — widget tests for backup-flow states.
+- `test/core/database/pre_migration_backup_integration_test.dart` — end-to-end integration.
+
+**Modified files:**
+
+- `lib/features/backup/domain/entities/backup_record.dart` — add new fields, make counts nullable, update JSON.
+- `lib/features/backup/data/services/backup_service.dart` — add `pinBackup` / `unpinBackup`.
+- `lib/core/presentation/pages/startup_page.dart` — new `backingUp` / `backupFailed` states, wire service.
+- `lib/features/backup/presentation/pages/backup_settings_page.dart` — pin toggle icon + pre-migration badge on list rows.
+- `lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart` — compat branching for pre-migration backups.
+- `test/features/backup/domain/entities/backup_record_test.dart` — cover new fields + backward-compat JSON.
+
+---
+
+## Task 1: Add BackupType enum
+
+**Files:**
+- Create: `lib/features/backup/domain/entities/backup_type.dart`
+
+- [ ] **Step 1: Create the enum file**
+
+```dart
+// lib/features/backup/domain/entities/backup_type.dart
+
+/// Distinguishes a user-initiated (manual / automatic) backup from a
+/// system-initiated backup taken before a schema migration runs.
+enum BackupType {
+  manual,
+  preMigration,
+}
+```
+
+- [ ] **Step 2: Run analyzer to verify no errors**
+
+Run: `flutter analyze lib/features/backup/domain/entities/backup_type.dart`
+Expected: No issues found.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/features/backup/domain/entities/backup_type.dart
+git commit -m "feat: add BackupType enum for distinguishing backup sources"
+```
+
+---
+
+## Task 2: Extend BackupRecord with new fields (TDD)
+
+**Files:**
+- Modify: `lib/features/backup/domain/entities/backup_record.dart` (full rewrite)
+- Modify: `test/features/backup/domain/entities/backup_record_test.dart`
+
+- [ ] **Step 1: Add failing tests for new fields and backward-compat JSON**
+
+Append these tests to `test/features/backup/domain/entities/backup_record_test.dart`
+(if groups already exist, place inside `group('BackupRecord', ...)`):
+
+```dart
+test('defaults: type is manual, pinned is false, counts may be null', () {
+  final record = BackupRecord(
+    id: 'id',
+    filename: 'f.db',
+    timestamp: DateTime(2026, 4, 12),
+    sizeBytes: 10,
+    location: BackupLocation.local,
+  );
+  expect(record.type, BackupType.manual);
+  expect(record.pinned, false);
+  expect(record.appVersion, isNull);
+  expect(record.fromSchemaVersion, isNull);
+  expect(record.toSchemaVersion, isNull);
+  expect(record.diveCount, isNull);
+  expect(record.siteCount, isNull);
+});
+
+test('toJson/fromJson round-trip with new fields populated', () {
+  final original = BackupRecord(
+    id: 'id',
+    filename: 'f.db',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1_700_000_000_000),
+    sizeBytes: 42,
+    location: BackupLocation.local,
+    diveCount: 3,
+    siteCount: 4,
+    type: BackupType.preMigration,
+    appVersion: '1.6.0.1241',
+    fromSchemaVersion: 63,
+    toSchemaVersion: 64,
+    pinned: true,
+    localPath: '/tmp/f.db',
+  );
+  final restored = BackupRecord.fromJson(original.toJson());
+  expect(restored, original);
+});
+
+test('fromJson reads legacy records (no type/pinned/appVersion fields)', () {
+  final legacyJson = {
+    'id': 'id',
+    'filename': 'f.db',
+    'timestamp': 1_700_000_000_000,
+    'sizeBytes': 42,
+    'location': 'local',
+    'diveCount': 3,
+    'siteCount': 4,
+    'cloudFileId': null,
+    'localPath': '/tmp/f.db',
+    'isAutomatic': false,
+  };
+  final record = BackupRecord.fromJson(legacyJson);
+  expect(record.type, BackupType.manual);
+  expect(record.pinned, false);
+  expect(record.appVersion, isNull);
+  expect(record.fromSchemaVersion, isNull);
+  expect(record.toSchemaVersion, isNull);
+  expect(record.diveCount, 3);
+  expect(record.siteCount, 4);
+});
+
+test('fromJson handles null counts for pre-migration records', () {
+  final json = {
+    'id': 'id',
+    'filename': 'f.db',
+    'timestamp': 1_700_000_000_000,
+    'sizeBytes': 42,
+    'location': 'local',
+    'diveCount': null,
+    'siteCount': null,
+    'cloudFileId': null,
+    'localPath': '/tmp/f.db',
+    'isAutomatic': true,
+    'type': 'preMigration',
+    'appVersion': '1.6.0.1241',
+    'fromSchemaVersion': 63,
+    'toSchemaVersion': 64,
+    'pinned': true,
+  };
+  final record = BackupRecord.fromJson(json);
+  expect(record.diveCount, isNull);
+  expect(record.siteCount, isNull);
+  expect(record.type, BackupType.preMigration);
+});
+
+test('copyWith preserves new fields when not overridden', () {
+  final original = BackupRecord(
+    id: 'id',
+    filename: 'f.db',
+    timestamp: DateTime(2026),
+    sizeBytes: 1,
+    location: BackupLocation.local,
+    type: BackupType.preMigration,
+    pinned: true,
+    fromSchemaVersion: 63,
+    toSchemaVersion: 64,
+  );
+  final copy = original.copyWith(sizeBytes: 2);
+  expect(copy.type, BackupType.preMigration);
+  expect(copy.pinned, true);
+  expect(copy.fromSchemaVersion, 63);
+  expect(copy.toSchemaVersion, 64);
+  expect(copy.sizeBytes, 2);
+});
+
+test('copyWith can set pinned independently', () {
+  final original = BackupRecord(
+    id: 'id',
+    filename: 'f.db',
+    timestamp: DateTime(2026),
+    sizeBytes: 1,
+    location: BackupLocation.local,
+    pinned: false,
+  );
+  final pinned = original.copyWith(pinned: true);
+  expect(pinned.pinned, true);
+});
+```
+
+Also add at top of file (below existing imports):
+
+```dart
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/domain/entities/backup_record_test.dart`
+Expected: New tests fail with compilation errors (type, pinned, etc. undefined) or missing named args.
+
+- [ ] **Step 3: Replace `lib/features/backup/domain/entities/backup_record.dart` with the extended shape**
+
+```dart
+import 'package:equatable/equatable.dart';
+
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+/// Where a backup is stored
+enum BackupLocation { local, cloud, both }
+
+/// A record of a single backup snapshot
+class BackupRecord extends Equatable {
+  final String id;
+  final String filename;
+  final DateTime timestamp;
+  final int sizeBytes;
+  final BackupLocation location;
+  final int? diveCount;
+  final int? siteCount;
+  final String? cloudFileId;
+  final String? localPath;
+  final bool isAutomatic;
+  final BackupType type;
+  final String? appVersion;
+  final int? fromSchemaVersion;
+  final int? toSchemaVersion;
+  final bool pinned;
+
+  const BackupRecord({
+    required this.id,
+    required this.filename,
+    required this.timestamp,
+    required this.sizeBytes,
+    required this.location,
+    this.diveCount,
+    this.siteCount,
+    this.cloudFileId,
+    this.localPath,
+    this.isAutomatic = false,
+    this.type = BackupType.manual,
+    this.appVersion,
+    this.fromSchemaVersion,
+    this.toSchemaVersion,
+    this.pinned = false,
+  });
+
+  BackupRecord copyWith({
+    String? id,
+    String? filename,
+    DateTime? timestamp,
+    int? sizeBytes,
+    BackupLocation? location,
+    int? diveCount,
+    int? siteCount,
+    String? cloudFileId,
+    String? localPath,
+    bool? isAutomatic,
+    BackupType? type,
+    String? appVersion,
+    int? fromSchemaVersion,
+    int? toSchemaVersion,
+    bool? pinned,
+  }) {
+    return BackupRecord(
+      id: id ?? this.id,
+      filename: filename ?? this.filename,
+      timestamp: timestamp ?? this.timestamp,
+      sizeBytes: sizeBytes ?? this.sizeBytes,
+      location: location ?? this.location,
+      diveCount: diveCount ?? this.diveCount,
+      siteCount: siteCount ?? this.siteCount,
+      cloudFileId: cloudFileId ?? this.cloudFileId,
+      localPath: localPath ?? this.localPath,
+      isAutomatic: isAutomatic ?? this.isAutomatic,
+      type: type ?? this.type,
+      appVersion: appVersion ?? this.appVersion,
+      fromSchemaVersion: fromSchemaVersion ?? this.fromSchemaVersion,
+      toSchemaVersion: toSchemaVersion ?? this.toSchemaVersion,
+      pinned: pinned ?? this.pinned,
+    );
+  }
+
+  /// Formatted file size for display (e.g., "2.3 MB")
+  String get formattedSize {
+    if (sizeBytes < 1024) return '$sizeBytes B';
+    if (sizeBytes < 1024 * 1024) {
+      return '${(sizeBytes / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(sizeBytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'filename': filename,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+      'sizeBytes': sizeBytes,
+      'location': location.name,
+      'diveCount': diveCount,
+      'siteCount': siteCount,
+      'cloudFileId': cloudFileId,
+      'localPath': localPath,
+      'isAutomatic': isAutomatic,
+      'type': type.name,
+      'appVersion': appVersion,
+      'fromSchemaVersion': fromSchemaVersion,
+      'toSchemaVersion': toSchemaVersion,
+      'pinned': pinned,
+    };
+  }
+
+  factory BackupRecord.fromJson(Map<String, dynamic> json) {
+    return BackupRecord(
+      id: json['id'] as String,
+      filename: json['filename'] as String,
+      timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] as int),
+      sizeBytes: json['sizeBytes'] as int,
+      location: BackupLocation.values.byName(json['location'] as String),
+      diveCount: json['diveCount'] as int?,
+      siteCount: json['siteCount'] as int?,
+      cloudFileId: json['cloudFileId'] as String?,
+      localPath: json['localPath'] as String?,
+      isAutomatic: json['isAutomatic'] as bool? ?? false,
+      type: _parseType(json['type'] as String?),
+      appVersion: json['appVersion'] as String?,
+      fromSchemaVersion: json['fromSchemaVersion'] as int?,
+      toSchemaVersion: json['toSchemaVersion'] as int?,
+      pinned: json['pinned'] as bool? ?? false,
+    );
+  }
+
+  static BackupType _parseType(String? value) {
+    if (value == null) return BackupType.manual;
+    return BackupType.values.asNameMap()[value] ?? BackupType.manual;
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    filename,
+    timestamp,
+    sizeBytes,
+    location,
+    diveCount,
+    siteCount,
+    cloudFileId,
+    localPath,
+    isAutomatic,
+    type,
+    appVersion,
+    fromSchemaVersion,
+    toSchemaVersion,
+    pinned,
+  ];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/domain/entities/backup_record_test.dart`
+Expected: All tests pass, including the five new ones.
+
+- [ ] **Step 5: Run analyzer**
+
+Run: `flutter analyze lib/features/backup/domain/entities/backup_record.dart test/features/backup/domain/entities/backup_record_test.dart`
+Expected: No issues. The nullable `diveCount` / `siteCount` change may surface call sites that assumed non-null — that's addressed in the next task.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/backup/domain/entities/backup_record.dart \
+        test/features/backup/domain/entities/backup_record_test.dart
+git commit -m "feat: extend BackupRecord with type, pinned, schema pair, appVersion"
+```
+
+---
+
+## Task 3: Fix non-null callers of diveCount/siteCount
+
+**Files:**
+- Modify: any files surfaced by the analyzer that use `record.diveCount` or `record.siteCount` without handling null.
+
+- [ ] **Step 1: Run analyzer across the full project to surface all breakages**
+
+Run: `flutter analyze`
+Expected: A list of errors referencing `diveCount` or `siteCount` on `BackupRecord`.
+
+- [ ] **Step 2: For each surfaced site, update the caller to handle null**
+
+Typical fix pattern — replace:
+```dart
+'${record.diveCount} dives, ${record.siteCount} sites'
+```
+with:
+```dart
+'${record.diveCount ?? 0} dives, ${record.siteCount ?? 0} sites'
+```
+
+Known caller per the current code: `lib/features/backup/presentation/pages/backup_settings_page.dart` around the `ListTile.subtitle` on the history row. Replace:
+```dart
+subtitle: Text(
+  '${record.diveCount} dives, ${record.siteCount} sites - ${record.formattedSize}'
+  '${record.isAutomatic ? ' (auto)' : ''}',
+),
+```
+with:
+```dart
+subtitle: Text(
+  record.type == BackupType.preMigration
+      ? 'v${record.fromSchemaVersion} → v${record.toSchemaVersion} - ${record.formattedSize}'
+      : '${record.diveCount ?? 0} dives, '
+        '${record.siteCount ?? 0} sites - ${record.formattedSize}'
+        '${record.isAutomatic ? ' (auto)' : ''}',
+),
+```
+
+Also add `import 'package:submersion/features/backup/domain/entities/backup_type.dart';` at the top of `backup_settings_page.dart` if not already imported.
+
+Fix any other surfaced sites the same way — null-coalesce to `0` or `'—'` as appropriate for display.
+
+- [ ] **Step 3: Re-run analyzer**
+
+Run: `flutter analyze`
+Expected: Zero issues.
+
+- [ ] **Step 4: Run the full test suite to catch any runtime fallout**
+
+Run: `flutter test`
+Expected: All tests pass. (This sweeps up any mocks/fixtures that built records with positional-ish-feeling counts.)
+
+- [ ] **Step 5: Format**
+
+Run: `dart format lib/ test/`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix: handle nullable diveCount/siteCount in existing callers"
+```
+
+---
+
+## Task 4: Define BackupFailedException (TDD)
+
+**Files:**
+- Create: `lib/features/backup/domain/exceptions/backup_failed_exception.dart`
+- Create: `test/features/backup/domain/exceptions/backup_failed_exception_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+// test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+void main() {
+  group('BackupFailedException.fromError', () {
+    test('classifies ENOSPC (28) as diskFull', () {
+      final fse = FileSystemException(
+        'copy failed',
+        '/tmp/f.db',
+        const OSError('No space left on device', 28),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.diskFull);
+      expect(e.userMessage, contains('disk space'));
+    });
+
+    test('classifies EACCES (13) as permissionDenied', () {
+      final fse = FileSystemException(
+        'open failed',
+        '/tmp/f.db',
+        const OSError('Permission denied', 13),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.permissionDenied);
+      expect(e.userMessage, contains('access'));
+    });
+
+    test('classifies EPERM (1) as permissionDenied', () {
+      final fse = FileSystemException(
+        'open failed',
+        '/tmp/f.db',
+        const OSError('Operation not permitted', 1),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.permissionDenied);
+    });
+
+    test('wraps unclassified errors as unknown', () {
+      final err = StateError('something odd');
+      final e = BackupFailedException.fromError(err, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.unknown);
+      expect(e.technicalDetails, contains('something odd'));
+    });
+
+    test('preserves original error in technicalDetails', () {
+      final fse = FileSystemException(
+        'copy failed',
+        '/tmp/f.db',
+        const OSError('No space left on device', 28),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.technicalDetails, contains('No space left on device'));
+    });
+  });
+
+  test('sourceMissing is constructible directly', () {
+    final e = BackupFailedException(
+      cause: BackupFailureCause.sourceMissing,
+      userMessage: 'Dive log file not found.',
+      technicalDetails: 'file /tmp/f.db does not exist',
+    );
+    expect(e.cause, BackupFailureCause.sourceMissing);
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/domain/exceptions/backup_failed_exception_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Implement the exception**
+
+```dart
+// lib/features/backup/domain/exceptions/backup_failed_exception.dart
+import 'dart:io';
+
+enum BackupFailureCause {
+  diskFull,
+  permissionDenied,
+  sourceMissing,
+  renameFailed,
+  unknown,
+}
+
+/// Thrown by PreMigrationBackupService when a backup cannot be completed.
+///
+/// Always carries a user-facing message safe to display, plus raw technical
+/// details (stack, error.toString) for support escalation.
+class BackupFailedException implements Exception {
+  final BackupFailureCause cause;
+  final String userMessage;
+  final String technicalDetails;
+
+  const BackupFailedException({
+    required this.cause,
+    required this.userMessage,
+    required this.technicalDetails,
+  });
+
+  factory BackupFailedException.fromError(Object error, StackTrace stack) {
+    if (error is FileSystemException) {
+      final code = error.osError?.errorCode;
+      switch (code) {
+        case 28: // ENOSPC
+          return BackupFailedException(
+            cause: BackupFailureCause.diskFull,
+            userMessage: 'Not enough free disk space to back up your data.',
+            technicalDetails: '${error.toString()}\n$stack',
+          );
+        case 13: // EACCES
+        case 1: // EPERM
+          return BackupFailedException(
+            cause: BackupFailureCause.permissionDenied,
+            userMessage: 'The app could not access the backup folder.',
+            technicalDetails: '${error.toString()}\n$stack',
+          );
+      }
+    }
+    return BackupFailedException(
+      cause: BackupFailureCause.unknown,
+      userMessage: 'Backup failed: ${error.toString()}',
+      technicalDetails: '${error.toString()}\n$stack',
+    );
+  }
+
+  @override
+  String toString() => 'BackupFailedException($cause): $userMessage';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/domain/exceptions/backup_failed_exception_test.dart`
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/backup/domain/exceptions/backup_failed_exception.dart \
+        test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+git commit -m "feat: add BackupFailedException with OS-error classification"
+```
+
+---
+
+## Task 5: PreMigrationBackupService happy-path copy + register (TDD)
+
+**Files:**
+- Create: `lib/features/backup/data/services/pre_migration_backup_service.dart`
+- Create: `test/features/backup/data/services/pre_migration_backup_service_test.dart`
+
+- [ ] **Step 1: Write failing happy-path test**
+
+```dart
+// test/features/backup/data/services/pre_migration_backup_service_test.dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+Future<_Fixture> _makeFixture() async {
+  final tmp = await Directory.systemTemp.createTemp('pmbs_test_');
+  final live = File(p.join(tmp.path, 'submersion.db'));
+  await live.writeAsBytes(List<int>.generate(1024, (i) => i % 256));
+  final backupsDir = Directory(p.join(tmp.path, 'backups'));
+  await backupsDir.create();
+  SharedPreferences.setMockInitialValues({});
+  final prefs = BackupPreferences(await SharedPreferences.getInstance());
+  return _Fixture(tmp: tmp, livePath: live.path, backupsDir: backupsDir.path, prefs: prefs);
+}
+
+class _Fixture {
+  final Directory tmp;
+  final String livePath;
+  final String backupsDir;
+  final BackupPreferences prefs;
+  _Fixture({required this.tmp, required this.livePath, required this.backupsDir, required this.prefs});
+  Future<void> dispose() async => tmp.delete(recursive: true);
+}
+
+void main() {
+  group('PreMigrationBackupService happy path', () {
+    test('copies live DB bytes into backups folder', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'test-id-1',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final expectedName = '20260412-081201-v63-v64.db';
+      final backupFile = File(p.join(f.backupsDir, expectedName));
+      expect(await backupFile.exists(), isTrue);
+      expect(await backupFile.readAsBytes(), await File(f.livePath).readAsBytes());
+    });
+
+    test('registers BackupRecord with preMigration type + schema pair', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'test-id-1',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final history = f.prefs.getHistory();
+      expect(history, hasLength(1));
+      final record = history.single;
+      expect(record.id, 'test-id-1');
+      expect(record.type, BackupType.preMigration);
+      expect(record.fromSchemaVersion, 63);
+      expect(record.toSchemaVersion, 64);
+      expect(record.appVersion, '1.6.0.1241');
+      expect(record.filename, '20260412-081201-v63-v64.db');
+      expect(record.diveCount, isNull);
+      expect(record.siteCount, isNull);
+      expect(record.pinned, false);
+      expect(record.isAutomatic, true);
+      expect(record.location, BackupLocation.local);
+      expect(record.localPath, p.join(f.backupsDir, record.filename));
+      expect(record.sizeBytes, 1024);
+    });
+
+    test('skips when stored == target (no-op)', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'x',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 64,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await Directory(f.backupsDir).list().isEmpty, isTrue);
+      expect(f.prefs.getHistory(), isEmpty);
+    });
+
+    test('skips when live DB file does not exist', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      await File(f.livePath).delete();
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'x',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await Directory(f.backupsDir).list().isEmpty, isTrue);
+      expect(f.prefs.getHistory(), isEmpty);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Implement the service (happy path only — sweep/prune added later)**
+
+```dart
+// lib/features/backup/data/services/pre_migration_backup_service.dart
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+typedef _PathProvider = Future<String> Function();
+
+/// Copies the live sqlite database before Drift runs a schema migration.
+///
+/// Operates on the closed database file. Registers the copy via the
+/// existing BackupPreferences registry so it appears alongside manual
+/// backups in the backup list UI.
+class PreMigrationBackupService {
+  final _PathProvider _livePathProvider;
+  final _PathProvider _backupsDirProvider;
+  final BackupPreferences _preferences;
+  final DateTime Function() _clock;
+  final String Function() _idGenerator;
+  final _log = LoggerService.forClass(PreMigrationBackupService);
+
+  PreMigrationBackupService({
+    required _PathProvider livePathProvider,
+    required _PathProvider backupsDirProvider,
+    required BackupPreferences preferences,
+    DateTime Function()? clock,
+    String Function()? idGenerator,
+  }) : _livePathProvider = livePathProvider,
+       _backupsDirProvider = backupsDirProvider,
+       _preferences = preferences,
+       _clock = clock ?? DateTime.now,
+       _idGenerator = idGenerator ?? (() => const Uuid().v4());
+
+  Future<void> backupIfMigrationPending({
+    required int stored,
+    required int target,
+    required String appVersion,
+  }) async {
+    if (stored >= target) return;
+
+    final livePath = await _livePathProvider();
+    if (!await File(livePath).exists()) return;
+
+    final backupsDir = await _backupsDirProvider();
+    await Directory(backupsDir).create(recursive: true);
+
+    final now = _clock().toUtc();
+    final ts = _formatTimestamp(now);
+    final filename = '$ts-v$stored-v$target.db';
+    final tempPath = p.join(backupsDir, '.$filename.tmp');
+    final finalPath = p.join(backupsDir, filename);
+
+    try {
+      await File(livePath).copy(tempPath);
+      await File(tempPath).rename(finalPath);
+    } catch (e, stack) {
+      await _safeDelete(tempPath);
+      throw BackupFailedException.fromError(e, stack);
+    }
+
+    final sizeBytes = await File(finalPath).length();
+
+    try {
+      await _preferences.addRecord(
+        BackupRecord(
+          id: _idGenerator(),
+          filename: filename,
+          timestamp: now,
+          sizeBytes: sizeBytes,
+          location: BackupLocation.local,
+          localPath: finalPath,
+          isAutomatic: true,
+          type: BackupType.preMigration,
+          appVersion: appVersion,
+          fromSchemaVersion: stored,
+          toSchemaVersion: target,
+        ),
+      );
+    } catch (e, stack) {
+      _log.warning('Pre-migration backup registered failed; .db is on disk at $finalPath', e, stack);
+    }
+  }
+
+  String _formatTimestamp(DateTime utc) {
+    String two(int v) => v.toString().padLeft(2, '0');
+    final d = utc;
+    return '${d.year}${two(d.month)}${two(d.day)}-'
+        '${two(d.hour)}${two(d.minute)}${two(d.second)}';
+  }
+
+  Future<void> _safeDelete(String path) async {
+    try {
+      final f = File(path);
+      if (await f.exists()) await f.delete();
+    } catch (_) {}
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: All 4 happy-path tests pass.
+
+- [ ] **Step 5: Run analyzer + format**
+
+Run: `flutter analyze lib/features/backup/data/services/pre_migration_backup_service.dart`
+Run: `dart format lib/features/backup/data/services/pre_migration_backup_service.dart`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/backup/data/services/pre_migration_backup_service.dart \
+        test/features/backup/data/services/pre_migration_backup_service_test.dart
+git commit -m "feat: PreMigrationBackupService happy path (copy + register)"
+```
+
+---
+
+## Task 6: Add `.tmp` sweep at step 6a (TDD)
+
+**Files:**
+- Modify: `lib/features/backup/data/services/pre_migration_backup_service.dart`
+- Modify: `test/features/backup/data/services/pre_migration_backup_service_test.dart`
+
+- [ ] **Step 1: Add failing test**
+
+Add this test to the test file (outside `group('happy path')`):
+
+```dart
+group('.tmp sweep', () {
+  test('deletes leftover .tmp files in backups dir before backup', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    // Pre-seed a stale .tmp file
+    final stale = File(p.join(f.backupsDir, '.20260101-000000-v62-v63.db.tmp'));
+    await stale.writeAsBytes([1, 2, 3]);
+    expect(await stale.exists(), isTrue);
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    expect(await stale.exists(), isFalse);
+  });
+
+  test('does not delete non-.tmp files', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    final keep = File(p.join(f.backupsDir, '20260101-000000-manual.db'));
+    await keep.writeAsBytes([1, 2, 3]);
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    expect(await keep.exists(), isTrue);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: the "deletes leftover .tmp" test FAILS because no sweep exists yet.
+
+- [ ] **Step 3: Add the sweep logic to `backupIfMigrationPending`**
+
+Insert immediately after `await Directory(backupsDir).create(recursive: true);`:
+
+```dart
+    await _sweepTempFiles(backupsDir);
+```
+
+And add the method to the class:
+
+```dart
+  Future<void> _sweepTempFiles(String backupsDir) async {
+    try {
+      final dir = Directory(backupsDir);
+      await for (final entity in dir.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final name = p.basename(entity.path);
+        if (name.endsWith('.tmp')) {
+          await _safeDelete(entity.path);
+        }
+      }
+    } catch (e, stack) {
+      _log.warning('Failed sweeping .tmp files in $backupsDir', e, stack);
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/backup/data/services/pre_migration_backup_service.dart \
+        test/features/backup/data/services/pre_migration_backup_service_test.dart
+git commit -m "feat: sweep stale .tmp files before pre-migration backup"
+```
+
+---
+
+## Task 7: Add prune logic (TDD)
+
+**Files:**
+- Modify: `lib/features/backup/data/services/pre_migration_backup_service.dart`
+- Modify: `test/features/backup/data/services/pre_migration_backup_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+Append this group to the test file:
+
+```dart
+group('retention prune', () {
+  test('keeps newest 3 unpinned pre-migration backups, deletes older', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    // Pre-seed 4 unpinned pre-migration records with disk files.
+    for (var i = 0; i < 4; i++) {
+      final ts = DateTime.utc(2026, 1, 1 + i);
+      final name = '${_ts(ts)}-v$i-v${i + 1}.db';
+      final file = File(p.join(f.backupsDir, name));
+      await file.writeAsBytes([i]);
+      await f.prefs.addRecord(
+        BackupRecord(
+          id: 'r$i',
+          filename: name,
+          timestamp: ts,
+          sizeBytes: 1,
+          location: BackupLocation.local,
+          localPath: file.path,
+          type: BackupType.preMigration,
+          fromSchemaVersion: i,
+          toSchemaVersion: i + 1,
+        ),
+      );
+    }
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'new',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final remaining = f.prefs
+        .getHistory()
+        .where((r) => r.type == BackupType.preMigration)
+        .toList();
+    // 4 pre-seeded + 1 new = 5 total; prune to 3 most recent unpinned
+    expect(remaining, hasLength(3));
+    // The newest 'new' record and the 2 most recent pre-seeded (r3, r2) survive.
+    expect(remaining.map((r) => r.id), containsAll(<String>['new', 'r3', 'r2']));
+    // The oldest two records are gone
+    expect(remaining.map((r) => r.id), isNot(contains('r0')));
+    expect(remaining.map((r) => r.id), isNot(contains('r1')));
+    // And their .db files were deleted
+    expect(await File(p.join(f.backupsDir, '${_ts(DateTime.utc(2026, 1, 1))}-v0-v1.db')).exists(), isFalse);
+    expect(await File(p.join(f.backupsDir, '${_ts(DateTime.utc(2026, 1, 2))}-v1-v2.db')).exists(), isFalse);
+  });
+
+  test('pinned pre-migration backups are never pruned', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    for (var i = 0; i < 5; i++) {
+      final ts = DateTime.utc(2026, 1, 1 + i);
+      final name = '${_ts(ts)}-v$i-v${i + 1}.db';
+      await File(p.join(f.backupsDir, name)).writeAsBytes([i]);
+      await f.prefs.addRecord(
+        BackupRecord(
+          id: 'pinned-$i',
+          filename: name,
+          timestamp: ts,
+          sizeBytes: 1,
+          location: BackupLocation.local,
+          localPath: p.join(f.backupsDir, name),
+          type: BackupType.preMigration,
+          fromSchemaVersion: i,
+          toSchemaVersion: i + 1,
+          pinned: true,
+        ),
+      );
+    }
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12),
+      idGenerator: () => 'new',
+    );
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final preMigrationRecords = f.prefs
+        .getHistory()
+        .where((r) => r.type == BackupType.preMigration)
+        .toList();
+    // All 5 pinned + 1 new = 6
+    expect(preMigrationRecords, hasLength(6));
+  });
+
+  test('does nothing when only 2 unpinned exist', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    for (var i = 0; i < 2; i++) {
+      final ts = DateTime.utc(2026, 1, 1 + i);
+      final name = '${_ts(ts)}-v$i-v${i + 1}.db';
+      await File(p.join(f.backupsDir, name)).writeAsBytes([i]);
+      await f.prefs.addRecord(
+        BackupRecord(
+          id: 'r$i',
+          filename: name,
+          timestamp: ts,
+          sizeBytes: 1,
+          location: BackupLocation.local,
+          localPath: p.join(f.backupsDir, name),
+          type: BackupType.preMigration,
+          fromSchemaVersion: i,
+          toSchemaVersion: i + 1,
+        ),
+      );
+    }
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12),
+      idGenerator: () => 'new',
+    );
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final count = f.prefs
+        .getHistory()
+        .where((r) => r.type == BackupType.preMigration)
+        .length;
+    expect(count, 3);
+  });
+
+  test('does not touch manual-backup records', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    for (var i = 0; i < 5; i++) {
+      final name = 'manual-$i.db';
+      await File(p.join(f.backupsDir, name)).writeAsBytes([i]);
+      await f.prefs.addRecord(
+        BackupRecord(
+          id: 'm$i',
+          filename: name,
+          timestamp: DateTime.utc(2026, 1, 1 + i),
+          sizeBytes: 1,
+          location: BackupLocation.local,
+          localPath: p.join(f.backupsDir, name),
+          type: BackupType.manual,
+        ),
+      );
+    }
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12),
+      idGenerator: () => 'new',
+    );
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final manualCount = f.prefs
+        .getHistory()
+        .where((r) => r.type == BackupType.manual)
+        .length;
+    expect(manualCount, 5);
+  });
+});
+
+String _ts(DateTime utc) {
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${utc.year}${two(utc.month)}${two(utc.day)}-'
+      '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}';
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: The prune-related tests FAIL (current service keeps all records).
+
+- [ ] **Step 3: Implement prune logic**
+
+Add a constant near the top of the class:
+
+```dart
+  static const int _retainN = 3;
+```
+
+Insert a call after the successful `addRecord`:
+
+```dart
+    await _pruneExcess();
+```
+
+(Wrap just that call in its own try/catch so prune errors don't abort the caller.)
+
+Replace the block from Step 3 of Task 5:
+
+```dart
+    try {
+      await _preferences.addRecord(...);
+    } catch (e, stack) {
+      _log.warning('Pre-migration backup registered failed; .db is on disk at $finalPath', e, stack);
+    }
+```
+
+with:
+
+```dart
+    try {
+      await _preferences.addRecord(
+        BackupRecord(
+          id: _idGenerator(),
+          filename: filename,
+          timestamp: now,
+          sizeBytes: sizeBytes,
+          location: BackupLocation.local,
+          localPath: finalPath,
+          isAutomatic: true,
+          type: BackupType.preMigration,
+          appVersion: appVersion,
+          fromSchemaVersion: stored,
+          toSchemaVersion: target,
+        ),
+      );
+    } catch (e, stack) {
+      _log.warning('Pre-migration backup registered failed; .db is on disk at $finalPath', e, stack);
+      return;
+    }
+
+    try {
+      await _pruneExcess();
+    } catch (e, stack) {
+      _log.warning('Pre-migration prune failed (backup kept)', e, stack);
+    }
+```
+
+And add the method:
+
+```dart
+  Future<void> _pruneExcess() async {
+    final all = _preferences.getHistory();
+    final preMigration = all
+        .where((r) => r.type == BackupType.preMigration)
+        .toList();
+    final unpinned = preMigration.where((r) => !r.pinned).toList()
+      ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    if (unpinned.length <= _retainN) return;
+    final toDelete = unpinned.sublist(_retainN);
+    for (final record in toDelete) {
+      await _preferences.removeRecord(record.id);
+      final path = record.localPath;
+      if (path != null) {
+        await _safeDelete(path);
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: All prune tests pass. Manual-backup records untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/backup/data/services/pre_migration_backup_service.dart \
+        test/features/backup/data/services/pre_migration_backup_service_test.dart
+git commit -m "feat: retention prune for pre-migration backups (N=3 unpinned)"
+```
+
+---
+
+## Task 8: Error classification on backup failure (TDD)
+
+**Files:**
+- Modify: `test/features/backup/data/services/pre_migration_backup_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```dart
+group('error handling', () {
+  test('throws BackupFailedException(sourceMissing) when backupsDir path itself is a file', () async {
+    // We can't portably simulate ENOSPC; instead trigger a file-system error
+    // by pointing backupsDirProvider at a path that is actually a regular
+    // file (so create(recursive) throws).
+    final tmp = await Directory.systemTemp.createTemp('pmbs_err_');
+    addTearDown(() => tmp.delete(recursive: true));
+    final live = File(p.join(tmp.path, 'submersion.db'));
+    await live.writeAsBytes([1, 2, 3]);
+    final conflicting = File(p.join(tmp.path, 'not-a-dir'));
+    await conflicting.writeAsBytes([0]);
+    SharedPreferences.setMockInitialValues({});
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => live.path,
+      backupsDirProvider: () async => conflicting.path,
+      preferences: prefs,
+      clock: () => DateTime.utc(2026, 4, 12),
+      idGenerator: () => 'id',
+    );
+
+    expect(
+      () async => service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      ),
+      throwsA(isA<BackupFailedException>()),
+    );
+  });
+});
+```
+
+Add this import near the top of the test file:
+
+```dart
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+```
+
+- [ ] **Step 2: Run test to verify failure mode is already wrapped**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: Test passes *or* fails. If the service already wraps thrown errors (from Task 5's `catch (e, stack)` around copy/rename), this test passes immediately. If it passes, skip Step 3 and commit only the test. If it fails (e.g. an error escapes outside copy/rename), add a top-level `try/catch` in `backupIfMigrationPending` that wraps directory-creation errors too:
+
+```dart
+    try {
+      await Directory(backupsDir).create(recursive: true);
+      await _sweepTempFiles(backupsDir);
+    } catch (e, stack) {
+      throw BackupFailedException.fromError(e, stack);
+    }
+```
+
+(Place this block replacing the existing create + sweep lines.)
+
+- [ ] **Step 3: Re-run test if code was changed**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat: wrap backup failures as BackupFailedException"
+```
+
+---
+
+## Task 9: Atomic rename guarantee test (TDD)
+
+**Files:**
+- Modify: `test/features/backup/data/services/pre_migration_backup_service_test.dart`
+
+- [ ] **Step 1: Add failing test — confirm no `.db` file exists if registration succeeded only after rename**
+
+This test is a regression guard for the temp-file-then-rename ordering. It does not need to simulate a crash; it verifies post-success state matches what atomicity promises.
+
+```dart
+group('atomicity', () {
+  test('final .db exists only under non-.tmp name after success', () async {
+    final f = await _makeFixture();
+    addTearDown(f.dispose);
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => f.livePath,
+      backupsDirProvider: () async => f.backupsDir,
+      preferences: f.prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final entries = await Directory(f.backupsDir).list().toList();
+    final names = entries.map((e) => p.basename(e.path)).toList();
+    expect(names.any((n) => n.endsWith('.tmp')), isFalse);
+    expect(names, contains('20260412-081201-v63-v64.db'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: Test passes (already implemented in Task 5).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/features/backup/data/services/pre_migration_backup_service_test.dart
+git commit -m "test: guard atomic temp-then-rename invariant"
+```
+
+---
+
+## Task 10: Add pinBackup / unpinBackup to BackupService (TDD)
+
+**Files:**
+- Modify: `lib/features/backup/data/services/backup_service.dart`
+- Modify: `test/features/backup/data/services/backup_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `test/features/backup/data/services/backup_service_test.dart` inside the existing `group('BackupService', ...)` (or at top level if no such group exists):
+
+```dart
+group('pinning', () {
+  test('pinBackup flips pinned to true on the record', () async {
+    // Reuse the test harness that backup_service_test already sets up;
+    // the existing test file demonstrates how FakeBackupDatabaseAdapter
+    // and FakeCloudStorageProvider are wired. Assume a helper `makeService`
+    // is present; if not, inline the setup from existing tests.
+    final harness = await BackupServiceTestHarness.make();
+    addTearDown(harness.dispose);
+    await harness.prefs.addRecord(
+      BackupRecord(
+        id: 'rec-1',
+        filename: 'f.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+        localPath: '/tmp/f.db',
+      ),
+    );
+
+    await harness.service.pinBackup('rec-1');
+
+    expect(harness.prefs.getHistory().single.pinned, true);
+  });
+
+  test('unpinBackup flips pinned to false', () async {
+    final harness = await BackupServiceTestHarness.make();
+    addTearDown(harness.dispose);
+    await harness.prefs.addRecord(
+      BackupRecord(
+        id: 'rec-1',
+        filename: 'f.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+        localPath: '/tmp/f.db',
+        pinned: true,
+      ),
+    );
+
+    await harness.service.unpinBackup('rec-1');
+
+    expect(harness.prefs.getHistory().single.pinned, false);
+  });
+
+  test('pinBackup is a no-op for unknown ids (does not throw)', () async {
+    final harness = await BackupServiceTestHarness.make();
+    addTearDown(harness.dispose);
+
+    await harness.service.pinBackup('unknown');
+
+    expect(harness.prefs.getHistory(), isEmpty);
+  });
+});
+```
+
+If `BackupServiceTestHarness` does not exist in the current test file, inline the fixture setup the existing tests use (look near the top of `backup_service_test.dart` for the pattern that builds `FakeBackupDatabaseAdapter`, `BackupPreferences`, and `BackupService`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/data/services/backup_service_test.dart`
+Expected: FAIL — `pinBackup` / `unpinBackup` undefined on `BackupService`.
+
+- [ ] **Step 3: Add methods to `BackupService`**
+
+Append to `lib/features/backup/data/services/backup_service.dart` inside the class (e.g., after `getValidatedBackupHistory`):
+
+```dart
+  Future<void> pinBackup(String id) => _setPinned(id, true);
+
+  Future<void> unpinBackup(String id) => _setPinned(id, false);
+
+  Future<void> _setPinned(String id, bool pinned) async {
+    final history = _preferences.getHistory();
+    BackupRecord? match;
+    for (final r in history) {
+      if (r.id == id) {
+        match = r;
+        break;
+      }
+    }
+    if (match == null) return;
+    await _preferences.updateRecord(match.copyWith(pinned: pinned));
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/data/services/backup_service_test.dart`
+Expected: All pin tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/backup/data/services/backup_service.dart \
+        test/features/backup/data/services/backup_service_test.dart
+git commit -m "feat: BackupService.pinBackup/unpinBackup"
+```
+
+---
+
+## Task 11: Add StartupState.backingUp and StartupState.backupFailed
+
+**Files:**
+- Modify: `lib/core/presentation/pages/startup_page.dart`
+
+- [ ] **Step 1: Extend the enum**
+
+Locate the existing `enum _StartupState { initializing, migrating, ready, error }` (around line 35) and replace with:
+
+```dart
+enum _StartupState {
+  initializing,
+  backingUp,
+  migrating,
+  backupFailed,
+  ready,
+  error,
+}
+```
+
+- [ ] **Step 2: Add state fields for the backup failure**
+
+Near the other state fields in `_StartupPageState`, add:
+
+```dart
+  BackupFailedException? _backupError;
+```
+
+At the top of the file, import:
+
+```dart
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+```
+
+- [ ] **Step 3: Analyze and commit (no behavior yet — wiring follows in later tasks)**
+
+Run: `flutter analyze lib/core/presentation/pages/startup_page.dart`
+Expected: No issues (the new enum values are unused but unused-enum-values is not a default warning).
+
+```bash
+git add lib/core/presentation/pages/startup_page.dart
+git commit -m "feat: add backingUp/backupFailed to _StartupState enum"
+```
+
+---
+
+## Task 12: Render the backing-up and backup-failed screens (TDD)
+
+**Files:**
+- Modify: `lib/core/presentation/pages/startup_page.dart`
+- Create: `test/core/presentation/pages/startup_page_backup_flow_test.dart`
+
+- [ ] **Step 1: Write failing widget tests for the two new screens**
+
+Create `test/core/presentation/pages/startup_page_backup_flow_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+// The startup page is a private-state widget; we test its pure-view helpers
+// by importing the build helpers. Since _buildSplashContent and _buildErrorContent
+// are private, the cleanest approach is to test the new screens via exported
+// widget factories in a new file:
+import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
+
+void main() {
+  testWidgets('BackingUpView shows spinner + explanation copy', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: BackingUpView())));
+    expect(find.text('Backing up your data'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.textContaining('before updating'), findsOneWidget);
+    // No cancel button
+    expect(find.widgetWithText(TextButton, 'Cancel'), findsNothing);
+    expect(find.widgetWithText(ElevatedButton, 'Cancel'), findsNothing);
+  });
+
+  testWidgets('BackupFailedView surfaces classified message + Retry and Quit', (tester) async {
+    var retried = 0;
+    var quit = 0;
+    final error = BackupFailedException(
+      cause: BackupFailureCause.diskFull,
+      userMessage: 'Not enough free disk space to back up your data.',
+      technicalDetails: 'FileSystemException(28)',
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: BackupFailedView(
+          error: error,
+          onRetry: () => retried++,
+          onQuit: () => quit++,
+        ),
+      ),
+    ));
+    expect(find.text("Couldn't back up your data"), findsOneWidget);
+    expect(find.text('Not enough free disk space to back up your data.'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Retry'));
+    await tester.pump();
+    expect(retried, 1);
+    expect(quit, 0);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Quit'));
+    await tester.pump();
+    expect(quit, 1);
+  });
+
+  testWidgets('BackupFailedView technical details are hidden until expanded', (tester) async {
+    final error = BackupFailedException(
+      cause: BackupFailureCause.unknown,
+      userMessage: 'Backup failed: something odd.',
+      technicalDetails: 'unique-detail-12345',
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: BackupFailedView(error: error, onRetry: () {}, onQuit: () {}),
+      ),
+    ));
+    expect(find.text('unique-detail-12345'), findsNothing);
+    await tester.tap(find.text('Technical details'));
+    await tester.pumpAndSettle();
+    expect(find.text('unique-detail-12345'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/core/presentation/pages/startup_page_backup_flow_test.dart`
+Expected: FAIL — `backup_status_views.dart` does not exist.
+
+- [ ] **Step 3: Create the extracted view widgets**
+
+Create `lib/core/presentation/widgets/backup_status_views.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+/// Shown while PreMigrationBackupService copies the live database.
+class BackingUpView extends StatelessWidget {
+  const BackingUpView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 24),
+          Text(
+            'Backing up your data',
+            style: Theme.of(context).textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            "We're saving a copy of your dive log before updating your database.",
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shown when the pre-migration backup fails. Offers Retry and Quit.
+class BackupFailedView extends StatelessWidget {
+  final BackupFailedException error;
+  final VoidCallback onRetry;
+  final VoidCallback onQuit;
+
+  const BackupFailedView({
+    super.key,
+    required this.error,
+    required this.onRetry,
+    required this.onQuit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: Theme.of(context).colorScheme.error),
+          const SizedBox(height: 16),
+          Text(
+            "Couldn't back up your data",
+            style: Theme.of(context).textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Text(error.userMessage, textAlign: TextAlign.center),
+          const SizedBox(height: 8),
+          const Text(
+            "Your dive log hasn't changed — we didn't update it. Free up space (or fix the issue) and try again.",
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
+          const SizedBox(height: 8),
+          TextButton(onPressed: onQuit, child: const Text('Quit')),
+          const SizedBox(height: 16),
+          ExpansionTile(
+            title: const Text('Technical details'),
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: SelectableText(
+                  error.technicalDetails,
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/core/presentation/pages/startup_page_backup_flow_test.dart`
+Expected: All 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/presentation/widgets/backup_status_views.dart \
+        test/core/presentation/pages/startup_page_backup_flow_test.dart
+git commit -m "feat: extracted BackingUpView + BackupFailedView widgets"
+```
+
+---
+
+## Task 13: Wire PreMigrationBackupService into StartupPage
+
+**Files:**
+- Modify: `lib/core/presentation/pages/startup_page.dart`
+
+- [ ] **Step 1: Add constructor dependency on `PreMigrationBackupService`**
+
+Find the `StartupPage` / `StartupWrapper` public constructor and add an optional field so tests can inject a fake:
+
+```dart
+final PreMigrationBackupService Function()? preMigrationBackupFactory;
+```
+
+Also add imports at the top:
+
+```dart
+import 'dart:io' show exit;
+import 'package:flutter/services.dart' show SystemNavigator;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+```
+
+(Prune any that already exist.)
+
+- [ ] **Step 2: Insert the backup call inside `_runInitialization`**
+
+Current shape (verbatim, lines ~108–142):
+
+```dart
+if (needsMigration && mounted) {
+  setState(() {
+    _state = _StartupState.migrating;
+    _progress = MigrationProgress(currentStep: 0, totalSteps: totalSteps);
+  });
+}
+```
+
+Replace with:
+
+```dart
+if (needsMigration) {
+  if (mounted) {
+    setState(() {
+      _state = _StartupState.backingUp;
+    });
+  }
+  try {
+    await _runPreMigrationBackup(dbPath: dbPath, stored: storedVersion!, target: AppDatabase.currentSchemaVersion);
+  } on BackupFailedException catch (e) {
+    if (mounted) {
+      setState(() {
+        _state = _StartupState.backupFailed;
+        _backupError = e;
+      });
+    }
+    return;
+  }
+  if (mounted) {
+    setState(() {
+      _state = _StartupState.migrating;
+      _progress = MigrationProgress(currentStep: 0, totalSteps: totalSteps);
+    });
+  }
+}
+```
+
+Then add the helper on the state class:
+
+```dart
+  Future<void> _runPreMigrationBackup({
+    required String dbPath,
+    required int stored,
+    required int target,
+  }) async {
+    final service = widget.preMigrationBackupFactory != null
+        ? widget.preMigrationBackupFactory!()
+        : await _defaultPreMigrationBackupService(dbPath);
+    final info = await PackageInfo.fromPlatform();
+    final appVersion = '${info.version}.${info.buildNumber}';
+    await service.backupIfMigrationPending(
+      stored: stored,
+      target: target,
+      appVersion: appVersion,
+    );
+  }
+
+  Future<PreMigrationBackupService> _defaultPreMigrationBackupService(String dbPath) async {
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+    // BackupService exposes getBackupsDirectory(); reuse it.
+    final backupService = BackupService(
+      dbAdapter: /* wire in your existing default — see app-wide provider */,
+      preferences: prefs,
+    );
+    return PreMigrationBackupService(
+      livePathProvider: () async => dbPath,
+      backupsDirProvider: backupService.getBackupsDirectory,
+      preferences: prefs,
+    );
+  }
+```
+
+The `/* wire in your existing default */` comment is intentional — the
+exact DI pattern depends on the existing provider graph in this app.
+Locate how `backupServiceProvider` or equivalent is constructed (grep for
+`BackupService(` instantiations outside tests) and mirror that.
+
+If the Riverpod `ProviderContainer` is available at this point in the
+startup lifecycle, **replace** this helper entirely with:
+
+```dart
+  Future<PreMigrationBackupService> _defaultPreMigrationBackupService(String dbPath) async {
+    final container = ProviderScope.containerOf(context, listen: false);
+    final backupService = container.read(backupServiceProvider);
+    final prefs = container.read(backupPreferencesProvider);
+    return PreMigrationBackupService(
+      livePathProvider: () async => dbPath,
+      backupsDirProvider: backupService.getBackupsDirectory,
+      preferences: prefs,
+    );
+  }
+```
+
+(Use whichever pattern matches the existing codebase — in the current
+`startup_page.dart`, `_initializeServices` already shows the canonical
+service-wiring pattern; mirror it.)
+
+- [ ] **Step 3: Render the new states in the build method**
+
+In the `build` or `_buildSplashContent` method, add branches for the two new states. Find the existing conditional (e.g. `if (_state == _StartupState.error) return _buildErrorContent();` or similar) and add:
+
+```dart
+if (_state == _StartupState.backingUp) {
+  return const BackingUpView();
+}
+if (_state == _StartupState.backupFailed && _backupError != null) {
+  return BackupFailedView(
+    error: _backupError!,
+    onRetry: _retryPreMigrationBackup,
+    onQuit: _quitApp,
+  );
+}
+```
+
+And add the handlers to the state class:
+
+```dart
+  Future<void> _retryPreMigrationBackup() async {
+    setState(() {
+      _state = _StartupState.backingUp;
+      _backupError = null;
+    });
+    try {
+      final dbPath = await widget.locationService.getDatabasePath();
+      final stored = DatabaseService.getStoredSchemaVersion(dbPath);
+      await _runPreMigrationBackup(
+        dbPath: dbPath,
+        stored: stored ?? 0,
+        target: AppDatabase.currentSchemaVersion,
+      );
+      if (!mounted) return;
+      setState(() {
+        _state = _StartupState.migrating;
+      });
+      await _initializeServices();
+      if (!mounted) return;
+      setState(() => _state = _StartupState.ready);
+      _splashFadeController.forward();
+    } on BackupFailedException catch (e) {
+      if (mounted) {
+        setState(() {
+          _state = _StartupState.backupFailed;
+          _backupError = e;
+        });
+      }
+    }
+  }
+
+  void _quitApp() {
+    if (Platform.isIOS || Platform.isAndroid) {
+      SystemNavigator.pop();
+    } else {
+      exit(0);
+    }
+  }
+```
+
+Add import if missing:
+
+```dart
+import 'dart:io' show Platform;
+```
+
+- [ ] **Step 4: Run analyzer**
+
+Run: `flutter analyze lib/core/presentation/pages/startup_page.dart`
+Expected: No issues. If issues surface around unused imports or missing
+providers, reconcile by wiring to the real app-provider graph.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `flutter test`
+Expected: All existing tests pass; no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/presentation/pages/startup_page.dart
+git commit -m "feat: wire PreMigrationBackupService into startup flow"
+```
+
+---
+
+## Task 14: Add pin/unpin toggle to backup list rows (TDD)
+
+**Files:**
+- Modify: `lib/features/backup/presentation/pages/backup_settings_page.dart`
+
+- [ ] **Step 1: Locate the existing history `ListTile` (around lines 311–345) and update**
+
+Replace:
+
+```dart
+ListTile(
+  leading: Icon(_locationIcon(record.location)),
+  title: Text(dateFormat.format(record.timestamp)),
+  subtitle: Text( ... ),
+  trailing: PopupMenuButton<String>( ... ),
+)
+```
+
+with:
+
+```dart
+ListTile(
+  leading: Icon(_locationIcon(record.location)),
+  title: Row(
+    children: [
+      Text(dateFormat.format(record.timestamp)),
+      if (record.type == BackupType.preMigration) ...[
+        const SizedBox(width: 8),
+        _PreMigrationBadge(
+          fromVersion: record.fromSchemaVersion ?? 0,
+          toVersion: record.toSchemaVersion ?? 0,
+        ),
+      ],
+    ],
+  ),
+  subtitle: Text(
+    record.type == BackupType.preMigration
+        ? 'v${record.fromSchemaVersion} → v${record.toSchemaVersion} - ${record.formattedSize}'
+        : '${record.diveCount ?? 0} dives, '
+          '${record.siteCount ?? 0} sites - ${record.formattedSize}'
+          '${record.isAutomatic ? ' (auto)' : ''}',
+  ),
+  trailing: Row(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      IconButton(
+        icon: Icon(record.pinned ? Icons.push_pin : Icons.push_pin_outlined),
+        tooltip: record.pinned ? 'Unpin backup' : 'Pin backup',
+        onPressed: () => _togglePin(ref, record),
+      ),
+      PopupMenuButton<String>(
+        onSelected: (action) =>
+            _handleHistoryAction(context, ref, action, record),
+        itemBuilder: (context) => [ /* existing menu items unchanged */ ],
+      ),
+    ],
+  ),
+)
+```
+
+Add these imports at the top of the file:
+
+```dart
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+```
+
+Add the private badge widget at the bottom of the file:
+
+```dart
+class _PreMigrationBadge extends StatelessWidget {
+  final int fromVersion;
+  final int toVersion;
+
+  const _PreMigrationBadge({required this.fromVersion, required this.toVersion});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        'v$fromVersion → v$toVersion',
+        style: TextStyle(
+          fontSize: 11,
+          color: Theme.of(context).colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}
+```
+
+Add the handler method on the page class:
+
+```dart
+  Future<void> _togglePin(WidgetRef ref, BackupRecord record) async {
+    final service = ref.read(backupServiceProvider);
+    if (record.pinned) {
+      await service.unpinBackup(record.id);
+    } else {
+      await service.pinBackup(record.id);
+    }
+  }
+```
+
+(Adjust `backupServiceProvider` to the actual provider name used in this file.)
+
+- [ ] **Step 2: Run analyzer**
+
+Run: `flutter analyze lib/features/backup/presentation/pages/backup_settings_page.dart`
+Expected: No issues.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `flutter test`
+Expected: All tests pass (any existing backup UI tests may need a minor update to account for the added trailing widgets, but behavior is preserved).
+
+- [ ] **Step 4: Manually verify on macOS**
+
+Run: `flutter run -d macos`
+- Open Settings → Backup
+- Create a manual backup
+- Verify the pin icon appears on the right side of the row
+- Tap it; verify it fills in (pinned)
+- Tap again; verify it unfills
+- Restart the app; verify pin state persists
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/backup/presentation/pages/backup_settings_page.dart
+git commit -m "feat: pin toggle and pre-migration badge in backup list"
+```
+
+---
+
+## Task 15: Restore-dialog compat branching for pre-migration backups (TDD)
+
+**Files:**
+- Modify: `lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart`
+- Create: `test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart`
+
+- [ ] **Step 1: Read the current dialog to understand its shape**
+
+Run: `flutter test --reporter=expanded test/features/backup/` — just to confirm existing dialog tests are green before changes.
+
+Expected: green baseline.
+
+- [ ] **Step 2: Write failing tests for the three compat branches**
+
+Create `test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
+
+BackupRecord _preMigration({
+  required int fromVersion,
+  required int toVersion,
+  String appVersion = '1.5.9.1000',
+}) {
+  return BackupRecord(
+    id: 'r',
+    filename: 'pre.db',
+    timestamp: DateTime(2026, 4, 12, 8, 12),
+    sizeBytes: 1024,
+    location: BackupLocation.local,
+    localPath: '/tmp/pre.db',
+    type: BackupType.preMigration,
+    appVersion: appVersion,
+    fromSchemaVersion: fromVersion,
+    toSchemaVersion: toVersion,
+  );
+}
+
+void main() {
+  testWidgets('green path: current == from — single Restore button, no warning', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (c) => RestoreConfirmationDialog(
+          record: _preMigration(fromVersion: 63, toVersion: 64),
+          currentSchemaVersion: 63,
+          onConfirm: () {},
+        )),
+      ),
+    ));
+    expect(find.text('Restore'), findsOneWidget);
+    expect(find.text('Restore anyway'), findsNothing);
+    expect(find.textContaining('will re-run'), findsNothing);
+    expect(find.textContaining('app version matches'), findsOneWidget);
+  });
+
+  testWidgets('warning path: current > from — "Restore anyway" destructive + warning text', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: RestoreConfirmationDialog(
+          record: _preMigration(fromVersion: 63, toVersion: 64),
+          currentSchemaVersion: 64,
+          onConfirm: () {},
+        ),
+      ),
+    ));
+    expect(find.textContaining('will re-run'), findsOneWidget);
+    expect(find.text('Restore anyway'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('hard block: current < from — only Cancel', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: RestoreConfirmationDialog(
+          record: _preMigration(fromVersion: 65, toVersion: 66),
+          currentSchemaVersion: 64,
+          onConfirm: () {},
+        ),
+      ),
+    ));
+    expect(find.textContaining('newer than your app'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+    expect(find.text('Restore'), findsNothing);
+    expect(find.text('Restore anyway'), findsNothing);
+  });
+
+  testWidgets('manual record still uses existing dialog behavior', (tester) async {
+    final manual = BackupRecord(
+      id: 'm',
+      filename: 'm.db',
+      timestamp: DateTime(2026, 4, 12),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+      localPath: '/tmp/m.db',
+      diveCount: 3,
+      siteCount: 4,
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: RestoreConfirmationDialog(
+          record: manual,
+          currentSchemaVersion: 64,
+          onConfirm: () {},
+        ),
+      ),
+    ));
+    expect(find.text('Restore'), findsOneWidget);
+    expect(find.textContaining('will re-run'), findsNothing);
+  });
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `flutter test test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart`
+Expected: FAIL — the dialog's constructor does not yet accept `record: BackupRecord` / `currentSchemaVersion: int`.
+
+- [ ] **Step 4: Refactor the dialog to accept these inputs and branch**
+
+Open `lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart`. The current file has a single existing dialog for manual restores. Extend the constructor so both pre-migration and manual cases work through one widget. Replace the relevant bits so:
+
+```dart
+class RestoreConfirmationDialog extends StatelessWidget {
+  final BackupRecord record;
+  final int currentSchemaVersion;
+  final VoidCallback onConfirm;
+
+  const RestoreConfirmationDialog({
+    super.key,
+    required this.record,
+    required this.currentSchemaVersion,
+    required this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (record.type == BackupType.preMigration) {
+      return _buildPreMigration(context);
+    }
+    return _buildManual(context);
+  }
+
+  Widget _buildPreMigration(BuildContext context) {
+    final fromV = record.fromSchemaVersion ?? 0;
+    final toV = record.toSchemaVersion ?? 0;
+    final appVersion = record.appVersion ?? 'unknown version';
+    if (currentSchemaVersion < fromV) {
+      return AlertDialog(
+        title: const Text('Restore pre-migration backup'),
+        content: Text(
+          'This backup is newer than your app. Install a newer app '
+          'version to restore it.\n\n'
+          'Backup made on ${record.timestamp.toLocal()} by app $appVersion '
+          '(database v$fromV).',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+        ],
+      );
+    }
+    if (currentSchemaVersion == fromV) {
+      return AlertDialog(
+        title: const Text('Restore pre-migration backup'),
+        content: Text(
+          'This backup was made on ${record.timestamp.toLocal()} by app '
+          '$appVersion, just before upgrading the database from v$fromV to v$toV.\n\n'
+          'Your app version matches the backup, so restore is safe.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              onConfirm();
+            },
+            child: const Text('Restore'),
+          ),
+        ],
+      );
+    }
+    // currentSchemaVersion > fromV — warning path
+    return AlertDialog(
+      title: const Text('Restore pre-migration backup'),
+      content: Text(
+        'This backup was made on ${record.timestamp.toLocal()} by app '
+        '$appVersion, just before upgrading the database from v$fromV to v$toV.\n\n'
+        'You are running a newer app (database v$currentSchemaVersion).\n\n'
+        'Restoring now will re-run the v$fromV → v$toV database upgrade '
+        'on your restored data — the same upgrade that was about to run '
+        'originally. If that upgrade caused the problem, you will hit '
+        'the same issue again.\n\n'
+        'To restore safely: install app $appVersion or earlier, then restore '
+        'this backup from that older app.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+          onPressed: () {
+            Navigator.of(context).pop();
+            onConfirm();
+          },
+          child: const Text('Restore anyway'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildManual(BuildContext context) {
+    // Mirror the existing manual-restore dialog exactly, preserving all
+    // copy from the pre-change version. If the existing dialog uses
+    // `record.diveCount` / `record.siteCount`, null-coalesce to 0 here.
+    // Also: include `record.appVersion` as a new line when non-null.
+    // Keep the Restore / Cancel buttons wired as before.
+    return AlertDialog(
+      title: const Text('Restore backup'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Backup from ${record.timestamp.toLocal()}'),
+          Text('${record.diveCount ?? 0} dives, ${record.siteCount ?? 0} sites'),
+          Text('Size: ${record.formattedSize}'),
+          if (record.appVersion != null) Text('App version: ${record.appVersion}'),
+          const SizedBox(height: 12),
+          const Text(
+            'Restoring will replace your current dive log with the contents '
+            'of this backup. This cannot be undone.',
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+            onConfirm();
+          },
+          child: const Text('Restore'),
+        ),
+      ],
+    );
+  }
+}
+```
+
+Note: the manual-dialog block above is a reconstruction. When editing,
+preserve any existing copy (warning icons, safety notes) verbatim from
+the current file — just add the `appVersion` line conditionally and the
+null-coalescing on counts. Remove any fields from the previous
+constructor that are now redundant (e.g., if the old dialog took
+`diveCount` separately, switch callers to pass the `BackupRecord`).
+
+- [ ] **Step 5: Update callers of the dialog**
+
+Grep for existing usage:
+
+Run: `flutter pub run grep RestoreConfirmationDialog lib/`
+(or use `Grep` against the codebase)
+
+Update every caller so the constructor is:
+```dart
+RestoreConfirmationDialog(
+  record: record,
+  currentSchemaVersion: AppDatabase.currentSchemaVersion,
+  onConfirm: () => /* existing restore logic */,
+)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `flutter test test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart`
+Expected: All 4 tests pass.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `flutter test`
+Expected: All tests pass.
+
+- [ ] **Step 8: Format and commit**
+
+Run: `dart format lib/ test/`
+
+```bash
+git add -A
+git commit -m "feat: restore-dialog compat branching for pre-migration backups"
+```
+
+---
+
+## Task 16: End-to-end integration test (backup-then-migrate)
+
+**Files:**
+- Create: `test/core/database/pre_migration_backup_integration_test.dart`
+
+- [ ] **Step 1: Write the integration test**
+
+```dart
+// test/core/database/pre_migration_backup_integration_test.dart
+import 'dart:io';
+
+import 'package:drift/native.dart' show NativeDatabase;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+void main() {
+  test('end-to-end: seeds v63 DB, backs up, verifies bytes + record', () async {
+    final tmp = await Directory.systemTemp.createTemp('pmbs_int_');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final livePath = p.join(tmp.path, 'submersion.db');
+    final backupsDir = p.join(tmp.path, 'backups');
+    await Directory(backupsDir).create(recursive: true);
+
+    // Seed a v63 sqlite file using raw sqlite3 to set PRAGMA user_version.
+    final seed = sqlite3.sqlite3.open(livePath);
+    try {
+      seed.execute('PRAGMA user_version = 63');
+      seed.execute('CREATE TABLE sentinel (id INTEGER PRIMARY KEY)');
+      seed.execute('INSERT INTO sentinel VALUES (42)');
+    } finally {
+      seed.dispose();
+    }
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => livePath,
+      backupsDirProvider: () async => backupsDir,
+      preferences: prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'integration-id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    // Assert backup .db exists and matches live bytes
+    final backupPath = p.join(backupsDir, '20260412-081201-v63-v64.db');
+    expect(await File(backupPath).exists(), isTrue);
+    expect(
+      await File(backupPath).readAsBytes(),
+      await File(livePath).readAsBytes(),
+    );
+
+    // Assert the backup DB itself reads back user_version = 63 with sentinel data
+    final verify = sqlite3.sqlite3.open(backupPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(verify.select('PRAGMA user_version').first.values.first, 63);
+      expect(verify.select('SELECT id FROM sentinel').first.values.first, 42);
+    } finally {
+      verify.dispose();
+    }
+
+    // Assert the BackupRecord is in the registry
+    final records = prefs.getHistory();
+    expect(records, hasLength(1));
+    expect(records.single.type, BackupType.preMigration);
+    expect(records.single.fromSchemaVersion, 63);
+    expect(records.single.toSchemaVersion, 64);
+  });
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `flutter test test/core/database/pre_migration_backup_integration_test.dart`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/core/database/pre_migration_backup_integration_test.dart
+git commit -m "test: end-to-end integration for pre-migration backup"
+```
+
+---
+
+## Task 17: Manual verification on macOS
+
+**Files:** none (manual test)
+
+- [ ] **Step 1: Clean rebuild**
+
+Run: `flutter clean && flutter pub get && dart run build_runner build --delete-conflicting-outputs`
+Expected: Clean build completes.
+
+- [ ] **Step 2: Simulate a pending migration**
+
+Set up a snapshot at an older schema:
+1. Run: `flutter run -d macos` — verify the app launches normally on current schema.
+2. Stop the app.
+3. Locate the DB file via: `ls "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db"`.
+4. Use sqlite3 to artificially lower the user_version:
+   ```bash
+   sqlite3 "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db" "PRAGMA user_version = 63;"
+   ```
+   (Adjust the target version if the current schema is not 64 — set it one lower than `AppDatabase.currentSchemaVersion`.)
+
+- [ ] **Step 3: Launch and observe backup UI**
+
+Run: `flutter run -d macos`
+Expected:
+1. Splash appears.
+2. "Backing up your data" screen with spinner appears briefly.
+3. Transitions to "Updating database…" (existing migration progress).
+4. Transitions to normal app UI.
+
+- [ ] **Step 4: Verify the backup was created + registered**
+
+In Finder or Terminal: `ls "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/Backups/"`
+Expected: A file named like `20260412-XXXXXX-v63-v64.db` exists.
+
+Open the app → Settings → Backup → Backup History.
+Expected: The pre-migration backup is visible with a `v63 → v64` badge.
+Pin it; verify the pin icon fills in.
+
+- [ ] **Step 5: Simulate a backup failure (optional — verify hard-fail UI)**
+
+1. Stop the app.
+2. Lower user_version again with sqlite3 (as in Step 2).
+3. Make the Backups folder read-only: `chmod -w "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/Backups"`.
+4. Launch: `flutter run -d macos`.
+Expected: "Couldn't back up your data" screen with Retry / Quit buttons.
+5. Restore write permission: `chmod +w "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/Backups"`.
+6. Tap Retry.
+Expected: Backup succeeds and startup continues to migration.
+
+- [ ] **Step 6: Commit a note about manual-verification completion**
+
+```bash
+git commit --allow-empty -m "chore: manual verification of pre-migration backup on macOS"
+```
+
+---
+
+## Self-Review Checklist (Author)
+
+- **Spec coverage:**
+  - File-level copy before migration → Tasks 5, 6, 9 (atomicity)
+  - Registration via BackupPreferences → Task 5
+  - Retention with pinning → Tasks 7, 10
+  - Hard-fail with Retry/Quit → Tasks 12, 13
+  - `.tmp` sweep → Task 6
+  - Error classification → Tasks 4, 8
+  - Pin/unpin on all backups → Tasks 10, 14
+  - Pre-migration badge → Task 14
+  - Restore dialog compat branching → Task 15
+  - Manual backup gains appVersion line → Task 15
+  - Integration test → Task 16
+  - Manual verification → Task 17
+  - BackupRecord shape extension → Tasks 1, 2, 3
+
+- **Placeholder scan:** There is one "wire in your existing default" comment in Task 13 Step 2 where exact DI wiring depends on how the app currently constructs `BackupService` at startup. This is an intentional judgment point for the implementer, with a concrete fallback pattern shown. Not a plan failure; it's a "mirror existing pattern" instruction with an example.
+
+- **Type consistency:** `BackupFailureCause` enum values (`diskFull`, `permissionDenied`, `sourceMissing`, `renameFailed`, `unknown`) used consistently in Tasks 4 and 12. `BackupType` values (`manual`, `preMigration`) consistent across Tasks 1, 2, 5, 7, 10, 14, 15. `PreMigrationBackupService` constructor params (`livePathProvider`, `backupsDirProvider`, `preferences`, `clock`, `idGenerator`) consistent across Tasks 5, 6, 7, 8, 9, 16. Service method name `backupIfMigrationPending` consistent everywhere.
+
+---
+
+## Execution Notes
+
+- Tasks are ordered so each one leaves the tree in a compilable, test-passing state. The entire suite `flutter test` should pass at every commit boundary.
+- Every task commits individually. Pre-push hooks (`dart format`, `flutter analyze`, `flutter test`) will run at push time; running them locally after each task is recommended.
+- The integration test in Task 16 uses `sqlite3.sqlite3` directly so it does not depend on Drift being opened — important because pre-migration backup is specifically about the closed-DB state.

--- a/docs/superpowers/specs/2026-04-12-db-backup-before-migration-design.md
+++ b/docs/superpowers/specs/2026-04-12-db-backup-before-migration-design.md
@@ -1,0 +1,469 @@
+# Pre-Migration Database Backup
+
+**Date:** 2026-04-12
+
+## Problem
+
+When `AppDatabase` opens at app startup with a stored schema version lower
+than `currentSchemaVersion`, Drift runs the `onUpgrade` migration
+strategy. Migration runs against the user's real dive log — dozens of
+tables with many years of data. A bug in a migration step, a
+platform-specific sqlite quirk, or a partial failure mid-migration can
+leave the user with a damaged database and no way back.
+
+The app already has a mature `BackupService` for manual and automatic
+backups, but nothing is wired into the startup path. The user's most
+recent backup may be weeks old, or they may never have triggered one.
+The exact moment when damage is most likely is also the moment when the
+user has no safety net.
+
+## Solution
+
+Add a `PreMigrationBackupService` that runs in the existing
+`StartupPage` state machine, after the schema-version probe but before
+Drift opens the database. When `storedSchemaVersion <
+currentSchemaVersion`, the service makes a file-level copy of
+`submersion.db` into `BackupService`'s existing backup folder and
+registers it via the existing `BackupPreferences` registry (the same
+SharedPreferences-backed registry that already tracks manual backups)
+with `type: BackupType.preMigration`, then prunes older pre-migration
+records to a rolling window of three (pinned records exempt).
+
+Failure to back up hard-fails startup with a dedicated error screen
+(Retry / Quit) — by design, the app must not migrate without a safety
+net. Descriptor-write and prune failures soft-fail and are logged.
+
+Pre-migration backups appear in the existing backup UI alongside manual
+backups, distinguished by a `v63 → v64` badge. Users can pin any backup
+(manual or pre-migration) to exempt it from retention. Restoring a
+pre-migration backup shows a compatibility dialog that warns honestly
+when the user's current app would re-trigger the same migration the
+backup was made to protect against.
+
+## Architecture and Components
+
+### New code
+
+- **`lib/features/backup/data/services/pre_migration_backup_service.dart`**
+  — new service. Single method:
+  `backupIfMigrationPending({required int stored, required int target,
+  required String appVersion}) → Future<void>`. Operates on the closed
+  DB file; holds no long-lived state. Throws
+  `BackupFailedException` on unrecoverable error.
+
+### Changes to existing code
+
+- **`lib/features/backup/data/entities/backup_record.dart`** — extend
+  the existing `BackupRecord` with new nullable fields: `type`
+  (`BackupType` enum — `manual` or `preMigration`, default `manual`
+  when absent), `appVersion` (String?), `fromSchemaVersion` (int?),
+  `toSchemaVersion` (int?), `pinned` (bool, default `false`). Also
+  make the existing `diveCount` / `siteCount` fields nullable because
+  pre-migration records can't compute them (the DB is closed). Update
+  `toJson` / `fromJson` to handle the new shape backward-compatibly
+  (absent `type` → `manual`).
+- **`lib/features/backup/data/services/backup_service.dart`** — add
+  `pinBackup(String id)` / `unpinBackup(String id)` methods
+  (rewrite the corresponding `BackupRecord` in `BackupPreferences`).
+  Existing manual-backup code paths are otherwise untouched; because
+  `getBackupHistory()` already returns every record in the registry,
+  pre-migration records show up automatically once they're added.
+- **`lib/core/services/startup_page.dart`** (or wherever
+  `_runInitialization` lives) — after the schema probe and before
+  `DatabaseService.initialize()`, invoke
+  `PreMigrationBackupService.backupIfMigrationPending(...)`. Add
+  `StartupState.backingUp` and `StartupState.backupFailed` to the
+  startup state enum with their corresponding views.
+- **Backup list UI** (under `lib/features/backup/presentation/`) — each
+  row gains a pin/unpin icon button. Pre-migration rows gain a `v63 →
+  v64` badge next to the timestamp.
+- **Restore confirmation dialog** — new compatibility branching (see
+  Restore UX below). Manual-backup dialog gains an `appVersion` line
+  pulled from the descriptor.
+
+### Why split `PreMigrationBackupService` out from `BackupService`
+
+`BackupService` collects backup metadata (counts of dives, sites, etc.)
+by querying the open DB. Pre-migration backups by definition run
+*before* the DB is opened for migration, so that metadata path is
+unavailable. Keeping two focused services avoids forcing
+`BackupService` to carry two lifecycle modes ("operates on an open DB"
+vs "operates on a closed DB file") with nullable fields and conditional
+branches. The `BackupDescriptor` entity is the shared seam — both
+services write descriptors into the same folder in the same format, and
+the listing side stays unified.
+
+## Data Flow and Sequencing
+
+```
+StartupPage._runInitialization
+   │
+   1. Read stored schema version via
+   │    `DatabaseService.getStoredSchemaVersion()` (raw sqlite3,
+   │    `PRAGMA user_version`)
+   │
+   2. Resolve DB path via DatabaseLocationService
+   │
+   3. Live DB file exists at path?
+   │     ├─ no (fresh install) → skip backup, go to step 7
+   │     └─ yes → continue
+   │
+   4. storedSchemaVersion < AppDatabase.currentSchemaVersion?
+   │     ├─ no (up-to-date) → skip backup, go to step 7
+   │     └─ yes → continue
+   │
+   5. UI state = StartupState.backingUp
+   │
+   6. PreMigrationBackupService.backupIfMigrationPending(...)
+   │        6a. Sweep <backupsDir> for any .tmp files, delete them
+   │        6b. Compute tempPath  = <backupsDir>/.<ts>-v<from>-v<to>.db.tmp
+   │        6c. Compute finalPath = <backupsDir>/<ts>-v<from>-v<to>.db
+   │        6d. Ensure backupsDir exists
+   │        6e. File.copy(livePath, tempPath)
+   │        6f. Rename tempPath → finalPath   (atomic on same filesystem)
+   │        6g. Register via BackupPreferences.addRecord() with a
+   │              BackupRecord: {id: uuid, filename, timestamp,
+   │              sizeBytes, localPath: finalPath, type: preMigration,
+   │              appVersion, fromSchemaVersion, toSchemaVersion,
+   │              pinned: false, diveCount: null, siteCount: null}
+   │        6h. Prune: load records where type == preMigration;
+   │              partition by pinned; sort unpinned by timestamp DESC;
+   │              keep first 3; for each to-delete unlink the .db
+   │              file first, then remove the record via
+   │              BackupPreferences.removeRecord()
+   │        6i. Return void
+   │
+   │  On exception at 6b–6f: rethrow wrapped as BackupFailedException
+   │  On exception at 6a, 6g, 6h: log at warning, do not abort
+   │
+   7. UI state = StartupState.migrating
+   │   DatabaseService.initialize()   ← Drift opens DB, runs onUpgrade
+   │
+   8. UI state = StartupState.ready → navigate to app
+```
+
+### Atomicity
+
+Every crash point must leave the filesystem + registry in a
+recoverable state:
+
+- Steps 6e + 6f use write-temp-then-rename so a crash during the copy
+  never leaves a partial file being mistaken for a complete backup.
+  The `.tmp` extension and leading dot also hide in-progress copies
+  from Finder.
+- Step 6h unlinks the paired `.db` file *before* removing the registry
+  record during prune. A crash mid-prune leaves a registry record
+  referencing a missing file — which the existing
+  `BackupService.getValidatedBackupHistory()` already filters
+  defensively, and which the user can dismiss through normal UI. This
+  is preferable to the reverse order, which would silently leak `.db`
+  files on disk (the `.tmp` sweep does not target `.db` files by
+  design).
+- Step 6g registers the record *after* the `.db` rename. A crash
+  between 6f and 6g leaves an orphan `.db` on disk — safer than a
+  record referring to a file that is not there. A subsequent
+  successful run will NOT reuse the orphan filename (timestamps
+  differ), so the orphan persists harmlessly.
+
+Orphan `.db` files are *not* automatically deleted on startup. They
+may be the user's only copy of a failed-to-register backup. The
+`.tmp` sweep at step 6a only deletes provably-incomplete files.
+
+## File Layout and Backup Record Format
+
+### Directory layout
+
+Pre-migration backup `.db` files live in `BackupService`'s existing
+backup folder alongside manual backup `.db` files. The folder
+contains *only* `.db` files; metadata is held in the
+`BackupPreferences` registry (SharedPreferences), matching existing
+practice:
+
+```
+<backupsDir>/
+  20260101-143022-manual.db                ← existing manual
+  20260412-081201-v63-v64.db               ← new pre-migration
+  .20260412-081535-v63-v64.db.tmp          ← transient; swept on next
+                                             migration-pending startup
+```
+
+### Filename convention
+
+- Manual backups: existing convention (unchanged).
+- Pre-migration backups: `<UTC-timestamp>-v<from>-v<to>.db` where
+  timestamp is `yyyyMMdd-HHmmss`. Encoding the schema pair in the
+  filename makes the folder self-describing for support purposes
+  (e.g., "the v63→v64 backup I'm looking for is on disk even if the
+  SharedPreferences registry is lost in a reinstall").
+
+### BackupRecord shape (extended)
+
+The existing `BackupRecord` entity gets new fields:
+
+| Field | Type | Default | Manual backup | Pre-migration backup |
+| --- | --- | --- | --- | --- |
+| `id` | String | (uuid) | uuid | uuid |
+| `filename` | String | required | `...-manual.db` | `...-v63-v64.db` |
+| `timestamp` | DateTime | required | set by service | set by service |
+| `sizeBytes` | int | required | file size | file size |
+| `location` | BackupLocation | required | local / cloud | local only |
+| `diveCount` | int? | null | computed | null |
+| `siteCount` | int? | null | computed | null |
+| `cloudFileId` | String? | null | set if cloud | null |
+| `localPath` | String? | null | set if local | set |
+| `isAutomatic` | bool | false | existing | true |
+| `type` *(new)* | BackupType | `manual` | `manual` | `preMigration` |
+| `appVersion` *(new)* | String? | null | current version | current version |
+| `fromSchemaVersion` *(new)* | int? | null | null | set |
+| `toSchemaVersion` *(new)* | int? | null | null | set |
+| `pinned` *(new)* | bool | false | user-toggled | user-toggled |
+
+Making `diveCount` and `siteCount` nullable is necessary because
+pre-migration backups can't compute them (the DB isn't open).
+Backward compatibility is preserved via `toJson` / `fromJson`
+fallbacks: `type` absent → `BackupType.manual`, `pinned` absent →
+`false`, `appVersion` absent → `null`, count fields absent or
+present → parsed as-is.
+
+### Listing behaviour
+
+`BackupService.getBackupHistory()` and `getValidatedBackupHistory()`
+continue to return every record in the registry (no API change). The
+row UI distinguishes types by reading `record.type`:
+
+- Pre-migration → badge `v63 → v64`
+- Pinned (either type) → filled pin icon; unpinned shows outlined pin
+
+## Error Handling and Startup UI
+
+### Startup states
+
+```
+StartupState {
+  initial,
+  checkingVersion,   // existing
+  migrating,         // existing
+  backingUp,         // new
+  backupFailed,      // new
+  ready,             // existing
+}
+```
+
+### Backing-up screen
+
+- Title: "Backing up your data"
+- Body: "We're saving a copy of your dive log before updating your
+  database."
+- Indeterminate spinner, no cancel button (cancelling would strand the
+  user in an inconsistent state).
+- No progress bar in this change. `File.copy` is sub-second for
+  typical dive logs and ~3–5 s for very large ones on SSD. We ship
+  the spinner and measure before investing in chunked-copy progress,
+  consistent with the "measure before optimising" policy.
+
+### Backup-failed screen
+
+- Title: "Couldn't back up your data"
+- Body: human-readable cause (see classification below), followed by
+  "Your dive log hasn't changed — we didn't update it. Free up space
+  (or fix the issue) and try again."
+- Primary: `Retry` → re-invokes `backupIfMigrationPending` only (not
+  the full startup).
+- Secondary: `Quit` → `SystemNavigator.pop()` on mobile, `exit(0)` on
+  desktop.
+- Expandable `Technical details` row with exception class + message,
+  for copy-paste to support.
+
+### Error classification
+
+```
+BackupFailedException(cause, userMessage, technicalDetails)
+   ├─ DiskFull           // FileSystemException errorCode ENOSPC (28)
+   ├─ PermissionDenied   // EACCES (13) / EPERM (1)
+   ├─ SourceMissing
+   ├─ RenameFailed
+   └─ Unknown(e)
+```
+
+Classification matches on `FileSystemException.osError?.errorCode`
+because OS error messages are localised on some platforms but
+`errorCode` is a POSIX integer. `Unknown(e)` is always logged with a
+full stack trace — never silently swallowed.
+
+### What is *not* a hard failure
+
+- Prune failures (step 6h) — logged at warning level, backup still
+  succeeds. The user's data is safe the moment step 6f completes.
+- Descriptor-write failures *after* successful `.db` rename — logged,
+  retried once, then logged again if still failing. The backup is
+  effectively orphaned from the listing UI but the data is on disk; a
+  warning is surfaced in the backup list if the user opens it, but
+  startup continues because the contract ("there will be a copy
+  before migration runs") is already fulfilled.
+
+## Retention, Pruning, and Pinning
+
+### When pruning runs
+
+Only after a successful backup, as step 6h. Not on app startup, not
+on a timer, not on backup-list view. This means prune failures are
+covered by the same error handling as the backup itself (soft-fail;
+logged).
+
+### Prune algorithm
+
+1. Load all `BackupRecord`s from `BackupPreferences` where
+   `type == BackupType.preMigration`.
+2. Partition into pinned vs unpinned.
+3. Sort unpinned by `timestamp` DESC.
+4. Keep the first 3; mark the rest for deletion.
+5. For each to-delete: unlink the `.db` file at `record.localPath`
+   first (if non-null), then remove the record via
+   `BackupPreferences.removeRecord(id)`.
+6. Pinned backups are never deleted (unbounded by design — pinning is
+   the user's explicit opt-in to retain).
+
+### Pinning UX
+
+- Every row in the backup list (manual and pre-migration alike) has a
+  pin icon button on the trailing side, alongside the existing
+  overflow menu.
+- Tapping toggles `pinned` on the underlying `BackupRecord` via
+  `BackupService.pinBackup(id)` / `unpinBackup(id)`.
+- Filled icon = pinned; outlined icon = unpinned.
+- No confirmation dialog; the operation is cheap and reversible.
+
+Manual-backup retention is unchanged by this project ("keep forever").
+Pinning a manual backup has no effect today but is honored by any
+future manual-backup retention policy.
+
+### Edge cases
+
+| Case | Behaviour |
+| --- | --- |
+| User pins many pre-migration backups over years | All retained; pinning is explicit user intent. |
+| N=3 but only 2 unpinned exist | No-op; prune list is empty. |
+| Registry record exists but `.db` is missing | `getValidatedBackupHistory()` already flags this via existing validation; row can be dismissed, which calls `BackupPreferences.removeRecord(id)`. |
+| `.db` on disk but no registry record (crash mid-creation, or user restored a reinstall with backups folder intact but prefs lost) | Not visible in listing. Startup `.tmp` sweep does **not** touch these. Orphans are logged at warning level as support recovery artefacts. |
+| User manually deletes a `.db` via Finder | Same as "record with missing `.db`" case. |
+
+## Restore UX
+
+`BackupService.restoreFromBackup(BackupRecord)` already performs
+"close DB → `File.copy` → reopen DB". Pre-migration restore reuses
+this; the only new code is a compatibility-warning dialog layered on
+top.
+
+### The compatibility problem
+
+A pre-migration backup's `.db` is at `fromSchemaVersion` (e.g. v63).
+The currently-installed app targets `currentSchemaVersion` (e.g. v64).
+Restoring the backup while running the current app overwrites the
+live DB with a v63 file; on the next open, Drift sees `PRAGMA
+user_version = 63` and re-runs `onUpgrade(63, 64)`. If that migration
+is what damaged the user's data originally, **the same bug happens
+again**.
+
+The only safe recovery path is: install an older app version first,
+then restore. The dialog must state this plainly.
+
+### Confirmation dialog (pre-migration backup)
+
+Fields pulled from the `BackupRecord`: `appVersion`, `timestamp`,
+`fromSchemaVersion`, `toSchemaVersion`. The dialog branches on
+schema compatibility:
+
+| Situation | Dialog behaviour |
+| --- | --- |
+| `currentSchemaVersion == fromSchemaVersion` | Green path. "Restore safe — app version matches." Single `Restore` button. |
+| `currentSchemaVersion > fromSchemaVersion` | Warning path. Explicitly states that restoring will re-run the same migration. `Restore anyway` styled destructive; also offers `Cancel`. |
+| `currentSchemaVersion < fromSchemaVersion` | Hard block. "This backup is newer than your app. Install a newer app version to restore it." Only `Cancel`. |
+
+### Manual-backup dialog
+
+No behavioural change. Gains an `appVersion` line when the
+underlying `BackupRecord.appVersion` is non-null (records created
+before this change will have `appVersion == null` and the line is
+simply omitted — no defensive conditional fallbacks needed).
+
+### After restore
+
+No change from existing `BackupService.restore()` behaviour. Drift
+inspects `user_version` on reopen and migrates as needed.
+
+## Testing Strategy
+
+### Unit tests
+
+`test/features/backup/pre_migration_backup_service_test.dart`:
+
+- Happy path: copies live DB byte-for-byte.
+- Registered `BackupRecord` has correct `type`, schema pair,
+  `appVersion`, `timestamp`.
+- Skip when live DB file does not exist (no exception, no output).
+- Skip when `stored == target`.
+- `.tmp` files from a previous crash are swept at step 6a of the
+  next migration-pending invocation (not on every app startup).
+- Prune keeps newest N unpinned plus all pinned.
+- Prune removes registry record before unlinking `.db` (inject a
+  fake `BackupPreferences` + filesystem where the file unlink fails;
+  assert record is gone, `.db` survives as orphan).
+- `ENOSPC` → `DiskFull`, `EACCES` → `PermissionDenied`, unknown code
+  → `Unknown(e)`.
+- Orphan `.db` with no corresponding registry record is preserved
+  (not deleted on next run).
+
+### Widget tests
+
+`test/features/startup/pre_migration_backup_flow_test.dart`:
+
+- `StartupState.backingUp` shows progress screen.
+- Successful backup transitions to `migrating`.
+- Failed backup shows `backupFailed` screen with classified message.
+- `Retry` re-invokes the service only (not full startup).
+- Classified errors render human-readable copy, not
+  `exception.toString()`.
+
+`test/features/backup/restore_dialog_compat_test.dart`:
+
+- Green path when `currentSchema == fromSchema`.
+- Warning path when `currentSchema > fromSchema`.
+- Hard block when `currentSchema < fromSchema`.
+
+### Integration test
+
+`test/core/database/pre_migration_backup_integration_test.dart`:
+
+- Seed a v63 SQLite file at the live DB path using the existing
+  migration fixture pattern (`PRAGMA user_version = 63`).
+- Stub `SharedPreferences` with `storedSchemaVersion = 63`.
+- Run the full startup flow with `AppDatabase` at
+  `currentSchemaVersion = 64`.
+- Assert: (a) a pre-migration backup `.db` exists post-startup; (b)
+  its bytes equal the original v63 seed; (c) the live DB opens at
+  schema 64 with migrated rows.
+
+### Out of scope for tests
+
+- Cross-platform filesystem oddities (Windows path limits, Android SAF
+  edges) — covered indirectly via the existing `BackupService` folder
+  resolution, which is reused verbatim.
+- Disk-full during integration tests — hard to simulate portably;
+  unit-level error classification covers the code path.
+
+## Out of Scope
+
+- Making pre-migration backup retention user-configurable. N=3 is a
+  constant; lifting it to settings adds test matrix for zero proven
+  demand.
+- Automatic upload of pre-migration backups to cloud storage. The
+  existing `BackupService` cloud hooks are reachable by a user if they
+  restore a pre-migration backup then manually upload it, but
+  pre-migration backups do not auto-upload.
+- Rolling out pinning to manual-backup retention semantics. The field
+  is now present on manual descriptors, but manual retention remains
+  "keep forever" as before.
+- Schema downgrade. Drift does not support this; restoring a v63
+  backup in a v64-only app will re-trigger the forward migration.
+  The restore dialog surfaces this clearly; we do not attempt to
+  mitigate at the storage layer.

--- a/docs/superpowers/specs/2026-04-12-db-backup-before-migration-design.md
+++ b/docs/superpowers/specs/2026-04-12-db-backup-before-migration-design.md
@@ -182,8 +182,8 @@ practice:
 ```
 <backupsDir>/
   20260101-143022-manual.db                ← existing manual
-  20260412-081201-v63-v64.db               ← new pre-migration
-  .20260412-081535-v63-v64.db.tmp          ← transient; swept on next
+  20260412-081201000-v63-v64.db            ← new pre-migration
+  .20260412-081535000-v63-v64.db.tmp       ← transient; swept on next
                                              migration-pending startup
 ```
 
@@ -191,8 +191,9 @@ practice:
 
 - Manual backups: existing convention (unchanged).
 - Pre-migration backups: `<UTC-timestamp>-v<from>-v<to>.db` where
-  timestamp is `yyyyMMdd-HHmmss`. Encoding the schema pair in the
-  filename makes the folder self-describing for support purposes
+  timestamp is `yyyyMMdd-HHmmssSSS` (millisecond precision prevents
+  same-second collisions on rapid retry). Encoding the schema pair in
+  the filename makes the folder self-describing for support purposes
   (e.g., "the v63→v64 backup I'm looking for is on disk even if the
   SharedPreferences registry is lost in a reinstall").
 

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -251,6 +251,15 @@ class _StartupWrapperState extends State<StartupWrapper>
     required String dbPath,
     required int stored,
   }) async {
+    assert(
+      widget.schemaVersionProbeOverride == null ||
+          widget.preMigrationBackupFactory != null,
+      'When schemaVersionProbeOverride is set in tests, you must also supply '
+      'preMigrationBackupFactory — otherwise the pre-migration backup will '
+      'run with stored=0 and attempt a real file copy against the production '
+      'database path.',
+    );
+
     final prefs = BackupPreferences(widget.prefs);
 
     final PreMigrationBackupService service;
@@ -281,6 +290,9 @@ class _StartupWrapperState extends State<StartupWrapper>
     );
   }
 
+  /// Re-runs backup → services → ready without the 1-second splash delay used
+  /// on first launch; the user is already looking at the splash and tapped Retry
+  /// themselves, so an enforced minimum delay would feel slow.
   Future<void> _retryPreMigrationBackup() async {
     if (!mounted) return;
     setState(() {

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -2,11 +2,14 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/domain/entities/migration_progress.dart';
+import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
 import 'package:submersion/core/services/background_service.dart';
 import 'package:submersion/core/services/database_location_service.dart';
@@ -14,7 +17,10 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/local_cache_database_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/notification_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/main.dart' show SubmersionRestart;
@@ -59,6 +65,14 @@ class StartupWrapper extends StatefulWidget {
   @visibleForTesting
   final VoidCallback? closeAppOverride;
 
+  /// Optional override for the pre-migration backup service factory (tests).
+  @visibleForTesting
+  final PreMigrationBackupService Function({
+    required String livePath,
+    required BackupPreferences preferences,
+  })?
+  preMigrationBackupFactory;
+
   const StartupWrapper({
     super.key,
     required this.prefs,
@@ -67,6 +81,7 @@ class StartupWrapper extends StatefulWidget {
     this.initializerOverride,
     this.schemaVersionProbeOverride,
     this.closeAppOverride,
+    this.preMigrationBackupFactory,
   });
 
   @override
@@ -119,6 +134,7 @@ class _StartupWrapperState extends State<StartupWrapper>
       // Determine if migration is needed before opening the database
       final dbPath = await widget.locationService.getDatabasePath();
 
+      final int? storedVersion;
       final bool needsMigration;
       final int totalSteps;
 
@@ -126,22 +142,43 @@ class _StartupWrapperState extends State<StartupWrapper>
         final probe = widget.schemaVersionProbeOverride!(dbPath);
         needsMigration = probe.needsMigration;
         totalSteps = probe.totalSteps;
+        storedVersion =
+            null; // probe path doesn't expose storedVersion; backup uses 0 default
       } else {
-        final storedVersion = DatabaseService.getStoredSchemaVersion(dbPath);
+        storedVersion = DatabaseService.getStoredSchemaVersion(dbPath);
+        final sv = storedVersion;
         needsMigration =
-            storedVersion != null &&
-            storedVersion > 0 &&
-            storedVersion < AppDatabase.currentSchemaVersion;
-        totalSteps = needsMigration
-            ? AppDatabase.migrationStepCount(storedVersion)
-            : 0;
+            sv != null && sv > 0 && sv < AppDatabase.currentSchemaVersion;
+        totalSteps = needsMigration ? AppDatabase.migrationStepCount(sv) : 0;
       }
 
-      if (needsMigration && mounted) {
-        setState(() {
-          _state = _StartupState.migrating;
-          _progress = MigrationProgress(currentStep: 0, totalSteps: totalSteps);
-        });
+      if (needsMigration) {
+        if (mounted) {
+          setState(() => _state = _StartupState.backingUp);
+        }
+        try {
+          await _runPreMigrationBackup(
+            dbPath: dbPath,
+            stored: storedVersion ?? 0,
+          );
+        } on BackupFailedException catch (e) {
+          if (mounted) {
+            setState(() {
+              _state = _StartupState.backupFailed;
+              _backupError = e;
+            });
+          }
+          return;
+        }
+        if (mounted) {
+          setState(() {
+            _state = _StartupState.migrating;
+            _progress = MigrationProgress(
+              currentStep: 0,
+              totalSteps: totalSteps,
+            );
+          });
+        }
       }
 
       // Run DB init and minimum splash duration in parallel
@@ -210,6 +247,87 @@ class _StartupWrapperState extends State<StartupWrapper>
     await speciesRepository.seedBuiltInSpecies();
   }
 
+  Future<void> _runPreMigrationBackup({
+    required String dbPath,
+    required int stored,
+  }) async {
+    final prefs = BackupPreferences(widget.prefs);
+
+    final PreMigrationBackupService service;
+    final String appVersion;
+    if (widget.preMigrationBackupFactory != null) {
+      service = widget.preMigrationBackupFactory!(
+        livePath: dbPath,
+        preferences: prefs,
+      );
+      appVersion = '0.0.0.0';
+    } else {
+      final info = await PackageInfo.fromPlatform();
+      appVersion = '${info.version}.${info.buildNumber}';
+      if (!mounted) return;
+      final container = ProviderScope.containerOf(context, listen: false);
+      final backupService = container.read(backupServiceProvider);
+      service = PreMigrationBackupService(
+        livePathProvider: () async => dbPath,
+        backupsDirProvider: backupService.getBackupsDirectory,
+        preferences: prefs,
+      );
+    }
+
+    await service.backupIfMigrationPending(
+      stored: stored,
+      target: AppDatabase.currentSchemaVersion,
+      appVersion: appVersion,
+    );
+  }
+
+  Future<void> _retryPreMigrationBackup() async {
+    if (!mounted) return;
+    setState(() {
+      _state = _StartupState.backingUp;
+      _backupError = null;
+    });
+    try {
+      final dbPath = await widget.locationService.getDatabasePath();
+      final stored = DatabaseService.getStoredSchemaVersion(dbPath) ?? 0;
+      await _runPreMigrationBackup(dbPath: dbPath, stored: stored);
+      if (!mounted) return;
+      setState(() {
+        _state = _StartupState.migrating;
+      });
+      await _initializeServices();
+      if (!mounted) return;
+      setState(() => _state = _StartupState.ready);
+      _splashFadeController.forward();
+    } on BackupFailedException catch (e) {
+      if (mounted) {
+        setState(() {
+          _state = _StartupState.backupFailed;
+          _backupError = e;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _state = _StartupState.error;
+          _errorMessage = '$e';
+        });
+      }
+    }
+  }
+
+  void _quitApp() {
+    if (widget.closeAppOverride != null) {
+      widget.closeAppOverride!();
+      return;
+    }
+    if (Platform.isIOS || Platform.isAndroid) {
+      SystemNavigator.pop();
+    } else {
+      exit(0);
+    }
+  }
+
   Future<void> _closeApp() async {
     if (widget.closeAppOverride != null) {
       widget.closeAppOverride!();
@@ -256,7 +374,9 @@ class _StartupWrapperState extends State<StartupWrapper>
               ),
               child: MaterialApp(
                 debugShowCheckedModeBanner: false,
-                home: _state == _StartupState.error
+                home:
+                    (_state == _StartupState.error ||
+                        _state == _StartupState.backupFailed)
                     ? Scaffold(
                         key: const ValueKey('error'),
                         backgroundColor: backgroundColor,
@@ -296,6 +416,10 @@ class _StartupWrapperState extends State<StartupWrapper>
   }
 
   Widget _buildSplashContent(bool isDark) {
+    if (_state == _StartupState.backingUp) {
+      return const BackingUpView();
+    }
+
     return SingleChildScrollView(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -351,6 +475,14 @@ class _StartupWrapperState extends State<StartupWrapper>
   }
 
   Widget _buildErrorContent(Color textColor, Color subtitleColor) {
+    if (_state == _StartupState.backupFailed && _backupError != null) {
+      return BackupFailedView(
+        error: _backupError!,
+        onRetry: _retryPreMigrationBackup,
+        onQuit: _quitApp,
+      );
+    }
+
     if (_isVersionMismatch) {
       return Padding(
         padding: const EdgeInsets.all(24),

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -291,6 +291,10 @@ class _StartupWrapperState extends State<StartupWrapper>
   /// themselves, so an enforced minimum delay would feel slow.
   Future<void> _retryPreMigrationBackup() async {
     if (!mounted) return;
+    if (_state != _StartupState.backupFailed) {
+      // Already retrying or moved on; ignore rapid taps.
+      return;
+    }
     setState(() {
       _state = _StartupState.backingUp;
       _backupError = null;

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -18,9 +17,9 @@ import 'package:submersion/core/services/local_cache_database_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/notification_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
-import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/main.dart' show SubmersionRestart;
@@ -273,12 +272,9 @@ class _StartupWrapperState extends State<StartupWrapper>
     } else {
       final info = await PackageInfo.fromPlatform();
       appVersion = '${info.version}.${info.buildNumber}';
-      if (!mounted) return;
-      final container = ProviderScope.containerOf(context, listen: false);
-      final backupService = container.read(backupServiceProvider);
       service = PreMigrationBackupService(
         livePathProvider: () async => dbPath,
-        backupsDirProvider: backupService.getBackupsDirectory,
+        backupsDirProvider: () => BackupService.resolveBackupsDirectory(prefs),
         preferences: prefs,
       );
     }

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -304,8 +304,10 @@ class _StartupWrapperState extends State<StartupWrapper>
       final stored = DatabaseService.getStoredSchemaVersion(dbPath) ?? 0;
       await _runPreMigrationBackup(dbPath: dbPath, stored: stored);
       if (!mounted) return;
+      final totalSteps = AppDatabase.migrationStepCount(stored);
       setState(() {
         _state = _StartupState.migrating;
+        _progress = MigrationProgress(currentStep: 0, totalSteps: totalSteps);
       });
       await _initializeServices();
       if (!mounted) return;

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/local_cache_database_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/notification_service.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/main.dart' show SubmersionRestart;
@@ -32,7 +33,14 @@ typedef ServiceInitializer =
 typedef SchemaVersionProbe =
     ({bool needsMigration, int totalSteps}) Function(String dbPath);
 
-enum _StartupState { initializing, migrating, ready, error }
+enum _StartupState {
+  initializing,
+  backingUp,
+  migrating,
+  backupFailed,
+  ready,
+  error,
+}
 
 class StartupWrapper extends StatefulWidget {
   final SharedPreferences prefs;
@@ -76,6 +84,7 @@ class _StartupWrapperState extends State<StartupWrapper>
   bool _isVersionMismatch = false;
   int _dbVersion = 0;
   int _appVersion = 0;
+  BackupFailedException? _backupError;
 
   /// Drives the dissolve of the splash layer over the mounted app beneath.
   /// Forward-only; starts when _state first reaches ready.

--- a/lib/core/presentation/widgets/backup_status_views.dart
+++ b/lib/core/presentation/widgets/backup_status_views.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+/// Shown while PreMigrationBackupService copies the live database.
+class BackingUpView extends StatelessWidget {
+  const BackingUpView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 24),
+          Text(
+            'Backing up your data',
+            style: Theme.of(context).textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            "We're saving a copy of your dive log before updating your database.",
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shown when the pre-migration backup fails. Offers Retry and Quit.
+class BackupFailedView extends StatelessWidget {
+  final BackupFailedException error;
+  final VoidCallback onRetry;
+  final VoidCallback onQuit;
+
+  const BackupFailedView({
+    super.key,
+    required this.error,
+    required this.onRetry,
+    required this.onQuit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 48,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            "Couldn't back up your data",
+            style: Theme.of(context).textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Text(error.userMessage, textAlign: TextAlign.center),
+          const SizedBox(height: 8),
+          const Text(
+            "Your dive log hasn't changed — we didn't update it. Free up space (or fix the issue) and try again.",
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
+          const SizedBox(height: 8),
+          TextButton(onPressed: onQuit, child: const Text('Quit')),
+          const SizedBox(height: 16),
+          ExpansionTile(
+            title: const Text('Technical details'),
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: SelectableText(
+                  error.technicalDetails,
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/presentation/widgets/backup_status_views.dart
+++ b/lib/core/presentation/widgets/backup_status_views.dart
@@ -13,7 +13,7 @@ class BackingUpView extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const CircularProgressIndicator(),
+          const CircularProgressIndicator(semanticsLabel: 'Backing up'),
           const SizedBox(height: 24),
           Text(
             'Backing up your data',
@@ -46,10 +46,10 @@ class BackupFailedView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Icon(

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -442,9 +442,13 @@ class BackupService {
   // File System Helpers
   // ===========================================================================
 
-  /// Get the active backups directory (custom or default), creating it if needed.
-  Future<String> getBackupsDirectory() async {
-    final settings = _preferences.getSettings();
+  /// Resolves the backups directory using the given preferences, without
+  /// needing a full BackupService instance. Used by startup paths that
+  /// run before Riverpod is established and before the DB is open.
+  static Future<String> resolveBackupsDirectory(
+    BackupPreferences preferences,
+  ) async {
+    final settings = preferences.getSettings();
     if (settings.backupLocation != null) {
       final customDir = Directory(settings.backupLocation!);
       if (!await customDir.exists()) {
@@ -452,11 +456,22 @@ class BackupService {
       }
       return customDir.path;
     }
-    return getLocalBackupsDirectory();
+    final appDir = await getApplicationDocumentsDirectory();
+    final backupDir = Directory(p.join(appDir.path, _localBackupFolder));
+    if (!await backupDir.exists()) {
+      await backupDir.create(recursive: true);
+    }
+    return backupDir.path;
   }
+
+  /// Get the active backups directory (custom or default), creating it if needed.
+  Future<String> getBackupsDirectory() =>
+      BackupService.resolveBackupsDirectory(_preferences);
 
   /// Get the local backups directory, creating it if needed.
   Future<String> getLocalBackupsDirectory() async {
+    // Direct-path version bypassing custom-location check; preserved for
+    // existing callers that want the default location specifically.
     final appDir = await getApplicationDocumentsDirectory();
     final backupDir = Directory(p.join(appDir.path, _localBackupFolder));
     if (!await backupDir.exists()) {

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -13,6 +13,7 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 
 /// Thin interface for the database operations BackupService needs.
 ///
@@ -399,13 +400,24 @@ class BackupService {
 
   /// Remove old backups beyond the retention count.
   ///
-  /// Keeps the [keepCount] most recent backups and deletes the rest.
+  /// Only prunes manual, unpinned records. Pre-migration records have their
+  /// own retention managed by PreMigrationBackupService. Pinned records are
+  /// exempt from all automatic retention.
+  ///
+  /// Keeps the [keepCount] most recent unpinned manual backups and deletes
+  /// the rest.
   Future<void> pruneOldBackups(int keepCount) async {
     final history = getBackupHistory(); // Already sorted newest-first
-    if (history.length <= keepCount) return;
 
-    final toDelete = history.sublist(keepCount);
-    _log.info('Pruning ${toDelete.length} old backups (keeping $keepCount)');
+    final eligible = history
+        .where((r) => r.type == BackupType.manual && !r.pinned)
+        .toList();
+    if (eligible.length <= keepCount) return;
+
+    final toDelete = eligible.sublist(keepCount);
+    _log.info(
+      'Pruning ${toDelete.length} old manual backups (keeping $keepCount)',
+    );
 
     for (final record in toDelete) {
       await deleteBackup(record);

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -378,6 +378,25 @@ class BackupService {
     _log.info('Backup deleted: ${record.filename}');
   }
 
+  /// Pin a backup record so it is excluded from automatic pruning.
+  Future<void> pinBackup(String id) => _setPinned(id, true);
+
+  /// Unpin a backup record so it is subject to automatic pruning again.
+  Future<void> unpinBackup(String id) => _setPinned(id, false);
+
+  Future<void> _setPinned(String id, bool pinned) async {
+    final history = _preferences.getHistory();
+    BackupRecord? match;
+    for (final r in history) {
+      if (r.id == id) {
+        match = r;
+        break;
+      }
+    }
+    if (match == null) return;
+    await _preferences.updateRecord(match.copyWith(pinned: pinned));
+  }
+
   /// Remove old backups beyond the retention count.
   ///
   /// Keeps the [keepCount] most recent backups and deletes the rest.

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -48,8 +48,12 @@ class PreMigrationBackupService {
     if (!await File(livePath).exists()) return;
 
     final backupsDir = await _backupsDirProvider();
-    await Directory(backupsDir).create(recursive: true);
-    await _sweepTempFiles(backupsDir);
+    try {
+      await Directory(backupsDir).create(recursive: true);
+      await _sweepTempFiles(backupsDir);
+    } catch (e, stack) {
+      throw BackupFailedException.fromError(e, stack);
+    }
 
     final now = _clock().toUtc();
     final ts = _formatTimestamp(now);

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -48,6 +48,7 @@ class PreMigrationBackupService {
 
     final backupsDir = await _backupsDirProvider();
     await Directory(backupsDir).create(recursive: true);
+    await _sweepTempFiles(backupsDir);
 
     final now = _clock().toUtc();
     final ts = _formatTimestamp(now);
@@ -102,5 +103,24 @@ class PreMigrationBackupService {
       final f = File(path);
       if (await f.exists()) await f.delete();
     } catch (_) {}
+  }
+
+  Future<void> _sweepTempFiles(String backupsDir) async {
+    try {
+      final dir = Directory(backupsDir);
+      await for (final entity in dir.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final name = p.basename(entity.path);
+        if (name.endsWith('.tmp')) {
+          await _safeDelete(entity.path);
+        }
+      }
+    } catch (e, stack) {
+      _log.warning(
+        'Failed sweeping .tmp files in $backupsDir',
+        error: e,
+        stackTrace: stack,
+      );
+    }
   }
 }

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -130,7 +130,13 @@ class PreMigrationBackupService {
     try {
       final f = File(path);
       if (await f.exists()) await f.delete();
-    } catch (_) {}
+    } catch (e, stack) {
+      _log.warning(
+        'Failed to delete backup file at $path (continuing)',
+        error: e,
+        stackTrace: stack,
+      );
+    }
   }
 
   Future<void> _pruneExcess() async {

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -44,12 +44,16 @@ class PreMigrationBackupService {
   }) async {
     if (stored >= target) return;
 
-    final livePath = await _livePathProvider();
-    if (!await File(livePath).exists()) return;
-
-    final backupsDir = await _backupsDirProvider();
+    late final String livePath;
+    late final String backupsDir;
     try {
+      livePath = await _livePathProvider();
+      if (!await File(livePath).exists()) return;
+
+      backupsDir = await _backupsDirProvider();
       await Directory(backupsDir).create(recursive: true);
+    } on BackupFailedException {
+      rethrow;
     } catch (e, stack) {
       throw BackupFailedException.fromError(e, stack);
     }
@@ -70,7 +74,12 @@ class PreMigrationBackupService {
       throw BackupFailedException.fromError(e, stack);
     }
 
-    final sizeBytes = await File(finalPath).length();
+    late final int sizeBytes;
+    try {
+      sizeBytes = await File(finalPath).length();
+    } catch (e, stack) {
+      throw BackupFailedException.fromError(e, stack);
+    }
 
     try {
       await _preferences.addRecord(

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -111,7 +111,7 @@ class PreMigrationBackupService {
       await for (final entity in dir.list(followLinks: false)) {
         if (entity is! File) continue;
         final name = p.basename(entity.path);
-        if (name.endsWith('.tmp')) {
+        if (name.startsWith('.') && name.endsWith('.db.tmp')) {
           await _safeDelete(entity.path);
         }
       }

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -127,11 +127,11 @@ class PreMigrationBackupService {
     if (unpinned.length <= _retainN) return;
     final toDelete = unpinned.sublist(_retainN);
     for (final record in toDelete) {
-      await _preferences.removeRecord(record.id);
       final path = record.localPath;
       if (path != null) {
         await _safeDelete(path);
       }
+      await _preferences.removeRecord(record.id);
     }
   }
 

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -50,10 +50,11 @@ class PreMigrationBackupService {
     final backupsDir = await _backupsDirProvider();
     try {
       await Directory(backupsDir).create(recursive: true);
-      await _sweepTempFiles(backupsDir);
     } catch (e, stack) {
       throw BackupFailedException.fromError(e, stack);
     }
+
+    await _sweepTempFiles(backupsDir);
 
     final now = _clock().toUtc();
     final ts = _formatTimestamp(now);

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -110,9 +110,11 @@ class PreMigrationBackupService {
 
   String _formatTimestamp(DateTime utc) {
     String two(int v) => v.toString().padLeft(2, '0');
+    String three(int v) => v.toString().padLeft(3, '0');
     final d = utc;
     return '${d.year}${two(d.month)}${two(d.day)}-'
-        '${two(d.hour)}${two(d.minute)}${two(d.second)}';
+        '${two(d.hour)}${two(d.minute)}${two(d.second)}'
+        '${three(d.millisecond)}';
   }
 
   Future<void> _safeDelete(String path) async {

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+typedef PathProvider = Future<String> Function();
+
+/// Copies the live sqlite database before Drift runs a schema migration.
+///
+/// Operates on the closed database file. Registers the copy via the
+/// existing BackupPreferences registry so it appears alongside manual
+/// backups in the backup list UI.
+class PreMigrationBackupService {
+  final PathProvider _livePathProvider;
+  final PathProvider _backupsDirProvider;
+  final BackupPreferences _preferences;
+  final DateTime Function() _clock;
+  final String Function() _idGenerator;
+  final _log = LoggerService.forClass(PreMigrationBackupService);
+
+  PreMigrationBackupService({
+    required PathProvider livePathProvider,
+    required PathProvider backupsDirProvider,
+    required BackupPreferences preferences,
+    DateTime Function()? clock,
+    String Function()? idGenerator,
+  }) : _livePathProvider = livePathProvider,
+       _backupsDirProvider = backupsDirProvider,
+       _preferences = preferences,
+       _clock = clock ?? DateTime.now,
+       _idGenerator = idGenerator ?? (() => const Uuid().v4());
+
+  Future<void> backupIfMigrationPending({
+    required int stored,
+    required int target,
+    required String appVersion,
+  }) async {
+    if (stored >= target) return;
+
+    final livePath = await _livePathProvider();
+    if (!await File(livePath).exists()) return;
+
+    final backupsDir = await _backupsDirProvider();
+    await Directory(backupsDir).create(recursive: true);
+
+    final now = _clock().toUtc();
+    final ts = _formatTimestamp(now);
+    final filename = '$ts-v$stored-v$target.db';
+    final tempPath = p.join(backupsDir, '.$filename.tmp');
+    final finalPath = p.join(backupsDir, filename);
+
+    try {
+      await File(livePath).copy(tempPath);
+      await File(tempPath).rename(finalPath);
+    } catch (e, stack) {
+      await _safeDelete(tempPath);
+      throw BackupFailedException.fromError(e, stack);
+    }
+
+    final sizeBytes = await File(finalPath).length();
+
+    try {
+      await _preferences.addRecord(
+        BackupRecord(
+          id: _idGenerator(),
+          filename: filename,
+          timestamp: now,
+          sizeBytes: sizeBytes,
+          location: BackupLocation.local,
+          localPath: finalPath,
+          isAutomatic: true,
+          type: BackupType.preMigration,
+          appVersion: appVersion,
+          fromSchemaVersion: stored,
+          toSchemaVersion: target,
+        ),
+      );
+    } catch (e, stack) {
+      _log.warning(
+        'Pre-migration backup registered failed; .db is on disk at $finalPath',
+        error: e,
+        stackTrace: stack,
+      );
+    }
+  }
+
+  String _formatTimestamp(DateTime utc) {
+    String two(int v) => v.toString().padLeft(2, '0');
+    final d = utc;
+    return '${d.year}${two(d.month)}${two(d.day)}-'
+        '${two(d.hour)}${two(d.minute)}${two(d.second)}';
+  }
+
+  Future<void> _safeDelete(String path) async {
+    try {
+      final f = File(path);
+      if (await f.exists()) await f.delete();
+    } catch (_) {}
+  }
+}

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -17,6 +17,7 @@ typedef AsyncPathResolver = Future<String> Function();
 /// existing BackupPreferences registry so it appears alongside manual
 /// backups in the backup list UI.
 class PreMigrationBackupService {
+  static const int _retainN = 3;
   final AsyncPathResolver _livePathProvider;
   final AsyncPathResolver _backupsDirProvider;
   final BackupPreferences _preferences;
@@ -88,6 +89,17 @@ class PreMigrationBackupService {
         error: e,
         stackTrace: stack,
       );
+      return;
+    }
+
+    try {
+      await _pruneExcess();
+    } catch (e, stack) {
+      _log.warning(
+        'Pre-migration prune failed (backup kept)',
+        error: e,
+        stackTrace: stack,
+      );
     }
   }
 
@@ -103,6 +115,24 @@ class PreMigrationBackupService {
       final f = File(path);
       if (await f.exists()) await f.delete();
     } catch (_) {}
+  }
+
+  Future<void> _pruneExcess() async {
+    final all = _preferences.getHistory();
+    final preMigration = all
+        .where((r) => r.type == BackupType.preMigration)
+        .toList();
+    final unpinned = preMigration.where((r) => !r.pinned).toList()
+      ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    if (unpinned.length <= _retainN) return;
+    final toDelete = unpinned.sublist(_retainN);
+    for (final record in toDelete) {
+      await _preferences.removeRecord(record.id);
+      final path = record.localPath;
+      if (path != null) {
+        await _safeDelete(path);
+      }
+    }
   }
 
   Future<void> _sweepTempFiles(String backupsDir) async {

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -9,7 +9,7 @@ import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
 
-typedef PathProvider = Future<String> Function();
+typedef AsyncPathResolver = Future<String> Function();
 
 /// Copies the live sqlite database before Drift runs a schema migration.
 ///
@@ -17,16 +17,16 @@ typedef PathProvider = Future<String> Function();
 /// existing BackupPreferences registry so it appears alongside manual
 /// backups in the backup list UI.
 class PreMigrationBackupService {
-  final PathProvider _livePathProvider;
-  final PathProvider _backupsDirProvider;
+  final AsyncPathResolver _livePathProvider;
+  final AsyncPathResolver _backupsDirProvider;
   final BackupPreferences _preferences;
   final DateTime Function() _clock;
   final String Function() _idGenerator;
   final _log = LoggerService.forClass(PreMigrationBackupService);
 
   PreMigrationBackupService({
-    required PathProvider livePathProvider,
-    required PathProvider backupsDirProvider,
+    required AsyncPathResolver livePathProvider,
+    required AsyncPathResolver backupsDirProvider,
     required BackupPreferences preferences,
     DateTime Function()? clock,
     String Function()? idGenerator,
@@ -83,7 +83,7 @@ class PreMigrationBackupService {
       );
     } catch (e, stack) {
       _log.warning(
-        'Pre-migration backup registered failed; .db is on disk at $finalPath',
+        'Pre-migration backup registration failed; .db is on disk at $finalPath',
         error: e,
         stackTrace: stack,
       );

--- a/lib/features/backup/domain/entities/backup_record.dart
+++ b/lib/features/backup/domain/entities/backup_record.dart
@@ -1,5 +1,7 @@
 import 'package:equatable/equatable.dart';
 
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
 /// Where a backup is stored
 enum BackupLocation { local, cloud, both }
 
@@ -10,11 +12,16 @@ class BackupRecord extends Equatable {
   final DateTime timestamp;
   final int sizeBytes;
   final BackupLocation location;
-  final int diveCount;
-  final int siteCount;
+  final int? diveCount;
+  final int? siteCount;
   final String? cloudFileId;
   final String? localPath;
   final bool isAutomatic;
+  final BackupType type;
+  final String? appVersion;
+  final int? fromSchemaVersion;
+  final int? toSchemaVersion;
+  final bool pinned;
 
   const BackupRecord({
     required this.id,
@@ -22,11 +29,16 @@ class BackupRecord extends Equatable {
     required this.timestamp,
     required this.sizeBytes,
     required this.location,
-    required this.diveCount,
-    required this.siteCount,
+    this.diveCount,
+    this.siteCount,
     this.cloudFileId,
     this.localPath,
     this.isAutomatic = false,
+    this.type = BackupType.manual,
+    this.appVersion,
+    this.fromSchemaVersion,
+    this.toSchemaVersion,
+    this.pinned = false,
   });
 
   BackupRecord copyWith({
@@ -40,6 +52,11 @@ class BackupRecord extends Equatable {
     String? cloudFileId,
     String? localPath,
     bool? isAutomatic,
+    BackupType? type,
+    String? appVersion,
+    int? fromSchemaVersion,
+    int? toSchemaVersion,
+    bool? pinned,
   }) {
     return BackupRecord(
       id: id ?? this.id,
@@ -52,6 +69,11 @@ class BackupRecord extends Equatable {
       cloudFileId: cloudFileId ?? this.cloudFileId,
       localPath: localPath ?? this.localPath,
       isAutomatic: isAutomatic ?? this.isAutomatic,
+      type: type ?? this.type,
+      appVersion: appVersion ?? this.appVersion,
+      fromSchemaVersion: fromSchemaVersion ?? this.fromSchemaVersion,
+      toSchemaVersion: toSchemaVersion ?? this.toSchemaVersion,
+      pinned: pinned ?? this.pinned,
     );
   }
 
@@ -76,6 +98,11 @@ class BackupRecord extends Equatable {
       'cloudFileId': cloudFileId,
       'localPath': localPath,
       'isAutomatic': isAutomatic,
+      'type': type.name,
+      'appVersion': appVersion,
+      'fromSchemaVersion': fromSchemaVersion,
+      'toSchemaVersion': toSchemaVersion,
+      'pinned': pinned,
     };
   }
 
@@ -86,12 +113,22 @@ class BackupRecord extends Equatable {
       timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] as int),
       sizeBytes: json['sizeBytes'] as int,
       location: BackupLocation.values.byName(json['location'] as String),
-      diveCount: json['diveCount'] as int,
-      siteCount: json['siteCount'] as int,
+      diveCount: json['diveCount'] as int?,
+      siteCount: json['siteCount'] as int?,
       cloudFileId: json['cloudFileId'] as String?,
       localPath: json['localPath'] as String?,
       isAutomatic: json['isAutomatic'] as bool? ?? false,
+      type: _parseType(json['type'] as String?),
+      appVersion: json['appVersion'] as String?,
+      fromSchemaVersion: json['fromSchemaVersion'] as int?,
+      toSchemaVersion: json['toSchemaVersion'] as int?,
+      pinned: json['pinned'] as bool? ?? false,
     );
+  }
+
+  static BackupType _parseType(String? value) {
+    if (value == null) return BackupType.manual;
+    return BackupType.values.asNameMap()[value] ?? BackupType.manual;
   }
 
   @override
@@ -106,5 +143,10 @@ class BackupRecord extends Equatable {
     cloudFileId,
     localPath,
     isAutomatic,
+    type,
+    appVersion,
+    fromSchemaVersion,
+    toSchemaVersion,
+    pinned,
   ];
 }

--- a/lib/features/backup/domain/entities/backup_type.dart
+++ b/lib/features/backup/domain/entities/backup_type.dart
@@ -1,0 +1,8 @@
+// lib/features/backup/domain/entities/backup_type.dart
+
+/// Distinguishes a user-initiated (manual / automatic) backup from a
+/// system-initiated backup taken before a schema migration runs.
+enum BackupType {
+  manual,
+  preMigration,
+}

--- a/lib/features/backup/domain/entities/backup_type.dart
+++ b/lib/features/backup/domain/entities/backup_type.dart
@@ -2,7 +2,4 @@
 
 /// Distinguishes a user-initiated (manual / automatic) backup from a
 /// system-initiated backup taken before a schema migration runs.
-enum BackupType {
-  manual,
-  preMigration,
-}
+enum BackupType { manual, preMigration }

--- a/lib/features/backup/domain/exceptions/backup_failed_exception.dart
+++ b/lib/features/backup/domain/exceptions/backup_failed_exception.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+enum BackupFailureCause {
+  diskFull,
+  permissionDenied,
+  sourceMissing,
+  renameFailed,
+  unknown,
+}
+
+/// Thrown by PreMigrationBackupService when a backup cannot be completed.
+///
+/// Always carries a user-facing message safe to display, plus raw technical
+/// details (stack, error.toString) for support escalation.
+class BackupFailedException implements Exception {
+  final BackupFailureCause cause;
+  final String userMessage;
+  final String technicalDetails;
+
+  const BackupFailedException({
+    required this.cause,
+    required this.userMessage,
+    required this.technicalDetails,
+  });
+
+  factory BackupFailedException.fromError(Object error, StackTrace stack) {
+    if (error is FileSystemException) {
+      final code = error.osError?.errorCode;
+      switch (code) {
+        case 28: // ENOSPC
+          return BackupFailedException(
+            cause: BackupFailureCause.diskFull,
+            userMessage: 'Not enough free disk space to back up your data.',
+            technicalDetails: '${error.toString()}\n$stack',
+          );
+        case 13: // EACCES
+        case 1: // EPERM
+          return BackupFailedException(
+            cause: BackupFailureCause.permissionDenied,
+            userMessage: 'The app could not access the backup folder.',
+            technicalDetails: '${error.toString()}\n$stack',
+          );
+      }
+    }
+    return BackupFailedException(
+      cause: BackupFailureCause.unknown,
+      userMessage: 'Backup failed: ${error.toString()}',
+      technicalDetails: '${error.toString()}\n$stack',
+    );
+  }
+
+  @override
+  String toString() => 'BackupFailedException($cause): $userMessage';
+}

--- a/lib/features/backup/domain/exceptions/backup_failed_exception.dart
+++ b/lib/features/backup/domain/exceptions/backup_failed_exception.dart
@@ -1,12 +1,6 @@
 import 'dart:io';
 
-enum BackupFailureCause {
-  diskFull,
-  permissionDenied,
-  sourceMissing,
-  renameFailed,
-  unknown,
-}
+enum BackupFailureCause { diskFull, permissionDenied, sourceMissing, unknown }
 
 /// Thrown by PreMigrationBackupService when a backup cannot be completed.
 ///

--- a/lib/features/backup/domain/exceptions/backup_failed_exception.dart
+++ b/lib/features/backup/domain/exceptions/backup_failed_exception.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
 enum BackupFailureCause { diskFull, permissionDenied, sourceMissing, unknown }
 
 /// Thrown by PreMigrationBackupService when a backup cannot be completed.
@@ -17,11 +19,21 @@ class BackupFailedException implements Exception {
     required this.technicalDetails,
   });
 
-  factory BackupFailedException.fromError(Object error, StackTrace stack) {
+  /// [debugIsWindows] is a test seam: pass `true` to run the classifier
+  /// against Win32 error codes without relying on the host platform.
+  /// Production callers should leave it null so `Platform.isWindows` is used.
+  factory BackupFailedException.fromError(
+    Object error,
+    StackTrace stack, {
+    @visibleForTesting bool? debugIsWindows,
+  }) {
     final details = _formatDetails(error, stack);
     if (error is FileSystemException) {
       final code = error.osError?.errorCode;
-      final classified = _classifyFileSystemCode(code);
+      final classified = _classifyFileSystemCode(
+        code,
+        isWindows: debugIsWindows ?? Platform.isWindows,
+      );
       if (classified != null) {
         return BackupFailedException(
           cause: classified.$1,
@@ -40,32 +52,51 @@ class BackupFailedException implements Exception {
     );
   }
 
-  static (BackupFailureCause, String)? _classifyFileSystemCode(int? code) {
+  /// Maps an [OSError.errorCode] to a [BackupFailureCause] + user message.
+  ///
+  /// Win32 and POSIX errno spaces overlap (e.g. POSIX `EIO=5` vs Win32
+  /// `ERROR_ACCESS_DENIED=5`), so the caller must indicate which namespace
+  /// the code came from. Unknown codes return `null` so the caller can fall
+  /// back to the generic `unknown` cause.
+  static (BackupFailureCause, String)? _classifyFileSystemCode(
+    int? code, {
+    required bool isWindows,
+  }) {
     if (code == null) return null;
+    const diskFull = (
+      BackupFailureCause.diskFull,
+      'Not enough free disk space to back up your data.',
+    );
+    const permissionDenied = (
+      BackupFailureCause.permissionDenied,
+      'The app could not access the backup folder.',
+    );
+    const sourceMissing = (
+      BackupFailureCause.sourceMissing,
+      'The dive log file could not be found.',
+    );
+
+    if (isWindows) {
+      switch (code) {
+        case 112: // ERROR_DISK_FULL
+        case 39: // ERROR_HANDLE_DISK_FULL
+          return diskFull;
+        case 5: // ERROR_ACCESS_DENIED
+          return permissionDenied;
+        case 2: // ERROR_FILE_NOT_FOUND
+        case 3: // ERROR_PATH_NOT_FOUND
+          return sourceMissing;
+      }
+      return null;
+    }
     switch (code) {
-      // POSIX ENOSPC + Win32 ERROR_DISK_FULL / ERROR_HANDLE_DISK_FULL
-      case 28:
-      case 112:
-      case 39:
-        return (
-          BackupFailureCause.diskFull,
-          'Not enough free disk space to back up your data.',
-        );
-      // POSIX EACCES, EPERM + Win32 ERROR_ACCESS_DENIED
-      case 13:
-      case 1:
-      case 5:
-        return (
-          BackupFailureCause.permissionDenied,
-          'The app could not access the backup folder.',
-        );
-      // POSIX ENOENT + Win32 ERROR_FILE_NOT_FOUND / ERROR_PATH_NOT_FOUND
-      case 2:
-      case 3:
-        return (
-          BackupFailureCause.sourceMissing,
-          'The dive log file could not be found.',
-        );
+      case 28: // ENOSPC
+        return diskFull;
+      case 1: // EPERM
+      case 13: // EACCES
+        return permissionDenied;
+      case 2: // ENOENT
+        return sourceMissing;
     }
     return null;
   }

--- a/lib/features/backup/domain/exceptions/backup_failed_exception.dart
+++ b/lib/features/backup/domain/exceptions/backup_failed_exception.dart
@@ -24,30 +24,60 @@ class BackupFailedException implements Exception {
   });
 
   factory BackupFailedException.fromError(Object error, StackTrace stack) {
+    final details = _formatDetails(error, stack);
     if (error is FileSystemException) {
       final code = error.osError?.errorCode;
-      switch (code) {
-        case 28: // ENOSPC
-          return BackupFailedException(
-            cause: BackupFailureCause.diskFull,
-            userMessage: 'Not enough free disk space to back up your data.',
-            technicalDetails: '${error.toString()}\n$stack',
-          );
-        case 13: // EACCES
-        case 1: // EPERM
-          return BackupFailedException(
-            cause: BackupFailureCause.permissionDenied,
-            userMessage: 'The app could not access the backup folder.',
-            technicalDetails: '${error.toString()}\n$stack',
-          );
+      final classified = _classifyFileSystemCode(code);
+      if (classified != null) {
+        return BackupFailedException(
+          cause: classified.$1,
+          userMessage: classified.$2,
+          technicalDetails: details,
+        );
       }
     }
     return BackupFailedException(
       cause: BackupFailureCause.unknown,
-      userMessage: 'Backup failed: ${error.toString()}',
-      technicalDetails: '${error.toString()}\n$stack',
+      userMessage:
+          'An unexpected error occurred while backing up your data. '
+          'Open Technical details below and share them with support if '
+          'the problem persists.',
+      technicalDetails: details,
     );
   }
+
+  static (BackupFailureCause, String)? _classifyFileSystemCode(int? code) {
+    if (code == null) return null;
+    switch (code) {
+      // POSIX ENOSPC + Win32 ERROR_DISK_FULL / ERROR_HANDLE_DISK_FULL
+      case 28:
+      case 112:
+      case 39:
+        return (
+          BackupFailureCause.diskFull,
+          'Not enough free disk space to back up your data.',
+        );
+      // POSIX EACCES, EPERM + Win32 ERROR_ACCESS_DENIED
+      case 13:
+      case 1:
+      case 5:
+        return (
+          BackupFailureCause.permissionDenied,
+          'The app could not access the backup folder.',
+        );
+      // POSIX ENOENT + Win32 ERROR_FILE_NOT_FOUND / ERROR_PATH_NOT_FOUND
+      case 2:
+      case 3:
+        return (
+          BackupFailureCause.sourceMissing,
+          'The dive log file could not be found.',
+        );
+    }
+    return null;
+  }
+
+  static String _formatDetails(Object error, StackTrace stack) =>
+      '${error.toString()}\n$stack';
 
   @override
   String toString() => 'BackupFailedException($cause): $userMessage';

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -322,7 +322,7 @@ class BackupSettingsPage extends ConsumerWidget {
           ),
           if (record.type == BackupType.preMigration) ...[
             const SizedBox(width: 8),
-            _PreMigrationBadge(
+            PreMigrationBadge(
               fromVersion: record.fromSchemaVersion ?? 0,
               toVersion: record.toSchemaVersion ?? 0,
             ),
@@ -344,7 +344,7 @@ class BackupSettingsPage extends ConsumerWidget {
               record.pinned ? Icons.push_pin : Icons.push_pin_outlined,
             ),
             tooltip: record.pinned ? 'Unpin backup' : 'Pin backup',
-            onPressed: () => _togglePin(ref, record),
+            onPressed: () => _togglePin(context, ref, record),
           ),
           PopupMenuButton<String>(
             onSelected: (action) =>
@@ -382,12 +382,23 @@ class BackupSettingsPage extends ConsumerWidget {
   // History Actions
   // ===========================================================================
 
-  Future<void> _togglePin(WidgetRef ref, BackupRecord record) async {
+  Future<void> _togglePin(
+    BuildContext context,
+    WidgetRef ref,
+    BackupRecord record,
+  ) async {
     final service = ref.read(backupServiceProvider);
-    if (record.pinned) {
-      await service.unpinBackup(record.id);
-    } else {
-      await service.pinBackup(record.id);
+    try {
+      if (record.pinned) {
+        await service.unpinBackup(record.id);
+      } else {
+        await service.pinBackup(record.id);
+      }
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not update pin state: $e')));
     }
   }
 
@@ -584,11 +595,12 @@ class BackupSettingsPage extends ConsumerWidget {
   }
 }
 
-class _PreMigrationBadge extends StatelessWidget {
+class PreMigrationBadge extends StatelessWidget {
   final int fromVersion;
   final int toVersion;
 
-  const _PreMigrationBadge({
+  const PreMigrationBadge({
+    super.key,
     required this.fromVersion,
     required this.toVersion,
   });

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -403,11 +403,12 @@ class BackupSettingsPage extends ConsumerWidget {
         await service.pinBackup(record.id);
       }
       ref.invalidate(backupHistoryProvider);
-    } catch (e) {
+    } catch (e, stackTrace) {
+      debugPrint('Failed to update pin state: $e\n$stackTrace');
       if (!context.mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Could not update pin state: $e')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not update pin state.')),
+      );
     }
   }
 

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -2,16 +2,15 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
-import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/backup/presentation/widgets/backup_history_tile.dart';
 import 'package:submersion/features/backup/presentation/widgets/export_bottom_sheet.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -311,84 +310,12 @@ class BackupSettingsPage extends ConsumerWidget {
     WidgetRef ref,
     BackupRecord record,
   ) {
-    final theme = Theme.of(context);
-    final dateFormat = DateFormat.yMMMd().add_jm();
-
-    return ListTile(
-      leading: Icon(_locationIcon(record.location)),
-      title: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Flexible(
-            child: Text(
-              dateFormat.format(record.timestamp),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          if (record.type == BackupType.preMigration &&
-              record.fromSchemaVersion != null &&
-              record.toSchemaVersion != null) ...[
-            const SizedBox(width: 8),
-            PreMigrationBadge(
-              fromVersion: record.fromSchemaVersion!,
-              toVersion: record.toSchemaVersion!,
-            ),
-          ],
-        ],
-      ),
-      subtitle: Text(
-        record.type == BackupType.preMigration
-            ? context.l10n.backup_history_preMigrationSubtitle(
-                record.formattedSize,
-              )
-            : '${record.diveCount ?? 0} dives, '
-                  '${record.siteCount ?? 0} sites - ${record.formattedSize}'
-                  '${record.isAutomatic ? ' (auto)' : ''}',
-      ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: Icon(
-              record.pinned ? Icons.push_pin : Icons.push_pin_outlined,
-              color: record.pinned
-                  ? Theme.of(context).colorScheme.primary
-                  : null,
-            ),
-            tooltip: record.pinned
-                ? context.l10n.backup_history_pinAction_unpin
-                : context.l10n.backup_history_pinAction_pin,
-            onPressed: () => _togglePin(context, ref, record),
-          ),
-          PopupMenuButton<String>(
-            onSelected: (action) =>
-                _handleHistoryAction(context, ref, action, record),
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'restore',
-                child: ListTile(
-                  leading: const Icon(Icons.restore),
-                  title: Text(context.l10n.backup_history_action_restore),
-                  contentPadding: EdgeInsets.zero,
-                  dense: true,
-                ),
-              ),
-              PopupMenuItem(
-                value: 'delete',
-                child: ListTile(
-                  leading: Icon(Icons.delete, color: theme.colorScheme.error),
-                  title: Text(
-                    context.l10n.backup_history_action_delete,
-                    style: TextStyle(color: theme.colorScheme.error),
-                  ),
-                  contentPadding: EdgeInsets.zero,
-                  dense: true,
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
+    return BackupHistoryTile(
+      record: record,
+      leadingIcon: _locationIcon(record.location),
+      onPinToggle: () => _togglePin(context, ref, record),
+      onRestore: () => _handleHistoryAction(context, ref, 'restore', record),
+      onDelete: () => _handleHistoryAction(context, ref, 'delete', record),
     );
   }
 
@@ -612,34 +539,5 @@ class BackupSettingsPage extends ConsumerWidget {
       case BackupFrequency.monthly:
         return context.l10n.backup_frequency_monthly;
     }
-  }
-}
-
-class PreMigrationBadge extends StatelessWidget {
-  final int fromVersion;
-  final int toVersion;
-
-  const PreMigrationBadge({
-    super.key,
-    required this.fromVersion,
-    required this.toVersion,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        'v$fromVersion \u2192 v$toVersion',
-        style: TextStyle(
-          fontSize: 11,
-          color: Theme.of(context).colorScheme.onSecondaryContainer,
-        ),
-      ),
-    );
   }
 }

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:share_plus/share_plus.dart';
 
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
@@ -237,7 +238,11 @@ class BackupSettingsPage extends ConsumerWidget {
 
     if (!context.mounted) return;
 
-    final confirmed = await RestoreConfirmationDialog.show(context, record);
+    final confirmed = await RestoreConfirmationDialog.show(
+      context,
+      record,
+      currentSchemaVersion: AppDatabase.currentSchemaVersion,
+    );
     if (confirmed) {
       ref.read(backupOperationProvider.notifier).restoreFromFilePath(filePath);
     }
@@ -410,7 +415,11 @@ class BackupSettingsPage extends ConsumerWidget {
   ) async {
     switch (action) {
       case 'restore':
-        final confirmed = await RestoreConfirmationDialog.show(context, record);
+        final confirmed = await RestoreConfirmationDialog.show(
+          context,
+          record,
+          currentSchemaVersion: AppDatabase.currentSchemaVersion,
+        );
         if (confirmed) {
           ref.read(backupOperationProvider.notifier).restoreFromBackup(record);
         }

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -325,11 +325,13 @@ class BackupSettingsPage extends ConsumerWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          if (record.type == BackupType.preMigration) ...[
+          if (record.type == BackupType.preMigration &&
+              record.fromSchemaVersion != null &&
+              record.toSchemaVersion != null) ...[
             const SizedBox(width: 8),
             PreMigrationBadge(
-              fromVersion: record.fromSchemaVersion ?? 0,
-              toVersion: record.toSchemaVersion ?? 0,
+              fromVersion: record.fromSchemaVersion!,
+              toVersion: record.toSchemaVersion!,
             ),
           ],
         ],

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
@@ -310,35 +311,67 @@ class BackupSettingsPage extends ConsumerWidget {
 
     return ListTile(
       leading: Icon(_locationIcon(record.location)),
-      title: Text(dateFormat.format(record.timestamp)),
-      subtitle: Text(
-        '${record.diveCount} dives, ${record.siteCount} sites - ${record.formattedSize}'
-        '${record.isAutomatic ? ' (auto)' : ''}',
-      ),
-      trailing: PopupMenuButton<String>(
-        onSelected: (action) =>
-            _handleHistoryAction(context, ref, action, record),
-        itemBuilder: (context) => [
-          PopupMenuItem(
-            value: 'restore',
-            child: ListTile(
-              leading: const Icon(Icons.restore),
-              title: Text(context.l10n.backup_history_action_restore),
-              contentPadding: EdgeInsets.zero,
-              dense: true,
+      title: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              dateFormat.format(record.timestamp),
+              overflow: TextOverflow.ellipsis,
             ),
           ),
-          PopupMenuItem(
-            value: 'delete',
-            child: ListTile(
-              leading: Icon(Icons.delete, color: theme.colorScheme.error),
-              title: Text(
-                context.l10n.backup_history_action_delete,
-                style: TextStyle(color: theme.colorScheme.error),
-              ),
-              contentPadding: EdgeInsets.zero,
-              dense: true,
+          if (record.type == BackupType.preMigration) ...[
+            const SizedBox(width: 8),
+            _PreMigrationBadge(
+              fromVersion: record.fromSchemaVersion ?? 0,
+              toVersion: record.toSchemaVersion ?? 0,
             ),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        record.type == BackupType.preMigration
+            ? 'Pre-migration backup - ${record.formattedSize}'
+            : '${record.diveCount ?? 0} dives, '
+                  '${record.siteCount ?? 0} sites - ${record.formattedSize}'
+                  '${record.isAutomatic ? ' (auto)' : ''}',
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(
+              record.pinned ? Icons.push_pin : Icons.push_pin_outlined,
+            ),
+            tooltip: record.pinned ? 'Unpin backup' : 'Pin backup',
+            onPressed: () => _togglePin(ref, record),
+          ),
+          PopupMenuButton<String>(
+            onSelected: (action) =>
+                _handleHistoryAction(context, ref, action, record),
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'restore',
+                child: ListTile(
+                  leading: const Icon(Icons.restore),
+                  title: Text(context.l10n.backup_history_action_restore),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+              PopupMenuItem(
+                value: 'delete',
+                child: ListTile(
+                  leading: Icon(Icons.delete, color: theme.colorScheme.error),
+                  title: Text(
+                    context.l10n.backup_history_action_delete,
+                    style: TextStyle(color: theme.colorScheme.error),
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -348,6 +381,15 @@ class BackupSettingsPage extends ConsumerWidget {
   // ===========================================================================
   // History Actions
   // ===========================================================================
+
+  Future<void> _togglePin(WidgetRef ref, BackupRecord record) async {
+    final service = ref.read(backupServiceProvider);
+    if (record.pinned) {
+      await service.unpinBackup(record.id);
+    } else {
+      await service.pinBackup(record.id);
+    }
+  }
 
   Future<void> _handleHistoryAction(
     BuildContext context,
@@ -539,5 +581,33 @@ class BackupSettingsPage extends ConsumerWidget {
       case BackupFrequency.monthly:
         return context.l10n.backup_frequency_monthly;
     }
+  }
+}
+
+class _PreMigrationBadge extends StatelessWidget {
+  final int fromVersion;
+  final int toVersion;
+
+  const _PreMigrationBadge({
+    required this.fromVersion,
+    required this.toVersion,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        'v$fromVersion \u2192 v$toVersion',
+        style: TextStyle(
+          fontSize: 11,
+          color: Theme.of(context).colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -399,6 +399,7 @@ class BackupSettingsPage extends ConsumerWidget {
       } else {
         await service.pinBackup(record.id);
       }
+      ref.invalidate(backupHistoryProvider);
     } catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -336,7 +336,9 @@ class BackupSettingsPage extends ConsumerWidget {
       ),
       subtitle: Text(
         record.type == BackupType.preMigration
-            ? 'Pre-migration backup - ${record.formattedSize}'
+            ? context.l10n.backup_history_preMigrationSubtitle(
+                record.formattedSize,
+              )
             : '${record.diveCount ?? 0} dives, '
                   '${record.siteCount ?? 0} sites - ${record.formattedSize}'
                   '${record.isAutomatic ? ' (auto)' : ''}',
@@ -351,7 +353,9 @@ class BackupSettingsPage extends ConsumerWidget {
                   ? Theme.of(context).colorScheme.primary
                   : null,
             ),
-            tooltip: record.pinned ? 'Unpin backup' : 'Pin backup',
+            tooltip: record.pinned
+                ? context.l10n.backup_history_pinAction_unpin
+                : context.l10n.backup_history_pinAction_pin,
             onPressed: () => _togglePin(context, ref, record),
           ),
           PopupMenuButton<String>(
@@ -407,7 +411,7 @@ class BackupSettingsPage extends ConsumerWidget {
       debugPrint('Failed to update pin state: $e\n$stackTrace');
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Could not update pin state.')),
+        SnackBar(content: Text(context.l10n.backup_history_pinError)),
       );
     }
   }

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -347,6 +347,9 @@ class BackupSettingsPage extends ConsumerWidget {
           IconButton(
             icon: Icon(
               record.pinned ? Icons.push_pin : Icons.push_pin_outlined,
+              color: record.pinned
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
             ),
             tooltip: record.pinned ? 'Unpin backup' : 'Pin backup',
             onPressed: () => _togglePin(context, ref, record),

--- a/lib/features/backup/presentation/widgets/backup_history_tile.dart
+++ b/lib/features/backup/presentation/widgets/backup_history_tile.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/presentation/widgets/pre_migration_badge.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Renders a single row in the backup history list.
+///
+/// Pure presentation + callbacks; no Riverpod/provider coupling, so it
+/// can be tested in isolation.
+class BackupHistoryTile extends StatelessWidget {
+  final BackupRecord record;
+  final IconData leadingIcon;
+  final VoidCallback onPinToggle;
+  final VoidCallback onRestore;
+  final VoidCallback onDelete;
+
+  const BackupHistoryTile({
+    super.key,
+    required this.record,
+    required this.leadingIcon,
+    required this.onPinToggle,
+    required this.onRestore,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat.yMMMd().add_jm();
+
+    return ListTile(
+      leading: Icon(leadingIcon),
+      title: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              dateFormat.format(record.timestamp),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (record.type == BackupType.preMigration &&
+              record.fromSchemaVersion != null &&
+              record.toSchemaVersion != null) ...[
+            const SizedBox(width: 8),
+            PreMigrationBadge(
+              fromVersion: record.fromSchemaVersion!,
+              toVersion: record.toSchemaVersion!,
+            ),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        record.type == BackupType.preMigration
+            ? context.l10n.backup_history_preMigrationSubtitle(
+                record.formattedSize,
+              )
+            : '${record.diveCount ?? 0} dives, '
+                  '${record.siteCount ?? 0} sites - ${record.formattedSize}'
+                  '${record.isAutomatic ? ' (auto)' : ''}',
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(
+              record.pinned ? Icons.push_pin : Icons.push_pin_outlined,
+              color: record.pinned ? theme.colorScheme.primary : null,
+            ),
+            tooltip: record.pinned
+                ? context.l10n.backup_history_pinAction_unpin
+                : context.l10n.backup_history_pinAction_pin,
+            onPressed: onPinToggle,
+          ),
+          PopupMenuButton<String>(
+            onSelected: (action) {
+              switch (action) {
+                case 'restore':
+                  onRestore();
+                case 'delete':
+                  onDelete();
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'restore',
+                child: ListTile(
+                  leading: const Icon(Icons.restore),
+                  title: Text(context.l10n.backup_history_action_restore),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+              PopupMenuItem(
+                value: 'delete',
+                child: ListTile(
+                  leading: Icon(Icons.delete, color: theme.colorScheme.error),
+                  title: Text(
+                    context.l10n.backup_history_action_delete,
+                    style: TextStyle(color: theme.colorScheme.error),
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/backup/presentation/widgets/pre_migration_badge.dart
+++ b/lib/features/backup/presentation/widgets/pre_migration_badge.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+/// Small "vFrom → vTo" badge used on pre-migration backup history rows.
+class PreMigrationBadge extends StatelessWidget {
+  final int fromVersion;
+  final int toVersion;
+
+  const PreMigrationBadge({
+    super.key,
+    required this.fromVersion,
+    required this.toVersion,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        'v$fromVersion \u2192 v$toVersion',
+        style: TextStyle(
+          fontSize: 11,
+          color: Theme.of(context).colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
+++ b/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
@@ -2,27 +2,48 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Confirmation dialog shown before restoring from a backup.
 ///
 /// Displays backup details and warns about data replacement.
+/// For pre-migration backups, branches on schema version compatibility.
 class RestoreConfirmationDialog extends StatelessWidget {
   final BackupRecord record;
+  final int currentSchemaVersion;
 
-  const RestoreConfirmationDialog({super.key, required this.record});
+  const RestoreConfirmationDialog({
+    super.key,
+    required this.record,
+    required this.currentSchemaVersion,
+  });
 
   /// Shows the dialog and returns true if the user confirms.
-  static Future<bool> show(BuildContext context, BackupRecord record) async {
+  static Future<bool> show(
+    BuildContext context,
+    BackupRecord record, {
+    required int currentSchemaVersion,
+  }) async {
     final result = await showDialog<bool>(
       context: context,
-      builder: (_) => RestoreConfirmationDialog(record: record),
+      builder: (_) => RestoreConfirmationDialog(
+        record: record,
+        currentSchemaVersion: currentSchemaVersion,
+      ),
     );
     return result ?? false;
   }
 
   @override
   Widget build(BuildContext context) {
+    if (record.type == BackupType.preMigration) {
+      return _buildPreMigration(context);
+    }
+    return _buildManual(context);
+  }
+
+  Widget _buildManual(BuildContext context) {
     final theme = Theme.of(context);
     final dateFormat = DateFormat.yMMMd().add_jm();
 
@@ -111,6 +132,84 @@ class RestoreConfirmationDialog extends StatelessWidget {
             backgroundColor: theme.colorScheme.error,
           ),
           child: Text(context.l10n.backup_restore_dialog_restore),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPreMigration(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat.yMMMd().add_jm();
+    final fromV = record.fromSchemaVersion ?? 0;
+    final toV = record.toSchemaVersion ?? 0;
+    final appVersion = record.appVersion ?? 'unknown version';
+    final timestamp = dateFormat.format(record.timestamp);
+
+    if (currentSchemaVersion < fromV) {
+      // Hard block: backup is from a newer app than currently installed.
+      return AlertDialog(
+        title: const Text('Restore pre-migration backup'),
+        content: Text(
+          'This backup is newer than your app. Install a newer app '
+          'version to restore it.\n\n'
+          'Backup made on $timestamp by app $appVersion (database v$fromV).',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+        ],
+      );
+    }
+
+    if (currentSchemaVersion == fromV) {
+      // Green path: app version matches; restore is safe.
+      return AlertDialog(
+        title: const Text('Restore pre-migration backup'),
+        content: Text(
+          'This backup was made on $timestamp by app $appVersion, just '
+          'before upgrading the database from v$fromV to v$toV.\n\n'
+          'Your app version matches the backup, so restore is safe.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Restore'),
+          ),
+        ],
+      );
+    }
+
+    // currentSchemaVersion > fromV — warning path.
+    return AlertDialog(
+      title: const Text('Restore pre-migration backup'),
+      content: Text(
+        'This backup was made on $timestamp by app $appVersion, just '
+        'before upgrading the database from v$fromV to v$toV.\n\n'
+        'You are running a newer app (database v$currentSchemaVersion).\n\n'
+        'Restoring now will re-run the v$fromV \u2192 v$toV database upgrade '
+        'on your restored data \u2014 the same upgrade that was about to run '
+        'originally. If that upgrade caused the problem, you will hit '
+        'the same issue again.\n\n'
+        'To restore safely: install app $appVersion or earlier, then restore '
+        'this backup from that older app.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          style: FilledButton.styleFrom(
+            backgroundColor: theme.colorScheme.error,
+          ),
+          child: const Text('Restore anyway'),
         ),
       ],
     );

--- a/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
+++ b/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
@@ -70,7 +70,7 @@ class RestoreConfirmationDialog extends StatelessWidget {
                 const SizedBox(height: 4),
                 if ((record.diveCount ?? 0) > 0 || (record.siteCount ?? 0) > 0)
                   Text(
-                    '${record.diveCount} dives, ${record.siteCount} sites',
+                    '${record.diveCount ?? 0} dives, ${record.siteCount ?? 0} sites',
                     style: theme.textTheme.bodySmall,
                   ),
                 Text(record.formattedSize, style: theme.textTheme.bodySmall),

--- a/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
+++ b/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
@@ -140,10 +140,31 @@ class RestoreConfirmationDialog extends StatelessWidget {
   Widget _buildPreMigration(BuildContext context) {
     final theme = Theme.of(context);
     final dateFormat = DateFormat.yMMMd().add_jm();
-    final fromV = record.fromSchemaVersion ?? 0;
-    final toV = record.toSchemaVersion ?? 0;
+    final fromSchemaVersion = record.fromSchemaVersion;
+    final toSchemaVersion = record.toSchemaVersion;
     final appVersion = record.appVersion ?? 'unknown version';
     final timestamp = dateFormat.format(record.timestamp);
+
+    if (fromSchemaVersion == null || toSchemaVersion == null) {
+      return AlertDialog(
+        title: const Text('Restore pre-migration backup'),
+        content: Text(
+          'This backup was made on $timestamp by app $appVersion, but its '
+          'database migration metadata is incomplete.\n\n'
+          'The app cannot verify whether restoring this backup is safe, '
+          'so restore is disabled.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+        ],
+      );
+    }
+
+    final fromV = fromSchemaVersion;
+    final toV = toSchemaVersion;
 
     if (currentSchemaVersion < fromV) {
       // Hard block: backup is from a newer app than currently installed.

--- a/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
+++ b/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
@@ -185,13 +185,15 @@ class RestoreConfirmationDialog extends StatelessWidget {
     }
 
     if (currentSchemaVersion == fromV) {
-      // Green path: app version matches; restore is safe.
+      // Green path: database schema matches the backup's pre-migration
+      // state; restore is safe.
       return AlertDialog(
         title: const Text('Restore pre-migration backup'),
         content: Text(
           'This backup was made on $timestamp by app $appVersion, just '
           'before upgrading the database from v$fromV to v$toV.\n\n'
-          'Your app version matches the backup, so restore is safe.',
+          "Your app's database schema matches this backup, so "
+          'restore is safe.',
         ),
         actions: [
           TextButton(

--- a/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
+++ b/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
@@ -47,7 +47,7 @@ class RestoreConfirmationDialog extends StatelessWidget {
                   style: theme.textTheme.titleSmall,
                 ),
                 const SizedBox(height: 4),
-                if (record.diveCount > 0 || record.siteCount > 0)
+                if ((record.diveCount ?? 0) > 0 || (record.siteCount ?? 0) > 0)
                   Text(
                     '${record.diveCount} dives, ${record.siteCount} sites',
                     style: theme.textTheme.bodySmall,

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -8632,6 +8632,36 @@
     }
   },
   "certifications_certificate_thisCertifies": "This certifies that",
+  "diveComputer_connectionType_ble": "Bluetooth LE",
+  "diveComputer_connectionType_bluetooth": "Bluetooth",
+  "diveComputer_connectionType_infrared": "Infrared",
+  "diveComputer_connectionType_unknown": "Unknown",
+  "diveComputer_connectionType_usb": "USB",
+  "diveComputer_connectionType_wifi": "Wi-Fi",
+  "diveComputer_detail_cannotFilterNoSerial": "Cannot filter: no serial number for this computer.",
+  "diveComputer_detail_deleteDialogContent": "Are you sure you want to remove \"{name}\"? This will not delete any dives that were imported from this computer.",
+  "@diveComputer_detail_deleteDialogContent": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_detail_deleteDialogTitle": "Delete Computer?",
+  "diveComputer_detail_divesImported": "Dives Imported",
+  "diveComputer_detail_downloadDivesButton": "Download Dives",
+  "diveComputer_detail_editDialogTitle": "Edit Computer",
+  "diveComputer_detail_editNameHint": "e.g., My Perdix",
+  "diveComputer_detail_editNotesHint": "Optional notes",
+  "diveComputer_detail_labelConnection": "Connection",
+  "diveComputer_detail_labelManufacturer": "Manufacturer",
+  "diveComputer_detail_labelModel": "Model",
+  "diveComputer_detail_labelName": "Name",
+  "diveComputer_detail_lastDownload": "Last Download",
+  "diveComputer_detail_notesTitle": "Notes",
+  "diveComputer_detail_statisticsTitle": "Statistics",
+  "diveComputer_detail_unknown": "Unknown",
+  "diveComputer_detail_viewDivesButton": "View Dives from This Computer",
   "diveComputer_discovery_chooseDifferentDevice": "Choose Different Device",
   "diveComputer_discovery_computer": "Computer",
   "diveComputer_discovery_connectAndDownload": "Connect & Download",
@@ -8675,6 +8705,10 @@
     }
   },
   "diveComputer_discovery_usbSearchHint": "Search by manufacturer or model...",
+  "diveComputer_downloadExit_content": "Leaving will cancel the current download from your dive computer. Are you sure?",
+  "diveComputer_downloadExit_leave": "Leave",
+  "diveComputer_downloadExit_stay": "Stay",
+  "diveComputer_downloadExit_title": "Download in Progress",
   "diveComputer_downloadStep_andMoreDives": "... and {count} more",
   "@diveComputer_downloadStep_andMoreDives": {
     "placeholders": {
@@ -8881,6 +8915,51 @@
   "diveComputer_list_loadFailed": "Failed to load dive computers",
   "diveComputer_list_retry": "Retry",
   "diveComputer_list_title": "Dive Computers",
+  "diveComputer_pinCode_instructions": "Enter the code displayed on your dive computer.",
+  "diveComputer_pinCode_label": "PIN Code",
+  "diveComputer_pinCode_submit": "Submit",
+  "diveComputer_pinCode_title": "PIN Code Required",
+  "diveComputer_pinEntry_connectButton": "Connect",
+  "diveComputer_pinEntry_helperText": "Enter the 4-6 digit PIN shown on your device",
+  "diveComputer_pinEntry_instructionsGeneric": "Check your dive computer display for the PIN code.",
+  "diveComputer_pinEntry_instructionsWithDevice": "Check your {deviceName} display for the PIN code.",
+  "@diveComputer_pinEntry_instructionsWithDevice": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_pinEntry_semanticLabel": "PIN code entry, 4 to 6 digits",
+  "diveComputer_pinEntry_title": "Enter PIN Code",
+  "diveComputer_scan_bluetoothSemanticLabel": "Bluetooth device: {name}",
+  "@diveComputer_scan_bluetoothSemanticLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_scan_emptyStateInstructions": "Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device",
+  "diveComputer_scan_knownBadge": "Known",
+  "diveComputer_scan_lookingForDevicesTitle": "Looking for Devices",
+  "diveComputer_scan_noUsbDevicesAvailable": "No USB devices available",
+  "diveComputer_scan_retry": "Retry",
+  "diveComputer_scan_scanAgain": "Scan Again",
+  "diveComputer_scan_scanningStatus": "Scanning for dive computers...",
+  "diveComputer_scan_stopScanning": "Stop Scanning",
+  "diveComputer_scan_supportedBadge": "Supported",
+  "diveComputer_scan_tabBluetooth": "Bluetooth",
+  "diveComputer_scan_tabUsb": "USB Cable",
+  "diveComputer_scan_usbCableLabel": "USB Cable",
+  "diveComputer_scan_usbSemanticLabel": "USB device: {model}",
+  "@diveComputer_scan_usbSemanticLabel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
   "diveComputer_summary_diveComputer": "dive computer",
   "diveComputer_summary_divesDownloaded": "{count} {count, plural, =1{dive} other{dives}} downloaded",
   "@diveComputer_summary_divesDownloaded": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -244,6 +244,17 @@
       }
     }
   },
+  "backup_history_pinAction_pin": "Pin backup",
+  "backup_history_pinAction_unpin": "Unpin backup",
+  "backup_history_pinError": "Could not update pin state.",
+  "backup_history_preMigrationSubtitle": "Pre-migration backup - {size}",
+  "@backup_history_preMigrationSubtitle": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
   "backup_import_invalidFile": "This file does not appear to be a valid Submersion backup",
   "backup_import_subtitle": "Import a backup from any location",
   "backup_import_title": "Restore from File",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -24141,6 +24141,144 @@ abstract class AppLocalizations {
   /// **'This certifies that'**
   String get certifications_certificate_thisCertifies;
 
+  /// No description provided for @diveComputer_connectionType_ble.
+  ///
+  /// In en, this message translates to:
+  /// **'Bluetooth LE'**
+  String get diveComputer_connectionType_ble;
+
+  /// No description provided for @diveComputer_connectionType_bluetooth.
+  ///
+  /// In en, this message translates to:
+  /// **'Bluetooth'**
+  String get diveComputer_connectionType_bluetooth;
+
+  /// No description provided for @diveComputer_connectionType_infrared.
+  ///
+  /// In en, this message translates to:
+  /// **'Infrared'**
+  String get diveComputer_connectionType_infrared;
+
+  /// No description provided for @diveComputer_connectionType_unknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get diveComputer_connectionType_unknown;
+
+  /// No description provided for @diveComputer_connectionType_usb.
+  ///
+  /// In en, this message translates to:
+  /// **'USB'**
+  String get diveComputer_connectionType_usb;
+
+  /// No description provided for @diveComputer_connectionType_wifi.
+  ///
+  /// In en, this message translates to:
+  /// **'Wi-Fi'**
+  String get diveComputer_connectionType_wifi;
+
+  /// No description provided for @diveComputer_detail_cannotFilterNoSerial.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot filter: no serial number for this computer.'**
+  String get diveComputer_detail_cannotFilterNoSerial;
+
+  /// No description provided for @diveComputer_detail_deleteDialogContent.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to remove \"{name}\"? This will not delete any dives that were imported from this computer.'**
+  String diveComputer_detail_deleteDialogContent(String name);
+
+  /// No description provided for @diveComputer_detail_deleteDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Computer?'**
+  String get diveComputer_detail_deleteDialogTitle;
+
+  /// No description provided for @diveComputer_detail_divesImported.
+  ///
+  /// In en, this message translates to:
+  /// **'Dives Imported'**
+  String get diveComputer_detail_divesImported;
+
+  /// No description provided for @diveComputer_detail_downloadDivesButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Download Dives'**
+  String get diveComputer_detail_downloadDivesButton;
+
+  /// No description provided for @diveComputer_detail_editDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Computer'**
+  String get diveComputer_detail_editDialogTitle;
+
+  /// No description provided for @diveComputer_detail_editNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g., My Perdix'**
+  String get diveComputer_detail_editNameHint;
+
+  /// No description provided for @diveComputer_detail_editNotesHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Optional notes'**
+  String get diveComputer_detail_editNotesHint;
+
+  /// No description provided for @diveComputer_detail_labelConnection.
+  ///
+  /// In en, this message translates to:
+  /// **'Connection'**
+  String get diveComputer_detail_labelConnection;
+
+  /// No description provided for @diveComputer_detail_labelManufacturer.
+  ///
+  /// In en, this message translates to:
+  /// **'Manufacturer'**
+  String get diveComputer_detail_labelManufacturer;
+
+  /// No description provided for @diveComputer_detail_labelModel.
+  ///
+  /// In en, this message translates to:
+  /// **'Model'**
+  String get diveComputer_detail_labelModel;
+
+  /// No description provided for @diveComputer_detail_labelName.
+  ///
+  /// In en, this message translates to:
+  /// **'Name'**
+  String get diveComputer_detail_labelName;
+
+  /// No description provided for @diveComputer_detail_lastDownload.
+  ///
+  /// In en, this message translates to:
+  /// **'Last Download'**
+  String get diveComputer_detail_lastDownload;
+
+  /// No description provided for @diveComputer_detail_notesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notes'**
+  String get diveComputer_detail_notesTitle;
+
+  /// No description provided for @diveComputer_detail_statisticsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Statistics'**
+  String get diveComputer_detail_statisticsTitle;
+
+  /// No description provided for @diveComputer_detail_unknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get diveComputer_detail_unknown;
+
+  /// No description provided for @diveComputer_detail_viewDivesButton.
+  ///
+  /// In en, this message translates to:
+  /// **'View Dives from This Computer'**
+  String get diveComputer_detail_viewDivesButton;
+
   /// No description provided for @diveComputer_discovery_chooseDifferentDevice.
   ///
   /// In en, this message translates to:
@@ -24314,6 +24452,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Search by manufacturer or model...'**
   String get diveComputer_discovery_usbSearchHint;
+
+  /// No description provided for @diveComputer_downloadExit_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Leaving will cancel the current download from your dive computer. Are you sure?'**
+  String get diveComputer_downloadExit_content;
+
+  /// No description provided for @diveComputer_downloadExit_leave.
+  ///
+  /// In en, this message translates to:
+  /// **'Leave'**
+  String get diveComputer_downloadExit_leave;
+
+  /// No description provided for @diveComputer_downloadExit_stay.
+  ///
+  /// In en, this message translates to:
+  /// **'Stay'**
+  String get diveComputer_downloadExit_stay;
+
+  /// No description provided for @diveComputer_downloadExit_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Download in Progress'**
+  String get diveComputer_downloadExit_title;
 
   /// No description provided for @diveComputer_downloadStep_andMoreDives.
   ///
@@ -24737,6 +24899,150 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Dive Computers'**
   String get diveComputer_list_title;
+
+  /// No description provided for @diveComputer_pinCode_instructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter the code displayed on your dive computer.'**
+  String get diveComputer_pinCode_instructions;
+
+  /// No description provided for @diveComputer_pinCode_label.
+  ///
+  /// In en, this message translates to:
+  /// **'PIN Code'**
+  String get diveComputer_pinCode_label;
+
+  /// No description provided for @diveComputer_pinCode_submit.
+  ///
+  /// In en, this message translates to:
+  /// **'Submit'**
+  String get diveComputer_pinCode_submit;
+
+  /// No description provided for @diveComputer_pinCode_title.
+  ///
+  /// In en, this message translates to:
+  /// **'PIN Code Required'**
+  String get diveComputer_pinCode_title;
+
+  /// No description provided for @diveComputer_pinEntry_connectButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect'**
+  String get diveComputer_pinEntry_connectButton;
+
+  /// No description provided for @diveComputer_pinEntry_helperText.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter the 4-6 digit PIN shown on your device'**
+  String get diveComputer_pinEntry_helperText;
+
+  /// No description provided for @diveComputer_pinEntry_instructionsGeneric.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your dive computer display for the PIN code.'**
+  String get diveComputer_pinEntry_instructionsGeneric;
+
+  /// No description provided for @diveComputer_pinEntry_instructionsWithDevice.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your {deviceName} display for the PIN code.'**
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName);
+
+  /// No description provided for @diveComputer_pinEntry_semanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'PIN code entry, 4 to 6 digits'**
+  String get diveComputer_pinEntry_semanticLabel;
+
+  /// No description provided for @diveComputer_pinEntry_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter PIN Code'**
+  String get diveComputer_pinEntry_title;
+
+  /// No description provided for @diveComputer_scan_bluetoothSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Bluetooth device: {name}'**
+  String diveComputer_scan_bluetoothSemanticLabel(String name);
+
+  /// No description provided for @diveComputer_scan_emptyStateInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device'**
+  String get diveComputer_scan_emptyStateInstructions;
+
+  /// No description provided for @diveComputer_scan_knownBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'Known'**
+  String get diveComputer_scan_knownBadge;
+
+  /// No description provided for @diveComputer_scan_lookingForDevicesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Looking for Devices'**
+  String get diveComputer_scan_lookingForDevicesTitle;
+
+  /// No description provided for @diveComputer_scan_noUsbDevicesAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'No USB devices available'**
+  String get diveComputer_scan_noUsbDevicesAvailable;
+
+  /// No description provided for @diveComputer_scan_retry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get diveComputer_scan_retry;
+
+  /// No description provided for @diveComputer_scan_scanAgain.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan Again'**
+  String get diveComputer_scan_scanAgain;
+
+  /// No description provided for @diveComputer_scan_scanningStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Scanning for dive computers...'**
+  String get diveComputer_scan_scanningStatus;
+
+  /// No description provided for @diveComputer_scan_stopScanning.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop Scanning'**
+  String get diveComputer_scan_stopScanning;
+
+  /// No description provided for @diveComputer_scan_supportedBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'Supported'**
+  String get diveComputer_scan_supportedBadge;
+
+  /// No description provided for @diveComputer_scan_tabBluetooth.
+  ///
+  /// In en, this message translates to:
+  /// **'Bluetooth'**
+  String get diveComputer_scan_tabBluetooth;
+
+  /// No description provided for @diveComputer_scan_tabUsb.
+  ///
+  /// In en, this message translates to:
+  /// **'USB Cable'**
+  String get diveComputer_scan_tabUsb;
+
+  /// No description provided for @diveComputer_scan_usbCableLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'USB Cable'**
+  String get diveComputer_scan_usbCableLabel;
+
+  /// No description provided for @diveComputer_scan_usbSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'USB device: {model}'**
+  String diveComputer_scan_usbSemanticLabel(String model);
 
   /// No description provided for @diveComputer_summary_diveComputer.
   ///

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -518,6 +518,30 @@ abstract class AppLocalizations {
   /// **'Failed to load history: {error}'**
   String backup_history_error(Object error);
 
+  /// No description provided for @backup_history_pinAction_pin.
+  ///
+  /// In en, this message translates to:
+  /// **'Pin backup'**
+  String get backup_history_pinAction_pin;
+
+  /// No description provided for @backup_history_pinAction_unpin.
+  ///
+  /// In en, this message translates to:
+  /// **'Unpin backup'**
+  String get backup_history_pinAction_unpin;
+
+  /// No description provided for @backup_history_pinError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update pin state.'**
+  String get backup_history_pinError;
+
+  /// No description provided for @backup_history_preMigrationSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pre-migration backup - {size}'**
+  String backup_history_preMigrationSubtitle(String size);
+
   /// No description provided for @backup_import_invalidFile.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -233,6 +233,20 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'لا يبدو أن هذا الملف نسخة احتياطية صالحة من Submersion';
 

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13955,6 +13955,79 @@ class AppLocalizationsAr extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'يشهد هذا بأن';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice => 'اختيار جهاز آخر';
 
   @override
@@ -14051,6 +14124,19 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'البحث حسب الشركة المصنعة أو الطراز...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14313,6 +14399,91 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'كمبيوترات الغوص';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'كمبيوتر غوص';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -14219,6 +14219,79 @@ class AppLocalizationsDe extends AppLocalizations {
       'Hiermit wird bescheinigt, dass';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Anderes Geraet waehlen';
 
@@ -14319,6 +14392,19 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Nach Hersteller oder Modell suchen...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14593,6 +14679,91 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Tauchcomputer';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'Tauchcomputer';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -233,6 +233,20 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Diese Datei scheint keine gueltige Submersion-Sicherung zu sein';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13993,6 +13993,79 @@ class AppLocalizationsEn extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'This certifies that';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Choose Different Device';
 
@@ -14090,6 +14163,19 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Search by manufacturer or model...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14352,6 +14438,91 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Dive Computers';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'dive computer';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -231,6 +231,20 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'This file does not appear to be a valid Submersion backup';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -233,6 +233,20 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Este archivo no parece ser una copia de seguridad valida de Submersion';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -14235,6 +14235,79 @@ class AppLocalizationsEs extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'Se certifica que';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Elegir otro dispositivo';
 
@@ -14337,6 +14410,19 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Buscar por fabricante o modelo...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14606,6 +14692,91 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Ordenadores de buceo';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'ordenador de buceo';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -233,6 +233,20 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Ce fichier ne semble pas etre une sauvegarde Submersion valide';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14289,6 +14289,79 @@ class AppLocalizationsFr extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'Ceci certifie que';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Choisir un autre appareil';
 
@@ -14390,6 +14463,19 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Rechercher par fabricant ou modèle...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14660,6 +14746,91 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Ordinateurs de plongee';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'ordinateur de plongee';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13855,6 +13855,79 @@ class AppLocalizationsHe extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'בזאת מאושר כי';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice => 'בחר מכשיר אחר';
 
   @override
@@ -13949,6 +14022,19 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get diveComputer_discovery_usbSearchHint => 'חיפוש לפי יצרן או דגם...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14210,6 +14296,91 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'מחשבי צלילה';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'מחשב צלילה';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -230,6 +230,20 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'נראה שקובץ זה אינו גיבוי תקין של Submersion';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -232,6 +232,20 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Ez a fájl nem tűnik érvényes Submersion biztonsági mentésnek';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -14190,6 +14190,79 @@ class AppLocalizationsHu extends AppLocalizations {
       'Ezennel tanusitjuk, hogy';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Masik eszkoz valasztasa';
 
@@ -14290,6 +14363,19 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Keresés gyártó vagy modell alapján...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14558,6 +14644,91 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Merulesszamitogepek';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'merulesszamitogep';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -234,6 +234,20 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Questo file non sembra essere un backup Submersion valido';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -14234,6 +14234,79 @@ class AppLocalizationsIt extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'Si certifica che';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Scegli un altro dispositivo';
 
@@ -14335,6 +14408,19 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Cerca per produttore o modello...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14603,6 +14689,91 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Computer subacquei';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'computer subacqueo';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -14114,6 +14114,79 @@ class AppLocalizationsNl extends AppLocalizations {
       'Hierbij wordt verklaard dat';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Kies een ander apparaat';
 
@@ -14213,6 +14286,19 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Zoeken op fabrikant of model...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14481,6 +14567,91 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Duikcomputers';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'duikcomputer';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -231,6 +231,20 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Dit bestand lijkt geen geldige Submersion-back-up te zijn';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -14236,6 +14236,79 @@ class AppLocalizationsPt extends AppLocalizations {
   String get certifications_certificate_thisCertifies => 'Isto certifica que';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice =>
       'Escolher Outro Dispositivo';
 
@@ -14336,6 +14409,19 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get diveComputer_discovery_usbSearchHint =>
       'Pesquisar por fabricante ou modelo...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -14604,6 +14690,91 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => 'Computadores de Mergulho';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => 'computador de mergulho';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -233,6 +233,20 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile =>
       'Este arquivo nao parece ser um backup valido do Submersion';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -227,6 +227,20 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get backup_history_pinAction_pin => 'Pin backup';
+
+  @override
+  String get backup_history_pinAction_unpin => 'Unpin backup';
+
+  @override
+  String get backup_history_pinError => 'Could not update pin state.';
+
+  @override
+  String backup_history_preMigrationSubtitle(String size) {
+    return 'Pre-migration backup - $size';
+  }
+
+  @override
   String get backup_import_invalidFile => '此文件似乎不是有效的 Submersion 备份文件';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13536,6 +13536,79 @@ class AppLocalizationsZh extends AppLocalizations {
   String get certifications_certificate_thisCertifies => '特此证明';
 
   @override
+  String get diveComputer_connectionType_ble => 'Bluetooth LE';
+
+  @override
+  String get diveComputer_connectionType_bluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_connectionType_infrared => 'Infrared';
+
+  @override
+  String get diveComputer_connectionType_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_connectionType_usb => 'USB';
+
+  @override
+  String get diveComputer_connectionType_wifi => 'Wi-Fi';
+
+  @override
+  String get diveComputer_detail_cannotFilterNoSerial =>
+      'Cannot filter: no serial number for this computer.';
+
+  @override
+  String diveComputer_detail_deleteDialogContent(String name) {
+    return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
+  }
+
+  @override
+  String get diveComputer_detail_deleteDialogTitle => 'Delete Computer?';
+
+  @override
+  String get diveComputer_detail_divesImported => 'Dives Imported';
+
+  @override
+  String get diveComputer_detail_downloadDivesButton => 'Download Dives';
+
+  @override
+  String get diveComputer_detail_editDialogTitle => 'Edit Computer';
+
+  @override
+  String get diveComputer_detail_editNameHint => 'e.g., My Perdix';
+
+  @override
+  String get diveComputer_detail_editNotesHint => 'Optional notes';
+
+  @override
+  String get diveComputer_detail_labelConnection => 'Connection';
+
+  @override
+  String get diveComputer_detail_labelManufacturer => 'Manufacturer';
+
+  @override
+  String get diveComputer_detail_labelModel => 'Model';
+
+  @override
+  String get diveComputer_detail_labelName => 'Name';
+
+  @override
+  String get diveComputer_detail_lastDownload => 'Last Download';
+
+  @override
+  String get diveComputer_detail_notesTitle => 'Notes';
+
+  @override
+  String get diveComputer_detail_statisticsTitle => 'Statistics';
+
+  @override
+  String get diveComputer_detail_unknown => 'Unknown';
+
+  @override
+  String get diveComputer_detail_viewDivesButton =>
+      'View Dives from This Computer';
+
+  @override
   String get diveComputer_discovery_chooseDifferentDevice => '选择其他设备';
 
   @override
@@ -13628,6 +13701,19 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get diveComputer_discovery_usbSearchHint => '按制造商或型号搜索...';
+
+  @override
+  String get diveComputer_downloadExit_content =>
+      'Leaving will cancel the current download from your dive computer. Are you sure?';
+
+  @override
+  String get diveComputer_downloadExit_leave => 'Leave';
+
+  @override
+  String get diveComputer_downloadExit_stay => 'Stay';
+
+  @override
+  String get diveComputer_downloadExit_title => 'Download in Progress';
 
   @override
   String diveComputer_downloadStep_andMoreDives(Object count) {
@@ -13881,6 +13967,91 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get diveComputer_list_title => '潜水电脑';
+
+  @override
+  String get diveComputer_pinCode_instructions =>
+      'Enter the code displayed on your dive computer.';
+
+  @override
+  String get diveComputer_pinCode_label => 'PIN Code';
+
+  @override
+  String get diveComputer_pinCode_submit => 'Submit';
+
+  @override
+  String get diveComputer_pinCode_title => 'PIN Code Required';
+
+  @override
+  String get diveComputer_pinEntry_connectButton => 'Connect';
+
+  @override
+  String get diveComputer_pinEntry_helperText =>
+      'Enter the 4-6 digit PIN shown on your device';
+
+  @override
+  String get diveComputer_pinEntry_instructionsGeneric =>
+      'Check your dive computer display for the PIN code.';
+
+  @override
+  String diveComputer_pinEntry_instructionsWithDevice(String deviceName) {
+    return 'Check your $deviceName display for the PIN code.';
+  }
+
+  @override
+  String get diveComputer_pinEntry_semanticLabel =>
+      'PIN code entry, 4 to 6 digits';
+
+  @override
+  String get diveComputer_pinEntry_title => 'Enter PIN Code';
+
+  @override
+  String diveComputer_scan_bluetoothSemanticLabel(String name) {
+    return 'Bluetooth device: $name';
+  }
+
+  @override
+  String get diveComputer_scan_emptyStateInstructions =>
+      'Make sure your dive computer is:\n• Turned on\n• In Bluetooth pairing mode\n• Close to your device';
+
+  @override
+  String get diveComputer_scan_knownBadge => 'Known';
+
+  @override
+  String get diveComputer_scan_lookingForDevicesTitle => 'Looking for Devices';
+
+  @override
+  String get diveComputer_scan_noUsbDevicesAvailable =>
+      'No USB devices available';
+
+  @override
+  String get diveComputer_scan_retry => 'Retry';
+
+  @override
+  String get diveComputer_scan_scanAgain => 'Scan Again';
+
+  @override
+  String get diveComputer_scan_scanningStatus =>
+      'Scanning for dive computers...';
+
+  @override
+  String get diveComputer_scan_stopScanning => 'Stop Scanning';
+
+  @override
+  String get diveComputer_scan_supportedBadge => 'Supported';
+
+  @override
+  String get diveComputer_scan_tabBluetooth => 'Bluetooth';
+
+  @override
+  String get diveComputer_scan_tabUsb => 'USB Cable';
+
+  @override
+  String get diveComputer_scan_usbCableLabel => 'USB Cable';
+
+  @override
+  String diveComputer_scan_usbSemanticLabel(String model) {
+    return 'USB device: $model';
+  }
 
   @override
   String get diveComputer_summary_diveComputer => '潜水电脑';

--- a/test/core/database/pre_migration_backup_integration_test.dart
+++ b/test/core/database/pre_migration_backup_integration_test.dart
@@ -9,8 +9,7 @@ import 'package:submersion/features/backup/data/services/pre_migration_backup_se
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 
 void main() {
-  test('end-to-end: seeds v63 DB, backs up, verifies bytes + record',
-      () async {
+  test('end-to-end: seeds v63 DB, backs up, verifies bytes + record', () async {
     final tmp = await Directory.systemTemp.createTemp('pmbs_int_');
     addTearDown(() => tmp.delete(recursive: true));
 
@@ -46,7 +45,7 @@ void main() {
     );
 
     // Assert backup .db exists and matches live bytes.
-    final backupPath = p.join(backupsDir, '20260412-081201-v63-v64.db');
+    final backupPath = p.join(backupsDir, '20260412-081201000-v63-v64.db');
     expect(await File(backupPath).exists(), isTrue);
     expect(
       await File(backupPath).readAsBytes(),
@@ -54,8 +53,10 @@ void main() {
     );
 
     // Assert the backup DB itself reads user_version == 63 and sentinel data.
-    final verify =
-        sqlite3.sqlite3.open(backupPath, mode: sqlite3.OpenMode.readOnly);
+    final verify = sqlite3.sqlite3.open(
+      backupPath,
+      mode: sqlite3.OpenMode.readOnly,
+    );
     try {
       expect(verify.select('PRAGMA user_version').first.values.first, 63);
       expect(verify.select('SELECT id FROM sentinel').first.values.first, 42);

--- a/test/core/database/pre_migration_backup_integration_test.dart
+++ b/test/core/database/pre_migration_backup_integration_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+void main() {
+  test('end-to-end: seeds v63 DB, backs up, verifies bytes + record',
+      () async {
+    final tmp = await Directory.systemTemp.createTemp('pmbs_int_');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final livePath = p.join(tmp.path, 'submersion.db');
+    final backupsDir = p.join(tmp.path, 'backups');
+    await Directory(backupsDir).create(recursive: true);
+
+    // Seed a v63 sqlite file with user_version + sentinel data.
+    final seed = sqlite3.sqlite3.open(livePath);
+    try {
+      seed.execute('PRAGMA user_version = 63');
+      seed.execute('CREATE TABLE sentinel (id INTEGER PRIMARY KEY)');
+      seed.execute('INSERT INTO sentinel VALUES (42)');
+    } finally {
+      seed.dispose();
+    }
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => livePath,
+      backupsDirProvider: () async => backupsDir,
+      preferences: prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'integration-id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    // Assert backup .db exists and matches live bytes.
+    final backupPath = p.join(backupsDir, '20260412-081201-v63-v64.db');
+    expect(await File(backupPath).exists(), isTrue);
+    expect(
+      await File(backupPath).readAsBytes(),
+      await File(livePath).readAsBytes(),
+    );
+
+    // Assert the backup DB itself reads user_version == 63 and sentinel data.
+    final verify =
+        sqlite3.sqlite3.open(backupPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(verify.select('PRAGMA user_version').first.values.first, 63);
+      expect(verify.select('SELECT id FROM sentinel').first.values.first, 42);
+    } finally {
+      verify.dispose();
+    }
+
+    // Assert the BackupRecord is in the registry with the right shape.
+    final records = prefs.getHistory();
+    expect(records, hasLength(1));
+    expect(records.single.type, BackupType.preMigration);
+    expect(records.single.fromSchemaVersion, 63);
+    expect(records.single.toSchemaVersion, 64);
+  });
+}

--- a/test/core/presentation/pages/startup_page_backup_flow_test.dart
+++ b/test/core/presentation/pages/startup_page_backup_flow_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+void main() {
+  testWidgets('BackingUpView shows spinner + explanation copy', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: BackingUpView())),
+    );
+    expect(find.text('Backing up your data'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.textContaining('before updating'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Cancel'), findsNothing);
+    expect(find.widgetWithText(ElevatedButton, 'Cancel'), findsNothing);
+  });
+
+  testWidgets('BackupFailedView surfaces classified message + Retry and Quit', (
+    tester,
+  ) async {
+    var retried = 0;
+    var quit = 0;
+    const error = BackupFailedException(
+      cause: BackupFailureCause.diskFull,
+      userMessage: 'Not enough free disk space to back up your data.',
+      technicalDetails: 'FileSystemException(28)',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BackupFailedView(
+            error: error,
+            onRetry: () => retried++,
+            onQuit: () => quit++,
+          ),
+        ),
+      ),
+    );
+    expect(find.text("Couldn't back up your data"), findsOneWidget);
+    expect(
+      find.text('Not enough free disk space to back up your data.'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Retry'));
+    await tester.pump();
+    expect(retried, 1);
+    expect(quit, 0);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Quit'));
+    await tester.pump();
+    expect(quit, 1);
+  });
+
+  testWidgets('BackupFailedView technical details are hidden until expanded', (
+    tester,
+  ) async {
+    const error = BackupFailedException(
+      cause: BackupFailureCause.unknown,
+      userMessage: 'Backup failed: something odd.',
+      technicalDetails: 'unique-detail-12345',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BackupFailedView(error: error, onRetry: () {}, onQuit: () {}),
+        ),
+      ),
+    );
+    expect(find.text('unique-detail-12345'), findsNothing);
+    await tester.tap(find.text('Technical details'));
+    await tester.pumpAndSettle();
+    expect(find.text('unique-detail-12345'), findsOneWidget);
+  });
+}

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -11,6 +11,7 @@ import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -913,4 +914,279 @@ void main() {
       expect(find.textContaining('Your data is safe'), findsOneWidget);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Pre-migration backup flow transitions
+  // ---------------------------------------------------------------------------
+  group('pre-migration backup flow', () {
+    late SharedPreferences prefs;
+    late LogFileService logFileService;
+    late DatabaseLocationService locationService;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      logFileService = LogFileService(logDirectory: '/tmp/test-logs');
+      locationService = _FakeLocationService(prefs);
+    });
+
+    testWidgets(
+      'BackupFailedException transitions to backupFailed with classified message',
+      (tester) async {
+        PreMigrationBackupService failingFactory({
+          required String livePath,
+          required BackupPreferences preferences,
+        }) {
+          return _ThrowingBackupService(
+            preferences: preferences,
+            error: const BackupFailedException(
+              cause: BackupFailureCause.diskFull,
+              userMessage: 'Not enough free disk space to back up your data.',
+              technicalDetails: 'FileSystemException(28)',
+            ),
+          );
+        }
+
+        await tester.pumpWidget(
+          _buildStartupWrapper(
+            prefs: prefs,
+            logFileService: logFileService,
+            locationService: locationService,
+            schemaVersionProbeOverride: (_) =>
+                (needsMigration: true, totalSteps: 5),
+            preMigrationBackupFactory: failingFactory,
+            initializerOverride: (_) async {
+              // Should never be called: backup failure blocks migration.
+              throw StateError('initializer must not run on backup failure');
+            },
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const ValueKey('error')), findsOneWidget);
+        expect(find.text("Couldn't back up your data"), findsOneWidget);
+        expect(
+          find.text('Not enough free disk space to back up your data.'),
+          findsOneWidget,
+        );
+        expect(find.widgetWithText(ElevatedButton, 'Retry'), findsOneWidget);
+        expect(find.widgetWithText(TextButton, 'Quit'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Retry after backup failure recovers when second attempt succeeds',
+      (tester) async {
+        var attempt = 0;
+        PreMigrationBackupService flakyFactory({
+          required String livePath,
+          required BackupPreferences preferences,
+        }) {
+          attempt += 1;
+          if (attempt == 1) {
+            return _ThrowingBackupService(
+              preferences: preferences,
+              error: const BackupFailedException(
+                cause: BackupFailureCause.unknown,
+                userMessage: 'Temporary backup failure.',
+                technicalDetails: 'flaky',
+              ),
+            );
+          }
+          return _NoOpBackupService(preferences: preferences);
+        }
+
+        await tester.pumpWidget(
+          _buildStartupWrapper(
+            prefs: prefs,
+            logFileService: logFileService,
+            locationService: locationService,
+            schemaVersionProbeOverride: (_) =>
+                (needsMigration: true, totalSteps: 3),
+            preMigrationBackupFactory: flakyFactory,
+            // Never completes so retry path stops at the "migrating" state,
+            // avoiding go_router redirect that would need DatabaseService.
+            initializerOverride: (_) => Completer<void>().future,
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(find.text("Couldn't back up your data"), findsOneWidget);
+
+        await tester.tap(find.widgetWithText(ElevatedButton, 'Retry'));
+        await tester.pump();
+        await tester.pump();
+
+        expect(attempt, 2);
+        // Recovery: the error scaffold is gone; the progress UI took its place.
+        expect(find.byKey(const ValueKey('error')), findsNothing);
+        expect(find.text("Couldn't back up your data"), findsNothing);
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+        // Drain any pending timers from the retry path.
+        await tester.pump(const Duration(seconds: 2));
+      },
+    );
+
+    testWidgets(
+      'Retry that fails again with BackupFailedException stays on backupFailed',
+      (tester) async {
+        var attempt = 0;
+        PreMigrationBackupService alwaysFailingFactory({
+          required String livePath,
+          required BackupPreferences preferences,
+        }) {
+          attempt += 1;
+          return _ThrowingBackupService(
+            preferences: preferences,
+            error: BackupFailedException(
+              cause: BackupFailureCause.permissionDenied,
+              userMessage: 'Attempt $attempt failed.',
+              technicalDetails: 'EACCES',
+            ),
+          );
+        }
+
+        await tester.pumpWidget(
+          _buildStartupWrapper(
+            prefs: prefs,
+            logFileService: logFileService,
+            locationService: locationService,
+            schemaVersionProbeOverride: (_) =>
+                (needsMigration: true, totalSteps: 1),
+            preMigrationBackupFactory: alwaysFailingFactory,
+            initializerOverride: (_) async {},
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+        expect(find.text('Attempt 1 failed.'), findsOneWidget);
+
+        await tester.tap(find.widgetWithText(ElevatedButton, 'Retry'));
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(attempt, 2);
+        expect(find.text("Couldn't back up your data"), findsOneWidget);
+        expect(find.text('Attempt 2 failed.'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Retry that throws a non-BackupFailedException goes to generic error',
+      (tester) async {
+        var attempt = 0;
+        PreMigrationBackupService factory({
+          required String livePath,
+          required BackupPreferences preferences,
+        }) {
+          attempt += 1;
+          if (attempt == 1) {
+            return _ThrowingBackupService(
+              preferences: preferences,
+              error: const BackupFailedException(
+                cause: BackupFailureCause.unknown,
+                userMessage: 'First failure.',
+                technicalDetails: '',
+              ),
+            );
+          }
+          return _ThrowingBackupService(
+            preferences: preferences,
+            error: Exception('unexpected non-backup-failed'),
+          );
+        }
+
+        await tester.pumpWidget(
+          _buildStartupWrapper(
+            prefs: prefs,
+            logFileService: logFileService,
+            locationService: locationService,
+            schemaVersionProbeOverride: (_) =>
+                (needsMigration: true, totalSteps: 1),
+            preMigrationBackupFactory: factory,
+            initializerOverride: (_) async {},
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.widgetWithText(ElevatedButton, 'Retry'));
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(attempt, 2);
+        expect(find.byKey(const ValueKey('error')), findsOneWidget);
+        expect(
+          find.textContaining('unexpected non-backup-failed'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('Quit button on backupFailed invokes closeAppOverride', (
+      tester,
+    ) async {
+      var quitCalled = 0;
+      PreMigrationBackupService factory({
+        required String livePath,
+        required BackupPreferences preferences,
+      }) {
+        return _ThrowingBackupService(
+          preferences: preferences,
+          error: const BackupFailedException(
+            cause: BackupFailureCause.diskFull,
+            userMessage: 'Disk is full.',
+            technicalDetails: '',
+          ),
+        );
+      }
+
+      await tester.pumpWidget(
+        _buildStartupWrapper(
+          prefs: prefs,
+          logFileService: logFileService,
+          locationService: locationService,
+          schemaVersionProbeOverride: (_) =>
+              (needsMigration: true, totalSteps: 1),
+          preMigrationBackupFactory: factory,
+          initializerOverride: (_) async {},
+          closeAppOverride: () => quitCalled++,
+        ),
+      );
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Quit'));
+      await tester.pump();
+
+      expect(quitCalled, 1);
+    });
+  });
+}
+
+/// A backup service whose `backupIfMigrationPending` always throws.
+class _ThrowingBackupService extends PreMigrationBackupService {
+  final Object error;
+  _ThrowingBackupService({required super.preferences, required this.error})
+    : super(
+        livePathProvider: () async => '/tmp/test.db',
+        backupsDirProvider: () async => '/tmp/test-backups',
+      );
+
+  @override
+  Future<void> backupIfMigrationPending({
+    required int stored,
+    required int target,
+    required String appVersion,
+  }) async {
+    throw error;
+  }
 }

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -9,6 +9,8 @@ import 'package:submersion/core/domain/entities/migration_progress.dart';
 import 'package:submersion/core/presentation/pages/startup_page.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -23,6 +25,34 @@ class _FakeLocationService extends DatabaseLocationService {
   Future<String> getDatabasePath() async => _path;
 }
 
+/// A synchronous no-op subclass of [PreMigrationBackupService] for tests that
+/// exercise the migration path without wanting real file I/O.
+class _NoOpBackupService extends PreMigrationBackupService {
+  _NoOpBackupService({required super.preferences})
+    : super(
+        livePathProvider: () async => '/tmp/test.db',
+        backupsDirProvider: () async => '/tmp/test-backups',
+      );
+
+  @override
+  Future<void> backupIfMigrationPending({
+    required int stored,
+    required int target,
+    required String appVersion,
+  }) async {
+    // Intentional no-op: skip all file I/O in widget tests.
+  }
+}
+
+/// Factory for the no-op backup service used by tests that exercise the
+/// migration path but do not want to test backup behaviour.
+PreMigrationBackupService _noOpBackupFactory({
+  required String livePath,
+  required BackupPreferences preferences,
+}) {
+  return _NoOpBackupService(preferences: preferences);
+}
+
 /// Builds a [StartupWrapper] for widget testing with injectable overrides.
 Widget _buildStartupWrapper({
   required SharedPreferences prefs,
@@ -31,6 +61,11 @@ Widget _buildStartupWrapper({
   ServiceInitializer? initializerOverride,
   SchemaVersionProbe? schemaVersionProbeOverride,
   VoidCallback? closeAppOverride,
+  PreMigrationBackupService Function({
+    required String livePath,
+    required BackupPreferences preferences,
+  })?
+  preMigrationBackupFactory,
 }) {
   return StartupWrapper(
     prefs: prefs,
@@ -39,6 +74,7 @@ Widget _buildStartupWrapper({
     initializerOverride: initializerOverride,
     schemaVersionProbeOverride: schemaVersionProbeOverride,
     closeAppOverride: closeAppOverride,
+    preMigrationBackupFactory: preMigrationBackupFactory,
   );
 }
 
@@ -538,6 +574,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 5),
+          preMigrationBackupFactory: _noOpBackupFactory,
           initializerOverride: (onProgress) {
             capturedCallback = onProgress;
             // Never completes -- we stay on the migration screen
@@ -546,7 +583,9 @@ void main() {
         ),
       );
 
-      // After first pump the widget should show migrating state
+      // Pump through the backup step (synchronous no-op factory) then into
+      // migrating state.
+      await tester.pump();
       await tester.pump();
 
       // Verify migration UI is shown
@@ -723,6 +762,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 10),
+          preMigrationBackupFactory: _noOpBackupFactory,
           initializerOverride: (onProgress) {
             progressCallback = onProgress;
             return Completer<void>().future;
@@ -730,6 +770,9 @@ void main() {
         ),
       );
 
+      // Pump through the backup step (synchronous no-op factory) then into
+      // migrating state.
+      await tester.pump();
       await tester.pump();
 
       // Initial: step 0 of 10
@@ -788,6 +831,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 3),
+          preMigrationBackupFactory: _noOpBackupFactory,
           initializerOverride: (_) => Completer<void>().future,
         ),
       );

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -903,6 +903,66 @@ void main() {
       });
     });
 
+    group('pinBackup / unpinBackup', () {
+      test('pinBackup flips pinned to true on the record', () async {
+        final record = BackupRecord(
+          id: 'pin-me',
+          filename: 'backup.db',
+          timestamp: DateTime(2025, 6, 15),
+          sizeBytes: 1000,
+          location: BackupLocation.local,
+          diveCount: 5,
+          siteCount: 2,
+        );
+        await preferences.addRecord(record);
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+        );
+
+        await service.pinBackup('pin-me');
+
+        final history = preferences.getHistory();
+        expect(history.single.pinned, true);
+      });
+
+      test('unpinBackup flips pinned to false', () async {
+        final record = BackupRecord(
+          id: 'unpin-me',
+          filename: 'backup.db',
+          timestamp: DateTime(2025, 6, 15),
+          sizeBytes: 1000,
+          location: BackupLocation.local,
+          diveCount: 5,
+          siteCount: 2,
+          pinned: true,
+        );
+        await preferences.addRecord(record);
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+        );
+
+        await service.unpinBackup('unpin-me');
+
+        final history = preferences.getHistory();
+        expect(history.single.pinned, false);
+      });
+
+      test('pinBackup is a no-op for unknown ids (does not throw)', () async {
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+        );
+
+        await expectLater(service.pinBackup('unknown'), completes);
+
+        expect(preferences.getHistory(), isEmpty);
+      });
+    });
+
     group('BackupSettings integration', () {
       test('isBackupDue returns true when never backed up', () {
         const settings = BackupSettings(enabled: true);

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/backup/data/repositories/backup_preferences.
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 
 // =============================================================================
 // Test Doubles
@@ -960,6 +961,148 @@ void main() {
         await expectLater(service.pinBackup('unknown'), completes);
 
         expect(preferences.getHistory(), isEmpty);
+      });
+    });
+
+    group('pruneOldBackups type + pinned isolation', () {
+      test('only prunes manual records, never pre-migration', () async {
+        // Seed 3 manual records + 2 pre-migration records
+        for (var i = 0; i < 3; i++) {
+          await preferences.addRecord(
+            BackupRecord(
+              id: 'm$i',
+              filename: 'm$i.db',
+              timestamp: DateTime(2026, 1, 1 + i),
+              sizeBytes: 1,
+              location: BackupLocation.local,
+              type: BackupType.manual,
+            ),
+          );
+        }
+        for (var i = 0; i < 2; i++) {
+          await preferences.addRecord(
+            BackupRecord(
+              id: 'p$i',
+              filename: 'p$i.db',
+              timestamp: DateTime(2025, 1, 1 + i), // older than manuals
+              sizeBytes: 1,
+              location: BackupLocation.local,
+              type: BackupType.preMigration,
+              fromSchemaVersion: 63,
+              toSchemaVersion: 64,
+            ),
+          );
+        }
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+        );
+
+        // Prune to keep 1 — should delete 2 manual, keep all pre-migration
+        await service.pruneOldBackups(1);
+
+        final remaining = preferences.getHistory();
+        final manualCount = remaining
+            .where((r) => r.type == BackupType.manual)
+            .length;
+        final preMigCount = remaining
+            .where((r) => r.type == BackupType.preMigration)
+            .length;
+        expect(manualCount, 1, reason: 'should keep only 1 manual');
+        expect(preMigCount, 2, reason: 'pre-migration untouched');
+      });
+
+      test('does not prune pinned manual records', () async {
+        // Seed 3 manual records, middle one pinned
+        await preferences.addRecord(
+          BackupRecord(
+            id: 'm0',
+            filename: 'm0.db',
+            timestamp: DateTime(2026, 1, 1),
+            sizeBytes: 1,
+            location: BackupLocation.local,
+            type: BackupType.manual,
+          ),
+        );
+        await preferences.addRecord(
+          BackupRecord(
+            id: 'm1-pinned',
+            filename: 'm1.db',
+            timestamp: DateTime(2026, 1, 2),
+            sizeBytes: 1,
+            location: BackupLocation.local,
+            type: BackupType.manual,
+            pinned: true,
+          ),
+        );
+        await preferences.addRecord(
+          BackupRecord(
+            id: 'm2',
+            filename: 'm2.db',
+            timestamp: DateTime(2026, 1, 3),
+            sizeBytes: 1,
+            location: BackupLocation.local,
+            type: BackupType.manual,
+          ),
+        );
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+        );
+
+        // Prune to keep 1 — should keep newest (m2) + pinned (m1-pinned), drop m0
+        await service.pruneOldBackups(1);
+
+        final remaining = preferences.getHistory();
+        final ids = remaining.map((r) => r.id).toSet();
+        expect(ids, contains('m1-pinned'));
+        expect(ids, contains('m2'));
+        expect(ids, isNot(contains('m0')));
+      });
+
+      test('keepCount applies only to unpinned manual records', () async {
+        // 2 pinned + 5 unpinned manuals
+        for (var i = 0; i < 2; i++) {
+          await preferences.addRecord(
+            BackupRecord(
+              id: 'pinned-$i',
+              filename: 'p$i.db',
+              timestamp: DateTime(2026, 1, 1 + i),
+              sizeBytes: 1,
+              location: BackupLocation.local,
+              type: BackupType.manual,
+              pinned: true,
+            ),
+          );
+        }
+        for (var i = 0; i < 5; i++) {
+          await preferences.addRecord(
+            BackupRecord(
+              id: 'u$i',
+              filename: 'u$i.db',
+              timestamp: DateTime(2026, 2, 1 + i),
+              sizeBytes: 1,
+              location: BackupLocation.local,
+              type: BackupType.manual,
+            ),
+          );
+        }
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+        );
+
+        // Keep 2 unpinned manuals; all 2 pinned stay
+        await service.pruneOldBackups(2);
+
+        final remaining = preferences.getHistory();
+        final pinnedCount = remaining.where((r) => r.pinned).length;
+        final unpinnedCount = remaining.where((r) => !r.pinned).length;
+        expect(pinnedCount, 2);
+        expect(unpinnedCount, 2);
       });
     });
 

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -197,5 +197,29 @@ void main() {
 
       expect(await keep.exists(), isTrue);
     });
+
+    test('does not delete .tmp files that are not our own form', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      // User-dropped file that happens to end in .tmp - must NOT be deleted.
+      final notOurs = File(p.join(f.backupsDir, 'notes.tmp'));
+      await notOurs.writeAsBytes([1, 2, 3]);
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'id',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await notOurs.exists(), isTrue);
+    });
   });
 }

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -448,6 +448,34 @@ void main() {
     });
   });
 
+  group('construction', () {
+    test('default idGenerator produces a UUID-shaped id', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final history = f.prefs.getHistory();
+      expect(history, hasLength(1));
+      final id = history.single.id;
+      // UUID v4 canonical form: 8-4-4-4-12 hex.
+      final uuid = RegExp(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-'
+        r'[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+      );
+      expect(uuid.hasMatch(id), isTrue, reason: 'id was "$id"');
+    });
+  });
+
   group('atomicity', () {
     test('final .db exists only under non-.tmp name after success', () async {
       final f = await _makeFixture();

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/backup/data/repositories/backup_preferences.
 import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
 
 Future<_Fixture> _makeFixture() async {
   final tmp = await Directory.systemTemp.createTemp('pmbs_test_');
@@ -411,6 +412,39 @@ void main() {
           .where((r) => r.type == BackupType.manual)
           .length;
       expect(manualCount, 5);
+    });
+  });
+
+  group('error handling', () {
+    test('wraps directory-creation errors as BackupFailedException '
+        '(backupsDir path is a regular file)', () async {
+      // Trigger a file-system error without needing ENOSPC by pointing the
+      // backupsDir at a path that already exists as a regular file.
+      final tmp = await Directory.systemTemp.createTemp('pmbs_err_');
+      addTearDown(() => tmp.delete(recursive: true));
+      final live = File(p.join(tmp.path, 'submersion.db'));
+      await live.writeAsBytes([1, 2, 3]);
+      final conflicting = File(p.join(tmp.path, 'not-a-dir'));
+      await conflicting.writeAsBytes([0]);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => live.path,
+        backupsDirProvider: () async => conflicting.path,
+        preferences: prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'id',
+      );
+
+      expect(
+        () async => service.backupIfMigrationPending(
+          stored: 63,
+          target: 64,
+          appVersion: '1.6.0.1241',
+        ),
+        throwsA(isA<BackupFailedException>()),
+      );
     });
   });
 }

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -58,7 +58,7 @@ void main() {
         appVersion: '1.6.0.1241',
       );
 
-      const expectedName = '20260412-081201-v63-v64.db';
+      const expectedName = '20260412-081201000-v63-v64.db';
       final backupFile = File(p.join(f.backupsDir, expectedName));
       expect(await backupFile.exists(), isTrue);
       expect(
@@ -94,7 +94,7 @@ void main() {
         expect(record.fromSchemaVersion, 63);
         expect(record.toSchemaVersion, 64);
         expect(record.appVersion, '1.6.0.1241');
-        expect(record.filename, '20260412-081201-v63-v64.db');
+        expect(record.filename, '20260412-081201000-v63-v64.db');
         expect(record.diveCount, isNull);
         expect(record.siteCount, isNull);
         expect(record.pinned, false);
@@ -469,13 +469,15 @@ void main() {
       final entries = await Directory(f.backupsDir).list().toList();
       final names = entries.map((e) => p.basename(e.path)).toList();
       expect(names.any((n) => n.endsWith('.tmp')), isFalse);
-      expect(names, contains('20260412-081201-v63-v64.db'));
+      expect(names, contains('20260412-081201000-v63-v64.db'));
     });
   });
 }
 
 String _ts(DateTime utc) {
   String two(int v) => v.toString().padLeft(2, '0');
+  String three(int v) => v.toString().padLeft(3, '0');
   return '${utc.year}${two(utc.month)}${two(utc.day)}-'
-      '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}';
+      '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}'
+      '${three(utc.millisecond)}';
 }

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -447,6 +447,31 @@ void main() {
       );
     });
   });
+
+  group('atomicity', () {
+    test('final .db exists only under non-.tmp name after success', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'id',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final entries = await Directory(f.backupsDir).list().toList();
+      final names = entries.map((e) => p.basename(e.path)).toList();
+      expect(names.any((n) => n.endsWith('.tmp')), isFalse);
+      expect(names, contains('20260412-081201-v63-v64.db'));
+    });
+  });
 }
 
 String _ts(DateTime utc) {

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -147,4 +147,55 @@ void main() {
       expect(f.prefs.getHistory(), isEmpty);
     });
   });
+
+  group('.tmp sweep', () {
+    test('deletes leftover .tmp files in backups dir before backup', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final stale = File(
+        p.join(f.backupsDir, '.20260101-000000-v62-v63.db.tmp'),
+      );
+      await stale.writeAsBytes([1, 2, 3]);
+      expect(await stale.exists(), isTrue);
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'id',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await stale.exists(), isFalse);
+    });
+
+    test('does not delete non-.tmp files', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final keep = File(p.join(f.backupsDir, '20260101-000000-manual.db'));
+      await keep.writeAsBytes([1, 2, 3]);
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'id',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await keep.exists(), isTrue);
+    });
+  });
 }

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+Future<_Fixture> _makeFixture() async {
+  final tmp = await Directory.systemTemp.createTemp('pmbs_test_');
+  final live = File(p.join(tmp.path, 'submersion.db'));
+  await live.writeAsBytes(List<int>.generate(1024, (i) => i % 256));
+  final backupsDir = Directory(p.join(tmp.path, 'backups'));
+  await backupsDir.create();
+  SharedPreferences.setMockInitialValues({});
+  final prefs = BackupPreferences(await SharedPreferences.getInstance());
+  return _Fixture(
+    tmp: tmp,
+    livePath: live.path,
+    backupsDir: backupsDir.path,
+    prefs: prefs,
+  );
+}
+
+class _Fixture {
+  final Directory tmp;
+  final String livePath;
+  final String backupsDir;
+  final BackupPreferences prefs;
+  _Fixture({
+    required this.tmp,
+    required this.livePath,
+    required this.backupsDir,
+    required this.prefs,
+  });
+  Future<void> dispose() async => tmp.delete(recursive: true);
+}
+
+void main() {
+  group('PreMigrationBackupService happy path', () {
+    test('copies live DB bytes into backups folder', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'test-id-1',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      const expectedName = '20260412-081201-v63-v64.db';
+      final backupFile = File(p.join(f.backupsDir, expectedName));
+      expect(await backupFile.exists(), isTrue);
+      expect(
+        await backupFile.readAsBytes(),
+        await File(f.livePath).readAsBytes(),
+      );
+    });
+
+    test(
+      'registers BackupRecord with preMigration type + schema pair',
+      () async {
+        final f = await _makeFixture();
+        addTearDown(f.dispose);
+        final service = PreMigrationBackupService(
+          livePathProvider: () async => f.livePath,
+          backupsDirProvider: () async => f.backupsDir,
+          preferences: f.prefs,
+          clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+          idGenerator: () => 'test-id-1',
+        );
+
+        await service.backupIfMigrationPending(
+          stored: 63,
+          target: 64,
+          appVersion: '1.6.0.1241',
+        );
+
+        final history = f.prefs.getHistory();
+        expect(history, hasLength(1));
+        final record = history.single;
+        expect(record.id, 'test-id-1');
+        expect(record.type, BackupType.preMigration);
+        expect(record.fromSchemaVersion, 63);
+        expect(record.toSchemaVersion, 64);
+        expect(record.appVersion, '1.6.0.1241');
+        expect(record.filename, '20260412-081201-v63-v64.db');
+        expect(record.diveCount, isNull);
+        expect(record.siteCount, isNull);
+        expect(record.pinned, false);
+        expect(record.isAutomatic, true);
+        expect(record.location, BackupLocation.local);
+        expect(record.localPath, p.join(f.backupsDir, record.filename));
+        expect(record.sizeBytes, 1024);
+      },
+    );
+
+    test('skips when stored == target (no-op)', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'x',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 64,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await Directory(f.backupsDir).list().isEmpty, isTrue);
+      expect(f.prefs.getHistory(), isEmpty);
+    });
+
+    test('skips when live DB file does not exist', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      await File(f.livePath).delete();
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'x',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      expect(await Directory(f.backupsDir).list().isEmpty, isTrue);
+      expect(f.prefs.getHistory(), isEmpty);
+    });
+  });
+}

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -222,4 +222,201 @@ void main() {
       expect(await notOurs.exists(), isTrue);
     });
   });
+
+  group('retention prune', () {
+    test(
+      'keeps newest 3 unpinned pre-migration backups, deletes older',
+      () async {
+        final f = await _makeFixture();
+        addTearDown(f.dispose);
+        for (var i = 0; i < 4; i++) {
+          final ts = DateTime.utc(2026, 1, 1 + i);
+          final name = '${_ts(ts)}-v$i-v${i + 1}.db';
+          final file = File(p.join(f.backupsDir, name));
+          await file.writeAsBytes([i]);
+          await f.prefs.addRecord(
+            BackupRecord(
+              id: 'r$i',
+              filename: name,
+              timestamp: ts,
+              sizeBytes: 1,
+              location: BackupLocation.local,
+              localPath: file.path,
+              type: BackupType.preMigration,
+              fromSchemaVersion: i,
+              toSchemaVersion: i + 1,
+            ),
+          );
+        }
+
+        final service = PreMigrationBackupService(
+          livePathProvider: () async => f.livePath,
+          backupsDirProvider: () async => f.backupsDir,
+          preferences: f.prefs,
+          clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+          idGenerator: () => 'new',
+        );
+
+        await service.backupIfMigrationPending(
+          stored: 63,
+          target: 64,
+          appVersion: '1.6.0.1241',
+        );
+
+        final remaining = f.prefs
+            .getHistory()
+            .where((r) => r.type == BackupType.preMigration)
+            .toList();
+        expect(remaining, hasLength(3));
+        expect(
+          remaining.map((r) => r.id),
+          containsAll(<String>['new', 'r3', 'r2']),
+        );
+        expect(remaining.map((r) => r.id), isNot(contains('r0')));
+        expect(remaining.map((r) => r.id), isNot(contains('r1')));
+        expect(
+          await File(
+            p.join(f.backupsDir, '${_ts(DateTime.utc(2026, 1, 1))}-v0-v1.db'),
+          ).exists(),
+          isFalse,
+        );
+        expect(
+          await File(
+            p.join(f.backupsDir, '${_ts(DateTime.utc(2026, 1, 2))}-v1-v2.db'),
+          ).exists(),
+          isFalse,
+        );
+      },
+    );
+
+    test('pinned pre-migration backups are never pruned', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      for (var i = 0; i < 5; i++) {
+        final ts = DateTime.utc(2026, 1, 1 + i);
+        final name = '${_ts(ts)}-v$i-v${i + 1}.db';
+        await File(p.join(f.backupsDir, name)).writeAsBytes([i]);
+        await f.prefs.addRecord(
+          BackupRecord(
+            id: 'pinned-$i',
+            filename: name,
+            timestamp: ts,
+            sizeBytes: 1,
+            location: BackupLocation.local,
+            localPath: p.join(f.backupsDir, name),
+            type: BackupType.preMigration,
+            fromSchemaVersion: i,
+            toSchemaVersion: i + 1,
+            pinned: true,
+          ),
+        );
+      }
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'new',
+      );
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final preMigrationRecords = f.prefs
+          .getHistory()
+          .where((r) => r.type == BackupType.preMigration)
+          .toList();
+      expect(preMigrationRecords, hasLength(6));
+    });
+
+    test('does nothing when only 2 unpinned exist', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      for (var i = 0; i < 2; i++) {
+        final ts = DateTime.utc(2026, 1, 1 + i);
+        final name = '${_ts(ts)}-v$i-v${i + 1}.db';
+        await File(p.join(f.backupsDir, name)).writeAsBytes([i]);
+        await f.prefs.addRecord(
+          BackupRecord(
+            id: 'r$i',
+            filename: name,
+            timestamp: ts,
+            sizeBytes: 1,
+            location: BackupLocation.local,
+            localPath: p.join(f.backupsDir, name),
+            type: BackupType.preMigration,
+            fromSchemaVersion: i,
+            toSchemaVersion: i + 1,
+          ),
+        );
+      }
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'new',
+      );
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final count = f.prefs
+          .getHistory()
+          .where((r) => r.type == BackupType.preMigration)
+          .length;
+      expect(count, 3);
+    });
+
+    test('does not touch manual-backup records', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      for (var i = 0; i < 5; i++) {
+        final name = 'manual-$i.db';
+        await File(p.join(f.backupsDir, name)).writeAsBytes([i]);
+        await f.prefs.addRecord(
+          BackupRecord(
+            id: 'm$i',
+            filename: name,
+            timestamp: DateTime.utc(2026, 1, 1 + i),
+            sizeBytes: 1,
+            location: BackupLocation.local,
+            localPath: p.join(f.backupsDir, name),
+            type: BackupType.manual,
+          ),
+        );
+      }
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 4, 12),
+        idGenerator: () => 'new',
+      );
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final manualCount = f.prefs
+          .getHistory()
+          .where((r) => r.type == BackupType.manual)
+          .length;
+      expect(manualCount, 5);
+    });
+  });
+}
+
+String _ts(DateTime utc) {
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${utc.year}${two(utc.month)}${two(utc.day)}-'
+      '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}';
 }

--- a/test/features/backup/domain/entities/backup_record_test.dart
+++ b/test/features/backup/domain/entities/backup_record_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 
 void main() {
   group('BackupRecord', () {
@@ -131,6 +132,123 @@ void main() {
 
         expect(different, isNot(equals(record)));
       });
+    });
+
+    test('defaults: type is manual, pinned is false, counts may be null', () {
+      final r = BackupRecord(
+        id: 'id',
+        filename: 'f.db',
+        timestamp: DateTime(2026, 4, 12),
+        sizeBytes: 10,
+        location: BackupLocation.local,
+      );
+      expect(r.type, BackupType.manual);
+      expect(r.pinned, false);
+      expect(r.appVersion, isNull);
+      expect(r.fromSchemaVersion, isNull);
+      expect(r.toSchemaVersion, isNull);
+      expect(r.diveCount, isNull);
+      expect(r.siteCount, isNull);
+    });
+
+    test('toJson/fromJson round-trip with new fields populated', () {
+      final original = BackupRecord(
+        id: 'id',
+        filename: 'f.db',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        sizeBytes: 42,
+        location: BackupLocation.local,
+        diveCount: 3,
+        siteCount: 4,
+        type: BackupType.preMigration,
+        appVersion: '1.6.0.1241',
+        fromSchemaVersion: 63,
+        toSchemaVersion: 64,
+        pinned: true,
+        localPath: '/tmp/f.db',
+      );
+      final restored = BackupRecord.fromJson(original.toJson());
+      expect(restored, original);
+    });
+
+    test('fromJson reads legacy records (no type/pinned/appVersion fields)', () {
+      final legacyJson = {
+        'id': 'id',
+        'filename': 'f.db',
+        'timestamp': 1700000000000,
+        'sizeBytes': 42,
+        'location': 'local',
+        'diveCount': 3,
+        'siteCount': 4,
+        'cloudFileId': null,
+        'localPath': '/tmp/f.db',
+        'isAutomatic': false,
+      };
+      final r = BackupRecord.fromJson(legacyJson);
+      expect(r.type, BackupType.manual);
+      expect(r.pinned, false);
+      expect(r.appVersion, isNull);
+      expect(r.fromSchemaVersion, isNull);
+      expect(r.toSchemaVersion, isNull);
+      expect(r.diveCount, 3);
+      expect(r.siteCount, 4);
+    });
+
+    test('fromJson handles null counts for pre-migration records', () {
+      final json = {
+        'id': 'id',
+        'filename': 'f.db',
+        'timestamp': 1700000000000,
+        'sizeBytes': 42,
+        'location': 'local',
+        'diveCount': null,
+        'siteCount': null,
+        'cloudFileId': null,
+        'localPath': '/tmp/f.db',
+        'isAutomatic': true,
+        'type': 'preMigration',
+        'appVersion': '1.6.0.1241',
+        'fromSchemaVersion': 63,
+        'toSchemaVersion': 64,
+        'pinned': true,
+      };
+      final r = BackupRecord.fromJson(json);
+      expect(r.diveCount, isNull);
+      expect(r.siteCount, isNull);
+      expect(r.type, BackupType.preMigration);
+    });
+
+    test('copyWith preserves new fields when not overridden', () {
+      final original = BackupRecord(
+        id: 'id',
+        filename: 'f.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+        type: BackupType.preMigration,
+        pinned: true,
+        fromSchemaVersion: 63,
+        toSchemaVersion: 64,
+      );
+      final copy = original.copyWith(sizeBytes: 2);
+      expect(copy.type, BackupType.preMigration);
+      expect(copy.pinned, true);
+      expect(copy.fromSchemaVersion, 63);
+      expect(copy.toSchemaVersion, 64);
+      expect(copy.sizeBytes, 2);
+    });
+
+    test('copyWith can set pinned independently', () {
+      final original = BackupRecord(
+        id: 'id',
+        filename: 'f.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+        pinned: false,
+      );
+      final pinned = original.copyWith(pinned: true);
+      expect(pinned.pinned, true);
     });
   });
 

--- a/test/features/backup/domain/entities/backup_record_test.dart
+++ b/test/features/backup/domain/entities/backup_record_test.dart
@@ -171,28 +171,31 @@ void main() {
       expect(restored, original);
     });
 
-    test('fromJson reads legacy records (no type/pinned/appVersion fields)', () {
-      final legacyJson = {
-        'id': 'id',
-        'filename': 'f.db',
-        'timestamp': 1700000000000,
-        'sizeBytes': 42,
-        'location': 'local',
-        'diveCount': 3,
-        'siteCount': 4,
-        'cloudFileId': null,
-        'localPath': '/tmp/f.db',
-        'isAutomatic': false,
-      };
-      final r = BackupRecord.fromJson(legacyJson);
-      expect(r.type, BackupType.manual);
-      expect(r.pinned, false);
-      expect(r.appVersion, isNull);
-      expect(r.fromSchemaVersion, isNull);
-      expect(r.toSchemaVersion, isNull);
-      expect(r.diveCount, 3);
-      expect(r.siteCount, 4);
-    });
+    test(
+      'fromJson reads legacy records (no type/pinned/appVersion fields)',
+      () {
+        final legacyJson = {
+          'id': 'id',
+          'filename': 'f.db',
+          'timestamp': 1700000000000,
+          'sizeBytes': 42,
+          'location': 'local',
+          'diveCount': 3,
+          'siteCount': 4,
+          'cloudFileId': null,
+          'localPath': '/tmp/f.db',
+          'isAutomatic': false,
+        };
+        final r = BackupRecord.fromJson(legacyJson);
+        expect(r.type, BackupType.manual);
+        expect(r.pinned, false);
+        expect(r.appVersion, isNull);
+        expect(r.fromSchemaVersion, isNull);
+        expect(r.toSchemaVersion, isNull);
+        expect(r.diveCount, 3);
+        expect(r.siteCount, 4);
+      },
+    );
 
     test('fromJson handles null counts for pre-migration records', () {
       final json = {

--- a/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+++ b/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
+
+void main() {
+  group('BackupFailedException.fromError', () {
+    test('classifies ENOSPC (28) as diskFull', () {
+      final fse = FileSystemException(
+        'copy failed',
+        '/tmp/f.db',
+        const OSError('No space left on device', 28),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.diskFull);
+      expect(e.userMessage, contains('disk space'));
+    });
+
+    test('classifies EACCES (13) as permissionDenied', () {
+      final fse = FileSystemException(
+        'open failed',
+        '/tmp/f.db',
+        const OSError('Permission denied', 13),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.permissionDenied);
+      expect(e.userMessage, contains('access'));
+    });
+
+    test('classifies EPERM (1) as permissionDenied', () {
+      final fse = FileSystemException(
+        'open failed',
+        '/tmp/f.db',
+        const OSError('Operation not permitted', 1),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.permissionDenied);
+    });
+
+    test('wraps unclassified errors as unknown', () {
+      final err = StateError('something odd');
+      final e = BackupFailedException.fromError(err, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.unknown);
+      expect(e.technicalDetails, contains('something odd'));
+    });
+
+    test('preserves original error in technicalDetails', () {
+      final fse = FileSystemException(
+        'copy failed',
+        '/tmp/f.db',
+        const OSError('No space left on device', 28),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.technicalDetails, contains('No space left on device'));
+    });
+  });
+
+  test('sourceMissing is constructible directly', () {
+    final e = BackupFailedException(
+      cause: BackupFailureCause.sourceMissing,
+      userMessage: 'Dive log file not found.',
+      technicalDetails: 'file /tmp/f.db does not exist',
+    );
+    expect(e.cause, BackupFailureCause.sourceMissing);
+  });
+}

--- a/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+++ b/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
@@ -142,4 +142,15 @@ void main() {
     );
     expect(e.cause, BackupFailureCause.sourceMissing);
   });
+
+  test('toString embeds cause and user message for logs', () {
+    const e = BackupFailedException(
+      cause: BackupFailureCause.diskFull,
+      userMessage: 'Disk is full.',
+      technicalDetails: 'ENOSPC',
+    );
+    final s = e.toString();
+    expect(s, contains('BackupFailureCause.diskFull'));
+    expect(s, contains('Disk is full.'));
+  });
 }

--- a/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+++ b/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
@@ -6,10 +6,10 @@ import 'package:submersion/features/backup/domain/exceptions/backup_failed_excep
 void main() {
   group('BackupFailedException.fromError', () {
     test('classifies ENOSPC (28) as diskFull', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'copy failed',
         '/tmp/f.db',
-        const OSError('No space left on device', 28),
+        OSError('No space left on device', 28),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.diskFull);
@@ -17,10 +17,10 @@ void main() {
     });
 
     test('classifies EACCES (13) as permissionDenied', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'open failed',
         '/tmp/f.db',
-        const OSError('Permission denied', 13),
+        OSError('Permission denied', 13),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.permissionDenied);
@@ -28,10 +28,10 @@ void main() {
     });
 
     test('classifies EPERM (1) as permissionDenied', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'open failed',
         '/tmp/f.db',
-        const OSError('Operation not permitted', 1),
+        OSError('Operation not permitted', 1),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.permissionDenied);
@@ -45,77 +45,77 @@ void main() {
     });
 
     test('preserves original error in technicalDetails', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'copy failed',
         '/tmp/f.db',
-        const OSError('No space left on device', 28),
+        OSError('No space left on device', 28),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.technicalDetails, contains('No space left on device'));
     });
 
     test('classifies Win32 ERROR_DISK_FULL (112) as diskFull', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'copy failed',
         'C:\\Users\\x\\f.db',
-        const OSError('There is not enough space on the disk.', 112),
+        OSError('There is not enough space on the disk.', 112),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.diskFull);
     });
 
     test('classifies Win32 ERROR_HANDLE_DISK_FULL (39) as diskFull', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'copy failed',
         'C:\\Users\\x\\f.db',
-        const OSError('The disk is full.', 39),
+        OSError('The disk is full.', 39),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.diskFull);
     });
 
     test('classifies Win32 ERROR_ACCESS_DENIED (5) as permissionDenied', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'open failed',
         'C:\\Users\\x\\f.db',
-        const OSError('Access is denied.', 5),
+        OSError('Access is denied.', 5),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.permissionDenied);
     });
 
     test('classifies ENOENT (2) as sourceMissing on POSIX', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'open failed',
         '/tmp/f.db',
-        const OSError('No such file or directory', 2),
+        OSError('No such file or directory', 2),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.sourceMissing);
     });
 
     test('classifies Win32 ERROR_FILE_NOT_FOUND (2) as sourceMissing', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'open failed',
         'C:\\Users\\x\\f.db',
-        const OSError('The system cannot find the file specified.', 2),
+        OSError('The system cannot find the file specified.', 2),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.sourceMissing);
     });
 
     test('classifies Win32 ERROR_PATH_NOT_FOUND (3) as sourceMissing', () {
-      final fse = FileSystemException(
+      const fse = FileSystemException(
         'open failed',
         'C:\\Users\\x\\f.db',
-        const OSError('The system cannot find the path specified.', 3),
+        OSError('The system cannot find the path specified.', 3),
       );
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.sourceMissing);
     });
 
     test('FileSystemException with null osError falls through to unknown', () {
-      final fse = FileSystemException('some error', '/tmp/f.db');
+      const fse = FileSystemException('some error', '/tmp/f.db');
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.cause, BackupFailureCause.unknown);
     });
@@ -135,7 +135,7 @@ void main() {
   });
 
   test('sourceMissing is constructible directly', () {
-    final e = BackupFailedException(
+    const e = BackupFailedException(
       cause: BackupFailureCause.sourceMissing,
       userMessage: 'Dive log file not found.',
       technicalDetails: 'file /tmp/f.db does not exist',

--- a/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+++ b/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
@@ -11,7 +11,11 @@ void main() {
         '/tmp/f.db',
         OSError('No space left on device', 28),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: false,
+      );
       expect(e.cause, BackupFailureCause.diskFull);
       expect(e.userMessage, contains('disk space'));
     });
@@ -22,7 +26,11 @@ void main() {
         '/tmp/f.db',
         OSError('Permission denied', 13),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: false,
+      );
       expect(e.cause, BackupFailureCause.permissionDenied);
       expect(e.userMessage, contains('access'));
     });
@@ -33,7 +41,11 @@ void main() {
         '/tmp/f.db',
         OSError('Operation not permitted', 1),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: false,
+      );
       expect(e.cause, BackupFailureCause.permissionDenied);
     });
 
@@ -50,7 +62,11 @@ void main() {
         '/tmp/f.db',
         OSError('No space left on device', 28),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: false,
+      );
       expect(e.technicalDetails, contains('No space left on device'));
     });
 
@@ -60,7 +76,11 @@ void main() {
         'C:\\Users\\x\\f.db',
         OSError('There is not enough space on the disk.', 112),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: true,
+      );
       expect(e.cause, BackupFailureCause.diskFull);
     });
 
@@ -70,7 +90,11 @@ void main() {
         'C:\\Users\\x\\f.db',
         OSError('The disk is full.', 39),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: true,
+      );
       expect(e.cause, BackupFailureCause.diskFull);
     });
 
@@ -80,7 +104,11 @@ void main() {
         'C:\\Users\\x\\f.db',
         OSError('Access is denied.', 5),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: true,
+      );
       expect(e.cause, BackupFailureCause.permissionDenied);
     });
 
@@ -90,7 +118,11 @@ void main() {
         '/tmp/f.db',
         OSError('No such file or directory', 2),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: false,
+      );
       expect(e.cause, BackupFailureCause.sourceMissing);
     });
 
@@ -100,7 +132,11 @@ void main() {
         'C:\\Users\\x\\f.db',
         OSError('The system cannot find the file specified.', 2),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: true,
+      );
       expect(e.cause, BackupFailureCause.sourceMissing);
     });
 
@@ -110,9 +146,66 @@ void main() {
         'C:\\Users\\x\\f.db',
         OSError('The system cannot find the path specified.', 3),
       );
-      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      final e = BackupFailedException.fromError(
+        fse,
+        StackTrace.empty,
+        debugIsWindows: true,
+      );
       expect(e.cause, BackupFailureCause.sourceMissing);
     });
+
+    test(
+      'POSIX EIO (5) on non-Windows is NOT misclassified as permissionDenied',
+      () {
+        const fse = FileSystemException(
+          'read failed',
+          '/tmp/f.db',
+          OSError('Input/output error', 5),
+        );
+        final e = BackupFailedException.fromError(
+          fse,
+          StackTrace.empty,
+          debugIsWindows: false,
+        );
+        // EIO is not in the POSIX classifier table → falls through to unknown,
+        // does not leak Win32 ERROR_ACCESS_DENIED guidance.
+        expect(e.cause, BackupFailureCause.unknown);
+      },
+    );
+
+    test(
+      'POSIX ENOTEMPTY (39) on non-Windows is NOT misclassified as diskFull',
+      () {
+        const fse = FileSystemException(
+          'rmdir failed',
+          '/tmp/dir',
+          OSError('Directory not empty', 39),
+        );
+        final e = BackupFailedException.fromError(
+          fse,
+          StackTrace.empty,
+          debugIsWindows: false,
+        );
+        expect(e.cause, BackupFailureCause.unknown);
+      },
+    );
+
+    test(
+      'POSIX EHOSTDOWN (112) on non-Windows is NOT misclassified as diskFull',
+      () {
+        const fse = FileSystemException(
+          'net op failed',
+          '/tmp/f.db',
+          OSError('Host is down', 112),
+        );
+        final e = BackupFailedException.fromError(
+          fse,
+          StackTrace.empty,
+          debugIsWindows: false,
+        );
+        expect(e.cause, BackupFailureCause.unknown);
+      },
+    );
 
     test('FileSystemException with null osError falls through to unknown', () {
       const fse = FileSystemException('some error', '/tmp/f.db');

--- a/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
+++ b/test/features/backup/domain/exceptions/backup_failed_exception_test.dart
@@ -53,6 +53,85 @@ void main() {
       final e = BackupFailedException.fromError(fse, StackTrace.empty);
       expect(e.technicalDetails, contains('No space left on device'));
     });
+
+    test('classifies Win32 ERROR_DISK_FULL (112) as diskFull', () {
+      final fse = FileSystemException(
+        'copy failed',
+        'C:\\Users\\x\\f.db',
+        const OSError('There is not enough space on the disk.', 112),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.diskFull);
+    });
+
+    test('classifies Win32 ERROR_HANDLE_DISK_FULL (39) as diskFull', () {
+      final fse = FileSystemException(
+        'copy failed',
+        'C:\\Users\\x\\f.db',
+        const OSError('The disk is full.', 39),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.diskFull);
+    });
+
+    test('classifies Win32 ERROR_ACCESS_DENIED (5) as permissionDenied', () {
+      final fse = FileSystemException(
+        'open failed',
+        'C:\\Users\\x\\f.db',
+        const OSError('Access is denied.', 5),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.permissionDenied);
+    });
+
+    test('classifies ENOENT (2) as sourceMissing on POSIX', () {
+      final fse = FileSystemException(
+        'open failed',
+        '/tmp/f.db',
+        const OSError('No such file or directory', 2),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.sourceMissing);
+    });
+
+    test('classifies Win32 ERROR_FILE_NOT_FOUND (2) as sourceMissing', () {
+      final fse = FileSystemException(
+        'open failed',
+        'C:\\Users\\x\\f.db',
+        const OSError('The system cannot find the file specified.', 2),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.sourceMissing);
+    });
+
+    test('classifies Win32 ERROR_PATH_NOT_FOUND (3) as sourceMissing', () {
+      final fse = FileSystemException(
+        'open failed',
+        'C:\\Users\\x\\f.db',
+        const OSError('The system cannot find the path specified.', 3),
+      );
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.sourceMissing);
+    });
+
+    test('FileSystemException with null osError falls through to unknown', () {
+      final fse = FileSystemException('some error', '/tmp/f.db');
+      final e = BackupFailedException.fromError(fse, StackTrace.empty);
+      expect(e.cause, BackupFailureCause.unknown);
+    });
+
+    test('unknown userMessage does not embed raw error.toString()', () {
+      final err = StateError('internal detail with /tmp/path/file.db');
+      final e = BackupFailedException.fromError(err, StackTrace.empty);
+      // User message must not leak raw error details
+      expect(e.userMessage, isNot(contains('/tmp/path/file.db')));
+      expect(e.userMessage, isNot(contains('internal detail')));
+      // But technical details must preserve them
+      expect(
+        e.technicalDetails,
+        contains('internal detail with /tmp/path/file.db'),
+      );
+    });
   });
 
   test('sourceMissing is constructible directly', () {

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -132,6 +132,29 @@ void main() {
       expect(preMig.type == BackupType.preMigration, isTrue);
       expect(manual.type == BackupType.preMigration, isFalse);
     });
+
+    test(
+      'preMigration record without schema versions fails badge render gate',
+      () {
+        final incomplete = BackupRecord(
+          id: 'pre-incomplete',
+          filename: 'pre.db',
+          timestamp: _kNow,
+          sizeBytes: 512,
+          location: BackupLocation.local,
+          type: BackupType.preMigration,
+        );
+
+        // Badge is rendered only when all three conditions hold:
+        //   type == preMigration AND fromSchemaVersion != null AND
+        //   toSchemaVersion != null.
+        final shouldRenderBadge =
+            incomplete.type == BackupType.preMigration &&
+            incomplete.fromSchemaVersion != null &&
+            incomplete.toSchemaVersion != null;
+        expect(shouldRenderBadge, isFalse);
+      },
+    );
   });
 }
 

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -1,9 +1,22 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/presentation/pages/backup_settings_page.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/backup/presentation/widgets/backup_history_tile.dart';
+import 'package:submersion/features/backup/presentation/widgets/pre_migration_badge.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 
 void main() {
   // ---------------------------------------------------------------------------
@@ -156,7 +169,149 @@ void main() {
       },
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // BackupSettingsPage integration — pin toggle success + error paths
+  // ---------------------------------------------------------------------------
+  group('BackupSettingsPage pin toggle', () {
+    late Directory tempDir;
+    late SharedPreferences prefs;
+    late BackupPreferences backupPrefs;
+    late BackupRecord seededRecord;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('bsp_test_');
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      backupPrefs = BackupPreferences(prefs);
+      seededRecord = BackupRecord(
+        id: 'rec-1',
+        filename: 'manual.db',
+        timestamp: _kNow,
+        sizeBytes: 2048,
+        location: BackupLocation.local,
+        localPath: '${tempDir.path}/manual.db',
+        diveCount: 0,
+        siteCount: 0,
+      );
+      await backupPrefs.addRecord(seededRecord);
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    Widget buildApp(BackupService service) {
+      return ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          backupServiceProvider.overrideWithValue(service),
+          cloudStorageProviderProvider.overrideWithValue(null),
+          backupHistoryProvider.overrideWith(
+            (ref) async => backupPrefs.getHistory(),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: BackupSettingsPage(),
+        ),
+      );
+    }
+
+    testWidgets('tapping outlined pin flips record to pinned', (tester) async {
+      final service = BackupService(
+        dbAdapter: _FakeBackupDatabaseAdapter(),
+        preferences: backupPrefs,
+        cloudProvider: null,
+      );
+
+      await tester.pumpWidget(buildApp(service));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BackupHistoryTile), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.push_pin_outlined));
+      await tester.pumpAndSettle();
+
+      expect(backupPrefs.getHistory().single.pinned, isTrue);
+    });
+
+    testWidgets('tapping filled pin flips pinned record back to unpinned', (
+      tester,
+    ) async {
+      // Seed as already pinned
+      await backupPrefs.updateRecord(seededRecord.copyWith(pinned: true));
+
+      final service = BackupService(
+        dbAdapter: _FakeBackupDatabaseAdapter(),
+        preferences: backupPrefs,
+        cloudProvider: null,
+      );
+
+      await tester.pumpWidget(buildApp(service));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.push_pin));
+      await tester.pumpAndSettle();
+
+      expect(backupPrefs.getHistory().single.pinned, isFalse);
+    });
+
+    testWidgets('pin failure shows SnackBar with user-facing message', (
+      tester,
+    ) async {
+      final service = _ThrowingPinBackupService(
+        dbAdapter: _FakeBackupDatabaseAdapter(),
+        preferences: backupPrefs,
+      );
+
+      await tester.pumpWidget(buildApp(service));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.push_pin_outlined));
+      await tester.pump(); // let snackbar enter
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      // Pin state did not change: error path kept the record unpinned.
+      expect(backupPrefs.getHistory().single.pinned, isFalse);
+    });
+  });
 }
 
 // Fixed timestamp used across tests.
 final _kNow = DateTime(2024, 6, 1, 12, 0, 0);
+
+/// Minimal BackupDatabaseAdapter fake — unused methods throw loud errors.
+class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
+  @override
+  Future<void> backup(String destinationPath) async =>
+      throw UnimplementedError('not used');
+
+  @override
+  Future<void> restore(String backupPath) async =>
+      throw UnimplementedError('not used');
+
+  @override
+  Future<String> get databasePath async => '/fake/db/path';
+
+  @override
+  AppDatabase get database =>
+      throw UnimplementedError('Fake does not support direct queries');
+}
+
+/// BackupService override that throws on pin/unpin to exercise the error path.
+class _ThrowingPinBackupService extends BackupService {
+  _ThrowingPinBackupService({
+    required super.dbAdapter,
+    required super.preferences,
+  });
+
+  @override
+  Future<void> pinBackup(String id) async =>
+      throw StateError('simulated pin failure');
+
+  @override
+  Future<void> unpinBackup(String id) async =>
+      throw StateError('simulated unpin failure');
+}

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/presentation/pages/backup_settings_page.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // PreMigrationBadge widget tests
+  // ---------------------------------------------------------------------------
+  group('PreMigrationBadge', () {
+    testWidgets('shows v63 → v64 text for schema versions 63 and 64', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PreMigrationBadge(fromVersion: 63, toVersion: 64),
+          ),
+        ),
+      );
+
+      // The badge renders "v63 → v64" (arrow is U+2192)
+      expect(find.text('v63 \u2192 v64'), findsOneWidget);
+    });
+
+    testWidgets('shows correct versions for different schema pair', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PreMigrationBadge(fromVersion: 10, toVersion: 11),
+          ),
+        ),
+      );
+
+      expect(find.text('v10 \u2192 v11'), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pin icon rendering tests — pump minimal widgets that mirror the tile logic
+  // ---------------------------------------------------------------------------
+  group('Pin icon rendering', () {
+    /// Builds a widget that renders the pin icon the same way _buildHistoryTile
+    /// does, so we can assert filled vs outlined.
+    Widget buildPinIcon(bool pinned) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Icon(pinned ? Icons.push_pin : Icons.push_pin_outlined),
+        ),
+      );
+    }
+
+    testWidgets('pinned record shows filled push_pin icon', (tester) async {
+      await tester.pumpWidget(buildPinIcon(true));
+
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.icon, Icons.push_pin);
+    });
+
+    testWidgets('unpinned record shows push_pin_outlined icon', (tester) async {
+      await tester.pumpWidget(buildPinIcon(false));
+
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.icon, Icons.push_pin_outlined);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // BackupRecord entity tests — badge visibility logic
+  // ---------------------------------------------------------------------------
+  group('BackupRecord badge visibility', () {
+    test('preMigration record has correct type and schema versions', () {
+      final record = BackupRecord(
+        id: 'pre-1',
+        filename: 'pre_migration.db',
+        timestamp: _kNow,
+        sizeBytes: 1024,
+        location: BackupLocation.local,
+        type: BackupType.preMigration,
+        fromSchemaVersion: 63,
+        toSchemaVersion: 64,
+        pinned: true,
+      );
+
+      expect(record.type, BackupType.preMigration);
+      expect(record.fromSchemaVersion, 63);
+      expect(record.toSchemaVersion, 64);
+      expect(record.pinned, isTrue);
+    });
+
+    test('manual record has type manual and no schema versions', () {
+      final record = BackupRecord(
+        id: 'manual-1',
+        filename: 'manual.db',
+        timestamp: _kNow,
+        sizeBytes: 2048,
+        location: BackupLocation.local,
+        pinned: false,
+      );
+
+      expect(record.type, BackupType.manual);
+      expect(record.fromSchemaVersion, isNull);
+      expect(record.toSchemaVersion, isNull);
+      expect(record.pinned, isFalse);
+    });
+
+    test('only preMigration type triggers badge condition', () {
+      final preMig = BackupRecord(
+        id: 'pre-1',
+        filename: 'pre.db',
+        timestamp: _kNow,
+        sizeBytes: 512,
+        location: BackupLocation.local,
+        type: BackupType.preMigration,
+        fromSchemaVersion: 63,
+        toSchemaVersion: 64,
+      );
+
+      final manual = BackupRecord(
+        id: 'man-1',
+        filename: 'man.db',
+        timestamp: _kNow,
+        sizeBytes: 512,
+        location: BackupLocation.local,
+      );
+
+      // The page shows the badge when type == BackupType.preMigration
+      expect(preMig.type == BackupType.preMigration, isTrue);
+      expect(manual.type == BackupType.preMigration, isFalse);
+    });
+  });
+}
+
+// Fixed timestamp used across tests.
+final _kNow = DateTime(2024, 6, 1, 12, 0, 0);

--- a/test/features/backup/presentation/widgets/backup_history_tile_test.dart
+++ b/test/features/backup/presentation/widgets/backup_history_tile_test.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/presentation/widgets/backup_history_tile.dart';
+import 'package:submersion/features/backup/presentation/widgets/pre_migration_badge.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+BackupRecord _manual({
+  bool pinned = false,
+  bool isAutomatic = false,
+  int? diveCount = 5,
+  int? siteCount = 3,
+}) {
+  return BackupRecord(
+    id: 'm',
+    filename: 'manual.db',
+    timestamp: DateTime(2026, 4, 12, 8, 12),
+    sizeBytes: 2048,
+    location: BackupLocation.local,
+    localPath: '/tmp/manual.db',
+    pinned: pinned,
+    isAutomatic: isAutomatic,
+    diveCount: diveCount,
+    siteCount: siteCount,
+  );
+}
+
+BackupRecord _preMigration({
+  int? fromVersion = 63,
+  int? toVersion = 64,
+  bool pinned = false,
+}) {
+  return BackupRecord(
+    id: 'pre',
+    filename: 'pre.db',
+    timestamp: DateTime(2026, 4, 12, 8, 12),
+    sizeBytes: 4096,
+    location: BackupLocation.local,
+    localPath: '/tmp/pre.db',
+    type: BackupType.preMigration,
+    appVersion: '1.5.9.1000',
+    fromSchemaVersion: fromVersion,
+    toSchemaVersion: toVersion,
+    pinned: pinned,
+  );
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  group('BackupHistoryTile rendering', () {
+    testWidgets('manual record shows dive/site counts + optional (auto)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(isAutomatic: true),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining('5 dives, 3 sites'), findsOneWidget);
+      expect(find.textContaining(' (auto)'), findsOneWidget);
+      expect(find.byIcon(Icons.phone_android), findsOneWidget);
+    });
+
+    testWidgets('manual record without isAutomatic omits (auto) suffix', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(isAutomatic: false),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining(' (auto)'), findsNothing);
+    });
+
+    testWidgets('manual record null counts render as 0 dives, 0 sites', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(diveCount: null, siteCount: null),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining('0 dives, 0 sites'), findsOneWidget);
+    });
+
+    testWidgets(
+      'preMigration record shows badge + pre-migration subtitle copy',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            BackupHistoryTile(
+              record: _preMigration(),
+              leadingIcon: Icons.phone_android,
+              onPinToggle: () {},
+              onRestore: () {},
+              onDelete: () {},
+            ),
+          ),
+        );
+        expect(find.byType(PreMigrationBadge), findsOneWidget);
+        expect(find.text('v63 \u2192 v64'), findsOneWidget);
+        expect(find.textContaining('Pre-migration backup'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'preMigration record with null schema versions hides the badge',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            BackupHistoryTile(
+              record: _preMigration(fromVersion: null, toVersion: null),
+              leadingIcon: Icons.phone_android,
+              onPinToggle: () {},
+              onRestore: () {},
+              onDelete: () {},
+            ),
+          ),
+        );
+        expect(find.byType(PreMigrationBadge), findsNothing);
+        expect(find.textContaining('Pre-migration backup'), findsOneWidget);
+      },
+    );
+
+    testWidgets('cloud leading icon is rendered', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(),
+            leadingIcon: Icons.cloud,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.cloud), findsOneWidget);
+    });
+  });
+
+  group('BackupHistoryTile pin control', () {
+    testWidgets('unpinned record shows outlined pin icon + Pin tooltip', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      expect(
+        find.widgetWithIcon(IconButton, Icons.push_pin_outlined),
+        findsOneWidget,
+      );
+      final button = tester.widget<IconButton>(
+        find.widgetWithIcon(IconButton, Icons.push_pin_outlined),
+      );
+      expect(button.tooltip, 'Pin backup');
+    });
+
+    testWidgets('pinned record shows filled pin icon + Unpin tooltip', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(pinned: true),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      final button = tester.widget<IconButton>(
+        find.widgetWithIcon(IconButton, Icons.push_pin),
+      );
+      expect(button.tooltip, 'Unpin backup');
+    });
+
+    testWidgets('tapping pin icon invokes onPinToggle', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () => taps++,
+            onRestore: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      await tester.tap(find.byIcon(Icons.push_pin_outlined));
+      await tester.pump();
+      expect(taps, 1);
+    });
+  });
+
+  group('BackupHistoryTile popup menu', () {
+    testWidgets('Restore menu item invokes onRestore', (tester) async {
+      var restores = 0;
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () => restores++,
+            onDelete: () {},
+          ),
+        ),
+      );
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.restore));
+      await tester.pumpAndSettle();
+      expect(restores, 1);
+    });
+
+    testWidgets('Delete menu item invokes onDelete', (tester) async {
+      var deletes = 0;
+      await tester.pumpWidget(
+        _wrap(
+          BackupHistoryTile(
+            record: _manual(),
+            leadingIcon: Icons.phone_android,
+            onPinToggle: () {},
+            onRestore: () {},
+            onDelete: () => deletes++,
+          ),
+        ),
+      );
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pumpAndSettle();
+      expect(deletes, 1);
+    });
+  });
+}

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -81,6 +81,30 @@ void main() {
     expect(find.text('Restore anyway'), findsNothing);
   });
 
+  testWidgets('metadata incomplete: null schema versions — only Cancel', (
+    tester,
+  ) async {
+    final incomplete = BackupRecord(
+      id: 'incomplete',
+      filename: 'pre.db',
+      timestamp: DateTime(2026, 4, 12, 8, 12),
+      sizeBytes: 1024,
+      location: BackupLocation.local,
+      localPath: '/tmp/pre.db',
+      type: BackupType.preMigration,
+      appVersion: '1.5.9.1000',
+    );
+    await tester.pumpWidget(
+      _wrap(
+        RestoreConfirmationDialog(record: incomplete, currentSchemaVersion: 64),
+      ),
+    );
+    expect(find.textContaining('metadata is incomplete'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+    expect(find.text('Restore'), findsNothing);
+    expect(find.text('Restore anyway'), findsNothing);
+  });
+
   testWidgets('manual record uses existing l10n-based dialog behaviour', (
     tester,
   ) async {

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -105,6 +105,107 @@ void main() {
     expect(find.text('Restore anyway'), findsNothing);
   });
 
+  group('show() static + button dismissal', () {
+    Future<bool?> openAndTap(
+      WidgetTester tester,
+      BackupRecord record,
+      int currentSchemaVersion,
+      String buttonText,
+    ) async {
+      bool? result;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (ctx) => TextButton(
+                onPressed: () async {
+                  result = await RestoreConfirmationDialog.show(
+                    ctx,
+                    record,
+                    currentSchemaVersion: currentSchemaVersion,
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(buttonText));
+      await tester.pumpAndSettle();
+      return result;
+    }
+
+    testWidgets('green path Restore returns true', (tester) async {
+      final result = await openAndTap(
+        tester,
+        _preMigration(fromVersion: 63, toVersion: 64),
+        63,
+        'Restore',
+      );
+      expect(result, isTrue);
+    });
+
+    testWidgets('green path Cancel returns false', (tester) async {
+      final result = await openAndTap(
+        tester,
+        _preMigration(fromVersion: 63, toVersion: 64),
+        63,
+        'Cancel',
+      );
+      expect(result, isFalse);
+    });
+
+    testWidgets('warning path Restore anyway returns true', (tester) async {
+      final result = await openAndTap(
+        tester,
+        _preMigration(fromVersion: 63, toVersion: 64),
+        64,
+        'Restore anyway',
+      );
+      expect(result, isTrue);
+    });
+
+    testWidgets('warning path Cancel returns false', (tester) async {
+      final result = await openAndTap(
+        tester,
+        _preMigration(fromVersion: 63, toVersion: 64),
+        64,
+        'Cancel',
+      );
+      expect(result, isFalse);
+    });
+
+    testWidgets('hard-block path Cancel returns false', (tester) async {
+      final result = await openAndTap(
+        tester,
+        _preMigration(fromVersion: 65, toVersion: 66),
+        64,
+        'Cancel',
+      );
+      expect(result, isFalse);
+    });
+
+    testWidgets('metadata-incomplete Cancel returns false', (tester) async {
+      final incomplete = BackupRecord(
+        id: 'inc',
+        filename: 'pre.db',
+        timestamp: DateTime(2026, 4, 12),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+        localPath: '/tmp/pre.db',
+        type: BackupType.preMigration,
+        appVersion: '1.0.0.0',
+      );
+      final result = await openAndTap(tester, incomplete, 64, 'Cancel');
+      expect(result, isFalse);
+    });
+  });
+
   testWidgets('manual record uses existing l10n-based dialog behaviour', (
     tester,
   ) async {

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -47,7 +47,7 @@ void main() {
     expect(find.text('Restore'), findsOneWidget);
     expect(find.text('Restore anyway'), findsNothing);
     expect(find.textContaining('will re-run'), findsNothing);
-    expect(find.textContaining('app version matches'), findsOneWidget);
+    expect(find.textContaining('database schema matches'), findsOneWidget);
   });
 
   testWidgets('warning path: current > from — Restore anyway + warning text', (

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+BackupRecord _preMigration({
+  required int fromVersion,
+  required int toVersion,
+  String appVersion = '1.5.9.1000',
+}) {
+  return BackupRecord(
+    id: 'r',
+    filename: 'pre.db',
+    timestamp: DateTime(2026, 4, 12, 8, 12),
+    sizeBytes: 1024,
+    location: BackupLocation.local,
+    localPath: '/tmp/pre.db',
+    type: BackupType.preMigration,
+    appVersion: appVersion,
+    fromSchemaVersion: fromVersion,
+    toSchemaVersion: toVersion,
+  );
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  testWidgets('green path: current == from — Restore button, no warning text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        RestoreConfirmationDialog(
+          record: _preMigration(fromVersion: 63, toVersion: 64),
+          currentSchemaVersion: 63,
+        ),
+      ),
+    );
+    expect(find.text('Restore'), findsOneWidget);
+    expect(find.text('Restore anyway'), findsNothing);
+    expect(find.textContaining('will re-run'), findsNothing);
+    expect(find.textContaining('app version matches'), findsOneWidget);
+  });
+
+  testWidgets('warning path: current > from — Restore anyway + warning text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        RestoreConfirmationDialog(
+          record: _preMigration(fromVersion: 63, toVersion: 64),
+          currentSchemaVersion: 64,
+        ),
+      ),
+    );
+    expect(find.textContaining('will re-run'), findsOneWidget);
+    expect(find.text('Restore anyway'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('hard block: current < from — only Cancel', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        RestoreConfirmationDialog(
+          record: _preMigration(fromVersion: 65, toVersion: 66),
+          currentSchemaVersion: 64,
+        ),
+      ),
+    );
+    expect(find.textContaining('newer than your app'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+    expect(find.text('Restore'), findsNothing);
+    expect(find.text('Restore anyway'), findsNothing);
+  });
+
+  testWidgets('manual record uses existing l10n-based dialog behaviour', (
+    tester,
+  ) async {
+    final manual = BackupRecord(
+      id: 'm',
+      filename: 'm.db',
+      timestamp: DateTime(2026, 4, 12),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+      localPath: '/tmp/m.db',
+      diveCount: 3,
+      siteCount: 4,
+    );
+    await tester.pumpWidget(
+      _wrap(
+        RestoreConfirmationDialog(record: manual, currentSchemaVersion: 64),
+      ),
+    );
+    expect(find.textContaining('will re-run'), findsNothing);
+    expect(find.textContaining('newer than your app'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Adds an automatic backup of `submersion.db` whenever a Drift schema migration
is pending at app startup. Hard-fails startup if the backup cannot be created
so users never run a risky migration without a safety net. Pre-migration
backups appear alongside manual backups in the existing Backup History list
with a `v63 → v64` badge and can be pinned to exempt them from retention.

Design: `docs/superpowers/specs/2026-04-12-db-backup-before-migration-design.md`
Plan: `docs/superpowers/plans/2026-04-12-db-backup-before-migration.md`

## Changes

- New `PreMigrationBackupService` runs between the schema-version probe and
  `DatabaseService.initialize()`. Copies the closed `.db` file atomically
  (write-temp + rename), registers via existing `BackupPreferences`, sweeps
  stale `.tmp` files, prunes old pre-migration records (keeps 3 newest
  unpinned; pinned exempt).
- `BackupService.pruneOldBackups` now filters to `manual && !pinned` —
  pre-migration safety snapshots and any pinned record are never auto-pruned.
- Error classification for `FileSystemException` maps both POSIX
  (ENOSPC/EACCES/EPERM/ENOENT) and Win32 (112/39/5/2/3) error codes to
  user-facing messages. `unknown` fallback does not leak raw `toString()`
  into user copy; details preserved in `technicalDetails` for support.
- New startup states `backingUp` + `backupFailed` with extracted
  `BackingUpView` / `BackupFailedView` widgets. Retry guard prevents
  re-entrance on rapid taps; Quit honors platform exit semantics and
  existing `closeAppOverride` test seam.
- `RestoreConfirmationDialog` gains compat branching for pre-migration
  backups: green (app version matches → safe restore), warning (would
  re-run the same migration that motivated the backup → destructive
  button styling), hard-block (backup from a newer app → only Cancel).
- `BackupRecord` extended with nullable `type`, `appVersion`,
  `fromSchemaVersion`, `toSchemaVersion`, `pinned`; `diveCount` /
  `siteCount` made nullable for pre-migration records. JSON is
  backward-compatible — records written before this change still load.
- Backup list UI: pin/unpin icon on every row (pinned rows render in
  primary theme color); pre-migration rows show a `v63 → v64` badge.

## Test Plan

- [x] `flutter test` passes (6445 tests passed, 7 skipped)
- [x] `flutter analyze` clean
- [x] Manual testing on macOS — verified migration-pending startup flow
      shows "Backing up your data" → migration progress → normal app,
      backup file + registry entry appear with correct `v63 → v64`
      badge, pin toggle works and persists across restarts.

## Known follow-ups (not in this PR)

- L10n migration for hardcoded English strings in new widgets
  (`BackingUpView`, `BackupFailedView`, pre-migration restore dialog,
  pin tooltip, badge). Matches the existing mixed-l10n pattern for
  recently added features.
- Stronger delete confirmation for pinned records.
- Optional user-configurable retention count (currently N=3 constant).