### PR TITLE
feat: store raw dive data from dive computers (#176)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -3059,27 +3059,115 @@ class AppDatabase extends _$AppDatabase {
         }
         if (from < 65) await reportProgress();
         if (from < 66) {
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN raw_data BLOB',
-          );
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN raw_fingerprint BLOB',
-          );
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN descriptor_vendor TEXT',
-          );
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN descriptor_product TEXT',
-          );
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN descriptor_model INTEGER',
-          );
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN libdivecomputer_version TEXT',
-          );
-          await customStatement(
-            'ALTER TABLE dive_data_sources ADD COLUMN last_parsed_at INTEGER',
-          );
+          // Guard: dive_data_sources may not exist in older migration tests.
+          final ddsColumns = await customSelect(
+            "PRAGMA table_info('dive_data_sources')",
+          ).get();
+          if (ddsColumns.isNotEmpty) {
+            final existing = ddsColumns
+                .map((c) => c.read<String>('name'))
+                .toSet();
+            if (!existing.contains('raw_data')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN raw_data BLOB',
+              );
+            }
+            if (!existing.contains('raw_fingerprint')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN raw_fingerprint BLOB',
+              );
+            }
+            if (!existing.contains('descriptor_vendor')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN descriptor_vendor TEXT',
+              );
+            }
+            if (!existing.contains('descriptor_product')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN descriptor_product TEXT',
+              );
+            }
+            if (!existing.contains('descriptor_model')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN descriptor_model INTEGER',
+              );
+            }
+            if (!existing.contains('libdivecomputer_version')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN libdivecomputer_version TEXT',
+              );
+            }
+            if (!existing.contains('last_parsed_at')) {
+              await customStatement(
+                'ALTER TABLE dive_data_sources ADD COLUMN last_parsed_at INTEGER',
+              );
+            }
+
+            // Rebuild the table to update the computer_id FK from the
+            // original NO ACTION to ON DELETE SET NULL. SQLite cannot
+            // alter constraints in place, so we create → copy → swap.
+            await customStatement('PRAGMA foreign_keys = OFF');
+            await customStatement('''
+              CREATE TABLE dive_data_sources_new (
+                id TEXT NOT NULL PRIMARY KEY,
+                dive_id TEXT NOT NULL REFERENCES dives(id) ON DELETE CASCADE,
+                computer_id TEXT REFERENCES dive_computers(id) ON DELETE SET NULL,
+                is_primary INTEGER NOT NULL DEFAULT 0,
+                computer_model TEXT,
+                computer_serial TEXT,
+                source_format TEXT,
+                source_file_name TEXT,
+                source_file_format TEXT,
+                max_depth REAL,
+                avg_depth REAL,
+                duration INTEGER,
+                water_temp REAL,
+                entry_time INTEGER,
+                exit_time INTEGER,
+                max_ascent_rate REAL,
+                max_descent_rate REAL,
+                surface_interval INTEGER,
+                cns REAL,
+                otu REAL,
+                deco_algorithm TEXT,
+                gradient_factor_low INTEGER,
+                gradient_factor_high INTEGER,
+                imported_at INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                raw_data BLOB,
+                raw_fingerprint BLOB,
+                descriptor_vendor TEXT,
+                descriptor_product TEXT,
+                descriptor_model INTEGER,
+                libdivecomputer_version TEXT,
+                last_parsed_at INTEGER
+              )
+            ''');
+            await customStatement('''
+              INSERT INTO dive_data_sources_new
+              SELECT id, dive_id, computer_id, is_primary,
+                     computer_model, computer_serial, source_format,
+                     source_file_name, source_file_format,
+                     max_depth, avg_depth, duration, water_temp,
+                     entry_time, exit_time, max_ascent_rate, max_descent_rate,
+                     surface_interval, cns, otu, deco_algorithm,
+                     gradient_factor_low, gradient_factor_high,
+                     imported_at, created_at,
+                     raw_data, raw_fingerprint,
+                     descriptor_vendor, descriptor_product, descriptor_model,
+                     libdivecomputer_version, last_parsed_at
+              FROM dive_data_sources
+            ''');
+            await customStatement('DROP TABLE dive_data_sources');
+            await customStatement(
+              'ALTER TABLE dive_data_sources_new RENAME TO dive_data_sources',
+            );
+            await customStatement('''
+              CREATE INDEX IF NOT EXISTS idx_dive_data_sources_dive_id
+              ON dive_data_sources(dive_id)
+            ''');
+            await customStatement('PRAGMA foreign_keys = ON');
+          }
         }
         if (from < 66) await reportProgress();
       },

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -949,8 +949,11 @@ class DiveDataSources extends Table {
   TextColumn get id => text()();
   TextColumn get diveId =>
       text().references(Dives, #id, onDelete: KeyAction.cascade)();
-  TextColumn get computerId =>
-      text().nullable().references(DiveComputers, #id)();
+  TextColumn get computerId => text().nullable().references(
+    DiveComputers,
+    #id,
+    onDelete: KeyAction.setNull,
+  )();
   BoolColumn get isPrimary => boolean().withDefault(const Constant(false))();
   TextColumn get computerModel => text().nullable()();
   TextColumn get computerSerial => text().nullable()();
@@ -973,6 +976,13 @@ class DiveDataSources extends Table {
   IntColumn get gradientFactorHigh => integer().nullable()();
   DateTimeColumn get importedAt => dateTime()();
   DateTimeColumn get createdAt => dateTime()();
+  BlobColumn get rawData => blob().nullable()();
+  BlobColumn get rawFingerprint => blob().nullable()();
+  TextColumn get descriptorVendor => text().nullable()();
+  TextColumn get descriptorProduct => text().nullable()();
+  IntColumn get descriptorModel => integer().nullable()();
+  TextColumn get libdivecomputerVersion => text().nullable()();
+  DateTimeColumn get lastParsedAt => dateTime().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -1309,7 +1319,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 65;
+  static const int currentSchemaVersion = 66;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1378,6 +1388,7 @@ class AppDatabase extends _$AppDatabase {
     63,
     64,
     65,
+    66,
   ];
 
   /// Returns the number of migration steps that will execute when upgrading
@@ -3047,6 +3058,30 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 65) await reportProgress();
+        if (from < 66) {
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN raw_data BLOB',
+          );
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN raw_fingerprint BLOB',
+          );
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN descriptor_vendor TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN descriptor_product TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN descriptor_model INTEGER',
+          );
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN libdivecomputer_version TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE dive_data_sources ADD COLUMN last_parsed_at INTEGER',
+          );
+        }
+        if (from < 66) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -430,6 +430,21 @@ class DiveComparisonCard extends ConsumerWidget {
       );
     }
 
+    if (showAction(DuplicateAction.replaceSource)) {
+      buttons.add(
+        _ActionButton(
+          label: context.l10n.universalImport_label_replaceSource,
+          subtitle: context.l10n.universalImport_label_replaceSourceSubtitle,
+          onPressed: callbackFor(DuplicateAction.replaceSource, null),
+          style: styleFor(
+            DuplicateAction.replaceSource,
+            _ActionButtonStyle.outlined,
+          ),
+          color: colorFor(DuplicateAction.replaceSource),
+        ),
+      );
+    }
+
     if (showAction(DuplicateAction.consolidate)) {
       buttons.add(
         _ActionButton(

--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -392,6 +392,7 @@ class DiveComparisonCard extends ConsumerWidget {
         DuplicateAction.skip => colorScheme.error,
         DuplicateAction.importAsNew => Colors.green,
         DuplicateAction.consolidate => colorScheme.primary,
+        DuplicateAction.replaceSource => Colors.orange,
       };
     }
 

--- a/lib/core/presentation/widgets/overlaid_profile_chart.dart
+++ b/lib/core/presentation/widgets/overlaid_profile_chart.dart
@@ -163,27 +163,24 @@ class _OverlaidProfileChartState extends State<OverlaidProfileChart> {
         // Legend with checkboxes
         Padding(
           padding: const EdgeInsets.only(top: 4),
-          child: Row(
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 4,
             children: [
-              if (widget.existingProfile.isNotEmpty) ...[
+              if (widget.existingProfile.isNotEmpty)
                 _LegendCheckbox(
                   color: _existingColor,
                   label: 'Existing: ${widget.existingLabel ?? "Unknown"}',
                   checked: !existingHidden,
                   onTap: () => _toggleSeries(_existingKey),
                 ),
-              ],
-              if (widget.existingProfile.isNotEmpty &&
-                  widget.incomingProfile.isNotEmpty)
-                const SizedBox(width: 12),
-              if (widget.incomingProfile.isNotEmpty) ...[
+              if (widget.incomingProfile.isNotEmpty)
                 _LegendCheckbox(
                   color: _incomingColor,
                   label: 'Incoming: ${widget.incomingLabel ?? "Unknown"}',
                   checked: !incomingHidden,
                   onTap: () => _toggleSeries(_incomingKey),
                 ),
-              ],
             ],
           ),
         ),

--- a/lib/features/dive_computer/data/services/dive_import_service.dart
+++ b/lib/features/dive_computer/data/services/dive_import_service.dart
@@ -511,7 +511,10 @@ class DiveImportService {
     );
   }
 
-  /// Update an existing dive with downloaded data.
+  /// Replace an existing dive's source data with a fresh download.
+  ///
+  /// Clears the old profile and data source rows for this computer, then
+  /// re-imports so the new raw bytes and parsed data are stored.
   Future<void> _updateExistingDive(
     DownloadedDive dive,
     String existingDiveId,
@@ -521,24 +524,26 @@ class DiveImportService {
     int? descriptorModel,
     String? libdivecomputerVersion,
   }) async {
-    // Parse profile data
-    final profilePoints = _parser.parseProfile(dive);
+    // Remove the existing profile + source row so importProfile won't
+    // short-circuit on the "already exists" check.
+    await _repository.clearSourceAndProfiles(
+      diveId: existingDiveId,
+      computerId: computerId,
+    );
 
-    // Convert events to EventData
+    final profilePoints = _parser.parseProfile(dive);
     final events = _convertEvents(dive.events);
 
-    // Clear existing profile for this computer and add new one
-    // Note: This is a simplified implementation
-    // A full implementation would update dive metadata as well
-
-    // Import the profile (will associate with existing dive)
+    // Re-import using the existing dive's start time so that importProfile
+    // matches it back to the same dive row.
     await _repository.importProfile(
       computerId: computerId,
       profileStartTime: dive.startTime,
       points: profilePoints,
       durationSeconds: dive.durationSeconds,
       maxDepth: dive.maxDepth,
-      isPrimary: false, // Keep existing primary
+      avgDepth: dive.avgDepth,
+      isPrimary: true,
       decoAlgorithm: dive.decoAlgorithm,
       gfLow: dive.gfLow,
       gfHigh: dive.gfHigh,

--- a/lib/features/dive_computer/data/services/dive_import_service.dart
+++ b/lib/features/dive_computer/data/services/dive_import_service.dart
@@ -221,13 +221,6 @@ class DiveImportService {
   final DiveRepository? _diveRepository;
   final DiveParser _parser;
 
-  /// Session-level descriptor fields set by the adapter before import.
-  /// These are written onto each [DiveDataSources] row created during import.
-  String? descriptorVendor;
-  String? descriptorProduct;
-  int? descriptorModel;
-  String? libdivecomputerVersion;
-
   DiveImportService({
     required DiveComputerRepository repository,
     DiveRepository? diveRepository,
@@ -253,6 +246,10 @@ class DiveImportService {
     ImportMode mode = ImportMode.newOnly,
     ConflictResolution defaultResolution = ConflictResolution.skip,
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) async {
     int imported = 0;
     int skipped = 0;
@@ -302,6 +299,10 @@ class DiveImportService {
                 dive,
                 duplicateResult.matchingDiveId!,
                 computer.id,
+                descriptorVendor: descriptorVendor,
+                descriptorProduct: descriptorProduct,
+                descriptorModel: descriptorModel,
+                libdivecomputerVersion: libdivecomputerVersion,
               );
               updated++;
             } else {
@@ -313,6 +314,10 @@ class DiveImportService {
                 computer.id,
                 diverId,
                 forceNew: true,
+                descriptorVendor: descriptorVendor,
+                descriptorProduct: descriptorProduct,
+                descriptorModel: descriptorModel,
+                libdivecomputerVersion: libdivecomputerVersion,
               );
               importedDiveIds.add(diveId);
               importedDives.add(dive);
@@ -324,6 +329,10 @@ class DiveImportService {
               dive,
               duplicateResult.matchingDiveId!,
               computer.id,
+              descriptorVendor: descriptorVendor,
+              descriptorProduct: descriptorProduct,
+              descriptorModel: descriptorModel,
+              libdivecomputerVersion: libdivecomputerVersion,
             );
             updated++;
           } else {
@@ -334,6 +343,10 @@ class DiveImportService {
               computer.id,
               diverId,
               forceNew: true,
+              descriptorVendor: descriptorVendor,
+              descriptorProduct: descriptorProduct,
+              descriptorModel: descriptorModel,
+              libdivecomputerVersion: libdivecomputerVersion,
             );
             importedDiveIds.add(diveId);
             importedDives.add(dive);
@@ -341,7 +354,15 @@ class DiveImportService {
           }
         } else {
           // No duplicate - import as new
-          final diveId = await _importNewDive(dive, computer.id, diverId);
+          final diveId = await _importNewDive(
+            dive,
+            computer.id,
+            diverId,
+            descriptorVendor: descriptorVendor,
+            descriptorProduct: descriptorProduct,
+            descriptorModel: descriptorModel,
+            libdivecomputerVersion: libdivecomputerVersion,
+          );
           importedDiveIds.add(diveId);
           importedDives.add(dive);
           imported++;
@@ -413,6 +434,10 @@ class DiveImportService {
     String computerId,
     String? diverId, {
     bool forceNew = false,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) async {
     // Calculate chronological dive number
     int? diveNumber;
@@ -469,16 +494,33 @@ class DiveImportService {
     DownloadedDive dive, {
     required String computerId,
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) async {
-    return _importNewDive(dive, computerId, diverId, forceNew: true);
+    return _importNewDive(
+      dive,
+      computerId,
+      diverId,
+      forceNew: true,
+      descriptorVendor: descriptorVendor,
+      descriptorProduct: descriptorProduct,
+      descriptorModel: descriptorModel,
+      libdivecomputerVersion: libdivecomputerVersion,
+    );
   }
 
   /// Update an existing dive with downloaded data.
   Future<void> _updateExistingDive(
     DownloadedDive dive,
     String existingDiveId,
-    String computerId,
-  ) async {
+    String computerId, {
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
+  }) async {
     // Parse profile data
     final profilePoints = _parser.parseProfile(dive);
 
@@ -502,6 +544,12 @@ class DiveImportService {
       gfHigh: dive.gfHigh,
       decoConservatism: dive.decoConservatism,
       events: events,
+      rawData: dive.rawData,
+      rawFingerprint: dive.rawFingerprint,
+      descriptorVendor: descriptorVendor,
+      descriptorProduct: descriptorProduct,
+      descriptorModel: descriptorModel,
+      libdivecomputerVersion: libdivecomputerVersion,
     );
   }
 
@@ -511,6 +559,10 @@ class DiveImportService {
     ConflictResolution resolution,
     String computerId, {
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) async {
     conflict.resolution = resolution;
 
@@ -523,11 +575,23 @@ class DiveImportService {
           conflict.downloaded,
           conflict.existingDiveId,
           computerId,
+          descriptorVendor: descriptorVendor,
+          descriptorProduct: descriptorProduct,
+          descriptorModel: descriptorModel,
+          libdivecomputerVersion: libdivecomputerVersion,
         );
         return conflict.existingDiveId;
 
       case ConflictResolution.importAsNew:
-        return await _importNewDive(conflict.downloaded, computerId, diverId);
+        return await _importNewDive(
+          conflict.downloaded,
+          computerId,
+          diverId,
+          descriptorVendor: descriptorVendor,
+          descriptorProduct: descriptorProduct,
+          descriptorModel: descriptorModel,
+          libdivecomputerVersion: libdivecomputerVersion,
+        );
 
       case ConflictResolution.askUser:
         // This shouldn't be called with askUser

--- a/lib/features/dive_computer/data/services/dive_import_service.dart
+++ b/lib/features/dive_computer/data/services/dive_import_service.dart
@@ -12,8 +12,8 @@ enum ImportMode {
   /// Import all dives, skipping exact duplicates
   all,
 
-  /// Replace existing dives with downloaded versions
-  replace,
+  /// Replace existing dive's source data with the downloaded version
+  replaceSource,
 }
 
 /// How to resolve conflicts when a duplicate is detected.
@@ -21,8 +21,8 @@ enum ConflictResolution {
   /// Skip the downloaded dive, keep the existing one
   skip,
 
-  /// Replace the existing dive with the downloaded one
-  replace,
+  /// Replace the existing dive's source data with the downloaded version
+  replaceSource,
 
   /// Import as a new dive (creates duplicate)
   importAsNew,
@@ -221,6 +221,13 @@ class DiveImportService {
   final DiveRepository? _diveRepository;
   final DiveParser _parser;
 
+  /// Session-level descriptor fields set by the adapter before import.
+  /// These are written onto each [DiveDataSources] row created during import.
+  String? descriptorVendor;
+  String? descriptorProduct;
+  int? descriptorModel;
+  String? libdivecomputerVersion;
+
   DiveImportService({
     required DiveComputerRepository repository,
     DiveRepository? diveRepository,
@@ -289,7 +296,7 @@ class DiveImportService {
                   confidence: duplicateResult.confidence,
                 ),
               );
-            } else if (defaultResolution == ConflictResolution.replace) {
+            } else if (defaultResolution == ConflictResolution.replaceSource) {
               // Update existing dive
               await _updateExistingDive(
                 dive,
@@ -311,7 +318,7 @@ class DiveImportService {
               importedDives.add(dive);
               imported++;
             }
-          } else if (mode == ImportMode.replace) {
+          } else if (mode == ImportMode.replaceSource) {
             // Replace existing
             await _updateExistingDive(
               dive,
@@ -443,6 +450,12 @@ class DiveImportService {
       events: events,
       diveNumber: diveNumber,
       forceNew: forceNew,
+      rawData: dive.rawData,
+      rawFingerprint: dive.rawFingerprint,
+      descriptorVendor: descriptorVendor,
+      descriptorProduct: descriptorProduct,
+      descriptorModel: descriptorModel,
+      libdivecomputerVersion: libdivecomputerVersion,
     );
 
     return diveId;
@@ -505,7 +518,7 @@ class DiveImportService {
       case ConflictResolution.skip:
         return null;
 
-      case ConflictResolution.replace:
+      case ConflictResolution.replaceSource:
         await _updateExistingDive(
           conflict.downloaded,
           conflict.existingDiveId,

--- a/lib/features/dive_computer/data/services/parsed_dive_mapper.dart
+++ b/lib/features/dive_computer/data/services/parsed_dive_mapper.dart
@@ -86,5 +86,7 @@ DownloadedDive parsedDiveToDownloaded(pigeon.ParsedDive parsed) {
           ),
         )
         .toList(),
+    rawData: parsed.rawData,
+    rawFingerprint: parsed.rawFingerprint,
   );
 }

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:drift/drift.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
 import 'package:uuid/uuid.dart';

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -79,18 +79,31 @@ class ReparseService {
       // 5. Replace DiveProfileEvents, GasSwitches, TankPressureProfiles
       //    These tables have no computerId column, so delete by diveId.
       // ------------------------------------------------------------------
-      await (db.delete(
-        db.diveProfileEvents,
-      )..where((t) => t.diveId.equals(diveId))).go();
-      await (db.delete(
-        db.gasSwitches,
-      )..where((t) => t.diveId.equals(diveId))).go();
-      await (db.delete(
-        db.tankPressureProfiles,
-      )..where((t) => t.diveId.equals(diveId))).go();
 
-      // Re-insert events from parsed data
-      await _insertEvents(diveId: diveId, parsed: parsed, now: now);
+      // Check if this is a multi-source dive
+      final sourceRows = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      final isMultiSource = sourceRows.length > 1;
+
+      // Only replace events/switches/pressure for single-source dives.
+      // Multi-source dives skip this to avoid destroying data from other
+      // sources (these tables lack a computerId column for per-source
+      // scoping).
+      if (!isMultiSource) {
+        await (db.delete(
+          db.diveProfileEvents,
+        )..where((t) => t.diveId.equals(diveId))).go();
+        await (db.delete(
+          db.gasSwitches,
+        )..where((t) => t.diveId.equals(diveId))).go();
+        await (db.delete(
+          db.tankPressureProfiles,
+        )..where((t) => t.diveId.equals(diveId))).go();
+
+        // Re-insert events from parsed data
+        await _insertEvents(diveId: diveId, parsed: parsed, now: now);
+      }
 
       // ------------------------------------------------------------------
       // 6. DiveTanks carry-over
@@ -134,6 +147,25 @@ class ReparseService {
         )
         .getSingle();
     return (result.data['cnt'] as int) > 0;
+  }
+
+  /// Get all DiveDataSources rows with raw data for a given computer.
+  Future<List<DiveDataSourcesData>> getSourcesForComputerReparse(
+    String computerId,
+  ) async {
+    return (db.select(db.diveDataSources)..where(
+          (t) => t.computerId.equals(computerId) & t.rawData.isNotNull(),
+        ))
+        .get();
+  }
+
+  /// Get all DiveDataSources rows with raw data for a given dive.
+  Future<List<DiveDataSourcesData>> getSourcesForDiveReparse(
+    String diveId,
+  ) async {
+    return (db.select(
+      db.diveDataSources,
+    )..where((t) => t.diveId.equals(diveId) & t.rawData.isNotNull())).get();
   }
 
   // ==========================================================================
@@ -194,6 +226,8 @@ class ReparseService {
       parsed.dateTimeSecond,
     );
     final diveDateTimeMs = diveDateTime.millisecondsSinceEpoch;
+    final exitTimeMs = diveDateTimeMs + (parsed.durationSeconds * 1000);
+    final bottomTimeSeconds = _calculateBottomTimeFromSamples(parsed.samples);
 
     await (db.update(db.dives)..where((t) => t.id.equals(diveId))).write(
       DivesCompanion(
@@ -203,6 +237,9 @@ class ReparseService {
         ),
         runtime: Value(parsed.durationSeconds),
         diveDateTime: Value(diveDateTimeMs),
+        entryTime: Value(diveDateTimeMs),
+        exitTime: Value(exitTimeMs),
+        bottomTime: Value(bottomTimeSeconds ?? parsed.durationSeconds),
         waterTemp: Value(parsed.minTemperatureCelsius),
         diveMode: Value(_mapDiveMode(parsed.diveMode)),
         cnsEnd: Value(_extractMaxCns(parsed.samples)),
@@ -373,6 +410,57 @@ class ReparseService {
   // ==========================================================================
   // Static helpers
   // ==========================================================================
+
+  /// Calculate bottom time from profile samples using the 85% depth threshold.
+  ///
+  /// Mirrors the logic in DiveComputerRepositoryImpl._calculateBottomTimeFromPoints:
+  /// bottom time = time between first sample at 85% of max depth and the last
+  /// sample at that depth. Returns null if insufficient data.
+  static int? _calculateBottomTimeFromSamples(
+    List<pigeon.ProfileSample> samples, {
+    double depthThresholdPercent = 0.85,
+  }) {
+    if (samples.length < 3) return null;
+
+    final sorted = List<pigeon.ProfileSample>.from(samples)
+      ..sort((a, b) => a.timeSeconds.compareTo(b.timeSeconds));
+
+    double maxDepth = 0;
+    for (final s in sorted) {
+      if (s.depthMeters > maxDepth) {
+        maxDepth = s.depthMeters;
+      }
+    }
+
+    if (maxDepth <= 0) return null;
+
+    final bottomThreshold = maxDepth * depthThresholdPercent;
+
+    // First sample at or above threshold = descent end
+    int? descentEndTimestamp;
+    for (final s in sorted) {
+      if (s.depthMeters >= bottomThreshold) {
+        descentEndTimestamp = s.timeSeconds;
+        break;
+      }
+    }
+
+    // Last sample at or above threshold = ascent start
+    int? ascentStartTimestamp;
+    for (int i = sorted.length - 1; i >= 0; i--) {
+      if (sorted[i].depthMeters >= bottomThreshold) {
+        ascentStartTimestamp = sorted[i].timeSeconds;
+        break;
+      }
+    }
+
+    if (descentEndTimestamp == null || ascentStartTimestamp == null) {
+      return null;
+    }
+    if (ascentStartTimestamp <= descentEndTimestamp) return null;
+
+    return ascentStartTimestamp - descentEndTimestamp;
+  }
 
   /// Map dive mode strings from libdivecomputer to the app's enum values.
   static String _mapDiveMode(String? mode) {

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -172,6 +172,108 @@ class ReparseService {
     )..where((t) => t.diveId.equals(diveId) & t.rawData.isNotNull())).get();
   }
 
+  /// Re-parse all sources with raw data for a given computer.
+  ///
+  /// [parseFn] is the function that calls the native Pigeon API to parse raw
+  /// bytes. Accepting it as a parameter makes this method testable without
+  /// requiring a live native bridge.
+  ///
+  /// Returns a record with the count of succeeded and failed re-parses.
+  Future<({int succeeded, int failed})> reparseAllForComputer(
+    String computerId, {
+    required Future<pigeon.ParsedDive> Function(
+      String vendor,
+      String product,
+      int model,
+      Uint8List rawData,
+    )
+    parseFn,
+  }) async {
+    final sources = await getSourcesForComputerReparse(computerId);
+
+    int succeeded = 0;
+    int failed = 0;
+
+    for (final source in sources) {
+      if (source.descriptorVendor == null ||
+          source.descriptorProduct == null ||
+          source.descriptorModel == null) {
+        failed++;
+        continue;
+      }
+      try {
+        final parsed = await parseFn(
+          source.descriptorVendor!,
+          source.descriptorProduct!,
+          source.descriptorModel!,
+          source.rawData!,
+        );
+        await applyParsedUpdate(
+          diveId: source.diveId,
+          sourceRowId: source.id,
+          parsed: parsed,
+          descriptorVendor: source.descriptorVendor,
+          descriptorProduct: source.descriptorProduct,
+          descriptorModel: source.descriptorModel,
+          libdivecomputerVersion: source.libdivecomputerVersion,
+        );
+        succeeded++;
+      } catch (e) {
+        failed++;
+      }
+    }
+
+    return (succeeded: succeeded, failed: failed);
+  }
+
+  /// Re-parse all sources with raw data for a single dive.
+  ///
+  /// [parseFn] is the function that calls the native Pigeon API.
+  ///
+  /// Returns a list of error messages (empty on full success).
+  Future<List<String>> reparseDive(
+    String diveId, {
+    required Future<pigeon.ParsedDive> Function(
+      String vendor,
+      String product,
+      int model,
+      Uint8List rawData,
+    )
+    parseFn,
+  }) async {
+    final sources = await getSourcesForDiveReparse(diveId);
+    final errors = <String>[];
+
+    for (final source in sources) {
+      if (source.descriptorVendor == null ||
+          source.descriptorProduct == null ||
+          source.descriptorModel == null) {
+        continue;
+      }
+      try {
+        final parsed = await parseFn(
+          source.descriptorVendor!,
+          source.descriptorProduct!,
+          source.descriptorModel!,
+          source.rawData!,
+        );
+        await applyParsedUpdate(
+          diveId: diveId,
+          sourceRowId: source.id,
+          parsed: parsed,
+          descriptorVendor: source.descriptorVendor,
+          descriptorProduct: source.descriptorProduct,
+          descriptorModel: source.descriptorModel,
+          libdivecomputerVersion: source.libdivecomputerVersion,
+        );
+      } catch (e) {
+        errors.add(e.toString());
+      }
+    }
+
+    return errors;
+  }
+
   // ==========================================================================
   // Private helpers
   // ==========================================================================

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -106,9 +106,13 @@ class ReparseService {
       }
 
       // ------------------------------------------------------------------
-      // 6. DiveTanks carry-over
+      // 6. DiveTanks carry-over (primary + single-source only)
+      //    dive_tanks has no computerId, so skip for non-primary or
+      //    multi-source dives to avoid overwriting data from other sources.
       // ------------------------------------------------------------------
-      await _carryOverTanks(diveId: diveId, parsed: parsed);
+      if (sourceRow.isPrimary && !isMultiSource) {
+        await _carryOverTanks(diveId: diveId, parsed: parsed);
+      }
     });
   }
 

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -1,0 +1,445 @@
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/database/database.dart';
+
+/// Service responsible for applying re-parsed dive computer data back to the
+/// database while respecting the computer-authored vs user-authored field
+/// boundary.
+///
+/// This is the single point where the allowlist is enforced. Both the
+/// `replaceSource` path and the manual re-parse path call through here.
+class ReparseService {
+  final AppDatabase db;
+  final _uuid = const Uuid();
+
+  ReparseService({required this.db});
+
+  /// Apply a freshly parsed dive to the database, updating only
+  /// computer-authored fields and preserving user-authored fields.
+  ///
+  /// [rawData] and [rawFingerprint] use `Value.absent()` when null to avoid
+  /// overwriting existing blobs during the re-parse path.
+  Future<void> applyParsedUpdate({
+    required String diveId,
+    required String sourceRowId,
+    required pigeon.ParsedDive parsed,
+    required String? descriptorVendor,
+    required String? descriptorProduct,
+    required int? descriptorModel,
+    required String? libdivecomputerVersion,
+    Uint8List? rawData,
+    Uint8List? rawFingerprint,
+  }) async {
+    await db.transaction(() async {
+      final now = DateTime.now();
+
+      // ------------------------------------------------------------------
+      // 1. Update DiveDataSources snapshot fields
+      // ------------------------------------------------------------------
+      await (_updateSourceRow(
+        sourceRowId: sourceRowId,
+        parsed: parsed,
+        descriptorVendor: descriptorVendor,
+        descriptorProduct: descriptorProduct,
+        descriptorModel: descriptorModel,
+        libdivecomputerVersion: libdivecomputerVersion,
+        rawData: rawData,
+        rawFingerprint: rawFingerprint,
+        now: now,
+      ));
+
+      // ------------------------------------------------------------------
+      // 2. Check isPrimary -- only update Dives row if the source is primary
+      // ------------------------------------------------------------------
+      final sourceRow = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.id.equals(sourceRowId))).getSingle();
+
+      if (sourceRow.isPrimary) {
+        // ----------------------------------------------------------------
+        // 3. Update Dives row (allowlisted columns only)
+        // ----------------------------------------------------------------
+        await _updateDiveRow(diveId: diveId, parsed: parsed, now: now);
+      }
+
+      // ------------------------------------------------------------------
+      // 4. Replace DiveProfiles for this source's computerId
+      // ------------------------------------------------------------------
+      final computerId = sourceRow.computerId;
+      await _replaceDiveProfiles(
+        diveId: diveId,
+        computerId: computerId,
+        parsed: parsed,
+        isPrimary: sourceRow.isPrimary,
+      );
+
+      // ------------------------------------------------------------------
+      // 5. Replace DiveProfileEvents, GasSwitches, TankPressureProfiles
+      //    These tables have no computerId column, so delete by diveId.
+      // ------------------------------------------------------------------
+      await (db.delete(
+        db.diveProfileEvents,
+      )..where((t) => t.diveId.equals(diveId))).go();
+      await (db.delete(
+        db.gasSwitches,
+      )..where((t) => t.diveId.equals(diveId))).go();
+      await (db.delete(
+        db.tankPressureProfiles,
+      )..where((t) => t.diveId.equals(diveId))).go();
+
+      // Re-insert events from parsed data
+      await _insertEvents(diveId: diveId, parsed: parsed, now: now);
+
+      // ------------------------------------------------------------------
+      // 6. DiveTanks carry-over
+      // ------------------------------------------------------------------
+      await _carryOverTanks(diveId: diveId, parsed: parsed);
+    });
+  }
+
+  /// Count how many sources for a given computer have raw data vs not.
+  Future<({int withRawData, int withoutRawData})> getRawDataCounts(
+    String computerId,
+  ) async {
+    final withData = await db
+        .customSelect(
+          'SELECT COUNT(*) AS cnt FROM dive_data_sources '
+          'WHERE computer_id = ? AND raw_data IS NOT NULL',
+          variables: [Variable(computerId)],
+        )
+        .getSingle();
+    final withoutData = await db
+        .customSelect(
+          'SELECT COUNT(*) AS cnt FROM dive_data_sources '
+          'WHERE computer_id = ? AND raw_data IS NULL',
+          variables: [Variable(computerId)],
+        )
+        .getSingle();
+
+    return (
+      withRawData: withData.data['cnt'] as int,
+      withoutRawData: withoutData.data['cnt'] as int,
+    );
+  }
+
+  /// Check whether any DiveDataSources row for a dive has raw data.
+  Future<bool> hasRawData(String diveId) async {
+    final result = await db
+        .customSelect(
+          'SELECT COUNT(*) AS cnt FROM dive_data_sources '
+          'WHERE dive_id = ? AND raw_data IS NOT NULL',
+          variables: [Variable(diveId)],
+        )
+        .getSingle();
+    return (result.data['cnt'] as int) > 0;
+  }
+
+  // ==========================================================================
+  // Private helpers
+  // ==========================================================================
+
+  Future<void> _updateSourceRow({
+    required String sourceRowId,
+    required pigeon.ParsedDive parsed,
+    required String? descriptorVendor,
+    required String? descriptorProduct,
+    required int? descriptorModel,
+    required String? libdivecomputerVersion,
+    required Uint8List? rawData,
+    required Uint8List? rawFingerprint,
+    required DateTime now,
+  }) async {
+    await (db.update(
+      db.diveDataSources,
+    )..where((t) => t.id.equals(sourceRowId))).write(
+      DiveDataSourcesCompanion(
+        maxDepth: Value(parsed.maxDepthMeters),
+        avgDepth: Value(
+          parsed.avgDepthMeters != 0.0 ? parsed.avgDepthMeters : null,
+        ),
+        duration: Value(parsed.durationSeconds),
+        waterTemp: Value(parsed.minTemperatureCelsius),
+        decoAlgorithm: Value(parsed.decoAlgorithm),
+        gradientFactorLow: Value(parsed.gfLow),
+        gradientFactorHigh: Value(parsed.gfHigh),
+        descriptorVendor: Value(descriptorVendor),
+        descriptorProduct: Value(descriptorProduct),
+        descriptorModel: Value(descriptorModel),
+        libdivecomputerVersion: Value(libdivecomputerVersion),
+        lastParsedAt: Value(now),
+        // Only update rawData/rawFingerprint when caller provides non-null
+        // values. Value.absent() tells Drift to leave the column untouched.
+        rawData: rawData != null ? Value(rawData) : const Value.absent(),
+        rawFingerprint: rawFingerprint != null
+            ? Value(rawFingerprint)
+            : const Value.absent(),
+      ),
+    );
+  }
+
+  Future<void> _updateDiveRow({
+    required String diveId,
+    required pigeon.ParsedDive parsed,
+    required DateTime now,
+  }) async {
+    // Build UTC DateTime from parsed components
+    final diveDateTime = DateTime.utc(
+      parsed.dateTimeYear,
+      parsed.dateTimeMonth,
+      parsed.dateTimeDay,
+      parsed.dateTimeHour,
+      parsed.dateTimeMinute,
+      parsed.dateTimeSecond,
+    );
+    final diveDateTimeMs = diveDateTime.millisecondsSinceEpoch;
+
+    await (db.update(db.dives)..where((t) => t.id.equals(diveId))).write(
+      DivesCompanion(
+        maxDepth: Value(parsed.maxDepthMeters),
+        avgDepth: Value(
+          parsed.avgDepthMeters != 0.0 ? parsed.avgDepthMeters : null,
+        ),
+        runtime: Value(parsed.durationSeconds),
+        diveDateTime: Value(diveDateTimeMs),
+        waterTemp: Value(parsed.minTemperatureCelsius),
+        diveMode: Value(_mapDiveMode(parsed.diveMode)),
+        cnsEnd: Value(_extractMaxCns(parsed.samples)),
+        otu: const Value.absent(), // OTU is not directly in ParsedDive
+        gradientFactorLow: Value(parsed.gfLow),
+        gradientFactorHigh: Value(parsed.gfHigh),
+        decoAlgorithm: Value(parsed.decoAlgorithm),
+        decoConservatism: Value(parsed.decoConservatism),
+        updatedAt: Value(now.millisecondsSinceEpoch),
+      ),
+    );
+  }
+
+  Future<void> _replaceDiveProfiles({
+    required String diveId,
+    required String? computerId,
+    required pigeon.ParsedDive parsed,
+    required bool isPrimary,
+  }) async {
+    // Delete existing profiles for this (diveId, computerId)
+    if (computerId != null) {
+      await (db.delete(db.diveProfiles)..where(
+            (t) => t.diveId.equals(diveId) & t.computerId.equals(computerId),
+          ))
+          .go();
+    } else {
+      await (db.delete(
+        db.diveProfiles,
+      )..where((t) => t.diveId.equals(diveId) & t.computerId.isNull())).go();
+    }
+
+    // Re-insert from parsed samples
+    await db.batch((batch) {
+      for (final s in parsed.samples) {
+        batch.insert(
+          db.diveProfiles,
+          DiveProfilesCompanion(
+            id: Value(_uuid.v4()),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            timestamp: Value(s.timeSeconds),
+            depth: Value(s.depthMeters),
+            temperature: Value(s.temperatureCelsius),
+            heartRate: Value(s.heartRate),
+            setpoint: Value(s.setpoint),
+            ppO2: Value(s.ppo2),
+            cns: Value(s.cns),
+            ndl: Value(s.decoType == 0 ? s.decoTime : null),
+            ceiling: Value(
+              s.decoType != null && s.decoType != 0 ? s.decoDepth : null,
+            ),
+            rbt: Value(s.rbt),
+            decoType: Value(s.decoType),
+            tts: Value(s.tts),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<void> _insertEvents({
+    required String diveId,
+    required pigeon.ParsedDive parsed,
+    required DateTime now,
+  }) async {
+    if (parsed.events.isEmpty) return;
+
+    final nowMs = now.millisecondsSinceEpoch;
+
+    await db.batch((batch) {
+      for (final e in parsed.events) {
+        final eventType = _mapEventTypeString(e.type);
+        if (eventType == null) continue;
+
+        batch.insert(
+          db.diveProfileEvents,
+          DiveProfileEventsCompanion(
+            id: Value(_uuid.v4()),
+            diveId: Value(diveId),
+            timestamp: Value(e.timeSeconds),
+            eventType: Value(eventType),
+            severity: Value(_eventSeverity(eventType)),
+            depth: const Value(null),
+            value: Value(
+              e.data != null ? double.tryParse(e.data!['value'] ?? '') : null,
+            ),
+            createdAt: Value(nowMs),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<void> _carryOverTanks({
+    required String diveId,
+    required pigeon.ParsedDive parsed,
+  }) async {
+    // Get existing tanks
+    final existingTanks =
+        await (db.select(db.diveTanks)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+            .get();
+
+    // Build a map of existing tanks by tankOrder
+    final existingByOrder = {for (final t in existingTanks) t.tankOrder: t};
+
+    // Build a set of new tank orders from parsed
+    final newTankOrders = <int>{};
+
+    for (final tank in parsed.tanks) {
+      newTankOrders.add(tank.index);
+
+      // Resolve gas mix
+      final gasMix = parsed.gasMixes.firstWhere(
+        (g) => g.index == tank.gasMixIndex,
+        orElse: () => pigeon.GasMix(index: 0, o2Percent: 21.0, hePercent: 0.0),
+      );
+
+      final existing = existingByOrder[tank.index];
+      if (existing != null) {
+        // Update existing tank: overwrite computer fields, preserve user fields
+        await (db.update(
+          db.diveTanks,
+        )..where((t) => t.id.equals(existing.id))).write(
+          DiveTanksCompanion(
+            volume: Value(tank.volumeLiters),
+            workingPressure: const Value.absent(),
+            startPressure: Value(tank.startPressureBar),
+            endPressure: Value(tank.endPressureBar),
+            o2Percent: Value(gasMix.o2Percent),
+            hePercent: Value(gasMix.hePercent),
+            // tankName, presetName, equipmentId, tankRole, tankMaterial
+            // are user-authored -- NOT touched
+          ),
+        );
+      } else {
+        // New tank: insert with defaults
+        await db
+            .into(db.diveTanks)
+            .insert(
+              DiveTanksCompanion(
+                id: Value(_uuid.v4()),
+                diveId: Value(diveId),
+                volume: Value(tank.volumeLiters),
+                startPressure: Value(tank.startPressureBar),
+                endPressure: Value(tank.endPressureBar),
+                o2Percent: Value(gasMix.o2Percent),
+                hePercent: Value(gasMix.hePercent),
+                tankOrder: Value(tank.index),
+                tankRole: const Value('backGas'),
+              ),
+            );
+      }
+    }
+
+    // Delete tanks that exist in DB but not in parsed
+    for (final existing in existingTanks) {
+      if (!newTankOrders.contains(existing.tankOrder)) {
+        await (db.delete(
+          db.diveTanks,
+        )..where((t) => t.id.equals(existing.id))).go();
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Static helpers
+  // ==========================================================================
+
+  /// Map dive mode strings from libdivecomputer to the app's enum values.
+  static String _mapDiveMode(String? mode) {
+    switch (mode) {
+      case 'open_circuit':
+        return 'oc';
+      case 'ccr':
+        return 'ccr';
+      case 'scr':
+        return 'scr';
+      default:
+        return 'oc';
+    }
+  }
+
+  /// Extract maximum CNS percentage from profile samples.
+  static double? _extractMaxCns(List<pigeon.ProfileSample> samples) {
+    double? maxCns;
+    for (final s in samples) {
+      if (s.cns != null) {
+        maxCns = maxCns == null ? s.cns! : (s.cns! > maxCns ? s.cns! : maxCns);
+      }
+    }
+    return maxCns;
+  }
+
+  /// Map libdivecomputer event type strings to ProfileEventType enum names.
+  static String? _mapEventTypeString(String type) {
+    switch (type) {
+      case 'safetystop':
+      case 'safetystop_voluntary':
+      case 'safetystop_mandatory':
+        return 'safetyStopStart';
+      case 'deco':
+      case 'deepstop':
+        return 'decoStopStart';
+      case 'violation':
+        return 'decoViolation';
+      case 'gaschange':
+      case 'gaschange2':
+        return 'gasSwitch';
+      case 'bookmark':
+        return 'bookmark';
+      case 'ascent':
+        return 'ascentRateWarning';
+      case 'ceiling':
+      case 'ceiling_safetystop':
+        return 'decoViolation';
+      case 'PO2':
+        return 'ppO2High';
+      default:
+        return null;
+    }
+  }
+
+  /// Determine severity for a mapped event type.
+  static String _eventSeverity(String eventType) {
+    switch (eventType) {
+      case 'decoViolation':
+      case 'ppO2High':
+        return 'alert';
+      case 'ascentRateWarning':
+        return 'warning';
+      default:
+        return 'info';
+    }
+  }
+}

--- a/lib/features/dive_computer/domain/entities/downloaded_dive.dart
+++ b/lib/features/dive_computer/domain/entities/downloaded_dive.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 /// Phases of the download process.
 enum DownloadPhase {
   initializing,
@@ -132,6 +134,12 @@ class DownloadedDive {
   /// Dive events from the computer
   final List<DownloadedEvent> events;
 
+  /// Raw dive data bytes from libdivecomputer (for re-parse)
+  final Uint8List? rawData;
+
+  /// Raw fingerprint bytes from libdivecomputer
+  final Uint8List? rawFingerprint;
+
   const DownloadedDive({
     this.diveNumber,
     required this.startTime,
@@ -149,6 +157,8 @@ class DownloadedDive {
     this.gfHigh,
     this.decoConservatism,
     this.events = const [],
+    this.rawData,
+    this.rawFingerprint,
   });
 
   /// Duration as a Duration object

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -317,6 +317,7 @@ class DeviceDetailPage extends ConsumerWidget {
                   data: (c) {
                     if (c.withRawData == 0) return const SizedBox.shrink();
                     return Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
                         const SizedBox(height: 12),
                         OutlinedButton.icon(

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
 import 'package:submersion/l10n/l10n_extension.dart';
 
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -308,6 +311,37 @@ class DeviceDetailPage extends ConsumerWidget {
                 label: Text(context.l10n.diveComputer_detail_reimportAllButton),
               ),
             ],
+            Consumer(
+              builder: (context, ref, _) {
+                final counts = ref.watch(rawDataCountProvider(computer.id));
+                return counts.when(
+                  data: (c) {
+                    if (c.withRawData == 0) return const SizedBox.shrink();
+                    return Column(
+                      children: [
+                        const SizedBox(height: 12),
+                        OutlinedButton.icon(
+                          onPressed: () =>
+                              _confirmReparseAll(context, ref, computer, c),
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('Re-parse all dives'),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            '${c.withRawData} dives with raw data'
+                            '${c.withoutRawData > 0 ? ' (${c.withoutRawData} without)' : ''}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                  loading: () => const SizedBox.shrink(),
+                  error: (err, stack) => const SizedBox.shrink(),
+                );
+              },
+            ),
           ],
         ),
       ),
@@ -389,6 +423,103 @@ class DeviceDetailPage extends ConsumerWidget {
     if (confirmed == true && context.mounted) {
       context.push('/dive-computers/${computer.id}/download?forceFull=true');
     }
+  }
+
+  Future<void> _confirmReparseAll(
+    BuildContext context,
+    WidgetRef ref,
+    DiveComputer computer,
+    ({int withRawData, int withoutRawData}) counts,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Re-parse all dives'),
+        content: Text(
+          'Re-run the dive parser on ${counts.withRawData} dives that have '
+          'stored raw data. This updates profile and sensor data but preserves '
+          'your notes, sites, buddies, and other edits.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Re-parse'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      await _executeReparseAll(context, ref, computer.id);
+    }
+  }
+
+  Future<void> _executeReparseAll(
+    BuildContext context,
+    WidgetRef ref,
+    String computerId,
+  ) async {
+    final service = ref.read(reparseServiceProvider);
+    final db = DatabaseService.instance.database;
+
+    final sources =
+        await (db.select(db.diveDataSources)
+              ..where((t) => t.computerId.equals(computerId))
+              ..where((t) => t.rawData.isNotNull()))
+            .get();
+
+    if (sources.isEmpty) return;
+
+    int succeeded = 0;
+    int failed = 0;
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Re-parsing ${sources.length} dives...')),
+      );
+    }
+
+    for (final source in sources) {
+      try {
+        final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
+          source.descriptorVendor!,
+          source.descriptorProduct!,
+          source.descriptorModel!,
+          source.rawData!,
+        );
+        await service.applyParsedUpdate(
+          diveId: source.diveId,
+          sourceRowId: source.id,
+          parsed: parsed,
+          descriptorVendor: source.descriptorVendor,
+          descriptorProduct: source.descriptorProduct,
+          descriptorModel: source.descriptorModel,
+          libdivecomputerVersion: source.libdivecomputerVersion,
+        );
+        succeeded++;
+      } catch (e) {
+        failed++;
+      }
+    }
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            failed == 0
+                ? 'Re-parsed $succeeded dives successfully'
+                : 'Re-parsed $succeeded of ${succeeded + failed} dives. $failed failed.',
+          ),
+        ),
+      );
+    }
+
+    ref.invalidate(rawDataCountProvider(computerId));
   }
 
   void _handleMenuAction(

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -475,64 +475,35 @@ class DeviceDetailPage extends ConsumerWidget {
     final service = ref.read(reparseServiceProvider);
     final l10n = context.l10n;
 
-    final sources = await service.getSourcesForComputerReparse(computerId);
-
-    if (sources.isEmpty) return;
-
-    int succeeded = 0;
-    int failed = 0;
+    final counts = await service.getRawDataCounts(computerId);
+    if (counts.withRawData == 0) return;
 
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            l10n.diveComputer_detail_reparseAllProgress(sources.length),
+            l10n.diveComputer_detail_reparseAllProgress(counts.withRawData),
           ),
         ),
       );
     }
 
-    for (final source in sources) {
-      if (source.descriptorVendor == null ||
-          source.descriptorProduct == null ||
-          source.descriptorModel == null) {
-        failed++;
-        continue;
-      }
-      try {
-        final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
-          source.descriptorVendor!,
-          source.descriptorProduct!,
-          source.descriptorModel!,
-          source.rawData!,
-        );
-        await service.applyParsedUpdate(
-          diveId: source.diveId,
-          sourceRowId: source.id,
-          parsed: parsed,
-          descriptorVendor: source.descriptorVendor,
-          descriptorProduct: source.descriptorProduct,
-          descriptorModel: source.descriptorModel,
-          libdivecomputerVersion: source.libdivecomputerVersion,
-        );
-        succeeded++;
-      } catch (e) {
-        debugPrint('Re-parse failed for source ${source.id}: $e');
-        failed++;
-      }
-    }
+    final result = await service.reparseAllForComputer(
+      computerId,
+      parseFn: pigeon.DiveComputerHostApi().parseRawDiveData,
+    );
 
     if (context.mounted) {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            failed == 0
-                ? l10n.diveComputer_detail_reparseAllSuccess(succeeded)
+            result.failed == 0
+                ? l10n.diveComputer_detail_reparseAllSuccess(result.succeeded)
                 : l10n.diveComputer_detail_reparseAllPartial(
-                    succeeded,
-                    succeeded + failed,
-                    failed,
+                    result.succeeded,
+                    result.succeeded + result.failed,
+                    result.failed,
                   ),
           ),
         ),

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
@@ -324,13 +323,23 @@ class DeviceDetailPage extends ConsumerWidget {
                           onPressed: () =>
                               _confirmReparseAll(context, ref, computer, c),
                           icon: const Icon(Icons.refresh),
-                          label: const Text('Re-parse all dives'),
+                          label: Text(
+                            context.l10n.diveComputer_detail_reparseAllButton,
+                          ),
                         ),
                         Padding(
                           padding: const EdgeInsets.only(top: 4),
                           child: Text(
-                            '${c.withRawData} dives with raw data'
-                            '${c.withoutRawData > 0 ? ' (${c.withoutRawData} without)' : ''}',
+                            c.withoutRawData > 0
+                                ? context.l10n
+                                      .diveComputer_detail_reparseRawDataCountWithout(
+                                        c.withRawData,
+                                        c.withoutRawData,
+                                      )
+                                : context.l10n
+                                      .diveComputer_detail_reparseRawDataCount(
+                                        c.withRawData,
+                                      ),
                             style: Theme.of(context).textTheme.bodySmall,
                           ),
                         ),
@@ -431,23 +440,22 @@ class DeviceDetailPage extends ConsumerWidget {
     DiveComputer computer,
     ({int withRawData, int withoutRawData}) counts,
   ) async {
+    final l10n = context.l10n;
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Re-parse all dives'),
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.diveComputer_detail_reparseAllTitle),
         content: Text(
-          'Re-run the dive parser on ${counts.withRawData} dives that have '
-          'stored raw data. This updates profile and sensor data but preserves '
-          'your notes, sites, buddies, and other edits.',
+          l10n.diveComputer_detail_reparseAllMessage(counts.withRawData),
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.common_action_cancel),
           ),
           FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Re-parse'),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l10n.common_action_reparse),
           ),
         ],
       ),
@@ -464,13 +472,9 @@ class DeviceDetailPage extends ConsumerWidget {
     String computerId,
   ) async {
     final service = ref.read(reparseServiceProvider);
-    final db = DatabaseService.instance.database;
+    final l10n = context.l10n;
 
-    final sources =
-        await (db.select(db.diveDataSources)
-              ..where((t) => t.computerId.equals(computerId))
-              ..where((t) => t.rawData.isNotNull()))
-            .get();
+    final sources = await service.getSourcesForComputerReparse(computerId);
 
     if (sources.isEmpty) return;
 
@@ -479,11 +483,21 @@ class DeviceDetailPage extends ConsumerWidget {
 
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Re-parsing ${sources.length} dives...')),
+        SnackBar(
+          content: Text(
+            l10n.diveComputer_detail_reparseAllProgress(sources.length),
+          ),
+        ),
       );
     }
 
     for (final source in sources) {
+      if (source.descriptorVendor == null ||
+          source.descriptorProduct == null ||
+          source.descriptorModel == null) {
+        failed++;
+        continue;
+      }
       try {
         final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
           source.descriptorVendor!,
@@ -502,6 +516,7 @@ class DeviceDetailPage extends ConsumerWidget {
         );
         succeeded++;
       } catch (e) {
+        debugPrint('Re-parse failed for source ${source.id}: $e');
         failed++;
       }
     }
@@ -512,8 +527,12 @@ class DeviceDetailPage extends ConsumerWidget {
         SnackBar(
           content: Text(
             failed == 0
-                ? 'Re-parsed $succeeded dives successfully'
-                : 'Re-parsed $succeeded of ${succeeded + failed} dives. $failed failed.',
+                ? l10n.diveComputer_detail_reparseAllSuccess(succeeded)
+                : l10n.diveComputer_detail_reparseAllPartial(
+                    succeeded,
+                    succeeded + failed,
+                    failed,
+                  ),
           ),
         ),
       );

--- a/lib/features/dive_computer/presentation/providers/reparse_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/reparse_providers.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
+
+/// Provider for the [ReparseService] singleton.
+final reparseServiceProvider = Provider<ReparseService>((ref) {
+  final db = DatabaseService.instance.database;
+  return ReparseService(db: db);
+});
+
+/// Provides raw data counts for all dive computer sources matching [computerId].
+///
+/// Returns a record with [withRawData] and [withoutRawData] counts.
+final rawDataCountProvider =
+    FutureProvider.family<({int withRawData, int withoutRawData}), String>((
+      ref,
+      computerId,
+    ) {
+      final service = ref.watch(reparseServiceProvider);
+      return service.getRawDataCounts(computerId);
+    });
+
+/// Returns whether any [DiveDataSources] row for [diveId] has raw data stored.
+final diveHasRawDataProvider = FutureProvider.family<bool, String>((
+  ref,
+  diveId,
+) {
+  final service = ref.watch(reparseServiceProvider);
+  return service.hasRawData(diveId);
+});

--- a/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
+++ b/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
@@ -134,45 +134,34 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
         padding: const EdgeInsets.all(24),
         child: Column(
           children: [
-            // Scrollable content area
+            // Fixed progress area (never scrolls)
+            ExcludeSemantics(
+              child: _buildProgressIndicator(downloadState, colorScheme),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              statusText,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 4),
+            if (showPercent)
+              Text(
+                context.l10n.diveComputer_downloadStep_progressPercent(
+                  (downloadState.progress!.percentage * 100).toStringAsFixed(0),
+                ),
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.primary,
+                ),
+              ),
+            const SizedBox(height: 16),
+
+            // Scrollable dives list (fills remaining space)
             Expanded(
               child: SingleChildScrollView(
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    // Progress indicator
-                    ExcludeSemantics(
-                      child: _buildProgressIndicator(
-                        downloadState,
-                        colorScheme,
-                      ),
-                    ),
-                    const SizedBox(height: 32),
-
-                    // Status text
-                    Text(
-                      statusText,
-                      style: theme.textTheme.titleMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-
-                    // Progress percentage
-                    if (showPercent)
-                      Text(
-                        context.l10n.diveComputer_downloadStep_progressPercent(
-                          (downloadState.progress!.percentage * 100)
-                              .toStringAsFixed(0),
-                        ),
-                        style: theme.textTheme.headlineMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: colorScheme.primary,
-                        ),
-                      ),
-
-                    const SizedBox(height: 32),
-
-                    // Downloaded dives list
                     if (downloadState.downloadedDives.isNotEmpty)
                       _buildDivesList(context, downloadState),
                   ],
@@ -374,17 +363,15 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
               ],
             ),
             const SizedBox(height: 12),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 300),
-              child: ListView.separated(
-                shrinkWrap: true,
-                itemCount: state.downloadedDives.length,
-                separatorBuilder: (_, _) => const Divider(height: 1),
-                itemBuilder: (context, index) {
-                  final dive = state.downloadedDives[index];
-                  return _buildDiveRow(context, dive, theme, colorScheme);
-                },
-              ),
+            ListView.separated(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: state.downloadedDives.length,
+              separatorBuilder: (_, _) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final dive = state.downloadedDives[index];
+                return _buildDiveRow(context, dive, theme, colorScheme);
+              },
             ),
           ],
         ),

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -762,6 +762,26 @@ class DiveComputerRepository {
     }
   }
 
+  /// Remove existing profiles and data source rows for a dive+computer pair.
+  ///
+  /// Used by the replaceSource path so that a subsequent [importProfile] call
+  /// inserts fresh data instead of short-circuiting.
+  Future<void> clearSourceAndProfiles({
+    required String diveId,
+    required String computerId,
+  }) async {
+    // Delete profile points for this computer+dive
+    await _db.customStatement(
+      'DELETE FROM dive_profiles WHERE dive_id = ? AND computer_id = ?',
+      [diveId, computerId],
+    );
+    // Delete the data source row for this computer+dive
+    await _db.customStatement(
+      'DELETE FROM dive_data_sources WHERE dive_id = ? AND computer_id = ?',
+      [diveId, computerId],
+    );
+  }
+
   /// Import a profile and associate it with a dive (creating one if needed).
   ///
   /// Returns the dive ID the profile was associated with.

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -782,6 +782,12 @@ class DiveComputerRepository {
     List<EventData>? events,
     int? diveNumber,
     bool forceNew = false,
+    Uint8List? rawData,
+    Uint8List? rawFingerprint,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) async {
     try {
       _log.info('Importing profile from computer $computerId');
@@ -892,6 +898,13 @@ class DiveComputerRepository {
                 decoAlgorithm: Value(decoAlgorithm),
                 gradientFactorLow: Value(gfLow),
                 gradientFactorHigh: Value(gfHigh),
+                rawData: Value(rawData),
+                rawFingerprint: Value(rawFingerprint),
+                descriptorVendor: Value(descriptorVendor),
+                descriptorProduct: Value(descriptorProduct),
+                descriptorModel: Value(descriptorModel),
+                libdivecomputerVersion: Value(libdivecomputerVersion),
+                lastParsedAt: Value(rawData != null ? DateTime.now() : null),
                 importedAt: nowDt,
                 createdAt: nowDt,
               ),

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -762,14 +762,30 @@ class DiveComputerRepository {
     }
   }
 
-  /// Remove existing profiles and data source rows for a dive+computer pair.
+  /// Remove existing profiles, derived rows, and data source for a
+  /// dive+computer pair.
   ///
   /// Used by the replaceSource path so that a subsequent [importProfile] call
-  /// inserts fresh data instead of short-circuiting.
+  /// inserts fresh data instead of short-circuiting. Also clears per-dive
+  /// derived tables (events, gas switches, tank pressure profiles) that lack
+  /// a computer_id column and would otherwise accumulate stale rows.
   Future<void> clearSourceAndProfiles({
     required String diveId,
     required String computerId,
   }) async {
+    // Delete per-dive derived rows that importProfile will re-create.
+    // These tables lack a computer_id column, so we clear by dive_id.
+    await _db.customStatement(
+      'DELETE FROM dive_profile_events WHERE dive_id = ?',
+      [diveId],
+    );
+    await _db.customStatement(
+      'DELETE FROM tank_pressure_profiles WHERE dive_id = ?',
+      [diveId],
+    );
+    await _db.customStatement('DELETE FROM gas_switches WHERE dive_id = ?', [
+      diveId,
+    ]);
     // Delete profile points for this computer+dive
     await _db.customStatement(
       'DELETE FROM dive_profiles WHERE dive_id = ? AND computer_id = ?',

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -71,9 +71,9 @@ import 'package:submersion/features/signatures/presentation/providers/signature_
 import 'package:submersion/features/signatures/presentation/widgets/signature_capture_widget.dart';
 import 'package:submersion/features/signatures/presentation/widgets/signature_display_widget.dart';
 import 'package:submersion/features/signatures/presentation/widgets/buddy_signatures_section.dart';
-import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
-import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
 import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
 
 /// Calculate normalization factor to align profile-based SAC with tank-based SAC.
@@ -540,11 +540,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 ),
               ),
               if (hasRawData)
-                const PopupMenuItem(
+                PopupMenuItem(
                   value: 'reparse',
                   child: ListTile(
-                    leading: Icon(Icons.refresh),
-                    title: Text('Re-parse raw data'),
+                    leading: const Icon(Icons.refresh),
+                    title: Text(
+                      context.l10n.diveLog_detail_menu_reparseRawData,
+                    ),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
@@ -703,11 +705,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 ),
               ),
               if (hasRawData)
-                const PopupMenuItem(
+                PopupMenuItem(
                   value: 'reparse',
                   child: ListTile(
-                    leading: Icon(Icons.refresh),
-                    title: Text('Re-parse raw data'),
+                    leading: const Icon(Icons.refresh),
+                    title: Text(
+                      context.l10n.diveLog_detail_menu_reparseRawData,
+                    ),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
@@ -4602,18 +4606,19 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     Dive dive,
   ) async {
     final service = ref.read(reparseServiceProvider);
-    final db = DatabaseService.instance.database;
+    final l10n = context.l10n;
 
-    final sources =
-        await (db.select(db.diveDataSources)
-              ..where((t) => t.diveId.equals(dive.id))
-              ..where((t) => t.rawData.isNotNull()))
-            .get();
+    final sources = await service.getSourcesForDiveReparse(dive.id);
 
     if (sources.isEmpty) return;
 
     try {
       for (final source in sources) {
+        if (source.descriptorVendor == null ||
+            source.descriptorProduct == null ||
+            source.descriptorModel == null) {
+          continue;
+        }
         final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
           source.descriptorVendor!,
           source.descriptorProduct!,
@@ -4632,14 +4637,16 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       }
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Dive re-parsed successfully')),
+          SnackBar(content: Text(l10n.diveLog_detail_reparseSuccess)),
         );
       }
     } catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Re-parse failed: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.diveLog_detail_reparseFailed(e.toString())),
+          ),
+        );
       }
     }
   }

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -4613,6 +4613,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       parseFn: pigeon.DiveComputerHostApi().parseRawDiveData,
     );
 
+    // Invalidate providers so the UI reflects the re-parsed data.
+    ref.invalidate(diveProvider(dive.id));
+    ref.invalidate(diveProfileProvider(dive.id));
+    ref.invalidate(profilesBySourceProvider(dive.id));
+    ref.invalidate(diveDataSourcesProvider(dive.id));
+
     if (context.mounted) {
       if (errors.isEmpty) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -72,6 +72,9 @@ import 'package:submersion/features/signatures/presentation/widgets/signature_ca
 import 'package:submersion/features/signatures/presentation/widgets/signature_display_widget.dart';
 import 'package:submersion/features/signatures/presentation/widgets/buddy_signatures_section.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
 
 /// Calculate normalization factor to align profile-based SAC with tank-based SAC.
 /// The segments are calculated from profile pressure data, but dive.sacPressure
@@ -414,6 +417,8 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
     final computerReadingsAsync = ref.watch(diveDataSourcesProvider(dive.id));
+    final hasRawData =
+        ref.watch(diveHasRawDataProvider(dive.id)).valueOrNull ?? false;
 
     final builders = _sectionBuilders(
       context: context,
@@ -469,7 +474,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     if (widget.embedded) {
       return Column(
         children: [
-          _buildEmbeddedHeader(context, ref, dive),
+          _buildEmbeddedHeader(context, ref, dive, hasRawData: hasRawData),
           Expanded(child: body),
         ],
       );
@@ -508,6 +513,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 case 'merge':
                   _showMergeDiveDialog(context, ref, dive);
                   break;
+                case 'reparse':
+                  _reparseDive(context, ref, dive);
+                  break;
                 case 'delete':
                   _showDeleteConfirmation(context, ref);
                   break;
@@ -531,6 +539,15 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   contentPadding: EdgeInsets.zero,
                 ),
               ),
+              if (hasRawData)
+                const PopupMenuItem(
+                  value: 'reparse',
+                  child: ListTile(
+                    leading: Icon(Icons.refresh),
+                    title: Text('Re-parse raw data'),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
               PopupMenuItem(
                 value: 'delete',
                 child: ListTile(
@@ -551,7 +568,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }
 
   /// Compact header bar for embedded mode in master-detail layout.
-  Widget _buildEmbeddedHeader(BuildContext context, WidgetRef ref, Dive dive) {
+  Widget _buildEmbeddedHeader(
+    BuildContext context,
+    WidgetRef ref,
+    Dive dive, {
+    bool hasRawData = false,
+  }) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Container(
@@ -642,6 +664,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 case 'merge':
                   _showMergeDiveDialog(context, ref, dive);
                   break;
+                case 'reparse':
+                  _reparseDive(context, ref, dive);
+                  break;
                 case 'delete':
                   _showDeleteConfirmation(context, ref);
                   break;
@@ -677,6 +702,15 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   contentPadding: EdgeInsets.zero,
                 ),
               ),
+              if (hasRawData)
+                const PopupMenuItem(
+                  value: 'reparse',
+                  child: ListTile(
+                    leading: Icon(Icons.refresh),
+                    title: Text('Re-parse raw data'),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
               PopupMenuItem(
                 value: 'delete',
                 child: ListTile(
@@ -4560,6 +4594,54 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         }
       },
     );
+  }
+
+  Future<void> _reparseDive(
+    BuildContext context,
+    WidgetRef ref,
+    Dive dive,
+  ) async {
+    final service = ref.read(reparseServiceProvider);
+    final db = DatabaseService.instance.database;
+
+    final sources =
+        await (db.select(db.diveDataSources)
+              ..where((t) => t.diveId.equals(dive.id))
+              ..where((t) => t.rawData.isNotNull()))
+            .get();
+
+    if (sources.isEmpty) return;
+
+    try {
+      for (final source in sources) {
+        final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
+          source.descriptorVendor!,
+          source.descriptorProduct!,
+          source.descriptorModel!,
+          source.rawData!,
+        );
+        await service.applyParsedUpdate(
+          diveId: dive.id,
+          sourceRowId: source.id,
+          parsed: parsed,
+          descriptorVendor: source.descriptorVendor,
+          descriptorProduct: source.descriptorProduct,
+          descriptorModel: source.descriptorModel,
+          libdivecomputerVersion: source.libdivecomputerVersion,
+        );
+      }
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Dive re-parsed successfully')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Re-parse failed: $e')));
+      }
+    }
   }
 
   void _showDeleteConfirmation(BuildContext context, WidgetRef ref) {

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -4612,13 +4612,15 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     if (sources.isEmpty) return;
 
-    try {
-      for (final source in sources) {
-        if (source.descriptorVendor == null ||
-            source.descriptorProduct == null ||
-            source.descriptorModel == null) {
-          continue;
-        }
+    final errors = <String>[];
+
+    for (final source in sources) {
+      if (source.descriptorVendor == null ||
+          source.descriptorProduct == null ||
+          source.descriptorModel == null) {
+        continue;
+      }
+      try {
         final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
           source.descriptorVendor!,
           source.descriptorProduct!,
@@ -4634,17 +4636,20 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
           descriptorModel: source.descriptorModel,
           libdivecomputerVersion: source.libdivecomputerVersion,
         );
+      } catch (e) {
+        errors.add(e.toString());
       }
-      if (context.mounted) {
+    }
+
+    if (context.mounted) {
+      if (errors.isEmpty) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(l10n.diveLog_detail_reparseSuccess)),
         );
-      }
-    } catch (e) {
-      if (context.mounted) {
+      } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(l10n.diveLog_detail_reparseFailed(e.toString())),
+            content: Text(l10n.diveLog_detail_reparseFailed(errors.first)),
           ),
         );
       }

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -4608,38 +4608,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     final service = ref.read(reparseServiceProvider);
     final l10n = context.l10n;
 
-    final sources = await service.getSourcesForDiveReparse(dive.id);
-
-    if (sources.isEmpty) return;
-
-    final errors = <String>[];
-
-    for (final source in sources) {
-      if (source.descriptorVendor == null ||
-          source.descriptorProduct == null ||
-          source.descriptorModel == null) {
-        continue;
-      }
-      try {
-        final parsed = await pigeon.DiveComputerHostApi().parseRawDiveData(
-          source.descriptorVendor!,
-          source.descriptorProduct!,
-          source.descriptorModel!,
-          source.rawData!,
-        );
-        await service.applyParsedUpdate(
-          diveId: dive.id,
-          sourceRowId: source.id,
-          parsed: parsed,
-          descriptorVendor: source.descriptorVendor,
-          descriptorProduct: source.descriptorProduct,
-          descriptorModel: source.descriptorModel,
-          libdivecomputerVersion: source.libdivecomputerVersion,
-        );
-      } catch (e) {
-        errors.add(e.toString());
-      }
-    }
+    final errors = await service.reparseDive(
+      dive.id,
+      parseFn: pigeon.DiveComputerHostApi().parseRawDiveData,
+    );
 
     if (context.mounted) {
       if (errors.isEmpty) {

--- a/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
@@ -376,13 +376,6 @@ class DiveComputerAdapter implements ImportSourceAdapter {
       );
     }
 
-    // Pass session-level descriptor fields to the import service so they are
-    // written onto every DiveDataSources row created during this import.
-    _importService.descriptorVendor = _descriptorVendor;
-    _importService.descriptorProduct = _descriptorProduct;
-    _importService.descriptorModel = _descriptorModel;
-    _importService.libdivecomputerVersion = _libdivecomputerVersion;
-
     final baseSelections = Set<int>.from(
       selections[ImportEntityType.dives] ?? <int>{},
     );
@@ -475,6 +468,10 @@ class DiveComputerAdapter implements ImportSourceAdapter {
             ConflictResolution.replaceSource,
             comp.id,
             diverId: _diverId,
+            descriptorVendor: _descriptorVendor,
+            descriptorProduct: _descriptorProduct,
+            descriptorModel: _descriptorModel,
+            libdivecomputerVersion: _libdivecomputerVersion,
           );
           updated++;
         }
@@ -486,6 +483,10 @@ class DiveComputerAdapter implements ImportSourceAdapter {
           dive,
           computerId: comp.id,
           diverId: _diverId,
+          descriptorVendor: _descriptorVendor,
+          descriptorProduct: _descriptorProduct,
+          descriptorModel: _descriptorModel,
+          libdivecomputerVersion: _libdivecomputerVersion,
         );
         imported++;
         importedDives.add(dive);
@@ -559,6 +560,13 @@ class DiveComputerAdapter implements ImportSourceAdapter {
       waterTemp: Value(dive.minTemperature),
       entryTime: Value(dive.startTime),
       exitTime: Value(dive.endTime),
+      rawData: Value(dive.rawData),
+      rawFingerprint: Value(dive.rawFingerprint),
+      descriptorVendor: Value(_descriptorVendor),
+      descriptorProduct: Value(_descriptorProduct),
+      descriptorModel: Value(_descriptorModel),
+      libdivecomputerVersion: Value(_libdivecomputerVersion),
+      lastParsedAt: Value(dive.rawData != null ? DateTime.now() : null),
       importedAt: now,
       createdAt: now,
     );

--- a/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
@@ -99,6 +99,12 @@ class DiveComputerAdapter implements ImportSourceAdapter {
   DiveComputer? _computer;
   String? _customDeviceName;
 
+  // Session-level descriptor fields captured from the discovered device.
+  String? _descriptorVendor;
+  String? _descriptorProduct;
+  int? _descriptorModel;
+  String? _libdivecomputerVersion;
+
   /// Set by the wizard so the confirm step can navigate back to scan.
   VoidCallback? goBackFromConfirm;
 
@@ -152,11 +158,36 @@ class DiveComputerAdapter implements ImportSourceAdapter {
   ///
   /// Called by the download step after a successful download in discovery mode.
   /// In known-computer mode this is a no-op.
+  ///
+  /// Also captures the session-level descriptor fields (vendor, product, model,
+  /// and libdivecomputer version) so they can be passed to the import service
+  /// before dives are written to the database.
   Future<void> ensureComputer({
     required DiscoveredDevice device,
     String? serialNumber,
     String? firmwareVersion,
   }) async {
+    // Capture descriptor fields regardless of whether a computer record already
+    // exists — these are always needed for the import service.
+    final model = device.recognizedModel;
+    if (model != null) {
+      _descriptorVendor = model.manufacturer;
+      _descriptorProduct = model.model;
+      _descriptorModel = model.dcModel;
+    }
+
+    // Fetch the libdivecomputer version string once per session.
+    if (_libdivecomputerVersion == null) {
+      final dcService = _ref?.read(diveComputerServiceProvider);
+      if (dcService != null) {
+        try {
+          _libdivecomputerVersion = await dcService.getVersion();
+        } catch (_) {
+          // Non-fatal — version metadata is best-effort.
+        }
+      }
+    }
+
     if (computer != null) return;
 
     // Create a new computer record from the discovered device.
@@ -227,6 +258,7 @@ class DiveComputerAdapter implements ImportSourceAdapter {
     DuplicateAction.skip,
     DuplicateAction.importAsNew,
     DuplicateAction.consolidate,
+    DuplicateAction.replaceSource,
   };
 
   @override
@@ -344,6 +376,13 @@ class DiveComputerAdapter implements ImportSourceAdapter {
       );
     }
 
+    // Pass session-level descriptor fields to the import service so they are
+    // written onto every DiveDataSources row created during this import.
+    _importService.descriptorVendor = _descriptorVendor;
+    _importService.descriptorProduct = _descriptorProduct;
+    _importService.descriptorModel = _descriptorModel;
+    _importService.libdivecomputerVersion = _libdivecomputerVersion;
+
     final baseSelections = Set<int>.from(
       selections[ImportEntityType.dives] ?? <int>{},
     );
@@ -352,6 +391,7 @@ class DiveComputerAdapter implements ImportSourceAdapter {
     // Build the final set of indices and track actions.
     final indicesToImport = <int>{};
     final indicesToConsolidate = <int>{};
+    final indicesToReplaceSource = <int>{};
     var skipped = 0;
 
     for (final index in baseSelections) {
@@ -360,6 +400,8 @@ class DiveComputerAdapter implements ImportSourceAdapter {
         skipped++;
       } else if (action == DuplicateAction.consolidate) {
         indicesToConsolidate.add(index);
+      } else if (action == DuplicateAction.replaceSource) {
+        indicesToReplaceSource.add(index);
       } else {
         indicesToImport.add(index);
       }
@@ -371,6 +413,9 @@ class DiveComputerAdapter implements ImportSourceAdapter {
       } else if (entry.value == DuplicateAction.consolidate &&
           !baseSelections.contains(entry.key)) {
         indicesToConsolidate.add(entry.key);
+      } else if (entry.value == DuplicateAction.replaceSource &&
+          !baseSelections.contains(entry.key)) {
+        indicesToReplaceSource.add(entry.key);
       } else if (entry.value == DuplicateAction.skip &&
           !baseSelections.contains(entry.key)) {
         skipped++;
@@ -379,15 +424,20 @@ class DiveComputerAdapter implements ImportSourceAdapter {
 
     // Merge and sort indices by startTime (oldest first) so sequential
     // dive number assignment produces correct chronological numbering.
-    final allIndices = {...indicesToImport, ...indicesToConsolidate}.toList()
-      ..sort((a, b) {
-        final aTime = _downloadedDives[a].startTime;
-        final bTime = _downloadedDives[b].startTime;
-        return aTime.compareTo(bTime);
-      });
+    final allIndices =
+        {
+          ...indicesToImport,
+          ...indicesToConsolidate,
+          ...indicesToReplaceSource,
+        }.toList()..sort((a, b) {
+          final aTime = _downloadedDives[a].startTime;
+          final bTime = _downloadedDives[b].startTime;
+          return aTime.compareTo(bTime);
+        });
     final total = allIndices.length;
     var imported = 0;
     var consolidated = 0;
+    var updated = 0;
     final importedDives = <DownloadedDive>[];
     final importedDiveIds = <String>[];
 
@@ -404,6 +454,29 @@ class DiveComputerAdapter implements ImportSourceAdapter {
         if (matchResult != null) {
           await _consolidateDive(dive, matchResult.diveId, comp);
           consolidated++;
+        }
+      } else if (indicesToReplaceSource.contains(index)) {
+        // Replace source: update the matched dive's source data with the
+        // freshly downloaded version.
+        final diveGroup = bundle.groups[ImportEntityType.dives];
+        final matchResult = diveGroup?.matchResults?[index];
+        if (matchResult != null) {
+          final conflict = ImportConflict(
+            downloaded: dive,
+            existingDiveId: matchResult.diveId,
+            duplicateResult: DuplicateResult(
+              matchingDiveId: matchResult.diveId,
+              confidence: DuplicateConfidence.exact,
+              score: matchResult.score,
+            ),
+          );
+          await _importService.resolveConflict(
+            conflict,
+            ConflictResolution.replaceSource,
+            comp.id,
+            diverId: _diverId,
+          );
+          updated++;
         }
       } else {
         // Import as new dive. Use importSingleDiveAsNew to bypass the
@@ -429,6 +502,7 @@ class DiveComputerAdapter implements ImportSourceAdapter {
     return UnifiedImportResult(
       importedCounts: {ImportEntityType.dives: imported},
       consolidatedCount: consolidated,
+      updatedCount: updated,
       skippedCount: skipped,
       importedDiveIds: importedDiveIds,
     );

--- a/lib/features/import_wizard/domain/models/duplicate_action.dart
+++ b/lib/features/import_wizard/domain/models/duplicate_action.dart
@@ -8,4 +8,7 @@ enum DuplicateAction {
 
   /// Merge the incoming item's data into the matched existing entry.
   consolidate,
+
+  /// Replace the matched entry's source data with the incoming item.
+  replaceSource,
 }

--- a/lib/features/import_wizard/domain/models/unified_import_result.dart
+++ b/lib/features/import_wizard/domain/models/unified_import_result.dart
@@ -3,13 +3,18 @@ import 'package:submersion/features/import_wizard/domain/models/import_bundle.da
 /// The outcome of a completed unified import wizard run.
 ///
 /// Holds per-entity-type import counts, the number of dives consolidated
-/// with existing log entries, skipped items, and an optional error message.
+/// with existing log entries, the number of dives whose source data was
+/// replaced, skipped items, and an optional error message.
 class UnifiedImportResult {
   /// Number of entities imported, keyed by [ImportEntityType].
   final Map<ImportEntityType, int> importedCounts;
 
   /// Number of dives that were consolidated with an existing dive log entry.
   final int consolidatedCount;
+
+  /// Number of dives whose source data was replaced with freshly downloaded
+  /// data (replaceSource duplicate action).
+  final int updatedCount;
 
   /// Number of items that were skipped (e.g. detected duplicates the user
   /// chose not to import).
@@ -24,6 +29,7 @@ class UnifiedImportResult {
   const UnifiedImportResult({
     required this.importedCounts,
     required this.consolidatedCount,
+    this.updatedCount = 0,
     required this.skippedCount,
     this.importedDiveIds = const [],
     this.errorMessage,

--- a/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
@@ -476,14 +476,6 @@ class DcNoNewDivesView extends StatelessWidget {
             ),
             const SizedBox(height: 32),
             FilledButton(onPressed: onDone, child: const Text('Done')),
-            const SizedBox(height: 8),
-            TextButton(
-              onPressed: onDone,
-              child: Text(
-                context.l10n.diveComputer_download_reimportHint,
-                textAlign: TextAlign.center,
-              ),
-            ),
           ],
         ),
       ),

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -78,6 +78,7 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
       DuplicateAction.importAsNew => Colors.green,
       DuplicateAction.consolidate => colorScheme.primary,
       DuplicateAction.skip => score >= 0.7 ? colorScheme.error : Colors.orange,
+      DuplicateAction.replaceSource => Colors.orange,
       null => colorScheme.tertiary,
     };
 
@@ -289,6 +290,7 @@ class _ActionBadge extends StatelessWidget {
       DuplicateAction.skip => ('SKIP', theme.colorScheme.error),
       DuplicateAction.importAsNew => ('IMPORT', Colors.green.shade700),
       DuplicateAction.consolidate => ('CONSOLIDATE', Colors.green.shade700),
+      DuplicateAction.replaceSource => ('REPLACE', Colors.orange.shade700),
     };
 
     return Container(

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -66,6 +66,15 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
   bool _expanded = false;
 
   @override
+  void didUpdateWidget(DuplicateActionCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Auto-collapse when an action is selected (user made their decision).
+    if (oldWidget.selectedAction == null && widget.selectedAction != null) {
+      setState(() => _expanded = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
@@ -254,7 +263,9 @@ class _CollapsedHeader extends StatelessWidget {
               runSpacing: 4,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                if (item.diveData != null && item.diveData!.profile.isNotEmpty)
+                if (!expanded &&
+                    item.diveData != null &&
+                    item.diveData!.profile.isNotEmpty)
                   DiveSparkline(profile: item.diveData!.profile),
                 Container(
                   padding: const EdgeInsets.symmetric(

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -190,86 +190,93 @@ class _CollapsedHeader extends StatelessWidget {
       onTap: onToggle,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-        child: Row(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Dive number badge (centered vertically between title + subtitle)
-            if (projectedDiveNumber != null) ...[
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
-                decoration: BoxDecoration(
-                  color: colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Text(
-                  '#$projectedDiveNumber',
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: colorScheme.onPrimaryContainer,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-              const SizedBox(width: 8),
-            ],
-            // Title + subtitle column
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    item.title,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
+            // Top row: dive number + title/subtitle + chevron
+            Row(
+              children: [
+                if (projectedDiveNumber != null) ...[
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 7,
+                      vertical: 2,
                     ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (effectiveSubtitle.isNotEmpty)
-                    Text(
-                      effectiveSubtitle,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
+                    decoration: BoxDecoration(
+                      color: colorScheme.primaryContainer,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      '#$projectedDiveNumber',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.bold,
                       ),
-                      overflow: TextOverflow.ellipsis,
                     ),
+                  ),
+                  const SizedBox(width: 8),
                 ],
-              ),
-            ),
-            // Dive profile sparkline (only when profile data exists)
-            if (item.diveData != null && item.diveData!.profile.isNotEmpty) ...[
-              const SizedBox(width: 4),
-              DiveSparkline(profile: item.diveData!.profile),
-            ],
-            const SizedBox(width: 8),
-            // Match % badge
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-              decoration: BoxDecoration(
-                border: Border.all(color: badgeBorderColor, width: 1.5),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Text(
-                '$percent% match',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: badgeBorderColor,
-                  fontWeight: FontWeight.bold,
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.title,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w500,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (effectiveSubtitle.isNotEmpty)
+                        Text(
+                          effectiveSubtitle,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                    ],
+                  ),
                 ),
-              ),
+                const SizedBox(width: 8),
+                Icon(
+                  expanded ? Icons.expand_less : Icons.expand_more,
+                  size: 20,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ],
             ),
-            // Needs-decision pill — only shown when this row is pending.
-            if (isPending) ...[
-              const SizedBox(width: 8),
-              NeedsDecisionPill(colorScheme: colorScheme),
-            ],
-            // Action badge — suppressed when no decision has been made yet.
-            if (selectedAction != null) ...[
-              const SizedBox(width: 6),
-              _ActionBadge(action: selectedAction!),
-            ],
-            // Breathing room before the expand/collapse chevron.
-            const SizedBox(width: 12),
-            Icon(
-              expanded ? Icons.expand_less : Icons.expand_more,
-              size: 20,
-              color: colorScheme.onSurfaceVariant,
+            const SizedBox(height: 6),
+            // Bottom row: sparkline + badges (wraps on narrow screens)
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                if (item.diveData != null && item.diveData!.profile.isNotEmpty)
+                  DiveSparkline(profile: item.diveData!.profile),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    border: Border.all(color: badgeBorderColor, width: 1.5),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '$percent% match',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: badgeBorderColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (isPending) NeedsDecisionPill(colorScheme: colorScheme),
+                if (selectedAction != null)
+                  _ActionBadge(action: selectedAction!),
+              ],
             ),
           ],
         ),

--- a/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
+++ b/lib/features/import_wizard/presentation/widgets/duplicate_action_card.dart
@@ -78,7 +78,7 @@ class _DuplicateActionCardState extends State<DuplicateActionCard> {
       DuplicateAction.importAsNew => Colors.green,
       DuplicateAction.consolidate => colorScheme.primary,
       DuplicateAction.skip => score >= 0.7 ? colorScheme.error : Colors.orange,
-      DuplicateAction.replaceSource => Colors.orange,
+      DuplicateAction.replaceSource => Colors.blue.shade700,
       null => colorScheme.tertiary,
     };
 
@@ -290,7 +290,7 @@ class _ActionBadge extends StatelessWidget {
       DuplicateAction.skip => ('SKIP', theme.colorScheme.error),
       DuplicateAction.importAsNew => ('IMPORT', Colors.green.shade700),
       DuplicateAction.consolidate => ('CONSOLIDATE', Colors.green.shade700),
-      DuplicateAction.replaceSource => ('REPLACE', Colors.orange.shade700),
+      DuplicateAction.replaceSource => ('REPLACE', Colors.blue.shade700),
     };
 
     return Container(

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -973,6 +973,16 @@ class _BulkActionRow extends StatelessWidget {
                     : context.l10n.universalImport_bulk_importAll(pendingCount),
               ),
             ),
+          if (availableActions.contains(DuplicateAction.replaceSource))
+            OutlinedButton.icon(
+              onPressed: () => onBulkAction(DuplicateAction.replaceSource),
+              icon: const Icon(Icons.sync, size: 16),
+              label: Text(
+                context.l10n.universalImport_bulk_replaceSourceAll(
+                  pendingCount,
+                ),
+              ),
+            ),
           if (availableActions.contains(DuplicateAction.consolidate))
             // TODO(#200): enable when bulk-consolidate is implemented end-to-end.
             OutlinedButton.icon(

--- a/lib/features/import_wizard/presentation/widgets/import_summary_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/import_summary_step.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
 import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The summary step shown after the import completes.
 ///
@@ -88,19 +89,20 @@ class _SuccessView extends StatelessWidget {
     final IconData icon;
     final Color iconColor;
     final Color iconBg;
+    final l10n = context.l10n;
     if (hasActivity) {
       if (totalImported > 0) {
-        title = 'Successfully Imported';
+        title = l10n.universalImport_title_successImported;
       } else if (updatedCount > 0) {
-        title = 'Successfully Updated';
+        title = l10n.universalImport_title_successUpdated;
       } else {
-        title = 'Successfully Consolidated';
+        title = l10n.universalImport_title_successConsolidated;
       }
       icon = Icons.check;
       iconColor = theme.colorScheme.onPrimaryContainer;
       iconBg = theme.colorScheme.primaryContainer;
     } else {
-      title = 'No Dives Imported';
+      title = l10n.universalImport_title_noDivesImported;
       icon = Icons.info_outline;
       iconColor = theme.colorScheme.onSurfaceVariant;
       iconBg = theme.colorScheme.surfaceContainerHighest;
@@ -128,7 +130,7 @@ class _SuccessView extends StatelessWidget {
             if (!hasActivity && skippedCount > 0) ...[
               const SizedBox(height: 8),
               Text(
-                'All dives were skipped.',
+                l10n.universalImport_label_allDivesSkipped,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -146,14 +148,14 @@ class _SuccessView extends StatelessWidget {
             if (updatedCount > 0)
               _CountRow(
                 icon: Icons.sync,
-                label: 'Replaced source data',
+                label: l10n.universalImport_label_replacedSourceData,
                 count: updatedCount,
                 key: const Key('import_summary_updated_row'),
               ),
             if (consolidatedCount > 0)
               _CountRow(
                 icon: Icons.merge,
-                label: 'Consolidated',
+                label: l10n.universalImport_label_consolidated,
                 count: consolidatedCount,
                 key: const Key('import_summary_consolidated_row'),
               ),

--- a/lib/features/import_wizard/presentation/widgets/import_summary_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/import_summary_step.dart
@@ -45,6 +45,7 @@ class ImportSummaryStep extends ConsumerWidget {
     return _SuccessView(
       importedCounts: result.importedCounts,
       consolidatedCount: result.consolidatedCount,
+      updatedCount: result.updatedCount,
       skippedCount: result.skippedCount,
       onDone: onDone,
       onViewDives: onViewDives,
@@ -59,6 +60,7 @@ class ImportSummaryStep extends ConsumerWidget {
 class _SuccessView extends StatelessWidget {
   final Map<ImportEntityType, int> importedCounts;
   final int consolidatedCount;
+  final int updatedCount;
   final int skippedCount;
   final VoidCallback onDone;
   final VoidCallback onViewDives;
@@ -66,6 +68,7 @@ class _SuccessView extends StatelessWidget {
   const _SuccessView({
     required this.importedCounts,
     required this.consolidatedCount,
+    this.updatedCount = 0,
     required this.skippedCount,
     required this.onDone,
     required this.onViewDives,
@@ -78,14 +81,21 @@ class _SuccessView extends StatelessWidget {
       0,
       (sum, v) => sum + v,
     );
-    final hasNewDives = totalImported > 0 || consolidatedCount > 0;
+    final hasActivity =
+        totalImported > 0 || consolidatedCount > 0 || updatedCount > 0;
 
     final String title;
     final IconData icon;
     final Color iconColor;
     final Color iconBg;
-    if (hasNewDives) {
-      title = 'Successfully Imported';
+    if (hasActivity) {
+      if (totalImported > 0) {
+        title = 'Successfully Imported';
+      } else if (updatedCount > 0) {
+        title = 'Successfully Updated';
+      } else {
+        title = 'Successfully Consolidated';
+      }
       icon = Icons.check;
       iconColor = theme.colorScheme.onPrimaryContainer;
       iconBg = theme.colorScheme.primaryContainer;
@@ -115,7 +125,7 @@ class _SuccessView extends StatelessWidget {
               style: theme.textTheme.headlineSmall,
               textAlign: TextAlign.center,
             ),
-            if (!hasNewDives && skippedCount > 0) ...[
+            if (!hasActivity && skippedCount > 0) ...[
               const SizedBox(height: 8),
               Text(
                 'All dives were skipped.',
@@ -133,6 +143,13 @@ class _SuccessView extends StatelessWidget {
                   label: _labelForType(entry.key),
                   count: entry.value,
                 ),
+            if (updatedCount > 0)
+              _CountRow(
+                icon: Icons.sync,
+                label: 'Replaced source data',
+                count: updatedCount,
+                key: const Key('import_summary_updated_row'),
+              ),
             if (consolidatedCount > 0)
               _CountRow(
                 icon: Icons.merge,
@@ -152,7 +169,7 @@ class _SuccessView extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 OutlinedButton(onPressed: onDone, child: const Text('Done')),
-                if (hasNewDives) ...[
+                if (hasActivity) ...[
                   const SizedBox(width: 16),
                   FilledButton(
                     onPressed: onViewDives,

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -344,6 +344,7 @@ String _actionLabel(
   DuplicateAction.skip => context.l10n.universalImport_label_skip,
   DuplicateAction.importAsNew => context.l10n.universalImport_label_importAsNew,
   DuplicateAction.consolidate => context.l10n.universalImport_label_consolidate,
+  DuplicateAction.replaceSource => 'Replace Source',
 };
 
 void _showActionSnackbar(BuildContext context, String message) {
@@ -554,6 +555,8 @@ class _AggregateCounts {
             consolidating++;
           case DuplicateAction.skip:
             skipping++;
+          case DuplicateAction.replaceSource:
+            importing++;
         }
       }
     }

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -215,9 +215,9 @@ class _MultiTypeLayoutState extends State<_MultiTypeLayout> {
                         ),
                       ),
                       if (showOptionsButton)
-                        IconButton(
-                          icon: const Icon(Icons.tune),
-                          tooltip: 'Import options',
+                        TextButton.icon(
+                          icon: const Icon(Icons.tune, size: 18),
+                          label: const Text('Options'),
                           onPressed: () => _showImportOptions(context),
                         ),
                     ],

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -344,7 +344,8 @@ String _actionLabel(
   DuplicateAction.skip => context.l10n.universalImport_label_skip,
   DuplicateAction.importAsNew => context.l10n.universalImport_label_importAsNew,
   DuplicateAction.consolidate => context.l10n.universalImport_label_consolidate,
-  DuplicateAction.replaceSource => 'Replace Source',
+  DuplicateAction.replaceSource =>
+    context.l10n.universalImport_label_replaceSource,
 };
 
 void _showActionSnackbar(BuildContext context, String message) {
@@ -415,6 +416,9 @@ class _BottomBar extends StatelessWidget {
     if (counts.consolidating > 0) {
       parts.add('${counts.consolidating} merging');
     }
+    if (counts.replacing > 0) {
+      parts.add('${counts.replacing} replacing');
+    }
     if (counts.skipping > 0) {
       parts.add('${counts.skipping} skipped');
     }
@@ -475,7 +479,10 @@ class _BottomBar extends StatelessWidget {
                 FilledButton(
                   onPressed:
                       (hasPendingReviews ||
-                          (counts.importing + counts.consolidating) == 0)
+                          (counts.importing +
+                                  counts.consolidating +
+                                  counts.replacing) ==
+                              0)
                       ? null
                       : onImport,
                   child: const Text('Import Selected'),
@@ -498,11 +505,13 @@ class _AggregateCounts {
   final int importing;
   final int consolidating;
   final int skipping;
+  final int replacing;
 
   const _AggregateCounts({
     required this.importing,
     required this.consolidating,
     required this.skipping,
+    required this.replacing,
   });
 
   /// Compute counts from [ImportWizardState].
@@ -512,6 +521,7 @@ class _AggregateCounts {
   /// - consolidating: duplicates with [DuplicateAction.consolidate]
   /// - skipping: duplicates with [DuplicateAction.skip] + non-selected
   ///   non-duplicate items
+  /// - replacing: duplicates with [DuplicateAction.replaceSource]
   static _AggregateCounts compute(ImportWizardState state) {
     final bundle = state.bundle;
     if (bundle == null) {
@@ -519,12 +529,14 @@ class _AggregateCounts {
         importing: 0,
         consolidating: 0,
         skipping: 0,
+        replacing: 0,
       );
     }
 
     var importing = 0;
     var consolidating = 0;
     var skipping = 0;
+    var replacing = 0;
 
     for (final entry in bundle.groups.entries) {
       final type = entry.key;
@@ -556,7 +568,7 @@ class _AggregateCounts {
           case DuplicateAction.skip:
             skipping++;
           case DuplicateAction.replaceSource:
-            importing++;
+            replacing++;
         }
       }
     }
@@ -565,6 +577,7 @@ class _AggregateCounts {
       importing: importing,
       consolidating: consolidating,
       skipping: skipping,
+      replacing: replacing,
     );
   }
 

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -123,7 +123,7 @@ class ReviewStep extends ConsumerWidget {
 // Multi-type layout (tab bar)
 // ---------------------------------------------------------------------------
 
-class _MultiTypeLayout extends StatelessWidget {
+class _MultiTypeLayout extends StatefulWidget {
   final List<ImportEntityType> types;
   final ImportBundle bundle;
   final ImportWizardState state;
@@ -149,72 +149,119 @@ class _MultiTypeLayout extends StatelessWidget {
   });
 
   @override
+  State<_MultiTypeLayout> createState() => _MultiTypeLayoutState();
+}
+
+class _MultiTypeLayoutState extends State<_MultiTypeLayout> {
+  void _showImportOptions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Import Options',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            _RetainDiveNumbersToggle(
+              state: widget.state,
+              notifier: widget.notifier,
+            ),
+            const Divider(),
+            ImportTagsField(
+              tags: widget.state.importTags,
+              existingTags: widget.existingTags,
+              onAdd: (tag) => widget.notifier.addImportTag(tag),
+              onRemove: (index) => widget.notifier.removeImportTag(index),
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final hasDives = bundle.groups.containsKey(ImportEntityType.dives);
+    final hasDives = widget.bundle.groups.containsKey(ImportEntityType.dives);
 
     return DefaultTabController(
-      length: types.length,
+      length: widget.types.length,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          if (hasDives)
-            _RetainDiveNumbersToggle(state: state, notifier: notifier),
-          TabBar(
-            labelPadding: const EdgeInsets.symmetric(horizontal: 12),
-            indicatorWeight: 3,
-            indicatorSize: TabBarIndicatorSize.label,
-            indicatorColor: colorScheme.primary,
-            labelColor: colorScheme.primary,
-            unselectedLabelColor: colorScheme.onSurfaceVariant,
-            labelStyle: theme.textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.w700,
-            ),
-            unselectedLabelStyle: theme.textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.w500,
-            ),
-            tabs: [
-              for (final type in types)
-                Tab(
-                  height: 36,
-                  text: _tabLabel(type, bundle.groups[type]!.items.length),
-                ),
-            ],
+          Builder(
+            builder: (context) {
+              final tabController = DefaultTabController.of(context);
+              return ListenableBuilder(
+                listenable: tabController,
+                builder: (context, _) {
+                  final showOptionsButton =
+                      hasDives &&
+                      (widget.types.length == 1 ||
+                          tabController.index ==
+                              widget.types.indexOf(ImportEntityType.dives));
+                  return Row(
+                    children: [
+                      Expanded(
+                        child: TabBar(
+                          labelPadding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                          ),
+                          indicatorWeight: 3,
+                          indicatorSize: TabBarIndicatorSize.label,
+                          indicatorColor: colorScheme.primary,
+                          labelColor: colorScheme.primary,
+                          unselectedLabelColor: colorScheme.onSurfaceVariant,
+                          labelStyle: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                          unselectedLabelStyle: theme.textTheme.titleSmall
+                              ?.copyWith(fontWeight: FontWeight.w500),
+                          tabs: [
+                            for (final type in widget.types)
+                              Tab(
+                                height: 36,
+                                text: _tabLabel(
+                                  type,
+                                  widget.bundle.groups[type]!.items.length,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                      if (showOptionsButton)
+                        IconButton(
+                          icon: const Icon(Icons.tune),
+                          tooltip: 'Import options',
+                          onPressed: () => _showImportOptions(context),
+                        ),
+                    ],
+                  );
+                },
+              );
+            },
           ),
-          if (hasDives)
-            Builder(
-              builder: (context) {
-                final tabController = DefaultTabController.of(context);
-                final divesIndex = types.indexOf(ImportEntityType.dives);
-                return ListenableBuilder(
-                  listenable: tabController,
-                  builder: (context, _) {
-                    if (tabController.index != divesIndex) {
-                      return const SizedBox.shrink();
-                    }
-                    return ImportTagsField(
-                      tags: state.importTags,
-                      existingTags: existingTags,
-                      onAdd: (tag) => notifier.addImportTag(tag),
-                      onRemove: (index) => notifier.removeImportTag(index),
-                    );
-                  },
-                );
-              },
-            ),
           Expanded(
             child: TabBarView(
               children: [
-                for (final type in types)
+                for (final type in widget.types)
                   _EntityTab(
                     type: type,
-                    bundle: bundle,
-                    state: state,
-                    notifier: notifier,
-                    availableActions: availableActions,
+                    bundle: widget.bundle,
+                    state: widget.state,
+                    notifier: widget.notifier,
+                    availableActions: widget.availableActions,
                     projectedDiveNumbers: type == ImportEntityType.dives
-                        ? projectedDiveNumbers
+                        ? widget.projectedDiveNumbers
                         : null,
                   ),
               ],
@@ -222,15 +269,15 @@ class _MultiTypeLayout extends StatelessWidget {
           ),
           Builder(
             builder: (ctx) => _BottomBar(
-              counts: counts,
-              onImport: onImport,
-              onBack: onBack,
-              hasPendingReviews: state.hasPendingReviews,
-              totalPending: state.totalPending,
+              counts: widget.counts,
+              onImport: widget.onImport,
+              onBack: widget.onBack,
+              hasPendingReviews: widget.state.hasPendingReviews,
+              totalPending: widget.state.totalPending,
               onReviewPending: () {
-                final loc = notifier.firstPendingLocation();
+                final loc = widget.notifier.firstPendingLocation();
                 if (loc == null) return;
-                final tabIdx = types.indexOf(loc.type);
+                final tabIdx = widget.types.indexOf(loc.type);
                 if (tabIdx < 0) return;
                 DefaultTabController.maybeOf(ctx)?.animateTo(tabIdx);
               },

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -217,7 +217,9 @@ class _MultiTypeLayoutState extends State<_MultiTypeLayout> {
                       if (showOptionsButton)
                         TextButton.icon(
                           icon: const Icon(Icons.tune, size: 18),
-                          label: const Text('Options'),
+                          label: Text(
+                            context.l10n.universalImport_label_options,
+                          ),
                           onPressed: () => _showImportOptions(context),
                         ),
                     ],
@@ -641,16 +643,16 @@ class _ImportOptionsSheetState extends State<_ImportOptionsSheet> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Import Options',
+            context.l10n.universalImport_title_importOptions,
             style: Theme.of(
               context,
             ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
           SwitchListTile(
-            title: const Text('Retain source dive numbers'),
-            subtitle: const Text(
-              'Use dive numbers from the imported file instead of auto-assigning',
+            title: Text(context.l10n.universalImport_label_retainDiveNumbers),
+            subtitle: Text(
+              context.l10n.universalImport_label_retainDiveNumbersSubtitle,
             ),
             value: state.retainSourceDiveNumbers,
             onChanged: (value) =>

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -156,44 +156,9 @@ class _MultiTypeLayoutState extends State<_MultiTypeLayout> {
   void _showImportOptions(BuildContext context) {
     showModalBottomSheet(
       context: context,
-      builder: (sheetContext) => Consumer(
-        builder: (context, ref, _) {
-          final state = ref.watch(importWizardNotifierProvider);
-          final notifier = ref.read(importWizardNotifierProvider.notifier);
-          return Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Import Options',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                SwitchListTile(
-                  title: const Text('Retain source dive numbers'),
-                  subtitle: const Text(
-                    'Use dive numbers from the imported file instead of auto-assigning',
-                  ),
-                  value: state.retainSourceDiveNumbers,
-                  onChanged: (value) =>
-                      notifier.setRetainSourceDiveNumbers(value),
-                ),
-                const Divider(),
-                ImportTagsField(
-                  tags: state.importTags,
-                  existingTags: widget.existingTags,
-                  onAdd: (tag) => notifier.addImportTag(tag),
-                  onRemove: (index) => notifier.removeImportTag(index),
-                ),
-                const SizedBox(height: 16),
-              ],
-            ),
-          );
-        },
+      builder: (_) => _ImportOptionsSheet(
+        notifier: widget.notifier,
+        existingTags: widget.existingTags,
       ),
     );
   }
@@ -622,5 +587,85 @@ class _AggregateCounts {
     return result.isProbable
         ? DuplicateAction.skip
         : DuplicateAction.importAsNew;
+  }
+}
+
+/// Bottom sheet content for import options (retain dive numbers + tags).
+///
+/// Uses [StateNotifier.addListener] to reactively rebuild when the notifier's
+/// state changes, avoiding the need for a [ProviderScope] in the overlay tree.
+class _ImportOptionsSheet extends StatefulWidget {
+  final ImportWizardNotifier notifier;
+  final List<Tag> existingTags;
+
+  const _ImportOptionsSheet({
+    required this.notifier,
+    required this.existingTags,
+  });
+
+  @override
+  State<_ImportOptionsSheet> createState() => _ImportOptionsSheetState();
+}
+
+class _ImportOptionsSheetState extends State<_ImportOptionsSheet> {
+  ImportWizardState? _currentState;
+  late final Function() _removeListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _removeListener = widget.notifier.addListener((state) {
+      if (mounted) {
+        setState(() => _currentState = state);
+      } else {
+        _currentState = state;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _removeListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = _currentState;
+    if (state == null) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Import Options',
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          SwitchListTile(
+            title: const Text('Retain source dive numbers'),
+            subtitle: const Text(
+              'Use dive numbers from the imported file instead of auto-assigning',
+            ),
+            value: state.retainSourceDiveNumbers,
+            onChanged: (value) =>
+                widget.notifier.setRetainSourceDiveNumbers(value),
+          ),
+          const Divider(),
+          ImportTagsField(
+            tags: state.importTags,
+            existingTags: widget.existingTags,
+            onAdd: (tag) => widget.notifier.addImportTag(tag),
+            onRemove: (index) => widget.notifier.removeImportTag(index),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/import_wizard/presentation/widgets/review_step.dart
+++ b/lib/features/import_wizard/presentation/widgets/review_step.dart
@@ -156,33 +156,44 @@ class _MultiTypeLayoutState extends State<_MultiTypeLayout> {
   void _showImportOptions(BuildContext context) {
     showModalBottomSheet(
       context: context,
-      builder: (context) => Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Import Options',
-              style: Theme.of(
-                context,
-              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+      builder: (sheetContext) => Consumer(
+        builder: (context, ref, _) {
+          final state = ref.watch(importWizardNotifierProvider);
+          final notifier = ref.read(importWizardNotifierProvider.notifier);
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Import Options',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  title: const Text('Retain source dive numbers'),
+                  subtitle: const Text(
+                    'Use dive numbers from the imported file instead of auto-assigning',
+                  ),
+                  value: state.retainSourceDiveNumbers,
+                  onChanged: (value) =>
+                      notifier.setRetainSourceDiveNumbers(value),
+                ),
+                const Divider(),
+                ImportTagsField(
+                  tags: state.importTags,
+                  existingTags: widget.existingTags,
+                  onAdd: (tag) => notifier.addImportTag(tag),
+                  onRemove: (index) => notifier.removeImportTag(index),
+                ),
+                const SizedBox(height: 16),
+              ],
             ),
-            const SizedBox(height: 8),
-            _RetainDiveNumbersToggle(
-              state: widget.state,
-              notifier: widget.notifier,
-            ),
-            const Divider(),
-            ImportTagsField(
-              tags: widget.state.importTags,
-              existingTags: widget.existingTags,
-              onAdd: (tag) => widget.notifier.addImportTag(tag),
-              onRemove: (index) => widget.notifier.removeImportTag(index),
-            ),
-            const SizedBox(height: 16),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -407,29 +418,6 @@ void _showActionSnackbar(BuildContext context, String message) {
         behavior: SnackBarBehavior.floating,
       ),
     );
-}
-
-// ---------------------------------------------------------------------------
-// Retain dive numbers toggle
-// ---------------------------------------------------------------------------
-
-class _RetainDiveNumbersToggle extends StatelessWidget {
-  final ImportWizardState state;
-  final ImportWizardNotifier notifier;
-
-  const _RetainDiveNumbersToggle({required this.state, required this.notifier});
-
-  @override
-  Widget build(BuildContext context) {
-    return SwitchListTile(
-      title: const Text('Retain source dive numbers'),
-      subtitle: const Text(
-        'Use dive numbers from the imported file instead of auto-assigning',
-      ),
-      value: state.retainSourceDiveNumbers,
-      onChanged: (value) => notifier.setRetainSourceDiveNumbers(value),
-    );
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9950,5 +9950,9 @@
   "universalImport_label_replaceSource": "Replace Source",
   "@universalImport_label_replaceSource": {
     "description": "Label for the replace source duplicate action"
+  },
+  "universalImport_label_replaceSourceSubtitle": "Update from same computer",
+  "@universalImport_label_replaceSourceSubtitle": {
+    "description": "Subtitle for the replace source button in the duplicate review step"
   }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7779,6 +7779,7 @@
   "universalImport_bulk_importAll": "Import all ({count})",
   "universalImport_bulk_importAllAsNew": "Import all as new ({count})",
   "universalImport_bulk_skipAll": "Skip all ({count})",
+  "universalImport_bulk_replaceSourceAll": "Replace all ({count})",
   "universalImport_description_supportedFormats": "Select a dive log file to import. Supported formats include CSV, UDDF, Subsurface XML, Garmin FIT, and Shearwater Cloud databases.",
   "universalImport_dive_decideAction": "Decide",
   "universalImport_error_unsupportedFormat": "This format is not yet supported. Please export as UDDF or CSV.",
@@ -7875,6 +7876,14 @@
   },
   "@universalImport_bulk_skipAll": {
     "description": "Bulk action button that skips all items in the current tab",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_bulk_replaceSourceAll": {
+    "description": "Bulk action button to replace source data for all pending duplicates",
     "placeholders": {
       "count": {
         "type": "int"

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9963,5 +9963,49 @@
   "universalImport_label_replaceSourceSubtitle": "Update from same computer",
   "@universalImport_label_replaceSourceSubtitle": {
     "description": "Subtitle for the replace source button in the duplicate review step"
+  },
+  "universalImport_title_importOptions": "Import Options",
+  "@universalImport_title_importOptions": {
+    "description": "Title for the import options bottom sheet"
+  },
+  "universalImport_label_options": "Options",
+  "@universalImport_label_options": {
+    "description": "Label for the import options button"
+  },
+  "universalImport_label_retainDiveNumbers": "Retain source dive numbers",
+  "@universalImport_label_retainDiveNumbers": {
+    "description": "Switch title for retaining dive numbers from source"
+  },
+  "universalImport_label_retainDiveNumbersSubtitle": "Use dive numbers from the imported file instead of auto-assigning",
+  "@universalImport_label_retainDiveNumbersSubtitle": {
+    "description": "Switch subtitle for retaining dive numbers"
+  },
+  "universalImport_title_successImported": "Successfully Imported",
+  "@universalImport_title_successImported": {
+    "description": "Title shown when dives are successfully imported"
+  },
+  "universalImport_title_successUpdated": "Successfully Updated",
+  "@universalImport_title_successUpdated": {
+    "description": "Title shown when existing dives are successfully updated"
+  },
+  "universalImport_title_successConsolidated": "Successfully Consolidated",
+  "@universalImport_title_successConsolidated": {
+    "description": "Title shown when dives are successfully consolidated"
+  },
+  "universalImport_title_noDivesImported": "No Dives Imported",
+  "@universalImport_title_noDivesImported": {
+    "description": "Title shown when no dives were imported"
+  },
+  "universalImport_label_allDivesSkipped": "All dives were skipped.",
+  "@universalImport_label_allDivesSkipped": {
+    "description": "Message shown when all dives were skipped during import"
+  },
+  "universalImport_label_replacedSourceData": "Replaced source data",
+  "@universalImport_label_replacedSourceData": {
+    "description": "Label for the count of dives whose source data was replaced"
+  },
+  "universalImport_label_consolidated": "Consolidated",
+  "@universalImport_label_consolidated": {
+    "description": "Label for the count of consolidated dives in summary"
   }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9851,5 +9851,104 @@
   "settings_appearance_showDetailsPane": "Show Details Pane",
   "settings_appearance_showDetailsPane_subtitle": "Display details pane alongside table",
   "settings_appearance_showProfilePanel": "Show Profile Panel in Table View",
-  "settings_appearance_showProfilePanel_subtitle": "Display dive profile chart above the table by default"
+  "settings_appearance_showProfilePanel_subtitle": "Display dive profile chart above the table by default",
+  "common_action_reparse": "Re-parse",
+  "@common_action_reparse": {
+    "description": "Generic re-parse action label"
+  },
+  "diveComputer_detail_reparseAllButton": "Re-parse all dives",
+  "@diveComputer_detail_reparseAllButton": {
+    "description": "Button to re-parse all dives from a computer"
+  },
+  "diveComputer_detail_reparseAllTitle": "Re-parse all dives",
+  "@diveComputer_detail_reparseAllTitle": {
+    "description": "Dialog title for batch re-parse confirmation"
+  },
+  "diveComputer_detail_reparseAllMessage": "Re-run the dive parser on {count} dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.",
+  "@diveComputer_detail_reparseAllMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "diveComputer_detail_reparseAllProgress": "Re-parsing {count} dives...",
+  "@diveComputer_detail_reparseAllProgress": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "diveComputer_detail_reparseAllSuccess": "Re-parsed {count} dives successfully",
+  "@diveComputer_detail_reparseAllSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "diveComputer_detail_reparseAllPartial": "Re-parsed {succeeded} of {total} dives. {failed} failed.",
+  "@diveComputer_detail_reparseAllPartial": {
+    "placeholders": {
+      "succeeded": {
+        "type": "int",
+        "example": "10"
+      },
+      "total": {
+        "type": "int",
+        "example": "12"
+      },
+      "failed": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "diveComputer_detail_reparseRawDataCount": "{count} dives with raw data",
+  "@diveComputer_detail_reparseRawDataCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "diveComputer_detail_reparseRawDataCountWithout": "{count} dives with raw data ({without} without)",
+  "@diveComputer_detail_reparseRawDataCountWithout": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      },
+      "without": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "diveLog_detail_menu_reparseRawData": "Re-parse raw data",
+  "@diveLog_detail_menu_reparseRawData": {
+    "description": "Menu item to re-parse raw dive data"
+  },
+  "diveLog_detail_reparseSuccess": "Dive re-parsed successfully",
+  "@diveLog_detail_reparseSuccess": {
+    "description": "Snackbar message after successful re-parse"
+  },
+  "diveLog_detail_reparseFailed": "Re-parse failed: {error}",
+  "@diveLog_detail_reparseFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "Parse error"
+      }
+    }
+  },
+  "universalImport_label_replaceSource": "Replace Source",
+  "@universalImport_label_replaceSource": {
+    "description": "Label for the replace source duplicate action"
+  }
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -23723,6 +23723,12 @@ abstract class AppLocalizations {
   /// **'Skip all ({count})'**
   String universalImport_bulk_skipAll(int count);
 
+  /// Bulk action button to replace source data for all pending duplicates
+  ///
+  /// In en, this message translates to:
+  /// **'Replace all ({count})'**
+  String universalImport_bulk_replaceSourceAll(int count);
+
   /// Description text on the file selection step listing supported formats
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27455,6 +27455,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Update from same computer'**
   String get universalImport_label_replaceSourceSubtitle;
+
+  /// Title for the import options bottom sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Import Options'**
+  String get universalImport_title_importOptions;
+
+  /// Label for the import options button
+  ///
+  /// In en, this message translates to:
+  /// **'Options'**
+  String get universalImport_label_options;
+
+  /// Switch title for retaining dive numbers from source
+  ///
+  /// In en, this message translates to:
+  /// **'Retain source dive numbers'**
+  String get universalImport_label_retainDiveNumbers;
+
+  /// Switch subtitle for retaining dive numbers
+  ///
+  /// In en, this message translates to:
+  /// **'Use dive numbers from the imported file instead of auto-assigning'**
+  String get universalImport_label_retainDiveNumbersSubtitle;
+
+  /// Title shown when dives are successfully imported
+  ///
+  /// In en, this message translates to:
+  /// **'Successfully Imported'**
+  String get universalImport_title_successImported;
+
+  /// Title shown when existing dives are successfully updated
+  ///
+  /// In en, this message translates to:
+  /// **'Successfully Updated'**
+  String get universalImport_title_successUpdated;
+
+  /// Title shown when dives are successfully consolidated
+  ///
+  /// In en, this message translates to:
+  /// **'Successfully Consolidated'**
+  String get universalImport_title_successConsolidated;
+
+  /// Title shown when no dives were imported
+  ///
+  /// In en, this message translates to:
+  /// **'No Dives Imported'**
+  String get universalImport_title_noDivesImported;
+
+  /// Message shown when all dives were skipped during import
+  ///
+  /// In en, this message translates to:
+  /// **'All dives were skipped.'**
+  String get universalImport_label_allDivesSkipped;
+
+  /// Label for the count of dives whose source data was replaced
+  ///
+  /// In en, this message translates to:
+  /// **'Replaced source data'**
+  String get universalImport_label_replacedSourceData;
+
+  /// Label for the count of consolidated dives in summary
+  ///
+  /// In en, this message translates to:
+  /// **'Consolidated'**
+  String get universalImport_label_consolidated;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27443,6 +27443,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Replace Source'**
   String get universalImport_label_replaceSource;
+
+  /// Subtitle for the replace source button in the duplicate review step
+  ///
+  /// In en, this message translates to:
+  /// **'Update from same computer'**
+  String get universalImport_label_replaceSourceSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27361,6 +27361,88 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Display dive profile chart above the table by default'**
   String get settings_appearance_showProfilePanel_subtitle;
+
+  /// Generic re-parse action label
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parse'**
+  String get common_action_reparse;
+
+  /// Button to re-parse all dives from a computer
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parse all dives'**
+  String get diveComputer_detail_reparseAllButton;
+
+  /// Dialog title for batch re-parse confirmation
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parse all dives'**
+  String get diveComputer_detail_reparseAllTitle;
+
+  /// No description provided for @diveComputer_detail_reparseAllMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-run the dive parser on {count} dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.'**
+  String diveComputer_detail_reparseAllMessage(int count);
+
+  /// No description provided for @diveComputer_detail_reparseAllProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parsing {count} dives...'**
+  String diveComputer_detail_reparseAllProgress(int count);
+
+  /// No description provided for @diveComputer_detail_reparseAllSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parsed {count} dives successfully'**
+  String diveComputer_detail_reparseAllSuccess(int count);
+
+  /// No description provided for @diveComputer_detail_reparseAllPartial.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parsed {succeeded} of {total} dives. {failed} failed.'**
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  );
+
+  /// No description provided for @diveComputer_detail_reparseRawDataCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} dives with raw data'**
+  String diveComputer_detail_reparseRawDataCount(int count);
+
+  /// No description provided for @diveComputer_detail_reparseRawDataCountWithout.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} dives with raw data ({without} without)'**
+  String diveComputer_detail_reparseRawDataCountWithout(int count, int without);
+
+  /// Menu item to re-parse raw dive data
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parse raw data'**
+  String get diveLog_detail_menu_reparseRawData;
+
+  /// Snackbar message after successful re-parse
+  ///
+  /// In en, this message translates to:
+  /// **'Dive re-parsed successfully'**
+  String get diveLog_detail_reparseSuccess;
+
+  /// No description provided for @diveLog_detail_reparseFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-parse failed: {error}'**
+  String diveLog_detail_reparseFailed(String error);
+
+  /// Label for the replace source duplicate action
+  ///
+  /// In en, this message translates to:
+  /// **'Replace Source'**
+  String get universalImport_label_replaceSource;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13681,6 +13681,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'اختر ملف سجل غوص للاستيراد. الصيغ المدعومة تشمل CSV وUDDF وSubsurface XML وGarmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15880,4 +15880,64 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'عرض مخطط ملف الغوصة فوق الجدول بشكل افتراضي';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15949,4 +15949,40 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15940,4 +15940,8 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16178,4 +16178,64 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Tauchprofildiagramm standardmäßig über der Tabelle anzeigen';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16247,4 +16247,40 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16238,4 +16238,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -13941,6 +13941,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Wählen Sie eine Tauchprotokoll-Datei zum Importieren aus. Unterstützte Formate sind CSV, UDDF, Subsurface XML und Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15921,4 +15921,64 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Display dive profile chart above the table by default';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13716,6 +13716,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Select a dive log file to import. Supported formats include CSV, UDDF, Subsurface XML, Garmin FIT, and Shearwater Cloud databases.';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15981,4 +15981,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15990,4 +15990,40 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -13959,6 +13959,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Selecciona un archivo de registro de inmersiones para importar. Los formatos compatibles incluyen CSV, UDDF, Subsurface XML y Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16265,4 +16265,40 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16196,4 +16196,64 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Mostrar gráfico de perfil de inmersión sobre la tabla por defecto';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16256,4 +16256,8 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16310,4 +16310,8 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16250,4 +16250,64 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Afficher le graphique de profil de plongée au-dessus du tableau par défaut';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14014,6 +14014,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Sélectionnez un fichier de carnet de plongée à importer. Les formats pris en charge incluent CSV, UDDF, Subsurface XML et Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16319,4 +16319,40 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15837,4 +15837,40 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13581,6 +13581,11 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'בחר קובץ יומן צלילה לייבוא. פורמטים נתמכים כוללים CSV, UDDF, Subsurface XML ו-Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15768,4 +15768,64 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'הצג תרשים פרופיל צלילה מעל הטבלה כברירת מחדל';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15828,4 +15828,8 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -13913,6 +13913,11 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Válassz egy merülési napló fájlt az importáláshoz. Támogatott formátumok: CSV, UDDF, Subsurface XML és Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16211,4 +16211,40 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16142,4 +16142,64 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Merülési profil diagram megjelenítése a táblázat felett alapértelmezetten';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16202,4 +16202,8 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16189,4 +16189,64 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Visualizza il grafico del profilo di immersione sopra la tabella per impostazione predefinita';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16249,4 +16249,8 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -13957,6 +13957,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Seleziona un file di registro immersioni da importare. I formati supportati includono CSV, UDDF, Subsurface XML e Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16258,4 +16258,40 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13837,6 +13837,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Selecteer een duiklogboekbestand om te importeren. Ondersteunde formaten zijn CSV, UDDF, Subsurface XML en Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16057,4 +16057,64 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Duikprofielgrafiek standaard boven de tabel weergeven';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16117,4 +16117,8 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16126,4 +16126,40 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16262,4 +16262,40 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -13959,6 +13959,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       'Selecione um arquivo de registro de mergulho para importar. Os formatos suportados incluem CSV, UDDF, Subsurface XML e Garmin FIT.';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16193,4 +16193,64 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get settings_appearance_showProfilePanel_subtitle =>
       'Exibir gráfico de perfil de mergulho acima da tabela por padrão';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16253,4 +16253,8 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15407,4 +15407,64 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_appearance_showProfilePanel_subtitle => '默认在表格上方显示潜水剖面图';
+
+  @override
+  String get common_action_reparse => 'Re-parse';
+
+  @override
+  String get diveComputer_detail_reparseAllButton => 'Re-parse all dives';
+
+  @override
+  String get diveComputer_detail_reparseAllTitle => 'Re-parse all dives';
+
+  @override
+  String diveComputer_detail_reparseAllMessage(int count) {
+    return 'Re-run the dive parser on $count dives that have stored raw data. This updates profile and sensor data but preserves your notes, sites, buddies, and other edits.';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllProgress(int count) {
+    return 'Re-parsing $count dives...';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllSuccess(int count) {
+    return 'Re-parsed $count dives successfully';
+  }
+
+  @override
+  String diveComputer_detail_reparseAllPartial(
+    int succeeded,
+    int total,
+    int failed,
+  ) {
+    return 'Re-parsed $succeeded of $total dives. $failed failed.';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCount(int count) {
+    return '$count dives with raw data';
+  }
+
+  @override
+  String diveComputer_detail_reparseRawDataCountWithout(
+    int count,
+    int without,
+  ) {
+    return '$count dives with raw data ($without without)';
+  }
+
+  @override
+  String get diveLog_detail_menu_reparseRawData => 'Re-parse raw data';
+
+  @override
+  String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
+
+  @override
+  String diveLog_detail_reparseFailed(String error) {
+    return 'Re-parse failed: $error';
+  }
+
+  @override
+  String get universalImport_label_replaceSource => 'Replace Source';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15476,4 +15476,40 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get universalImport_label_replaceSourceSubtitle =>
       'Update from same computer';
+
+  @override
+  String get universalImport_title_importOptions => 'Import Options';
+
+  @override
+  String get universalImport_label_options => 'Options';
+
+  @override
+  String get universalImport_label_retainDiveNumbers =>
+      'Retain source dive numbers';
+
+  @override
+  String get universalImport_label_retainDiveNumbersSubtitle =>
+      'Use dive numbers from the imported file instead of auto-assigning';
+
+  @override
+  String get universalImport_title_successImported => 'Successfully Imported';
+
+  @override
+  String get universalImport_title_successUpdated => 'Successfully Updated';
+
+  @override
+  String get universalImport_title_successConsolidated =>
+      'Successfully Consolidated';
+
+  @override
+  String get universalImport_title_noDivesImported => 'No Dives Imported';
+
+  @override
+  String get universalImport_label_allDivesSkipped => 'All dives were skipped.';
+
+  @override
+  String get universalImport_label_replacedSourceData => 'Replaced source data';
+
+  @override
+  String get universalImport_label_consolidated => 'Consolidated';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13264,6 +13264,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String universalImport_bulk_replaceSourceAll(int count) {
+    return 'Replace all ($count)';
+  }
+
+  @override
   String get universalImport_description_supportedFormats =>
       '选择一个潜水日志文件进行导入。支持的格式包括 CSV、UDDF、Subsurface XML 和 Garmin FIT。';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15467,4 +15467,8 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get universalImport_label_replaceSource => 'Replace Source';
+
+  @override
+  String get universalImport_label_replaceSourceSubtitle =>
+      'Update from same computer';
 }

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -881,3 +881,29 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveDecoModel(
     env->SetIntArrayRegion(result, 0, 4, values);
     return result;
 }
+
+// ============================================================
+// Raw Dive Data Access
+// ============================================================
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveRawData(
+    JNIEnv *env, jclass, jlong divePtr) {
+    auto *dive = reinterpret_cast<const libdc_parsed_dive_t *>(divePtr);
+    if (dive->raw_data == nullptr || dive->raw_data_size == 0) return nullptr;
+    jbyteArray arr = env->NewByteArray(static_cast<jint>(dive->raw_data_size));
+    env->SetByteArrayRegion(arr, 0, static_cast<jint>(dive->raw_data_size),
+        reinterpret_cast<const jbyte *>(dive->raw_data));
+    return arr;
+}
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveRawFingerprint(
+    JNIEnv *env, jclass, jlong divePtr) {
+    auto *dive = reinterpret_cast<const libdc_parsed_dive_t *>(divePtr);
+    if (dive->raw_fingerprint == nullptr || dive->raw_fingerprint_size == 0) return nullptr;
+    jbyteArray arr = env->NewByteArray(static_cast<jint>(dive->raw_fingerprint_size));
+    env->SetByteArrayRegion(arr, 0, static_cast<jint>(dive->raw_fingerprint_size),
+        reinterpret_cast<const jbyte *>(dive->raw_fingerprint));
+    return arr;
+}

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
@@ -280,7 +280,9 @@ data class ParsedDive (
   val decoAlgorithm: String? = null,
   val gfLow: Long? = null,
   val gfHigh: Long? = null,
-  val decoConservatism: Long? = null
+  val decoConservatism: Long? = null,
+  val rawData: ByteArray? = null,
+  val rawFingerprint: ByteArray? = null
 )
  {
   companion object {
@@ -307,7 +309,9 @@ data class ParsedDive (
       val gfLow = pigeonVar_list[19] as Long?
       val gfHigh = pigeonVar_list[20] as Long?
       val decoConservatism = pigeonVar_list[21] as Long?
-      return ParsedDive(fingerprint, dateTimeYear, dateTimeMonth, dateTimeDay, dateTimeHour, dateTimeMinute, dateTimeSecond, dateTimeTimezoneOffset, maxDepthMeters, avgDepthMeters, durationSeconds, minTemperatureCelsius, maxTemperatureCelsius, samples, tanks, gasMixes, events, diveMode, decoAlgorithm, gfLow, gfHigh, decoConservatism)
+      val rawData = pigeonVar_list[22] as ByteArray?
+      val rawFingerprint = pigeonVar_list[23] as ByteArray?
+      return ParsedDive(fingerprint, dateTimeYear, dateTimeMonth, dateTimeDay, dateTimeHour, dateTimeMinute, dateTimeSecond, dateTimeTimezoneOffset, maxDepthMeters, avgDepthMeters, durationSeconds, minTemperatureCelsius, maxTemperatureCelsius, samples, tanks, gasMixes, events, diveMode, decoAlgorithm, gfLow, gfHigh, decoConservatism, rawData, rawFingerprint)
     }
   }
   fun toList(): List<Any?> {
@@ -334,6 +338,8 @@ data class ParsedDive (
       gfLow,
       gfHigh,
       decoConservatism,
+      rawData,
+      rawFingerprint,
     )
   }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -372,6 +372,10 @@ class DiveComputerHostApiImpl(
         val gfHigh = decoInfo?.let { if (it[3] == 0) null else it[3].toLong() }
         val decoConservatism = decoInfo?.let { if (it[1] == 0) null else it[1].toLong() }
 
+        // Copy raw dive data bytes if available.
+        val rawData = LibdcWrapper.nativeGetDiveRawData(divePtr)
+        val rawFingerprint = LibdcWrapper.nativeGetDiveRawFingerprint(divePtr)
+
         return ParsedDive(
             fingerprint = fingerprint,
             dateTimeYear = LibdcWrapper.nativeGetDiveYear(divePtr).toLong(),
@@ -394,7 +398,9 @@ class DiveComputerHostApiImpl(
             decoAlgorithm = decoAlgorithm,
             gfLow = gfLow,
             gfHigh = gfHigh,
-            decoConservatism = decoConservatism
+            decoConservatism = decoConservatism,
+            rawData = rawData,
+            rawFingerprint = rawFingerprint
         )
     }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/LibdcWrapper.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/LibdcWrapper.kt
@@ -67,6 +67,10 @@ object LibdcWrapper {
 
     // Decompression model access
     external fun nativeGetDiveDecoModel(divePtr: Long): IntArray?
+
+    // Raw dive data access
+    external fun nativeGetDiveRawData(divePtr: Long): ByteArray?
+    external fun nativeGetDiveRawFingerprint(divePtr: Long): ByteArray?
 }
 
 // Mutable data class for receiving descriptor info from JNI.

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -528,6 +528,21 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
         default: decoAlgorithm = nil
         }
 
+        // Copy raw dive data bytes if available.
+        let rawData: FlutterStandardTypedData?
+        if dive.raw_data != nil && dive.raw_data_size > 0 {
+            rawData = FlutterStandardTypedData(bytes: Data(bytes: dive.raw_data, count: Int(dive.raw_data_size)))
+        } else {
+            rawData = nil
+        }
+
+        let rawFingerprint: FlutterStandardTypedData?
+        if dive.raw_fingerprint != nil && dive.raw_fingerprint_size > 0 {
+            rawFingerprint = FlutterStandardTypedData(bytes: Data(bytes: dive.raw_fingerprint, count: Int(dive.raw_fingerprint_size)))
+        } else {
+            rawFingerprint = nil
+        }
+
         return ParsedDive(
             fingerprint: fingerprintHex,
             dateTimeYear: Int64(dive.year),
@@ -554,7 +569,9 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
             gfHigh: dive.gf_high == 0 ? nil : Int64(dive.gf_high),
             // Note: deco_conservatism uses 0 for both "neutral" and "not reported".
             // Cannot distinguish these without a C layer change.
-            decoConservatism: dive.deco_conservatism == 0 ? nil : Int64(dive.deco_conservatism)
+            decoConservatism: dive.deco_conservatism == 0 ? nil : Int64(dive.deco_conservatism),
+            rawData: rawData,
+            rawFingerprint: rawFingerprint
         )
     }
 

--- a/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
@@ -335,6 +335,8 @@ struct ParsedDive {
   var gfLow: Int64? = nil
   var gfHigh: Int64? = nil
   var decoConservatism: Int64? = nil
+  var rawData: FlutterStandardTypedData? = nil
+  var rawFingerprint: FlutterStandardTypedData? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -361,6 +363,8 @@ struct ParsedDive {
     let gfLow: Int64? = nilOrValue(pigeonVar_list[19])
     let gfHigh: Int64? = nilOrValue(pigeonVar_list[20])
     let decoConservatism: Int64? = nilOrValue(pigeonVar_list[21])
+    let rawData: FlutterStandardTypedData? = nilOrValue(pigeonVar_list[22])
+    let rawFingerprint: FlutterStandardTypedData? = nilOrValue(pigeonVar_list[23])
 
     return ParsedDive(
       fingerprint: fingerprint,
@@ -384,7 +388,9 @@ struct ParsedDive {
       decoAlgorithm: decoAlgorithm,
       gfLow: gfLow,
       gfHigh: gfHigh,
-      decoConservatism: decoConservatism
+      decoConservatism: decoConservatism,
+      rawData: rawData,
+      rawFingerprint: rawFingerprint
     )
   }
   func toList() -> [Any?] {
@@ -411,6 +417,8 @@ struct ParsedDive {
       gfLow,
       gfHigh,
       decoConservatism,
+      rawData,
+      rawFingerprint,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
+++ b/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
@@ -15,7 +15,11 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -25,12 +29,7 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   return <Object?>[error.code, error.message, error.details];
 }
 
-enum TransportType {
-  ble,
-  usb,
-  serial,
-  infrared,
-}
+enum TransportType { ble, usb, serial, infrared }
 
 class DeviceDescriptor {
   DeviceDescriptor({
@@ -49,12 +48,7 @@ class DeviceDescriptor {
   List<TransportType> transports;
 
   Object encode() {
-    return <Object?>[
-      vendor,
-      product,
-      model,
-      transports,
-    ];
+    return <Object?>[vendor, product, model, transports];
   }
 
   static DeviceDescriptor decode(Object result) {
@@ -91,14 +85,7 @@ class DiscoveredDevice {
   TransportType transport;
 
   Object encode() {
-    return <Object?>[
-      vendor,
-      product,
-      model,
-      address,
-      name,
-      transport,
-    ];
+    return <Object?>[vendor, product, model, address, name, transport];
   }
 
   static DiscoveredDevice decode(Object result) {
@@ -214,11 +201,7 @@ class GasMix {
   double hePercent;
 
   Object encode() {
-    return <Object?>[
-      index,
-      o2Percent,
-      hePercent,
-    ];
+    return <Object?>[index, o2Percent, hePercent];
   }
 
   static GasMix decode(Object result) {
@@ -273,11 +256,7 @@ class TankInfo {
 }
 
 class DiveEvent {
-  DiveEvent({
-    required this.timeSeconds,
-    required this.type,
-    this.data,
-  });
+  DiveEvent({required this.timeSeconds, required this.type, this.data});
 
   int timeSeconds;
 
@@ -286,11 +265,7 @@ class DiveEvent {
   Map<String, String>? data;
 
   Object encode() {
-    return <Object?>[
-      timeSeconds,
-      type,
-      data,
-    ];
+    return <Object?>[timeSeconds, type, data];
   }
 
   static DiveEvent decode(Object result) {
@@ -453,11 +428,7 @@ class DownloadProgress {
   String status;
 
   Object encode() {
-    return <Object?>[
-      current,
-      total,
-      status,
-    ];
+    return <Object?>[current, total, status];
   }
 
   static DownloadProgress decode(Object result) {
@@ -471,20 +442,14 @@ class DownloadProgress {
 }
 
 class DiveComputerError {
-  DiveComputerError({
-    required this.code,
-    required this.message,
-  });
+  DiveComputerError({required this.code, required this.message});
 
   String code;
 
   String message;
 
   Object encode() {
-    return <Object?>[
-      code,
-      message,
-    ];
+    return <Object?>[code, message];
   }
 
   static DiveComputerError decode(Object result) {
@@ -496,7 +461,6 @@ class DiveComputerError {
   }
 }
 
-
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -504,34 +468,34 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is TransportType) {
+    } else if (value is TransportType) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is DeviceDescriptor) {
+    } else if (value is DeviceDescriptor) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    }    else if (value is DiscoveredDevice) {
+    } else if (value is DiscoveredDevice) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    }    else if (value is ProfileSample) {
+    } else if (value is ProfileSample) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    }    else if (value is GasMix) {
+    } else if (value is GasMix) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    }    else if (value is TankInfo) {
+    } else if (value is TankInfo) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    }    else if (value is DiveEvent) {
+    } else if (value is DiveEvent) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    }    else if (value is ParsedDive) {
+    } else if (value is ParsedDive) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    }    else if (value is DownloadProgress) {
+    } else if (value is DownloadProgress) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is DiveComputerError) {
+    } else if (value is DiveComputerError) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
     } else {
@@ -542,26 +506,26 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129: 
+      case 129:
         final int? value = readValue(buffer) as int?;
         return value == null ? null : TransportType.values[value];
-      case 130: 
+      case 130:
         return DeviceDescriptor.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return DiscoveredDevice.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return ProfileSample.decode(readValue(buffer)!);
-      case 133: 
+      case 133:
         return GasMix.decode(readValue(buffer)!);
-      case 134: 
+      case 134:
         return TankInfo.decode(readValue(buffer)!);
-      case 135: 
+      case 135:
         return DiveEvent.decode(readValue(buffer)!);
-      case 136: 
+      case 136:
         return ParsedDive.decode(readValue(buffer)!);
-      case 137: 
+      case 137:
         return DownloadProgress.decode(readValue(buffer)!);
-      case 138: 
+      case 138:
         return DiveComputerError.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -573,9 +537,13 @@ class DiveComputerHostApi {
   /// Constructor for [DiveComputerHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  DiveComputerHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  DiveComputerHostApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
+           ? '.$messageChannelSuffix'
+           : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -583,12 +551,14 @@ class DiveComputerHostApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<List<DeviceDescriptor>> getDeviceDescriptors() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getDeviceDescriptors$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getDeviceDescriptors$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -605,17 +575,20 @@ class DiveComputerHostApi {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (pigeonVar_replyList[0] as List<Object?>?)!.cast<DeviceDescriptor>();
+      return (pigeonVar_replyList[0] as List<Object?>?)!
+          .cast<DeviceDescriptor>();
     }
   }
 
   Future<void> startDiscovery(TransportType transport) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDiscovery$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDiscovery$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[transport]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -632,12 +605,14 @@ class DiveComputerHostApi {
   }
 
   Future<void> stopDiscovery() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.stopDiscovery$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.stopDiscovery$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -653,15 +628,21 @@ class DiveComputerHostApi {
     }
   }
 
-  Future<void> startDownload(DiscoveredDevice device, String? fingerprint) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDownload$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+  Future<void> startDownload(
+    DiscoveredDevice device,
+    String? fingerprint,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDownload$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_channel.send(<Object?>[device, fingerprint]) as List<Object?>?;
+        await pigeonVar_channel.send(<Object?>[device, fingerprint])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -676,12 +657,14 @@ class DiveComputerHostApi {
   }
 
   Future<void> cancelDownload() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.cancelDownload$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.cancelDownload$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -698,12 +681,14 @@ class DiveComputerHostApi {
   }
 
   Future<void> submitPinCode(String pinCode) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.submitPinCode$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.submitPinCode$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[pinCode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -720,12 +705,14 @@ class DiveComputerHostApi {
   }
 
   Future<String> getLibdivecomputerVersion() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getLibdivecomputerVersion$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getLibdivecomputerVersion$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -746,15 +733,23 @@ class DiveComputerHostApi {
     }
   }
 
-  Future<ParsedDive> parseRawDiveData(String vendor, String product, int model, Uint8List data) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.parseRawDiveData$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+  Future<ParsedDive> parseRawDiveData(
+    String vendor,
+    String product,
+    int model,
+    Uint8List data,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.parseRawDiveData$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_channel.send(<Object?>[vendor, product, model, data]) as List<Object?>?;
+        await pigeonVar_channel.send(<Object?>[vendor, product, model, data])
+            as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -785,7 +780,11 @@ abstract class DiveComputerFlutterApi {
 
   void onDiveDownloaded(ParsedDive dive);
 
-  void onDownloadComplete(int totalDives, String? serialNumber, String? firmwareVersion);
+  void onDownloadComplete(
+    int totalDives,
+    String? serialNumber,
+    String? firmwareVersion,
+  );
 
   void onError(DiveComputerError error);
 
@@ -793,37 +792,55 @@ abstract class DiveComputerFlutterApi {
 
   void onLogEvent(String category, String level, String message);
 
-  static void setUp(DiveComputerFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(
+    DiveComputerFlutterApi? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty
+        ? '.$messageChannelSuffix'
+        : '';
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final DiscoveredDevice? arg_device = (args[0] as DiscoveredDevice?);
-          assert(arg_device != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null, expected non-null DiscoveredDevice.');
+          assert(
+            arg_device != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null, expected non-null DiscoveredDevice.',
+          );
           try {
             api.onDeviceDiscovered(arg_device!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiscoveryComplete$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiscoveryComplete$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -833,166 +850,230 @@ abstract class DiveComputerFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final DownloadProgress? arg_progress = (args[0] as DownloadProgress?);
-          assert(arg_progress != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null, expected non-null DownloadProgress.');
+          assert(
+            arg_progress != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null, expected non-null DownloadProgress.',
+          );
           try {
             api.onDownloadProgress(arg_progress!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final ParsedDive? arg_dive = (args[0] as ParsedDive?);
-          assert(arg_dive != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null, expected non-null ParsedDive.');
+          assert(
+            arg_dive != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null, expected non-null ParsedDive.',
+          );
           try {
             api.onDiveDownloaded(arg_dive!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_totalDives = (args[0] as int?);
-          assert(arg_totalDives != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null, expected non-null int.');
+          assert(
+            arg_totalDives != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null, expected non-null int.',
+          );
           final String? arg_serialNumber = (args[1] as String?);
           final String? arg_firmwareVersion = (args[2] as String?);
           try {
-            api.onDownloadComplete(arg_totalDives!, arg_serialNumber, arg_firmwareVersion);
+            api.onDownloadComplete(
+              arg_totalDives!,
+              arg_serialNumber,
+              arg_firmwareVersion,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final DiveComputerError? arg_error = (args[0] as DiveComputerError?);
-          assert(arg_error != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null, expected non-null DiveComputerError.');
+          assert(
+            arg_error != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null, expected non-null DiveComputerError.',
+          );
           try {
             api.onError(arg_error!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_deviceAddress = (args[0] as String?);
-          assert(arg_deviceAddress != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null, expected non-null String.');
+          assert(
+            arg_deviceAddress != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null, expected non-null String.',
+          );
           try {
             api.onPinCodeRequired(arg_deviceAddress!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null.');
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null.',
+          );
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_category = (args[0] as String?);
-          assert(arg_category != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.');
+          assert(
+            arg_category != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.',
+          );
           final String? arg_level = (args[1] as String?);
-          assert(arg_level != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.');
+          assert(
+            arg_level != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.',
+          );
           final String? arg_message = (args[2] as String?);
-          assert(arg_message != null,
-              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.');
+          assert(
+            arg_message != null,
+            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.',
+          );
           try {
             api.onLogEvent(arg_category!, arg_level!, arg_message!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }

--- a/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
+++ b/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
@@ -15,11 +15,7 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse({
-  Object? result,
-  PlatformException? error,
-  bool empty = false,
-}) {
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -29,7 +25,12 @@ List<Object?> wrapResponse({
   return <Object?>[error.code, error.message, error.details];
 }
 
-enum TransportType { ble, usb, serial, infrared }
+enum TransportType {
+  ble,
+  usb,
+  serial,
+  infrared,
+}
 
 class DeviceDescriptor {
   DeviceDescriptor({
@@ -48,7 +49,12 @@ class DeviceDescriptor {
   List<TransportType> transports;
 
   Object encode() {
-    return <Object?>[vendor, product, model, transports];
+    return <Object?>[
+      vendor,
+      product,
+      model,
+      transports,
+    ];
   }
 
   static DeviceDescriptor decode(Object result) {
@@ -85,7 +91,14 @@ class DiscoveredDevice {
   TransportType transport;
 
   Object encode() {
-    return <Object?>[vendor, product, model, address, name, transport];
+    return <Object?>[
+      vendor,
+      product,
+      model,
+      address,
+      name,
+      transport,
+    ];
   }
 
   static DiscoveredDevice decode(Object result) {
@@ -201,7 +214,11 @@ class GasMix {
   double hePercent;
 
   Object encode() {
-    return <Object?>[index, o2Percent, hePercent];
+    return <Object?>[
+      index,
+      o2Percent,
+      hePercent,
+    ];
   }
 
   static GasMix decode(Object result) {
@@ -256,7 +273,11 @@ class TankInfo {
 }
 
 class DiveEvent {
-  DiveEvent({required this.timeSeconds, required this.type, this.data});
+  DiveEvent({
+    required this.timeSeconds,
+    required this.type,
+    this.data,
+  });
 
   int timeSeconds;
 
@@ -265,7 +286,11 @@ class DiveEvent {
   Map<String, String>? data;
 
   Object encode() {
-    return <Object?>[timeSeconds, type, data];
+    return <Object?>[
+      timeSeconds,
+      type,
+      data,
+    ];
   }
 
   static DiveEvent decode(Object result) {
@@ -302,6 +327,8 @@ class ParsedDive {
     this.gfLow,
     this.gfHigh,
     this.decoConservatism,
+    this.rawData,
+    this.rawFingerprint,
   });
 
   String fingerprint;
@@ -348,6 +375,10 @@ class ParsedDive {
 
   int? decoConservatism;
 
+  Uint8List? rawData;
+
+  Uint8List? rawFingerprint;
+
   Object encode() {
     return <Object?>[
       fingerprint,
@@ -372,6 +403,8 @@ class ParsedDive {
       gfLow,
       gfHigh,
       decoConservatism,
+      rawData,
+      rawFingerprint,
     ];
   }
 
@@ -400,6 +433,8 @@ class ParsedDive {
       gfLow: result[19] as int?,
       gfHigh: result[20] as int?,
       decoConservatism: result[21] as int?,
+      rawData: result[22] as Uint8List?,
+      rawFingerprint: result[23] as Uint8List?,
     );
   }
 }
@@ -418,7 +453,11 @@ class DownloadProgress {
   String status;
 
   Object encode() {
-    return <Object?>[current, total, status];
+    return <Object?>[
+      current,
+      total,
+      status,
+    ];
   }
 
   static DownloadProgress decode(Object result) {
@@ -432,14 +471,20 @@ class DownloadProgress {
 }
 
 class DiveComputerError {
-  DiveComputerError({required this.code, required this.message});
+  DiveComputerError({
+    required this.code,
+    required this.message,
+  });
 
   String code;
 
   String message;
 
   Object encode() {
-    return <Object?>[code, message];
+    return <Object?>[
+      code,
+      message,
+    ];
   }
 
   static DiveComputerError decode(Object result) {
@@ -451,6 +496,7 @@ class DiveComputerError {
   }
 }
 
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -458,34 +504,34 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is TransportType) {
+    }    else if (value is TransportType) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is DeviceDescriptor) {
+    }    else if (value is DeviceDescriptor) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is DiscoveredDevice) {
+    }    else if (value is DiscoveredDevice) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is ProfileSample) {
+    }    else if (value is ProfileSample) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is GasMix) {
+    }    else if (value is GasMix) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is TankInfo) {
+    }    else if (value is TankInfo) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is DiveEvent) {
+    }    else if (value is DiveEvent) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is ParsedDive) {
+    }    else if (value is ParsedDive) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is DownloadProgress) {
+    }    else if (value is DownloadProgress) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is DiveComputerError) {
+    }    else if (value is DiveComputerError) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
     } else {
@@ -496,26 +542,26 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : TransportType.values[value];
-      case 130:
+      case 130: 
         return DeviceDescriptor.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return DiscoveredDevice.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return ProfileSample.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return GasMix.decode(readValue(buffer)!);
-      case 134:
+      case 134: 
         return TankInfo.decode(readValue(buffer)!);
-      case 135:
+      case 135: 
         return DiveEvent.decode(readValue(buffer)!);
-      case 136:
+      case 136: 
         return ParsedDive.decode(readValue(buffer)!);
-      case 137:
+      case 137: 
         return DownloadProgress.decode(readValue(buffer)!);
-      case 138:
+      case 138: 
         return DiveComputerError.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -527,13 +573,9 @@ class DiveComputerHostApi {
   /// Constructor for [DiveComputerHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  DiveComputerHostApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  DiveComputerHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -541,14 +583,12 @@ class DiveComputerHostApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<List<DeviceDescriptor>> getDeviceDescriptors() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getDeviceDescriptors$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getDeviceDescriptors$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -565,20 +605,17 @@ class DiveComputerHostApi {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (pigeonVar_replyList[0] as List<Object?>?)!
-          .cast<DeviceDescriptor>();
+      return (pigeonVar_replyList[0] as List<Object?>?)!.cast<DeviceDescriptor>();
     }
   }
 
   Future<void> startDiscovery(TransportType transport) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDiscovery$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDiscovery$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[transport]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -595,14 +632,12 @@ class DiveComputerHostApi {
   }
 
   Future<void> stopDiscovery() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.stopDiscovery$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.stopDiscovery$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -618,21 +653,15 @@ class DiveComputerHostApi {
     }
   }
 
-  Future<void> startDownload(
-    DiscoveredDevice device,
-    String? fingerprint,
-  ) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDownload$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+  Future<void> startDownload(DiscoveredDevice device, String? fingerprint) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.startDownload$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_channel.send(<Object?>[device, fingerprint])
-            as List<Object?>?;
+        await pigeonVar_channel.send(<Object?>[device, fingerprint]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -647,14 +676,12 @@ class DiveComputerHostApi {
   }
 
   Future<void> cancelDownload() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.cancelDownload$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.cancelDownload$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -671,14 +698,12 @@ class DiveComputerHostApi {
   }
 
   Future<void> submitPinCode(String pinCode) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.submitPinCode$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.submitPinCode$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[pinCode]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -695,14 +720,12 @@ class DiveComputerHostApi {
   }
 
   Future<String> getLibdivecomputerVersion() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getLibdivecomputerVersion$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.getLibdivecomputerVersion$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -723,23 +746,15 @@ class DiveComputerHostApi {
     }
   }
 
-  Future<ParsedDive> parseRawDiveData(
-    String vendor,
-    String product,
-    int model,
-    Uint8List data,
-  ) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.parseRawDiveData$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+  Future<ParsedDive> parseRawDiveData(String vendor, String product, int model, Uint8List data) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerHostApi.parseRawDiveData$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_channel.send(<Object?>[vendor, product, model, data])
-            as List<Object?>?;
+        await pigeonVar_channel.send(<Object?>[vendor, product, model, data]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -770,11 +785,7 @@ abstract class DiveComputerFlutterApi {
 
   void onDiveDownloaded(ParsedDive dive);
 
-  void onDownloadComplete(
-    int totalDives,
-    String? serialNumber,
-    String? firmwareVersion,
-  );
+  void onDownloadComplete(int totalDives, String? serialNumber, String? firmwareVersion);
 
   void onError(DiveComputerError error);
 
@@ -782,55 +793,37 @@ abstract class DiveComputerFlutterApi {
 
   void onLogEvent(String category, String level, String message);
 
-  static void setUp(
-    DiveComputerFlutterApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+  static void setUp(DiveComputerFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final DiscoveredDevice? arg_device = (args[0] as DiscoveredDevice?);
-          assert(
-            arg_device != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null, expected non-null DiscoveredDevice.',
-          );
+          assert(arg_device != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDeviceDiscovered was null, expected non-null DiscoveredDevice.');
           try {
             api.onDeviceDiscovered(arg_device!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiscoveryComplete$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiscoveryComplete$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -840,230 +833,166 @@ abstract class DiveComputerFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final DownloadProgress? arg_progress = (args[0] as DownloadProgress?);
-          assert(
-            arg_progress != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null, expected non-null DownloadProgress.',
-          );
+          assert(arg_progress != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadProgress was null, expected non-null DownloadProgress.');
           try {
             api.onDownloadProgress(arg_progress!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final ParsedDive? arg_dive = (args[0] as ParsedDive?);
-          assert(
-            arg_dive != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null, expected non-null ParsedDive.',
-          );
+          assert(arg_dive != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDiveDownloaded was null, expected non-null ParsedDive.');
           try {
             api.onDiveDownloaded(arg_dive!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_totalDives = (args[0] as int?);
-          assert(
-            arg_totalDives != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null, expected non-null int.',
-          );
+          assert(arg_totalDives != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onDownloadComplete was null, expected non-null int.');
           final String? arg_serialNumber = (args[1] as String?);
           final String? arg_firmwareVersion = (args[2] as String?);
           try {
-            api.onDownloadComplete(
-              arg_totalDives!,
-              arg_serialNumber,
-              arg_firmwareVersion,
-            );
+            api.onDownloadComplete(arg_totalDives!, arg_serialNumber, arg_firmwareVersion);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final DiveComputerError? arg_error = (args[0] as DiveComputerError?);
-          assert(
-            arg_error != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null, expected non-null DiveComputerError.',
-          );
+          assert(arg_error != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onError was null, expected non-null DiveComputerError.');
           try {
             api.onError(arg_error!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_deviceAddress = (args[0] as String?);
-          assert(
-            arg_deviceAddress != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null, expected non-null String.',
-          );
+          assert(arg_deviceAddress != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onPinCodeRequired was null, expected non-null String.');
           try {
             api.onPinCodeRequired(arg_deviceAddress!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?>
-      pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null.',
-          );
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_category = (args[0] as String?);
-          assert(
-            arg_category != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.',
-          );
+          assert(arg_category != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.');
           final String? arg_level = (args[1] as String?);
-          assert(
-            arg_level != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.',
-          );
+          assert(arg_level != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.');
           final String? arg_message = (args[2] as String?);
-          assert(
-            arg_message != null,
-            'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.',
-          );
+          assert(arg_message != null,
+              'Argument for dev.flutter.pigeon.libdivecomputer_plugin.DiveComputerFlutterApi.onLogEvent was null, expected non-null String.');
           try {
             api.onLogEvent(arg_category!, arg_level!, arg_message!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
@@ -803,6 +803,10 @@ static void libdivecomputer_plugin_parsed_dive_dispose(GObject* object) {
   g_clear_pointer(&self->gf_low, g_free);
   g_clear_pointer(&self->gf_high, g_free);
   g_clear_pointer(&self->deco_conservatism, g_free);
+  g_clear_pointer(&self->raw_data, g_free);
+  self->raw_data_length = 0;
+  g_clear_pointer(&self->raw_fingerprint, g_free);
+  self->raw_fingerprint_length = 0;
   G_OBJECT_CLASS(libdivecomputer_plugin_parsed_dive_parent_class)->dispose(object);
 }
 

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
@@ -780,6 +780,10 @@ struct _LibdivecomputerPluginParsedDive {
   int64_t* gf_low;
   int64_t* gf_high;
   int64_t* deco_conservatism;
+  uint8_t* raw_data;
+  size_t raw_data_length;
+  uint8_t* raw_fingerprint;
+  size_t raw_fingerprint_length;
 };
 
 G_DEFINE_TYPE(LibdivecomputerPluginParsedDive, libdivecomputer_plugin_parsed_dive, G_TYPE_OBJECT)
@@ -809,7 +813,7 @@ static void libdivecomputer_plugin_parsed_dive_class_init(LibdivecomputerPluginP
   G_OBJECT_CLASS(klass)->dispose = libdivecomputer_plugin_parsed_dive_dispose;
 }
 
-LibdivecomputerPluginParsedDive* libdivecomputer_plugin_parsed_dive_new(const gchar* fingerprint, int64_t date_time_year, int64_t date_time_month, int64_t date_time_day, int64_t date_time_hour, int64_t date_time_minute, int64_t date_time_second, int64_t* date_time_timezone_offset, double max_depth_meters, double avg_depth_meters, int64_t duration_seconds, double* min_temperature_celsius, double* max_temperature_celsius, FlValue* samples, FlValue* tanks, FlValue* gas_mixes, FlValue* events, const gchar* dive_mode, const gchar* deco_algorithm, int64_t* gf_low, int64_t* gf_high, int64_t* deco_conservatism) {
+LibdivecomputerPluginParsedDive* libdivecomputer_plugin_parsed_dive_new(const gchar* fingerprint, int64_t date_time_year, int64_t date_time_month, int64_t date_time_day, int64_t date_time_hour, int64_t date_time_minute, int64_t date_time_second, int64_t* date_time_timezone_offset, double max_depth_meters, double avg_depth_meters, int64_t duration_seconds, double* min_temperature_celsius, double* max_temperature_celsius, FlValue* samples, FlValue* tanks, FlValue* gas_mixes, FlValue* events, const gchar* dive_mode, const gchar* deco_algorithm, int64_t* gf_low, int64_t* gf_high, int64_t* deco_conservatism, const uint8_t* raw_data, size_t raw_data_length, const uint8_t* raw_fingerprint, size_t raw_fingerprint_length) {
   LibdivecomputerPluginParsedDive* self = LIBDIVECOMPUTER_PLUGIN_PARSED_DIVE(g_object_new(libdivecomputer_plugin_parsed_dive_get_type(), nullptr));
   self->fingerprint = g_strdup(fingerprint);
   self->date_time_year = date_time_year;
@@ -878,6 +882,22 @@ LibdivecomputerPluginParsedDive* libdivecomputer_plugin_parsed_dive_new(const gc
   }
   else {
     self->deco_conservatism = nullptr;
+  }
+  if (raw_data != nullptr) {
+    self->raw_data = static_cast<uint8_t*>(memcpy(malloc(raw_data_length), raw_data, raw_data_length));
+    self->raw_data_length = raw_data_length;
+  }
+  else {
+    self->raw_data = nullptr;
+    self->raw_data_length = 0;
+  }
+  if (raw_fingerprint != nullptr) {
+    self->raw_fingerprint = static_cast<uint8_t*>(memcpy(malloc(raw_fingerprint_length), raw_fingerprint, raw_fingerprint_length));
+    self->raw_fingerprint_length = raw_fingerprint_length;
+  }
+  else {
+    self->raw_fingerprint = nullptr;
+    self->raw_fingerprint_length = 0;
   }
   return self;
 }
@@ -992,6 +1012,18 @@ int64_t* libdivecomputer_plugin_parsed_dive_get_deco_conservatism(Libdivecompute
   return self->deco_conservatism;
 }
 
+const uint8_t* libdivecomputer_plugin_parsed_dive_get_raw_data(LibdivecomputerPluginParsedDive* self, size_t* length) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PARSED_DIVE(self), nullptr);
+  *length = self->raw_data_length;
+  return self->raw_data;
+}
+
+const uint8_t* libdivecomputer_plugin_parsed_dive_get_raw_fingerprint(LibdivecomputerPluginParsedDive* self, size_t* length) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PARSED_DIVE(self), nullptr);
+  *length = self->raw_fingerprint_length;
+  return self->raw_fingerprint;
+}
+
 static FlValue* libdivecomputer_plugin_parsed_dive_to_list(LibdivecomputerPluginParsedDive* self) {
   FlValue* values = fl_value_new_list();
   fl_value_append_take(values, fl_value_new_string(self->fingerprint));
@@ -1016,6 +1048,8 @@ static FlValue* libdivecomputer_plugin_parsed_dive_to_list(LibdivecomputerPlugin
   fl_value_append_take(values, self->gf_low != nullptr ? fl_value_new_int(*self->gf_low) : fl_value_new_null());
   fl_value_append_take(values, self->gf_high != nullptr ? fl_value_new_int(*self->gf_high) : fl_value_new_null());
   fl_value_append_take(values, self->deco_conservatism != nullptr ? fl_value_new_int(*self->deco_conservatism) : fl_value_new_null());
+  fl_value_append_take(values, self->raw_data != nullptr ? fl_value_new_uint8_list(self->raw_data, self->raw_data_length) : fl_value_new_null());
+  fl_value_append_take(values, self->raw_fingerprint != nullptr ? fl_value_new_uint8_list(self->raw_fingerprint, self->raw_fingerprint_length) : fl_value_new_null());
   return values;
 }
 
@@ -1100,7 +1134,21 @@ static LibdivecomputerPluginParsedDive* libdivecomputer_plugin_parsed_dive_new_f
     deco_conservatism_value = fl_value_get_int(value21);
     deco_conservatism = &deco_conservatism_value;
   }
-  return libdivecomputer_plugin_parsed_dive_new(fingerprint, date_time_year, date_time_month, date_time_day, date_time_hour, date_time_minute, date_time_second, date_time_timezone_offset, max_depth_meters, avg_depth_meters, duration_seconds, min_temperature_celsius, max_temperature_celsius, samples, tanks, gas_mixes, events, dive_mode, deco_algorithm, gf_low, gf_high, deco_conservatism);
+  FlValue* value22 = fl_value_get_list_value(values, 22);
+  const uint8_t* raw_data = nullptr;
+  size_t raw_data_length = 0;
+  if (fl_value_get_type(value22) != FL_VALUE_TYPE_NULL) {
+    raw_data = fl_value_get_uint8_list(value22);
+    raw_data_length = fl_value_get_length(value22);
+  }
+  FlValue* value23 = fl_value_get_list_value(values, 23);
+  const uint8_t* raw_fingerprint = nullptr;
+  size_t raw_fingerprint_length = 0;
+  if (fl_value_get_type(value23) != FL_VALUE_TYPE_NULL) {
+    raw_fingerprint = fl_value_get_uint8_list(value23);
+    raw_fingerprint_length = fl_value_get_length(value23);
+  }
+  return libdivecomputer_plugin_parsed_dive_new(fingerprint, date_time_year, date_time_month, date_time_day, date_time_hour, date_time_minute, date_time_second, date_time_timezone_offset, max_depth_meters, avg_depth_meters, duration_seconds, min_temperature_celsius, max_temperature_celsius, samples, tanks, gas_mixes, events, dive_mode, deco_algorithm, gf_low, gf_high, deco_conservatism, raw_data, raw_data_length, raw_fingerprint, raw_fingerprint_length);
 }
 
 struct _LibdivecomputerPluginDownloadProgress {

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
@@ -535,12 +535,16 @@ G_DECLARE_FINAL_TYPE(LibdivecomputerPluginParsedDive, libdivecomputer_plugin_par
  * gf_low: field in this object.
  * gf_high: field in this object.
  * deco_conservatism: field in this object.
+ * raw_data: field in this object.
+ * raw_data_length: length of @raw_data.
+ * raw_fingerprint: field in this object.
+ * raw_fingerprint_length: length of @raw_fingerprint.
  *
  * Creates a new #ParsedDive object.
  *
  * Returns: a new #LibdivecomputerPluginParsedDive
  */
-LibdivecomputerPluginParsedDive* libdivecomputer_plugin_parsed_dive_new(const gchar* fingerprint, int64_t date_time_year, int64_t date_time_month, int64_t date_time_day, int64_t date_time_hour, int64_t date_time_minute, int64_t date_time_second, int64_t* date_time_timezone_offset, double max_depth_meters, double avg_depth_meters, int64_t duration_seconds, double* min_temperature_celsius, double* max_temperature_celsius, FlValue* samples, FlValue* tanks, FlValue* gas_mixes, FlValue* events, const gchar* dive_mode, const gchar* deco_algorithm, int64_t* gf_low, int64_t* gf_high, int64_t* deco_conservatism);
+LibdivecomputerPluginParsedDive* libdivecomputer_plugin_parsed_dive_new(const gchar* fingerprint, int64_t date_time_year, int64_t date_time_month, int64_t date_time_day, int64_t date_time_hour, int64_t date_time_minute, int64_t date_time_second, int64_t* date_time_timezone_offset, double max_depth_meters, double avg_depth_meters, int64_t duration_seconds, double* min_temperature_celsius, double* max_temperature_celsius, FlValue* samples, FlValue* tanks, FlValue* gas_mixes, FlValue* events, const gchar* dive_mode, const gchar* deco_algorithm, int64_t* gf_low, int64_t* gf_high, int64_t* deco_conservatism, const uint8_t* raw_data, size_t raw_data_length, const uint8_t* raw_fingerprint, size_t raw_fingerprint_length);
 
 /**
  * libdivecomputer_plugin_parsed_dive_get_fingerprint
@@ -761,6 +765,28 @@ int64_t* libdivecomputer_plugin_parsed_dive_get_gf_high(LibdivecomputerPluginPar
  * Returns: the field value.
  */
 int64_t* libdivecomputer_plugin_parsed_dive_get_deco_conservatism(LibdivecomputerPluginParsedDive* object);
+
+/**
+ * libdivecomputer_plugin_parsed_dive_get_raw_data
+ * @object: a #LibdivecomputerPluginParsedDive.
+ * @length: location to write the length of this value.
+ *
+ * Gets the value of the rawData field of @object.
+ *
+ * Returns: the field value.
+ */
+const uint8_t* libdivecomputer_plugin_parsed_dive_get_raw_data(LibdivecomputerPluginParsedDive* object, size_t* length);
+
+/**
+ * libdivecomputer_plugin_parsed_dive_get_raw_fingerprint
+ * @object: a #LibdivecomputerPluginParsedDive.
+ * @length: location to write the length of this value.
+ *
+ * Gets the value of the rawFingerprint field of @object.
+ *
+ * Returns: the field value.
+ */
+const uint8_t* libdivecomputer_plugin_parsed_dive_get_raw_fingerprint(LibdivecomputerPluginParsedDive* object, size_t* length);
 
 /**
  * LibdivecomputerPluginDownloadProgress:

--- a/packages/libdivecomputer_plugin/linux/dive_converter.c
+++ b/packages/libdivecomputer_plugin/linux/dive_converter.c
@@ -232,13 +232,26 @@ LibdivecomputerPluginParsedDive* convert_parsed_dive(
     int64_t* conservatism =
         (dive->deco_conservatism == 0) ? NULL : &conserv_val;
 
+    // Raw dive data: pass pointer and length (NULL/0 if not available).
+    const uint8_t* raw_data =
+        (dive->raw_data != NULL && dive->raw_data_size > 0)
+            ? dive->raw_data : NULL;
+    size_t raw_data_length =
+        (raw_data != NULL) ? (size_t)dive->raw_data_size : 0;
+
+    const uint8_t* raw_fp =
+        (dive->raw_fingerprint != NULL && dive->raw_fingerprint_size > 0)
+            ? dive->raw_fingerprint : NULL;
+    size_t raw_fp_length =
+        (raw_fp != NULL) ? (size_t)dive->raw_fingerprint_size : 0;
+
     LibdivecomputerPluginParsedDive* result =
         libdivecomputer_plugin_parsed_dive_new(
             hex, dt_year, dt_month, dt_day, dt_hour, dt_minute, dt_second,
             tz_offset, dive->max_depth, dive->avg_depth,
             (int64_t)dive->duration, min_temp, max_temp, samples, tanks,
             gas_mixes, events, dive_mode, deco_algorithm, gf_low, gf_high,
-            conservatism);
+            conservatism, raw_data, raw_data_length, raw_fp, raw_fp_length);
 
     fl_value_unref(samples);
     fl_value_unref(gas_mixes);

--- a/packages/libdivecomputer_plugin/macos/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/DiveComputerApi.g.swift
@@ -335,6 +335,8 @@ struct ParsedDive {
   var gfLow: Int64? = nil
   var gfHigh: Int64? = nil
   var decoConservatism: Int64? = nil
+  var rawData: FlutterStandardTypedData? = nil
+  var rawFingerprint: FlutterStandardTypedData? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -361,6 +363,8 @@ struct ParsedDive {
     let gfLow: Int64? = nilOrValue(pigeonVar_list[19])
     let gfHigh: Int64? = nilOrValue(pigeonVar_list[20])
     let decoConservatism: Int64? = nilOrValue(pigeonVar_list[21])
+    let rawData: FlutterStandardTypedData? = nilOrValue(pigeonVar_list[22])
+    let rawFingerprint: FlutterStandardTypedData? = nilOrValue(pigeonVar_list[23])
 
     return ParsedDive(
       fingerprint: fingerprint,
@@ -384,7 +388,9 @@ struct ParsedDive {
       decoAlgorithm: decoAlgorithm,
       gfLow: gfLow,
       gfHigh: gfHigh,
-      decoConservatism: decoConservatism
+      decoConservatism: decoConservatism,
+      rawData: rawData,
+      rawFingerprint: rawFingerprint
     )
   }
   func toList() -> [Any?] {
@@ -411,6 +417,8 @@ struct ParsedDive {
       gfLow,
       gfHigh,
       decoConservatism,
+      rawData,
+      rawFingerprint,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -333,6 +333,10 @@ static int parse_dive(download_state_t *state,
     dive->events = NULL;
     dive->event_count = 0;
     dive->event_capacity = 0;
+    dive->raw_data = NULL;
+    dive->raw_data_size = 0;
+    dive->raw_fingerprint = NULL;
+    dive->raw_fingerprint_size = 0;
 
     // Store fingerprint.
     if (fingerprint != NULL && fsize > 0) {
@@ -366,6 +370,12 @@ static int dive_callback(const unsigned char *data, unsigned int size,
 
     libdc_parsed_dive_t dive;
     if (parse_dive(state, data, size, fingerprint, fsize, &dive) == 0) {
+        // Retain raw bytes for archival (pointers valid for this callback scope)
+        dive.raw_data = data;
+        dive.raw_data_size = size;
+        dive.raw_fingerprint = fingerprint;
+        dive.raw_fingerprint_size = fsize;
+
         if (state->callbacks->on_dive != NULL) {
             state->callbacks->on_dive(&dive, state->callbacks->userdata);
         }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -213,6 +213,12 @@ typedef struct {
     libdc_event_t *events;
     unsigned int event_count;
     unsigned int event_capacity;
+
+    // Raw dive data for archival (not malloc'd — valid only during callback)
+    const unsigned char *raw_data;
+    unsigned int raw_data_size;
+    const unsigned char *raw_fingerprint;
+    unsigned int raw_fingerprint_size;
 } libdc_parsed_dive_t;
 
 // Free a parsed dive (frees the samples array).

--- a/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
+++ b/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
@@ -140,6 +140,8 @@ class ParsedDive {
     this.gfLow,
     this.gfHigh,
     this.decoConservatism,
+    this.rawData,
+    this.rawFingerprint,
   });
   final String fingerprint;
   final int dateTimeYear;
@@ -163,6 +165,8 @@ class ParsedDive {
   final int? gfLow;
   final int? gfHigh;
   final int? decoConservatism;
+  final Uint8List? rawData;
+  final Uint8List? rawFingerprint;
 }
 
 class DownloadProgress {

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
@@ -776,7 +776,9 @@ ParsedDive::ParsedDive(
   const std::string* deco_algorithm,
   const int64_t* gf_low,
   const int64_t* gf_high,
-  const int64_t* deco_conservatism)
+  const int64_t* deco_conservatism,
+  const std::vector<uint8_t>* raw_data,
+  const std::vector<uint8_t>* raw_fingerprint)
  : fingerprint_(fingerprint),
     date_time_year_(date_time_year),
     date_time_month_(date_time_month),
@@ -798,7 +800,9 @@ ParsedDive::ParsedDive(
     deco_algorithm_(deco_algorithm ? std::optional<std::string>(*deco_algorithm) : std::nullopt),
     gf_low_(gf_low ? std::optional<int64_t>(*gf_low) : std::nullopt),
     gf_high_(gf_high ? std::optional<int64_t>(*gf_high) : std::nullopt),
-    deco_conservatism_(deco_conservatism ? std::optional<int64_t>(*deco_conservatism) : std::nullopt) {}
+    deco_conservatism_(deco_conservatism ? std::optional<int64_t>(*deco_conservatism) : std::nullopt),
+    raw_data_(raw_data ? std::optional<std::vector<uint8_t>>(*raw_data) : std::nullopt),
+    raw_fingerprint_(raw_fingerprint ? std::optional<std::vector<uint8_t>>(*raw_fingerprint) : std::nullopt) {}
 
 const std::string& ParsedDive::fingerprint() const {
   return fingerprint_;
@@ -1030,9 +1034,35 @@ void ParsedDive::set_deco_conservatism(int64_t value_arg) {
 }
 
 
+const std::vector<uint8_t>* ParsedDive::raw_data() const {
+  return raw_data_ ? &(*raw_data_) : nullptr;
+}
+
+void ParsedDive::set_raw_data(const std::vector<uint8_t>* value_arg) {
+  raw_data_ = value_arg ? std::optional<std::vector<uint8_t>>(*value_arg) : std::nullopt;
+}
+
+void ParsedDive::set_raw_data(const std::vector<uint8_t>& value_arg) {
+  raw_data_ = value_arg;
+}
+
+
+const std::vector<uint8_t>* ParsedDive::raw_fingerprint() const {
+  return raw_fingerprint_ ? &(*raw_fingerprint_) : nullptr;
+}
+
+void ParsedDive::set_raw_fingerprint(const std::vector<uint8_t>* value_arg) {
+  raw_fingerprint_ = value_arg ? std::optional<std::vector<uint8_t>>(*value_arg) : std::nullopt;
+}
+
+void ParsedDive::set_raw_fingerprint(const std::vector<uint8_t>& value_arg) {
+  raw_fingerprint_ = value_arg;
+}
+
+
 EncodableList ParsedDive::ToEncodableList() const {
   EncodableList list;
-  list.reserve(22);
+  list.reserve(24);
   list.push_back(EncodableValue(fingerprint_));
   list.push_back(EncodableValue(date_time_year_));
   list.push_back(EncodableValue(date_time_month_));
@@ -1055,6 +1085,8 @@ EncodableList ParsedDive::ToEncodableList() const {
   list.push_back(gf_low_ ? EncodableValue(*gf_low_) : EncodableValue());
   list.push_back(gf_high_ ? EncodableValue(*gf_high_) : EncodableValue());
   list.push_back(deco_conservatism_ ? EncodableValue(*deco_conservatism_) : EncodableValue());
+  list.push_back(raw_data_ ? EncodableValue(*raw_data_) : EncodableValue());
+  list.push_back(raw_fingerprint_ ? EncodableValue(*raw_fingerprint_) : EncodableValue());
   return list;
 }
 
@@ -1105,6 +1137,14 @@ ParsedDive ParsedDive::FromEncodableList(const EncodableList& list) {
   auto& encodable_deco_conservatism = list[21];
   if (!encodable_deco_conservatism.IsNull()) {
     decoded.set_deco_conservatism(std::get<int64_t>(encodable_deco_conservatism));
+  }
+  auto& encodable_raw_data = list[22];
+  if (!encodable_raw_data.IsNull()) {
+    decoded.set_raw_data(std::get<std::vector<uint8_t>>(encodable_raw_data));
+  }
+  auto& encodable_raw_fingerprint = list[23];
+  if (!encodable_raw_fingerprint.IsNull()) {
+    decoded.set_raw_fingerprint(std::get<std::vector<uint8_t>>(encodable_raw_fingerprint));
   }
   return decoded;
 }

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
@@ -425,7 +425,9 @@ class ParsedDive {
     const std::string* deco_algorithm,
     const int64_t* gf_low,
     const int64_t* gf_high,
-    const int64_t* deco_conservatism);
+    const int64_t* deco_conservatism,
+    const std::vector<uint8_t>* raw_data,
+    const std::vector<uint8_t>* raw_fingerprint);
 
   const std::string& fingerprint() const;
   void set_fingerprint(std::string_view value_arg);
@@ -501,6 +503,14 @@ class ParsedDive {
   void set_deco_conservatism(const int64_t* value_arg);
   void set_deco_conservatism(int64_t value_arg);
 
+  const std::vector<uint8_t>* raw_data() const;
+  void set_raw_data(const std::vector<uint8_t>* value_arg);
+  void set_raw_data(const std::vector<uint8_t>& value_arg);
+
+  const std::vector<uint8_t>* raw_fingerprint() const;
+  void set_raw_fingerprint(const std::vector<uint8_t>* value_arg);
+  void set_raw_fingerprint(const std::vector<uint8_t>& value_arg);
+
 
  private:
   static ParsedDive FromEncodableList(const flutter::EncodableList& list);
@@ -530,6 +540,8 @@ class ParsedDive {
   std::optional<int64_t> gf_low_;
   std::optional<int64_t> gf_high_;
   std::optional<int64_t> deco_conservatism_;
+  std::optional<std::vector<uint8_t>> raw_data_;
+  std::optional<std::vector<uint8_t>> raw_fingerprint_;
 
 };
 

--- a/packages/libdivecomputer_plugin/windows/dive_converter.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_converter.cc
@@ -238,6 +238,17 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
             : std::optional<int64_t>(
                   static_cast<int64_t>(dive.deco_conservatism));
 
+    // Copy raw dive data bytes if available.
+    std::optional<std::vector<uint8_t>> raw_data;
+    if (dive.raw_data != nullptr && dive.raw_data_size > 0) {
+        raw_data.emplace(dive.raw_data, dive.raw_data + dive.raw_data_size);
+    }
+    std::optional<std::vector<uint8_t>> raw_fp;
+    if (dive.raw_fingerprint != nullptr && dive.raw_fingerprint_size > 0) {
+        raw_fp.emplace(dive.raw_fingerprint,
+                       dive.raw_fingerprint + dive.raw_fingerprint_size);
+    }
+
     return ParsedDive(
         std::string(hex),
         dt_year,
@@ -260,7 +271,9 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
         deco_algorithm ? &*deco_algorithm : nullptr,
         gf_low ? &*gf_low : nullptr,
         gf_high ? &*gf_high : nullptr,
-        deco_conservatism ? &*deco_conservatism : nullptr);
+        deco_conservatism ? &*deco_conservatism : nullptr,
+        raw_data ? &*raw_data : nullptr,
+        raw_fp ? &*raw_fp : nullptr);
 }
 
 }  // namespace libdivecomputer_plugin

--- a/test/core/database/migration_v66_test.dart
+++ b/test/core/database/migration_v66_test.dart
@@ -1,0 +1,303 @@
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+void main() {
+  group('Migration v66 - raw dive data columns and FK rebuild', () {
+    /// Creates an in-memory database at v65 with the tables the v66 migration
+    /// touches: dives, dive_computers, and dive_data_sources.
+    ///
+    /// The dive_data_sources schema includes all columns through v55 but
+    /// none of the v66 additions (raw_data, raw_fingerprint, etc.).
+    NativeDatabase setupDb({
+      List<(String id, String diverId)> dives = const [],
+      List<(String id, String? diverId)> computers = const [],
+      List<
+            (
+              String id,
+              String diveId,
+              String? computerId,
+              int importedAt,
+              int createdAt,
+            )
+          >
+          dataSources =
+          const [],
+    }) {
+      return NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA foreign_keys = ON');
+          rawDb.execute('PRAGMA user_version = 65');
+
+          rawDb.execute('''
+            CREATE TABLE divers (
+              id TEXT NOT NULL PRIMARY KEY,
+              name TEXT NOT NULL,
+              created_at INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+          rawDb.execute(
+            "INSERT INTO divers (id, name) VALUES ('diver1', 'Alice')",
+          );
+
+          rawDb.execute('''
+            CREATE TABLE dives (
+              id TEXT NOT NULL PRIMARY KEY,
+              diver_id TEXT REFERENCES divers(id),
+              dive_date_time INTEGER NOT NULL DEFAULT 0,
+              notes TEXT NOT NULL DEFAULT '',
+              created_at INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+
+          rawDb.execute('''
+            CREATE TABLE dive_computers (
+              id TEXT NOT NULL PRIMARY KEY,
+              diver_id TEXT REFERENCES divers(id),
+              name TEXT NOT NULL DEFAULT '',
+              bluetooth_address TEXT,
+              last_dive_fingerprint TEXT,
+              last_download_timestamp INTEGER,
+              dive_count INTEGER NOT NULL DEFAULT 0,
+              is_favorite INTEGER NOT NULL DEFAULT 0,
+              notes TEXT NOT NULL DEFAULT '',
+              manufacturer TEXT, model TEXT, serial_number TEXT,
+              firmware_version TEXT, connection_type TEXT,
+              created_at INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+
+          // v65 schema: original v53 columns + v54 renames/additions.
+          // FK on computer_id is NO ACTION (the original default).
+          rawDb.execute('''
+            CREATE TABLE dive_data_sources (
+              id TEXT NOT NULL PRIMARY KEY,
+              dive_id TEXT NOT NULL REFERENCES dives(id) ON DELETE CASCADE,
+              computer_id TEXT REFERENCES dive_computers(id),
+              is_primary INTEGER NOT NULL DEFAULT 0,
+              computer_model TEXT,
+              computer_serial TEXT,
+              source_format TEXT,
+              source_file_name TEXT,
+              source_file_format TEXT,
+              max_depth REAL,
+              avg_depth REAL,
+              duration INTEGER,
+              water_temp REAL,
+              entry_time INTEGER,
+              exit_time INTEGER,
+              max_ascent_rate REAL,
+              max_descent_rate REAL,
+              surface_interval INTEGER,
+              cns REAL,
+              otu REAL,
+              deco_algorithm TEXT,
+              gradient_factor_low INTEGER,
+              gradient_factor_high INTEGER,
+              imported_at INTEGER NOT NULL,
+              created_at INTEGER NOT NULL
+            )
+          ''');
+          rawDb.execute('''
+            CREATE INDEX IF NOT EXISTS idx_dive_data_sources_dive_id
+            ON dive_data_sources(dive_id)
+          ''');
+
+          for (final d in dives) {
+            rawDb.execute(
+              "INSERT INTO dives (id, diver_id) VALUES ('${d.$1}', '${d.$2}')",
+            );
+          }
+          for (final c in computers) {
+            final dv = c.$2 == null ? 'NULL' : "'${c.$2}'";
+            rawDb.execute(
+              "INSERT INTO dive_computers (id, diver_id, name)"
+              " VALUES ('${c.$1}', $dv, 'Computer')",
+            );
+          }
+          for (final ds in dataSources) {
+            final cId = ds.$3 == null ? 'NULL' : "'${ds.$3}'";
+            rawDb.execute(
+              "INSERT INTO dive_data_sources"
+              " (id, dive_id, computer_id, is_primary,"
+              "  computer_model, source_format, imported_at, created_at)"
+              " VALUES ('${ds.$1}', '${ds.$2}', $cId, 1,"
+              "  'Perdix', 'dc', ${ds.$4}, ${ds.$5})",
+            );
+          }
+        },
+      );
+    }
+
+    test('adds new columns to dive_data_sources', () async {
+      final nativeDb = setupDb(
+        dives: [('dive1', 'diver1')],
+        computers: [('comp1', 'diver1')],
+        dataSources: [('ds1', 'dive1', 'comp1', 1000, 1000)],
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      // Verify new columns exist by querying PRAGMA table_info.
+      final columns = await db
+          .customSelect("PRAGMA table_info('dive_data_sources')")
+          .get();
+      final colNames = columns.map((c) => c.read<String>('name')).toSet();
+
+      expect(colNames, contains('raw_data'));
+      expect(colNames, contains('raw_fingerprint'));
+      expect(colNames, contains('descriptor_vendor'));
+      expect(colNames, contains('descriptor_product'));
+      expect(colNames, contains('descriptor_model'));
+      expect(colNames, contains('libdivecomputer_version'));
+      expect(colNames, contains('last_parsed_at'));
+    });
+
+    test('preserves existing data through table rebuild', () async {
+      final nativeDb = setupDb(
+        dives: [('dive1', 'diver1')],
+        computers: [('comp1', 'diver1')],
+        dataSources: [('ds1', 'dive1', 'comp1', 2000, 3000)],
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      final rows = await db
+          .customSelect(
+            'SELECT id, dive_id, computer_id, is_primary,'
+            ' computer_model, source_format, imported_at, created_at'
+            ' FROM dive_data_sources',
+          )
+          .get();
+      expect(rows, hasLength(1));
+      final row = rows.first;
+      expect(row.read<String>('id'), 'ds1');
+      expect(row.read<String>('dive_id'), 'dive1');
+      expect(row.read<String>('computer_id'), 'comp1');
+      expect(row.read<int>('is_primary'), 1);
+      expect(row.read<String>('computer_model'), 'Perdix');
+      expect(row.read<String>('source_format'), 'dc');
+      expect(row.read<int>('imported_at'), 2000);
+      expect(row.read<int>('created_at'), 3000);
+    });
+
+    test('new columns default to NULL after migration', () async {
+      final nativeDb = setupDb(
+        dives: [('dive1', 'diver1')],
+        computers: [('comp1', 'diver1')],
+        dataSources: [('ds1', 'dive1', 'comp1', 1000, 1000)],
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      final rows = await db
+          .customSelect(
+            'SELECT raw_data, raw_fingerprint, descriptor_vendor,'
+            ' descriptor_product, descriptor_model,'
+            ' libdivecomputer_version, last_parsed_at'
+            ' FROM dive_data_sources',
+          )
+          .get();
+      expect(rows, hasLength(1));
+      final row = rows.first;
+      expect(row.readNullable<Uint8List>('raw_data'), isNull);
+      expect(row.readNullable<Uint8List>('raw_fingerprint'), isNull);
+      expect(row.readNullable<String>('descriptor_vendor'), isNull);
+      expect(row.readNullable<String>('descriptor_product'), isNull);
+      expect(row.readNullable<int>('descriptor_model'), isNull);
+      expect(row.readNullable<String>('libdivecomputer_version'), isNull);
+      expect(row.readNullable<int>('last_parsed_at'), isNull);
+    });
+
+    test('ON DELETE SET NULL on computer_id after FK rebuild', () async {
+      final nativeDb = setupDb(
+        dives: [('dive1', 'diver1')],
+        computers: [('comp1', 'diver1')],
+        dataSources: [('ds1', 'dive1', 'comp1', 1000, 1000)],
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      // Verify the data source references the computer before deletion.
+      var rows = await db
+          .customSelect(
+            "SELECT computer_id FROM dive_data_sources WHERE id = 'ds1'",
+          )
+          .get();
+      expect(rows.first.read<String>('computer_id'), 'comp1');
+
+      // Delete the dive computer.
+      await db.customStatement("DELETE FROM dive_computers WHERE id = 'comp1'");
+
+      // The FK should now be NULL (ON DELETE SET NULL).
+      rows = await db
+          .customSelect(
+            "SELECT computer_id FROM dive_data_sources WHERE id = 'ds1'",
+          )
+          .get();
+      expect(rows.first.readNullable<String>('computer_id'), isNull);
+    });
+
+    test('multiple data sources preserved through rebuild', () async {
+      final nativeDb = setupDb(
+        dives: [('dive1', 'diver1'), ('dive2', 'diver1')],
+        computers: [('comp1', 'diver1'), ('comp2', 'diver1')],
+        dataSources: [
+          ('ds1', 'dive1', 'comp1', 1000, 1000),
+          ('ds2', 'dive1', 'comp2', 2000, 2000),
+          ('ds3', 'dive2', null, 3000, 3000),
+        ],
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      final rows = await db
+          .customSelect(
+            'SELECT id, dive_id, computer_id'
+            ' FROM dive_data_sources ORDER BY id',
+          )
+          .get();
+      expect(rows, hasLength(3));
+      expect(rows[0].read<String>('id'), 'ds1');
+      expect(rows[0].read<String>('dive_id'), 'dive1');
+      expect(rows[0].read<String>('computer_id'), 'comp1');
+
+      expect(rows[1].read<String>('id'), 'ds2');
+      expect(rows[1].read<String>('dive_id'), 'dive1');
+      expect(rows[1].read<String>('computer_id'), 'comp2');
+
+      expect(rows[2].read<String>('id'), 'ds3');
+      expect(rows[2].read<String>('dive_id'), 'dive2');
+      expect(rows[2].readNullable<String>('computer_id'), isNull);
+    });
+
+    test('cascade delete on dive_id still works after rebuild', () async {
+      final nativeDb = setupDb(
+        dives: [('dive1', 'diver1')],
+        computers: [('comp1', 'diver1')],
+        dataSources: [('ds1', 'dive1', 'comp1', 1000, 1000)],
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      // Deleting the dive should cascade-delete the data source.
+      await db.customStatement("DELETE FROM dives WHERE id = 'dive1'");
+
+      final rows = await db
+          .customSelect('SELECT id FROM dive_data_sources')
+          .get();
+      expect(rows, isEmpty);
+    });
+  });
+}

--- a/test/core/database/migration_v66_test.dart
+++ b/test/core/database/migration_v66_test.dart
@@ -281,6 +281,147 @@ void main() {
       expect(rows[2].readNullable<String>('computer_id'), isNull);
     });
 
+    test(
+      'migration succeeds when new columns already exist (re-run guard)',
+      () async {
+        // Simulate a database where the v66 columns were already added (e.g.
+        // partial migration or re-run). The PRAGMA table_info guard should
+        // skip the ALTER TABLE statements without error.
+        final nativeDb = NativeDatabase.memory(
+          setup: (rawDb) {
+            rawDb.execute('PRAGMA foreign_keys = ON');
+            rawDb.execute('PRAGMA user_version = 65');
+
+            rawDb.execute('''
+            CREATE TABLE divers (
+              id TEXT NOT NULL PRIMARY KEY,
+              name TEXT NOT NULL,
+              created_at INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+            rawDb.execute(
+              "INSERT INTO divers (id, name) VALUES ('diver1', 'Alice')",
+            );
+
+            rawDb.execute('''
+            CREATE TABLE dives (
+              id TEXT NOT NULL PRIMARY KEY,
+              diver_id TEXT REFERENCES divers(id),
+              dive_date_time INTEGER NOT NULL DEFAULT 0,
+              notes TEXT NOT NULL DEFAULT '',
+              created_at INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+
+            rawDb.execute('''
+            CREATE TABLE dive_computers (
+              id TEXT NOT NULL PRIMARY KEY,
+              diver_id TEXT REFERENCES divers(id),
+              name TEXT NOT NULL DEFAULT '',
+              bluetooth_address TEXT,
+              last_dive_fingerprint TEXT,
+              last_download_timestamp INTEGER,
+              dive_count INTEGER NOT NULL DEFAULT 0,
+              is_favorite INTEGER NOT NULL DEFAULT 0,
+              notes TEXT NOT NULL DEFAULT '',
+              manufacturer TEXT, model TEXT, serial_number TEXT,
+              firmware_version TEXT, connection_type TEXT,
+              created_at INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+
+            // v65 schema WITH the v66 columns already present -- simulates
+            // a partial migration where ADD COLUMN succeeded but the table
+            // rebuild did not complete.
+            rawDb.execute('''
+            CREATE TABLE dive_data_sources (
+              id TEXT NOT NULL PRIMARY KEY,
+              dive_id TEXT NOT NULL REFERENCES dives(id) ON DELETE CASCADE,
+              computer_id TEXT REFERENCES dive_computers(id),
+              is_primary INTEGER NOT NULL DEFAULT 0,
+              computer_model TEXT,
+              computer_serial TEXT,
+              source_format TEXT,
+              source_file_name TEXT,
+              source_file_format TEXT,
+              max_depth REAL,
+              avg_depth REAL,
+              duration INTEGER,
+              water_temp REAL,
+              entry_time INTEGER,
+              exit_time INTEGER,
+              max_ascent_rate REAL,
+              max_descent_rate REAL,
+              surface_interval INTEGER,
+              cns REAL,
+              otu REAL,
+              deco_algorithm TEXT,
+              gradient_factor_low INTEGER,
+              gradient_factor_high INTEGER,
+              imported_at INTEGER NOT NULL,
+              created_at INTEGER NOT NULL,
+              raw_data BLOB,
+              raw_fingerprint BLOB,
+              descriptor_vendor TEXT,
+              descriptor_product TEXT,
+              descriptor_model INTEGER,
+              libdivecomputer_version TEXT,
+              last_parsed_at INTEGER
+            )
+          ''');
+
+            rawDb.execute(
+              "INSERT INTO dives (id, diver_id) VALUES ('dive1', 'diver1')",
+            );
+            rawDb.execute(
+              "INSERT INTO dive_computers (id, diver_id, name)"
+              " VALUES ('comp1', 'diver1', 'Computer')",
+            );
+            rawDb.execute(
+              "INSERT INTO dive_data_sources"
+              " (id, dive_id, computer_id, is_primary,"
+              "  source_format, imported_at, created_at,"
+              "  raw_data, descriptor_vendor)"
+              " VALUES ('ds1', 'dive1', 'comp1', 1,"
+              "  'dc', 1000, 1000, X'0102', 'Shearwater')",
+            );
+          },
+        );
+
+        final db = AppDatabase(nativeDb);
+        addTearDown(db.close);
+
+        // Migration should complete without error
+        final columns = await db
+            .customSelect("PRAGMA table_info('dive_data_sources')")
+            .get();
+        final colNames = columns.map((c) => c.read<String>('name')).toSet();
+
+        // All v66 columns should still be present
+        expect(colNames, contains('raw_data'));
+        expect(colNames, contains('raw_fingerprint'));
+        expect(colNames, contains('descriptor_vendor'));
+        expect(colNames, contains('descriptor_product'));
+        expect(colNames, contains('descriptor_model'));
+        expect(colNames, contains('libdivecomputer_version'));
+        expect(colNames, contains('last_parsed_at'));
+
+        // Pre-existing data should be preserved through the rebuild
+        final rows = await db
+            .customSelect(
+              'SELECT id, descriptor_vendor, raw_data FROM dive_data_sources',
+            )
+            .get();
+        expect(rows, hasLength(1));
+        expect(rows.first.read<String>('id'), 'ds1');
+        expect(rows.first.read<String>('descriptor_vendor'), 'Shearwater');
+        expect(rows.first.read<Uint8List>('raw_data'), isNotNull);
+      },
+    );
+
     test('cascade delete on dive_id still works after rebuild', () async {
       final nativeDb = setupDb(
         dives: [('dive1', 'diver1')],

--- a/test/core/presentation/widgets/dive_comparison_card_test.dart
+++ b/test/core/presentation/widgets/dive_comparison_card_test.dart
@@ -186,7 +186,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // The selected button (Consolidate) renders as FilledButton.tonal.
-      // Inactive buttons (Skip, Import as New) render as OutlinedButton.
+      // Inactive buttons (Skip, Import as New, Replace Source) render as
+      // OutlinedButton.
       final filledButtons = tester
           .widgetList<FilledButton>(find.byType(FilledButton))
           .toList();
@@ -196,8 +197,8 @@ void main() {
 
       // Exactly one filled button (the selected one).
       expect(filledButtons.length, 1);
-      // Two outlined buttons (the inactive ones).
-      expect(outlinedButtons.length, 2);
+      // Three outlined buttons (the inactive ones).
+      expect(outlinedButtons.length, 3);
     });
 
     testWidgets(

--- a/test/features/dive_computer/data/services/dive_import_service_test.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -539,6 +541,131 @@ void main() {
           libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
         ),
       ).called(1);
+    });
+
+    test(
+      'resolveConflict with replaceSource calls clearSourceAndProfiles then importProfile',
+      () async {
+        final dive = DownloadedDive(
+          fingerprint: 'fp-replace',
+          startTime: DateTime(2026, 4, 5, 8, 30),
+          durationSeconds: 3000,
+          maxDepth: 22.0,
+          avgDepth: 14.5,
+          profile: const [],
+          tanks: const [],
+          events: const [],
+          rawData: Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]),
+          rawFingerprint: Uint8List.fromList([0x01, 0x02, 0x03]),
+        );
+
+        final conflict = ImportConflict(
+          downloaded: dive,
+          existingDiveId: 'existing-dive-42',
+          duplicateResult: const DuplicateResult(
+            matchingDiveId: 'existing-dive-42',
+            confidence: DuplicateConfidence.exact,
+            score: 0.95,
+          ),
+        );
+
+        // Stub clearSourceAndProfiles
+        when(
+          mockComputerRepo.clearSourceAndProfiles(
+            diveId: anyNamed('diveId'),
+            computerId: anyNamed('computerId'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final result = await service.resolveConflict(
+          conflict,
+          ConflictResolution.replaceSource,
+          computer.id,
+          descriptorVendor: 'Shearwater',
+          descriptorProduct: 'Perdix',
+          descriptorModel: 42,
+          libdivecomputerVersion: '0.8.0',
+        );
+
+        // Returns the existing dive ID
+        expect(result, equals('existing-dive-42'));
+
+        // Verify clearSourceAndProfiles was called with correct IDs
+        verify(
+          mockComputerRepo.clearSourceAndProfiles(
+            diveId: 'existing-dive-42',
+            computerId: computer.id,
+          ),
+        ).called(1);
+
+        // Verify importProfile was called with isPrimary: true, descriptor
+        // fields, rawData, rawFingerprint, and avgDepth
+        verify(
+          mockComputerRepo.importProfile(
+            computerId: computer.id,
+            profileStartTime: DateTime(2026, 4, 5, 8, 30),
+            points: anyNamed('points'),
+            durationSeconds: 3000,
+            maxDepth: 22.0,
+            avgDepth: 14.5,
+            isPrimary: true,
+            diverId: anyNamed('diverId'),
+            tanks: anyNamed('tanks'),
+            decoAlgorithm: anyNamed('decoAlgorithm'),
+            gfLow: anyNamed('gfLow'),
+            gfHigh: anyNamed('gfHigh'),
+            decoConservatism: anyNamed('decoConservatism'),
+            events: anyNamed('events'),
+            diveNumber: anyNamed('diveNumber'),
+            forceNew: anyNamed('forceNew'),
+            rawData: anyNamed('rawData'),
+            rawFingerprint: anyNamed('rawFingerprint'),
+            descriptorVendor: 'Shearwater',
+            descriptorProduct: 'Perdix',
+            descriptorModel: 42,
+            libdivecomputerVersion: '0.8.0',
+          ),
+        ).called(1);
+      },
+    );
+
+    test('resolveConflict with consolidate returns null', () async {
+      final dive = DownloadedDive(
+        fingerprint: 'fp-consolidate',
+        startTime: DateTime(2026, 4, 10, 11, 0),
+        durationSeconds: 2400,
+        maxDepth: 18.0,
+        profile: const [],
+        tanks: const [],
+        events: const [],
+      );
+
+      final conflict = ImportConflict(
+        downloaded: dive,
+        existingDiveId: 'existing-dive-99',
+        duplicateResult: const DuplicateResult(
+          matchingDiveId: 'existing-dive-99',
+          confidence: DuplicateConfidence.likely,
+          score: 0.80,
+        ),
+      );
+
+      final result = await service.resolveConflict(
+        conflict,
+        ConflictResolution.consolidate,
+        computer.id,
+      );
+
+      expect(result, isNull);
+      expect(conflict.resolution, ConflictResolution.consolidate);
+
+      // Neither clearSourceAndProfiles nor importProfile should be called
+      verifyNever(
+        mockComputerRepo.clearSourceAndProfiles(
+          diveId: anyNamed('diveId'),
+          computerId: anyNamed('computerId'),
+        ),
+      );
     });
   });
 }

--- a/test/features/dive_computer/data/services/dive_import_service_test.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.dart
@@ -62,6 +62,12 @@ void main() {
         events: anyNamed('events'),
         diveNumber: anyNamed('diveNumber'),
         forceNew: anyNamed('forceNew'),
+        rawData: anyNamed('rawData'),
+        rawFingerprint: anyNamed('rawFingerprint'),
+        descriptorVendor: anyNamed('descriptorVendor'),
+        descriptorProduct: anyNamed('descriptorProduct'),
+        descriptorModel: anyNamed('descriptorModel'),
+        libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
       ),
     ).thenAnswer((_) async => 'dive-id');
   });
@@ -139,6 +145,12 @@ void main() {
           decoConservatism: anyNamed('decoConservatism'),
           events: anyNamed('events'),
           diveNumber: 1,
+          rawData: anyNamed('rawData'),
+          rawFingerprint: anyNamed('rawFingerprint'),
+          descriptorVendor: anyNamed('descriptorVendor'),
+          descriptorProduct: anyNamed('descriptorProduct'),
+          descriptorModel: anyNamed('descriptorModel'),
+          libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
         ),
       ).called(1);
 
@@ -159,6 +171,12 @@ void main() {
           decoConservatism: anyNamed('decoConservatism'),
           events: anyNamed('events'),
           diveNumber: 2,
+          rawData: anyNamed('rawData'),
+          rawFingerprint: anyNamed('rawFingerprint'),
+          descriptorVendor: anyNamed('descriptorVendor'),
+          descriptorProduct: anyNamed('descriptorProduct'),
+          descriptorModel: anyNamed('descriptorModel'),
+          libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
         ),
       ).called(1);
 
@@ -179,6 +197,12 @@ void main() {
           decoConservatism: anyNamed('decoConservatism'),
           events: anyNamed('events'),
           diveNumber: 3,
+          rawData: anyNamed('rawData'),
+          rawFingerprint: anyNamed('rawFingerprint'),
+          descriptorVendor: anyNamed('descriptorVendor'),
+          descriptorProduct: anyNamed('descriptorProduct'),
+          descriptorModel: anyNamed('descriptorModel'),
+          libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
         ),
       ).called(1);
     });
@@ -243,6 +267,12 @@ void main() {
             decoConservatism: anyNamed('decoConservatism'),
             events: anyNamed('events'),
             diveNumber: 1,
+            rawData: anyNamed('rawData'),
+            rawFingerprint: anyNamed('rawFingerprint'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
           ),
         ).called(1);
 
@@ -264,6 +294,12 @@ void main() {
             decoConservatism: anyNamed('decoConservatism'),
             events: anyNamed('events'),
             diveNumber: 2,
+            rawData: anyNamed('rawData'),
+            rawFingerprint: anyNamed('rawFingerprint'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
           ),
         ).called(1);
       },
@@ -309,6 +345,12 @@ void main() {
             decoConservatism: anyNamed('decoConservatism'),
             events: anyNamed('events'),
             diveNumber: 6,
+            rawData: anyNamed('rawData'),
+            rawFingerprint: anyNamed('rawFingerprint'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
           ),
         ).called(1);
       },
@@ -376,6 +418,12 @@ void main() {
             events: anyNamed('events'),
             diveNumber: anyNamed('diveNumber'),
             forceNew: true,
+            rawData: anyNamed('rawData'),
+            rawFingerprint: anyNamed('rawFingerprint'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
           ),
         ).called(1);
       },
@@ -420,6 +468,12 @@ void main() {
           events: anyNamed('events'),
           diveNumber: anyNamed('diveNumber'),
           forceNew: true,
+          rawData: anyNamed('rawData'),
+          rawFingerprint: anyNamed('rawFingerprint'),
+          descriptorVendor: anyNamed('descriptorVendor'),
+          descriptorProduct: anyNamed('descriptorProduct'),
+          descriptorModel: anyNamed('descriptorModel'),
+          libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
         ),
       ).called(1);
     });
@@ -477,6 +531,12 @@ void main() {
           decoConservatism: anyNamed('decoConservatism'),
           events: anyNamed('events'),
           diveNumber: 4,
+          rawData: anyNamed('rawData'),
+          rawFingerprint: anyNamed('rawFingerprint'),
+          descriptorVendor: anyNamed('descriptorVendor'),
+          descriptorProduct: anyNamed('descriptorProduct'),
+          descriptorModel: anyNamed('descriptorModel'),
+          libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
         ),
       ).called(1);
     });

--- a/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
@@ -4,12 +4,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i7;
+import 'dart:typed_data' as _i9;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i9;
-import 'package:submersion/core/constants/sort_options.dart' as _i13;
+import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:submersion/core/constants/sort_options.dart' as _i14;
 import 'package:submersion/core/database/database.dart' as _i8;
-import 'package:submersion/core/models/sort_state.dart' as _i12;
+import 'package:submersion/core/models/sort_state.dart' as _i13;
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart'
     as _i6;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart'
@@ -18,13 +19,13 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart' as _i3;
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
     as _i2;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart'
-    as _i14;
+    as _i15;
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart'
-    as _i10;
+    as _i11;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart'
     as _i5;
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart'
-    as _i11;
+    as _i12;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -315,6 +316,12 @@ class MockDiveComputerRepository extends _i1.Mock
     List<_i6.EventData>? events,
     int? diveNumber,
     bool? forceNew = false,
+    _i9.Uint8List? rawData,
+    _i9.Uint8List? rawFingerprint,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importProfile, [], {
@@ -334,9 +341,15 @@ class MockDiveComputerRepository extends _i1.Mock
               #events: events,
               #diveNumber: diveNumber,
               #forceNew: forceNew,
+              #rawData: rawData,
+              #rawFingerprint: rawFingerprint,
+              #descriptorVendor: descriptorVendor,
+              #descriptorProduct: descriptorProduct,
+              #descriptorModel: descriptorModel,
+              #libdivecomputerVersion: libdivecomputerVersion,
             }),
             returnValue: _i7.Future<String>.value(
-              _i9.dummyValue<String>(
+              _i10.dummyValue<String>(
                 this,
                 Invocation.method(#importProfile, [], {
                   #computerId: computerId,
@@ -355,6 +368,12 @@ class MockDiveComputerRepository extends _i1.Mock
                   #events: events,
                   #diveNumber: diveNumber,
                   #forceNew: forceNew,
+                  #rawData: rawData,
+                  #rawFingerprint: rawFingerprint,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -570,13 +589,13 @@ class MockDiveRepository extends _i1.Mock implements _i4.DiveRepository {
           as _i7.Future<List<_i3.Dive>>);
 
   @override
-  _i7.Future<List<_i10.DiveSummary>> getDiveSummaries({
+  _i7.Future<List<_i11.DiveSummary>> getDiveSummaries({
     String? diverId,
-    _i11.DiveFilterState? filter = const _i11.DiveFilterState(),
-    _i10.DiveSummaryCursor? cursor,
+    _i12.DiveFilterState? filter = const _i12.DiveFilterState(),
+    _i11.DiveSummaryCursor? cursor,
     int? offset,
     int? limit = 50,
-    _i12.SortState<_i13.DiveSortField>? sort,
+    _i13.SortState<_i14.DiveSortField>? sort,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveSummaries, [], {
@@ -587,16 +606,16 @@ class MockDiveRepository extends _i1.Mock implements _i4.DiveRepository {
               #limit: limit,
               #sort: sort,
             }),
-            returnValue: _i7.Future<List<_i10.DiveSummary>>.value(
-              <_i10.DiveSummary>[],
+            returnValue: _i7.Future<List<_i11.DiveSummary>>.value(
+              <_i11.DiveSummary>[],
             ),
           )
-          as _i7.Future<List<_i10.DiveSummary>>);
+          as _i7.Future<List<_i11.DiveSummary>>);
 
   @override
   _i7.Future<int> getDiveCount({
     String? diverId,
-    _i11.DiveFilterState? filter = const _i11.DiveFilterState(),
+    _i12.DiveFilterState? filter = const _i12.DiveFilterState(),
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveCount, [], {
@@ -761,7 +780,7 @@ class MockDiveRepository extends _i1.Mock implements _i4.DiveRepository {
               {#actualDateTime: actualDateTime},
             ),
             returnValue: _i7.Future<String>.value(
-              _i9.dummyValue<String>(
+              _i10.dummyValue<String>(
                 this,
                 Invocation.method(
                   #convertPlanToActualDive,
@@ -919,14 +938,14 @@ class MockDiveRepository extends _i1.Mock implements _i4.DiveRepository {
           as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i14.DiveDataSource>> getDataSources(String? diveId) =>
+  _i7.Future<List<_i15.DiveDataSource>> getDataSources(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getDataSources, [diveId]),
-            returnValue: _i7.Future<List<_i14.DiveDataSource>>.value(
-              <_i14.DiveDataSource>[],
+            returnValue: _i7.Future<List<_i15.DiveDataSource>>.value(
+              <_i15.DiveDataSource>[],
             ),
           )
-          as _i7.Future<List<_i14.DiveDataSource>>);
+          as _i7.Future<List<_i15.DiveDataSource>>);
 
   @override
   _i7.Future<bool> hasMultipleDataSources(String? diveId) =>
@@ -1006,7 +1025,7 @@ class MockDiveRepository extends _i1.Mock implements _i4.DiveRepository {
               #computerReadingId: computerReadingId,
             }),
             returnValue: _i7.Future<String>.value(
-              _i9.dummyValue<String>(
+              _i10.dummyValue<String>(
                 this,
                 Invocation.method(#unlinkComputer, [], {
                   #diveId: diveId,

--- a/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
@@ -299,6 +299,21 @@ class MockDiveComputerRepository extends _i1.Mock
           as _i7.Future<List<String>>);
 
   @override
+  _i7.Future<void> clearSourceAndProfiles({
+    required String? diveId,
+    required String? computerId,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#clearSourceAndProfiles, [], {
+              #diveId: diveId,
+              #computerId: computerId,
+            }),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
   _i7.Future<String> importProfile({
     required String? computerId,
     required DateTime? profileStartTime,

--- a/test/features/dive_computer/data/services/raw_data_persistence_test.dart
+++ b/test/features/dive_computer/data/services/raw_data_persistence_test.dart
@@ -1,0 +1,216 @@
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  /// Insert a minimal dive row and return its ID.
+  Future<String> insertDive(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    return id;
+  }
+
+  /// Insert a minimal dive computer row and return its ID.
+  Future<String> insertComputer(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            name: Value('Test Computer $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    return id;
+  }
+
+  /// Insert a DiveDataSources row with optional rawData.
+  Future<String> insertSource({
+    required String id,
+    required String diveId,
+    String? computerId,
+    bool isPrimary = true,
+    Uint8List? rawData,
+    Uint8List? rawFingerprint,
+  }) async {
+    final now = DateTime.now();
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            sourceFormat: const Value('dive_computer'),
+            rawData: Value(rawData),
+            rawFingerprint: Value(rawFingerprint),
+            importedAt: Value(now),
+            createdAt: Value(now),
+          ),
+        );
+    return id;
+  }
+
+  group('DiveDataSources blob persistence', () {
+    test('stores and retrieves rawData blob byte-for-byte', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+
+      // Create a non-trivial blob with various byte patterns
+      final rawBytes = Uint8List.fromList([
+        0x00, 0x01, 0x02, 0xFF, 0xFE, 0xAB, 0xCD, 0xEF, //
+        0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+      ]);
+
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        rawData: rawBytes,
+        rawFingerprint: Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]),
+      );
+
+      // Retrieve and verify byte-for-byte round-trip
+      final row = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.id.equals('src-1'))).getSingle();
+
+      expect(row.rawData, isNotNull);
+      expect(row.rawData!.length, rawBytes.length);
+      expect(row.rawData!, equals(rawBytes));
+
+      // Also verify rawFingerprint round-trip
+      expect(row.rawFingerprint, isNotNull);
+      expect(
+        row.rawFingerprint!,
+        equals(Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF])),
+      );
+    });
+
+    test('rawData is nullable and null by default', () async {
+      await insertDive('dive-1');
+
+      // Insert a source row without rawData
+      await insertSource(id: 'src-1', diveId: 'dive-1');
+
+      final row = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.id.equals('src-1'))).getSingle();
+
+      expect(row.rawData, isNull);
+      expect(row.rawFingerprint, isNull);
+    });
+
+    test('FK setNull: deleting DiveComputer sets computerId to null '
+        'while preserving rawData', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+
+      final blob = Uint8List.fromList(List.generate(256, (i) => i % 256));
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        rawData: blob,
+      );
+
+      // Verify the source has a computerId before delete
+      var row = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.id.equals('src-1'))).getSingle();
+      expect(row.computerId, equals('comp-1'));
+
+      // Delete the computer -- FK ON DELETE SET NULL should fire.
+      // The repository uses manual nulling + delete; in a direct-db test
+      // we need to do the same because Drift/SQLite may not have the FK
+      // pragma enabled by default in all configurations.
+      await db.customStatement(
+        'UPDATE dive_data_sources SET computer_id = NULL WHERE computer_id = ?',
+        ['comp-1'],
+      );
+      await (db.delete(
+        db.diveComputers,
+      )..where((t) => t.id.equals('comp-1'))).go();
+
+      // Re-read the source row
+      row = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.id.equals('src-1'))).getSingle();
+
+      // computerId should be null now
+      expect(row.computerId, isNull);
+
+      // rawData must still be intact
+      expect(row.rawData, isNotNull);
+      expect(row.rawData!.length, blob.length);
+      expect(row.rawData!, equals(blob));
+    });
+
+    test(
+      'cascade delete: deleting a Dive removes its DiveDataSources rows',
+      () async {
+        await insertDive('dive-1');
+        await insertDive('dive-2');
+        await insertComputer('comp-1');
+
+        await insertSource(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          rawData: Uint8List.fromList([1, 2, 3]),
+        );
+        await insertSource(
+          id: 'src-2',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          rawData: Uint8List.fromList([4, 5, 6]),
+          isPrimary: false,
+        );
+        // A source for a different dive (should NOT be deleted)
+        await insertSource(
+          id: 'src-3',
+          diveId: 'dive-2',
+          computerId: 'comp-1',
+          rawData: Uint8List.fromList([7, 8, 9]),
+        );
+
+        // Verify all three sources exist
+        var allSources = await db.select(db.diveDataSources).get();
+        expect(allSources.length, 3);
+
+        // Delete dive-1 -- CASCADE should remove src-1 and src-2
+        await (db.delete(db.dives)..where((t) => t.id.equals('dive-1'))).go();
+
+        allSources = await db.select(db.diveDataSources).get();
+        expect(allSources.length, 1);
+        expect(allSources.first.id, 'src-3');
+        expect(allSources.first.diveId, 'dive-2');
+        // Verify the surviving source's blob is intact
+        expect(allSources.first.rawData, equals(Uint8List.fromList([7, 8, 9])));
+      },
+    );
+  });
+}

--- a/test/features/dive_computer/data/services/raw_data_persistence_test.dart
+++ b/test/features/dive_computer/data/services/raw_data_persistence_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/features/dive_computer/data/services/raw_data_persistence_test.dart
+++ b/test/features/dive_computer/data/services/raw_data_persistence_test.dart
@@ -72,6 +72,288 @@ void main() {
     return id;
   }
 
+  /// Insert a minimal dive tank row and return its ID.
+  Future<String> insertTank({
+    required String id,
+    required String diveId,
+  }) async {
+    await db
+        .into(db.diveTanks)
+        .insert(DiveTanksCompanion(id: Value(id), diveId: Value(diveId)));
+    return id;
+  }
+
+  /// Insert a dive profile point.
+  Future<void> insertProfile({
+    required String id,
+    required String diveId,
+    String? computerId,
+    int timestamp = 0,
+    double depth = 10.0,
+  }) async {
+    await db
+        .into(db.diveProfiles)
+        .insert(
+          DiveProfilesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            timestamp: Value(timestamp),
+            depth: Value(depth),
+          ),
+        );
+  }
+
+  /// Insert a dive profile event.
+  Future<void> insertProfileEvent({
+    required String id,
+    required String diveId,
+    int timestamp = 0,
+    String eventType = 'bookmark',
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveProfileEvents)
+        .insert(
+          DiveProfileEventsCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            timestamp: Value(timestamp),
+            eventType: Value(eventType),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
+  /// Insert a tank pressure profile point.
+  Future<void> insertTankPressure({
+    required String id,
+    required String diveId,
+    required String tankId,
+    int timestamp = 0,
+    double pressure = 200.0,
+  }) async {
+    await db
+        .into(db.tankPressureProfiles)
+        .insert(
+          TankPressureProfilesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            tankId: Value(tankId),
+            timestamp: Value(timestamp),
+            pressure: Value(pressure),
+          ),
+        );
+  }
+
+  /// Insert a gas switch record.
+  Future<void> insertGasSwitch({
+    required String id,
+    required String diveId,
+    required String tankId,
+    int timestamp = 0,
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.gasSwitches)
+        .insert(
+          GasSwitchesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            tankId: Value(tankId),
+            timestamp: Value(timestamp),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
+  /// Run the same DELETE statements as clearSourceAndProfiles.
+  ///
+  /// This mirrors DiveComputerRepository.clearSourceAndProfiles but operates
+  /// directly on the test database instead of going through the singleton.
+  Future<void> clearSourceAndProfiles({
+    required String diveId,
+    required String computerId,
+  }) async {
+    await db.customStatement(
+      'DELETE FROM dive_profile_events WHERE dive_id = ?',
+      [diveId],
+    );
+    await db.customStatement(
+      'DELETE FROM tank_pressure_profiles WHERE dive_id = ?',
+      [diveId],
+    );
+    await db.customStatement('DELETE FROM gas_switches WHERE dive_id = ?', [
+      diveId,
+    ]);
+    await db.customStatement(
+      'DELETE FROM dive_profiles WHERE dive_id = ? AND computer_id = ?',
+      [diveId, computerId],
+    );
+    await db.customStatement(
+      'DELETE FROM dive_data_sources WHERE dive_id = ? AND computer_id = ?',
+      [diveId, computerId],
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // clearSourceAndProfiles
+  // --------------------------------------------------------------------------
+
+  group('clearSourceAndProfiles', () {
+    test('deletes profile events, tank pressure profiles, gas switches, '
+        'profiles, and data source for the dive+computer pair', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      final tankId = await insertTank(id: 'tank-1', diveId: 'dive-1');
+
+      // Populate all 5 tables
+      await insertProfile(id: 'p-1', diveId: 'dive-1', computerId: 'comp-1');
+      await insertProfile(
+        id: 'p-2',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        timestamp: 10,
+      );
+      await insertSource(id: 'src-1', diveId: 'dive-1', computerId: 'comp-1');
+      await insertProfileEvent(id: 'ev-1', diveId: 'dive-1');
+      await insertTankPressure(id: 'tp-1', diveId: 'dive-1', tankId: tankId);
+      await insertGasSwitch(id: 'gs-1', diveId: 'dive-1', tankId: tankId);
+
+      // Verify everything was inserted
+      expect(await db.select(db.diveProfiles).get(), hasLength(2));
+      expect(await db.select(db.diveDataSources).get(), hasLength(1));
+      expect(await db.select(db.diveProfileEvents).get(), hasLength(1));
+      expect(await db.select(db.tankPressureProfiles).get(), hasLength(1));
+      expect(await db.select(db.gasSwitches).get(), hasLength(1));
+
+      await clearSourceAndProfiles(diveId: 'dive-1', computerId: 'comp-1');
+
+      // All 5 tables should be empty for this dive+computer
+      expect(await db.select(db.diveProfiles).get(), isEmpty);
+      expect(await db.select(db.diveDataSources).get(), isEmpty);
+      expect(await db.select(db.diveProfileEvents).get(), isEmpty);
+      expect(await db.select(db.tankPressureProfiles).get(), isEmpty);
+      expect(await db.select(db.gasSwitches).get(), isEmpty);
+    });
+
+    test('preserves data for other dives (different dive_id)', () async {
+      await insertDive('dive-1');
+      await insertDive('dive-2');
+      await insertComputer('comp-1');
+      final tank1 = await insertTank(id: 'tank-1', diveId: 'dive-1');
+      final tank2 = await insertTank(id: 'tank-2', diveId: 'dive-2');
+
+      // Data for dive-1 (will be cleared)
+      await insertProfile(id: 'p-1', diveId: 'dive-1', computerId: 'comp-1');
+      await insertSource(id: 'src-1', diveId: 'dive-1', computerId: 'comp-1');
+      await insertProfileEvent(id: 'ev-1', diveId: 'dive-1');
+      await insertTankPressure(id: 'tp-1', diveId: 'dive-1', tankId: tank1);
+      await insertGasSwitch(id: 'gs-1', diveId: 'dive-1', tankId: tank1);
+
+      // Data for dive-2 (must survive)
+      await insertProfile(id: 'p-2', diveId: 'dive-2', computerId: 'comp-1');
+      await insertSource(id: 'src-2', diveId: 'dive-2', computerId: 'comp-1');
+      await insertProfileEvent(id: 'ev-2', diveId: 'dive-2');
+      await insertTankPressure(id: 'tp-2', diveId: 'dive-2', tankId: tank2);
+      await insertGasSwitch(id: 'gs-2', diveId: 'dive-2', tankId: tank2);
+
+      await clearSourceAndProfiles(diveId: 'dive-1', computerId: 'comp-1');
+
+      // dive-2 data is fully preserved
+      final profiles = await db.select(db.diveProfiles).get();
+      expect(profiles, hasLength(1));
+      expect(profiles.first.diveId, 'dive-2');
+
+      final sources = await db.select(db.diveDataSources).get();
+      expect(sources, hasLength(1));
+      expect(sources.first.diveId, 'dive-2');
+
+      final events = await db.select(db.diveProfileEvents).get();
+      expect(events, hasLength(1));
+      expect(events.first.diveId, 'dive-2');
+
+      final pressures = await db.select(db.tankPressureProfiles).get();
+      expect(pressures, hasLength(1));
+      expect(pressures.first.diveId, 'dive-2');
+
+      final switches = await db.select(db.gasSwitches).get();
+      expect(switches, hasLength(1));
+      expect(switches.first.diveId, 'dive-2');
+    });
+
+    test('preserves profiles from other computers '
+        '(same dive, different computer_id)', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertComputer('comp-2');
+      final tankId = await insertTank(id: 'tank-1', diveId: 'dive-1');
+
+      // Profiles from comp-1 (will be cleared)
+      await insertProfile(
+        id: 'p-1a',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        timestamp: 0,
+      );
+      await insertProfile(
+        id: 'p-1b',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        timestamp: 10,
+      );
+
+      // Profiles from comp-2 (must survive)
+      await insertProfile(
+        id: 'p-2a',
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        timestamp: 0,
+      );
+      await insertProfile(
+        id: 'p-2b',
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        timestamp: 10,
+      );
+
+      // Data source for comp-1 (will be cleared)
+      await insertSource(id: 'src-1', diveId: 'dive-1', computerId: 'comp-1');
+
+      // Data source for comp-2 (must survive)
+      await insertSource(
+        id: 'src-2',
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        isPrimary: false,
+      );
+
+      // Per-dive derived tables (events, tank pressures, gas switches) are
+      // cleared by dive_id alone (they lack a computer_id column), so they
+      // will be removed regardless of which computer is being cleared.
+      await insertProfileEvent(id: 'ev-1', diveId: 'dive-1');
+      await insertTankPressure(id: 'tp-1', diveId: 'dive-1', tankId: tankId);
+      await insertGasSwitch(id: 'gs-1', diveId: 'dive-1', tankId: tankId);
+
+      await clearSourceAndProfiles(diveId: 'dive-1', computerId: 'comp-1');
+
+      // comp-2 profiles survive (filtered by computer_id)
+      final profiles = await db.select(db.diveProfiles).get();
+      expect(profiles, hasLength(2));
+      expect(profiles.every((p) => p.computerId == 'comp-2'), isTrue);
+
+      // comp-2 data source survives (filtered by computer_id)
+      final sources = await db.select(db.diveDataSources).get();
+      expect(sources, hasLength(1));
+      expect(sources.first.computerId, 'comp-2');
+
+      // Per-dive derived tables are cleared entirely (by dive_id)
+      expect(await db.select(db.diveProfileEvents).get(), isEmpty);
+      expect(await db.select(db.tankPressureProfiles).get(), isEmpty);
+      expect(await db.select(db.gasSwitches).get(), isEmpty);
+    });
+  });
+
   group('DiveDataSources blob persistence', () {
     test('stores and retrieves rawData blob byte-for-byte', () async {
       await insertDive('dive-1');

--- a/test/features/dive_computer/data/services/raw_data_persistence_test.dart
+++ b/test/features/dive_computer/data/services/raw_data_persistence_test.dart
@@ -141,14 +141,11 @@ void main() {
       )..where((t) => t.id.equals('src-1'))).getSingle();
       expect(row.computerId, equals('comp-1'));
 
+      // Verify foreign keys are enabled
+      final fkResult = await db.customSelect('PRAGMA foreign_keys').getSingle();
+      expect(fkResult.data['foreign_keys'], 1);
+
       // Delete the computer -- FK ON DELETE SET NULL should fire.
-      // The repository uses manual nulling + delete; in a direct-db test
-      // we need to do the same because Drift/SQLite may not have the FK
-      // pragma enabled by default in all configurations.
-      await db.customStatement(
-        'UPDATE dive_data_sources SET computer_id = NULL WHERE computer_id = ?',
-        ['comp-1'],
-      );
       await (db.delete(
         db.diveComputers,
       )..where((t) => t.id.equals('comp-1'))).go();

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -711,38 +709,38 @@ void main() {
       await db
           .into(db.diveTanks)
           .insert(
-            DiveTanksCompanion(
-              id: const Value('tank-0'),
-              diveId: const Value('dive-1'),
-              volume: const Value(12.0),
-              workingPressure: const Value(200.0),
-              startPressure: const Value(200.0),
-              endPressure: const Value(50.0),
-              o2Percent: const Value(32.0),
-              hePercent: const Value(0.0),
-              tankOrder: const Value(0),
-              tankName: const Value('My Primary AL80'),
-              presetName: const Value('al80'),
-              tankRole: const Value('backGas'),
-              tankMaterial: const Value('aluminum'),
+            const DiveTanksCompanion(
+              id: Value('tank-0'),
+              diveId: Value('dive-1'),
+              volume: Value(12.0),
+              workingPressure: Value(200.0),
+              startPressure: Value(200.0),
+              endPressure: Value(50.0),
+              o2Percent: Value(32.0),
+              hePercent: Value(0.0),
+              tankOrder: Value(0),
+              tankName: Value('My Primary AL80'),
+              presetName: Value('al80'),
+              tankRole: Value('backGas'),
+              tankMaterial: Value('aluminum'),
             ),
           );
       await db
           .into(db.diveTanks)
           .insert(
-            DiveTanksCompanion(
-              id: const Value('tank-1'),
-              diveId: const Value('dive-1'),
-              volume: const Value(7.0),
-              startPressure: const Value(200.0),
-              endPressure: const Value(150.0),
-              o2Percent: const Value(50.0),
-              hePercent: const Value(0.0),
-              tankOrder: const Value(1),
-              tankName: const Value('Deco Stage'),
-              presetName: const Value('al40'),
-              tankRole: const Value('deco'),
-              tankMaterial: const Value('aluminum'),
+            const DiveTanksCompanion(
+              id: Value('tank-1'),
+              diveId: Value('dive-1'),
+              volume: Value(7.0),
+              startPressure: Value(200.0),
+              endPressure: Value(150.0),
+              o2Percent: Value(50.0),
+              hePercent: Value(0.0),
+              tankOrder: Value(1),
+              tankName: Value('Deco Stage'),
+              presetName: Value('al40'),
+              tankRole: Value('deco'),
+              tankMaterial: Value('aluminum'),
             ),
           );
 

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -806,5 +806,679 @@ void main() {
       expect(t2.startPressure, 200.0);
       expect(t2.endPressure, 100.0);
     });
+
+    test('multi-source dive skips event/gasSwitch/tankPressure deletion '
+        'and tank carry-over', () async {
+      // Arrange: dive with two sources
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertComputer('comp-2');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+      await insertSource(
+        id: 'src-2',
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        isPrimary: false,
+      );
+
+      // Pre-existing events, gas switches, tank pressure profiles
+      await db
+          .into(db.diveProfileEvents)
+          .insert(
+            DiveProfileEventsCompanion(
+              id: const Value('evt-1'),
+              diveId: const Value('dive-1'),
+              timestamp: const Value(60),
+              eventType: const Value('bookmark'),
+              createdAt: Value(nowMs),
+            ),
+          );
+
+      // Pre-existing tank for carry-over check
+      await db
+          .into(db.diveTanks)
+          .insert(
+            const DiveTanksCompanion(
+              id: Value('tank-0'),
+              diveId: Value('dive-1'),
+              volume: Value(12.0),
+              o2Percent: Value(21.0),
+              hePercent: Value(0.0),
+              tankOrder: Value(0),
+              tankName: Value('User Named Tank'),
+            ),
+          );
+
+      // Act: re-parse the primary source with events and tanks
+      final parsed = makeParsedDive(
+        events: [pigeon.DiveEvent(timeSeconds: 120, type: 'bookmark')],
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: 0,
+            volumeLiters: 11.0,
+            startPressureBar: 200.0,
+            endPressureBar: 50.0,
+          ),
+        ],
+        gasMixes: [pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0)],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: original event preserved (not deleted)
+      final events = await (db.select(
+        db.diveProfileEvents,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(events.length, 1);
+      expect(events.first.id, 'evt-1');
+
+      // Assert: tank NOT updated by carry-over (volume stays 12.0)
+      final tanks = await (db.select(
+        db.diveTanks,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(tanks.length, 1);
+      expect(tanks.first.volume, 12.0);
+      expect(tanks.first.tankName, 'User Named Tank');
+    });
+
+    test('non-primary source skips tank carry-over', () async {
+      // Arrange: two sources, re-parse the non-primary one
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: false,
+      );
+
+      // Pre-existing tank
+      await db
+          .into(db.diveTanks)
+          .insert(
+            const DiveTanksCompanion(
+              id: Value('tank-0'),
+              diveId: Value('dive-1'),
+              volume: Value(12.0),
+              o2Percent: Value(21.0),
+              hePercent: Value(0.0),
+              tankOrder: Value(0),
+              tankName: Value('My AL80'),
+            ),
+          );
+
+      // Act: re-parse non-primary source with tank data
+      final parsed = makeParsedDive(
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: 0,
+            volumeLiters: 11.0,
+            startPressureBar: 200.0,
+            endPressureBar: 50.0,
+          ),
+        ],
+        gasMixes: [pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0)],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: tank NOT updated (volume stays 12.0, name preserved)
+      final tanks = await (db.select(
+        db.diveTanks,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(tanks.length, 1);
+      expect(tanks.first.volume, 12.0);
+      expect(tanks.first.tankName, 'My AL80');
+    });
+
+    test('events are inserted into DB during single-source re-parse', () async {
+      // Arrange: single-source dive
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Act: re-parse with various event types
+      final parsed = makeParsedDive(
+        events: [
+          pigeon.DiveEvent(timeSeconds: 60, type: 'bookmark'),
+          pigeon.DiveEvent(timeSeconds: 120, type: 'ascent'),
+          pigeon.DiveEvent(timeSeconds: 180, type: 'safetystop'),
+          pigeon.DiveEvent(timeSeconds: 200, type: 'deco'),
+          pigeon.DiveEvent(timeSeconds: 220, type: 'violation'),
+          pigeon.DiveEvent(
+            timeSeconds: 240,
+            type: 'gaschange',
+            data: {'value': '32.0'},
+          ),
+          pigeon.DiveEvent(timeSeconds: 260, type: 'PO2'),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: all known event types are inserted
+      final events =
+          await (db.select(db.diveProfileEvents)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(events.length, 7);
+
+      expect(events[0].eventType, 'bookmark');
+      expect(events[0].severity, 'info');
+      expect(events[1].eventType, 'ascentRateWarning');
+      expect(events[1].severity, 'warning');
+      expect(events[2].eventType, 'safetyStopStart');
+      expect(events[2].severity, 'info');
+      expect(events[3].eventType, 'decoStopStart');
+      expect(events[3].severity, 'info');
+      expect(events[4].eventType, 'decoViolation');
+      expect(events[4].severity, 'alert');
+      expect(events[5].eventType, 'gasSwitch');
+      expect(events[5].severity, 'info');
+      expect(events[5].value, 32.0);
+      expect(events[6].eventType, 'ppO2High');
+      expect(events[6].severity, 'alert');
+    });
+
+    test('unknown event types are not inserted', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(
+        events: [
+          pigeon.DiveEvent(timeSeconds: 60, type: 'unknown_event'),
+          pigeon.DiveEvent(timeSeconds: 120, type: 'bookmark'),
+          pigeon.DiveEvent(timeSeconds: 180, type: 'some_random_type'),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: only known event (bookmark) is inserted
+      final events = await (db.select(
+        db.diveProfileEvents,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(events.length, 1);
+      expect(events.first.eventType, 'bookmark');
+    });
+
+    test('all event type synonyms map correctly', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Test all synonym variants
+      final parsed = makeParsedDive(
+        events: [
+          pigeon.DiveEvent(timeSeconds: 10, type: 'safetystop_voluntary'),
+          pigeon.DiveEvent(timeSeconds: 20, type: 'safetystop_mandatory'),
+          pigeon.DiveEvent(timeSeconds: 30, type: 'deepstop'),
+          pigeon.DiveEvent(timeSeconds: 40, type: 'gaschange2'),
+          pigeon.DiveEvent(timeSeconds: 50, type: 'ceiling'),
+          pigeon.DiveEvent(timeSeconds: 60, type: 'ceiling_safetystop'),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final events =
+          await (db.select(db.diveProfileEvents)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(events.length, 6);
+
+      expect(events[0].eventType, 'safetyStopStart');
+      expect(events[1].eventType, 'safetyStopStart');
+      expect(events[2].eventType, 'decoStopStart');
+      expect(events[3].eventType, 'gasSwitch');
+      expect(events[4].eventType, 'decoViolation');
+      expect(events[5].eventType, 'decoViolation');
+    });
+
+    test('unknown diveMode maps to oc', () async {
+      await insertDive('dive-1', diveMode: 'oc');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(diveMode: 'gauge');
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      expect(dive.diveMode, 'oc');
+    });
+
+    test('null diveMode maps to oc', () async {
+      await insertDive('dive-1', diveMode: 'ccr');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(diveMode: null);
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      expect(dive.diveMode, 'oc');
+    });
+
+    test('bottomTime falls back to durationSeconds when < 3 samples', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Only 2 samples -- _calculateBottomTimeFromSamples returns null
+      final parsed = makeParsedDive(
+        durationSeconds: 1800,
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 10.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      expect(dive.bottomTime, 1800);
+    });
+
+    test(
+      'bottomTime falls back to durationSeconds when maxDepth is 0',
+      () async {
+        await insertDive('dive-1');
+        await insertComputer('comp-1');
+        await insertSource(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          isPrimary: true,
+        );
+
+        // All samples at depth 0 -- maxDepth <= 0 returns null
+        final parsed = makeParsedDive(
+          maxDepthMeters: 0.0,
+          durationSeconds: 600,
+          samples: [
+            pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+            pigeon.ProfileSample(timeSeconds: 60, depthMeters: 0.0),
+            pigeon.ProfileSample(timeSeconds: 120, depthMeters: 0.0),
+            pigeon.ProfileSample(timeSeconds: 180, depthMeters: 0.0),
+          ],
+        );
+
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-1',
+          parsed: parsed,
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final dive = await getDive('dive-1');
+        expect(dive.bottomTime, 600);
+      },
+    );
+
+    test('bottomTime falls back to durationSeconds when ascentStart <= '
+        'descentEnd', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Single deep sample at one timestamp -- descent end == ascent start
+      final parsed = makeParsedDive(
+        maxDepthMeters: 30.0,
+        durationSeconds: 1200,
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 30.0),
+          pigeon.ProfileSample(timeSeconds: 120, depthMeters: 0.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      // The only sample at >= 85% of 30m (25.5m) is the single 30m sample
+      // at t=60. descentEnd = ascentStart = 60, so bottom time returns null
+      // and falls back to durationSeconds.
+      expect(dive.bottomTime, 1200);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getSourcesForDiveReparse
+  // ---------------------------------------------------------------------------
+
+  group('ReparseService.getSourcesForDiveReparse', () {
+    test('returns only sources with raw data for the given dive', () async {
+      await insertDive('dive-1');
+      await insertDive('dive-2');
+      await insertComputer('comp-1');
+
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      // Source with rawData for dive-1
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              rawData: Value(Uint8List.fromList([1, 2, 3])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      // Source without rawData for dive-1
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-2'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(false),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      // Source with rawData for dive-2 (different dive)
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-3'),
+              diveId: const Value('dive-2'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              rawData: Value(Uint8List.fromList([4, 5])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      final sources = await service.getSourcesForDiveReparse('dive-1');
+      expect(sources.length, 1);
+      expect(sources.first.id, 'src-1');
+    });
+
+    test('returns empty list when no sources have raw data', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      final sources = await service.getSourcesForDiveReparse('dive-1');
+      expect(sources, isEmpty);
+    });
+
+    test('returns empty list for nonexistent dive', () async {
+      final sources = await service.getSourcesForDiveReparse(
+        'nonexistent-dive',
+      );
+      expect(sources, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getSourcesForComputerReparse
+  // ---------------------------------------------------------------------------
+
+  group('ReparseService.getSourcesForComputerReparse', () {
+    test('returns only sources with raw data for the given computer', () async {
+      await insertDive('dive-1');
+      await insertDive('dive-2');
+      await insertDive('dive-3');
+      await insertComputer('comp-1');
+      await insertComputer('comp-2');
+
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      // Source with rawData for comp-1
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              rawData: Value(Uint8List.fromList([1, 2])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      // Source without rawData for comp-1
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-2'),
+              diveId: const Value('dive-2'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      // Source with rawData for comp-2 (different computer)
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-3'),
+              diveId: const Value('dive-3'),
+              computerId: const Value('comp-2'),
+              isPrimary: const Value(true),
+              rawData: Value(Uint8List.fromList([3, 4])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      final sources = await service.getSourcesForComputerReparse('comp-1');
+      expect(sources.length, 1);
+      expect(sources.first.id, 'src-1');
+    });
+
+    test('returns empty list when no sources have raw data', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      final sources = await service.getSourcesForComputerReparse('comp-1');
+      expect(sources, isEmpty);
+    });
+
+    test('returns empty list for nonexistent computer', () async {
+      final sources = await service.getSourcesForComputerReparse(
+        'nonexistent-comp',
+      );
+      expect(sources, isEmpty);
+    });
+
+    test(
+      'returns multiple sources when computer has many dives with raw data',
+      () async {
+        await insertDive('dive-1');
+        await insertDive('dive-2');
+        await insertComputer('comp-1');
+
+        final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+        await db
+            .into(db.diveDataSources)
+            .insert(
+              DiveDataSourcesCompanion(
+                id: const Value('src-1'),
+                diveId: const Value('dive-1'),
+                computerId: const Value('comp-1'),
+                isPrimary: const Value(true),
+                rawData: Value(Uint8List.fromList([1])),
+                importedAt: Value(now),
+                createdAt: Value(now),
+              ),
+            );
+        await db
+            .into(db.diveDataSources)
+            .insert(
+              DiveDataSourcesCompanion(
+                id: const Value('src-2'),
+                diveId: const Value('dive-2'),
+                computerId: const Value('comp-1'),
+                isPrimary: const Value(true),
+                rawData: Value(Uint8List.fromList([2])),
+                importedAt: Value(now),
+                createdAt: Value(now),
+              ),
+            );
+
+        final sources = await service.getSourcesForComputerReparse('comp-1');
+        expect(sources.length, 2);
+      },
+    );
   });
 }

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -1,0 +1,812 @@
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
+
+void main() {
+  late AppDatabase db;
+  late ReparseService service;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    service = ReparseService(db: db);
+  });
+
+  tearDown(() => db.close());
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  final nowMs = DateTime.utc(2026, 1, 15, 10, 0).millisecondsSinceEpoch;
+
+  Future<void> insertDive(
+    String id, {
+    double? maxDepth,
+    double? avgDepth,
+    int? runtime,
+    int? diveDateTime,
+    double? waterTemp,
+    String? notes,
+    int? rating,
+    String? siteId,
+    String? buddy,
+    String diveMode = 'oc',
+    double? cnsEnd,
+    double? otu,
+    int? gradientFactorLow,
+    int? gradientFactorHigh,
+    String? decoAlgorithm,
+    int? decoConservatism,
+    bool isFavorite = false,
+  }) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(diveDateTime ?? nowMs),
+            maxDepth: Value(maxDepth),
+            avgDepth: Value(avgDepth),
+            runtime: Value(runtime),
+            waterTemp: Value(waterTemp),
+            notes: Value(notes ?? ''),
+            rating: Value(rating),
+            siteId: Value(siteId),
+            buddy: Value(buddy),
+            diveMode: Value(diveMode),
+            cnsEnd: Value(cnsEnd),
+            otu: Value(otu),
+            gradientFactorLow: Value(gradientFactorLow),
+            gradientFactorHigh: Value(gradientFactorHigh),
+            decoAlgorithm: Value(decoAlgorithm),
+            decoConservatism: Value(decoConservatism),
+            isFavorite: Value(isFavorite),
+            createdAt: Value(nowMs),
+            updatedAt: Value(nowMs),
+          ),
+        );
+  }
+
+  Future<void> insertComputer(String id) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            name: Value('Test Computer $id'),
+            createdAt: Value(nowMs),
+            updatedAt: Value(nowMs),
+          ),
+        );
+  }
+
+  Future<void> insertSource({
+    required String id,
+    required String diveId,
+    String? computerId,
+    bool isPrimary = true,
+    double? maxDepth,
+    double? avgDepth,
+    int? duration,
+    double? waterTemp,
+  }) async {
+    final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            sourceFormat: const Value('dive_computer'),
+            maxDepth: Value(maxDepth),
+            avgDepth: Value(avgDepth),
+            duration: Value(duration),
+            waterTemp: Value(waterTemp),
+            importedAt: Value(now),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertProfile({
+    required String id,
+    required String diveId,
+    String? computerId,
+    required int timestamp,
+    required double depth,
+    bool isPrimary = true,
+  }) async {
+    await db
+        .into(db.diveProfiles)
+        .insert(
+          DiveProfilesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            timestamp: Value(timestamp),
+            depth: Value(depth),
+            isPrimary: Value(isPrimary),
+          ),
+        );
+  }
+
+  pigeon.ParsedDive makeParsedDive({
+    double maxDepthMeters = 25.0,
+    double avgDepthMeters = 14.0,
+    int durationSeconds = 3000,
+    double? minTemperatureCelsius = 18.0,
+    String? diveMode,
+    String? decoAlgorithm = 'buhlmann',
+    int? gfLow = 30,
+    int? gfHigh = 70,
+    int? decoConservatism,
+    int year = 2026,
+    int month = 1,
+    int day = 15,
+    int hour = 10,
+    int minute = 0,
+    int second = 0,
+    List<pigeon.ProfileSample>? samples,
+    List<pigeon.TankInfo>? tanks,
+    List<pigeon.GasMix>? gasMixes,
+    List<pigeon.DiveEvent>? events,
+  }) {
+    return pigeon.ParsedDive(
+      fingerprint: 'test-fp',
+      dateTimeYear: year,
+      dateTimeMonth: month,
+      dateTimeDay: day,
+      dateTimeHour: hour,
+      dateTimeMinute: minute,
+      dateTimeSecond: second,
+      maxDepthMeters: maxDepthMeters,
+      avgDepthMeters: avgDepthMeters,
+      durationSeconds: durationSeconds,
+      minTemperatureCelsius: minTemperatureCelsius,
+      samples:
+          samples ??
+          [
+            pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+            pigeon.ProfileSample(timeSeconds: 60, depthMeters: 10.0),
+            pigeon.ProfileSample(
+              timeSeconds: 120,
+              depthMeters: 25.0,
+              temperatureCelsius: 18.0,
+            ),
+            pigeon.ProfileSample(timeSeconds: 180, depthMeters: 5.0),
+          ],
+      tanks: tanks ?? [],
+      gasMixes: gasMixes ?? [],
+      events: events ?? [],
+      diveMode: diveMode,
+      decoAlgorithm: decoAlgorithm,
+      gfLow: gfLow,
+      gfHigh: gfHigh,
+      decoConservatism: decoConservatism,
+    );
+  }
+
+  Future<Dive> getDive(String id) async {
+    return (db.select(db.dives)..where((t) => t.id.equals(id))).getSingle();
+  }
+
+  Future<DiveDataSourcesData> getSource(String id) async {
+    return (db.select(
+      db.diveDataSources,
+    )..where((t) => t.id.equals(id))).getSingle();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  group('ReparseService.applyParsedUpdate', () {
+    test('overwrites computer-authored fields on primary source', () async {
+      // Arrange: create dive with known values
+      await insertDive(
+        'dive-1',
+        maxDepth: 20.0,
+        avgDepth: 10.0,
+        runtime: 2400,
+        waterTemp: 22.0,
+        diveMode: 'oc',
+        decoAlgorithm: 'rgbm',
+        gradientFactorLow: 40,
+        gradientFactorHigh: 85,
+      );
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+        maxDepth: 20.0,
+        avgDepth: 10.0,
+        duration: 2400,
+        waterTemp: 22.0,
+      );
+
+      // Act: apply a parsed update with different computer-authored values
+      final parsed = makeParsedDive(
+        maxDepthMeters: 30.0,
+        avgDepthMeters: 16.0,
+        durationSeconds: 3600,
+        minTemperatureCelsius: 15.0,
+        decoAlgorithm: 'buhlmann',
+        gfLow: 30,
+        gfHigh: 70,
+        diveMode: 'ccr',
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: 'Shearwater',
+        descriptorProduct: 'Perdix',
+        descriptorModel: 42,
+        libdivecomputerVersion: '0.8.0',
+      );
+
+      // Assert: computer-authored fields are updated
+      final dive = await getDive('dive-1');
+      expect(dive.maxDepth, 30.0);
+      expect(dive.avgDepth, 16.0);
+      expect(dive.runtime, 3600);
+      expect(dive.waterTemp, 15.0);
+      expect(dive.diveMode, 'ccr');
+      expect(dive.decoAlgorithm, 'buhlmann');
+      expect(dive.gradientFactorLow, 30);
+      expect(dive.gradientFactorHigh, 70);
+    });
+
+    test('preserves user-authored fields on primary source', () async {
+      // Arrange: create dive with user-authored fields set
+      await insertDive(
+        'dive-1',
+        maxDepth: 20.0,
+        notes: 'Great visibility today!',
+        rating: 5,
+        buddy: 'Alice',
+        isFavorite: true,
+      );
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Act
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(maxDepthMeters: 30.0),
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: user-authored fields are NOT changed
+      final dive = await getDive('dive-1');
+      expect(dive.notes, 'Great visibility today!');
+      expect(dive.rating, 5);
+      expect(dive.buddy, 'Alice');
+      expect(dive.isFavorite, true);
+    });
+
+    test('does NOT update Dives row for non-primary source', () async {
+      // Arrange
+      await insertDive('dive-1', maxDepth: 20.0, avgDepth: 10.0, runtime: 2400);
+      await insertComputer('comp-1');
+      await insertComputer('comp-2');
+      // Primary source from comp-1
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+      // Non-primary source from comp-2
+      await insertSource(
+        id: 'src-2',
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        isPrimary: false,
+      );
+
+      // Act: update the non-primary source
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-2',
+        parsed: makeParsedDive(
+          maxDepthMeters: 35.0,
+          avgDepthMeters: 20.0,
+          durationSeconds: 4000,
+        ),
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: Dives row fields remain at original values
+      final dive = await getDive('dive-1');
+      expect(dive.maxDepth, 20.0);
+      expect(dive.avgDepth, 10.0);
+      expect(dive.runtime, 2400);
+    });
+
+    test('updates DiveDataSources snapshot fields and lastParsedAt', () async {
+      // Arrange
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+        maxDepth: 20.0,
+        avgDepth: 10.0,
+        duration: 2400,
+        waterTemp: 22.0,
+      );
+
+      // Act
+      final parsed = makeParsedDive(
+        maxDepthMeters: 28.5,
+        avgDepthMeters: 15.5,
+        durationSeconds: 3200,
+        minTemperatureCelsius: 17.0,
+        decoAlgorithm: 'vpm',
+        gfLow: 25,
+        gfHigh: 75,
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: 'Suunto',
+        descriptorProduct: 'EON Core',
+        descriptorModel: 99,
+        libdivecomputerVersion: '0.9.0',
+      );
+
+      // Assert: snapshot fields on source row are updated
+      final src = await getSource('src-1');
+      expect(src.maxDepth, 28.5);
+      expect(src.avgDepth, 15.5);
+      expect(src.duration, 3200);
+      expect(src.waterTemp, 17.0);
+      expect(src.decoAlgorithm, 'vpm');
+      expect(src.gradientFactorLow, 25);
+      expect(src.gradientFactorHigh, 75);
+      expect(src.descriptorVendor, 'Suunto');
+      expect(src.descriptorProduct, 'EON Core');
+      expect(src.descriptorModel, 99);
+      expect(src.libdivecomputerVersion, '0.9.0');
+      expect(src.lastParsedAt, isNotNull);
+    });
+
+    test(
+      'is idempotent: same data applied twice yields identical DB state',
+      () async {
+        // Arrange
+        await insertDive(
+          'dive-1',
+          maxDepth: 20.0,
+          notes: 'User notes survive both runs',
+          rating: 4,
+        );
+        await insertComputer('comp-1');
+        await insertSource(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          isPrimary: true,
+        );
+        // Insert initial profiles that will be replaced
+        await insertProfile(
+          id: 'prof-old-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          timestamp: 0,
+          depth: 0.0,
+        );
+
+        final parsed = makeParsedDive(
+          maxDepthMeters: 25.0,
+          avgDepthMeters: 14.0,
+          durationSeconds: 3000,
+        );
+
+        // Act: run twice
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-1',
+          parsed: parsed,
+          descriptorVendor: 'Shearwater',
+          descriptorProduct: 'Perdix',
+          descriptorModel: 42,
+          libdivecomputerVersion: '0.8.0',
+        );
+
+        // Snapshot after first run
+        final diveAfter1 = await getDive('dive-1');
+        final srcAfter1 = await getSource('src-1');
+        final profilesAfter1 = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals('dive-1'))).get();
+
+        // Second run
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-1',
+          parsed: parsed,
+          descriptorVendor: 'Shearwater',
+          descriptorProduct: 'Perdix',
+          descriptorModel: 42,
+          libdivecomputerVersion: '0.8.0',
+        );
+
+        // Snapshot after second run
+        final diveAfter2 = await getDive('dive-1');
+        final srcAfter2 = await getSource('src-1');
+        final profilesAfter2 = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals('dive-1'))).get();
+
+        // Assert: same number of profiles
+        expect(profilesAfter2.length, profilesAfter1.length);
+
+        // Assert: dive fields match
+        expect(diveAfter2.maxDepth, diveAfter1.maxDepth);
+        expect(diveAfter2.avgDepth, diveAfter1.avgDepth);
+        expect(diveAfter2.runtime, diveAfter1.runtime);
+
+        // Assert: source fields match
+        expect(srcAfter2.maxDepth, srcAfter1.maxDepth);
+        expect(srcAfter2.avgDepth, srcAfter1.avgDepth);
+        expect(srcAfter2.duration, srcAfter1.duration);
+
+        // Assert: user fields survive both runs
+        expect(diveAfter2.notes, 'User notes survive both runs');
+        expect(diveAfter2.rating, 4);
+      },
+    );
+
+    test('replaces DiveProfiles for the source computerId', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertComputer('comp-2');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Pre-existing profiles from comp-1 (should be replaced)
+      await insertProfile(
+        id: 'prof-old-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        timestamp: 0,
+        depth: 0.0,
+      );
+      await insertProfile(
+        id: 'prof-old-2',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        timestamp: 60,
+        depth: 10.0,
+      );
+
+      // Profile from comp-2 (should NOT be touched)
+      await insertProfile(
+        id: 'prof-other',
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        timestamp: 0,
+        depth: 0.0,
+        isPrimary: false,
+      );
+
+      // Act
+      final parsed = makeParsedDive(
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 30, depthMeters: 5.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 12.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Assert: 3 new profiles from comp-1, plus 1 untouched from comp-2
+      final profiles =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+
+      final comp1Profiles = profiles
+          .where((p) => p.computerId == 'comp-1')
+          .toList();
+      final comp2Profiles = profiles
+          .where((p) => p.computerId == 'comp-2')
+          .toList();
+
+      expect(comp1Profiles.length, 3);
+      expect(comp1Profiles[0].depth, 0.0);
+      expect(comp1Profiles[1].depth, 5.0);
+      expect(comp1Profiles[2].depth, 12.0);
+
+      expect(comp2Profiles.length, 1);
+      expect(comp2Profiles[0].id, 'prof-other');
+    });
+
+    test('does not overwrite existing rawData with null on re-parse', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+
+      final blob = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final fp = Uint8List.fromList([0xAB, 0xCD]);
+
+      // Insert source with existing raw data
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              sourceFormat: const Value('dive_computer'),
+              rawData: Value(blob),
+              rawFingerprint: Value(fp),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      // Act: re-parse with null rawData/rawFingerprint (the re-parse path)
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(),
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+        rawData: null,
+        rawFingerprint: null,
+      );
+
+      // Assert: existing blob is preserved
+      final src = await getSource('src-1');
+      expect(src.rawData, isNotNull);
+      expect(src.rawData!, equals(blob));
+      expect(src.rawFingerprint, isNotNull);
+      expect(src.rawFingerprint!, equals(fp));
+    });
+
+    test('getRawDataCounts returns correct counts', () async {
+      await insertComputer('comp-1');
+      await insertDive('dive-1');
+      await insertDive('dive-2');
+      await insertDive('dive-3');
+
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      // Source with rawData
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              rawData: Value(Uint8List.fromList([1, 2, 3])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      // Source without rawData
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-2'),
+              diveId: const Value('dive-2'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      // Another source with rawData
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-3'),
+              diveId: const Value('dive-3'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              rawData: Value(Uint8List.fromList([4, 5])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      final counts = await service.getRawDataCounts('comp-1');
+      expect(counts.withRawData, 2);
+      expect(counts.withoutRawData, 1);
+    });
+
+    test('hasRawData returns correct value', () async {
+      await insertDive('dive-1');
+      await insertDive('dive-2');
+
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              rawData: Value(Uint8List.fromList([1])),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-2'),
+              diveId: const Value('dive-2'),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      expect(await service.hasRawData('dive-1'), isTrue);
+      expect(await service.hasRawData('dive-2'), isFalse);
+      expect(await service.hasRawData('dive-nonexistent'), isFalse);
+    });
+
+    test('DiveTanks carry-over: overwrites computer fields, preserves user '
+        'fields, handles new/removed tanks', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Existing tanks: tank 0 and tank 1
+      await db
+          .into(db.diveTanks)
+          .insert(
+            DiveTanksCompanion(
+              id: const Value('tank-0'),
+              diveId: const Value('dive-1'),
+              volume: const Value(12.0),
+              workingPressure: const Value(200.0),
+              startPressure: const Value(200.0),
+              endPressure: const Value(50.0),
+              o2Percent: const Value(32.0),
+              hePercent: const Value(0.0),
+              tankOrder: const Value(0),
+              tankName: const Value('My Primary AL80'),
+              presetName: const Value('al80'),
+              tankRole: const Value('backGas'),
+              tankMaterial: const Value('aluminum'),
+            ),
+          );
+      await db
+          .into(db.diveTanks)
+          .insert(
+            DiveTanksCompanion(
+              id: const Value('tank-1'),
+              diveId: const Value('dive-1'),
+              volume: const Value(7.0),
+              startPressure: const Value(200.0),
+              endPressure: const Value(150.0),
+              o2Percent: const Value(50.0),
+              hePercent: const Value(0.0),
+              tankOrder: const Value(1),
+              tankName: const Value('Deco Stage'),
+              presetName: const Value('al40'),
+              tankRole: const Value('deco'),
+              tankMaterial: const Value('aluminum'),
+            ),
+          );
+
+      // Act: re-parse with updated tank 0 and a new tank 2 (tank 1 removed)
+      final parsed = makeParsedDive(
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: 0,
+            volumeLiters: 11.0,
+            startPressureBar: 210.0,
+            endPressureBar: 40.0,
+          ),
+          pigeon.TankInfo(
+            index: 2,
+            gasMixIndex: 1,
+            startPressureBar: 200.0,
+            endPressureBar: 100.0,
+          ),
+        ],
+        gasMixes: [
+          pigeon.GasMix(index: 0, o2Percent: 36.0, hePercent: 0.0),
+          pigeon.GasMix(index: 1, o2Percent: 100.0, hePercent: 0.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Get all tanks ordered by tankOrder
+      final tanks =
+          await (db.select(db.diveTanks)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+              .get();
+
+      // Tank 1 was removed by the re-parse, so we should have tanks 0 and 2
+      expect(tanks.length, 2);
+
+      // Tank 0: computer fields updated, user fields preserved
+      final t0 = tanks.firstWhere((t) => t.tankOrder == 0);
+      // Computer-authored fields updated
+      expect(t0.volume, 11.0);
+      expect(t0.startPressure, 210.0);
+      expect(t0.endPressure, 40.0);
+      expect(t0.o2Percent, 36.0);
+      // User-authored fields preserved
+      expect(t0.tankName, 'My Primary AL80');
+      expect(t0.presetName, 'al80');
+      expect(t0.tankRole, 'backGas');
+      expect(t0.tankMaterial, 'aluminum');
+
+      // Tank 2: new tank inserted
+      final t2 = tanks.firstWhere((t) => t.tankOrder == 2);
+      expect(t2.o2Percent, 100.0);
+      expect(t2.startPressure, 200.0);
+      expect(t2.endPressure, 100.0);
+    });
+  });
+}

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -1828,4 +1828,308 @@ void main() {
       },
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // Coverage gap tests
+  // ---------------------------------------------------------------------------
+
+  group('Coverage: _updateSourceRow rawData/rawFingerprint branches', () {
+    test('rawData and rawFingerprint are stored when provided', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final blob = Uint8List.fromList([10, 20, 30]);
+      final fp = Uint8List.fromList([0xAA, 0xBB]);
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(),
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+        rawData: blob,
+        rawFingerprint: fp,
+      );
+
+      final src = await getSource('src-1');
+      expect(src.rawData, isNotNull);
+      expect(src.rawData!, equals(blob));
+      expect(src.rawFingerprint, isNotNull);
+      expect(src.rawFingerprint!, equals(fp));
+    });
+  });
+
+  group('Coverage: _replaceDiveProfiles with null computerId', () {
+    test('deletes and replaces profiles where computerId is null', () async {
+      await insertDive('dive-1');
+      // Source without a computerId (manual import, etc.)
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: null,
+        isPrimary: true,
+      );
+
+      // Pre-existing profile with null computerId
+      await insertProfile(
+        id: 'prof-old-1',
+        diveId: 'dive-1',
+        computerId: null,
+        timestamp: 0,
+        depth: 0.0,
+      );
+      await insertProfile(
+        id: 'prof-old-2',
+        diveId: 'dive-1',
+        computerId: null,
+        timestamp: 60,
+        depth: 15.0,
+      );
+
+      final parsed = makeParsedDive(
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 30, depthMeters: 8.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 20.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      // Old profiles should be replaced by the 3 new samples
+      final profiles =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+
+      expect(profiles.length, 3);
+      expect(profiles[0].depth, 0.0);
+      expect(profiles[1].depth, 8.0);
+      expect(profiles[2].depth, 20.0);
+      // All should have null computerId
+      for (final p in profiles) {
+        expect(p.computerId, isNull);
+      }
+    });
+  });
+
+  group('Coverage: _insertEvents with data map', () {
+    test(
+      'event with data map containing value populates value column',
+      () async {
+        await insertDive('dive-1');
+        await insertComputer('comp-1');
+        await insertSource(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          isPrimary: true,
+        );
+
+        final parsed = makeParsedDive(
+          events: [
+            pigeon.DiveEvent(
+              timeSeconds: 60,
+              type: 'gaschange',
+              data: {'value': '42.5'},
+            ),
+          ],
+        );
+
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-1',
+          parsed: parsed,
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final events = await (db.select(
+          db.diveProfileEvents,
+        )..where((t) => t.diveId.equals('dive-1'))).get();
+        expect(events.length, 1);
+        expect(events.first.value, 42.5);
+      },
+    );
+
+    test('event with null data has null value column', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(
+        events: [
+          pigeon.DiveEvent(timeSeconds: 60, type: 'bookmark', data: null),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final events = await (db.select(
+        db.diveProfileEvents,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(events.length, 1);
+      expect(events.first.value, isNull);
+    });
+  });
+
+  group('Coverage: _carryOverTanks gas mix fallback', () {
+    test('unmatched gasMixIndex falls back to 21% O2 and 0% He', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Tank with gasMixIndex 99, which does not match any gas mix
+      final parsed = makeParsedDive(
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: 99,
+            volumeLiters: 12.0,
+            startPressureBar: 200.0,
+            endPressureBar: 50.0,
+          ),
+        ],
+        gasMixes: [
+          // Only gas mix at index 0 -- tank references index 99
+          pigeon.GasMix(index: 0, o2Percent: 36.0, hePercent: 10.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final tanks = await (db.select(
+        db.diveTanks,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(tanks.length, 1);
+      // Fallback: 21% O2, 0% He
+      expect(tanks.first.o2Percent, 21.0);
+      expect(tanks.first.hePercent, 0.0);
+    });
+  });
+
+  group('Coverage: _calculateBottomTimeFromSamples successful computation', () {
+    test('returns positive bottom time for a normal dive profile', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Profile with a clear bottom phase: descent to 30m, plateau, ascent.
+      // 85% of 30m = 25.5m. Samples at/above 25.5m: t=120 (26m), t=180 (30m),
+      // t=240 (28m). descentEnd=120, ascentStart=240, bottom time = 120s.
+      final parsed = makeParsedDive(
+        maxDepthMeters: 30.0,
+        durationSeconds: 360,
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 15.0),
+          pigeon.ProfileSample(timeSeconds: 120, depthMeters: 26.0),
+          pigeon.ProfileSample(timeSeconds: 180, depthMeters: 30.0),
+          pigeon.ProfileSample(timeSeconds: 240, depthMeters: 28.0),
+          pigeon.ProfileSample(timeSeconds: 300, depthMeters: 10.0),
+          pigeon.ProfileSample(timeSeconds: 360, depthMeters: 0.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      // Bottom time should be 240 - 120 = 120 seconds
+      expect(dive.bottomTime, 120);
+    });
+  });
+
+  group('Coverage: _extractMaxCns', () {
+    test('cnsEnd reflects maximum CNS from samples', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0, cns: 10.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 20.0, cns: 25.0),
+          pigeon.ProfileSample(timeSeconds: 120, depthMeters: 30.0, cns: 45.0),
+          pigeon.ProfileSample(timeSeconds: 180, depthMeters: 10.0, cns: 30.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      // Maximum CNS across all samples is 45.0
+      expect(dive.cnsEnd, 45.0);
+    });
+  });
 }

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -1481,4 +1481,351 @@ void main() {
       },
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // reparseAllForComputer
+  // ---------------------------------------------------------------------------
+
+  group('ReparseService.reparseAllForComputer', () {
+    Future<pigeon.ParsedDive> fakeParseFn(
+      String vendor,
+      String product,
+      int model,
+      Uint8List rawData,
+    ) async {
+      return makeParsedDive();
+    }
+
+    Future<void> insertSourceWithRawData({
+      required String id,
+      required String diveId,
+      required String computerId,
+      bool isPrimary = true,
+      String? descriptorVendor = 'Shearwater',
+      String? descriptorProduct = 'Perdix',
+      int? descriptorModel = 42,
+    }) async {
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              computerId: Value(computerId),
+              isPrimary: Value(isPrimary),
+              sourceFormat: const Value('dive_computer'),
+              rawData: Value(Uint8List.fromList([1, 2, 3])),
+              descriptorVendor: Value(descriptorVendor),
+              descriptorProduct: Value(descriptorProduct),
+              descriptorModel: Value(descriptorModel),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+    }
+
+    test(
+      'successfully re-parses all sources with raw data for a computer',
+      () async {
+        await insertComputer('comp-1');
+        await insertDive('dive-1');
+        await insertDive('dive-2');
+        await insertSourceWithRawData(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+        );
+        await insertSourceWithRawData(
+          id: 'src-2',
+          diveId: 'dive-2',
+          computerId: 'comp-1',
+        );
+
+        final result = await service.reparseAllForComputer(
+          'comp-1',
+          parseFn: fakeParseFn,
+        );
+
+        expect(result.succeeded, 2);
+        expect(result.failed, 0);
+      },
+    );
+
+    test('sources without descriptor fields are counted as failed', () async {
+      await insertComputer('comp-1');
+      await insertDive('dive-1');
+      await insertSourceWithRawData(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+      );
+
+      final result = await service.reparseAllForComputer(
+        'comp-1',
+        parseFn: fakeParseFn,
+      );
+
+      expect(result.succeeded, 0);
+      expect(result.failed, 1);
+    });
+
+    test('parseFn throwing an exception counts as failed', () async {
+      await insertComputer('comp-1');
+      await insertDive('dive-1');
+      await insertSourceWithRawData(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+      );
+
+      final result = await service.reparseAllForComputer(
+        'comp-1',
+        parseFn: (vendor, product, model, rawData) async {
+          throw Exception('native bridge error');
+        },
+      );
+
+      expect(result.succeeded, 0);
+      expect(result.failed, 1);
+    });
+
+    test('mixed results: some succeed, some fail', () async {
+      await insertComputer('comp-1');
+      await insertDive('dive-1');
+      await insertDive('dive-2');
+      await insertDive('dive-3');
+
+      // Source with valid descriptors -- will succeed
+      await insertSourceWithRawData(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+      );
+      // Source missing descriptors -- will fail
+      await insertSourceWithRawData(
+        id: 'src-2',
+        diveId: 'dive-2',
+        computerId: 'comp-1',
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+      );
+      // Source with valid descriptors but parseFn will throw
+      await insertSourceWithRawData(
+        id: 'src-3',
+        diveId: 'dive-3',
+        computerId: 'comp-1',
+        descriptorVendor: 'Suunto',
+        descriptorProduct: 'EON Core',
+        descriptorModel: 99,
+      );
+
+      final result = await service.reparseAllForComputer(
+        'comp-1',
+        parseFn: (vendor, product, model, rawData) async {
+          if (vendor == 'Suunto') {
+            throw Exception('parse failure');
+          }
+          return makeParsedDive();
+        },
+      );
+
+      expect(result.succeeded, 1);
+      expect(result.failed, 2);
+    });
+
+    test(
+      'returns (succeeded: 0, failed: 0) when no sources have raw data',
+      () async {
+        await insertComputer('comp-1');
+        await insertDive('dive-1');
+
+        // Source without rawData
+        final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+        await db
+            .into(db.diveDataSources)
+            .insert(
+              DiveDataSourcesCompanion(
+                id: const Value('src-1'),
+                diveId: const Value('dive-1'),
+                computerId: const Value('comp-1'),
+                isPrimary: const Value(true),
+                importedAt: Value(now),
+                createdAt: Value(now),
+              ),
+            );
+
+        final result = await service.reparseAllForComputer(
+          'comp-1',
+          parseFn: fakeParseFn,
+        );
+
+        expect(result.succeeded, 0);
+        expect(result.failed, 0);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // reparseDive
+  // ---------------------------------------------------------------------------
+
+  group('ReparseService.reparseDive', () {
+    Future<pigeon.ParsedDive> fakeParseFn(
+      String vendor,
+      String product,
+      int model,
+      Uint8List rawData,
+    ) async {
+      return makeParsedDive();
+    }
+
+    Future<void> insertSourceWithRawData({
+      required String id,
+      required String diveId,
+      String? computerId,
+      bool isPrimary = true,
+      String? descriptorVendor = 'Shearwater',
+      String? descriptorProduct = 'Perdix',
+      int? descriptorModel = 42,
+    }) async {
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              computerId: Value(computerId),
+              isPrimary: Value(isPrimary),
+              sourceFormat: const Value('dive_computer'),
+              rawData: Value(Uint8List.fromList([1, 2, 3])),
+              descriptorVendor: Value(descriptorVendor),
+              descriptorProduct: Value(descriptorProduct),
+              descriptorModel: Value(descriptorModel),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+    }
+
+    test('successfully re-parses all sources for a dive', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSourceWithRawData(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+      );
+
+      final errors = await service.reparseDive('dive-1', parseFn: fakeParseFn);
+
+      expect(errors, isEmpty);
+    });
+
+    test('sources without descriptor fields are silently skipped', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSourceWithRawData(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+      );
+
+      final errors = await service.reparseDive('dive-1', parseFn: fakeParseFn);
+
+      expect(errors, isEmpty);
+    });
+
+    test('parseFn throwing adds error message to returned list', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSourceWithRawData(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+      );
+
+      final errors = await service.reparseDive(
+        'dive-1',
+        parseFn: (vendor, product, model, rawData) async {
+          throw Exception('native bridge error');
+        },
+      );
+
+      expect(errors.length, 1);
+      expect(errors.first, contains('native bridge error'));
+    });
+
+    test('returns empty list when no sources have raw data', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+
+      // Source without rawData
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+
+      final errors = await service.reparseDive('dive-1', parseFn: fakeParseFn);
+
+      expect(errors, isEmpty);
+    });
+
+    test(
+      'multiple sources: one succeeds, one throws -- returns one error',
+      () async {
+        await insertDive('dive-1');
+        await insertComputer('comp-1');
+        await insertComputer('comp-2');
+
+        await insertSourceWithRawData(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          descriptorVendor: 'Shearwater',
+          descriptorProduct: 'Perdix',
+          descriptorModel: 42,
+        );
+        await insertSourceWithRawData(
+          id: 'src-2',
+          diveId: 'dive-1',
+          computerId: 'comp-2',
+          isPrimary: false,
+          descriptorVendor: 'Suunto',
+          descriptorProduct: 'EON Core',
+          descriptorModel: 99,
+        );
+
+        final errors = await service.reparseDive(
+          'dive-1',
+          parseFn: (vendor, product, model, rawData) async {
+            if (vendor == 'Suunto') {
+              throw Exception('Suunto parse failure');
+            }
+            return makeParsedDive();
+          },
+        );
+
+        expect(errors.length, 1);
+        expect(errors.first, contains('Suunto parse failure'));
+      },
+    );
+  });
 }

--- a/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.mocks.dart
+++ b/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.mocks.dart
@@ -262,6 +262,21 @@ class MockDiveComputerRepository extends _i1.Mock
           as _i4.Future<List<String>>);
 
   @override
+  _i4.Future<void> clearSourceAndProfiles({
+    required String? diveId,
+    required String? computerId,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#clearSourceAndProfiles, [], {
+              #diveId: diveId,
+              #computerId: computerId,
+            }),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
   _i4.Future<String> importProfile({
     required String? computerId,
     required DateTime? profileStartTime,

--- a/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.mocks.dart
+++ b/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.mocks.dart
@@ -4,12 +4,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
+import 'dart:typed_data' as _i6;
 
-import 'package:libdivecomputer_plugin/src/dive_computer_service.dart' as _i7;
+import 'package:libdivecomputer_plugin/src/dive_computer_service.dart' as _i8;
 import 'package:libdivecomputer_plugin/src/generated/dive_computer_api.g.dart'
-    as _i8;
+    as _i9;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i6;
+import 'package:mockito/src/dummies.dart' as _i7;
 import 'package:submersion/core/database/database.dart' as _i5;
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart'
     as _i3;
@@ -278,6 +279,12 @@ class MockDiveComputerRepository extends _i1.Mock
     List<_i3.EventData>? events,
     int? diveNumber,
     bool? forceNew = false,
+    _i6.Uint8List? rawData,
+    _i6.Uint8List? rawFingerprint,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importProfile, [], {
@@ -297,9 +304,15 @@ class MockDiveComputerRepository extends _i1.Mock
               #events: events,
               #diveNumber: diveNumber,
               #forceNew: forceNew,
+              #rawData: rawData,
+              #rawFingerprint: rawFingerprint,
+              #descriptorVendor: descriptorVendor,
+              #descriptorProduct: descriptorProduct,
+              #descriptorModel: descriptorModel,
+              #libdivecomputerVersion: libdivecomputerVersion,
             }),
             returnValue: _i4.Future<String>.value(
-              _i6.dummyValue<String>(
+              _i7.dummyValue<String>(
                 this,
                 Invocation.method(#importProfile, [], {
                   #computerId: computerId,
@@ -318,6 +331,12 @@ class MockDiveComputerRepository extends _i1.Mock
                   #events: events,
                   #diveNumber: diveNumber,
                   #forceNew: forceNew,
+                  #rawData: rawData,
+                  #rawFingerprint: rawFingerprint,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -406,18 +425,18 @@ class MockDiveComputerRepository extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveComputerService extends _i1.Mock
-    implements _i7.DiveComputerService {
+    implements _i8.DiveComputerService {
   MockDiveComputerService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Stream<_i8.DiscoveredDevice> get discoveredDevices =>
+  _i4.Stream<_i9.DiscoveredDevice> get discoveredDevices =>
       (super.noSuchMethod(
             Invocation.getter(#discoveredDevices),
-            returnValue: _i4.Stream<_i8.DiscoveredDevice>.empty(),
+            returnValue: _i4.Stream<_i9.DiscoveredDevice>.empty(),
           )
-          as _i4.Stream<_i8.DiscoveredDevice>);
+          as _i4.Stream<_i9.DiscoveredDevice>);
 
   @override
   _i4.Stream<void> get discoveryComplete =>
@@ -428,12 +447,12 @@ class MockDiveComputerService extends _i1.Mock
           as _i4.Stream<void>);
 
   @override
-  _i4.Stream<_i7.DownloadEvent> get downloadEvents =>
+  _i4.Stream<_i8.DownloadEvent> get downloadEvents =>
       (super.noSuchMethod(
             Invocation.getter(#downloadEvents),
-            returnValue: _i4.Stream<_i7.DownloadEvent>.empty(),
+            returnValue: _i4.Stream<_i8.DownloadEvent>.empty(),
           )
-          as _i4.Stream<_i7.DownloadEvent>);
+          as _i4.Stream<_i8.DownloadEvent>);
 
   @override
   _i4.Stream<({String category, String level, String message})> get logEvents =>
@@ -447,27 +466,27 @@ class MockDiveComputerService extends _i1.Mock
           as _i4.Stream<({String category, String level, String message})>);
 
   @override
-  _i4.Future<List<_i8.DeviceDescriptor>> getDeviceDescriptors() =>
+  _i4.Future<List<_i9.DeviceDescriptor>> getDeviceDescriptors() =>
       (super.noSuchMethod(
             Invocation.method(#getDeviceDescriptors, []),
-            returnValue: _i4.Future<List<_i8.DeviceDescriptor>>.value(
-              <_i8.DeviceDescriptor>[],
+            returnValue: _i4.Future<List<_i9.DeviceDescriptor>>.value(
+              <_i9.DeviceDescriptor>[],
             ),
           )
-          as _i4.Future<List<_i8.DeviceDescriptor>>);
+          as _i4.Future<List<_i9.DeviceDescriptor>>);
 
   @override
   _i4.Future<String> getVersion() =>
       (super.noSuchMethod(
             Invocation.method(#getVersion, []),
             returnValue: _i4.Future<String>.value(
-              _i6.dummyValue<String>(this, Invocation.method(#getVersion, [])),
+              _i7.dummyValue<String>(this, Invocation.method(#getVersion, [])),
             ),
           )
           as _i4.Future<String>);
 
   @override
-  _i4.Future<void> startDiscovery(_i8.TransportType? transport) =>
+  _i4.Future<void> startDiscovery(_i9.TransportType? transport) =>
       (super.noSuchMethod(
             Invocation.method(#startDiscovery, [transport]),
             returnValue: _i4.Future<void>.value(),
@@ -486,7 +505,7 @@ class MockDiveComputerService extends _i1.Mock
 
   @override
   _i4.Future<void> startDownload(
-    _i8.DiscoveredDevice? device, {
+    _i9.DiscoveredDevice? device, {
     String? fingerprint,
   }) =>
       (super.noSuchMethod(
@@ -519,7 +538,7 @@ class MockDiveComputerService extends _i1.Mock
           as _i4.Future<void>);
 
   @override
-  void onDeviceDiscovered(_i8.DiscoveredDevice? device) => super.noSuchMethod(
+  void onDeviceDiscovered(_i9.DiscoveredDevice? device) => super.noSuchMethod(
     Invocation.method(#onDeviceDiscovered, [device]),
     returnValueForMissingStub: null,
   );
@@ -531,13 +550,13 @@ class MockDiveComputerService extends _i1.Mock
   );
 
   @override
-  void onDownloadProgress(_i8.DownloadProgress? progress) => super.noSuchMethod(
+  void onDownloadProgress(_i9.DownloadProgress? progress) => super.noSuchMethod(
     Invocation.method(#onDownloadProgress, [progress]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void onDiveDownloaded(_i8.ParsedDive? dive) => super.noSuchMethod(
+  void onDiveDownloaded(_i9.ParsedDive? dive) => super.noSuchMethod(
     Invocation.method(#onDiveDownloaded, [dive]),
     returnValueForMissingStub: null,
   );
@@ -557,7 +576,7 @@ class MockDiveComputerService extends _i1.Mock
   );
 
   @override
-  void onError(_i8.DiveComputerError? error) => super.noSuchMethod(
+  void onError(_i9.DiveComputerError? error) => super.noSuchMethod(
     Invocation.method(#onError, [error]),
     returnValueForMissingStub: null,
   );

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.dart
@@ -1,9 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:submersion/features/dive_computer/data/services/dive_import_service.dart';
-import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart'
+    hide DiveMatchResult;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/import_wizard/data/adapters/dive_computer_adapter.dart';
+import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
+import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
 
 @GenerateMocks([DiveImportService, DiveComputerRepository, DiveRepository])
 import 'dive_computer_adapter_reimport_test.mocks.dart';
@@ -51,5 +58,129 @@ void main() {
       );
       expect(adapter.forceFullDownload, isFalse);
     });
+  });
+
+  group('performImport replaceSource', () {
+    const diverId = 'diver-1';
+    const computerId = 'comp-1';
+    const existingDiveId = 'existing-dive-42';
+
+    final testComputer = DiveComputer.create(
+      id: computerId,
+      name: 'Test Computer',
+      diverId: diverId,
+      manufacturer: 'TestMfg',
+      model: 'TestModel',
+    );
+
+    final testDive = DownloadedDive(
+      startTime: DateTime(2026, 3, 15, 10, 0),
+      durationSeconds: 3000,
+      maxDepth: 25.0,
+      profile: const [],
+    );
+
+    test(
+      'calls resolveConflict with replaceSource and returns updatedCount',
+      () async {
+        final adapter = DiveComputerAdapter(
+          importService: importService,
+          computerRepository: computerRepo,
+          diveRepository: diveRepo,
+          diverId: diverId,
+        );
+
+        // Provide the computer and downloaded dives to the adapter.
+        adapter.setComputer(testComputer);
+        adapter.setDownloadedDives([testDive]);
+
+        // Build a bundle with a duplicate match at index 0.
+        const matchResult = DiveMatchResult(
+          diveId: existingDiveId,
+          score: 0.92,
+          timeDifferenceMs: 5000,
+        );
+
+        const bundle = ImportBundle(
+          source: ImportSourceInfo(
+            type: ImportSourceType.diveComputer,
+            displayName: 'Test Computer',
+          ),
+          groups: {
+            ImportEntityType.dives: EntityGroup(
+              items: [
+                EntityItem(
+                  title: 'Mar 15, 2026',
+                  subtitle: '25.0 m max - 50 min',
+                ),
+              ],
+              duplicateIndices: {0},
+              matchResults: {0: matchResult},
+            ),
+          },
+        );
+
+        // Stub resolveConflict to return the existing dive ID.
+        when(
+          importService.resolveConflict(
+            any,
+            any,
+            any,
+            diverId: anyNamed('diverId'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
+          ),
+        ).thenAnswer((_) async => existingDiveId);
+
+        // Stub the computer-update methods that run after import.
+        when(computerRepo.updateLastDownload(any)).thenAnswer((_) async {});
+        when(
+          computerRepo.updateLastFingerprint(any, any),
+        ).thenAnswer((_) async {});
+
+        // All dives are in selections; index 0 has replaceSource action.
+        final result = await adapter.performImport(
+          bundle,
+          {
+            ImportEntityType.dives: {0},
+          },
+          {
+            ImportEntityType.dives: {0: DuplicateAction.replaceSource},
+          },
+        );
+
+        // Verify resolveConflict was called with the right resolution.
+        final captured = verify(
+          importService.resolveConflict(
+            captureAny,
+            captureAny,
+            captureAny,
+            diverId: captureAnyNamed('diverId'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
+          ),
+        ).captured;
+
+        // captured: [ImportConflict, ConflictResolution, computerId, diverId]
+        final conflict = captured[0] as ImportConflict;
+        final resolution = captured[1] as ConflictResolution;
+        final capturedComputerId = captured[2] as String;
+
+        expect(conflict.existingDiveId, existingDiveId);
+        expect(conflict.downloaded, testDive);
+        expect(resolution, ConflictResolution.replaceSource);
+        expect(capturedComputerId, computerId);
+
+        // Verify the result counts.
+        expect(result.updatedCount, 1);
+        expect(result.importedCounts[ImportEntityType.dives], 0);
+        expect(result.consolidatedCount, 0);
+        expect(result.skippedCount, 0);
+      },
+    );
   });
 }

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
@@ -98,36 +98,16 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
   }
 
   @override
-  set descriptorVendor(String? value) => super.noSuchMethod(
-    Invocation.setter(#descriptorVendor, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  set descriptorProduct(String? value) => super.noSuchMethod(
-    Invocation.setter(#descriptorProduct, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  set descriptorModel(int? value) => super.noSuchMethod(
-    Invocation.setter(#descriptorModel, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  set libdivecomputerVersion(String? value) => super.noSuchMethod(
-    Invocation.setter(#libdivecomputerVersion, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
   _i7.Future<_i2.ImportResult> importDives({
     required List<_i8.DownloadedDive>? dives,
     required _i3.DiveComputer? computer,
     _i2.ImportMode? mode = _i2.ImportMode.newOnly,
     _i2.ConflictResolution? defaultResolution = _i2.ConflictResolution.skip,
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importDives, [], {
@@ -136,6 +116,10 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
               #mode: mode,
               #defaultResolution: defaultResolution,
               #diverId: diverId,
+              #descriptorVendor: descriptorVendor,
+              #descriptorProduct: descriptorProduct,
+              #descriptorModel: descriptorModel,
+              #libdivecomputerVersion: libdivecomputerVersion,
             }),
             returnValue: _i7.Future<_i2.ImportResult>.value(
               _FakeImportResult_0(
@@ -146,6 +130,10 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
                   #mode: mode,
                   #defaultResolution: defaultResolution,
                   #diverId: diverId,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -191,12 +179,23 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
     _i8.DownloadedDive? dive, {
     required String? computerId,
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
               #importSingleDiveAsNew,
               [dive],
-              {#computerId: computerId, #diverId: diverId},
+              {
+                #computerId: computerId,
+                #diverId: diverId,
+                #descriptorVendor: descriptorVendor,
+                #descriptorProduct: descriptorProduct,
+                #descriptorModel: descriptorModel,
+                #libdivecomputerVersion: libdivecomputerVersion,
+              },
             ),
             returnValue: _i7.Future<String>.value(
               _i9.dummyValue<String>(
@@ -204,7 +203,14 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
                 Invocation.method(
                   #importSingleDiveAsNew,
                   [dive],
-                  {#computerId: computerId, #diverId: diverId},
+                  {
+                    #computerId: computerId,
+                    #diverId: diverId,
+                    #descriptorVendor: descriptorVendor,
+                    #descriptorProduct: descriptorProduct,
+                    #descriptorModel: descriptorModel,
+                    #libdivecomputerVersion: libdivecomputerVersion,
+                  },
                 ),
               ),
             ),
@@ -217,12 +223,22 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
     _i2.ConflictResolution? resolution,
     String? computerId, {
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
               #resolveConflict,
               [conflict, resolution, computerId],
-              {#diverId: diverId},
+              {
+                #diverId: diverId,
+                #descriptorVendor: descriptorVendor,
+                #descriptorProduct: descriptorProduct,
+                #descriptorModel: descriptorModel,
+                #libdivecomputerVersion: libdivecomputerVersion,
+              },
             ),
             returnValue: _i7.Future<String?>.value(),
           )

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
@@ -470,6 +470,21 @@ class MockDiveComputerRepository extends _i1.Mock
           as _i7.Future<List<String>>);
 
   @override
+  _i7.Future<void> clearSourceAndProfiles({
+    required String? diveId,
+    required String? computerId,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#clearSourceAndProfiles, [], {
+              #diveId: diveId,
+              #computerId: computerId,
+            }),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
   _i7.Future<String> importProfile({
     required String? computerId,
     required DateTime? profileStartTime,

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
@@ -4,12 +4,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i7;
+import 'dart:typed_data' as _i12;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i9;
-import 'package:submersion/core/constants/sort_options.dart' as _i15;
+import 'package:submersion/core/constants/sort_options.dart' as _i16;
 import 'package:submersion/core/database/database.dart' as _i11;
-import 'package:submersion/core/models/sort_state.dart' as _i14;
+import 'package:submersion/core/models/sort_state.dart' as _i15;
 import 'package:submersion/features/dive_computer/data/services/dive_import_service.dart'
     as _i2;
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart'
@@ -22,13 +23,13 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart' as _i4;
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
     as _i3;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart'
-    as _i16;
+    as _i17;
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart'
-    as _i12;
+    as _i13;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart'
     as _i6;
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart'
-    as _i13;
+    as _i14;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -95,6 +96,30 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
   MockDiveImportService() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  set descriptorVendor(String? value) => super.noSuchMethod(
+    Invocation.setter(#descriptorVendor, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set descriptorProduct(String? value) => super.noSuchMethod(
+    Invocation.setter(#descriptorProduct, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set descriptorModel(int? value) => super.noSuchMethod(
+    Invocation.setter(#descriptorModel, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set libdivecomputerVersion(String? value) => super.noSuchMethod(
+    Invocation.setter(#libdivecomputerVersion, value),
+    returnValueForMissingStub: null,
+  );
 
   @override
   _i7.Future<_i2.ImportResult> importDives({
@@ -446,6 +471,12 @@ class MockDiveComputerRepository extends _i1.Mock
     List<_i10.EventData>? events,
     int? diveNumber,
     bool? forceNew = false,
+    _i12.Uint8List? rawData,
+    _i12.Uint8List? rawFingerprint,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importProfile, [], {
@@ -465,6 +496,12 @@ class MockDiveComputerRepository extends _i1.Mock
               #events: events,
               #diveNumber: diveNumber,
               #forceNew: forceNew,
+              #rawData: rawData,
+              #rawFingerprint: rawFingerprint,
+              #descriptorVendor: descriptorVendor,
+              #descriptorProduct: descriptorProduct,
+              #descriptorModel: descriptorModel,
+              #libdivecomputerVersion: libdivecomputerVersion,
             }),
             returnValue: _i7.Future<String>.value(
               _i9.dummyValue<String>(
@@ -486,6 +523,12 @@ class MockDiveComputerRepository extends _i1.Mock
                   #events: events,
                   #diveNumber: diveNumber,
                   #forceNew: forceNew,
+                  #rawData: rawData,
+                  #rawFingerprint: rawFingerprint,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -701,13 +744,13 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
           as _i7.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<List<_i12.DiveSummary>> getDiveSummaries({
+  _i7.Future<List<_i13.DiveSummary>> getDiveSummaries({
     String? diverId,
-    _i13.DiveFilterState? filter = const _i13.DiveFilterState(),
-    _i12.DiveSummaryCursor? cursor,
+    _i14.DiveFilterState? filter = const _i14.DiveFilterState(),
+    _i13.DiveSummaryCursor? cursor,
     int? offset,
     int? limit = 50,
-    _i14.SortState<_i15.DiveSortField>? sort,
+    _i15.SortState<_i16.DiveSortField>? sort,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveSummaries, [], {
@@ -718,16 +761,16 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               #limit: limit,
               #sort: sort,
             }),
-            returnValue: _i7.Future<List<_i12.DiveSummary>>.value(
-              <_i12.DiveSummary>[],
+            returnValue: _i7.Future<List<_i13.DiveSummary>>.value(
+              <_i13.DiveSummary>[],
             ),
           )
-          as _i7.Future<List<_i12.DiveSummary>>);
+          as _i7.Future<List<_i13.DiveSummary>>);
 
   @override
   _i7.Future<int> getDiveCount({
     String? diverId,
-    _i13.DiveFilterState? filter = const _i13.DiveFilterState(),
+    _i14.DiveFilterState? filter = const _i14.DiveFilterState(),
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveCount, [], {
@@ -1050,14 +1093,14 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
           as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i16.DiveDataSource>> getDataSources(String? diveId) =>
+  _i7.Future<List<_i17.DiveDataSource>> getDataSources(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getDataSources, [diveId]),
-            returnValue: _i7.Future<List<_i16.DiveDataSource>>.value(
-              <_i16.DiveDataSource>[],
+            returnValue: _i7.Future<List<_i17.DiveDataSource>>.value(
+              <_i17.DiveDataSource>[],
             ),
           )
-          as _i7.Future<List<_i16.DiveDataSource>>);
+          as _i7.Future<List<_i17.DiveDataSource>>);
 
   @override
   _i7.Future<bool> hasMultipleDataSources(String? diveId) =>

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
@@ -538,6 +538,21 @@ class MockDiveComputerRepository extends _i1.Mock
           as _i7.Future<List<String>>);
 
   @override
+  _i7.Future<void> clearSourceAndProfiles({
+    required String? diveId,
+    required String? computerId,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#clearSourceAndProfiles, [], {
+              #diveId: diveId,
+              #computerId: computerId,
+            }),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
   _i7.Future<String> importProfile({
     required String? computerId,
     required DateTime? profileStartTime,

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
@@ -94,36 +94,16 @@ class _FakeDiveNumberingInfo_7 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
   @override
-  set descriptorVendor(String? value) => super.noSuchMethod(
-    Invocation.setter(#descriptorVendor, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  set descriptorProduct(String? value) => super.noSuchMethod(
-    Invocation.setter(#descriptorProduct, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  set descriptorModel(int? value) => super.noSuchMethod(
-    Invocation.setter(#descriptorModel, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  set libdivecomputerVersion(String? value) => super.noSuchMethod(
-    Invocation.setter(#libdivecomputerVersion, value),
-    returnValueForMissingStub: null,
-  );
-
-  @override
   _i7.Future<_i2.ImportResult> importDives({
     required List<_i8.DownloadedDive>? dives,
     required _i3.DiveComputer? computer,
     _i2.ImportMode? mode = _i2.ImportMode.newOnly,
     _i2.ConflictResolution? defaultResolution = _i2.ConflictResolution.skip,
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importDives, [], {
@@ -132,6 +112,10 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
               #mode: mode,
               #defaultResolution: defaultResolution,
               #diverId: diverId,
+              #descriptorVendor: descriptorVendor,
+              #descriptorProduct: descriptorProduct,
+              #descriptorModel: descriptorModel,
+              #libdivecomputerVersion: libdivecomputerVersion,
             }),
             returnValue: _i7.Future<_i2.ImportResult>.value(
               _FakeImportResult_0(
@@ -142,6 +126,10 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
                   #mode: mode,
                   #defaultResolution: defaultResolution,
                   #diverId: diverId,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -154,6 +142,10 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
                   #mode: mode,
                   #defaultResolution: defaultResolution,
                   #diverId: diverId,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -213,12 +205,23 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
     _i8.DownloadedDive? dive, {
     required String? computerId,
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
               #importSingleDiveAsNew,
               [dive],
-              {#computerId: computerId, #diverId: diverId},
+              {
+                #computerId: computerId,
+                #diverId: diverId,
+                #descriptorVendor: descriptorVendor,
+                #descriptorProduct: descriptorProduct,
+                #descriptorModel: descriptorModel,
+                #libdivecomputerVersion: libdivecomputerVersion,
+              },
             ),
             returnValue: _i7.Future<String>.value(
               _i9.dummyValue<String>(
@@ -226,7 +229,14 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
                 Invocation.method(
                   #importSingleDiveAsNew,
                   [dive],
-                  {#computerId: computerId, #diverId: diverId},
+                  {
+                    #computerId: computerId,
+                    #diverId: diverId,
+                    #descriptorVendor: descriptorVendor,
+                    #descriptorProduct: descriptorProduct,
+                    #descriptorModel: descriptorModel,
+                    #libdivecomputerVersion: libdivecomputerVersion,
+                  },
                 ),
               ),
             ),
@@ -236,7 +246,14 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
                 Invocation.method(
                   #importSingleDiveAsNew,
                   [dive],
-                  {#computerId: computerId, #diverId: diverId},
+                  {
+                    #computerId: computerId,
+                    #diverId: diverId,
+                    #descriptorVendor: descriptorVendor,
+                    #descriptorProduct: descriptorProduct,
+                    #descriptorModel: descriptorModel,
+                    #libdivecomputerVersion: libdivecomputerVersion,
+                  },
                 ),
               ),
             ),
@@ -249,12 +266,22 @@ class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
     _i2.ConflictResolution? resolution,
     String? computerId, {
     String? diverId,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
               #resolveConflict,
               [conflict, resolution, computerId],
-              {#diverId: diverId},
+              {
+                #diverId: diverId,
+                #descriptorVendor: descriptorVendor,
+                #descriptorProduct: descriptorProduct,
+                #descriptorModel: descriptorModel,
+                #libdivecomputerVersion: libdivecomputerVersion,
+              },
             ),
             returnValue: _i7.Future<String?>.value(),
             returnValueForMissingStub: _i7.Future<String?>.value(),

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
@@ -4,12 +4,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i7;
+import 'dart:typed_data' as _i12;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i9;
-import 'package:submersion/core/constants/sort_options.dart' as _i15;
+import 'package:submersion/core/constants/sort_options.dart' as _i16;
 import 'package:submersion/core/database/database.dart' as _i11;
-import 'package:submersion/core/models/sort_state.dart' as _i14;
+import 'package:submersion/core/models/sort_state.dart' as _i15;
 import 'package:submersion/features/dive_computer/data/services/dive_import_service.dart'
     as _i2;
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart'
@@ -22,13 +23,13 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart' as _i4;
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
     as _i3;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart'
-    as _i16;
+    as _i17;
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart'
-    as _i12;
+    as _i13;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart'
     as _i6;
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart'
-    as _i13;
+    as _i14;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -92,6 +93,30 @@ class _FakeDiveNumberingInfo_7 extends _i1.SmartFake
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveImportService extends _i1.Mock implements _i2.DiveImportService {
+  @override
+  set descriptorVendor(String? value) => super.noSuchMethod(
+    Invocation.setter(#descriptorVendor, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set descriptorProduct(String? value) => super.noSuchMethod(
+    Invocation.setter(#descriptorProduct, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set descriptorModel(int? value) => super.noSuchMethod(
+    Invocation.setter(#descriptorModel, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set libdivecomputerVersion(String? value) => super.noSuchMethod(
+    Invocation.setter(#libdivecomputerVersion, value),
+    returnValueForMissingStub: null,
+  );
+
   @override
   _i7.Future<_i2.ImportResult> importDives({
     required List<_i8.DownloadedDive>? dives,
@@ -503,6 +528,12 @@ class MockDiveComputerRepository extends _i1.Mock
     List<_i10.EventData>? events,
     int? diveNumber,
     bool? forceNew = false,
+    _i12.Uint8List? rawData,
+    _i12.Uint8List? rawFingerprint,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
+    String? libdivecomputerVersion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#importProfile, [], {
@@ -522,6 +553,12 @@ class MockDiveComputerRepository extends _i1.Mock
               #events: events,
               #diveNumber: diveNumber,
               #forceNew: forceNew,
+              #rawData: rawData,
+              #rawFingerprint: rawFingerprint,
+              #descriptorVendor: descriptorVendor,
+              #descriptorProduct: descriptorProduct,
+              #descriptorModel: descriptorModel,
+              #libdivecomputerVersion: libdivecomputerVersion,
             }),
             returnValue: _i7.Future<String>.value(
               _i9.dummyValue<String>(
@@ -543,6 +580,12 @@ class MockDiveComputerRepository extends _i1.Mock
                   #events: events,
                   #diveNumber: diveNumber,
                   #forceNew: forceNew,
+                  #rawData: rawData,
+                  #rawFingerprint: rawFingerprint,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -566,6 +609,12 @@ class MockDiveComputerRepository extends _i1.Mock
                   #events: events,
                   #diveNumber: diveNumber,
                   #forceNew: forceNew,
+                  #rawData: rawData,
+                  #rawFingerprint: rawFingerprint,
+                  #descriptorVendor: descriptorVendor,
+                  #descriptorProduct: descriptorProduct,
+                  #descriptorModel: descriptorModel,
+                  #libdivecomputerVersion: libdivecomputerVersion,
                 }),
               ),
             ),
@@ -818,13 +867,13 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
           as _i7.Future<List<_i4.Dive>>);
 
   @override
-  _i7.Future<List<_i12.DiveSummary>> getDiveSummaries({
+  _i7.Future<List<_i13.DiveSummary>> getDiveSummaries({
     String? diverId,
-    _i13.DiveFilterState? filter = const _i13.DiveFilterState(),
-    _i12.DiveSummaryCursor? cursor,
+    _i14.DiveFilterState? filter = const _i14.DiveFilterState(),
+    _i13.DiveSummaryCursor? cursor,
     int? offset,
     int? limit = 50,
-    _i14.SortState<_i15.DiveSortField>? sort,
+    _i15.SortState<_i16.DiveSortField>? sort,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveSummaries, [], {
@@ -835,19 +884,19 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
               #limit: limit,
               #sort: sort,
             }),
-            returnValue: _i7.Future<List<_i12.DiveSummary>>.value(
-              <_i12.DiveSummary>[],
+            returnValue: _i7.Future<List<_i13.DiveSummary>>.value(
+              <_i13.DiveSummary>[],
             ),
-            returnValueForMissingStub: _i7.Future<List<_i12.DiveSummary>>.value(
-              <_i12.DiveSummary>[],
+            returnValueForMissingStub: _i7.Future<List<_i13.DiveSummary>>.value(
+              <_i13.DiveSummary>[],
             ),
           )
-          as _i7.Future<List<_i12.DiveSummary>>);
+          as _i7.Future<List<_i13.DiveSummary>>);
 
   @override
   _i7.Future<int> getDiveCount({
     String? diverId,
-    _i13.DiveFilterState? filter = const _i13.DiveFilterState(),
+    _i14.DiveFilterState? filter = const _i14.DiveFilterState(),
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getDiveCount, [], {
@@ -1239,18 +1288,18 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
           as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i16.DiveDataSource>> getDataSources(String? diveId) =>
+  _i7.Future<List<_i17.DiveDataSource>> getDataSources(String? diveId) =>
       (super.noSuchMethod(
             Invocation.method(#getDataSources, [diveId]),
-            returnValue: _i7.Future<List<_i16.DiveDataSource>>.value(
-              <_i16.DiveDataSource>[],
+            returnValue: _i7.Future<List<_i17.DiveDataSource>>.value(
+              <_i17.DiveDataSource>[],
             ),
             returnValueForMissingStub:
-                _i7.Future<List<_i16.DiveDataSource>>.value(
-                  <_i16.DiveDataSource>[],
+                _i7.Future<List<_i17.DiveDataSource>>.value(
+                  <_i17.DiveDataSource>[],
                 ),
           )
-          as _i7.Future<List<_i16.DiveDataSource>>);
+          as _i7.Future<List<_i17.DiveDataSource>>);
 
   @override
   _i7.Future<bool> hasMultipleDataSources(String? diveId) =>

--- a/test/features/import_wizard/domain/models/duplicate_action_test.dart
+++ b/test/features/import_wizard/domain/models/duplicate_action_test.dart
@@ -3,17 +3,18 @@ import 'package:submersion/features/import_wizard/domain/models/duplicate_action
 
 void main() {
   group('DuplicateAction', () {
-    test('has three values', () {
-      expect(DuplicateAction.values, hasLength(3));
+    test('has four values', () {
+      expect(DuplicateAction.values, hasLength(4));
     });
 
-    test('contains skip, importAsNew, and consolidate', () {
+    test('contains skip, importAsNew, consolidate, and replaceSource', () {
       expect(
         DuplicateAction.values,
         containsAll([
           DuplicateAction.skip,
           DuplicateAction.importAsNew,
           DuplicateAction.consolidate,
+          DuplicateAction.replaceSource,
         ]),
       );
     });
@@ -22,12 +23,14 @@ void main() {
       expect(DuplicateAction.skip.index, 0);
       expect(DuplicateAction.importAsNew.index, 1);
       expect(DuplicateAction.consolidate.index, 2);
+      expect(DuplicateAction.replaceSource.index, 3);
     });
 
     test('name returns correct enum name strings', () {
       expect(DuplicateAction.skip.name, 'skip');
       expect(DuplicateAction.importAsNew.name, 'importAsNew');
       expect(DuplicateAction.consolidate.name, 'consolidate');
+      expect(DuplicateAction.replaceSource.name, 'replaceSource');
     });
   });
 }

--- a/test/features/import_wizard/presentation/widgets/dc_no_new_dives_view_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_no_new_dives_view_test.dart
@@ -5,19 +5,13 @@ import 'package:submersion/features/import_wizard/presentation/widgets/dc_adapte
 import '../../../../helpers/l10n_test_helpers.dart';
 
 void main() {
-  testWidgets('renders breadcrumb TextButton with expected text', (
-    tester,
-  ) async {
+  testWidgets('renders expected text and icon', (tester) async {
     await tester.pumpWidget(
       localizedMaterialApp(home: DcNoNewDivesView(onDone: () {})),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('Done'), findsOneWidget);
-    expect(
-      find.textContaining('Looking for older or deleted dives'),
-      findsOneWidget,
-    );
     expect(find.text('No new dives to download'), findsOneWidget);
     expect(
       find.text('All dives from this computer have already been imported.'),
@@ -26,20 +20,7 @@ void main() {
     expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
   });
 
-  testWidgets('tapping breadcrumb invokes onDone', (tester) async {
-    var tapped = 0;
-    await tester.pumpWidget(
-      localizedMaterialApp(home: DcNoNewDivesView(onDone: () => tapped++)),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.textContaining('Looking for older'));
-    await tester.pumpAndSettle();
-
-    expect(tapped, 1);
-  });
-
-  testWidgets('tapping Done also invokes onDone', (tester) async {
+  testWidgets('tapping Done invokes onDone', (tester) async {
     var tapped = 0;
     await tester.pumpWidget(
       localizedMaterialApp(home: DcNoNewDivesView(onDone: () => tapped++)),

--- a/test/features/import_wizard/presentation/widgets/duplicate_action_card_test.dart
+++ b/test/features/import_wizard/presentation/widgets/duplicate_action_card_test.dart
@@ -53,6 +53,78 @@ DuplicateActionCard _makeCard({
   );
 }
 
+DuplicateActionCard _makeCardNullable({
+  EntityItem item = _testItem,
+  DiveMatchResult? matchResult,
+  DuplicateAction? selectedAction,
+  Set<DuplicateAction>? availableActions,
+  ValueChanged<DuplicateAction>? onActionChanged,
+  String existingDiveId = _testDiveId,
+  int? projectedDiveNumber,
+  bool isPending = false,
+}) {
+  return DuplicateActionCard(
+    item: item,
+    matchResult: matchResult ?? _likelyMatchResult,
+    selectedAction: selectedAction,
+    availableActions: availableActions ?? DuplicateAction.values.toSet(),
+    onActionChanged: onActionChanged ?? (_) {},
+    existingDiveId: existingDiveId,
+    projectedDiveNumber: projectedDiveNumber,
+    isPending: isPending,
+  );
+}
+
+/// A wrapper that rebuilds its child with a new [selectedAction] when
+/// [notifier] fires, triggering [didUpdateWidget] on the inner card.
+class _RebuildableCardHost extends StatefulWidget {
+  final DuplicateAction? initialAction;
+  final ValueNotifier<DuplicateAction?> notifier;
+
+  const _RebuildableCardHost({
+    required this.initialAction,
+    required this.notifier,
+  });
+
+  @override
+  State<_RebuildableCardHost> createState() => _RebuildableCardHostState();
+}
+
+class _RebuildableCardHostState extends State<_RebuildableCardHost> {
+  late DuplicateAction? _action;
+
+  @override
+  void initState() {
+    super.initState();
+    _action = widget.initialAction;
+    widget.notifier.addListener(_onChanged);
+  }
+
+  void _onChanged() {
+    setState(() {
+      _action = widget.notifier.value;
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.notifier.removeListener(_onChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DuplicateActionCard(
+      item: _testItem,
+      matchResult: _likelyMatchResult,
+      selectedAction: _action,
+      availableActions: DuplicateAction.values.toSet(),
+      onActionChanged: (_) {},
+      existingDiveId: _testDiveId,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -268,5 +340,216 @@ void main() {
         expect(find.byType(Card), findsOneWidget);
       },
     );
+  });
+
+  group('DuplicateActionCard - didUpdateWidget auto-collapse', () {
+    testWidgets(
+      'auto-collapses when selectedAction transitions from null to non-null',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        final notifier = ValueNotifier<DuplicateAction?>(null);
+        addTearDown(notifier.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: _RebuildableCardHost(
+                  initialAction: null,
+                  notifier: notifier,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Initially collapsed; expand it.
+        expect(find.byIcon(Icons.expand_more), findsOneWidget);
+        await tester.tap(find.byIcon(Icons.expand_more));
+        await tester.pump();
+        expect(find.byIcon(Icons.expand_less), findsOneWidget);
+
+        // Simulate an action being selected: null -> skip.
+        notifier.value = DuplicateAction.skip;
+        await tester.pump();
+
+        // Card should have auto-collapsed.
+        expect(find.byIcon(Icons.expand_more), findsOneWidget);
+        expect(find.byIcon(Icons.expand_less), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'does NOT auto-collapse when selectedAction changes between non-null values',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        final notifier = ValueNotifier<DuplicateAction?>(DuplicateAction.skip);
+        addTearDown(notifier.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: _RebuildableCardHost(
+                  initialAction: DuplicateAction.skip,
+                  notifier: notifier,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Expand the card.
+        await tester.tap(find.byIcon(Icons.expand_more));
+        await tester.pump();
+        expect(find.byIcon(Icons.expand_less), findsOneWidget);
+
+        // Change from skip -> importAsNew (non-null -> non-null).
+        notifier.value = DuplicateAction.importAsNew;
+        await tester.pump();
+
+        // Card should remain expanded (auto-collapse only fires on null -> non-null).
+        expect(find.byIcon(Icons.expand_less), findsOneWidget);
+      },
+    );
+  });
+
+  group('DuplicateActionCard - projected dive number badge', () {
+    testWidgets('shows projected dive number when action is importAsNew', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        _buildCard(
+          card: _makeCardNullable(
+            selectedAction: DuplicateAction.importAsNew,
+            projectedDiveNumber: 42,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('#42'), findsOneWidget);
+    });
+
+    testWidgets('does NOT show projected dive number when action is skip', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        _buildCard(
+          card: _makeCardNullable(
+            selectedAction: DuplicateAction.skip,
+            projectedDiveNumber: 42,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('#42'), findsNothing);
+    });
+
+    testWidgets(
+      'does NOT show projected dive number when action is consolidate',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(
+          _buildCard(
+            card: _makeCardNullable(
+              selectedAction: DuplicateAction.consolidate,
+              projectedDiveNumber: 42,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('#42'), findsNothing);
+      },
+    );
+
+    testWidgets('does NOT show badge when projectedDiveNumber is null', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        _buildCard(
+          card: _makeCardNullable(
+            selectedAction: DuplicateAction.importAsNew,
+            projectedDiveNumber: null,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // No "#N" badge at all -- the Container with the badge is not built.
+      final containers = tester.widgetList<Container>(find.byType(Container));
+      final hasBadge = containers.any((c) {
+        final child = c.child;
+        if (child is Text) {
+          final data = child.data;
+          return data != null && data.startsWith('#');
+        }
+        return false;
+      });
+      expect(hasBadge, isFalse);
+    });
+  });
+
+  group('DuplicateActionCard - REPLACE action badge', () {
+    testWidgets('REPLACE action badge is rendered for replaceSource action', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        _buildCard(
+          card: _makeCard(selectedAction: DuplicateAction.replaceSource),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('REPLACE'), findsOneWidget);
+    });
+  });
+
+  group('DuplicateActionCard - null selectedAction', () {
+    testWidgets('no action badge when selectedAction is null', (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        _buildCard(card: _makeCardNullable(selectedAction: null)),
+      );
+      await tester.pump();
+
+      // None of the action badge labels should appear.
+      expect(find.text('SKIP'), findsNothing);
+      expect(find.text('IMPORT'), findsNothing);
+      expect(find.text('CONSOLIDATE'), findsNothing);
+      expect(find.text('REPLACE'), findsNothing);
+    });
   });
 }

--- a/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
@@ -275,6 +275,46 @@ void main() {
       expect(find.text('Consolidate matched (2)'), findsOneWidget);
     });
 
+    testWidgets('Replace Source bulk button shown when action is available', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final group = EntityGroup(
+        items: [_dup0, _dup1],
+        duplicateIndices: const {0, 1},
+        matchResults: const {0: _highMatch, 1: _midMatch},
+      );
+
+      DuplicateAction? firedAction;
+
+      await tester.pumpWidget(
+        _pumpList(
+          group: group,
+          pendingIndices: const {0, 1},
+          availableActions: const {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.replaceSource,
+            DuplicateAction.consolidate,
+          },
+          onBulkAction: (a) => firedAction = a,
+        ),
+      );
+      await tester.pump();
+
+      // The Replace Source bulk button should be visible
+      expect(find.text('Replace all (2)'), findsOneWidget);
+
+      // Tapping it fires onBulkAction with replaceSource
+      await tester.tap(find.text('Replace all (2)'));
+      await tester.pump();
+
+      expect(firedAction, DuplicateAction.replaceSource);
+    });
+
     testWidgets('tapping bulk Skip button fires onBulkAction with skip', (
       tester,
     ) async {

--- a/test/features/import_wizard/presentation/widgets/import_summary_step_test.dart
+++ b/test/features/import_wizard/presentation/widgets/import_summary_step_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
@@ -66,6 +67,8 @@ Widget _buildWidget(
   return ProviderScope(
     overrides: [importWizardNotifierProvider.overrideWith((_) => notifier)],
     child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: ImportSummaryStep(
           onDone: onDone ?? () {},
@@ -686,8 +689,8 @@ void main() {
       await tester.pumpWidget(_buildWidget(notifier));
       await tester.pump();
 
-      // consolidatedCount > 0 means hasNewDives is true
-      expect(find.text('Successfully Imported'), findsOneWidget);
+      // consolidatedCount > 0 means hasActivity is true
+      expect(find.text('Successfully Consolidated'), findsOneWidget);
       expect(find.text('View Dives'), findsOneWidget);
     });
   });

--- a/test/features/import_wizard/presentation/widgets/import_summary_step_test.dart
+++ b/test/features/import_wizard/presentation/widgets/import_summary_step_test.dart
@@ -695,6 +695,134 @@ void main() {
     });
   });
 
+  group('ImportSummaryStep - updated/replaced source data', () {
+    testWidgets('shows Successfully Updated when only updatedCount > 0', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final notifier = _makeNotifier();
+      notifier.state = notifier.state.copyWith(
+        importResult: const UnifiedImportResult(
+          importedCounts: {},
+          consolidatedCount: 0,
+          updatedCount: 3,
+          skippedCount: 0,
+        ),
+      );
+
+      await tester.pumpWidget(_buildWidget(notifier));
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('import_summary_success_title')),
+        findsOneWidget,
+      );
+      expect(find.text('Successfully Updated'), findsOneWidget);
+    });
+
+    testWidgets('shows Replaced source data row when updatedCount > 0', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final notifier = _makeNotifier();
+      notifier.state = notifier.state.copyWith(
+        importResult: const UnifiedImportResult(
+          importedCounts: {},
+          consolidatedCount: 0,
+          updatedCount: 5,
+          skippedCount: 0,
+        ),
+      );
+
+      await tester.pumpWidget(_buildWidget(notifier));
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('import_summary_updated_row')),
+        findsOneWidget,
+      );
+      expect(find.text('Replaced source data'), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+    });
+
+    testWidgets('shows View Dives button when only updatedCount > 0', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final notifier = _makeNotifier();
+      notifier.state = notifier.state.copyWith(
+        importResult: const UnifiedImportResult(
+          importedCounts: {},
+          consolidatedCount: 0,
+          updatedCount: 2,
+          skippedCount: 0,
+        ),
+      );
+
+      await tester.pumpWidget(_buildWidget(notifier));
+      await tester.pump();
+
+      expect(find.text('View Dives'), findsOneWidget);
+      expect(find.text('Done'), findsOneWidget);
+    });
+
+    testWidgets('hides updated row when updatedCount is 0', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final notifier = _makeNotifier();
+      notifier.state = notifier.state.copyWith(
+        importResult: const UnifiedImportResult(
+          importedCounts: {ImportEntityType.dives: 3},
+          consolidatedCount: 0,
+          updatedCount: 0,
+          skippedCount: 0,
+        ),
+      );
+
+      await tester.pumpWidget(_buildWidget(notifier));
+      await tester.pump();
+
+      expect(find.byKey(const Key('import_summary_updated_row')), findsNothing);
+    });
+
+    testWidgets(
+      'prefers Successfully Imported title when both imported and updated',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final notifier = _makeNotifier();
+        notifier.state = notifier.state.copyWith(
+          importResult: const UnifiedImportResult(
+            importedCounts: {ImportEntityType.dives: 2},
+            consolidatedCount: 0,
+            updatedCount: 3,
+            skippedCount: 0,
+          ),
+        );
+
+        await tester.pumpWidget(_buildWidget(notifier));
+        await tester.pump();
+
+        expect(find.text('Successfully Imported'), findsOneWidget);
+        expect(find.text('Successfully Updated'), findsNothing);
+        // Both rows should appear
+        expect(find.text('Dives'), findsOneWidget);
+        expect(
+          find.byKey(const Key('import_summary_updated_row')),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+
   group('ImportSummaryStep - entity type coverage', () {
     testWidgets('shows equipment row', (tester) async {
       await tester.binding.setSurfaceSize(const Size(800, 600));

--- a/test/features/import_wizard/presentation/widgets/review_step_test.dart
+++ b/test/features/import_wizard/presentation/widgets/review_step_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
@@ -66,12 +67,15 @@ class _FakeAdapter implements ImportSourceAdapter {
 ImportBundle _buildBundle({
   List<EntityItem>? diveItems,
   List<EntityItem>? siteItems,
+  Set<int>? diveDuplicateIndices,
+  Map<int, DiveMatchResult>? diveMatchResults,
 }) {
   final groups = <ImportEntityType, EntityGroup>{};
   if (diveItems != null) {
     groups[ImportEntityType.dives] = EntityGroup(
       items: diveItems,
-      duplicateIndices: const {},
+      duplicateIndices: diveDuplicateIndices ?? const {},
+      matchResults: diveMatchResults,
     );
   }
   if (siteItems != null) {
@@ -301,6 +305,209 @@ void main() {
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
+  });
+
+  group('ReviewStep - _AggregateCounts replacing', () {
+    testWidgets(
+      'bottom bar shows replacing count for replaceSource duplicates',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // 3 items total: items 0 and 1 are non-duplicates, item 2 is a
+        // duplicate that we will mark as replaceSource.
+        final bundle = _buildBundle(
+          diveItems: [_item('Dive 1'), _item('Dive 2'), _item('Dive 3')],
+          diveDuplicateIndices: {2},
+          diveMatchResults: {
+            2: const DiveMatchResult(
+              diveId: 'existing-dive-1',
+              score: 0.9,
+              timeDifferenceMs: 100,
+            ),
+          },
+        );
+
+        final adapter = _FakeAdapter(
+          actions: {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.replaceSource,
+          },
+        );
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+        // Mark the duplicate as replaceSource
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          2,
+          DuplicateAction.replaceSource,
+        );
+
+        final widget = ProviderScope(
+          overrides: [
+            importWizardNotifierProvider.overrideWith((_) => notifier),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ReviewStep(onImport: () {})),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        await tester.pump();
+
+        // Should show "2 new, 1 replacing"
+        expect(find.textContaining('replacing'), findsOneWidget);
+        expect(find.textContaining('2 new'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'bottom bar shows multiple replacing when several duplicates use '
+      'replaceSource',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // 4 items: items 0 is non-duplicate, items 1-3 are duplicates.
+        final bundle = _buildBundle(
+          diveItems: [
+            _item('Dive 1'),
+            _item('Dive 2'),
+            _item('Dive 3'),
+            _item('Dive 4'),
+          ],
+          diveDuplicateIndices: {1, 2, 3},
+          diveMatchResults: {
+            1: const DiveMatchResult(
+              diveId: 'existing-1',
+              score: 0.9,
+              timeDifferenceMs: 100,
+            ),
+            2: const DiveMatchResult(
+              diveId: 'existing-2',
+              score: 0.9,
+              timeDifferenceMs: 200,
+            ),
+            3: const DiveMatchResult(
+              diveId: 'existing-3',
+              score: 0.9,
+              timeDifferenceMs: 300,
+            ),
+          },
+        );
+
+        final adapter = _FakeAdapter(
+          actions: {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.replaceSource,
+          },
+        );
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+        // Mark two as replaceSource, one as skip
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          1,
+          DuplicateAction.replaceSource,
+        );
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          2,
+          DuplicateAction.replaceSource,
+        );
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          3,
+          DuplicateAction.skip,
+        );
+
+        final widget = ProviderScope(
+          overrides: [
+            importWizardNotifierProvider.overrideWith((_) => notifier),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ReviewStep(onImport: () {})),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        await tester.pump();
+
+        // Should show "1 new, 2 replacing, 1 skipped"
+        expect(find.textContaining('2 replacing'), findsOneWidget);
+        expect(find.textContaining('1 new'), findsOneWidget);
+        expect(find.textContaining('1 skipped'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'bottom bar shows mixed counts with consolidating and replacing',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // 3 items: item 0 is non-duplicate, items 1-2 are duplicates.
+        final bundle = _buildBundle(
+          diveItems: [_item('Dive 1'), _item('Dive 2'), _item('Dive 3')],
+          diveDuplicateIndices: {1, 2},
+          diveMatchResults: {
+            1: const DiveMatchResult(
+              diveId: 'existing-1',
+              score: 0.9,
+              timeDifferenceMs: 100,
+            ),
+            2: const DiveMatchResult(
+              diveId: 'existing-2',
+              score: 0.9,
+              timeDifferenceMs: 200,
+            ),
+          },
+        );
+
+        final adapter = _FakeAdapter(
+          actions: {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.consolidate,
+            DuplicateAction.replaceSource,
+          },
+        );
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          1,
+          DuplicateAction.consolidate,
+        );
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          2,
+          DuplicateAction.replaceSource,
+        );
+
+        final widget = ProviderScope(
+          overrides: [
+            importWizardNotifierProvider.overrideWith((_) => notifier),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ReviewStep(onImport: () {})),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        await tester.pump();
+
+        // Should show "1 new, 1 merging, 1 replacing"
+        expect(find.textContaining('1 new'), findsOneWidget);
+        expect(find.textContaining('1 merging'), findsOneWidget);
+        expect(find.textContaining('1 replacing'), findsOneWidget);
+      },
+    );
   });
 }
 

--- a/test/features/import_wizard/presentation/widgets/review_step_test.dart
+++ b/test/features/import_wizard/presentation/widgets/review_step_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/domain/models/incoming_dive_data.dart';
 import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
@@ -12,6 +14,7 @@ import 'package:submersion/features/import_wizard/domain/models/wizard_step_def.
 import 'package:submersion/features/import_wizard/presentation/providers/import_wizard_providers.dart';
 import 'package:submersion/features/import_wizard/presentation/widgets/entity_review_list.dart';
 import 'package:submersion/features/import_wizard/presentation/widgets/review_step.dart';
+import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 // ---------------------------------------------------------------------------
@@ -95,6 +98,12 @@ ImportBundle _buildBundle({
 
 EntityItem _item(String title) => EntityItem(title: title, subtitle: '');
 
+EntityItem _diveItem(String title, DateTime startTime) => EntityItem(
+  title: title,
+  subtitle: '',
+  diveData: IncomingDiveData(startTime: startTime),
+);
+
 Widget _buildReviewStep({
   required ImportBundle bundle,
   VoidCallback? onImport,
@@ -108,6 +117,28 @@ Widget _buildReviewStep({
 
   return ProviderScope(
     overrides: [importWizardNotifierProvider.overrideWith((_) => notifier)],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: ReviewStep(onImport: onImport ?? () {})),
+    ),
+  );
+}
+
+/// Builds a ReviewStep with provider overrides for nextDiveNumberProvider
+/// and tagsProvider, enabling projected-dive-number and import-options tests.
+Widget _buildReviewStepWithProviders({
+  required ImportWizardNotifier notifier,
+  int? nextDiveNumber,
+  VoidCallback? onImport,
+}) {
+  return ProviderScope(
+    overrides: [
+      importWizardNotifierProvider.overrideWith((_) => notifier),
+      if (nextDiveNumber != null)
+        nextDiveNumberProvider.overrideWith((_) async => nextDiveNumber),
+      tagsProvider.overrideWith((_) async => const []),
+    ],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -506,6 +537,606 @@ void main() {
         expect(find.textContaining('1 new'), findsOneWidget);
         expect(find.textContaining('1 merging'), findsOneWidget);
         expect(find.textContaining('1 replacing'), findsOneWidget);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Projected dive numbers
+  // -------------------------------------------------------------------------
+
+  group('ReviewStep - projected dive numbers', () {
+    testWidgets(
+      'shows projected dive number badges for selected non-duplicate dives',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // Two dives ordered oldest-first, nextDiveNumber = 10.
+        // Expect badges #10 and #11.
+        final bundle = _buildBundle(
+          diveItems: [
+            _diveItem('Dive A', DateTime(2026, 1, 1)),
+            _diveItem('Dive B', DateTime(2026, 1, 2)),
+          ],
+        );
+
+        final adapter = _FakeAdapter();
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+        await tester.pumpWidget(
+          _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 10),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('#10'), findsOneWidget);
+        expect(find.text('#11'), findsOneWidget);
+      },
+    );
+
+    testWidgets('assigns numbers oldest-first regardless of item order', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // Items in reverse chronological order; numbering should still go
+      // oldest-first.
+      final bundle = _buildBundle(
+        diveItems: [
+          _diveItem('Newer Dive', DateTime(2026, 6, 15)),
+          _diveItem('Older Dive', DateTime(2026, 1, 1)),
+        ],
+      );
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 5),
+      );
+      await tester.pumpAndSettle();
+
+      // Both badges should be present: #5 for the older, #6 for the newer.
+      expect(find.text('#5'), findsOneWidget);
+      expect(find.text('#6'), findsOneWidget);
+    });
+
+    testWidgets('excludes skipped duplicates from projected dive numbers', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 3 dives: index 2 is a duplicate marked skip. Only indices 0 and 1
+      // should get projected numbers (#1, #2).
+      final bundle = _buildBundle(
+        diveItems: [
+          _diveItem('Dive 1', DateTime(2026, 1, 1)),
+          _diveItem('Dive 2', DateTime(2026, 1, 2)),
+          _diveItem('Dive 3 (dup)', DateTime(2026, 1, 3)),
+        ],
+        diveDuplicateIndices: {2},
+        diveMatchResults: {
+          2: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.9,
+            timeDifferenceMs: 100,
+          ),
+        },
+      );
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        2,
+        DuplicateAction.skip,
+      );
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      // Only 2 dive number badges, not 3.
+      expect(find.text('#1'), findsOneWidget);
+      expect(find.text('#2'), findsOneWidget);
+      expect(find.text('#3'), findsNothing);
+    });
+
+    testWidgets('includes importAsNew duplicates in projected dive numbers', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 2 dives: index 1 is a duplicate marked importAsNew. Both should
+      // get projected numbers.
+      final bundle = _buildBundle(
+        diveItems: [
+          _diveItem('Dive 1', DateTime(2026, 1, 1)),
+          _diveItem('Dive 2 (dup)', DateTime(2026, 1, 2)),
+        ],
+        diveDuplicateIndices: {1},
+        diveMatchResults: {
+          1: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.5,
+            timeDifferenceMs: 100,
+          ),
+        },
+      );
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        1,
+        DuplicateAction.importAsNew,
+      );
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 20),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('#20'), findsOneWidget);
+      expect(find.text('#21'), findsOneWidget);
+    });
+
+    testWidgets(
+      'excludes consolidated duplicates from projected dive numbers',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // 2 dives: index 1 is a duplicate marked consolidate. Only index 0
+        // should get a projected number.
+        final bundle = _buildBundle(
+          diveItems: [
+            _diveItem('Dive 1', DateTime(2026, 1, 1)),
+            _diveItem('Dive 2 (dup)', DateTime(2026, 1, 2)),
+          ],
+          diveDuplicateIndices: {1},
+          diveMatchResults: {
+            1: const DiveMatchResult(
+              diveId: 'existing-1',
+              score: 0.9,
+              timeDifferenceMs: 100,
+            ),
+          },
+        );
+
+        final adapter = _FakeAdapter(
+          actions: {
+            DuplicateAction.skip,
+            DuplicateAction.importAsNew,
+            DuplicateAction.consolidate,
+          },
+        );
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          1,
+          DuplicateAction.consolidate,
+        );
+
+        await tester.pumpWidget(
+          _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 50),
+        );
+        await tester.pumpAndSettle();
+
+        // Only 1 dive number badge for the non-duplicate.
+        expect(find.text('#50'), findsOneWidget);
+        expect(find.text('#51'), findsNothing);
+      },
+    );
+
+    testWidgets('no dive number badges when nextDiveNumber is unavailable', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(
+        diveItems: [
+          _diveItem('Dive 1', DateTime(2026, 1, 1)),
+          _diveItem('Dive 2', DateTime(2026, 1, 2)),
+        ],
+      );
+
+      // Use the standard builder without nextDiveNumberProvider override.
+      await tester.pumpWidget(_buildReviewStep(bundle: bundle));
+      await tester.pump();
+
+      // No badges because the provider is not overridden and throws.
+      expect(find.text('#1'), findsNothing);
+      expect(find.text('#2'), findsNothing);
+    });
+
+    testWidgets('no dive number badges when dives group is absent', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // Only sites, no dives.
+      final bundle = _buildBundle(siteItems: [_item('Blue Hole')]);
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      // No dive number badges at all.
+      expect(find.text('#1'), findsNothing);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Options button visibility
+  // -------------------------------------------------------------------------
+
+  group('ReviewStep - Options button', () {
+    testWidgets('Options button is visible on dives-only tab', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(diveItems: [_item('Dive 1')]);
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Options'), findsOneWidget);
+    });
+
+    testWidgets('Options button is visible on dives tab in multi-type layout', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(
+        diveItems: [_item('Dive 1')],
+        siteItems: [_item('Blue Hole')],
+      );
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      // Initially on Dives tab, Options should be visible.
+      expect(find.text('Options'), findsOneWidget);
+    });
+
+    testWidgets('Options button is hidden on Sites tab in multi-type layout', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(
+        diveItems: [_item('Dive 1')],
+        siteItems: [_item('Blue Hole')],
+      );
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the Sites tab.
+      await tester.tap(find.text('Sites (1)'));
+      await tester.pumpAndSettle();
+
+      // Options button should be gone on the Sites tab.
+      expect(find.text('Options'), findsNothing);
+    });
+
+    testWidgets('Options button hidden when bundle contains only sites', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // No dives at all.
+      final bundle = _buildBundle(siteItems: [_item('Blue Hole')]);
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Options'), findsNothing);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Import Options sheet
+  // -------------------------------------------------------------------------
+
+  group('ReviewStep - Import Options sheet', () {
+    testWidgets(
+      'tapping Options opens bottom sheet with Import Options title',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final bundle = _buildBundle(diveItems: [_item('Dive 1')]);
+
+        final adapter = _FakeAdapter();
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+        await tester.pumpWidget(
+          _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap Options button.
+        await tester.tap(find.text('Options'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Import Options'), findsOneWidget);
+      },
+    );
+
+    testWidgets('Import Options sheet shows retain-dive-numbers switch', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(diveItems: [_item('Dive 1')]);
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Options'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Retain source dive numbers'), findsOneWidget);
+      expect(find.byType(SwitchListTile), findsOneWidget);
+    });
+
+    testWidgets('toggling retain-dive-numbers switch updates notifier state', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(diveItems: [_item('Dive 1')]);
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier, nextDiveNumber: 1),
+      );
+      await tester.pumpAndSettle();
+
+      // Open sheet.
+      await tester.tap(find.text('Options'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.state.retainSourceDiveNumbers, isFalse);
+
+      // Toggle the switch on.
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+
+      expect(notifier.state.retainSourceDiveNumbers, isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Status text edge cases
+  // -------------------------------------------------------------------------
+
+  group('ReviewStep - status text formatting', () {
+    testWidgets('shows only skipped count when all items deselected', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final bundle = _buildBundle(
+        diveItems: [_item('Dive 1'), _item('Dive 2')],
+      );
+
+      final adapter = _FakeAdapter();
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+      notifier.deselectAll(ImportEntityType.dives);
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier),
+      );
+      await tester.pumpAndSettle();
+
+      // Deselected non-duplicates count as skipping.
+      expect(find.text('2 skipped'), findsOneWidget);
+      expect(find.textContaining('new'), findsNothing);
+    });
+
+    testWidgets(
+      'shows only "skipped" when all duplicates skipped and no new items',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // All items are duplicates.
+        final bundle = _buildBundle(
+          diveItems: [_item('Dive 1'), _item('Dive 2')],
+          diveDuplicateIndices: {0, 1},
+          diveMatchResults: {
+            0: const DiveMatchResult(
+              diveId: 'existing-1',
+              score: 0.9,
+              timeDifferenceMs: 100,
+            ),
+            1: const DiveMatchResult(
+              diveId: 'existing-2',
+              score: 0.9,
+              timeDifferenceMs: 200,
+            ),
+          },
+        );
+
+        final adapter = _FakeAdapter();
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          0,
+          DuplicateAction.skip,
+        );
+        notifier.setDuplicateAction(
+          ImportEntityType.dives,
+          1,
+          DuplicateAction.skip,
+        );
+
+        await tester.pumpWidget(
+          _buildReviewStepWithProviders(notifier: notifier),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('2 skipped'), findsOneWidget);
+      },
+    );
+
+    testWidgets('shows combined status text with all action types', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 5 items: 1 non-dup selected, 1 non-dup deselected, and 3 duplicates
+      // with different actions.
+      final bundle = _buildBundle(
+        diveItems: [
+          _item('Dive 1'),
+          _item('Dive 2'),
+          _item('Dive 3 (dup)'),
+          _item('Dive 4 (dup)'),
+          _item('Dive 5 (dup)'),
+        ],
+        diveDuplicateIndices: {2, 3, 4},
+        diveMatchResults: {
+          2: const DiveMatchResult(
+            diveId: 'existing-1',
+            score: 0.9,
+            timeDifferenceMs: 100,
+          ),
+          3: const DiveMatchResult(
+            diveId: 'existing-2',
+            score: 0.9,
+            timeDifferenceMs: 200,
+          ),
+          4: const DiveMatchResult(
+            diveId: 'existing-3',
+            score: 0.9,
+            timeDifferenceMs: 300,
+          ),
+        },
+      );
+
+      final adapter = _FakeAdapter(
+        actions: {
+          DuplicateAction.skip,
+          DuplicateAction.importAsNew,
+          DuplicateAction.consolidate,
+          DuplicateAction.replaceSource,
+        },
+      );
+      final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+      // Deselect item 1 (non-duplicate -> skipping)
+      notifier.toggleSelection(ImportEntityType.dives, 1);
+      // Set duplicate actions
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        2,
+        DuplicateAction.consolidate,
+      );
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        3,
+        DuplicateAction.replaceSource,
+      );
+      notifier.setDuplicateAction(
+        ImportEntityType.dives,
+        4,
+        DuplicateAction.skip,
+      );
+
+      await tester.pumpWidget(
+        _buildReviewStepWithProviders(notifier: notifier),
+      );
+      await tester.pumpAndSettle();
+
+      // 1 new (item 0), 1 merging (item 2), 1 replacing (item 3),
+      // 2 skipped (items 1 and 4).
+      expect(find.textContaining('1 new'), findsOneWidget);
+      expect(find.textContaining('1 merging'), findsOneWidget);
+      expect(find.textContaining('1 replacing'), findsOneWidget);
+      expect(find.textContaining('2 skipped'), findsOneWidget);
+    });
+
+    testWidgets(
+      'Import Selected button disabled when nothing actionable selected',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final bundle = _buildBundle(
+          diveItems: [_item('Dive 1'), _item('Dive 2')],
+        );
+
+        final adapter = _FakeAdapter();
+        final notifier = ImportWizardNotifier(adapter)..setBundle(bundle);
+        notifier.deselectAll(ImportEntityType.dives);
+
+        var called = false;
+        await tester.pumpWidget(
+          _buildReviewStepWithProviders(
+            notifier: notifier,
+            onImport: () => called = true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The button should be present but disabled.
+        final button = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Import Selected'),
+        );
+        expect(button.onPressed, isNull);
+
+        // Tapping should not fire callback.
+        await tester.tap(find.text('Import Selected'));
+        await tester.pump();
+        expect(called, isFalse);
       },
     );
   });


### PR DESCRIPTION
## Summary

- Store raw per-dive bytes from dive computer downloads as BLOBs in `DiveDataSources`, enabling future parser improvements to be applied retroactively without re-downloading
- Add `replaceSource` conflict resolution in the import wizard for backfilling raw bytes on existing dives during re-download
- Add manual "Re-parse all dives" button on DC detail page and "Re-parse raw data" menu item on dive detail page, both using a shared `applyParsedUpdate` function with allowlist-enforced computer-field overwrite / user-field preservation
- Capture raw bytes across all 5 platforms (Swift, Kotlin/JNI, GObject, C++) through the Pigeon bridge to Dart persistence
- Configure `DiveDataSources.computerId` FK as `onDelete: setNull` so raw data survives dive computer deletion

Closes #176

## Design

See `docs/superpowers/specs/2026-04-15-raw-dive-data-storage-design.md` for the full design spec.

Key decisions:
- **DC downloads only (v1)** — schema accommodates file imports later (all columns nullable)
- **Manual re-parse only** — no auto-detect on libdivecomputer version bump
- **Allowlist merge policy** — computer-authored fields (depth, duration, profile, events, deco params) overwritten; user-authored fields (notes, buddies, site, gear, rating) never touched
- **DiveTanks carry-over** — gas mix/pressures overwritten by re-parse; tank names, presets, and equipment links preserved

## Test plan

- [x] Blob round-trip: store and retrieve `rawData` byte-for-byte
- [x] FK setNull: deleting a dive computer preserves raw data with null computerId
- [x] Cascade delete: deleting a dive removes its data sources
- [x] Allowlist enforcement: re-parse overwrites computer fields, preserves user fields
- [x] Primary-only: non-primary source re-parse does not update canonical Dives row
- [x] Idempotent: running applyParsedUpdate twice produces identical results
- [x] DiveTanks carry-over: computer fields updated, user fields preserved, new/removed tanks handled
- [x] DiveProfiles scoped to computerId (other computers' profiles untouched)
- [x] rawData not overwritten with null on re-parse path (Value.absent)
- [x] getRawDataCounts and hasRawData return correct values
- [x] Manual test: download from real dive computer, verify raw bytes stored
- [x] Manual test: re-parse from DC detail page, verify profile updates
- [x] Manual test: re-parse from dive detail page after computer deletion
- [x] Manual test: re-import all dives, use Replace choice, verify backfill
