### PR TITLE
fix(media): apply wall-clock-UTC→local conversion in photo picker

### DIFF
--- a/lib/features/media/presentation/helpers/photo_import_helper.dart
+++ b/lib/features/media/presentation/helpers/photo_import_helper.dart
@@ -5,6 +5,7 @@ import 'package:flutter/scheduler.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/presentation/pages/photo_picker_page.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
@@ -38,11 +39,16 @@ class PhotoImportHelper {
     // Check context is still valid after async gap
     if (!context.mounted) return false;
 
-    // Open photo picker with already-linked IDs
+    // Open photo picker with already-linked IDs.
+    //
+    // Dive times are stored as wall-clock-as-UTC (the time on the dive
+    // computer, regardless of timezone), but photo_manager filters by the
+    // device's local time. Convert to wall-clock-local before passing —
+    // mirrors what TripMediaScanner does for the "scan gallery" path.
     final selectedAssets = await showPhotoPicker(
       context: context,
-      diveStartTime: diveStart,
-      diveEndTime: diveEnd,
+      diveStartTime: TripMediaScanner.wallClockUtcToLocal(diveStart),
+      diveEndTime: TripMediaScanner.wallClockUtcToLocal(diveEnd),
       alreadyLinkedIds: alreadyLinkedIds,
     );
 

--- a/lib/features/media/presentation/helpers/photo_import_helper.dart
+++ b/lib/features/media/presentation/helpers/photo_import_helper.dart
@@ -43,12 +43,20 @@ class PhotoImportHelper {
     //
     // Dive times are stored as wall-clock-as-UTC (the time on the dive
     // computer, regardless of timezone), but photo_manager filters by the
-    // device's local time. Convert to wall-clock-local before passing —
-    // mirrors what TripMediaScanner does for the "scan gallery" path.
+    // device's local time. To produce the same filter window as
+    // TripMediaScanner.scanGalleryForDive, apply the buffer in UTC first
+    // and only then convert to local — this avoids DST-transition
+    // divergence that would arise from applying the buffer in local time
+    // after the conversion. We pass buffer: Duration.zero to disable
+    // showPhotoPicker's internal buffer-in-local logic.
+    const buffer = Duration(minutes: 30);
     final selectedAssets = await showPhotoPicker(
       context: context,
-      diveStartTime: TripMediaScanner.wallClockUtcToLocal(diveStart),
-      diveEndTime: TripMediaScanner.wallClockUtcToLocal(diveEnd),
+      diveStartTime: TripMediaScanner.wallClockUtcToLocal(
+        diveStart.subtract(buffer),
+      ),
+      diveEndTime: TripMediaScanner.wallClockUtcToLocal(diveEnd.add(buffer)),
+      buffer: Duration.zero,
       alreadyLinkedIds: alreadyLinkedIds,
     );
 


### PR DESCRIPTION
## Summary

The "Scan gallery for photos" button correctly converts dive times before querying `photo_manager` (which filters by the device's local time), but the per-dive photo picker (the "Add photo or video" button) doesn't — it passes the dive's stored `entryTime` / `exitTime` straight through. Because Submersion stores dive times as wall-clock-UTC (the time on the dive computer regardless of timezone), the picker's filter window is offset by the device's timezone, and gallery photos taken during the dive can fall outside that window.

User-visible symptom: the scan finds photos, but the per-dive picker shows an empty list for the same dive.

This PR mirrors the conversion `TripMediaScanner.scanGalleryForDive` already applies (`wallClockUtcToLocal`) at the picker's callsite in `PhotoImportHelper.importPhotosForDive`. Both paths now produce the same filter window for the same dive.

## Files changed

- `lib/features/media/presentation/helpers/photo_import_helper.dart` (+9 / −3): import `TripMediaScanner`, wrap `diveStart` / `diveEnd` in `wallClockUtcToLocal()` before passing to `showPhotoPicker`.

## Test Plan

- [x] `flutter test` passes (full suite)
- [x] `flutter analyze` clean
- [x] `dart format` clean
- [x] Manual smoke test on macOS: open a dive whose entry/exit times match real Photos.app photos, click "Add photo or video", verify the picker now shows those photos