### PR TITLE
fix(dive-computer): log download failures to the file log

### DIFF
--- a/lib/features/dive_computer/presentation/providers/download_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/download_providers.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/logger_service.dart';
 
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
@@ -111,6 +113,8 @@ class DownloadState {
 /// record when the download completes. Import and consolidation are handled
 /// by the unified import wizard via [DiveComputerAdapter].
 class DownloadNotifier extends StateNotifier<DownloadState> {
+  static final LoggerService _log = LoggerService.forClass(DownloadNotifier);
+
   final pigeon.DiveComputerService _service;
   final DiveComputerRepository _repository;
   StreamSubscription<pigeon.DownloadEvent>? _downloadSubscription;
@@ -159,7 +163,13 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
       }
 
       await _service.startDownload(device.toPigeon(), fingerprint: fingerprint);
-    } catch (e) {
+    } catch (e, stackTrace) {
+      _log.error(
+        'Download failed',
+        category: LogCategory.libdc,
+        error: e,
+        stackTrace: stackTrace,
+      );
       state = state.copyWith(
         phase: DownloadPhase.error,
         errorMessage: 'Download failed: $e',
@@ -200,6 +210,10 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
         // Persist device info on the computer record.
         _persistDeviceInfo(serialNumber, firmwareVersion);
       case pigeon.DownloadErrorEvent(:final error):
+        _log.error(
+          'Download failed (${error.code}): ${error.message}',
+          category: LogCategory.libdc,
+        );
         state = state.copyWith(
           phase: DownloadPhase.error,
           errorMessage: error.message,

--- a/lib/features/dive_computer/presentation/providers/download_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/download_providers.dart
@@ -170,6 +170,10 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
         error: e,
         stackTrace: stackTrace,
       );
+      // Cancel the event subscription so stray events from the native side
+      // cannot mutate state after a synchronous start failure.
+      _downloadSubscription?.cancel();
+      _downloadSubscription = null;
       state = state.copyWith(
         phase: DownloadPhase.error,
         errorMessage: 'Download failed: $e',

--- a/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.dart
+++ b/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.dart
@@ -5,6 +5,8 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart'
     hide DiscoveredDevice;
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/dive_computer/domain/entities/device_model.dart';
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/download_providers.dart';
@@ -86,5 +88,93 @@ void main() {
       testNotifier.dispose();
       await controller.close();
     });
+  });
+
+  group('download failures are logged', () {
+    test('DownloadErrorEvent writes an ERROR log entry', () async {
+      final controller = StreamController<DownloadEvent>.broadcast();
+      when(mockService.downloadEvents).thenAnswer((_) => controller.stream);
+      when(
+        mockService.startDownload(any, fingerprint: anyNamed('fingerprint')),
+      ).thenAnswer((_) async {});
+
+      final testNotifier = DownloadNotifier(
+        service: mockService,
+        repository: mockRepository,
+      );
+
+      final errorEntries = <LogEntry>[];
+      final sub = LoggerService.logStream
+          .where((e) => e.level == LogLevel.error)
+          .listen(errorEntries.add);
+
+      final device = DiscoveredDevice(
+        id: 'test-err-1',
+        name: 'Test Device',
+        connectionType: DeviceConnectionType.ble,
+        address: '00:11:22:33:44:55',
+        discoveredAt: DateTime(2026, 1, 1),
+      );
+
+      await testNotifier.startDownload(device);
+
+      controller.add(
+        DownloadErrorEvent(
+          DiveComputerError(
+            code: 'comm_timeout',
+            message: 'Communication timeout',
+          ),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errorEntries, hasLength(1));
+      expect(errorEntries.first.message, contains('comm_timeout'));
+      expect(errorEntries.first.message, contains('Communication timeout'));
+      expect(errorEntries.first.category, LogCategory.libdc);
+
+      await sub.cancel();
+      testNotifier.dispose();
+      await controller.close();
+    });
+
+    test(
+      'Exception thrown by startDownload writes an ERROR log entry',
+      () async {
+        when(
+          mockService.downloadEvents,
+        ).thenAnswer((_) => const Stream.empty());
+        when(
+          mockService.startDownload(any, fingerprint: anyNamed('fingerprint')),
+        ).thenThrow(StateError('boom'));
+
+        final testNotifier = DownloadNotifier(
+          service: mockService,
+          repository: mockRepository,
+        );
+
+        final errorEntries = <LogEntry>[];
+        final sub = LoggerService.logStream
+            .where((e) => e.level == LogLevel.error)
+            .listen(errorEntries.add);
+
+        final device = DiscoveredDevice(
+          id: 'test-err-2',
+          name: 'Test Device',
+          connectionType: DeviceConnectionType.usb,
+          address: 'COM3',
+          discoveredAt: DateTime(2026, 1, 1),
+        );
+
+        await testNotifier.startDownload(device);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(errorEntries, hasLength(1));
+        expect(errorEntries.first.message, contains('boom'));
+
+        await sub.cancel();
+        testNotifier.dispose();
+      },
+    );
   });
 }

--- a/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.dart
+++ b/test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.dart
@@ -91,8 +91,20 @@ void main() {
   });
 
   group('download failures are logged', () {
+    List<LogEntry> captureLibdcErrors() {
+      final entries = <LogEntry>[];
+      final sub = LoggerService.logStream
+          .where(
+            (e) => e.level == LogLevel.error && e.category == LogCategory.libdc,
+          )
+          .listen(entries.add);
+      addTearDown(sub.cancel);
+      return entries;
+    }
+
     test('DownloadErrorEvent writes an ERROR log entry', () async {
       final controller = StreamController<DownloadEvent>.broadcast();
+      addTearDown(controller.close);
       when(mockService.downloadEvents).thenAnswer((_) => controller.stream);
       when(
         mockService.startDownload(any, fingerprint: anyNamed('fingerprint')),
@@ -102,11 +114,9 @@ void main() {
         service: mockService,
         repository: mockRepository,
       );
+      addTearDown(testNotifier.dispose);
 
-      final errorEntries = <LogEntry>[];
-      final sub = LoggerService.logStream
-          .where((e) => e.level == LogLevel.error)
-          .listen(errorEntries.add);
+      final errorEntries = captureLibdcErrors();
 
       final device = DiscoveredDevice(
         id: 'test-err-1',
@@ -131,11 +141,6 @@ void main() {
       expect(errorEntries, hasLength(1));
       expect(errorEntries.first.message, contains('comm_timeout'));
       expect(errorEntries.first.message, contains('Communication timeout'));
-      expect(errorEntries.first.category, LogCategory.libdc);
-
-      await sub.cancel();
-      testNotifier.dispose();
-      await controller.close();
     });
 
     test(
@@ -152,11 +157,9 @@ void main() {
           service: mockService,
           repository: mockRepository,
         );
+        addTearDown(testNotifier.dispose);
 
-        final errorEntries = <LogEntry>[];
-        final sub = LoggerService.logStream
-            .where((e) => e.level == LogLevel.error)
-            .listen(errorEntries.add);
+        final errorEntries = captureLibdcErrors();
 
         final device = DiscoveredDevice(
           id: 'test-err-2',
@@ -171,10 +174,46 @@ void main() {
 
         expect(errorEntries, hasLength(1));
         expect(errorEntries.first.message, contains('boom'));
-
-        await sub.cancel();
-        testNotifier.dispose();
       },
     );
+
+    test('startDownload catch block cancels the events subscription', () async {
+      final controller = StreamController<DownloadEvent>.broadcast();
+      addTearDown(controller.close);
+      when(mockService.downloadEvents).thenAnswer((_) => controller.stream);
+      when(
+        mockService.startDownload(any, fingerprint: anyNamed('fingerprint')),
+      ).thenThrow(StateError('boom'));
+
+      final testNotifier = DownloadNotifier(
+        service: mockService,
+        repository: mockRepository,
+      );
+      addTearDown(testNotifier.dispose);
+
+      final errorEntries = captureLibdcErrors();
+
+      final device = DiscoveredDevice(
+        id: 'test-err-3',
+        name: 'Test Device',
+        connectionType: DeviceConnectionType.usb,
+        address: 'COM3',
+        discoveredAt: DateTime(2026, 1, 1),
+      );
+
+      await testNotifier.startDownload(device);
+
+      // If the catch block did not cancel the subscription, this stray
+      // event would reach _onDownloadEvent and emit a second error log.
+      controller.add(
+        DownloadErrorEvent(
+          DiveComputerError(code: 'stray', message: 'Stray event'),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errorEntries, hasLength(1));
+      expect(errorEntries.first.message, contains('boom'));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- `DownloadNotifier` handled `DownloadErrorEvent` and caught `startDownload` exceptions by updating UI state only, never calling the logger. A user reporting "Download failed" on a Shearwater Teric over Windows 11 BLE had no `[LDC]` or `[ERROR]` entries in `submersion.log`, making remote diagnosis impossible.
- Both error paths now emit `_log.error(...)` under `LogCategory.libdc`. The Dart catch block also forwards the exception and stack trace; the native `DownloadErrorEvent` handler logs the error code and message from libdivecomputer.

## Why
Without a logged error, a libdc-reported BLE comms failure, a permission error on `startDownload`, and a "download completed with 0 dives" outcome are all indistinguishable in a user-submitted log. This blocks support triage on exactly the flows most likely to break (BLE dive computers on Windows).

## Test plan
- [x] `flutter test test/features/dive_computer/presentation/providers/download_notifier_fingerprint_test.dart` — 5/5 pass (2 new)
- [x] New tests subscribe to `LoggerService.logStream`, assert exactly one `LogLevel.error` entry per failure path with the expected category and message substrings
- [x] Tests verified RED first (assertion `hasLength(1)` vs `[]`), then GREEN after the fix
- [x] `dart format` — clean
- [x] `flutter analyze` — "No issues found"
- [x] Full pre-push suite — 7098 tests passing