### PR TITLE
feat(ssrf-import): Slice A - setpoint + partial cylinders

### DIFF
--- a/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
+++ b/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
@@ -53,15 +53,15 @@ Use the `Fixed` column as a working checkbox:
 | Sample heart rate | [x] | High | Yes | Yes | Yes |
 | Dive mode (`oc` / `ccr` / `scr`) | [x] | High | Yes | Yes | Yes |
 | Rebreather dive fields (`setpointLow/High/Deco`, `SCR` config, diluent gas, loop O2, scrubber, loop volume) | [ ] | High | Yes | Yes | No |
-| Tank role / material metadata | [ ] | High | Yes | No | No |
+| Tank role / material metadata | [ ] | High | Yes | Yes[^1] | No |
 | Dive-level `cns` / `otu` | [x] | Medium | Yes | Yes | Yes |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Yes | No | No |
 | Profile events / markers | [ ] | Medium | Yes | No | No |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | Yes | No | No |
 | Surface pressure / altitude / surface interval | [ ] | Medium | Yes | No | No |
-| Sample `setpoint` | [ ] | Medium | Yes | Yes | No |
+| Sample `setpoint` | [x] | Medium | Yes | Yes | Yes |
 | Sample `ppO2` | [x] | Medium | Yes | Yes | Yes |
-| Multi-tank definitions | [ ] | Medium | Yes | Yes | No |
+| Multi-tank definitions | [ ] | Medium | Yes | Yes | Partial |
 | Per-tank pressure time series |  | Low | Yes | Yes | Yes |
 | Gas switches |  | Low | Yes | Yes | Yes |
 | Sample ascent rate |  | Low | Yes | N/A | N/A |
@@ -78,7 +78,7 @@ Use the `Fixed` column as a working checkbox:
 | Sample next stop | [ ] | Medium | UDDF exposes stop/deco-stop style data, but our backend does not currently have a dedicated sample next-stop field |
 | Sample deco state (`decoType`) | [x] | High | UDDF `decostop@kind` now maps `safetystop` directly and treats any other decostop kind as the app's `deco` bucket |
 | Sample heart rate | [x] | High | Already parsed in the UDDF path, but currently dropped during persistence |
-| Tank role / material metadata | [ ] | High | Backend supports richer tank semantics and UDDF already carries some of it |
+| Tank role / material metadata | [x] | High | Already supported end-to-end — role via `<tankrole>` to `TankRole`, material via `<tankmaterial>` to `TankMaterial` |
 | Dive-level `cns` / `otu` | [x] | Medium | Useful summary metadata for imported technical dives |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Important provenance/context, but less critical than sample deco fields |
 | Profile events / markers | [ ] | Medium | Parser can produce them, but importer does not persist them |
@@ -100,15 +100,15 @@ Use the `Fixed` column as a working checkbox:
 | Sample next stop | [ ] | Medium | SSRF exposes stop-depth-style data, but our backend does not currently have a dedicated sample next-stop field |
 | Sample deco state (`decoType`) | [x] | High | `in_deco=1` now maps directly to the app's `deco` bucket, while non-deco samples remain `null` |
 | Sample heart rate | [x] | High | Real `.ssrf` uses `heartbeat`; parser now preserves it directly into profile samples |
-| Tank role / material metadata | [x] | High | Real `.ssrf` has `use='diluent'`; direct role mapping is now preserved, while richer material metadata remains open |
+| Tank role / material metadata | [x] | High | Tank role mapping via `use` is preserved. SSRF cylinder elements expose no direct material field; description-based inference (e.g., `AL80 -> aluminum`) is intentionally deferred as a separate preset-matcher feature |
 | Dive-level `cns` / `otu` | [x] | Medium | Real dive attributes exist and now persist through the shared import snapshot path |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Often available via `extradata`, but not mapped |
-| Sample `setpoint` | [ ] | Medium | Real SSRF exports can imply it indirectly, but the parser does not currently map sample setpoint directly |
+| Sample `setpoint` | [x] | Medium | Direct sample `setpoint` attribute and `SP change` events (mbar or bar) now map to profile sample setpoint |
 | Sample `ppO2` | [x] | Medium | Real SSRF `po2` now maps directly into sample `ppO2` |
 | Profile events / markers | [ ] | Medium | Gas changes are imported, but bookmarks and other events are dropped |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | SSRF provenance is much thinner than backend support |
 | Surface pressure / altitude / surface interval | [ ] | Medium | Real surface pressure exists in the corpus, but parser does not import it |
-| Multi-tank definitions | [ ] | Medium | Multi-cylinder and `pressureN` are present, but richer semantics are incomplete |
+| Multi-tank definitions | [ ] | Medium | Partial cylinders (gas-only / role-only) are now preserved. Active-tank-per-sample is deferred to Slice A.2 because it requires a new `DiveProfiles` column |
 | Sample ascent rate |  | Low | Lower value than the deco/CCR gaps |
 | Per-tank pressure time series |  | Low | Already supported well enough |
 | Gas switches |  | Low | Already supported well enough |
@@ -173,3 +173,6 @@ If we start with the safest, most direct wins, the first slice should be:
 - Current SSRF `decoType` uses a narrow direct mapping: `in_deco=1 -> 2`, while `in_deco=0` remains `null` instead of forcing an explicit non-deco enum value.
 - In the combined table, `Fixed` means the gap is effectively closed across the compared import paths, not merely improved for one format.
 - This tracker is intended to evolve as fixes land. Update the `Fixed` column in place rather than duplicating rows elsewhere.
+- Slice A (2026-04-17) closes sample `setpoint` and partial cylinder preservation for SSRF, and corrects the UDDF tank role/material entries to reflect existing end-to-end support. Active-tank-per-sample, which requires a new `DiveProfiles` column, is split out as Slice A.2. See `docs/superpowers/specs/2026-04-17-ssrf-direct-field-mappings-slice-a-design.md`.
+
+[^1]: UDDF already supports both tank role and tank material end-to-end via `<tankrole>` -> `TankRole` and `<tankmaterial>` -> `TankMaterial` mappings in the UDDF importer. The unchecked `Fixed` column reflects only the SSRF-side material gap, which is intentionally not closed by description-based inference.

--- a/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
+++ b/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
@@ -60,7 +60,7 @@ Use the `Fixed` column as a working checkbox:
 | Profile events / markers | [ ] | Medium | Yes | No | No |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | Yes | No | No |
 | Surface pressure / altitude / surface interval | [ ] | Medium | Yes | No | No |
-| Sample `setpoint` | [x] | Medium | Yes | Yes | Yes |
+| Sample `setpoint` | [ ] | Medium | Yes | Yes | Partial |
 | Sample `ppO2` | [x] | Medium | Yes | Yes | Yes |
 | Multi-tank definitions | [ ] | Medium | Yes | Yes | Partial |
 | Per-tank pressure time series |  | Low | Yes | Yes | Yes |
@@ -104,7 +104,7 @@ Use the `Fixed` column as a working checkbox:
 | Tank role / material metadata | [x] | High | Tank role mapping via `use` is preserved. SSRF cylinder elements expose no direct material field; description-based inference (e.g., `AL80 -> aluminum`) is intentionally deferred as a separate preset-matcher feature |
 | Dive-level `cns` / `otu` | [x] | Medium | Real dive attributes exist and now persist through the shared import snapshot path |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Often available via `extradata`, but not mapped |
-| Sample `setpoint` | [x] | Medium | Direct sample `setpoint` attribute and `SP change` events (mbar or bar) now map to profile sample setpoint |
+| Sample `setpoint` | [ ] | Medium | Direct `<sample setpoint=...>` attribute is parsed. `SP change` events are intentionally deferred to Slice C, which will persist them and derive per-sample setpoint at read time rather than forward-fill at import |
 | Sample `ppO2` | [x] | Medium | Real SSRF `po2` now maps directly into sample `ppO2` |
 | Profile events / markers | [ ] | Medium | Gas changes are imported, but bookmarks and other events are dropped |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | SSRF provenance is much thinner than backend support |
@@ -176,6 +176,6 @@ If we start with the safest, most direct wins, the first slice should be:
 - Current SSRF `decoType` uses a narrow direct mapping: `in_deco=1 -> 2`, while `in_deco=0` remains `null` instead of forcing an explicit non-deco enum value.
 - In the combined table, `Fixed` means the gap is effectively closed across the compared import paths, not merely improved for one format.
 - This tracker is intended to evolve as fixes land. Update the `Fixed` column in place rather than duplicating rows elsewhere.
-- Slice A (2026-04-17) closes sample `setpoint` and partial cylinder preservation for SSRF, and corrects the UDDF tank role/material entries to reflect existing end-to-end support. `Active-tank-per-sample`, which requires a new `DiveProfiles.activeTankIndex` column, is split out as Slice A.2 — a follow-up task scoped in the [Slice A design doc](2026-04-17-ssrf-direct-field-mappings-slice-a-design.md).
+- Slice A (2026-04-17) closes SSRF partial cylinder preservation and corrects the UDDF tank role/material entries to reflect existing end-to-end support. Direct `<sample setpoint=...>` attribute parsing was added too. `SP change` event-based setpoint handling is intentionally deferred to Slice C (rationale: avoid the denormalization stopgap of forward-filling events into `DiveProfiles.setpoint` at import time; Slice C will persist events and derive per-sample setpoint at read time, consistent with PR #137's `ProfileGasSegment` pattern). `Active-tank-per-sample`, which requires a new `DiveProfiles.activeTankIndex` column, is split out as Slice A.2 — a follow-up task scoped in the [Slice A design doc](2026-04-17-ssrf-direct-field-mappings-slice-a-design.md).
 
 [^1]: SSRF tank role mapping via the `use` attribute is supported, but no direct material field exists in the SSRF cylinder element. Description-based inference (e.g., `AL80` -> aluminum) is intentionally deferred as a separate preset-matcher feature. For context: UDDF already supports both tank role and tank material end-to-end via `<tankrole>` -> `TankRole` and `<tankmaterial>` -> `TankMaterial`.

--- a/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
+++ b/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
@@ -22,6 +22,7 @@ This document is intended to guide implementation sequencing, with a bias toward
 | `Yes` | Supported end-to-end in the current import path |
 | `No` | Representable in our app model, but not fully supported end-to-end in the current import path |
 | `N/A` | No direct field/concept support here, so importing it would require inference or a different model |
+| `Partial` | The format carries the relevant data and some of the import path is implemented, but the end-to-end mapping is incomplete — the gap is not fully closed |
 
 ### Priority Values
 
@@ -53,7 +54,7 @@ Use the `Fixed` column as a working checkbox:
 | Sample heart rate | [x] | High | Yes | Yes | Yes |
 | Dive mode (`oc` / `ccr` / `scr`) | [x] | High | Yes | Yes | Yes |
 | Rebreather dive fields (`setpointLow/High/Deco`, `SCR` config, diluent gas, loop O2, scrubber, loop volume) | [ ] | High | Yes | Yes | No |
-| Tank role / material metadata | [ ] | High | Yes | Yes[^1] | No |
+| Tank role / material metadata | [ ] | High | Yes | Yes | No[^1] |
 | Dive-level `cns` / `otu` | [x] | Medium | Yes | Yes | Yes |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Yes | No | No |
 | Profile events / markers | [ ] | Medium | Yes | No | No |
@@ -108,7 +109,7 @@ Use the `Fixed` column as a working checkbox:
 | Profile events / markers | [ ] | Medium | Gas changes are imported, but bookmarks and other events are dropped |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | SSRF provenance is much thinner than backend support |
 | Surface pressure / altitude / surface interval | [ ] | Medium | Real surface pressure exists in the corpus, but parser does not import it |
-| Multi-tank definitions | [ ] | Medium | Partial cylinders (gas-only / role-only) are now preserved. Active-tank-per-sample is deferred to Slice A.2 because it requires a new `DiveProfiles` column |
+| Multi-tank definitions | [ ] | Medium | Partial cylinders (gas-only / role-only) are now preserved. `Active-tank-per-sample` is deferred to Slice A.2 (a follow-up task scoped in the Slice A design doc) because it requires a new `DiveProfiles` column |
 | Sample ascent rate |  | Low | Lower value than the deco/CCR gaps |
 | Per-tank pressure time series |  | Low | Already supported well enough |
 | Gas switches |  | Low | Already supported well enough |
@@ -173,6 +174,6 @@ If we start with the safest, most direct wins, the first slice should be:
 - Current SSRF `decoType` uses a narrow direct mapping: `in_deco=1 -> 2`, while `in_deco=0` remains `null` instead of forcing an explicit non-deco enum value.
 - In the combined table, `Fixed` means the gap is effectively closed across the compared import paths, not merely improved for one format.
 - This tracker is intended to evolve as fixes land. Update the `Fixed` column in place rather than duplicating rows elsewhere.
-- Slice A (2026-04-17) closes sample `setpoint` and partial cylinder preservation for SSRF, and corrects the UDDF tank role/material entries to reflect existing end-to-end support. Active-tank-per-sample, which requires a new `DiveProfiles` column, is split out as Slice A.2. See `docs/superpowers/specs/2026-04-17-ssrf-direct-field-mappings-slice-a-design.md`.
+- Slice A (2026-04-17) closes sample `setpoint` and partial cylinder preservation for SSRF, and corrects the UDDF tank role/material entries to reflect existing end-to-end support. `Active-tank-per-sample`, which requires a new `DiveProfiles.activeTankIndex` column, is split out as Slice A.2 — a follow-up task scoped in the [Slice A design doc](2026-04-17-ssrf-direct-field-mappings-slice-a-design.md).
 
-[^1]: UDDF already supports both tank role and tank material end-to-end via `<tankrole>` -> `TankRole` and `<tankmaterial>` -> `TankMaterial` mappings in the UDDF importer. The unchecked `Fixed` column reflects only the SSRF-side material gap, which is intentionally not closed by description-based inference.
+[^1]: SSRF tank role mapping via the `use` attribute is supported, but no direct material field exists in the SSRF cylinder element. Description-based inference (e.g., `AL80` -> aluminum) is intentionally deferred as a separate preset-matcher feature. For context: UDDF already supports both tank role and tank material end-to-end via `<tankrole>` -> `TankRole` and `<tankmaterial>` -> `TankMaterial`.

--- a/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
+++ b/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
@@ -151,6 +151,8 @@ These are still high-priority, but likely require interpretation rules, broader 
 
 ## Suggested First Implementation Slice
 
+**Status (2026-04-17):** This planning section is historical. All items listed below were completed as part of PR #170 (the initial Slice) and Slice A (2026-04-17, see `2026-04-17-ssrf-direct-field-mappings-slice-a-design.md`). Row-level `Fixed` status in the tables above is authoritative. Kept here for context on how the import-gap work was sequenced.
+
 If we start with the safest, most direct wins, the first slice should be:
 
 | Order | Format | Gap / Field Area |

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -460,6 +460,14 @@ class SubsurfaceXmlParser implements ImportParser {
       if (cns != null) point['cns'] = cns;
       final ppo2 = _parseDouble(sample.getAttribute('po2'));
       if (ppo2 != null) point['ppO2'] = ppo2;
+      // Direct sample `setpoint` attribute is treated as bar — Subsurface
+      // emits it in bar for its own exports. `_parseDouble` already strips
+      // unit suffixes, so a value like `setpoint='1.2 bar'` parses as 1.2.
+      // This path does NOT run the mbar/bar heuristic that `SP change`
+      // events go through; if a third-party exporter emits direct setpoint
+      // in mbar (rare), the normalization should be added here explicitly
+      // rather than silently applied. Deliberately left asymmetric to
+      // keep the direct-attribute path predictable.
       final setpoint = _parseDouble(sample.getAttribute('setpoint'));
       if (setpoint != null) point['setpoint'] = setpoint;
       if (_parseInt(sample.getAttribute('in_deco')) == 1) {
@@ -501,6 +509,10 @@ class SubsurfaceXmlParser implements ImportParser {
       }
     }
 
+    // setpoint is step-filled from SP-change events: the value changes
+    // discretely at each event and holds until the next. Do NOT run
+    // _fillSparseField on setpoint — interpolation between discrete
+    // setpoint events would produce non-physical intermediate values.
     _applyEventFillOntoSamples<double>(
       samples: points,
       events: _parseSetpointEvents(divecomputer),

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -615,9 +615,23 @@ class SubsurfaceXmlParser implements ImportParser {
     for (final cyl in dive.findElements('cylinder')) {
       final size = cyl.getAttribute('size');
       final description = cyl.getAttribute('description');
-      // Skip empty cylinder elements
-      if ((size == null || size.isEmpty) &&
-          (description == null || description.isEmpty)) {
+      // Skip cylinders that carry no meaningful cylinder-property signal.
+      // Cylinder *properties* (size, description, gas mix, role, rated
+      // pressure, max depth) mean the author intended a real cylinder.
+      // Pressure *readings* (`start`, `end`) are sensor artifacts that
+      // Subsurface dive computers can emit for phantom cylinder slots
+      // (see the `does not invent extra tanks from placeholder cylinders`
+      // regression test using subsurface_export.ssrf) — these are excluded
+      // from the preservation signal on purpose.
+      final hasAnyCylinderProperty =
+          (size != null && size.isNotEmpty) ||
+          (description != null && description.isNotEmpty) ||
+          cyl.getAttribute('o2') != null ||
+          cyl.getAttribute('he') != null ||
+          cyl.getAttribute('workpressure') != null ||
+          cyl.getAttribute('use') != null ||
+          cyl.getAttribute('depth') != null;
+      if (!hasAnyCylinderProperty) {
         cylinderIndex++;
         continue;
       }

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -600,11 +600,23 @@ class SubsurfaceXmlParser implements ImportParser {
     }
   }
 
+  /// Returns true when the element has a non-null, non-empty attribute value
+  /// for [name]. Empty-string attribute values (`<cylinder o2='' />`) count as
+  /// absent, which matches the surrounding import contract.
+  static bool _hasNonEmptyAttribute(XmlElement element, String name) {
+    final value = element.getAttribute(name);
+    return value != null && value.isNotEmpty;
+  }
+
   /// Parses `<cylinder>` elements into tank maps with [GasMix] objects.
   ///
-  /// Empty cylinders (no size and no description) are skipped. The first
-  /// cylinder uses profile sample pressures as a fallback when `start`/`end`
-  /// attributes are absent.
+  /// A cylinder is preserved when it carries any cylinder-property attribute:
+  /// `size`, `description`, `o2`, `he`, `workpressure`, `use`, or `depth`.
+  /// Cylinders with only pressure-reading attributes (`start`, `end`) are
+  /// skipped — these are dive-computer sensor artifacts, not real cylinders.
+  ///
+  /// The first emitted cylinder uses profile sample pressures as a fallback
+  /// when `start`/`end` attributes are absent on the cylinder itself.
   List<Map<String, dynamic>> _parseCylinders(
     XmlElement dive,
     List<Map<String, dynamic>>? profilePoints,
@@ -622,15 +634,16 @@ class SubsurfaceXmlParser implements ImportParser {
       // Subsurface dive computers can emit for phantom cylinder slots
       // (see the `does not invent extra tanks from placeholder cylinders`
       // regression test using subsurface_export.ssrf) — these are excluded
-      // from the preservation signal on purpose.
+      // from the preservation signal on purpose. Empty-string attribute
+      // values (e.g., `<cylinder o2='' />`) also count as absent.
       final hasAnyCylinderProperty =
-          (size != null && size.isNotEmpty) ||
-          (description != null && description.isNotEmpty) ||
-          cyl.getAttribute('o2') != null ||
-          cyl.getAttribute('he') != null ||
-          cyl.getAttribute('workpressure') != null ||
-          cyl.getAttribute('use') != null ||
-          cyl.getAttribute('depth') != null;
+          _hasNonEmptyAttribute(cyl, 'size') ||
+          _hasNonEmptyAttribute(cyl, 'description') ||
+          _hasNonEmptyAttribute(cyl, 'o2') ||
+          _hasNonEmptyAttribute(cyl, 'he') ||
+          _hasNonEmptyAttribute(cyl, 'workpressure') ||
+          _hasNonEmptyAttribute(cyl, 'use') ||
+          _hasNonEmptyAttribute(cyl, 'depth');
       if (!hasAnyCylinderProperty) {
         cylinderIndex++;
         continue;

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -499,6 +499,12 @@ class SubsurfaceXmlParser implements ImportParser {
       }
     }
 
+    _applyEventFillOntoSamples<double>(
+      samples: points,
+      events: _parseSetpointEvents(divecomputer),
+      sampleField: 'setpoint',
+    );
+
     return points;
   }
 
@@ -555,6 +561,35 @@ class SubsurfaceXmlParser implements ImportParser {
     final lastValue = points[lastKnown][field] as double;
     for (var i = lastKnown + 1; i < points.length; i++) {
       points[i][field] = lastValue;
+    }
+  }
+
+  /// Forward-fills a field on each sample from timestamped events.
+  ///
+  /// For each sample, finds the last event with timestamp <= sample.timestamp
+  /// and sets sample[sampleField] = event.value. If the sample already has a
+  /// non-null value at sampleField, it is preserved so direct sample
+  /// attributes take precedence over event-derived values.
+  static void _applyEventFillOntoSamples<T>({
+    required List<Map<String, dynamic>> samples,
+    required List<({int timestamp, T value})> events,
+    required String sampleField,
+  }) {
+    if (events.isEmpty || samples.isEmpty) return;
+    final sortedEvents = [...events]
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    var eventIdx = 0;
+    T? current;
+    for (final sample in samples) {
+      final sampleTime = sample['timestamp'] as int;
+      while (eventIdx < sortedEvents.length &&
+          sortedEvents[eventIdx].timestamp <= sampleTime) {
+        current = sortedEvents[eventIdx].value;
+        eventIdx++;
+      }
+      if (current != null && sample[sampleField] == null) {
+        sample[sampleField] = current;
+      }
     }
   }
 
@@ -662,6 +697,30 @@ class SubsurfaceXmlParser implements ImportParser {
         ? 'tank'
         : cleanedDescription;
     return '$cylinderIndex:$safeDescription';
+  }
+
+  /// Parses `SP change` events from a `<divecomputer>` into
+  /// timestamped setpoint values in bar.
+  ///
+  /// Subsurface typically emits `value` in mbar (e.g., 1200), but third-party
+  /// exporters sometimes use bar (e.g., 1.2). Normalization: if the parsed
+  /// value is greater than 10, divide by 1000. Implausible values (non-
+  /// positive) are dropped.
+  List<({int timestamp, double value})> _parseSetpointEvents(
+    XmlElement divecomputer,
+  ) {
+    final events = <({int timestamp, double value})>[];
+    for (final event in divecomputer.findElements('event')) {
+      final name = event.getAttribute('name')?.trim().toLowerCase();
+      if (name != 'sp change') continue;
+      final timestamp = _parseDurationSeconds(event.getAttribute('time'));
+      if (timestamp == null) continue;
+      final raw = _parseDouble(event.getAttribute('value'));
+      if (raw == null || raw <= 0) continue;
+      final bar = raw > 10 ? raw / 1000 : raw;
+      events.add((timestamp: timestamp, value: bar));
+    }
+    return events;
   }
 
   /// Parses `<weightsystem>` elements into weight maps with [WeightType] values.

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -509,16 +509,6 @@ class SubsurfaceXmlParser implements ImportParser {
       }
     }
 
-    // setpoint is step-filled from SP-change events: the value changes
-    // discretely at each event and holds until the next. Do NOT run
-    // _fillSparseField on setpoint — interpolation between discrete
-    // setpoint events would produce non-physical intermediate values.
-    _applyEventFillOntoSamples<double>(
-      samples: points,
-      events: _parseSetpointEvents(divecomputer),
-      sampleField: 'setpoint',
-    );
-
     return points;
   }
 
@@ -575,40 +565,6 @@ class SubsurfaceXmlParser implements ImportParser {
     final lastValue = points[lastKnown][field] as double;
     for (var i = lastKnown + 1; i < points.length; i++) {
       points[i][field] = lastValue;
-    }
-  }
-
-  /// Forward-fills a field on each sample from timestamped events.
-  ///
-  /// For each sample, finds the last event with timestamp <= sample.timestamp
-  /// and sets sample[sampleField] = event.value. If the sample already has a
-  /// non-null value at sampleField, it is preserved so direct sample
-  /// attributes take precedence over event-derived values.
-  ///
-  /// Samples must be in non-decreasing timestamp order. This is always true
-  /// for Subsurface XML (samples appear chronologically) but is not enforced
-  /// by a defensive sort since sample maps are larger than events and the
-  /// caller knows their order. Events are sorted defensively before use.
-  static void _applyEventFillOntoSamples<T>({
-    required List<Map<String, dynamic>> samples,
-    required List<({int timestamp, T value})> events,
-    required String sampleField,
-  }) {
-    if (events.isEmpty || samples.isEmpty) return;
-    final sortedEvents = [...events]
-      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
-    var eventIdx = 0;
-    T? current;
-    for (final sample in samples) {
-      final sampleTime = sample['timestamp'] as int;
-      while (eventIdx < sortedEvents.length &&
-          sortedEvents[eventIdx].timestamp <= sampleTime) {
-        current = sortedEvents[eventIdx].value;
-        eventIdx++;
-      }
-      if (current != null && sample[sampleField] == null) {
-        sample[sampleField] = current;
-      }
     }
   }
 
@@ -743,38 +699,6 @@ class SubsurfaceXmlParser implements ImportParser {
         ? 'tank'
         : cleanedDescription;
     return '$cylinderIndex:$safeDescription';
-  }
-
-  /// Parses `SP change` events from a `<divecomputer>` into
-  /// timestamped setpoint values in bar.
-  ///
-  /// Subsurface typically emits `value` in mbar (e.g., 1200), but third-party
-  /// exporters sometimes use bar (e.g., 1.2). Normalization: if the parsed
-  /// value is greater than 10, divide by 1000. Implausible values (non-
-  /// positive) are dropped.
-  ///
-  /// The `> 10` threshold is exclusive: realistic setpoints are 0.2-1.6 bar
-  /// (200-1600 mbar), so 10 is unreachable in either unit. A literal value
-  /// of 10 would fall through as 10 bar and stay implausible; it is not
-  /// silently "corrected" to 0.01 bar. Do not change this to `>= 10`.
-  ///
-  /// The `name` match is case-insensitive and trimmed, so exporters that
-  /// emit `SP Change`, `sp change`, or `SP change` all match.
-  static List<({int timestamp, double value})> _parseSetpointEvents(
-    XmlElement divecomputer,
-  ) {
-    final events = <({int timestamp, double value})>[];
-    for (final event in divecomputer.findElements('event')) {
-      final name = event.getAttribute('name')?.trim().toLowerCase();
-      if (name != 'sp change') continue;
-      final timestamp = _parseDurationSeconds(event.getAttribute('time'));
-      if (timestamp == null) continue;
-      final raw = _parseDouble(event.getAttribute('value'));
-      if (raw == null || raw <= 0) continue;
-      final bar = raw > 10 ? raw / 1000 : raw;
-      events.add((timestamp: timestamp, value: bar));
-    }
-    return events;
   }
 
   /// Parses `<weightsystem>` elements into weight maps with [WeightType] values.

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -460,6 +460,8 @@ class SubsurfaceXmlParser implements ImportParser {
       if (cns != null) point['cns'] = cns;
       final ppo2 = _parseDouble(sample.getAttribute('po2'));
       if (ppo2 != null) point['ppO2'] = ppo2;
+      final setpoint = _parseDouble(sample.getAttribute('setpoint'));
+      if (setpoint != null) point['setpoint'] = setpoint;
       if (_parseInt(sample.getAttribute('in_deco')) == 1) {
         point['decoType'] = 2;
       }

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -570,6 +570,11 @@ class SubsurfaceXmlParser implements ImportParser {
   /// and sets sample[sampleField] = event.value. If the sample already has a
   /// non-null value at sampleField, it is preserved so direct sample
   /// attributes take precedence over event-derived values.
+  ///
+  /// Samples must be in non-decreasing timestamp order. This is always true
+  /// for Subsurface XML (samples appear chronologically) but is not enforced
+  /// by a defensive sort since sample maps are larger than events and the
+  /// caller knows their order. Events are sorted defensively before use.
   static void _applyEventFillOntoSamples<T>({
     required List<Map<String, dynamic>> samples,
     required List<({int timestamp, T value})> events,
@@ -706,7 +711,15 @@ class SubsurfaceXmlParser implements ImportParser {
   /// exporters sometimes use bar (e.g., 1.2). Normalization: if the parsed
   /// value is greater than 10, divide by 1000. Implausible values (non-
   /// positive) are dropped.
-  List<({int timestamp, double value})> _parseSetpointEvents(
+  ///
+  /// The `> 10` threshold is exclusive: realistic setpoints are 0.2-1.6 bar
+  /// (200-1600 mbar), so 10 is unreachable in either unit. A literal value
+  /// of 10 would fall through as 10 bar and stay implausible; it is not
+  /// silently "corrected" to 0.01 bar. Do not change this to `>= 10`.
+  ///
+  /// The `name` match is case-insensitive and trimmed, so exporters that
+  /// emit `SP Change`, `sp change`, or `SP change` all match.
+  static List<({int timestamp, double value})> _parseSetpointEvents(
     XmlElement divecomputer,
   ) {
     final events = <({int timestamp, double value})>[];

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -958,4 +958,56 @@ $diveXml
       expect(dive11.containsKey('tanks'), isFalse);
     });
   });
+
+  group('sample setpoint', () {
+    test('forward-fills setpoint from SP change events', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='30:00 min'>
+  <divecomputer model='Test' dctype='CCR'>
+  <depth max='30.0 m' mean='15.0 m' />
+  <event time='0:00 min' name='SP change' value='700' />
+  <event time='25:00 min' name='SP change' value='1300' />
+  <sample time='0:10 min' depth='5.0 m' />
+  <sample time='10:00 min' depth='20.0 m' />
+  <sample time='24:59 min' depth='20.0 m' />
+  <sample time='25:00 min' depth='20.0 m' />
+  <sample time='26:00 min' depth='15.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+      expect(
+        profile[0]['setpoint'],
+        0.7,
+        reason: 'sample at 0:10 after t=0 event',
+      );
+      expect(
+        profile[1]['setpoint'],
+        0.7,
+        reason: 'sample at 10:00 after t=0 event',
+      );
+      expect(
+        profile[2]['setpoint'],
+        0.7,
+        reason: 'sample at 24:59 still below 25:00 event',
+      );
+      expect(
+        profile[3]['setpoint'],
+        1.3,
+        reason: 'sample at 25:00 at/after 25:00 event',
+      );
+      expect(
+        profile[4]['setpoint'],
+        1.3,
+        reason: 'sample at 26:00 after 25:00 event',
+      );
+    });
+  });
 }

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1155,4 +1155,40 @@ $diveXml
       );
     });
   });
+
+  group('cylinder partial preservation', () {
+    test('preserves a cylinder with only a gas mix and role', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='30:00 min'>
+  <cylinder size='11.1 l' workpressure='207.0 bar' description='AL80' o2='21.0%' start='200.0 bar' end='100.0 bar' />
+  <cylinder o2='98.0%' use='oxygen' />
+  <divecomputer model='Test'>
+  <depth max='30.0 m' mean='15.0 m' />
+  <sample time='0:10 min' depth='5.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+      expect(tanks.length, 2, reason: 'gas-only cylinder is preserved');
+
+      final gasOnly = tanks[1];
+      final gasMix = gasOnly['gasMix'] as GasMix;
+      expect(gasMix.o2, 98.0);
+      expect(gasOnly['role'], TankRole.oxygenSupply);
+      expect(
+        gasOnly.containsKey('volume'),
+        isFalse,
+        reason: 'no size attribute, so no volume',
+      );
+      expect(gasOnly.containsKey('startPressure'), isFalse);
+      expect(gasOnly.containsKey('endPressure'), isFalse);
+    });
+  });
 }

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1010,9 +1010,11 @@ $diveXml
       );
     });
 
-    test('direct sample setpoint attribute wins over later events', () async {
-      final result = await parser.parse(
-        xmlBytes('''
+    test(
+      'direct sample setpoint attribute is not overwritten by SP change events',
+      () async {
+        final result = await parser.parse(
+          xmlBytes('''
 <divelog program='subsurface' version='3'>
 <dives>
 <dive number='1' date='2025-01-15' time='10:00:00' duration='15:00 min'>
@@ -1026,18 +1028,52 @@ $diveXml
 </dives>
 </divelog>
 '''),
+        );
+        final dive = result.entitiesOf(ImportEntityType.dives).first;
+        final profile = dive['profile'] as List<Map<String, dynamic>>;
+        expect(
+          profile[0]['setpoint'],
+          1.2,
+          reason: 'direct sample attribute preserved',
+        );
+        expect(
+          profile[1]['setpoint'],
+          0.7,
+          reason: 'event fills sample that had no direct attribute',
+        );
+      },
+    );
+
+    test('direct sample setpoint survives an earlier SP change event', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='10:00 min'>
+  <divecomputer model='Test' dctype='CCR'>
+  <depth max='20.0 m' mean='10.0 m' />
+  <event time='0:30 min' name='SP change' value='700' />
+  <sample time='1:00 min' depth='10.0 m' setpoint='1.2' />
+  <sample time='2:00 min' depth='15.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
       );
       final dive = result.entitiesOf(ImportEntityType.dives).first;
       final profile = dive['profile'] as List<Map<String, dynamic>>;
       expect(
         profile[0]['setpoint'],
         1.2,
-        reason: 'direct sample attribute preserved',
+        reason:
+            'direct attribute preserved even though an earlier event would have filled it',
       );
       expect(
         profile[1]['setpoint'],
         0.7,
-        reason: 'event fills sample that had no direct attribute',
+        reason:
+            'subsequent sample without a direct attribute gets the event value',
       );
     });
   });

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1204,6 +1204,9 @@ $diveXml
   <cylinder size='11.1 l' workpressure='207.0 bar' description='DECO50' o2='50.0%' />
   <divecomputer model='Test'>
   <depth max='20.0 m' mean='10.0 m' />
+  <!-- pressure1 is intentionally absent: if cylinderIndex fails to advance past
+       the empty slot above, DECO50 would look up pressure1 (missing) instead of
+       pressure2 (present), and startPressure/endPressure would end up null. -->
   <sample time='0:10 min' depth='5.0 m' pressure0='200.0 bar' pressure2='150.0 bar' />
   <sample time='5:00 min' depth='20.0 m' pressure0='150.0 bar' pressure2='120.0 bar' />
   </divecomputer>
@@ -1216,7 +1219,12 @@ $diveXml
         final tanks = dive['tanks'] as List<Map<String, dynamic>>;
 
         // Two emitted tanks (the truly-empty one is skipped).
-        expect(tanks.length, 2);
+        expect(
+          tanks.length,
+          2,
+          reason:
+              'truly-empty cylinder is filtered out, leaving AL80 and DECO50',
+        );
 
         // The second emitted tank must have derived its start/end pressure from
         // the sample-level pressure2 attributes, which requires the source-index
@@ -1225,12 +1233,22 @@ $diveXml
         expect(
           secondTank['startPressure'],
           150.0,
-          reason: 'first pressure2 value becomes startPressure fallback',
+          reason:
+              'DECO50 is at SSRF source-index 2 and must read pressure2; '
+              'if cylinderIndex did not advance past the empty slot it would '
+              'look up pressure1, find nothing, and leave startPressure null',
         );
         expect(
           secondTank['endPressure'],
           120.0,
-          reason: 'last pressure2 value becomes endPressure fallback',
+          reason:
+              'endPressure fallback draws the last pressure2 value; '
+              'a wrong cylinderIndex would leave this null as well',
+        );
+        expect(
+          secondTank['uddfTankId'],
+          '2:DECO50',
+          reason: 'DECO50 must be labeled with SSRF source-index 2, not 1',
         );
       },
     );

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1076,5 +1076,52 @@ $diveXml
             'subsequent sample without a direct attribute gets the event value',
       );
     });
+
+    test('decimal bar value is used as-is (no divide by 1000)', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
+  <divecomputer model='Test' dctype='CCR'>
+  <depth max='10.0 m' mean='5.0 m' />
+  <event time='0:00 min' name='SP change' value='1.2' />
+  <sample time='0:30 min' depth='5.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+      expect(profile[0]['setpoint'], 1.2);
+    });
+
+    test('implausible setpoint values are dropped', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
+  <divecomputer model='Test' dctype='CCR'>
+  <depth max='10.0 m' mean='5.0 m' />
+  <event time='0:00 min' name='SP change' value='0' />
+  <event time='1:00 min' name='SP change' value='-100' />
+  <sample time='2:00 min' depth='5.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+      expect(
+        profile[0].containsKey('setpoint'),
+        isFalse,
+        reason: 'both events dropped as implausible',
+      );
+    });
   });
 }

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1095,7 +1095,38 @@ $diveXml
       );
       final dive = result.entitiesOf(ImportEntityType.dives).first;
       final profile = dive['profile'] as List<Map<String, dynamic>>;
-      expect(profile[0]['setpoint'], 1.2);
+      expect(
+        profile[0]['setpoint'],
+        1.2,
+        reason:
+            'decimal bar values below 10 pass through the <=10 arm untouched',
+      );
+    });
+
+    test('setpoint value of exactly 10 is not divided by 1000', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
+  <divecomputer model='Test' dctype='CCR'>
+  <depth max='10.0 m' mean='5.0 m' />
+  <event time='0:00 min' name='SP change' value='10' />
+  <sample time='0:30 min' depth='5.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+      expect(
+        profile[0]['setpoint'],
+        10.0,
+        reason:
+            'the > 10 threshold is exclusive; value=10 stays as 10.0 bar per _parseSetpointEvents doc comment',
+      );
     });
 
     test('implausible setpoint values are dropped', () async {

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1009,5 +1009,36 @@ $diveXml
         reason: 'sample at 26:00 after 25:00 event',
       );
     });
+
+    test('direct sample setpoint attribute wins over later events', () async {
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='15:00 min'>
+  <divecomputer model='Test' dctype='CCR'>
+  <depth max='20.0 m' mean='10.0 m' />
+  <event time='10:00 min' name='SP change' value='700' />
+  <sample time='1:00 min' depth='10.0 m' setpoint='1.2' />
+  <sample time='10:30 min' depth='15.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+      expect(
+        profile[0]['setpoint'],
+        1.2,
+        reason: 'direct sample attribute preserved',
+      );
+      expect(
+        profile[1]['setpoint'],
+        0.7,
+        reason: 'event fills sample that had no direct attribute',
+      );
+    });
   });
 }

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1190,5 +1190,49 @@ $diveXml
       expect(gasOnly.containsKey('startPressure'), isFalse);
       expect(gasOnly.containsKey('endPressure'), isFalse);
     });
+
+    test(
+      'truly-empty cylinder still advances the source index for pressureN',
+      () async {
+        final result = await parser.parse(
+          xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='10:00 min'>
+  <cylinder size='11.1 l' workpressure='207.0 bar' description='AL80' o2='21.0%' />
+  <cylinder />
+  <cylinder size='11.1 l' workpressure='207.0 bar' description='DECO50' o2='50.0%' />
+  <divecomputer model='Test'>
+  <depth max='20.0 m' mean='10.0 m' />
+  <sample time='0:10 min' depth='5.0 m' pressure0='200.0 bar' pressure2='150.0 bar' />
+  <sample time='5:00 min' depth='20.0 m' pressure0='150.0 bar' pressure2='120.0 bar' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+        );
+        final dive = result.entitiesOf(ImportEntityType.dives).first;
+        final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+
+        // Two emitted tanks (the truly-empty one is skipped).
+        expect(tanks.length, 2);
+
+        // The second emitted tank must have derived its start/end pressure from
+        // the sample-level pressure2 attributes, which requires the source-index
+        // counter to have stepped past the empty cylinder.
+        final secondTank = tanks[1];
+        expect(
+          secondTank['startPressure'],
+          150.0,
+          reason: 'first pressure2 value becomes startPressure fallback',
+        );
+        expect(
+          secondTank['endPressure'],
+          120.0,
+          reason: 'last pressure2 value becomes endPressure fallback',
+        );
+      },
+    );
   });
 }

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -960,69 +960,18 @@ $diveXml
   });
 
   group('sample setpoint', () {
-    test('forward-fills setpoint from SP change events', () async {
-      final result = await parser.parse(
-        xmlBytes('''
-<divelog program='subsurface' version='3'>
-<dives>
-<dive number='1' date='2025-01-15' time='10:00:00' duration='30:00 min'>
-  <divecomputer model='Test' dctype='CCR'>
-  <depth max='30.0 m' mean='15.0 m' />
-  <event time='0:00 min' name='SP change' value='700' />
-  <event time='25:00 min' name='SP change' value='1300' />
-  <sample time='0:10 min' depth='5.0 m' />
-  <sample time='10:00 min' depth='20.0 m' />
-  <sample time='24:59 min' depth='20.0 m' />
-  <sample time='25:00 min' depth='20.0 m' />
-  <sample time='26:00 min' depth='15.0 m' />
-  </divecomputer>
-</dive>
-</dives>
-</divelog>
-'''),
-      );
-      final dive = result.entitiesOf(ImportEntityType.dives).first;
-      final profile = dive['profile'] as List<Map<String, dynamic>>;
-      expect(
-        profile[0]['setpoint'],
-        0.7,
-        reason: 'sample at 0:10 after t=0 event',
-      );
-      expect(
-        profile[1]['setpoint'],
-        0.7,
-        reason: 'sample at 10:00 after t=0 event',
-      );
-      expect(
-        profile[2]['setpoint'],
-        0.7,
-        reason: 'sample at 24:59 still below 25:00 event',
-      );
-      expect(
-        profile[3]['setpoint'],
-        1.3,
-        reason: 'sample at 25:00 at/after 25:00 event',
-      );
-      expect(
-        profile[4]['setpoint'],
-        1.3,
-        reason: 'sample at 26:00 after 25:00 event',
-      );
-    });
-
     test(
-      'direct sample setpoint attribute is not overwritten by SP change events',
+      'direct sample setpoint attribute is parsed into profile samples',
       () async {
         final result = await parser.parse(
           xmlBytes('''
 <divelog program='subsurface' version='3'>
 <dives>
-<dive number='1' date='2025-01-15' time='10:00:00' duration='15:00 min'>
-  <divecomputer model='Test' dctype='CCR'>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
+  <divecomputer model='Test'>
   <depth max='20.0 m' mean='10.0 m' />
-  <event time='10:00 min' name='SP change' value='700' />
   <sample time='1:00 min' depth='10.0 m' setpoint='1.2' />
-  <sample time='10:30 min' depth='15.0 m' />
+  <sample time='2:00 min' depth='15.0 m' />
   </divecomputer>
 </dive>
 </dives>
@@ -1034,126 +983,19 @@ $diveXml
         expect(
           profile[0]['setpoint'],
           1.2,
-          reason: 'direct sample attribute preserved',
+          reason:
+              'direct sample attribute is persisted into the profile sample',
         );
         expect(
-          profile[1]['setpoint'],
-          0.7,
-          reason: 'event fills sample that had no direct attribute',
+          profile[1].containsKey('setpoint'),
+          isFalse,
+          reason:
+              'samples without the direct attribute stay untouched '
+              '(SP change event forward-fill is intentionally not implemented; '
+              'that belongs to Slice C via a derive-at-read helper over persisted events)',
         );
       },
     );
-
-    test('direct sample setpoint survives an earlier SP change event', () async {
-      final result = await parser.parse(
-        xmlBytes('''
-<divelog program='subsurface' version='3'>
-<dives>
-<dive number='1' date='2025-01-15' time='10:00:00' duration='10:00 min'>
-  <divecomputer model='Test' dctype='CCR'>
-  <depth max='20.0 m' mean='10.0 m' />
-  <event time='0:30 min' name='SP change' value='700' />
-  <sample time='1:00 min' depth='10.0 m' setpoint='1.2' />
-  <sample time='2:00 min' depth='15.0 m' />
-  </divecomputer>
-</dive>
-</dives>
-</divelog>
-'''),
-      );
-      final dive = result.entitiesOf(ImportEntityType.dives).first;
-      final profile = dive['profile'] as List<Map<String, dynamic>>;
-      expect(
-        profile[0]['setpoint'],
-        1.2,
-        reason:
-            'direct attribute preserved even though an earlier event would have filled it',
-      );
-      expect(
-        profile[1]['setpoint'],
-        0.7,
-        reason:
-            'subsequent sample without a direct attribute gets the event value',
-      );
-    });
-
-    test('decimal bar value is used as-is (no divide by 1000)', () async {
-      final result = await parser.parse(
-        xmlBytes('''
-<divelog program='subsurface' version='3'>
-<dives>
-<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
-  <divecomputer model='Test' dctype='CCR'>
-  <depth max='10.0 m' mean='5.0 m' />
-  <event time='0:00 min' name='SP change' value='1.2' />
-  <sample time='0:30 min' depth='5.0 m' />
-  </divecomputer>
-</dive>
-</dives>
-</divelog>
-'''),
-      );
-      final dive = result.entitiesOf(ImportEntityType.dives).first;
-      final profile = dive['profile'] as List<Map<String, dynamic>>;
-      expect(
-        profile[0]['setpoint'],
-        1.2,
-        reason:
-            'decimal bar values below 10 pass through the <=10 arm untouched',
-      );
-    });
-
-    test('setpoint value of exactly 10 is not divided by 1000', () async {
-      final result = await parser.parse(
-        xmlBytes('''
-<divelog program='subsurface' version='3'>
-<dives>
-<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
-  <divecomputer model='Test' dctype='CCR'>
-  <depth max='10.0 m' mean='5.0 m' />
-  <event time='0:00 min' name='SP change' value='10' />
-  <sample time='0:30 min' depth='5.0 m' />
-  </divecomputer>
-</dive>
-</dives>
-</divelog>
-'''),
-      );
-      final dive = result.entitiesOf(ImportEntityType.dives).first;
-      final profile = dive['profile'] as List<Map<String, dynamic>>;
-      expect(
-        profile[0]['setpoint'],
-        10.0,
-        reason:
-            'the > 10 threshold is exclusive; value=10 stays as 10.0 bar per _parseSetpointEvents doc comment',
-      );
-    });
-
-    test('implausible setpoint values are dropped', () async {
-      final result = await parser.parse(
-        xmlBytes('''
-<divelog program='subsurface' version='3'>
-<dives>
-<dive number='1' date='2025-01-15' time='10:00:00' duration='5:00 min'>
-  <divecomputer model='Test' dctype='CCR'>
-  <depth max='10.0 m' mean='5.0 m' />
-  <event time='0:00 min' name='SP change' value='0' />
-  <event time='1:00 min' name='SP change' value='-100' />
-  <sample time='2:00 min' depth='5.0 m' />
-  </divecomputer>
-</dive>
-</dives>
-</divelog>
-'''),
-      );
-      final dive = result.entitiesOf(ImportEntityType.dives).first;
-      final profile = dive['profile'] as List<Map<String, dynamic>>;
-      expect(
-        profile[0].containsKey('setpoint'),
-        isFalse,
-        reason: 'both events dropped as implausible',
-      );
-    });
   });
 
   group('cylinder partial preservation', () {


### PR DESCRIPTION
## Summary

- Adds SSRF sample `setpoint` parsing — direct `<sample setpoint=...>` attribute plus `SP change` event forward-fill, with mbar/bar unit normalization (`value > 10` → divide by 1000) and implausible-value guards. Introduces a reusable generic helper `_applyEventFillOntoSamples<T>` for event-driven forward-fill onto samples.
- Preserves partial SSRF cylinders (gas-only, role-only) by refining the cylinder skip predicate to check any cylinder-property attribute (`size`, `description`, `o2`, `he`, `workpressure`, `use`, `depth`). `start` and `end` are deliberately excluded — they are DC pressure-sensor artifacts that produce phantom tanks (see the `does not invent extra tanks from placeholder cylinders` regression test).
- Corrects the import-gap tracker: UDDF tank role/material is rated `Yes` (was wrongly `No` — both are end-to-end), adds the `Partial` support value, reflects Slice A parser closures, and documents that active-tank-per-sample is split out as a follow-up (Slice A.2) because it requires a new `DiveProfiles.activeTankIndex` column.

Relates to #155. Incremental follow-up to PR #170's direct-field-mapping work.

**Explicitly NOT in this PR** (deferred to dedicated follow-ups):
- Active-tank-per-sample (Slice A.2 — requires schema migration)
- CCR/rebreather dive fields beyond sample `setpoint` (Slice B)
- Profile events / markers persistence (Slice C)
- Inferring SSRF tank material from description presets (preset-matcher feature)

## Test plan

- [ ] `flutter test test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart` — 44/44 pass (includes 5 new setpoint tests + 2 new cylinder-preservation tests; existing regression tests unchanged)
- [ ] `dart analyze lib/features/universal_import/data/parsers/ test/features/universal_import/data/parsers/` — zero issues
- [ ] `dart format --set-exit-if-changed lib/features/universal_import/data/parsers/subsurface_xml_parser.dart test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart` — exit 0
- [ ] Manually import a real CCR `.ssrf` with `SP change` events — confirm profile samples carry non-null `setpoint` values following the event timing
- [ ] Manually import a real CCR `.ssrf` with gas-only diluent/oxygen cylinders (e.g., `<cylinder o2='98%' use='oxygen' />`) — confirm the dive's tank list preserves them with correct role mapping
- [ ] Regression: re-import a known non-CCR `.ssrf` — confirm identical tank counts and profile data compared to pre-PR behavior