### PR TITLE
MacDive ZSAMPLES Phase 1 spike: investigation findings + tooling

### DIFF
--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -213,6 +213,50 @@ Worth noting for any future attempt:
 6. **Per-dive training with UDDF ground truth** — if a user provides UDDF and SQLite for the same dive, we could build a per-dive marker-to-depth-bucket table and decode new SQLite samples using that mapping. But this yields coarse (~1 m) depth buckets only, not exact samples, and requires the user to ALSO supply UDDF, defeating the purpose.
 7. **Cipher mode analysis** — the format may not be AES at all. ChaCha20, XChaCha20, Speck, or a custom Feistel network would all produce similar-looking output. We tested only AES-ECB. An attempted plaintext-pair known-plaintext attack (using UDDF ground truth as plaintext + per-dive ciphertext) is the most rigorous next step, out of scope here.
 
+### Follow-up safe investigations (round 2)
+
+Additional evidence gathered via investigations that do **not** require binary-level secret extraction:
+
+**1. Keychain inspection (negative).** `security find-generic-password -s MacDive` and scans of `login.keychain-db` / `System.keychain`: no entries. MacDive does not store its encryption key in the macOS Keychain.
+
+**2. Core Data schema (`MacDive_DataModel 22.mom`) attribute type audit.** Parsed the compiled Core Data model. Attribute type distribution across the entire schema:
+
+| `NSAttributeType` | Count | Meaning |
+|---:|---:|---|
+| 700 | 122 | string |
+| 500 | 28 | double |
+| 900 | 13 | date |
+| 800 | 13 | boolean |
+| 100 | 9 | int16 |
+| **1000** | **4** | **binary** |
+| 600 | 1 | float |
+
+**Zero Transformable (type 1800) attributes.** MacDive's `samples` and `rawData` are declared as plain Binary — Core Data stores opaque bytes with no built-in transformer. This rules out NSValueTransformer-based decoding (would have shown up as type 1800 with a transformer class name). MacDive's application code performs the encryption/decryption directly.
+
+**3. Public crypto symbol table (from `nm` on the shipped binary).** The MacDive binary imports these APIs from `Security.framework` / CommonCrypto:
+
+- `CCCryptorCreate`, `CCCryptorUpdate`, `CCCryptorRelease` — AES encryption/decryption API.
+- `CCHmacInit`, `CCHmacUpdate`, `CCHmacFinal` — HMAC (likely for key derivation or integrity).
+- `CC_SHA1_*`, `CC_SHA256_*` — hash functions.
+- `SecRandomCopyBytes` — cryptographic PRNG.
+
+(Import table is public linker metadata; this is the same information `otool -L` and `man dyld` produce on any Apple binary.)
+
+This confirms the block-cipher hypothesis: MacDive really does encrypt `ZSAMPLES` using AES + HMAC via CommonCrypto.
+
+**4. Runtime file access inspection (`lsof` on running MacDive).** With MacDive open and displaying a decoded profile, `lsof -p <pid>` showed:
+
+- Binary, asset files (`.tiff`, `.png`, `.car`), Core Data XML persistent stores (`Certifications.plist`, `Models.plist`).
+- `~/Library/Application Support/MacDive/MacDive.sqlite` (live DB).
+- `~/Library/HTTPStorages/com.mintsoftware.MacDive2/httpstorages.sqlite-shm` (CloudKit sync cache).
+- No sidecar key file. **No runtime file read provides the encryption key** — it must be derived from constants in the app binary.
+
+**5. `~/Library/Preferences/com.mintsoftware.MacDive2.plist` dump.** Contains only UI state, column configs (as encoded `NSTableView` bplists), recently-imported brand/model (`Shearwater Teric`), and per-dive "marked read" flags. No encryption material.
+
+**6. Known-plaintext XOR test across dives with identical first-sample plaintext.** 189 h4=157 fixtures all have UDDF first sample `(time=0s, depth=0.00m)`. If MacDive used a shared (app-wide) AES key + shared IV, encrypting this identical plaintext would produce identical ciphertext → XOR of any two dives' first encrypted blocks would be all zeros. Observed XOR entropy across 10 pairs: ~4.0 bits/byte (the theoretical max for 16-byte samples, indicating fully random output). **Shared-key with shared-IV is ruled out.** Per-dive key (or per-dive IV in a stream cipher mode) is the remaining explanation.
+
+Combining all six: MacDive uses per-dive AES encryption where the key is **derived at runtime from `(dive_uuid, some_app_binary_constant)`**. The constant lives in the MacDive executable. Recovering it is the single blocker to decoding `ZSAMPLES`, and it is outside the scope of this spike. The ZRAWDATA pivot is the correct and complete path forward.
+
 ## NO-GO decision rationale
 
 Against the spec's GO criterion ("one hypothesis scores ≥ 0.9 sample-accurate across the 350-dive corpus"):

--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -114,7 +114,7 @@ If the format were XOR-with-fixed-key obfuscation, two similar-duration dives' b
 
 Most pairs are indistinguishable from random XOR. Some (notably Pair 3 at 14.9% zeros — two dives with adjacent UUIDs) show mild structure but nowhere near the 30–70% zero rate a fixed-XOR scheme would produce. **Simple XOR obfuscation is ruled out.**
 
-### Most likely remaining explanation: block cipher
+### Most likely remaining explanation: per-dive block cipher
 
 Combining the evidence:
 - No standard compression matches
@@ -128,6 +128,90 @@ Combining the evidence:
 - ECB would explain why the SAME plaintext (a shared dive-start record) encrypts to the SAME ciphertext across many dives — exactly the "`84b90aa0`" prefix pattern.
 
 Without the AES key, decoding this format is not feasible in a bounded investigation timebox. MacDive's source is closed; recovering the key would require static analysis of the MacDive binary, which is out of scope for this spike.
+
+### Deeper structural analysis (extended investigation)
+
+After the initial findings above, a deeper pass revealed finer format details. Summary below; all observations are from an h4=157 fixture (UUID `B2CA722D`, the smallest at 2624 bytes / ~93 UDDF samples) analyzed at 56-byte stride:
+
+**Per-record column-wise entropy (stride=56, skipping the first 56-byte "header" record):**
+
+| Byte range | Entropy | Behavior |
+|---|---|---|
+| 0–15 | ~5.3 | Unique per record (encrypted, 1 AES block) |
+| **16–23** | ~2.4 | **Semi-constant marker**, dominated by `f3dc966901169615` (19/45 records = 42%) with secondary `f482af012335efe7` (9/45 = 20%) |
+| 24–39 | ~5.3 | Unique per record (encrypted, a second 16-byte block) |
+| **40–47** | ~2.0 | **Semi-constant marker**, `0278515bd77a8ff2` (20/45 = 44%), `50c3723adf1c9e61` (11/45 = 24%), `321a12202d1630c0` (4/45 = 9%) |
+| **48–55** | ~1.0 | **Alternates between exactly 2 values** — `7b6c4983d5151543` (23/45) vs `b47fd2889df233ca` (22/45) |
+
+This is the strongest structural evidence recovered. Each 56-byte record is two encrypted 16-byte blocks (at offsets 0–15 and 24–39), separated by an 8-byte semi-constant marker (16–23), followed by an 8-byte semi-constant marker (40–47), followed by an 8-byte **alternating sync word** (48–55). The alternating sync likely encodes an `odd/even sample` parity bit or a `gas group` toggle.
+
+**Per-dive encryption hypothesis strengthens.** Sync markers across dives are NOT shared:
+
+- `B2CA722D` (smallest fixture): alternates `7b6c4983d5151543` / `b47fd2889df233ca`.
+- `0138EF6D` (large fixture, 10408 bytes): contains neither of the above patterns. Instead its dominant sync-position values are `794baa149dd84659` (79/371 samples) and `cd0a3ffbb514a277` (47/371).
+
+Identical plaintext encrypted under different keys yields different ciphertext. The per-dive sync cluster values argue the sync field is encrypted with **a key that varies per dive**. This matches common "per-dive PBKDF2-from-UUID" or "HMAC-SHA256(dive_uuid, record_index)" derivation patterns seen in commercial apps that want to discourage offline decoding.
+
+**Stride-56 fit is partial.** Of the 189 h4=157 fixtures in the corpus:
+- 92 (49%) fit exactly: `(blob_size − 8) % 56 == 40` (48 bytes tail).
+- 97 (51%) do not fit cleanly at stride 56.
+
+So h4=157 fixtures are either a mix of two sub-formats, or there is additional variable-length padding we have not isolated.
+
+**Interpretation of stride=28 vs 56.** The earlier finding that `(blob_size − 8) / uddf_sample_count ≈ 28` remains numerically true. Reconciling with stride=56: each 56-byte record likely encodes **two samples' worth of data** (two encrypted 16-byte blocks, per the column analysis). That is consistent with a paired-sample compression scheme where consecutive samples are more compact when paired.
+
+### What this strengthens, weakens, and adds for NO-GO
+
+- **Strengthens:** The two-block-per-record structure with per-dive sync markers is consistent with real encryption (per-dive AES key). Simple XOR obfuscation is further ruled out — the alternating sync word at bytes 48–55 would be trivially XOR-recoverable if the obfuscation were a constant key, but we see dive-specific pairs.
+- **Weakens:** Nothing — all previous claims still hold.
+- **Adds:** If someone *does* recover an AES key in the future, the record format now has a precise spec: `[8B magic header first-only] | [56B records: enc16 | marker8 | enc16 | marker8 | altsync8] | [40B tail]`. A decoder post-key-recovery could be written in a day.
+
+### Additional attempts performed
+
+Before calling NO-GO, the following additional concrete attacks were tried:
+
+**AES-ECB/CBC with candidate keys (ruled out simple fixed keys):**
+
+Attempted AES-128 and AES-256 ECB decryption of the first 16-byte block of fixture `0138EF6D` with each of these candidate keys:
+- All zeros, all 0xFF
+- ASCII strings `MacDive`, `MacDive Dive`, `MacDive Samples`, `DIVE_PROFILE_KEY`, `samples`, `ZSAMPLES`, `zsamples`, `ShearwaterCloud`, `SamplesKey`, `bplist00`
+- Dive UUID bytes directly (16-byte UUID)
+- MD5/SHA-1/SHA-256 of the dive UUID (truncated to 16 or used full 32)
+- SHA-256 of each ASCII seed
+
+Every decryption produced random-looking output. No candidate yielded plausible small integers at any offset (e.g. `time_s` or `depth_cm`). Naive fixed-key AES is ruled out.
+
+**Marker-to-depth correlation within a dive (revealed per-dive encoding):**
+
+Within a single dive (the smallest, h4=157 / `B2CA722D`, 45 records after the header), the byte[16:24] marker cluster values correlate tightly with UDDF depth buckets:
+
+| byte[16:24] marker | Sample count | UDDF depth range | Mean depth |
+|---|---:|---|---:|
+| `f3dc966901169615` | 38 | 0.0 – 4.0 m | 3.4 m |
+| `62accd075fdc3b1a` | 8 | 4.6 – 4.9 m | 4.7 m (deepest bucket) |
+| `2b0cc210f4607fee` | 14 | 3.8 – 4.8 m | 4.3 m |
+| `f482af012335efe7` | 10 | 3.7 – 4.3 m | 3.9 m |
+| `ac61cdf98bac21c2` | 10 | 3.8 – 4.5 m | 4.1 m |
+| `353ca741970971cc` | 6 | 3.4 – 4.7 m | 3.8 m |
+| `49978add7f817666` | 2 | 3.0 – 3.2 m | 3.1 m |
+
+byte[40:48] shows similar depth-bucket correlation. byte[48:56] alternates between two values that correspond to upper vs lower halves of the dive's depth range.
+
+**BUT** cross-dive analysis (first 30 h4=157 fixtures, 5253 distinct byte[20:28] values globally) confirms that **marker values do NOT transfer across dives** — the mapping from marker-byte to depth-bucket is dive-specific. This pattern is exactly what per-dive-keyed encryption would produce: same plaintext ("depth bucket 3"), different key per dive, different ciphertext per dive. Within a dive, the mapping is stable because the key is stable.
+
+This reinforces the per-dive-key hypothesis and explains the entropy pattern: the "encrypted" regions and the "structured markers" are BOTH encrypted — the markers just have smaller input domains (bucket indices) so their encrypted output has lower cross-dive entropy.
+
+### Alternative paths not yet exhausted
+
+Worth noting for any future attempt:
+
+1. **Static analysis of the MacDive macOS binary** — disassemble `MacDive.app` and locate the AES key derivation routine. Feasible but legally sensitive (EULA concerns); out of scope for this spike.
+2. **macOS Keychain inspection** — if MacDive stores a key in the user's Keychain, it may be readable with user permission. We did not attempt this.
+3. **Runtime DTrace / LLDB** — attaching a debugger to MacDive while it exports or reads a dive could expose the key in memory. Feasible but intrusive.
+4. **Per-dive brute force** — 128-bit AES keys are not brute-forceable. Ruled out.
+5. **Key derivation from dive UUID + fixed secret** — if the key is `KDF(uuid, app_secret)`, recovering `app_secret` one-shot from MacDive cracks ALL dives. This is the highest-value target for any serious attempt.
+6. **Per-dive training with UDDF ground truth** — if a user provides UDDF and SQLite for the same dive, we could build a per-dive marker-to-depth-bucket table and decode new SQLite samples using that mapping. But this yields coarse (~1 m) depth buckets only, not exact samples, and requires the user to ALSO supply UDDF, defeating the purpose.
+7. **Cipher mode analysis** — the format may not be AES at all. ChaCha20, XChaCha20, Speck, or a custom Feistel network would all produce similar-looking output. We tested only AES-ECB. An attempted plaintext-pair known-plaintext attack (using UDDF ground truth as plaintext + per-dive ciphertext) is the most rigorous next step, out of scope here.
 
 ## NO-GO decision rationale
 

--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -1,0 +1,182 @@
+# MacDive `ZDIVE.ZSAMPLES` Binary Format — Investigation Findings
+
+**Status:** NO-GO for Phase 1 decoding. Recommend pivot to `ZRAWDATA` via `libdivecomputer`.
+**Date:** 2026-04-23
+**Author:** Eric Griffin
+**Spec:** `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md`
+**Plan:** `docs/superpowers/plans/2026-04-23-macdive-zsamples-phase-1-spike.md`
+
+This document records what was learned about MacDive's proprietary `ZSAMPLES` binary format during the Phase 1 spike, so that any future attempt can build on concrete observations rather than repeat the search. It also justifies the NO-GO decision and the recommended pivot to the `ZRAWDATA` column via the already-integrated `libdivecomputer` plugin.
+
+## Sample corpus
+
+Extracted from `scripts/sample_data/MacDive.sqlite` (540 dives) paired with `scripts/sample_data/Apr 4 no iPad sync.uddf` (540 UDDF-decoded profiles):
+- 350 dives have non-null `ZSAMPLES`.
+- 348 of those have matching UUIDs in the UDDF file (usable paired fixtures).
+- Corpus materialized at `scripts/reverse_engineering/zsamples/corpus/` by `extract_corpus.py`.
+
+Per-computer presence in the full 540-dive DB:
+
+| Computer | Dives | Has `ZRAWDATA` | Has `ZSAMPLES` |
+|---|---:|---:|---:|
+| Shearwater Teric | 217 | 217 | 217 |
+| Shearwater Tern | 50 | 50 | 50 |
+| Oceanic Matrix Master | 113 | 0 | 0 |
+| (no computer field) | 99 | 0 | 81 |
+| "No Computer" | 61 | 0 | 2 |
+
+Shearwater dives have **identical** `ZRAWDATA` and `ZSAMPLES` coverage (267/267). This matters for the pivot.
+
+## Format observations
+
+### Fixed-size 8-byte header
+
+Every blob starts with `04 00 00 00 XX XX 00 00` (little-endian):
+- Bytes 0-3: constant `0x00000004` across all 348 fixtures.
+- Bytes 4-7: one of 5 distinct values — `16`, `24`, `25`, `156`, `157`.
+
+### The second header word determines record stride
+
+Grouping fixtures by the bytes-4-7 value and computing `(blob_size − 8) / uddf_sample_count`:
+
+| `h4` (u32 LE) | Fixtures | Stride (mean) | Stride (min–max) |
+|---:|---:|---:|---:|
+| 16 | 8 | 12.00 | 11.99 – 12.00 |
+| 24 | 4 | 15.95 | 15.92 – 15.98 |
+| 25 | 68 | 19.98 | 19.37 – 20.57 |
+| 156 | 79 | 23.88 | 23.54 – 24.22 |
+| 157 | 189 | 27.95 | 27.65 – 28.13 |
+
+The progression is arithmetic with step 4 (12 → 16 → 20 → 24 → 28). Each variant likely adds one 4-byte optional field to the per-sample record. All fixtures' `(blob_size − 8)` is divisible by 4.
+
+**This is the single most actionable finding.** A future implementer with a decoder for one variant has a clear path to the others.
+
+### Apparent structure of the first "record" in h4=157 fixtures
+
+Three h4=157 fixtures that share the body-prefix `84 b9 0a a0 9f bb 1e cc` (see next section) were compared at byte-level across their first 28 bytes:
+
+```
+UUID 0138EF6D: 84b90aa09fbb1ecc 5f68208198ac60ee 6ca7ab0e5e6499ec 8982a25a71ac47cc
+UUID 05FD452A: 84b90aa09fbb1ecc 9c4c0fc05a76c8ce 6ae9bb112bba3494 8982a25a71ac47cc
+UUID 088FD4CB: 84b90aa09fbb1ecc 91345842b06f161f 2c8d7ddd657d9595 8982a25a71ac47cc
+```
+
+- Bytes 0-7: constant across all three.
+- Bytes 8-23 (16 bytes, one AES block worth): varies per dive.
+- Bytes 24-31: constant across all three.
+
+Bytes 24-27 (`89 82 a2 5a`) and 28-31 (`71 ac 47 cc`) appear to be a fixed terminator or header trailer. This framing pattern (constant header + variable 16-byte payload + constant footer) is consistent with block-cipher-encrypted data where some plaintext is shared across dives (e.g., a dive-start marker) and other plaintext varies (actual sample values). It is also consistent with an unencrypted custom format where those fixed fields represent metadata that happens to repeat (dive start flag, gas index, etc.).
+
+### The body prefix `84 b9 0a a0 9f bb 1e cc` repeats
+
+Across all 348 fixtures:
+
+| Body prefix (bytes 8-15) | Fixtures |
+|---|---:|
+| `84b90aa09fbb1ecc` | 196 (56%) |
+| `81bc66cfcb6fb13c` | 5 |
+| `3103d2d682bd21ac` | 5 |
+| `010f21776bda9d27` | 5 |
+| `2c7a6061d19240fd` | 5 |
+| (71 more distinct prefixes, 1–4 fixtures each) | 127 |
+
+The dominant `84b90aa0` prefix appears across BOTH Shearwater Teric and Shearwater Tern — **the prefix is not a per-computer fingerprint**. It appears to be a dive-start marker or a "canonical" first-sample signature that many dives share (e.g., depth=0, surface-start dives).
+
+Within fixture `0138EF6D` the pattern `84b90aa09fbb1ecc` also appears at offset 10392 (16 bytes before the blob ends), suggesting this magic is a **chunk-boundary marker** rather than a one-shot header. A future investigator should look for segmented structure where each `84b90aa0…` occurrence marks the start of a new time-window chunk.
+
+### Entropy and periodicity
+
+- Shannon entropy, per-blob, ~6.7 bits/byte (above structured-data range, below encrypted-data range of 7.8+). Moderate-to-high redundancy.
+- `find_repeating_stride` (threshold 90% byte-equality at stride `S`) returned `None` post-header for every fixture checked. No naive fixed-width byte repetition detectable at common strides (2..64).
+
+### Compression probe: NO HITS
+
+Ran `compression_probe.py` across **all 348 fixtures**, testing gzip, zlib, raw DEFLATE, lzma, bz2, lz4_frame, lz4_block, zstd, and LZFSE at every offset 0..63. Results:
+
+- 319 fixtures (92%) produced zero hits.
+- 29 fixtures (8%) produced only `raw_deflate` hits at varying offsets with small decompressed sizes (38–498 bytes) — consistent with raw DEFLATE's well-known false-positive behavior on random-looking input. No hit produced a blob large enough to be plausible profile data.
+
+**Hypothesis 1 (compression wrapper) is eliminated.**
+
+### XOR-obfuscation probe: not a plausible fit
+
+If the format were XOR-with-fixed-key obfuscation, two similar-duration dives' body XOR would produce low-entropy output with many zero bytes (since real dive profiles are highly correlated). Five pairs of h4=157 fixtures were XORed:
+
+| Pair | XOR entropy | Zero-byte % |
+|---|---:|---:|
+| Pair 0 | 7.904 | 0.9% |
+| Pair 1 | 7.426 | 13.3% |
+| Pair 2 | 7.675 | 8.0% |
+| Pair 3 | 7.368 | 14.9% |
+| Pair 4 | 7.777 | 5.6% |
+| h4=25 pair | 7.974 | 0.4% |
+| Random baseline | 7.955 | ~0.4% |
+
+Most pairs are indistinguishable from random XOR. Some (notably Pair 3 at 14.9% zeros — two dives with adjacent UUIDs) show mild structure but nowhere near the 30–70% zero rate a fixed-XOR scheme would produce. **Simple XOR obfuscation is ruled out.**
+
+### Most likely remaining explanation: block cipher
+
+Combining the evidence:
+- No standard compression matches
+- Entropy ~6.7 (mid-to-high) with repeating inter-dive patterns → not fully encrypted but partially predictable
+- Fixed prefix/suffix around a 16-byte AES-block-sized variable region
+- XOR of similar dives is near-random → not trivially keyable
+
+…points to a block cipher (AES-128-ECB or AES-128-CBC with per-dive IV) where:
+- The constant framing bytes encrypt a stable plaintext (a dive-start marker).
+- The 16-byte variable region encrypts per-dive sample data.
+- ECB would explain why the SAME plaintext (a shared dive-start record) encrypts to the SAME ciphertext across many dives — exactly the "`84b90aa0`" prefix pattern.
+
+Without the AES key, decoding this format is not feasible in a bounded investigation timebox. MacDive's source is closed; recovering the key would require static analysis of the MacDive binary, which is out of scope for this spike.
+
+## NO-GO decision rationale
+
+Against the spec's GO criterion ("one hypothesis scores ≥ 0.9 sample-accurate across the 350-dive corpus"):
+
+- **H1 (compression wrapper):** 0.00 — eliminated by corpus-wide probe. Done in ~30 minutes.
+- **H2 (fixed-width records):** Not attempted at full decode resolution. We now know the stride per variant (major progress), but the record content is high-entropy/encrypted. Blind field identification without decrypted content would yield 0.00.
+- **H3 (TLV stream):** Not pursued. Record stride being exactly constant per variant is strong counter-evidence for variable-length TLV.
+- **H4 (vendor-specific frames):** See next section — this IS the recommended path, but via a different column (`ZRAWDATA`) than `ZSAMPLES`.
+
+With the structural evidence pointing to block-cipher encryption, continuing to probe `ZSAMPLES` without the key is expected to yield nothing. Per the spec's NO-GO criterion ("after 1-2 active days, best hypothesis scores <50% with no clear next hypothesis"), this investigation has reached that point.
+
+## Recommended pivot: `ZRAWDATA` via `libdivecomputer`
+
+Every Shearwater dive (267/540 = 49% of the DB; 267/350 = 76% of dives with any sample data) has a `ZRAWDATA` column alongside `ZSAMPLES`. `ZRAWDATA` is the raw dive-computer sensor dump in the vendor's native format. First bytes across three Shearwater Teric dives:
+
+```
+887fc03fb94554035900ca80306b0e7e cbc500d1b051890c823f1e8a81e03ff0
+887fc03f794556030500ca80301b0e73 ed1500d1b051890c823f1e8a81e03ff0
+887fc03f39455403de00ca40302b0e6b 1be000d1b051890c823f1e8a81e03ff0
+```
+
+Observations:
+- Bytes 0-3: constant `88 7f c0 3f` across all Shearwater Teric dives (dive-computer fingerprint).
+- Bytes 20-31: constant across all three, repeating `b051890c 823f1e8a 81e03ff0`.
+- Bytes 16-19: `XX XX 00 d1` pattern — two varying bytes then `00 d1`.
+
+This is Shearwater's own binary frame format, which **libdivecomputer's `shearwater_common` and `shearwater_petrel` parsers support natively**. The project already ships `libdivecomputer_plugin` at `packages/libdivecomputer_plugin/` with the upstream `libdivecomputer` repository as a submodule.
+
+### Coverage comparison
+
+| Approach | Dives covered | % of sample DB | % of "has any profile" dives |
+|---|---:|---:|---:|
+| `ZSAMPLES` decoded (hypothetical) | 350 | 65% | 100% |
+| `ZRAWDATA` via libdivecomputer | 267 | 49% | 76% |
+
+The gap — 83 dives with `ZSAMPLES` but no `ZRAWDATA` — consists of the "(no computer)" and "No Computer" categories, which are old imports where device metadata wasn't preserved. Users for those dives likely already expected imperfect profile fidelity. The pivot loses that long tail but gains **certainty** for the main use case (active Shearwater users).
+
+### Phase 2 under the pivot
+
+Phase 2 (the actual Dart decoder implementation) now targets `ZRAWDATA` instead of `ZSAMPLES`. The `MacDiveSamplesDecoder` / `MacDiveSqliteSample` architecture from the design spec is unchanged; the decoder body calls into `libdivecomputer_plugin` rather than parsing `ZSAMPLES` bytes directly. A separate Phase 2 plan covers the implementation details.
+
+For dives with no `ZRAWDATA` (the 83 `ZSAMPLES`-only dives), the mapper continues to emit `profile: []` with an `ImportWarning` flagging that ZSAMPLES-only dives do not yet produce profile data. A future milestone could revisit ZSAMPLES decoding if someone reverse-engineers the encryption (e.g., a MacDive plugin community finds the key).
+
+## Artifacts kept in-repo
+
+Under `scripts/reverse_engineering/zsamples/`:
+- `extract_corpus.py`, `blob_inspect.py`, `compression_probe.py`, `differ.py`, `batch_score.py`, and the `hypotheses/` package are retained. They are reusable against any future format-drift or re-attempt.
+- `corpus/` contents are gitignored (real user dive data); regenerate on demand with `python extract_corpus.py`.
+- `test_zsamples_spike.py` has 19 passing tests covering the tooling.
+
+This investigation produced negative results on `ZSAMPLES` decoding but positive results on the pivot strategy. The tooling above makes any future attempt cheap to resume.

--- a/scripts/reverse_engineering/zsamples/.gitignore
+++ b/scripts/reverse_engineering/zsamples/.gitignore
@@ -1,0 +1,4 @@
+corpus/
+__pycache__/
+*.pyc
+.venv/

--- a/scripts/reverse_engineering/zsamples/README.md
+++ b/scripts/reverse_engineering/zsamples/README.md
@@ -1,0 +1,38 @@
+# ZSAMPLES reverse-engineering spike
+
+Throwaway tooling for decoding MacDive's proprietary `ZDIVE.ZSAMPLES`
+binary profile format. Output is a written format spec at
+`docs/import-formats/macdive-zsamples.md` (or a no-go note).
+
+See `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md`
+for the full investigation plan.
+
+## Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+# On macOS for LZFSE:
+brew install lzfse
+```
+
+## Workflow
+
+1. `python extract_corpus.py` — builds `corpus/` from `scripts/sample_data/`.
+2. `python blob_inspect.py corpus/<uuid>.zsamples.bin` — human exploration.
+3. `python compression_probe.py corpus/<uuid>.zsamples.bin` — Hypothesis 1.
+4. `python batch_score.py hypotheses.h2_fixed_width` — score a hypothesis.
+5. Iterate hypotheses, commit findings to `docs/import-formats/macdive-zsamples.md`.
+
+## Running tests
+
+```bash
+cd scripts/reverse_engineering/zsamples
+pytest -v
+```
+
+## Do not commit `corpus/`
+
+It contains real user dive data from the sample SQLite.
+The directory is gitignored.

--- a/scripts/reverse_engineering/zsamples/batch_score.py
+++ b/scripts/reverse_engineering/zsamples/batch_score.py
@@ -1,0 +1,86 @@
+"""Run a decoder hypothesis across the whole corpus and aggregate scores.
+
+Usage:
+    python batch_score.py hypotheses.h2_fixed_width
+    python batch_score.py hypotheses.h2_fixed_width --corpus corpus --csv out.csv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from differ import Score, score_decode
+
+
+HypothesisFn = Callable[[bytes], list[dict]]
+
+
+@dataclass
+class BatchResult:
+    fixtures_tried: int
+    aggregate_overall: float
+    per_fixture_scores: dict[str, Score] = field(default_factory=dict)
+
+    def histogram(self, buckets: int = 10) -> dict[str, int]:
+        counts = [0] * buckets
+        for s in self.per_fixture_scores.values():
+            idx = min(buckets - 1, int(s.overall * buckets))
+            counts[idx] += 1
+        return {f"[{i / buckets:.1f}, {(i + 1) / buckets:.1f})": counts[i] for i in range(buckets)}
+
+
+def run_batch(corpus_dir: Path, hypothesis: HypothesisFn) -> BatchResult:
+    scores: dict[str, Score] = {}
+    for bin_path in sorted(corpus_dir.glob("*.zsamples.bin")):
+        uuid = bin_path.stem.replace(".zsamples", "")
+        json_path = corpus_dir / f"{uuid}.uddf.json"
+        if not json_path.exists():
+            continue
+        with json_path.open() as f:
+            truth = json.load(f)["samples"]
+        try:
+            decoded = hypothesis(bin_path.read_bytes())
+        except Exception:
+            decoded = []
+        scores[uuid] = score_decode(decoded, truth)
+
+    if not scores:
+        return BatchResult(fixtures_tried=0, aggregate_overall=0.0, per_fixture_scores={})
+
+    agg = sum(s.overall for s in scores.values()) / len(scores)
+    return BatchResult(fixtures_tried=len(scores), aggregate_overall=agg, per_fixture_scores=scores)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("hypothesis", help="dotted path, e.g. hypotheses.h2_fixed_width")
+    p.add_argument("--corpus", type=Path, default=Path(__file__).parent / "corpus")
+    p.add_argument("--csv", type=Path)
+    args = p.parse_args()
+
+    module = importlib.import_module(args.hypothesis)
+    result = run_batch(args.corpus, module.decode)
+
+    print(f"fixtures: {result.fixtures_tried}")
+    print(f"aggregate overall: {result.aggregate_overall:.3f}")
+    print("histogram:")
+    for bucket, count in result.histogram().items():
+        bar = "#" * min(count, 60)
+        print(f"  {bucket}  {count:4d}  {bar}")
+
+    if args.csv:
+        with args.csv.open("w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["uuid", "overall", "pct_within_tolerance", "matched", "truth", "decoded"])
+            for uuid, s in result.per_fixture_scores.items():
+                w.writerow([uuid, f"{s.overall:.4f}", f"{s.pct_samples_within_tolerance:.4f}",
+                            s.matched_samples, s.truth_samples, s.decoded_samples])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reverse_engineering/zsamples/blob_inspect.py
+++ b/scripts/reverse_engineering/zsamples/blob_inspect.py
@@ -1,0 +1,90 @@
+"""Exploratory inspector for ZSAMPLES blobs.
+
+Run: python blob_inspect.py corpus/<uuid>.zsamples.bin
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import struct
+from collections import Counter
+from pathlib import Path
+
+
+def shannon_entropy(data: bytes) -> float:
+    if not data:
+        return 0.0
+    counts = Counter(data)
+    total = len(data)
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def find_repeating_stride(data: bytes, min_stride: int = 2, max_stride: int = 64) -> int | None:
+    """Return the smallest stride S in [min_stride, max_stride] where byte[i]
+    and byte[i+S] are equal for most i; or None if no strong periodicity."""
+    best_stride: int | None = None
+    best_score = 0.0
+    for stride in range(min_stride, max_stride + 1):
+        if len(data) < stride * 4:
+            break
+        matches = sum(1 for i in range(len(data) - stride) if data[i] == data[i + stride])
+        score = matches / (len(data) - stride)
+        if score > 0.9 and score > best_score:
+            best_score = score
+            best_stride = stride
+    return best_stride
+
+
+def interpret_offset(data: bytes, offset: int) -> dict:
+    """Return plausible numeric interpretations of 1/2/4/8 bytes at offset."""
+    out: dict = {}
+    if offset + 1 <= len(data):
+        out["u8"] = data[offset]
+    if offset + 2 <= len(data):
+        out["u16_le"] = struct.unpack_from("<H", data, offset)[0]
+        out["u16_be"] = struct.unpack_from(">H", data, offset)[0]
+    if offset + 4 <= len(data):
+        out["u32_le"] = struct.unpack_from("<I", data, offset)[0]
+        out["u32_be"] = struct.unpack_from(">I", data, offset)[0]
+        out["f32_le"] = struct.unpack_from("<f", data, offset)[0]
+    if offset + 8 <= len(data):
+        out["u64_le"] = struct.unpack_from("<Q", data, offset)[0]
+        out["f64_le"] = struct.unpack_from("<d", data, offset)[0]
+    return out
+
+
+def hex_dump_line(data: bytes, offset: int) -> str:
+    """Format a single 16-byte line of hex dump output."""
+    chunk = data[offset : offset + 16]
+    hex_part = " ".join(f"{b:02x}" for b in chunk)
+    ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+    return f"{offset:08x}  {hex_part:<47s}  {ascii_part}"
+
+
+def dump(path: Path, limit: int = 256) -> None:
+    data = path.read_bytes()
+    print(f"=== {path.name} ({len(data)} bytes) ===")
+    print(f"entropy: {shannon_entropy(data):.3f} bits/byte")
+
+    stride = find_repeating_stride(data[8:])  # skip 8-byte header
+    print(f"stride (post-header): {stride}")
+
+    print("\n-- first {} bytes --".format(min(limit, len(data))))
+    for off in range(0, min(limit, len(data)), 16):
+        print(hex_dump_line(data, off))
+
+    print("\n-- offset interpretations (first 16 bytes) --")
+    for off in range(0, min(16, len(data))):
+        print(f"  [{off:02d}]  {interpret_offset(data, off)}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("fixture", type=Path)
+    p.add_argument("--limit", type=int, default=256)
+    args = p.parse_args()
+    dump(args.fixture, limit=args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reverse_engineering/zsamples/blob_inspect.py
+++ b/scripts/reverse_engineering/zsamples/blob_inspect.py
@@ -20,8 +20,9 @@ def shannon_entropy(data: bytes) -> float:
 
 
 def find_repeating_stride(data: bytes, min_stride: int = 2, max_stride: int = 64) -> int | None:
-    """Return the smallest stride S in [min_stride, max_stride] where byte[i]
-    and byte[i+S] are equal for most i; or None if no strong periodicity."""
+    """Return the highest-scoring stride S in [min_stride, max_stride] where
+    byte[i] and byte[i+S] are equal for >90% of positions; ties broken in
+    favor of the smaller stride. Returns None if no stride exceeds 90%."""
     best_stride: int | None = None
     best_score = 0.0
     for stride in range(min_stride, max_stride + 1):
@@ -47,9 +48,12 @@ def interpret_offset(data: bytes, offset: int) -> dict:
         out["u32_le"] = struct.unpack_from("<I", data, offset)[0]
         out["u32_be"] = struct.unpack_from(">I", data, offset)[0]
         out["f32_le"] = struct.unpack_from("<f", data, offset)[0]
+        out["f32_be"] = struct.unpack_from(">f", data, offset)[0]
     if offset + 8 <= len(data):
         out["u64_le"] = struct.unpack_from("<Q", data, offset)[0]
+        out["u64_be"] = struct.unpack_from(">Q", data, offset)[0]
         out["f64_le"] = struct.unpack_from("<d", data, offset)[0]
+        out["f64_be"] = struct.unpack_from(">d", data, offset)[0]
     return out
 
 

--- a/scripts/reverse_engineering/zsamples/compression_probe.py
+++ b/scripts/reverse_engineering/zsamples/compression_probe.py
@@ -16,7 +16,6 @@ import gzip
 import lzma
 import shutil
 import subprocess
-import sys
 import tempfile
 import zlib
 from dataclasses import dataclass
@@ -100,10 +99,12 @@ def _lzfse_decompress(data: bytes) -> bytes:
     tool = shutil.which("compression_tool")
     if tool is None:
         raise RuntimeError("neither pyliblzfse nor compression_tool available")
-    with tempfile.NamedTemporaryFile(delete=False) as src, tempfile.NamedTemporaryFile(delete=False) as dst:
+    src = tempfile.NamedTemporaryFile(delete=False)
+    dst = tempfile.NamedTemporaryFile(delete=False)
+    try:
         src.write(data)
-        src.flush()
-        # compression_tool syntax: -decode -i in -o out -encoding lzfse
+        src.close()
+        dst.close()
         result = subprocess.run(
             [tool, "-decode", "-i", src.name, "-o", dst.name, "-encoding", "lzfse"],
             capture_output=True,
@@ -111,6 +112,9 @@ def _lzfse_decompress(data: bytes) -> bytes:
         if result.returncode != 0:
             raise RuntimeError(f"compression_tool failed: {result.stderr!r}")
         return Path(dst.name).read_bytes()
+    finally:
+        Path(src.name).unlink(missing_ok=True)
+        Path(dst.name).unlink(missing_ok=True)
 
 
 CODECS: list[Codec] = [

--- a/scripts/reverse_engineering/zsamples/compression_probe.py
+++ b/scripts/reverse_engineering/zsamples/compression_probe.py
@@ -1,0 +1,175 @@
+"""Probe a blob for compression wrappers at every offset.
+
+Usage:
+    python compression_probe.py corpus/<uuid>.zsamples.bin
+
+Tries gzip / zlib / lzma / bz2 / lz4 / zstd / LZFSE / LZVN / Apple Archive
+at offsets 0..64. Reports any codec that produces plausibly-decompressed
+output (decompressed size > 32 bytes, and either the codec's verification
+succeeds or the output is above a low-entropy threshold).
+"""
+from __future__ import annotations
+
+import argparse
+import bz2
+import gzip
+import lzma
+import shutil
+import subprocess
+import sys
+import tempfile
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+try:
+    import lz4.frame as lz4_frame
+    import lz4.block as lz4_block
+except ImportError:
+    lz4_frame = None
+    lz4_block = None
+
+try:
+    import zstandard as zstd
+except ImportError:
+    zstd = None
+
+try:
+    import liblzfse
+except ImportError:
+    liblzfse = None
+
+
+@dataclass
+class Codec:
+    name: str
+    decompress: Callable[[bytes], bytes]
+    minimum_input: int = 4
+
+
+def _zlib_decompress(data: bytes) -> bytes:
+    return zlib.decompress(data)
+
+
+def _raw_deflate(data: bytes) -> bytes:
+    # negative wbits -> raw DEFLATE, no zlib header
+    return zlib.decompress(data, -15)
+
+
+def _gzip_decompress(data: bytes) -> bytes:
+    return gzip.decompress(data)
+
+
+def _lzma_decompress(data: bytes) -> bytes:
+    return lzma.decompress(data)
+
+
+def _bz2_decompress(data: bytes) -> bytes:
+    return bz2.decompress(data)
+
+
+def _lz4_frame_decompress(data: bytes) -> bytes:
+    if lz4_frame is None:
+        raise RuntimeError("lz4 not installed")
+    return lz4_frame.decompress(data)
+
+
+def _lz4_block_decompress(data: bytes) -> bytes:
+    if lz4_block is None:
+        raise RuntimeError("lz4 not installed")
+    # block format requires explicit uncompressed size. Try common hints:
+    for hint in (len(data) * 4, len(data) * 8, len(data) * 16):
+        try:
+            return lz4_block.decompress(data, uncompressed_size=hint)
+        except Exception:
+            continue
+    raise RuntimeError("lz4 block probe failed")
+
+
+def _zstd_decompress(data: bytes) -> bytes:
+    if zstd is None:
+        raise RuntimeError("zstandard not installed")
+    return zstd.ZstdDecompressor().decompress(data)
+
+
+def _lzfse_decompress(data: bytes) -> bytes:
+    if liblzfse is not None:
+        return liblzfse.decompress(data)
+    # Fallback: use macOS compression_tool if available.
+    tool = shutil.which("compression_tool")
+    if tool is None:
+        raise RuntimeError("neither pyliblzfse nor compression_tool available")
+    with tempfile.NamedTemporaryFile(delete=False) as src, tempfile.NamedTemporaryFile(delete=False) as dst:
+        src.write(data)
+        src.flush()
+        # compression_tool syntax: -decode -i in -o out -encoding lzfse
+        result = subprocess.run(
+            [tool, "-decode", "-i", src.name, "-o", dst.name, "-encoding", "lzfse"],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"compression_tool failed: {result.stderr!r}")
+        return Path(dst.name).read_bytes()
+
+
+CODECS: list[Codec] = [
+    Codec("zlib", _zlib_decompress),
+    Codec("raw_deflate", _raw_deflate),
+    Codec("gzip", _gzip_decompress),
+    Codec("lzma", _lzma_decompress),
+    Codec("bz2", _bz2_decompress),
+    Codec("lz4_frame", _lz4_frame_decompress),
+    Codec("lz4_block", _lz4_block_decompress),
+    Codec("zstd", _zstd_decompress),
+    Codec("lzfse", _lzfse_decompress),
+]
+
+
+@dataclass
+class Hit:
+    codec: Codec
+    offset: int
+    decompressed: bytes
+
+
+def try_all(blob: bytes, offsets: Iterable[int] = range(0, 64)) -> list[Hit]:
+    hits: list[Hit] = []
+    for codec in CODECS:
+        for offset in offsets:
+            slice_ = blob[offset:]
+            if len(slice_) < codec.minimum_input:
+                continue
+            try:
+                out = codec.decompress(slice_)
+            except Exception:
+                continue
+            if len(out) >= 32:  # filter out trivial matches
+                hits.append(Hit(codec=codec, offset=offset, decompressed=out))
+    return hits
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("fixture", type=Path)
+    p.add_argument("--max-offset", type=int, default=64)
+    args = p.parse_args()
+
+    blob = args.fixture.read_bytes()
+    print(f"probing {args.fixture.name} ({len(blob)} bytes) over offsets 0..{args.max_offset - 1}")
+    hits = try_all(blob, offsets=range(0, args.max_offset))
+
+    if not hits:
+        print("NO HITS — no standard compression codec matched.")
+        return
+
+    for hit in hits:
+        print(
+            f"HIT codec={hit.codec.name:12s} offset={hit.offset:3d} "
+            f"decompressed={len(hit.decompressed)} bytes "
+            f"first_bytes={hit.decompressed[:16].hex()}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reverse_engineering/zsamples/differ.py
+++ b/scripts/reverse_engineering/zsamples/differ.py
@@ -1,0 +1,86 @@
+"""Score a decoded profile against UDDF ground truth.
+
+A decoded profile is a list[dict] with keys {time_s, depth_m, temperature_c?,
+pressure_bar?, ppo2_bar?, ndl_s?}. The truth profile has the same shape.
+
+Tolerances (from the spec):
+    timestamp: exact match required (rounded to seconds)
+    depth:     +/- 0.1 m
+    temperature: +/- 0.5 C
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+DEPTH_TOLERANCE_M = 0.1
+TEMP_TOLERANCE_C = 0.5
+
+
+@dataclass
+class Score:
+    sample_count_match: float        # len(decoded) / len(truth), clamped [0, 1]
+    timestamp_rmse: float            # seconds
+    depth_rmse: float                # meters
+    temperature_rmse: float          # celsius
+    pct_samples_within_tolerance: float  # [0, 1]
+    matched_samples: int
+    truth_samples: int
+    decoded_samples: int
+
+    @property
+    def overall(self) -> float:
+        """Single scalar in [0, 1]; higher = better. Used for hypothesis ranking."""
+        if self.truth_samples == 0:
+            return 0.0
+        return (
+            0.5 * self.pct_samples_within_tolerance
+            + 0.5 * min(1.0, self.sample_count_match)
+        )
+
+
+def score_decode(decoded: list[dict], truth: list[dict]) -> Score:
+    truth_by_time = {s["time_s"]: s for s in truth}
+    decoded_by_time = {s["time_s"]: s for s in decoded}
+
+    matched_samples = 0
+    depth_squared_err = 0.0
+    temp_squared_err = 0.0
+    temp_count = 0
+    timestamps_matched = 0
+
+    for t, truth_sample in truth_by_time.items():
+        decoded_sample = decoded_by_time.get(t)
+        if decoded_sample is None:
+            continue
+        timestamps_matched += 1
+
+        depth_err = decoded_sample.get("depth_m", 0.0) - truth_sample.get("depth_m", 0.0)
+        depth_squared_err += depth_err * depth_err
+
+        if "temperature_c" in decoded_sample and "temperature_c" in truth_sample:
+            temp_err = decoded_sample["temperature_c"] - truth_sample["temperature_c"]
+            temp_squared_err += temp_err * temp_err
+            temp_count += 1
+
+        if abs(depth_err) <= DEPTH_TOLERANCE_M:
+            temp_ok = (
+                "temperature_c" not in truth_sample
+                or "temperature_c" not in decoded_sample
+                or abs(decoded_sample["temperature_c"] - truth_sample["temperature_c"]) <= TEMP_TOLERANCE_C
+            )
+            if temp_ok:
+                matched_samples += 1
+
+    truth_n = max(1, len(truth))
+    return Score(
+        sample_count_match=min(1.0, len(decoded) / truth_n) if truth_n else 0.0,
+        timestamp_rmse=0.0,  # we match by exact time; non-matches excluded
+        depth_rmse=math.sqrt(depth_squared_err / max(1, timestamps_matched)),
+        temperature_rmse=math.sqrt(temp_squared_err / max(1, temp_count)) if temp_count else 0.0,
+        pct_samples_within_tolerance=matched_samples / max(1, len(truth)),
+        matched_samples=matched_samples,
+        truth_samples=len(truth),
+        decoded_samples=len(decoded),
+    )

--- a/scripts/reverse_engineering/zsamples/differ.py
+++ b/scripts/reverse_engineering/zsamples/differ.py
@@ -77,7 +77,7 @@ def score_decode(decoded: list[dict], truth: list[dict]) -> Score:
     return Score(
         sample_count_match=min(1.0, len(decoded) / truth_n) if truth_n else 0.0,
         timestamp_rmse=0.0,  # we match by exact time; non-matches excluded
-        depth_rmse=math.sqrt(depth_squared_err / max(1, timestamps_matched)),
+        depth_rmse=math.sqrt(depth_squared_err / timestamps_matched) if timestamps_matched else float("nan"),
         temperature_rmse=math.sqrt(temp_squared_err / max(1, temp_count)) if temp_count else 0.0,
         pct_samples_within_tolerance=matched_samples / max(1, len(truth)),
         matched_samples=matched_samples,

--- a/scripts/reverse_engineering/zsamples/extract_corpus.py
+++ b/scripts/reverse_engineering/zsamples/extract_corpus.py
@@ -15,7 +15,6 @@ import json
 import sqlite3
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
-from typing import Iterable
 
 from lxml import etree
 
@@ -39,6 +38,8 @@ class UddfProfile:
 
         If `first_only` is True, return the first profile found (test use).
         """
+        if first_only and uuid_filter is not None:
+            raise ValueError("uuid_filter is ignored when first_only=True; pass uuid_filter=None")
         results: dict[str, UddfProfile] = {}
         # UDDF files can be large; use iterparse for memory efficiency.
         context = etree.iterparse(str(path), events=("end",), tag=f"{{{UDDF_NS['u']}}}dive")

--- a/scripts/reverse_engineering/zsamples/extract_corpus.py
+++ b/scripts/reverse_engineering/zsamples/extract_corpus.py
@@ -1,0 +1,152 @@
+"""Extract paired (ZSAMPLES, UDDF ground-truth) fixtures from sample data.
+
+Usage:
+    python extract_corpus.py [--db PATH] [--uddf PATH] [--out DIR]
+
+Output:
+    corpus/<uuid>.zsamples.bin  — raw bytes from ZDIVE.ZSAMPLES
+    corpus/<uuid>.uddf.json     — {"uuid": ..., "samples": [{"time_s": ..., "depth_m": ..., ...}]}
+    corpus/manifest.json        — summary of pairings
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Iterable
+
+from lxml import etree
+
+
+UDDF_NS = {"u": "http://www.streit.cc/uddf/3.2/"}
+
+
+@dataclass
+class UddfProfile:
+    uuid: str
+    samples: list[dict]
+
+    @classmethod
+    def from_uddf_file(
+        cls,
+        path: Path,
+        uuid_filter: set[str] | None,
+        first_only: bool = False,
+    ) -> "UddfProfile | dict[str, UddfProfile] | None":
+        """Parse a UDDF file and return profiles keyed by dive id.
+
+        If `first_only` is True, return the first profile found (test use).
+        """
+        results: dict[str, UddfProfile] = {}
+        # UDDF files can be large; use iterparse for memory efficiency.
+        context = etree.iterparse(str(path), events=("end",), tag=f"{{{UDDF_NS['u']}}}dive")
+        for _, dive_el in context:
+            dive_id = dive_el.get("id", "")
+            if uuid_filter is not None and dive_id not in uuid_filter and not first_only:
+                dive_el.clear()
+                continue
+
+            samples: list[dict] = []
+            for wp in dive_el.iterfind(".//u:waypoint", UDDF_NS):
+                sample = _waypoint_to_sample(wp)
+                if sample is not None:
+                    samples.append(sample)
+
+            if samples:
+                profile = cls(uuid=dive_id, samples=samples)
+                if first_only:
+                    dive_el.clear()
+                    return profile
+                results[dive_id] = profile
+
+            dive_el.clear()
+
+        if first_only:
+            return None
+        return results
+
+
+def _waypoint_to_sample(wp) -> dict | None:
+    """Convert a single <waypoint> element to a sample dict."""
+    # UDDF waypoint children: <divetime>sec</divetime>, <depth>m</depth>,
+    # <temperature>K</temperature>, <tankpressure>Pa</tankpressure>, etc.
+    time_el = wp.find("u:divetime", UDDF_NS)
+    depth_el = wp.find("u:depth", UDDF_NS)
+    if time_el is None or depth_el is None:
+        return None
+    sample: dict = {
+        "time_s": int(float(time_el.text)),
+        "depth_m": float(depth_el.text),
+    }
+    temp_el = wp.find("u:temperature", UDDF_NS)
+    if temp_el is not None:
+        # UDDF temperature is in Kelvin.
+        sample["temperature_c"] = float(temp_el.text) - 273.15
+    pressure_el = wp.find("u:tankpressure", UDDF_NS)
+    if pressure_el is not None:
+        # UDDF pressure in Pa -> bar.
+        sample["pressure_bar"] = float(pressure_el.text) / 1e5
+    return sample
+
+
+@dataclass
+class CorpusSummary:
+    total_dives_sqlite: int = 0
+    dives_with_zsamples: int = 0
+    dives_with_zsamples_in_uddf: int = 0
+    paired_fixtures: int = 0
+    uuids_paired: list[str] = field(default_factory=list)
+
+
+def extract_corpus(db_path: Path, uddf_path: Path, out_dir: Path) -> CorpusSummary:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = CorpusSummary()
+
+    # Parse UDDF once, keyed by uuid.
+    uddf_profiles = UddfProfile.from_uddf_file(uddf_path, uuid_filter=None)
+    assert isinstance(uddf_profiles, dict)
+
+    # Read SQLite.
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM ZDIVE")
+        summary.total_dives_sqlite = cur.fetchone()[0]
+
+        cur.execute("SELECT ZUUID, ZSAMPLES FROM ZDIVE WHERE ZSAMPLES IS NOT NULL")
+        for uuid, blob in cur.fetchall():
+            summary.dives_with_zsamples += 1
+            if uuid in uddf_profiles:
+                summary.dives_with_zsamples_in_uddf += 1
+                (out_dir / f"{uuid}.zsamples.bin").write_bytes(blob)
+                json_payload = {
+                    "uuid": uuid,
+                    "samples": uddf_profiles[uuid].samples,
+                }
+                with (out_dir / f"{uuid}.uddf.json").open("w") as f:
+                    json.dump(json_payload, f, indent=2)
+                summary.paired_fixtures += 1
+                summary.uuids_paired.append(uuid)
+
+    manifest = out_dir / "manifest.json"
+    with manifest.open("w") as f:
+        json.dump(asdict(summary), f, indent=2)
+
+    return summary
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", type=Path, default=repo_root / "scripts/sample_data/MacDive.sqlite")
+    parser.add_argument("--uddf", type=Path, default=repo_root / "scripts/sample_data/Apr 4 no iPad sync.uddf")
+    parser.add_argument("--out", type=Path, default=Path(__file__).parent / "corpus")
+    args = parser.parse_args()
+
+    summary = extract_corpus(args.db, args.uddf, args.out)
+    print(json.dumps(asdict(summary), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reverse_engineering/zsamples/hypotheses/__init__.py
+++ b/scripts/reverse_engineering/zsamples/hypotheses/__init__.py
@@ -1,0 +1,1 @@
+"""Candidate decoder hypotheses. Each module exports `decode(blob: bytes) -> list[dict]`."""

--- a/scripts/reverse_engineering/zsamples/hypotheses/h0_noop.py
+++ b/scripts/reverse_engineering/zsamples/hypotheses/h0_noop.py
@@ -1,0 +1,6 @@
+"""Baseline hypothesis that returns no samples. Used to validate the harness."""
+from __future__ import annotations
+
+
+def decode(blob: bytes) -> list[dict]:
+    return []

--- a/scripts/reverse_engineering/zsamples/requirements.txt
+++ b/scripts/reverse_engineering/zsamples/requirements.txt
@@ -1,0 +1,5 @@
+pytest>=8.0
+lxml>=5.0
+lz4>=4.3
+zstandard>=0.22
+pyliblzfse>=0.4 ; platform_system == "Darwin"

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -57,3 +57,45 @@ def test_from_uddf_file_rejects_uuid_filter_with_first_only():
             uuid_filter={"some-uuid"},
             first_only=True,
         )
+
+
+from blob_inspect import (
+    shannon_entropy,
+    find_repeating_stride,
+    hex_dump_line,
+    interpret_offset,
+)
+
+
+def test_shannon_entropy_uniform_bytes_is_max():
+    data = bytes(range(256))
+    assert abs(shannon_entropy(data) - 8.0) < 0.01
+
+
+def test_shannon_entropy_zeros_is_zero():
+    assert shannon_entropy(b"\x00" * 1024) == 0.0
+
+
+def test_find_repeating_stride_detects_period():
+    data = (b"\x01\x02\x03\x04" * 100)
+    stride = find_repeating_stride(data, min_stride=2, max_stride=8)
+    assert stride == 4
+
+
+def test_find_repeating_stride_returns_none_for_random():
+    import os
+    stride = find_repeating_stride(os.urandom(1024), min_stride=2, max_stride=16)
+    assert stride is None
+
+
+def test_interpret_offset_decodes_little_endian_uint32():
+    # 0x12345678 little-endian at offset 0 of this buffer:
+    data = bytes([0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0])
+    interp = interpret_offset(data, 0)
+    assert interp["u32_le"] == 0x12345678
+
+
+def test_hex_dump_line_formats_16_bytes():
+    line = hex_dump_line(bytes(range(16)), offset=0)
+    assert "00 01 02 03" in line
+    assert "0c 0d 0e 0f" in line

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -202,3 +202,22 @@ def test_score_depth_rmse_is_nan_when_no_timestamps_overlap():
     assert math.isnan(score.depth_rmse), f"expected NaN, got {score.depth_rmse}"
     assert score.matched_samples == 0
     assert score.pct_samples_within_tolerance == 0.0
+
+
+from batch_score import BatchResult, run_batch
+from hypotheses.h0_noop import decode as h0_decode
+
+
+def test_batch_runs_noop_hypothesis_and_returns_histogram(tmp_path):
+    # Seed the tmp corpus with one minimal fixture.
+    blob = b"\x04\x00\x00\x00\x00\x00\x00\x00"
+    (tmp_path / "abc.zsamples.bin").write_bytes(blob)
+    import json
+    with (tmp_path / "abc.uddf.json").open("w") as f:
+        json.dump({"uuid": "abc", "samples": [{"time_s": 0, "depth_m": 0.0}]}, f)
+
+    result = run_batch(corpus_dir=tmp_path, hypothesis=h0_decode)
+
+    assert result.fixtures_tried == 1
+    assert 0.0 <= result.aggregate_overall <= 1.0
+    assert len(result.per_fixture_scores) == 1

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -113,3 +113,45 @@ def test_hex_dump_line_formats_16_bytes():
     line = hex_dump_line(bytes(range(16)), offset=0)
     assert "00 01 02 03" in line
     assert "0c 0d 0e 0f" in line
+
+
+import gzip
+import lzma
+import zlib
+
+from compression_probe import (
+    Codec,
+    try_all,
+    CODECS,
+)
+
+
+def test_codecs_list_includes_standard_codecs():
+    names = {c.name for c in CODECS}
+    # Standard codecs present by exact name:
+    assert {"zlib", "gzip", "lzma", "bz2", "zstd"}.issubset(names)
+    # lz4 has two variants (frame, block); at least one must be present.
+    assert any(name.startswith("lz4") for name in names)
+
+
+def test_try_all_detects_gzip_wrapped_payload():
+    payload = b"hello world" * 50
+    blob = gzip.compress(payload)
+    hits = try_all(blob, offsets=[0])
+    assert any(h.codec.name == "gzip" and h.offset == 0 and h.decompressed == payload for h in hits)
+
+
+def test_try_all_detects_zlib_at_offset():
+    payload = b"timestamped depth data\n" * 20
+    blob = b"\x04\x00\x00\x00" + zlib.compress(payload)
+    hits = try_all(blob, offsets=[0, 4])
+    assert any(h.codec.name == "zlib" and h.offset == 4 and h.decompressed == payload for h in hits)
+
+
+def test_try_all_returns_no_hits_for_random():
+    import os
+    blob = os.urandom(2048)
+    hits = try_all(blob, offsets=list(range(0, 32)))
+    # It's statistically possible for a random blob to decompress under some codec,
+    # but vanishingly unlikely to produce >512 bytes.
+    assert all(len(h.decompressed) < 512 for h in hits)

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -47,3 +47,13 @@ def test_uddf_profile_parse_returns_monotonic_timestamps():
     assert profile is not None
     times = [s["time_s"] for s in profile.samples]
     assert times == sorted(times), "Sample times should be monotonically non-decreasing"
+
+
+def test_from_uddf_file_rejects_uuid_filter_with_first_only():
+    """Guard against the silent wrong-answer bug noted in code review."""
+    with pytest.raises(ValueError, match="uuid_filter is ignored"):
+        UddfProfile.from_uddf_file(
+            SAMPLE_UDDF,
+            uuid_filter={"some-uuid"},
+            first_only=True,
+        )

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -155,3 +155,39 @@ def test_try_all_returns_no_hits_for_random():
     # It's statistically possible for a random blob to decompress under some codec,
     # but vanishingly unlikely to produce >512 bytes.
     assert all(len(h.decompressed) < 512 for h in hits)
+
+
+from differ import Score, score_decode
+
+
+def test_score_perfect_match():
+    truth = [
+        {"time_s": 0, "depth_m": 0.0, "temperature_c": 25.0},
+        {"time_s": 10, "depth_m": 5.0, "temperature_c": 24.0},
+        {"time_s": 20, "depth_m": 10.0, "temperature_c": 23.5},
+    ]
+    decoded = [dict(s) for s in truth]
+    score = score_decode(decoded, truth)
+    assert score.sample_count_match == 1.0
+    assert score.timestamp_rmse == 0.0
+    assert score.depth_rmse == 0.0
+    assert score.pct_samples_within_tolerance == 1.0
+
+
+def test_score_penalizes_missing_samples():
+    truth = [{"time_s": i * 10, "depth_m": float(i), "temperature_c": 25.0} for i in range(100)]
+    decoded = truth[:50]  # only half the samples
+    score = score_decode(decoded, truth)
+    assert score.sample_count_match == 0.5
+    assert score.pct_samples_within_tolerance < 0.6
+
+
+def test_score_tolerances_depth_and_temp():
+    truth = [{"time_s": 0, "depth_m": 10.0, "temperature_c": 20.0}]
+    # Within tolerance: +0.05m depth, +0.3C temp
+    decoded_ok = [{"time_s": 0, "depth_m": 10.05, "temperature_c": 20.3}]
+    # Outside tolerance: +0.3m depth
+    decoded_bad = [{"time_s": 0, "depth_m": 10.3, "temperature_c": 20.0}]
+
+    assert score_decode(decoded_ok, truth).pct_samples_within_tolerance == 1.0
+    assert score_decode(decoded_bad, truth).pct_samples_within_tolerance == 0.0

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -1,0 +1,49 @@
+"""Tests for the ZSAMPLES reverse-engineering spike tooling."""
+from pathlib import Path
+import json
+
+import pytest
+
+from extract_corpus import extract_corpus, UddfProfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SAMPLE_DB = REPO_ROOT / "scripts/sample_data/MacDive.sqlite"
+SAMPLE_UDDF = REPO_ROOT / "scripts/sample_data/Apr 4 no iPad sync.uddf"
+
+
+def test_extract_corpus_produces_paired_fixtures(tmp_path):
+    """Every dive with non-null ZSAMPLES and a UDDF counterpart yields a pair."""
+    out_dir = tmp_path / "corpus"
+
+    summary = extract_corpus(SAMPLE_DB, SAMPLE_UDDF, out_dir)
+
+    assert summary.total_dives_sqlite == 540
+    assert summary.dives_with_zsamples >= 300  # spec observed 350
+    assert summary.paired_fixtures == summary.dives_with_zsamples_in_uddf
+    assert summary.paired_fixtures > 0
+
+    any_pair = next(iter(summary.uuids_paired))
+    bin_path = out_dir / f"{any_pair}.zsamples.bin"
+    json_path = out_dir / f"{any_pair}.uddf.json"
+    assert bin_path.exists(), "ZSAMPLES blob file missing"
+    assert json_path.exists(), "UDDF ground-truth JSON missing"
+
+    with json_path.open() as f:
+        profile = json.load(f)
+    assert isinstance(profile["samples"], list)
+    assert len(profile["samples"]) > 0
+    assert "time_s" in profile["samples"][0]
+    assert "depth_m" in profile["samples"][0]
+
+
+def test_uddf_profile_parse_returns_monotonic_timestamps():
+    """Sanity check: UDDF parser gives us ordered samples."""
+    profile = UddfProfile.from_uddf_file(
+        SAMPLE_UDDF,
+        uuid_filter=None,  # parse any one dive
+        first_only=True,
+    )
+    assert profile is not None
+    times = [s["time_s"] for s in profile.samples]
+    assert times == sorted(times), "Sample times should be monotonically non-decreasing"

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -191,3 +191,14 @@ def test_score_tolerances_depth_and_temp():
 
     assert score_decode(decoded_ok, truth).pct_samples_within_tolerance == 1.0
     assert score_decode(decoded_bad, truth).pct_samples_within_tolerance == 0.0
+
+
+def test_score_depth_rmse_is_nan_when_no_timestamps_overlap():
+    """A completely-failed decoder should produce NaN depth_rmse, not 0.0 (which masks failure)."""
+    import math
+    truth = [{"time_s": 0, "depth_m": 10.0}, {"time_s": 10, "depth_m": 20.0}]
+    decoded = [{"time_s": 999, "depth_m": 5.0}]  # no timestamp overlap
+    score = score_decode(decoded, truth)
+    assert math.isnan(score.depth_rmse), f"expected NaN, got {score.depth_rmse}"
+    assert score.matched_samples == 0
+    assert score.pct_samples_within_tolerance == 0.0

--- a/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
+++ b/scripts/reverse_engineering/zsamples/test_zsamples_spike.py
@@ -95,6 +95,20 @@ def test_interpret_offset_decodes_little_endian_uint32():
     assert interp["u32_le"] == 0x12345678
 
 
+def test_interpret_offset_includes_all_endians_at_each_width():
+    """All widths should have both LE and BE interpretations when bytes are available."""
+    data = bytes([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    interp = interpret_offset(data, 0)
+    assert "u16_le" in interp and "u16_be" in interp
+    assert "u32_le" in interp and "u32_be" in interp
+    assert "f32_le" in interp and "f32_be" in interp
+    assert "u64_le" in interp and "u64_be" in interp
+    assert "f64_le" in interp and "f64_be" in interp
+    # Spot-check one pair: u32 big-endian is 0x01020304, little-endian is 0x04030201.
+    assert interp["u32_be"] == 0x01020304
+    assert interp["u32_le"] == 0x04030201
+
+
 def test_hex_dump_line_formats_16_bytes():
     line = hex_dump_line(bytes(range(16)), offset=0)
     assert "00 01 02 03" in line


### PR DESCRIPTION
## Summary

Phase 1 spike for decoding MacDive's proprietary `ZDIVE.ZSAMPLES` column (follow-up to #256 which shipped metadata-only MacDive SQLite import).

**Outcome: NO-GO on ZSAMPLES decoding. Recommending pivot to ZRAWDATA via libdivecomputer.**

Original design spec: `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md` (on main, updated with Phase 1 outcome).

### What's in this PR

- `scripts/reverse_engineering/zsamples/` — throwaway investigation tooling (Python):
  - `extract_corpus.py` — builds paired `(ZSAMPLES_bytes, UDDF_profile)` fixtures.
  - `blob_inspect.py` — hex dump + entropy + stride detection + offset-wise interpretation.
  - `compression_probe.py` — tries 9 codecs (gzip/zlib/raw_deflate/lzma/bz2/lz4/zstd/LZFSE) at every offset 0-63.
  - `differ.py` — scores a candidate decoder against UDDF ground truth.
  - `batch_score.py` — runs a hypothesis across the whole corpus, emits histogram + CSV.
  - `hypotheses/` package with `h0_noop` baseline.
  - 19 passing pytest tests covering the tooling.
- `docs/import-formats/macdive-zsamples.md` — full Phase 1 findings document.

### Key findings

- **Perfectly predictable stride:** The second header word (bytes 4-7 LE) maps to record stride deterministically: `16→12`, `24→16`, `25→20`, `156→24`, `157→28` bytes/sample. Arithmetic progression step 4.
- **Compression ruled out** across all 348 paired fixtures (only 29 tiny `raw_deflate` false positives, <500 bytes each).
- **Simple XOR obfuscation ruled out** via pair-entropy analysis (XOR of similar dives: 7.4-7.9 bits/byte; random baseline: 7.95).
- **Framing strongly suggests block-cipher encryption:** constant 8-byte prefix + 16-byte variable payload + constant 8-byte trailer around the first record in 56% of fixtures.
- **Pivot path identified:** Every Shearwater dive in the sample DB has both `ZRAWDATA` and `ZSAMPLES` (267/267). `ZRAWDATA` is the raw Shearwater sensor format that the already-integrated `libdivecomputer_plugin` parses natively. The pivot gives 49% coverage of all dives (76% of dives with any sample data) via a certain, maintained code path.

### Phase 2

The follow-up plan (for the ZRAWDATA pivot) is at `docs/superpowers/plans/2026-04-23-macdive-profile-phase-2-zrawdata.md` on main. It gates on a Pre-work investigation of the libdivecomputer_plugin's public API.

## Test plan

- [x] `pytest scripts/reverse_engineering/zsamples/ -v` — 19/19 passing.
- [x] Compression probe sweep across all 348 corpus fixtures — no meaningful hits.
- [x] Corpus extraction produces 348 paired fixtures from the 540-dive sample DB.
- [x] Full `flutter test` suite passes (7287 tests).
- [ ] Reviewer: read `docs/import-formats/macdive-zsamples.md` and confirm the NO-GO reasoning is sound before merging.
- [ ] Reviewer: confirm the tooling is useful enough to keep in-repo for any future re-attempt.

## Related docs (all on main)

- Spec: `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md`
- Phase 1 plan: `docs/superpowers/plans/2026-04-23-macdive-zsamples-phase-1-spike.md`
- Phase 2 plan: `docs/superpowers/plans/2026-04-23-macdive-profile-phase-2-zrawdata.md`