### PR TITLE
feat: add map style selector (Street, Topo, Satellite)

### DIFF
--- a/lib/core/constants/map_style.dart
+++ b/lib/core/constants/map_style.dart
@@ -1,0 +1,14 @@
+/// Available map tile styles.
+enum MapStyle {
+  openStreetMap,
+  openTopoMap,
+  esriSatellite;
+
+  /// Parse from stored string, defaulting to openStreetMap.
+  static MapStyle fromName(String name) {
+    return MapStyle.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => MapStyle.openStreetMap,
+    );
+  }
+}

--- a/lib/core/constants/map_tile_config.dart
+++ b/lib/core/constants/map_tile_config.dart
@@ -1,0 +1,46 @@
+import 'package:submersion/core/constants/map_style.dart';
+
+/// Centralized configuration for map tile providers.
+class MapTileConfig {
+  MapTileConfig._();
+
+  /// Returns the tile URL template for the given [style].
+  static String urlTemplate(MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap =>
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      MapStyle.openTopoMap => 'https://tile.opentopomap.org/{z}/{x}/{y}.png',
+      MapStyle.esriSatellite =>
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    };
+  }
+
+  /// Returns the maximum zoom level supported by the given [style].
+  static int maxZoom(MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap => 19,
+      MapStyle.openTopoMap => 17,
+      MapStyle.esriSatellite => 18,
+    };
+  }
+
+  /// Returns a concrete tile URL for the given [style], zoom, x, and y indices.
+  static String tileUrl(MapStyle style, int z, int x, int y) {
+    return switch (style) {
+      MapStyle.openStreetMap => 'https://tile.openstreetmap.org/$z/$x/$y.png',
+      MapStyle.openTopoMap => 'https://tile.opentopomap.org/$z/$x/$y.png',
+      MapStyle.esriSatellite =>
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/$z/$y/$x',
+    };
+  }
+
+  /// Returns the attribution string for the given [style].
+  static String attribution(MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap => '\u00a9 OpenStreetMap contributors',
+      MapStyle.openTopoMap =>
+        '\u00a9 OpenStreetMap contributors, SRTM | Style: \u00a9 OpenTopoMap (CC-BY-SA)',
+      MapStyle.esriSatellite => '\u00a9 Esri, Maxar, Earthstar Geographics',
+    };
+  }
+}

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -674,6 +674,9 @@ class DiverSettings extends Table {
       text().withDefault(const Constant('detailed'))();
   TextColumn get diveCenterListViewMode =>
       text().withDefault(const Constant('detailed'))();
+  // Map style (v64)
+  TextColumn get mapStyle =>
+      text().withDefault(const Constant('openStreetMap'))();
   // Dive profile chart defaults
   TextColumn get defaultRightAxisMetric =>
       text().withDefault(const Constant('temperature'))();
@@ -1319,7 +1322,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 66;
+  static const int currentSchemaVersion = 67;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1389,6 +1392,7 @@ class AppDatabase extends _$AppDatabase {
     64,
     65,
     66,
+    67,
   ];
 
   /// Returns the number of migration steps that will execute when upgrading
@@ -3170,6 +3174,21 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 66) await reportProgress();
+
+        if (from < 67) {
+          final cols = await customSelect(
+            "PRAGMA table_info('diver_settings')",
+          ).get();
+          if (cols.isNotEmpty) {
+            final existing = cols.map((c) => c.read<String>('name')).toSet();
+            if (!existing.contains('map_style')) {
+              await customStatement(
+                "ALTER TABLE diver_settings ADD COLUMN map_style TEXT NOT NULL DEFAULT 'openStreetMap'",
+              );
+            }
+          }
+        }
+        if (from < 67) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -674,7 +674,7 @@ class DiverSettings extends Table {
       text().withDefault(const Constant('detailed'))();
   TextColumn get diveCenterListViewMode =>
       text().withDefault(const Constant('detailed'))();
-  // Map style (v64)
+  // Map style (v67)
   TextColumn get mapStyle =>
       text().withDefault(const Constant('openStreetMap'))();
   // Dive profile chart defaults

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 
 class DiveCenterDetailPage extends ConsumerStatefulWidget {
   final String centerId;
@@ -644,6 +645,7 @@ class _MapSection extends ConsumerWidget {
                     ),
                   ],
                 ),
+                const MapAttribution(),
               ],
             ),
             Positioned(
@@ -737,6 +739,7 @@ class _MapSection extends ConsumerWidget {
                   ),
                 ],
               ),
+              const MapAttribution(),
             ],
           ),
         ),

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.d
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 
 class DiveCenterDetailPage extends ConsumerStatefulWidget {
   final String centerId;
@@ -573,13 +574,13 @@ class _NotesSection extends StatelessWidget {
   }
 }
 
-class _MapSection extends StatelessWidget {
+class _MapSection extends ConsumerWidget {
   final DiveCenter center;
 
   const _MapSection({required this.center});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
     final centerLocation = LatLng(center.latitude!, center.longitude!);
 
@@ -603,9 +604,9 @@ class _MapSection extends StatelessWidget {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,
@@ -657,7 +658,7 @@ class _MapSection extends StatelessWidget {
                       context.l10n.diveCenters_accessibility_viewFullscreenMap,
                   child: InkWell(
                     borderRadius: BorderRadius.circular(4),
-                    onTap: () => _showFullscreenMap(context),
+                    onTap: () => _showFullscreenMap(context, ref),
                     child: Padding(
                       padding: const EdgeInsets.all(6),
                       child: Icon(
@@ -676,7 +677,7 @@ class _MapSection extends StatelessWidget {
     );
   }
 
-  void _showFullscreenMap(BuildContext context) {
+  void _showFullscreenMap(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
     final centerLocation = LatLng(center.latitude!, center.longitude!);
 
@@ -696,9 +697,9 @@ class _MapSection extends StatelessWidget {
             ),
             children: [
               TileLayer(
-                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
-                maxZoom: 19,
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
                     ? TileCacheService.instance.getTileProvider()
                     : null,

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
 
 class DiveCenterMapPage extends ConsumerStatefulWidget {
@@ -260,6 +261,7 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
                 },
               ),
             ),
+            const MapAttribution(),
           ],
         ),
 

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/dive_centers/presentation/widgets/dive_cente
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
 
 class DiveCenterMapPage extends ConsumerStatefulWidget {
@@ -221,9 +222,9 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -8,6 +8,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
@@ -215,9 +216,9 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
@@ -254,6 +255,7 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
                 },
               ),
             ),
+            const MapAttribution(),
           ],
         ),
 

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/core/constants/tank_presets.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/core/deco/altitude_calculator.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_card.dart';
 import 'package:submersion/core/services/export/export_service.dart';
@@ -919,6 +920,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                         ),
                       ],
                     ),
+                    const MapAttribution(),
                   ],
                 ),
               ),

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/tank_presets.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/core/deco/altitude_calculator.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_card.dart';
 import 'package:submersion/core/services/export/export_service.dart';
@@ -885,10 +886,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   ),
                   children: [
                     TileLayer(
-                      urlTemplate:
-                          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      urlTemplate: ref.watch(mapTileUrlProvider),
                       userAgentPackageName: 'app.submersion',
-                      maxZoom: 19,
+                      maxZoom: ref.watch(mapTileMaxZoomProvider),
                       tileProvider: TileCacheService.instance.isInitialized
                           ? TileCacheService.instance.getTileProvider()
                           : null,

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -40,11 +40,12 @@ import 'package:submersion/features/dive_log/presentation/providers/highlight_pr
 import 'package:submersion/shared/widgets/table_mode_layout/table_mode_layout.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Compute a single OSM tile URL for the given lat/lng at [zoom].
+/// Compute a single map tile URL for the given lat/lng at [zoom].
 ///
 /// Converts WGS-84 coordinates to slippy map tile x/y using the standard
-/// Web Mercator projection formula, then returns the OSM raster tile URL.
-String _osmTileUrl(double lat, double lng, int zoom, MapStyle style) {
+/// Web Mercator projection formula, then returns the tile URL for the
+/// requested [style] (Street, Topo, or Satellite).
+String _tileUrl(double lat, double lng, int zoom, MapStyle style) {
   final n = 1 << zoom; // 2^zoom
   final x = ((lng + 180.0) / 360.0 * n).floor();
   final latRad = lat * math.pi / 180.0;
@@ -887,7 +888,7 @@ class DiveListTile extends ConsumerWidget {
 
     // Build the card with or without map background
     if (shouldShowMap) {
-      final tileUrl = _osmTileUrl(
+      final tileUrl = _tileUrl(
         siteLatitude!,
         siteLongitude!,
         13,

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -892,7 +892,7 @@ class DiveListTile extends ConsumerWidget {
         siteLatitude!,
         siteLongitude!,
         13,
-        ref.watch(settingsProvider).mapStyle,
+        ref.watch(settingsProvider.select((s) => s.mapStyle)),
       );
       return Card(
         margin:

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -7,6 +7,8 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/constants/map_tile_config.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -42,7 +44,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 ///
 /// Converts WGS-84 coordinates to slippy map tile x/y using the standard
 /// Web Mercator projection formula, then returns the OSM raster tile URL.
-String _osmTileUrl(double lat, double lng, int zoom) {
+String _osmTileUrl(double lat, double lng, int zoom, MapStyle style) {
   final n = 1 << zoom; // 2^zoom
   final x = ((lng + 180.0) / 360.0 * n).floor();
   final latRad = lat * math.pi / 180.0;
@@ -51,7 +53,7 @@ String _osmTileUrl(double lat, double lng, int zoom) {
               2.0 *
               n)
           .floor();
-  return 'https://tile.openstreetmap.org/$zoom/$x/$y.png';
+  return MapTileConfig.tileUrl(style, zoom, x, y);
 }
 
 /// Main dive list page with master-detail layout on desktop.
@@ -885,7 +887,12 @@ class DiveListTile extends ConsumerWidget {
 
     // Build the card with or without map background
     if (shouldShowMap) {
-      final tileUrl = _osmTileUrl(siteLatitude!, siteLongitude!, 13);
+      final tileUrl = _osmTileUrl(
+        siteLatitude!,
+        siteLongitude!,
+        13,
+        ref.watch(settingsProvider).mapStyle,
+      );
       return Card(
         margin:
             margin ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 4),

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -372,6 +373,7 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
                 loading: () => const SizedBox.shrink(),
                 error: (_, _) => const SizedBox.shrink(),
               ),
+            const MapAttribution(),
           ],
         ),
 

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
@@ -306,9 +307,9 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/site_marine_life_section.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_section.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -424,6 +425,7 @@ class _SiteDetailContent extends ConsumerWidget {
                     ),
                   ],
                 ),
+                const MapAttribution(),
               ],
             ),
             Positioned(
@@ -520,6 +522,7 @@ class _SiteDetailContent extends ConsumerWidget {
                   ),
                 ],
               ),
+              const MapAttribution(),
             ],
           ),
         ),

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/site_marine_life_section.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_section.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -134,7 +135,7 @@ class _SiteDetailContent extends ConsumerWidget {
         children: [
           // Map Section (if coordinates exist)
           if (site.hasCoordinates) ...[
-            _buildMapSection(context, site),
+            _buildMapSection(context, ref, site),
             const SizedBox(height: 16),
           ],
 
@@ -355,7 +356,7 @@ class _SiteDetailContent extends ConsumerWidget {
     }
   }
 
-  Widget _buildMapSection(BuildContext context, DiveSite site) {
+  Widget _buildMapSection(BuildContext context, WidgetRef ref, DiveSite site) {
     final colorScheme = Theme.of(context).colorScheme;
     final siteLocation = LatLng(
       site.location!.latitude,
@@ -383,9 +384,9 @@ class _SiteDetailContent extends ConsumerWidget {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,
@@ -437,7 +438,7 @@ class _SiteDetailContent extends ConsumerWidget {
                       context.l10n.diveSites_detail_semantics_viewFullscreenMap,
                   child: InkWell(
                     borderRadius: BorderRadius.circular(4),
-                    onTap: () => _showFullscreenMap(context, site),
+                    onTap: () => _showFullscreenMap(context, ref, site),
                     child: Padding(
                       padding: const EdgeInsets.all(6),
                       child: Icon(
@@ -456,7 +457,7 @@ class _SiteDetailContent extends ConsumerWidget {
     );
   }
 
-  void _showFullscreenMap(BuildContext context, DiveSite site) {
+  void _showFullscreenMap(BuildContext context, WidgetRef ref, DiveSite site) {
     final colorScheme = Theme.of(context).colorScheme;
     final siteLocation = LatLng(
       site.location!.latitude,
@@ -479,9 +480,9 @@ class _SiteDetailContent extends ConsumerWidget {
             ),
             children: [
               TileLayer(
-                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
-                maxZoom: 19,
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
                     ? TileCacheService.instance.getTileProvider()
                     : null,

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
@@ -235,9 +236,9 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -302,6 +303,7 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
                   );
                 },
               ),
+            const MapAttribution(),
           ],
         ),
 

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 
 /// Result from the location picker
 class PickedLocation {
@@ -210,6 +211,7 @@ class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
                       ),
                     ],
                   ),
+                const MapAttribution(),
               ],
             ),
 

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -162,7 +162,7 @@ class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
                 initialCenter: initialCenter,
                 initialZoom: initialZoom,
                 minZoom: 2.0,
-                maxZoom: 18.0,
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
                 onTap: _onMapTap,
                 interactionOptions: const InteractionOptions(
                   flags: InteractiveFlag.all & ~InteractiveFlag.rotate,

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -3,8 +3,10 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 
 /// Result from the location picker
 class PickedLocation {
@@ -24,17 +26,17 @@ class PickedLocation {
 }
 
 /// A full-screen map for picking a location
-class LocationPickerMap extends StatefulWidget {
+class LocationPickerMap extends ConsumerStatefulWidget {
   /// Initial location to center the map on (optional)
   final LatLng? initialLocation;
 
   const LocationPickerMap({super.key, this.initialLocation});
 
   @override
-  State<LocationPickerMap> createState() => _LocationPickerMapState();
+  ConsumerState<LocationPickerMap> createState() => _LocationPickerMapState();
 }
 
-class _LocationPickerMapState extends State<LocationPickerMap> {
+class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
   final MapController _mapController = MapController();
   LatLng? _selectedLocation;
   bool _isGeocoding = false;
@@ -167,9 +169,9 @@ class _LocationPickerMapState extends State<LocationPickerMap> {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/shared/widgets/entity_table/entity_table_view.dart';
@@ -1363,6 +1364,7 @@ class SiteListTile extends ConsumerWidget {
                             ? TileCacheService.instance.getTileProvider()
                             : null,
                       ),
+                      const MapAttribution(),
                     ],
                   ),
                 ),

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/shared/widgets/entity_table/entity_table_view.dart';
@@ -1355,10 +1356,9 @@ class SiteListTile extends ConsumerWidget {
                     ),
                     children: [
                       TileLayer(
-                        urlTemplate:
-                            'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                        urlTemplate: ref.watch(mapTileUrlProvider),
                         userAgentPackageName: 'app.submersion',
-                        maxZoom: 19,
+                        maxZoom: ref.watch(mapTileMaxZoomProvider),
                         tileProvider: TileCacheService.instance.isInitialized
                             ? TileCacheService.instance.getTileProvider()
                             : null,

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
@@ -321,6 +322,7 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
                 loading: () => const SizedBox.shrink(),
                 error: (_, _) => const SizedBox.shrink(),
               ),
+            const MapAttribution(),
           ],
         ),
 

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
 /// Map content widget for displaying dive sites on a map.
@@ -262,9 +263,9 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -144,7 +144,7 @@ class TileCacheService {
   /// Example:
   /// ```dart
   /// TileLayer(
-  ///   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  ///   urlTemplate: ref.watch(mapTileUrlProvider), // URL from selected map style
   ///   tileProvider: TileCacheService.instance.getTileProvider(),
   /// )
   /// ```

--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -139,14 +139,21 @@ class TileCacheService {
 
   /// Get a tile provider that caches tiles.
   ///
-  /// This provider can be used with FlutterMap's TileLayer.
+  /// This provider can be used with FlutterMap's TileLayer. Read
+  /// `mapTileUrlProvider` inside a `ConsumerWidget`/`ConsumerState` so the
+  /// URL tracks the user's selected map style.
   ///
   /// Example:
   /// ```dart
-  /// TileLayer(
-  ///   urlTemplate: ref.watch(mapTileUrlProvider), // URL from selected map style
-  ///   tileProvider: TileCacheService.instance.getTileProvider(),
-  /// )
+  /// class MyMap extends ConsumerWidget {
+  ///   @override
+  ///   Widget build(BuildContext context, WidgetRef ref) {
+  ///     return TileLayer(
+  ///       urlTemplate: ref.watch(mapTileUrlProvider),
+  ///       tileProvider: TileCacheService.instance.getTileProvider(),
+  ///     );
+  ///   }
+  /// }
   /// ```
   FMTCTileProvider getTileProvider({
     BrowseLoadingStrategy loadingStrategy = BrowseLoadingStrategy.cacheFirst,

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -19,6 +19,7 @@ import 'package:submersion/features/maps/presentation/providers/heat_map_provide
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -336,6 +337,7 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
                 loading: () => const SizedBox.shrink(),
                 error: (_, _) => const SizedBox.shrink(),
               ),
+            const MapAttribution(),
           ],
         ),
 

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -18,6 +18,7 @@ import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
 import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -270,9 +271,9 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
           ),
           children: [
             TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
-              maxZoom: 19,
+              maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
                   ? TileCacheService.instance.getTileProvider()
                   : null,

--- a/lib/features/maps/presentation/providers/map_tile_providers.dart
+++ b/lib/features/maps/presentation/providers/map_tile_providers.dart
@@ -1,0 +1,21 @@
+import 'package:submersion/core/constants/map_tile_config.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Provides the current tile URL template based on the selected map style.
+final mapTileUrlProvider = Provider<String>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return MapTileConfig.urlTemplate(settings.mapStyle);
+});
+
+/// Provides the maximum zoom level for the selected map style.
+final mapTileMaxZoomProvider = Provider<double>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return MapTileConfig.maxZoom(settings.mapStyle).toDouble();
+});
+
+/// Provides the attribution string for the selected map style.
+final mapTileAttributionProvider = Provider<String>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return MapTileConfig.attribution(settings.mapStyle);
+});

--- a/lib/features/maps/presentation/providers/map_tile_providers.dart
+++ b/lib/features/maps/presentation/providers/map_tile_providers.dart
@@ -4,18 +4,18 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 
 /// Provides the current tile URL template based on the selected map style.
 final mapTileUrlProvider = Provider<String>((ref) {
-  final settings = ref.watch(settingsProvider);
-  return MapTileConfig.urlTemplate(settings.mapStyle);
+  final mapStyle = ref.watch(settingsProvider.select((s) => s.mapStyle));
+  return MapTileConfig.urlTemplate(mapStyle);
 });
 
 /// Provides the maximum zoom level for the selected map style.
 final mapTileMaxZoomProvider = Provider<double>((ref) {
-  final settings = ref.watch(settingsProvider);
-  return MapTileConfig.maxZoom(settings.mapStyle).toDouble();
+  final mapStyle = ref.watch(settingsProvider.select((s) => s.mapStyle));
+  return MapTileConfig.maxZoom(mapStyle).toDouble();
 });
 
 /// Provides the attribution string for the selected map style.
 final mapTileAttributionProvider = Provider<String>((ref) {
-  final settings = ref.watch(settingsProvider);
-  return MapTileConfig.attribution(settings.mapStyle);
+  final mapStyle = ref.watch(settingsProvider.select((s) => s.mapStyle));
+  return MapTileConfig.attribution(mapStyle);
 });

--- a/lib/features/maps/presentation/widgets/map_attribution.dart
+++ b/lib/features/maps/presentation/widgets/map_attribution.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+
+/// Visible attribution for the current map tile source.
+///
+/// Rendered as a child of [FlutterMap] so that OpenStreetMap, OpenTopoMap,
+/// and Esri tile usage policies are met (each requires visible attribution).
+/// Reacts to [mapTileAttributionProvider] so the displayed text updates when
+/// the user switches map style in settings.
+class MapAttribution extends ConsumerWidget {
+  const MapAttribution({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final attribution = ref.watch(mapTileAttributionProvider);
+    return RichAttributionWidget(
+      attributions: [TextSourceAttribution(attribution)],
+      showFlutterMapAttribution: false,
+    );
+  }
+}

--- a/lib/features/maps/presentation/widgets/region_download_dialog.dart
+++ b/lib/features/maps/presentation/widgets/region_download_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/offline_map_providers.dart';
 
 /// Dialog for configuring and starting a region download.
@@ -35,11 +36,11 @@ class _RegionDownloadDialogState extends ConsumerState<RegionDownloadDialog> {
   bool _isLoadingName = false;
   int? _estimatedTiles;
 
-  /// Default tile layer options for OpenStreetMap.
+  /// Default tile layer options using the selected map style.
   TileLayer get _tileLayerOptions => TileLayer(
-    urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    urlTemplate: ref.watch(mapTileUrlProvider),
     userAgentPackageName: 'app.submersion',
-    maxZoom: 19,
+    maxZoom: ref.watch(mapTileMaxZoomProvider),
   );
 
   @override

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
@@ -98,6 +99,7 @@ class DiverSettingsRepository {
               equipmentListViewMode: Value(s.equipmentListViewMode.name),
               buddyListViewMode: Value(s.buddyListViewMode.name),
               diveCenterListViewMode: Value(s.diveCenterListViewMode.name),
+              mapStyle: Value(s.mapStyle.name),
               cardColorGradientPreset: Value(s.cardColorGradientPreset),
               cardColorGradientStart: Value(s.cardColorGradientStart),
               cardColorGradientEnd: Value(s.cardColorGradientEnd),
@@ -229,6 +231,7 @@ class DiverSettingsRepository {
           equipmentListViewMode: Value(settings.equipmentListViewMode.name),
           buddyListViewMode: Value(settings.buddyListViewMode.name),
           diveCenterListViewMode: Value(settings.diveCenterListViewMode.name),
+          mapStyle: Value(settings.mapStyle.name),
           cardColorGradientPreset: Value(settings.cardColorGradientPreset),
           cardColorGradientStart: Value(settings.cardColorGradientStart),
           cardColorGradientEnd: Value(settings.cardColorGradientEnd),
@@ -399,6 +402,7 @@ class DiverSettingsRepository {
       equipmentListViewMode: ListViewMode.fromName(row.equipmentListViewMode),
       buddyListViewMode: ListViewMode.fromName(row.buddyListViewMode),
       diveCenterListViewMode: ListViewMode.fromName(row.diveCenterListViewMode),
+      mapStyle: MapStyle.fromName(row.mapStyle),
       cardColorGradientPreset: row.cardColorGradientPreset,
       cardColorGradientStart: row.cardColorGradientStart,
       cardColorGradientEnd: row.cardColorGradientEnd,

--- a/lib/features/settings/presentation/pages/appearance_page.dart
+++ b/lib/features/settings/presentation/pages/appearance_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_theme_registry.dart';
 import 'package:submersion/features/settings/presentation/pages/language_settings_page.dart';
@@ -68,6 +69,27 @@ class AppearancePage extends ConsumerWidget {
             ),
             trailing: const Icon(Icons.chevron_right),
             onTap: () => context.go('/settings/language'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.map_outlined),
+            title: Text(context.l10n.settings_appearance_mapStyle),
+            subtitle: Text(_getMapStyleDisplayName(context, settings.mapStyle)),
+            trailing: DropdownButton<MapStyle>(
+              value: settings.mapStyle,
+              underline: const SizedBox.shrink(),
+              onChanged: (style) {
+                if (style != null) {
+                  ref.read(settingsProvider.notifier).setMapStyle(style);
+                }
+              },
+              items: MapStyle.values.map((style) {
+                return DropdownMenuItem(
+                  value: style,
+                  child: Text(_getMapStyleDisplayName(context, style)),
+                );
+              }).toList(),
+            ),
           ),
           const Divider(),
 
@@ -150,6 +172,17 @@ class AppearancePage extends ConsumerWidget {
       case ThemeMode.dark:
         return Icons.dark_mode;
     }
+  }
+
+  String _getMapStyleDisplayName(BuildContext context, MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap =>
+        context.l10n.settings_appearance_mapStyle_openStreetMap,
+      MapStyle.openTopoMap =>
+        context.l10n.settings_appearance_mapStyle_openTopoMap,
+      MapStyle.esriSatellite =>
+        context.l10n.settings_appearance_mapStyle_esriSatellite,
+    };
   }
 
   String _resolveCurrentThemeName(BuildContext context, WidgetRef ref) {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/settings/presentation/pages/column_config_page.dart';
@@ -1221,6 +1222,29 @@ class _AppearanceSectionContentState
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () => setState(() => _showLanguageList = true),
                 ),
+                const Divider(height: 1),
+                ListTile(
+                  leading: const Icon(Icons.map_outlined),
+                  title: Text(context.l10n.settings_appearance_mapStyle),
+                  subtitle: Text(
+                    _getMapStyleDisplayName(context, settings.mapStyle),
+                  ),
+                  trailing: DropdownButton<MapStyle>(
+                    value: settings.mapStyle,
+                    underline: const SizedBox.shrink(),
+                    onChanged: (style) {
+                      if (style != null) {
+                        ref.read(settingsProvider.notifier).setMapStyle(style);
+                      }
+                    },
+                    items: MapStyle.values.map((style) {
+                      return DropdownMenuItem(
+                        value: style,
+                        child: Text(_getMapStyleDisplayName(context, style)),
+                      );
+                    }).toList(),
+                  ),
+                ),
               ],
             ),
           ),
@@ -1265,6 +1289,17 @@ class _AppearanceSectionContentState
       default:
         return preset.nameKey;
     }
+  }
+
+  String _getMapStyleDisplayName(BuildContext context, MapStyle style) {
+    return switch (style) {
+      MapStyle.openStreetMap =>
+        context.l10n.settings_appearance_mapStyle_openStreetMap,
+      MapStyle.openTopoMap =>
+        context.l10n.settings_appearance_mapStyle_openTopoMap,
+      MapStyle.esriSatellite =>
+        context.l10n.settings_appearance_mapStyle_esriSatellite,
+    };
   }
 
   Widget _buildLanguageSubPage(BuildContext context, AppSettings settings) {

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -3,6 +3,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_theme_preset.dart';
 import 'package:submersion/core/theme/app_theme_registry.dart';
@@ -154,6 +155,9 @@ class AppSettings {
 
   /// Which layout to use for the dive center list
   final ListViewMode diveCenterListViewMode;
+
+  /// Which map tile style to use
+  final MapStyle mapStyle;
 
   /// Name of the selected gradient preset ('ocean', 'thermal', etc.)
   final String cardColorGradientPreset;
@@ -308,6 +312,7 @@ class AppSettings {
     this.equipmentListViewMode = ListViewMode.detailed,
     this.buddyListViewMode = ListViewMode.detailed,
     this.diveCenterListViewMode = ListViewMode.detailed,
+    this.mapStyle = MapStyle.openStreetMap,
     this.cardColorGradientPreset = 'ocean',
     this.cardColorGradientStart,
     this.cardColorGradientEnd,
@@ -430,6 +435,7 @@ class AppSettings {
     ListViewMode? equipmentListViewMode,
     ListViewMode? buddyListViewMode,
     ListViewMode? diveCenterListViewMode,
+    MapStyle? mapStyle,
     String? cardColorGradientPreset,
     int? cardColorGradientStart,
     int? cardColorGradientEnd,
@@ -522,6 +528,7 @@ class AppSettings {
       buddyListViewMode: buddyListViewMode ?? this.buddyListViewMode,
       diveCenterListViewMode:
           diveCenterListViewMode ?? this.diveCenterListViewMode,
+      mapStyle: mapStyle ?? this.mapStyle,
       cardColorGradientPreset:
           cardColorGradientPreset ?? this.cardColorGradientPreset,
       cardColorGradientStart: clearCardColorGradientStart
@@ -935,6 +942,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   Future<void> setDiveCenterListViewMode(ListViewMode mode) async {
     state = state.copyWith(diveCenterListViewMode: mode);
+    await _saveSettings();
+  }
+
+  Future<void> setMapStyle(MapStyle style) async {
+    state = state.copyWith(mapStyle: style);
     await _saveSettings();
   }
 

--- a/lib/features/trips/presentation/widgets/trip_overview_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_overview_tab.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
@@ -196,9 +197,9 @@ class TripOverviewTab extends ConsumerWidget {
               ),
               children: [
                 TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
-                  maxZoom: 19,
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
                       ? TileCacheService.instance.getTileProvider()
                       : null,

--- a/lib/features/trips/presentation/widgets/trip_overview_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_overview_tab.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
@@ -233,6 +234,7 @@ class TripOverviewTab extends ConsumerWidget {
                     );
                   }).toList(),
                 ),
+                const MapAttribution(),
               ],
             ),
           ),

--- a/lib/features/trips/presentation/widgets/trip_voyage_map.dart
+++ b/lib/features/trips/presentation/widgets/trip_voyage_map.dart
@@ -6,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
 import 'package:submersion/features/trips/presentation/providers/liveaboard_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -62,10 +63,9 @@ class TripVoyageMap extends ConsumerWidget {
                     ),
                     children: [
                       TileLayer(
-                        urlTemplate:
-                            'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                        urlTemplate: ref.watch(mapTileUrlProvider),
                         userAgentPackageName: 'app.submersion',
-                        maxZoom: 19,
+                        maxZoom: ref.watch(mapTileMaxZoomProvider),
                         tileProvider: TileCacheService.instance.isInitialized
                             ? TileCacheService.instance.getTileProvider()
                             : null,

--- a/lib/features/trips/presentation/widgets/trip_voyage_map.dart
+++ b/lib/features/trips/presentation/widgets/trip_voyage_map.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
 import 'package:submersion/features/trips/presentation/providers/liveaboard_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -83,6 +84,7 @@ class TripVoyageMap extends ConsumerWidget {
                         ],
                       ),
                       MarkerLayer(markers: markers),
+                      const MapAttribution(),
                     ],
                   ),
                 ),

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9869,6 +9869,11 @@
   "settings_appearance_showDetailsPane_subtitle": "Display details pane alongside table",
   "settings_appearance_showProfilePanel": "Show Profile Panel in Table View",
   "settings_appearance_showProfilePanel_subtitle": "Display dive profile chart above the table by default",
+  "settings_appearance_mapStyle": "Map Style",
+  "settings_appearance_mapStyle_subtitle": "Choose map tile appearance",
+  "settings_appearance_mapStyle_openStreetMap": "Street Map",
+  "settings_appearance_mapStyle_openTopoMap": "Topographic",
+  "settings_appearance_mapStyle_esriSatellite": "Satellite",
   "common_action_reparse": "Re-parse",
   "@common_action_reparse": {
     "description": "Generic re-parse action label"

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9870,7 +9870,6 @@
   "settings_appearance_showProfilePanel": "Show Profile Panel in Table View",
   "settings_appearance_showProfilePanel_subtitle": "Display dive profile chart above the table by default",
   "settings_appearance_mapStyle": "Map Style",
-  "settings_appearance_mapStyle_subtitle": "Choose map tile appearance",
   "settings_appearance_mapStyle_openStreetMap": "Street Map",
   "settings_appearance_mapStyle_openTopoMap": "Topographic",
   "settings_appearance_mapStyle_esriSatellite": "Satellite",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27386,12 +27386,6 @@ abstract class AppLocalizations {
   /// **'Map Style'**
   String get settings_appearance_mapStyle;
 
-  /// No description provided for @settings_appearance_mapStyle_subtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Choose map tile appearance'**
-  String get settings_appearance_mapStyle_subtitle;
-
   /// No description provided for @settings_appearance_mapStyle_openStreetMap.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27380,6 +27380,36 @@ abstract class AppLocalizations {
   /// **'Display dive profile chart above the table by default'**
   String get settings_appearance_showProfilePanel_subtitle;
 
+  /// No description provided for @settings_appearance_mapStyle.
+  ///
+  /// In en, this message translates to:
+  /// **'Map Style'**
+  String get settings_appearance_mapStyle;
+
+  /// No description provided for @settings_appearance_mapStyle_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose map tile appearance'**
+  String get settings_appearance_mapStyle_subtitle;
+
+  /// No description provided for @settings_appearance_mapStyle_openStreetMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Street Map'**
+  String get settings_appearance_mapStyle_openStreetMap;
+
+  /// No description provided for @settings_appearance_mapStyle_openTopoMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Topographic'**
+  String get settings_appearance_mapStyle_openTopoMap;
+
+  /// No description provided for @settings_appearance_mapStyle_esriSatellite.
+  ///
+  /// In en, this message translates to:
+  /// **'Satellite'**
+  String get settings_appearance_mapStyle_esriSatellite;
+
   /// Generic re-parse action label
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15897,10 +15897,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15894,6 +15894,20 @@ class AppLocalizationsAr extends AppLocalizations {
       'عرض مخطط ملف الغوصة فوق الجدول بشكل افتراضي';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15904,6 +15904,8 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16192,6 +16192,20 @@ class AppLocalizationsDe extends AppLocalizations {
       'Tauchprofildiagramm standardmäßig über der Tabelle anzeigen';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16202,6 +16202,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16195,10 +16195,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15935,6 +15935,20 @@ class AppLocalizationsEn extends AppLocalizations {
       'Display dive profile chart above the table by default';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15945,6 +15945,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15938,10 +15938,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16210,6 +16210,20 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar gráfico de perfil de inmersión sobre la tabla por defecto';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16213,10 +16213,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16220,6 +16220,8 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16267,10 +16267,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16264,6 +16264,20 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher le graphique de profil de plongée au-dessus du tableau par défaut';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16274,6 +16274,8 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15782,6 +15782,20 @@ class AppLocalizationsHe extends AppLocalizations {
       'הצג תרשים פרופיל צלילה מעל הטבלה כברירת מחדל';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15792,6 +15792,8 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15785,10 +15785,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16159,10 +16159,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16166,6 +16166,8 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16156,6 +16156,20 @@ class AppLocalizationsHu extends AppLocalizations {
       'Merülési profil diagram megjelenítése a táblázat felett alapértelmezetten';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16203,6 +16203,20 @@ class AppLocalizationsIt extends AppLocalizations {
       'Visualizza il grafico del profilo di immersione sopra la tabella per impostazione predefinita';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16213,6 +16213,8 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16206,10 +16206,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16081,6 +16081,8 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16071,6 +16071,20 @@ class AppLocalizationsNl extends AppLocalizations {
       'Duikprofielgrafiek standaard boven de tabel weergeven';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16074,10 +16074,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16217,6 +16217,8 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16207,6 +16207,20 @@ class AppLocalizationsPt extends AppLocalizations {
       'Exibir gráfico de perfil de mergulho acima da tabela por padrão';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16210,10 +16210,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15424,10 +15424,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_appearance_mapStyle => 'Map Style';
 
   @override
-  String get settings_appearance_mapStyle_subtitle =>
-      'Choose map tile appearance';
-
-  @override
   String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15431,6 +15431,8 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
+
+  @override
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15421,6 +15421,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_appearance_showProfilePanel_subtitle => '默认在表格上方显示潜水剖面图';
 
   @override
+  String get settings_appearance_mapStyle => 'Map Style';
+
+  @override
+  String get settings_appearance_mapStyle_subtitle =>
+      'Choose map tile appearance';
+
+  @override
+  String get settings_appearance_mapStyle_openStreetMap => 'Street Map';
+
+  @override
+  String get settings_appearance_mapStyle_openTopoMap => 'Topographic';
+
+  @override
+  String get settings_appearance_mapStyle_esriSatellite => 'Satellite';
   String get common_action_reparse => 'Re-parse';
 
   @override

--- a/test/core/presentation/widgets/dive_comparison_card_test.dart
+++ b/test/core/presentation/widgets/dive_comparison_card_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/domain/models/incoming_dive_data.dart';
 import 'package:submersion/core/presentation/widgets/dive_comparison_card.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
@@ -21,6 +22,10 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/pages/dive_detail_page_section_config_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_section_config_test.dart
@@ -5,6 +5,7 @@ import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
@@ -29,6 +30,10 @@ typedef Override = riverpod.Override;
 class _MockSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _MockSettingsNotifier(super.initial);
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/providers/profile_analysis_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_analysis_provider_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
@@ -9,6 +10,10 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 class _SettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _SettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_dive_list_tile.dart';
@@ -11,6 +12,10 @@ import '../../../../helpers/test_app.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/dense_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/dense_dive_list_tile_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dense_dive_list_tile.dart';
@@ -11,6 +12,10 @@ import '../../../../helpers/test_app.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
@@ -27,6 +28,10 @@ import '../../../../helpers/test_app.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2,6 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/deco/ascent_rate_calculator.dart';
 import 'package:submersion/core/providers/provider.dart';
 
@@ -20,6 +21,10 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -49,6 +54,10 @@ class _AllMetricsSettingsNotifier extends StateNotifier<AppSettings>
           showAscentRateColors: true,
         ),
       );
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -13,6 +14,10 @@ import '../../../../helpers/test_app.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -16,6 +17,10 @@ import '../../../../helpers/test_app.dart';
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_log/presentation/widgets/merge_dive_dialog_test.dart
+++ b/test/features/dive_log/presentation/widgets/merge_dive_dialog_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -103,6 +104,10 @@ class _FakeDiveListNotifier extends StateNotifier<AsyncValue<List<Dive>>>
 class _FakeSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _FakeSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
+++ b/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_planner/data/services/plan_calculator_service.dart';
@@ -16,6 +17,10 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
   void updatePressureUnitForTest(PressureUnit unit) {
     state = AppSettings(pressureUnit: unit);
   }
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_planner/presentation/widgets/plan_settings_panel_test.dart
+++ b/test/features/dive_planner/presentation/widgets/plan_settings_panel_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/plan_settings_panel.dart';
@@ -14,6 +15,10 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier({PressureUnit pressureUnit = PressureUnit.bar})
     : super(AppSettings(pressureUnit: pressureUnit));
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/dive_planner/presentation/widgets/plan_tank_list_test.dart
+++ b/test/features/dive_planner/presentation/widgets/plan_tank_list_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
@@ -15,6 +16,10 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
     PressureUnit pressureUnit = PressureUnit.bar,
     VolumeUnit volumeUnit = VolumeUnit.liters,
   }) : super(AppSettings(pressureUnit: pressureUnit, volumeUnit: volumeUnit));
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/import_wizard/data/adapters/healthkit_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/healthkit_adapter_test.dart
@@ -19,6 +19,7 @@ import 'package:submersion/features/import_wizard/domain/models/duplicate_action
 import 'package:submersion/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_bundle.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_phase.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/test_app.dart';
@@ -2483,6 +2484,10 @@ void main() {
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/import_wizard/data/adapters/universal_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/universal_adapter_test.dart
@@ -10,6 +10,7 @@ import 'package:mockito/mockito.dart';
 // ignore: implementation_imports
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
@@ -98,6 +99,10 @@ Diver _testDiver() =>
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/maps/map_attribution_test.dart
+++ b/test/features/maps/map_attribution_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../helpers/mock_providers.dart';
+
+/// Widget tests for [MapAttribution].
+///
+/// Covers PR review feedback items:
+/// 1. Attribution widget must be rendered on each FlutterMap (shipping blocker
+///    per OSM, OpenTopoMap, and Esri tile usage policies).
+/// 7. A ProviderContainer-style test that flips `mapStyle` and asserts the
+///    attribution text reacts accordingly, proving the reactive wiring works.
+void main() {
+  Widget wrapInMap(List<Override> overrides) {
+    return ProviderScope(
+      overrides: overrides.cast(),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: FlutterMap(
+            options: const MapOptions(
+              initialCenter: LatLng(0, 0),
+              initialZoom: 2,
+            ),
+            children: const [MapAttribution()],
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('MapAttribution', () {
+    testWidgets('renders a RichAttributionWidget', (tester) async {
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(wrapInMap(overrides));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RichAttributionWidget), findsOneWidget);
+    });
+
+    testWidgets('shows OpenStreetMap attribution by default', (tester) async {
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(wrapInMap(overrides));
+      await tester.pumpAndSettle();
+
+      final richWidget = tester.widget<RichAttributionWidget>(
+        find.byType(RichAttributionWidget),
+      );
+      final textSource = richWidget.attributions
+          .whereType<TextSourceAttribution>()
+          .single;
+      expect(textSource.text, contains('OpenStreetMap'));
+    });
+
+    testWidgets(
+      'attribution text updates when mapStyle switches to OpenTopoMap',
+      (tester) async {
+        final settings = MockSettingsNotifier();
+        final overrides = [
+          settingsProvider.overrideWith((ref) => settings),
+        ];
+
+        await tester.pumpWidget(wrapInMap(overrides));
+        await tester.pumpAndSettle();
+
+        // Default is OpenStreetMap.
+        var richWidget = tester.widget<RichAttributionWidget>(
+          find.byType(RichAttributionWidget),
+        );
+        expect(
+          richWidget.attributions
+              .whereType<TextSourceAttribution>()
+              .single
+              .text,
+          contains('OpenStreetMap'),
+        );
+
+        // Flip to OpenTopoMap; attribution must react.
+        await settings.setMapStyle(MapStyle.openTopoMap);
+        await tester.pumpAndSettle();
+
+        richWidget = tester.widget<RichAttributionWidget>(
+          find.byType(RichAttributionWidget),
+        );
+        expect(
+          richWidget.attributions
+              .whereType<TextSourceAttribution>()
+              .single
+              .text,
+          contains('OpenTopoMap'),
+        );
+      },
+    );
+
+    testWidgets(
+      'attribution text updates when mapStyle switches to Esri',
+      (tester) async {
+        final settings = MockSettingsNotifier();
+        final overrides = [
+          settingsProvider.overrideWith((ref) => settings),
+        ];
+
+        await tester.pumpWidget(wrapInMap(overrides));
+        await tester.pumpAndSettle();
+
+        await settings.setMapStyle(MapStyle.esriSatellite);
+        await tester.pumpAndSettle();
+
+        final richWidget = tester.widget<RichAttributionWidget>(
+          find.byType(RichAttributionWidget),
+        );
+        expect(
+          richWidget.attributions
+              .whereType<TextSourceAttribution>()
+              .single
+              .text,
+          contains('Esri'),
+        );
+      },
+    );
+  });
+}

--- a/test/features/maps/map_attribution_test.dart
+++ b/test/features/maps/map_attribution_test.dart
@@ -26,10 +26,7 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: FlutterMap(
-            options: MapOptions(
-              initialCenter: LatLng(0, 0),
-              initialZoom: 2,
-            ),
+            options: MapOptions(initialCenter: LatLng(0, 0), initialZoom: 2),
             children: [MapAttribution()],
           ),
         ),
@@ -66,9 +63,7 @@ void main() {
       'attribution text updates when mapStyle switches to OpenTopoMap',
       (tester) async {
         final settings = MockSettingsNotifier();
-        final overrides = [
-          settingsProvider.overrideWith((ref) => settings),
-        ];
+        final overrides = [settingsProvider.overrideWith((ref) => settings)];
 
         await tester.pumpWidget(wrapInMap(overrides));
         await tester.pumpAndSettle();
@@ -102,31 +97,25 @@ void main() {
       },
     );
 
-    testWidgets(
-      'attribution text updates when mapStyle switches to Esri',
-      (tester) async {
-        final settings = MockSettingsNotifier();
-        final overrides = [
-          settingsProvider.overrideWith((ref) => settings),
-        ];
+    testWidgets('attribution text updates when mapStyle switches to Esri', (
+      tester,
+    ) async {
+      final settings = MockSettingsNotifier();
+      final overrides = [settingsProvider.overrideWith((ref) => settings)];
 
-        await tester.pumpWidget(wrapInMap(overrides));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(wrapInMap(overrides));
+      await tester.pumpAndSettle();
 
-        await settings.setMapStyle(MapStyle.esriSatellite);
-        await tester.pumpAndSettle();
+      await settings.setMapStyle(MapStyle.esriSatellite);
+      await tester.pumpAndSettle();
 
-        final richWidget = tester.widget<RichAttributionWidget>(
-          find.byType(RichAttributionWidget),
-        );
-        expect(
-          richWidget.attributions
-              .whereType<TextSourceAttribution>()
-              .single
-              .text,
-          contains('Esri'),
-        );
-      },
-    );
+      final richWidget = tester.widget<RichAttributionWidget>(
+        find.byType(RichAttributionWidget),
+      );
+      expect(
+        richWidget.attributions.whereType<TextSourceAttribution>().single.text,
+        contains('Esri'),
+      );
+    });
   });
 }

--- a/test/features/maps/map_attribution_test.dart
+++ b/test/features/maps/map_attribution_test.dart
@@ -21,16 +21,16 @@ void main() {
   Widget wrapInMap(List<Override> overrides) {
     return ProviderScope(
       overrides: overrides.cast(),
-      child: MaterialApp(
+      child: const MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: FlutterMap(
-            options: const MapOptions(
+            options: MapOptions(
               initialCenter: LatLng(0, 0),
               initialZoom: 2,
             ),
-            children: const [MapAttribution()],
+            children: [MapAttribution()],
           ),
         ),
       ),

--- a/test/features/maps/map_tile_providers_test.dart
+++ b/test/features/maps/map_tile_providers_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../helpers/mock_providers.dart';
+
+void main() {
+  group('mapTileUrlProvider reacts to mapStyle changes', () {
+    test('returns OSM URL for default mapStyle', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(mapTileUrlProvider),
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      );
+    });
+
+    test('updates when mapStyle flips to OpenTopoMap', () async {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setMapStyle(MapStyle.openTopoMap);
+
+      expect(
+        container.read(mapTileUrlProvider),
+        'https://tile.opentopomap.org/{z}/{x}/{y}.png',
+      );
+    });
+
+    test('updates when mapStyle flips to Esri Satellite', () async {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setMapStyle(MapStyle.esriSatellite);
+
+      expect(
+        container.read(mapTileUrlProvider),
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      );
+    });
+  });
+
+  group('mapTileMaxZoomProvider reacts to mapStyle changes', () {
+    test('returns 19 for OpenStreetMap (default)', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(mapTileMaxZoomProvider), 19.0);
+    });
+
+    test('returns 17 for OpenTopoMap', () async {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setMapStyle(MapStyle.openTopoMap);
+
+      expect(container.read(mapTileMaxZoomProvider), 17.0);
+    });
+
+    test('returns 18 for Esri Satellite', () async {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setMapStyle(MapStyle.esriSatellite);
+
+      expect(container.read(mapTileMaxZoomProvider), 18.0);
+    });
+  });
+
+  group('mapTileAttributionProvider reacts to mapStyle changes', () {
+    test('returns OSM attribution by default', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(mapTileAttributionProvider),
+        contains('OpenStreetMap'),
+      );
+    });
+
+    test('updates when mapStyle flips to OpenTopoMap', () async {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setMapStyle(MapStyle.openTopoMap);
+
+      expect(
+        container.read(mapTileAttributionProvider),
+        contains('OpenTopoMap'),
+      );
+    });
+
+    test('updates when mapStyle flips to Esri Satellite', () async {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setMapStyle(MapStyle.esriSatellite);
+
+      expect(container.read(mapTileAttributionProvider), contains('Esri'));
+    });
+  });
+}

--- a/test/features/osm_tile_user_agent_test.dart
+++ b/test/features/osm_tile_user_agent_test.dart
@@ -133,11 +133,16 @@ void main() {
   // -- LocationPickerMap (covers 1 patch line: location_picker_map.dart:171) --
   group('LocationPickerMap TileLayer', () {
     testWidgets('renders TileLayer for OSM tiles', (tester) async {
+      final overrides = await getBaseOverrides();
+
       await tester.pumpWidget(
-        const MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: LocationPickerMap(initialLocation: LatLng(17.3161, -87.5347)),
+        ProviderScope(
+          overrides: [...overrides].cast(),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: LocationPickerMap(initialLocation: LatLng(17.3161, -87.5347)),
+          ),
         ),
       );
       await tester.pumpAndSettle();

--- a/test/features/settings/presentation/pages/appearance_page_test.dart
+++ b/test/features/settings/presentation/pages/appearance_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/settings/presentation/pages/appearance_page.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -9,6 +10,10 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 class _MockSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _MockSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/settings/presentation/pages/dive_detail_sections_page_test.dart
+++ b/test/features/settings/presentation/pages/dive_detail_sections_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/settings/presentation/pages/dive_detail_sections_page.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -19,6 +20,10 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> resetDiveDetailSections() async =>
       state = state.copyWith(clearDiveDetailSections: true);
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   // Stub remaining SettingsNotifier methods
   @override
@@ -39,6 +44,10 @@ class _MockSettingsNotifierWithSections extends StateNotifier<AppSettings>
   @override
   Future<void> resetDiveDetailSections() async =>
       state = state.copyWith(clearDiveDetailSections: true);
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/settings/presentation/pages/section_appearance_page.dart';
 import 'package:submersion/features/settings/presentation/pages/settings_page.dart';
 import 'package:submersion/core/constants/card_color.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
@@ -162,6 +163,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setDiveCenterListViewMode(ListViewMode mode) async =>
       state = state.copyWith(diveCenterListViewMode: mode);
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
   @override
   Future<void> setCardColorGradientPreset(String preset) async =>
       state = state.copyWith(cardColorGradientPreset: preset);
@@ -732,6 +736,9 @@ void main() {
     testWidgets('_getSectionDisplayName returns display name for known keys', (
       tester,
     ) async {
+      await tester.binding.setSurfaceSize(const Size(400, 4000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
       await tester.pumpWidget(buildAppearanceWidget(getOverrides()));
       await tester.pumpAndSettle();
 

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_log/data/repositories/dive_repository_i
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/core/constants/card_color.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/tissue_color_schemes.dart';
@@ -156,6 +157,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setDiveCenterListViewMode(ListViewMode mode) async =>
       state = state.copyWith(diveCenterListViewMode: mode);
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
   @override
   Future<void> setCardColorGradientPreset(String preset) async =>
       state = state.copyWith(cardColorGradientPreset: preset);

--- a/test/features/trips/presentation/pages/trip_detail_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -830,6 +831,10 @@ void main() {
 class _MockSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _MockSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -4,6 +4,7 @@ import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -152,6 +153,9 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setDiveCenterListViewMode(ListViewMode mode) async =>
       state = state.copyWith(diveCenterListViewMode: mode);
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
   @override
   Future<void> setCardColorGradientPreset(String preset) async =>
       state = state.copyWith(cardColorGradientPreset: preset);

--- a/test/l10n/localization_test.dart
+++ b/test/l10n/localization_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/app.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -326,6 +327,10 @@ class _DirectionTestWidget extends StatelessWidget {
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/shared/providers/table_details_pane_provider_test.dart
+++ b/test/shared/providers/table_details_pane_provider_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/table_details_pane_provider.dart';
@@ -7,6 +8,10 @@ import 'package:submersion/shared/providers/table_details_pane_provider.dart';
 class _MockSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _MockSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/shared/widgets/table_mode_layout/table_mode_layout_test.dart
+++ b/test/shared/widgets/table_mode_layout/table_mode_layout_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -17,6 +18,10 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
     String sectionKey,
     bool value,
   ) async {}
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);


### PR DESCRIPTION
## Summary
- Supersedes #193, which was merged and then reverted due to a local merge flow that bypassed the normal PR UI.
- Restores the full map-style-selector feature from Jaibar's rebased branch, including tile-source attribution rendering on every `FlutterMap` and the const/format follow-ups.
- Adds a v67 migration introducing `diver_settings.map_style` (default `openStreetMap`).

## What's included
- Original PR #193 content: `MapStyle` constants, tile URL providers, Appearance settings row, 11 locales, migration.
- New since #193: `map_attribution.dart` widget + test, attribution rendering wired into all `FlutterMap` callsites, `_osmTileUrl` → `_tileUrl` rename.

## Test plan
- [ ] CI passes (unit, analyze, format)
- [ ] Fresh-install: default map style is OpenStreetMap with visible attribution
- [ ] Change style in Settings → Appearance → Map Style; verify tiles swap on Dive Sites map
- [ ] Change to Satellite; verify Esri attribution updates accordingly
- [ ] Upgrade path: existing DB migrates to v67 cleanly with `map_style='openStreetMap'`