### PR TITLE
feat(uddf-import): Slice C.3 - UDDF event parity

### DIFF
--- a/docs/superpowers/plans/2026-04-17-ssrf-slice-c3-discovery.md
+++ b/docs/superpowers/plans/2026-04-17-ssrf-slice-c3-discovery.md
@@ -1,0 +1,160 @@
+# Slice C.3 Discovery Findings — UDDF Event Parity
+
+Date: 2026-04-17
+Branch: feat/ssrf-slice-c3
+
+---
+
+## Exporter Field Coverage
+
+File: `lib/core/services/export/uddf/uddf_export_builders.dart`
+
+The `profileevents` builder block runs at lines 742–787. Inside each `<event>` element
+the exporter writes:
+
+| XML element   | Source expression          | Line | Conditional? |
+|---------------|----------------------------|------|--------------|
+| `time`        | `event.timestamp.toString()` | 752  | No (always)  |
+| `eventtype`   | `event.eventType.name`     | 755  | No (always)  |
+| `severity`    | `event.severity.name`      | 759  | No (always)  |
+| `depth`       | `event.depth.toString()`   | 761  | Yes (non-null)|
+| `value`       | `event.value.toString()`   | 766  | Yes (non-null)|
+| `description` | `event.description`        | 772  | Yes (non-null)|
+| `tankref`     | `event.tankId`             | 779  | Yes (non-null)|
+
+All seven fields the plan claims are present. No silent drops.
+
+**Match verdict: YES — exporter writes every field the plan's pre-findings enumerate.**
+
+---
+
+## `buildDiveElement` Signature
+
+File: `lib/core/services/export/uddf/uddf_export_builders.dart`, line 93.
+
+```dart
+static void buildDiveElement(
+  XmlBuilder builder,
+  Dive dive,
+  List<Buddy>? buddies,
+  List<BuddyWithRole> diveBuddyList,
+  List<Tag> diveTags,
+  List<ProfileEvent> profileEvents,
+  List<DiveWeight> diveWeights,
+  List<Trip>? trips,
+  List<GasSwitchWithTank> gasSwitches, {
+  Map<String, List<TankPressurePoint>>? tankPressures,
+})
+```
+
+Parameter breakdown:
+
+| # | Name | Type | Required? | Default |
+|---|------|------|-----------|---------|
+| 1 | `builder` | `XmlBuilder` | Yes | — |
+| 2 | `dive` | `Dive` | Yes | — |
+| 3 | `buddies` | `List<Buddy>?` | Yes (nullable) | — |
+| 4 | `diveBuddyList` | `List<BuddyWithRole>` | Yes | — |
+| 5 | `diveTags` | `List<Tag>` | Yes | — |
+| 6 | `profileEvents` | `List<ProfileEvent>` | Yes | — |
+| 7 | `diveWeights` | `List<DiveWeight>` | Yes | — |
+| 8 | `trips` | `List<Trip>?` | Yes (nullable) | — |
+| 9 | `gasSwitches` | `List<GasSwitchWithTank>` | Yes | — |
+| 10 | `tankPressures` | `Map<String, List<TankPressurePoint>>?` | No (named) | `null` |
+
+`profileEvents` is positional parameter #6 — not a named parameter. The round-trip
+test must pass it as a positional argument, not `profileEvents: events`.
+
+For the round-trip test, all non-nullable list parameters can be passed as `const []`
+except `profileEvents` (which carries the test events) and `buddies`/`trips` (nullable,
+pass `null`).
+
+---
+
+## Import Service Public API
+
+File: `lib/core/services/export/uddf/uddf_full_import_service.dart`, line 21.
+
+```dart
+Future<UddfImportResult> importAllDataFromUddf(String uddfContent) async
+```
+
+- Accepts raw UDDF XML as a `String`.
+- Returns `UddfImportResult` (has `.dives` as `List<Map<String, dynamic>>`).
+- Parsed events land in `diveData['profileEvents']` at line 872 — the key Task 2
+  renames to `'events'` for SSRF/UDDF consumer parity.
+- No bytes variant — test passes a `String` directly.
+
+---
+
+## Test Helper Availability
+
+An extensive test file exists at:
+`test/core/services/export/uddf/uddf_export_builders_test.dart`
+
+It shows the exact call pattern for `buildDiveElement` with a bare `XmlBuilder`:
+
+```dart
+final builder = XmlBuilder();
+builder.element('root', nest: () {
+  UddfExportBuilders.buildDiveElement(
+    builder,
+    dive,
+    null,        // buddies
+    const [],    // diveBuddyList
+    const [],    // diveTags
+    const [],    // profileEvents
+    const [],    // diveWeights
+    null,        // trips
+    const [],    // gasSwitches
+  );
+});
+final xml = builder.buildDocument().toXmlString();
+```
+
+The `UddfFullImportService` is exercised via direct instantiation in
+`test/core/services/export/uddf/uddf_macdive_import_test.dart`:
+
+```dart
+late UddfFullImportService service;
+setUp(() { service = UddfFullImportService(); });
+final result = await service.importAllDataFromUddf(_macDiveUddf);
+```
+
+**Task 4 can reuse both patterns directly** — no new scaffold needed.
+
+For a valid UDDF document the importer requires a `<uddf>` root element and will
+throw `FormatException` otherwise. The round-trip test must wrap the export output
+in at minimum:
+
+```xml
+<?xml version="1.0"?>
+<uddf>
+  <profiledata>
+    <repetitiongroup id="rg1">
+      <!-- UddfExportBuilders.buildDiveElement output here -->
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+```
+
+---
+
+## Surprises
+
+1. **`profileEvents` is positional, not named.** The plan's pseudocode shows
+   `profileEvents: sourceEvents` (named). The real signature is positional.
+   Task 4 must use positional call order (see signature above).
+
+2. **`diveData['profileEvents']` key mismatch confirmed at line 872.** The importer
+   stores parsed events under `'profileEvents'`; `_importDives` reads `'events'`
+   (line 1244). Task 2's rename is necessary and sufficient.
+
+3. **`tankRef` map key is camelCase.** The importer writes `event['tankRef']` (capital R),
+   consistent with how `gasSwitches` consumes `gs['tankRef']` at line 1211.
+   This is not consumed by the profile-events path in `_importDives` today (tankRef
+   consumption for profile events is out of scope per plan). No action needed.
+
+4. **No divergence from plan pre-findings on field coverage.** All seven fields
+   (time, eventtype, severity, depth, value, description, tankref) confirmed written
+   by exporter and read by importer.

--- a/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
+++ b/docs/superpowers/specs/2026-04-05-imported-profile-gap-priority-tracker.md
@@ -57,7 +57,7 @@ Use the `Fixed` column as a working checkbox:
 | Tank role / material metadata | [ ] | High | Yes | Yes | No[^1] |
 | Dive-level `cns` / `otu` | [x] | Medium | Yes | Yes | Yes |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Yes | No | No |
-| Profile events / markers | [ ] | Medium | Yes | Partial | Partial |
+| Profile events / markers | [ ] | Medium | Yes | Yes | Partial |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | Yes | No | No |
 | Surface pressure / altitude / surface interval | [ ] | Medium | Yes | No | No |
 | Sample `setpoint` | [x] | Medium | Yes | Yes | Yes |
@@ -82,7 +82,7 @@ Use the `Fixed` column as a working checkbox:
 | Tank role / material metadata | [x] | High | Already supported end-to-end — role via `<tankrole>` to `TankRole`, material via `<tankmaterial>` to `TankMaterial` |
 | Dive-level `cns` / `otu` | [x] | Medium | Useful summary metadata for imported technical dives |
 | Dive-level deco metadata (`decoAlgorithm`, `GF low/high`, conservatism) | [ ] | Medium | Important provenance/context, but less critical than sample deco fields |
-| Profile events / markers | [ ] | Medium | Parser can produce them, but importer does not persist them |
+| Profile events / markers | [x] | Medium | Submersion-authored UDDF round-trip preserves all 8 event types via the `<profileevents>` element. `diveData['events']` key unified with SSRF path (Slice C.3). Third-party UDDF parsers that don't emit `<profileevents>` remain out of scope |
 | Source provenance snapshot (`DiveDataSources`) | [ ] | Medium | Current UDDF provenance row is under-filled |
 | Surface pressure / altitude / surface interval | [ ] | Medium | Helps reproduce altitude/weather/computer context |
 | Sample ascent rate |  | Low | Nice to have, but lower value than the core deco fields |
@@ -179,5 +179,6 @@ If we start with the safest, most direct wins, the first slice should be:
 - Slice A (2026-04-17) closes SSRF partial cylinder preservation and corrects the UDDF tank role/material entries to reflect existing end-to-end support. Direct `<sample setpoint=...>` attribute parsing was added too. `SP change` event-based setpoint handling is intentionally deferred to Slice C (rationale: avoid the denormalization stopgap of forward-filling events into `DiveProfiles.setpoint` at import time; Slice C will persist events and derive per-sample setpoint at read time, consistent with PR #137's `ProfileGasSegment` pattern). `Active-tank-per-sample`, which requires a new `DiveProfiles.activeTankIndex` column, is split out as Slice A.2 — a follow-up task scoped in the [Slice A design doc](2026-04-17-ssrf-direct-field-mappings-slice-a-design.md).
 - Slice C (2026-04-17) adds source tagging to `DiveProfileEvents` (new `source` column) and closes SSRF `SP change` event persistence via a `setpointChange` event type, consumed by a `SetpointSegment` derivation helper parallel to PR #137's `ProfileGasSegment`. Further SSRF event types (bookmarks, alarms) remain open. See `docs/superpowers/specs/2026-04-17-ssrf-slice-c-profile-events-design.md`.
 - Slice C.2 (2026-04-17) extends SSRF `_parseProfileEvents` with 6 additional event names (`bookmark`, `safety stop`, `deco stop`, `ceiling`, `violation`, `ascent`, `po2`), mostly flat one-to-one mapping to existing `ProfileEventType` values. Deliberate exception: `po2` is threshold-split at 1.4 / 0.18 bar into `ppO2High` / `ppO2Low` for CCR safety correctness. Four new factory constructors on `ProfileEvent` (`decoStop`, `decoViolation`, `ppO2High`, `ppO2Low`). One synthetic compound fixture `profile-events-variety.ssrf`. No schema change. Mapping is based on Subsurface's documented event vocabulary — not verified against real-world exports. See `docs/superpowers/specs/2026-04-17-ssrf-slice-c2-profile-events-level2-design.md`.
+- Slice C.3 (2026-04-17) fixes the UDDF-vs-SSRF event-key mismatch — the UDDF parser now writes `diveData['events']` instead of `diveData['profileEvents']`. Extends `_importDives` to consume UDDF's richer event shape (severity, depth) via post-construction `copyWith` overrides, while keeping the SSRF path unchanged. Round-trip test confirms Submersion-authored UDDF exports preserve all 8 event types end-to-end. Third-party UDDF event parsing remains a separate future slice. See `docs/superpowers/specs/2026-04-17-ssrf-slice-c3-uddf-event-parity-design.md`.
 
 [^1]: SSRF tank role mapping via the `use` attribute is supported, but no direct material field exists in the SSRF cylinder element. Description-based inference (e.g., `AL80` -> aluminum) is intentionally deferred as a separate preset-matcher feature. For context: UDDF already supports both tank role and tank material end-to-end via `<tankrole>` -> `TankRole` and `<tankmaterial>` -> `TankMaterial`.

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -869,7 +869,7 @@ class UddfFullImportService {
           eventsList.add(event);
         }
         if (eventsList.isNotEmpty) {
-          diveData['profileEvents'] = eventsList;
+          diveData['events'] = eventsList;
         }
       }
 

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -177,6 +177,20 @@ class UddfEntityImportResult {
   }
 }
 
+/// Parse an [EventSeverity] from its string name.
+///
+/// Returns null for unknown/absent values so callers can fall back to the
+/// factory-default severity. Mirrors the pattern used by
+/// `profile_event_mapper._parseSeverity` — duplicated here rather than
+/// extracted to a shared location to keep Slice C.3's scope bounded.
+EventSeverity? _parseSeverity(String? raw) {
+  if (raw == null) return null;
+  for (final value in EventSeverity.values) {
+    if (value.name == raw) return value;
+  }
+  return null;
+}
+
 /// Stateless service that creates entities from parsed UDDF data.
 ///
 /// Takes repository instances directly (not Riverpod Ref) for testability.
@@ -1234,13 +1248,12 @@ class UddfEntityImporter {
       // ascentRateWarning, ppO2High, ppO2Low. Future slices may add more types as
       // real SSRF exports surface additional event names.
       //
-      // NOTE ON UDDF DIVERGENCE: SSRF's subsurface_xml_parser emits events under
-      // `diveData['events']` (read here). The UDDF path in
-      // `uddf_full_import_service.dart` emits events under
-      // `diveData['profileEvents']` — a pre-existing key mismatch. UDDF-side
-      // event persistence is intentionally out of scope for Slice C; when a
-      // future slice adds UDDF event import, unify the keys or add a second
-      // consumer block here.
+      // UDDF vs SSRF event shape: SSRF-shape events supply `eventType`,
+      // `timestamp`, `value`, `description`. UDDF-shape events additionally
+      // supply `severity` and `depth` at the map level. Both paths write to
+      // `diveData['events']` since Slice C.3 unified the keys. Severity is
+      // applied as a post-construction override; depth is passed to factories
+      // when available, falling back to 0.0 for SSRF.
       final eventMaps = (diveData['events'] as List?)
           ?.cast<Map<String, dynamic>>();
       if (eventMaps != null && eventMaps.isNotEmpty) {
@@ -1254,73 +1267,99 @@ class UddfEntityImporter {
           if (timestamp == null) continue;
           final value = m['value'] as double?;
           final description = m['description'] as String?;
+          final severity = m['severity'] as String?;
+          final depth = m['depth'] as double?;
+
+          // Apply UDDF-provided severity override when present. SSRF-shape
+          // events don't supply severity, so the closure is a pass-through
+          // for them.
+          ProfileEvent applyOverrides(ProfileEvent event) {
+            final severityOverride = _parseSeverity(severity);
+            if (severityOverride != null) {
+              return event.copyWith(severity: severityOverride);
+            }
+            return event;
+          }
+
           switch (eventTypeStr) {
             case 'setpointChange':
               if (value == null) continue;
               events.add(
-                ProfileEvent.setpointChange(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  setpoint: value,
-                  createdAt: now,
+                applyOverrides(
+                  ProfileEvent.setpointChange(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    setpoint: value,
+                    depth: depth,
+                    createdAt: now,
+                  ),
                 ),
               );
               break;
 
             case 'bookmark':
               events.add(
-                ProfileEvent.bookmark(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  note: description,
-                  createdAt: now,
-                  source:
-                      EventSource.imported, // override `user` factory default
+                applyOverrides(
+                  ProfileEvent.bookmark(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    note: description,
+                    depth: depth,
+                    createdAt: now,
+                    source:
+                        EventSource.imported, // override `user` factory default
+                  ),
                 ),
               );
               break;
 
             case 'safetyStopStart':
               events.add(
-                ProfileEvent.safetyStop(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  depth:
-                      0.0, // parser does not emit depth on event elements; placeholder used across safety/deco/ascent cases. Future enrichment slice may interpolate from samples.
-                  createdAt: now,
-                  isStart: true,
-                  source: EventSource
-                      .imported, // override `computed` factory default
+                applyOverrides(
+                  ProfileEvent.safetyStop(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    depth: depth ?? 0.0,
+                    createdAt: now,
+                    isStart: true,
+                    source: EventSource
+                        .imported, // override `computed` factory default
+                  ),
                 ),
               );
               break;
 
             case 'decoStopStart':
               events.add(
-                ProfileEvent.decoStop(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  depth: 0.0,
-                  createdAt: now,
-                  isStart: true,
-                  // factory default is already `imported`; no override needed
+                applyOverrides(
+                  ProfileEvent.decoStop(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    depth: depth ?? 0.0,
+                    createdAt: now,
+                    isStart: true,
+                    // factory default is already `imported`; no override needed
+                  ),
                 ),
               );
               break;
 
             case 'decoViolation':
               events.add(
-                ProfileEvent.decoViolation(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  value: value,
-                  createdAt: now,
-                  // factory default is already `imported`; no override needed
+                applyOverrides(
+                  ProfileEvent.decoViolation(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    depth: depth,
+                    value: value,
+                    createdAt: now,
+                    // factory default is already `imported`; no override needed
+                  ),
                 ),
               );
               break;
@@ -1333,15 +1372,17 @@ class UddfEntityImporter {
                 continue; // match setpointChange/ppO2 null-guard pattern
               }
               events.add(
-                ProfileEvent.ascentRateWarning(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  depth: 0.0,
-                  rate: value,
-                  createdAt: now,
-                  source: EventSource
-                      .imported, // override `computed` factory default
+                applyOverrides(
+                  ProfileEvent.ascentRateWarning(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    depth: depth ?? 0.0,
+                    rate: value,
+                    createdAt: now,
+                    source: EventSource
+                        .imported, // override `computed` factory default
+                  ),
                 ),
               );
               break;
@@ -1352,12 +1393,15 @@ class UddfEntityImporter {
                 continue; // match setpointChange null-guard pattern
               }
               events.add(
-                ProfileEvent.ppO2High(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  value: value,
-                  createdAt: now,
+                applyOverrides(
+                  ProfileEvent.ppO2High(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    value: value,
+                    depth: depth,
+                    createdAt: now,
+                  ),
                 ),
               );
               break;
@@ -1368,12 +1412,15 @@ class UddfEntityImporter {
                 continue; // match setpointChange null-guard pattern
               }
               events.add(
-                ProfileEvent.ppO2Low(
-                  id: _uuid.v4(),
-                  diveId: diveId,
-                  timestamp: timestamp,
-                  value: value,
-                  createdAt: now,
+                applyOverrides(
+                  ProfileEvent.ppO2Low(
+                    id: _uuid.v4(),
+                    diveId: diveId,
+                    timestamp: timestamp,
+                    value: value,
+                    depth: depth,
+                    createdAt: now,
+                  ),
                 ),
               );
               break;

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1365,6 +1365,7 @@ class UddfEntityImporter {
                     timestamp: timestamp,
                     depth: depth,
                     value: value,
+                    description: description,
                     createdAt: now,
                     // factory default is already `imported`; no override needed
                   ),

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1273,6 +1273,14 @@ class UddfEntityImporter {
           // Apply UDDF-provided severity override when present. SSRF-shape
           // events don't supply severity, so the closure is a pass-through
           // for them.
+          //
+          // Severity uses copyWith rather than being passed to factories
+          // because ProfileEvent factories don't expose a severity parameter —
+          // each factory sets the severity implicitly based on the event type
+          // (e.g., decoViolation → alert, ppO2High → warning). The copyWith
+          // override is the only way to preserve a UDDF-provided severity
+          // without changing factory signatures. depth and value, by contrast,
+          // ARE factory parameters, so they're passed directly above.
           ProfileEvent applyOverrides(ProfileEvent event) {
             final severityOverride = _parseSeverity(severity);
             if (severityOverride != null) {

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -2163,6 +2163,43 @@ void main() {
       expect(events[1].source, EventSource.imported);
     });
 
+    test('decoViolation preserves description from UDDF event', () async {
+      // decoViolation factory accepts `description`; the switch case now
+      // passes it through rather than dropping it. Pins end-to-end fidelity
+      // of free-text notes on ceiling/violation events.
+      final data = UddfImportResult(
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 40.0,
+            'events': [
+              {
+                'eventType': 'decoViolation',
+                'timestamp': 200,
+                'description': 'ceiling broken by 1.2 m',
+                'depth': 12.0,
+              },
+            ],
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: UddfImportSelections.selectAll(data),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(
+        mockDiveRepo.insertProfileEvents(captureAny),
+      ).captured;
+      final events = captured.first as List<ProfileEvent>;
+      expect(events, hasLength(1));
+      expect(events[0].eventType, ProfileEventType.decoViolation);
+      expect(events[0].description, 'ceiling broken by 1.2 m');
+    });
+
     test(
       'SSRF path continues to use factory default severity (no regression)',
       () async {

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -3,8 +3,12 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_builders.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart';
+import 'package:xml/xml.dart';
 import 'package:submersion/features/certifications/data/repositories/certification_repository.dart';
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
 import 'package:submersion/features/courses/data/repositories/course_repository.dart';
@@ -2235,5 +2239,210 @@ void main() {
         EventSeverity.warning,
       ); // factory default, not overridden
     });
+
+    test(
+      'UDDF round-trip preserves all 8 event types with severity and depth',
+      () async {
+        final roundTripNow = DateTime.utc(2026, 3, 15, 10, 0, 0);
+        const diveId = 'roundtrip-dive';
+
+        // 1. Build source events covering all 8 types, each with a distinctive
+        //    (timestamp, eventType, severity, value, depth) tuple.
+        final sourceEvents = <ProfileEvent>[
+          ProfileEvent.setpointChange(
+            id: 'e1',
+            diveId: diveId,
+            timestamp: 0,
+            setpoint: 0.7,
+            depth: 0.0,
+            createdAt: roundTripNow,
+          ),
+          ProfileEvent.bookmark(
+            id: 'e2',
+            diveId: diveId,
+            timestamp: 120,
+            depth: 5.0,
+            note: 'cool fish',
+            createdAt: roundTripNow,
+            source: EventSource.imported,
+          ),
+          ProfileEvent.ascentRateWarning(
+            id: 'e3',
+            diveId: diveId,
+            timestamp: 300,
+            depth: 10.0,
+            rate: 12.5,
+            createdAt: roundTripNow,
+          ),
+          ProfileEvent.ppO2High(
+            id: 'e4',
+            diveId: diveId,
+            timestamp: 600,
+            value: 1.65,
+            depth: 20.0,
+            createdAt: roundTripNow,
+          ),
+          ProfileEvent.ppO2Low(
+            id: 'e5',
+            diveId: diveId,
+            timestamp: 700,
+            value: 0.15,
+            depth: 25.0,
+            createdAt: roundTripNow,
+          ),
+          ProfileEvent.decoViolation(
+            id: 'e6',
+            diveId: diveId,
+            timestamp: 1500,
+            value: 18.0,
+            depth: 15.0,
+            createdAt: roundTripNow,
+          ),
+          ProfileEvent.decoStop(
+            id: 'e7',
+            diveId: diveId,
+            timestamp: 2100,
+            depth: 6.0,
+            createdAt: roundTripNow,
+          ),
+          ProfileEvent.safetyStop(
+            id: 'e8',
+            diveId: diveId,
+            timestamp: 2400,
+            depth: 5.0,
+            createdAt: roundTripNow,
+          ),
+        ];
+
+        // 2. Build a minimal Dive entity mirroring the export-builders test.
+        final dive = Dive(
+          id: diveId,
+          diveNumber: 1,
+          dateTime: DateTime(2026, 3, 15, 10, 0),
+          bottomTime: const Duration(minutes: 40),
+          maxDepth: 30.0,
+          profile: const [],
+          tanks: const [],
+          equipment: const [],
+          notes: '',
+          photoIds: const [],
+          sightings: const [],
+          weights: const [],
+          tags: const [],
+        );
+
+        // 3. Export via buildDiveElement with POSITIONAL args per Discovery.
+        final builder = XmlBuilder();
+        builder.processing('xml', 'version="1.0" encoding="UTF-8"');
+        builder.element(
+          'uddf',
+          nest: () {
+            builder.element(
+              'profiledata',
+              nest: () {
+                builder.element(
+                  'repetitiongroup',
+                  nest: () {
+                    UddfExportBuilders.buildDiveElement(
+                      builder,
+                      dive,
+                      null, // buddies
+                      const <BuddyWithRole>[],
+                      const <Tag>[],
+                      sourceEvents,
+                      const <DiveWeight>[],
+                      null, // trips
+                      const <GasSwitchWithTank>[],
+                    );
+                  },
+                );
+              },
+            );
+          },
+        );
+        final uddfXml = builder.buildDocument().toXmlString();
+
+        // 4. Parse back via UddfFullImportService.
+        final importService = UddfFullImportService();
+        final importResult = await importService.importAllDataFromUddf(uddfXml);
+
+        // 5. Verify the parser produced exactly 8 events in the dives list.
+        expect(importResult.dives, hasLength(1));
+        final parsedDiveData = importResult.dives[0];
+        final parsedEvents =
+            parsedDiveData['events'] as List<Map<String, dynamic>>;
+        expect(parsedEvents, hasLength(8));
+
+        // 6. Feed parsed data through the importer to verify full
+        //    _importDives -> insertProfileEvents path.
+        await importer.import(
+          data: importResult,
+          selections: UddfImportSelections.selectAll(importResult),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        final captured = verify(
+          mockDiveRepo.insertProfileEvents(captureAny),
+        ).captured;
+        final persistedEvents = captured.first as List<ProfileEvent>;
+
+        // 7. Assert on the persisted ProfileEvent list.
+        expect(persistedEvents, hasLength(8));
+
+        // setpointChange
+        expect(persistedEvents[0].eventType, ProfileEventType.setpointChange);
+        expect(persistedEvents[0].value, closeTo(0.7, 0.001));
+        expect(persistedEvents[0].depth, closeTo(0.0, 0.001));
+        expect(persistedEvents[0].source, EventSource.imported);
+
+        // bookmark
+        expect(persistedEvents[1].eventType, ProfileEventType.bookmark);
+        expect(persistedEvents[1].depth, closeTo(5.0, 0.001));
+        expect(persistedEvents[1].description, 'cool fish');
+        expect(persistedEvents[1].source, EventSource.imported);
+
+        // ascentRateWarning — severity exported as 'warning', round-trips
+        expect(
+          persistedEvents[2].eventType,
+          ProfileEventType.ascentRateWarning,
+        );
+        expect(persistedEvents[2].severity, EventSeverity.warning);
+        expect(persistedEvents[2].depth, closeTo(10.0, 0.001));
+        expect(persistedEvents[2].value, closeTo(12.5, 0.001));
+        expect(persistedEvents[2].source, EventSource.imported);
+
+        // ppO2High — severity exported as 'warning', round-trips
+        expect(persistedEvents[3].eventType, ProfileEventType.ppO2High);
+        expect(persistedEvents[3].severity, EventSeverity.warning);
+        expect(persistedEvents[3].value, closeTo(1.65, 0.001));
+        expect(persistedEvents[3].depth, closeTo(20.0, 0.001));
+        expect(persistedEvents[3].source, EventSource.imported);
+
+        // ppO2Low — severity exported as 'warning', round-trips
+        expect(persistedEvents[4].eventType, ProfileEventType.ppO2Low);
+        expect(persistedEvents[4].severity, EventSeverity.warning);
+        expect(persistedEvents[4].value, closeTo(0.15, 0.001));
+        expect(persistedEvents[4].depth, closeTo(25.0, 0.001));
+        expect(persistedEvents[4].source, EventSource.imported);
+
+        // decoViolation — severity exported as 'alert', round-trips
+        expect(persistedEvents[5].eventType, ProfileEventType.decoViolation);
+        expect(persistedEvents[5].severity, EventSeverity.alert);
+        expect(persistedEvents[5].value, closeTo(18.0, 0.001));
+        expect(persistedEvents[5].depth, closeTo(15.0, 0.001));
+        expect(persistedEvents[5].source, EventSource.imported);
+
+        // decoStopStart (decoStop factory with isStart=true)
+        expect(persistedEvents[6].eventType, ProfileEventType.decoStopStart);
+        expect(persistedEvents[6].depth, closeTo(6.0, 0.001));
+        expect(persistedEvents[6].source, EventSource.imported);
+
+        // safetyStopStart (safetyStop factory with isStart=true)
+        expect(persistedEvents[7].eventType, ProfileEventType.safetyStopStart);
+        expect(persistedEvents[7].depth, closeTo(5.0, 0.001));
+        expect(persistedEvents[7].source, EventSource.imported);
+      },
+    );
   });
 }

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -2107,5 +2107,133 @@ void main() {
         verifyNever(mockDiveRepo.insertProfileEvents(any));
       },
     );
+
+    test('UDDF severity overrides factory default via copyWith', () async {
+      // ascentRateWarning factory default: warning -> UDDF says: alert
+      // decoViolation factory default: alert -> UDDF says: warning
+      final data = UddfImportResult(
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 30.0,
+            'events': [
+              {
+                'eventType': 'ascentRateWarning',
+                'timestamp': 120,
+                'value': 18.0,
+                'severity': 'alert',
+                'depth': 15.0,
+              },
+              {
+                'eventType': 'decoViolation',
+                'timestamp': 240,
+                'severity': 'warning',
+                'depth': 12.0,
+              },
+            ],
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: UddfImportSelections.selectAll(data),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(
+        mockDiveRepo.insertProfileEvents(captureAny),
+      ).captured;
+      final events = captured.first as List<ProfileEvent>;
+      expect(events, hasLength(2));
+
+      expect(events[0].eventType, ProfileEventType.ascentRateWarning);
+      expect(events[0].severity, EventSeverity.alert); // overridden
+      expect(events[0].depth, 15.0);
+      expect(events[0].source, EventSource.imported);
+
+      expect(events[1].eventType, ProfileEventType.decoViolation);
+      expect(events[1].severity, EventSeverity.warning); // overridden
+      expect(events[1].depth, 12.0);
+      expect(events[1].source, EventSource.imported);
+    });
+
+    test(
+      'SSRF path continues to use factory default severity (no regression)',
+      () async {
+        // SSRF-shape: no `severity` key in event map. Factory default applies.
+        // decoViolation factory default severity = alert.
+        final data = UddfImportResult(
+          dives: [
+            {
+              'dateTime': now,
+              'maxDepth': 25.0,
+              'events': [
+                // No 'severity' or 'depth' keys — SSRF shape
+                {'eventType': 'decoViolation', 'timestamp': 180},
+              ],
+            },
+          ],
+        );
+
+        await importer.import(
+          data: data,
+          selections: UddfImportSelections.selectAll(data),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        final captured = verify(
+          mockDiveRepo.insertProfileEvents(captureAny),
+        ).captured;
+        final events = captured.first as List<ProfileEvent>;
+        expect(events, hasLength(1));
+        expect(
+          events[0].severity,
+          EventSeverity.alert,
+        ); // factory default preserved
+        expect(events[0].depth, isNull); // factory received no depth
+      },
+    );
+
+    test('unknown severity string falls through to factory default', () async {
+      // UDDF event with a malformed severity string -> _parseSeverity returns null.
+      // No override applied. Factory default wins.
+      // ppO2High factory default severity = warning.
+      final data = UddfImportResult(
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 20.0,
+            'events': [
+              {
+                'eventType': 'ppO2High',
+                'timestamp': 90,
+                'value': 1.8,
+                'severity': 'catastrophic', // unknown value
+              },
+            ],
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: UddfImportSelections.selectAll(data),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(
+        mockDiveRepo.insertProfileEvents(captureAny),
+      ).captured;
+      final events = captured.first as List<ProfileEvent>;
+      expect(events, hasLength(1));
+      expect(
+        events[0].severity,
+        EventSeverity.warning,
+      ); // factory default, not overridden
+    });
   });
 }

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -2444,5 +2444,56 @@ void main() {
         expect(persistedEvents[7].source, EventSource.imported);
       },
     );
+
+    test(
+      'stop-end event types silently drop on UDDF round-trip (known gap)',
+      () async {
+        // safetyStopEnd and decoStopEnd are produced by profile_analysis_service
+        // with isStart: false. The exporter writes them to UDDF verbatim, but
+        // the importer's _importDives switch only handles the *Start variants —
+        // the End variants fall through the default: log-and-skip branch.
+        //
+        // This test pins that behavior so it can't regress silently, and so a
+        // future developer who adds handling for stop-end events updates this
+        // test + the round-trip coverage. Not a bug to fix today — Slice C.3
+        // deliberately kept the 8-type scope from Slice C.2.
+        //
+        // TODO-IF-EXTENDED: when a future slice adds safetyStopEnd/decoStopEnd
+        // handling, this test should be updated: either delete it, or change
+        // the assertion to verify(insertProfileEvents(captureAny)).captured
+        // contains two events with the correct eventTypes.
+        final data = UddfImportResult(
+          dives: [
+            {
+              'dateTime': now,
+              'maxDepth': 20.0,
+              'events': [
+                {
+                  'eventType': 'safetyStopEnd',
+                  'timestamp': 2700,
+                  'depth': 5.0,
+                  'severity': 'info',
+                },
+                {
+                  'eventType': 'decoStopEnd',
+                  'timestamp': 2400,
+                  'depth': 6.0,
+                  'severity': 'info',
+                },
+              ],
+            },
+          ],
+        );
+
+        await importer.import(
+          data: data,
+          selections: UddfImportSelections.selectAll(data),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        verifyNever(mockDiveRepo.insertProfileEvents(any));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Closes the UDDF-vs-SSRF event-key mismatch and preserves UDDF's richer event shape (severity + depth) through the import pipeline. Fixes a long-standing latent bug: Submersion-authored UDDF exports round-tripped through the importer were silently dropping all profile events because the parser wrote to one key (`profileEvents`) and the consumer read a different one (`events`). Slice C surfaced this by becoming the first consumer; Slice C.3 fixes it.

**Changes:**

- **Key unification** (`uddf_full_import_service.dart:872`): `diveData['profileEvents']` → `diveData['events']`. One-line fix to the long-standing key mismatch.
- **Rich-shape handling** in `_importDives`: extract `severity` and `depth` from UDDF event maps (SSRF maps don't emit these; code handles absence gracefully). New `_parseSeverity` helper. `applyOverrides` closure wraps each factory call to conditionally apply `copyWith(severity: ...)` when UDDF provided one. Factory-default severity preserved when absent (SSRF path unchanged).
- **Depth passthrough**: replaces the `depth: 0.0` placeholders from Slice C.2 with `depth: depth ?? 0.0` (required-depth factories) or `depth: depth` (optional-depth factories). SSRF path still hits the `0.0` fallback; UDDF preserves the real value.
- **Round-trip test**: exports 8 ProfileEvents via real `UddfExportBuilders.buildDiveElement`, parses via real `UddfFullImportService`, feeds through the full `_importDives → insertProfileEvents` path, verifies severity + depth + value + description preserved end-to-end.
- **Known-gap pin**: `safetyStopEnd` / `decoStopEnd` event types (created by `profile_analysis_service` with `isStart: false`) still fall through the switch's `default:` branch and log-and-skip. Test added to pin this silent-drop behavior so it can't regress; future slice can handle stop-end variants by updating both the switch and the pin test.
- **Tracker doc**: UDDF Support → `Yes`, UDDF sub-table Fixed → `[x]`, Slice C.3 notes bullet.

**Stacked on PR #244 (Slice C.2) → PR #243 (Slice C)**: this PR targets `feat/ssrf-slice-c2` rather than `main` so the diff shows only Slice C.3's ~7 commits. When #243 and #244 merge, this PR auto-retargets to main.

## Explicitly NOT in this PR

- Third-party UDDF event parsing (Diviac, Shearwater Cloud, etc. — those don't emit `<profileevents>`; separate slice if needed).
- `tankRef` consumption for non-gas-switch events — no current use case.
- `safetyStopEnd` / `decoStopEnd` handling — pinned as a known gap but deliberately deferred.
- Schema work — none needed.
- Severity on factory signatures — deliberately deferred in favor of the `copyWith` pattern to avoid touching Slice C factories.

## Test plan

- [x] `flutter test test/features/dive_import/data/services/uddf_entity_importer_test.dart` — 71/71 pass (includes 4 new tests: 3 severity/depth unit tests + 1 round-trip + 1 stop-end silent-drop pin)
- [x] `dart analyze lib/ test/` — zero issues
- [x] `dart format --set-exit-if-changed` on touched files — exit 0
- [x] Manual verification: export a dive with events via `UddfExportService`, reimport via file-import flow, confirm `DiveProfileEvents` rows have correct eventType + severity + depth