### PR TITLE
fix: wire up Open Settings button in photo picker permission view

### DIFF
--- a/lib/features/media/presentation/pages/photo_picker_page.dart
+++ b/lib/features/media/presentation/pages/photo_picker_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:photo_manager/photo_manager.dart' as pm;
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
@@ -638,18 +639,7 @@ class _PermissionDeniedView extends StatelessWidget {
             const SizedBox(height: 24),
             if (isPermanentlyDenied)
               FilledButton(
-                onPressed: () {
-                  // Open app settings
-                  // Note: This requires platform-specific handling
-                  // For now, just show a message
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        context.l10n.media_photoPicker_openSettingsSnackbar,
-                      ),
-                    ),
-                  );
-                },
+                onPressed: () => pm.PhotoManager.openSetting(),
                 child: Text(context.l10n.media_photoPicker_openSettingsButton),
               )
             else

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -2895,7 +2895,6 @@
   "media_photoPicker_emptyTitle": "لم يتم العثور على صور",
   "media_photoPicker_grantAccessButton": "متابعة",
   "media_photoPicker_openSettingsButton": "فتح الإعدادات",
-  "media_photoPicker_openSettingsSnackbar": "يرجى فتح الإعدادات وتمكين الوصول إلى الصور",
   "media_photoPicker_permissionDeniedMessage": "تم رفض الوصول إلى مكتبة الصور. يرجى تمكينه في الإعدادات لإضافة صور الغوص.",
   "media_photoPicker_permissionRequestMessage": "يحتاج Submersion إلى الوصول إلى مكتبة الصور لإضافة صور الغوص.",
   "media_photoPicker_permissionTitle": "مطلوب الوصول إلى الصور",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -2895,7 +2895,6 @@
   "media_photoPicker_emptyTitle": "Keine Fotos gefunden",
   "media_photoPicker_grantAccessButton": "Weiter",
   "media_photoPicker_openSettingsButton": "Einstellungen oeffnen",
-  "media_photoPicker_openSettingsSnackbar": "Bitte oeffnen Sie die Einstellungen und aktivieren Sie den Fotozugriff",
   "media_photoPicker_permissionDeniedMessage": "Der Zugriff auf die Fotobibliothek wurde verweigert. Bitte aktivieren Sie ihn in den Einstellungen, um Tauchfotos hinzuzufuegen.",
   "media_photoPicker_permissionRequestMessage": "Submersion benoetigt Zugriff auf Ihre Fotobibliothek, um Tauchfotos hinzuzufuegen.",
   "media_photoPicker_permissionTitle": "Fotozugriff erforderlich",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -4835,7 +4835,6 @@
   "media_photoPicker_emptyTitle": "No photos found",
   "media_photoPicker_grantAccessButton": "Continue",
   "media_photoPicker_openSettingsButton": "Open Settings",
-  "media_photoPicker_openSettingsSnackbar": "Please open Settings and enable photo access",
   "media_photoPicker_permissionDeniedMessage": "Photo library access was denied. Please enable it in Settings to add dive photos.",
   "media_photoPicker_permissionRequestMessage": "Submersion needs access to your photo library to add dive photos.",
   "media_photoPicker_permissionTitle": "Photo Access Required",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -2895,7 +2895,6 @@
   "media_photoPicker_emptyTitle": "No se encontraron fotos",
   "media_photoPicker_grantAccessButton": "Continuar",
   "media_photoPicker_openSettingsButton": "Abrir ajustes",
-  "media_photoPicker_openSettingsSnackbar": "Por favor, abre Ajustes y activa el acceso a fotos",
   "media_photoPicker_permissionDeniedMessage": "Se denego el acceso a la biblioteca de fotos. Activalo en Ajustes para agregar fotos de buceo.",
   "media_photoPicker_permissionRequestMessage": "Submersion necesita acceso a tu biblioteca de fotos para agregar fotos de buceo.",
   "media_photoPicker_permissionTitle": "Se requiere acceso a fotos",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -2861,7 +2861,6 @@
   "media_photoPicker_emptyTitle": "Aucune photo trouvee",
   "media_photoPicker_grantAccessButton": "Continuer",
   "media_photoPicker_openSettingsButton": "Ouvrir les reglages",
-  "media_photoPicker_openSettingsSnackbar": "Veuillez ouvrir les Reglages et activer l'acces aux photos",
   "media_photoPicker_permissionDeniedMessage": "L'acces a la phototheque a ete refuse. Veuillez l'activer dans les Reglages pour ajouter des photos de plongee.",
   "media_photoPicker_permissionRequestMessage": "Submersion a besoin d'acceder a votre phototheque pour ajouter des photos de plongee.",
   "media_photoPicker_permissionTitle": "Acces aux photos requis",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -2861,7 +2861,6 @@
   "media_photoPicker_emptyTitle": "לא נמצאו תמונות",
   "media_photoPicker_grantAccessButton": "המשך",
   "media_photoPicker_openSettingsButton": "פתח הגדרות",
-  "media_photoPicker_openSettingsSnackbar": "נא לפתוח הגדרות ולאפשר גישה לתמונות",
   "media_photoPicker_permissionDeniedMessage": "הגישה לספריית התמונות נדחתה. נא לאפשר אותה בהגדרות כדי להוסיף תמונות צלילה.",
   "media_photoPicker_permissionRequestMessage": "Submersion זקוקה לגישה לספריית התמונות שלך כדי להוסיף תמונות צלילה.",
   "media_photoPicker_permissionTitle": "נדרשת גישה לתמונות",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -2861,7 +2861,6 @@
   "media_photoPicker_emptyTitle": "Nincsenek fotok",
   "media_photoPicker_grantAccessButton": "Tovább",
   "media_photoPicker_openSettingsButton": "Beallitasok megnyitasa",
-  "media_photoPicker_openSettingsSnackbar": "Kerem, nyissa meg a Beallitasokat es engedelyezze a fotohozzaferest",
   "media_photoPicker_permissionDeniedMessage": "A fotogaleriahoz valo hozzaferes megtagadva. Kerem, engedelyezze a Beallitasokban a merülesi fotok hozzaadasahoz.",
   "media_photoPicker_permissionRequestMessage": "A Submersion hozzaferest igenyel a fotogaleriajahoz merülesi fotok hozzaadasahoz.",
   "media_photoPicker_permissionTitle": "Foto hozzaferes szukseges",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -2861,7 +2861,6 @@
   "media_photoPicker_emptyTitle": "Nessuna foto trovata",
   "media_photoPicker_grantAccessButton": "Continua",
   "media_photoPicker_openSettingsButton": "Apri Impostazioni",
-  "media_photoPicker_openSettingsSnackbar": "Apri Impostazioni e abilita l'accesso alle foto",
   "media_photoPicker_permissionDeniedMessage": "L'accesso alla libreria foto è stato negato. Abilitalo nelle Impostazioni per aggiungere foto delle immersioni.",
   "media_photoPicker_permissionRequestMessage": "Submersion ha bisogno dell'accesso alla tua libreria foto per aggiungere foto delle immersioni.",
   "media_photoPicker_permissionTitle": "Accesso alle foto richiesto",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -15610,12 +15610,6 @@ abstract class AppLocalizations {
   /// **'Open Settings'**
   String get media_photoPicker_openSettingsButton;
 
-  /// No description provided for @media_photoPicker_openSettingsSnackbar.
-  ///
-  /// In en, this message translates to:
-  /// **'Please open Settings and enable photo access'**
-  String get media_photoPicker_openSettingsSnackbar;
-
   /// No description provided for @media_photoPicker_permissionDeniedMessage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -8920,10 +8920,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'فتح الإعدادات';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'يرجى فتح الإعدادات وتمكين الوصول إلى الصور';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'تم رفض الوصول إلى مكتبة الصور. يرجى تمكينه في الإعدادات لإضافة صور الغوص.';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -9102,10 +9102,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Einstellungen oeffnen';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Bitte oeffnen Sie die Einstellungen und aktivieren Sie den Fotozugriff';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'Der Zugriff auf die Fotobibliothek wurde verweigert. Bitte aktivieren Sie ihn in den Einstellungen, um Tauchfotos hinzuzufuegen.';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -8956,10 +8956,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Open Settings';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Please open Settings and enable photo access';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'Photo library access was denied. Please enable it in Settings to add dive photos.';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -9081,10 +9081,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Abrir ajustes';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Por favor, abre Ajustes y activa el acceso a fotos';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'Se denego el acceso a la biblioteca de fotos. Activalo en Ajustes para agregar fotos de buceo.';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -9130,10 +9130,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Ouvrir les reglages';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Veuillez ouvrir les Reglages et activer l\'acces aux photos';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'L\'acces a la phototheque a ete refuse. Veuillez l\'activer dans les Reglages pour ajouter des photos de plongee.';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -8862,10 +8862,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'פתח הגדרות';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'נא לפתוח הגדרות ולאפשר גישה לתמונות';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'הגישה לספריית התמונות נדחתה. נא לאפשר אותה בהגדרות כדי להוסיף תמונות צלילה.';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -9070,10 +9070,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Beallitasok megnyitasa';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Kerem, nyissa meg a Beallitasokat es engedelyezze a fotohozzaferest';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'A fotogaleriahoz valo hozzaferes megtagadva. Kerem, engedelyezze a Beallitasokban a merülesi fotok hozzaadasahoz.';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -9099,10 +9099,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Apri Impostazioni';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Apri Impostazioni e abilita l\'accesso alle foto';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'L\'accesso alla libreria foto è stato negato. Abilitalo nelle Impostazioni per aggiungere foto delle immersioni.';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -9031,10 +9031,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Instellingen openen';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Open Instellingen en schakel fototoegang in';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'Toegang tot de fotobibliotheek is geweigerd. Schakel deze in via Instellingen om duikfoto\'s toe te voegen.';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -9101,10 +9101,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => 'Abrir Configuracoes';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar =>
-      'Abra as Configuracoes e habilite o acesso a fotos';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       'O acesso a biblioteca de fotos foi negado. Habilite-o nas Configuracoes para adicionar fotos de mergulho.';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -8710,9 +8710,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get media_photoPicker_openSettingsButton => '打开设置';
 
   @override
-  String get media_photoPicker_openSettingsSnackbar => '请打开设置并启用照片访问权限';
-
-  @override
   String get media_photoPicker_permissionDeniedMessage =>
       '照片库访问被拒绝。请在设置中启用以添加潜水照片。';
 

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -2895,7 +2895,6 @@
   "media_photoPicker_emptyTitle": "Geen foto's gevonden",
   "media_photoPicker_grantAccessButton": "Doorgaan",
   "media_photoPicker_openSettingsButton": "Instellingen openen",
-  "media_photoPicker_openSettingsSnackbar": "Open Instellingen en schakel fototoegang in",
   "media_photoPicker_permissionDeniedMessage": "Toegang tot de fotobibliotheek is geweigerd. Schakel deze in via Instellingen om duikfoto's toe te voegen.",
   "media_photoPicker_permissionRequestMessage": "Submersion heeft toegang tot je fotobibliotheek nodig om duikfoto's toe te voegen.",
   "media_photoPicker_permissionTitle": "Fototoegang vereist",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -2895,7 +2895,6 @@
   "media_photoPicker_emptyTitle": "Nenhuma foto encontrada",
   "media_photoPicker_grantAccessButton": "Continuar",
   "media_photoPicker_openSettingsButton": "Abrir Configuracoes",
-  "media_photoPicker_openSettingsSnackbar": "Abra as Configuracoes e habilite o acesso a fotos",
   "media_photoPicker_permissionDeniedMessage": "O acesso a biblioteca de fotos foi negado. Habilite-o nas Configuracoes para adicionar fotos de mergulho.",
   "media_photoPicker_permissionRequestMessage": "O Submersion precisa de acesso a sua biblioteca de fotos para adicionar fotos de mergulho.",
   "media_photoPicker_permissionTitle": "Acesso a Fotos Necessario",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -3045,7 +3045,6 @@
   "media_photoPicker_emptyTitle": "无照片已找到",
   "media_photoPicker_grantAccessButton": "继续",
   "media_photoPicker_openSettingsButton": "打开设置",
-  "media_photoPicker_openSettingsSnackbar": "请打开设置并启用照片访问权限",
   "media_photoPicker_permissionDeniedMessage": "照片库访问被拒绝。请在设置中启用以添加潜水照片。",
   "media_photoPicker_permissionRequestMessage": "Submersion 需要访问您的照片库以添加潜水照片。",
   "media_photoPicker_permissionTitle": "照片访问必填",


### PR DESCRIPTION
## Summary

The "Open Settings" button on the photo picker permission-denied view was a stub — line 642 had a literal `// For now, just show a message` comment, and clicking it just displayed a snackbar telling users to open Settings, with no path to do so.

This PR replaces the stub with `PhotoManager.openSetting()` (provided by the existing `photo_manager` dependency), which:

- macOS / iOS → jumps directly to the Privacy & Security pane for the app
- Android → opens the app's Settings page

End users who legitimately deny photo permission via the system prompt and later try to recover can now actually get to the toggle.

Also removes the now-unused `media_photoPicker_openSettingsSnackbar` l10n key and its 11 locale translations, since the snackbar code path is gone.

## Test Plan

- [x] `flutter test` — 7429 passed, 9 skipped, 0 failed
- [x] `flutter analyze` — no issues
- [x] `dart format --set-exit-if-changed lib/` — clean
- [ ] Manual smoke test on macOS: deny photo permission, click "Open Settings" in the picker → verify System Settings opens at Privacy & Security → Photos