### PR TITLE
fix(ci): honor pinned Flutter version on Windows runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -496,6 +496,11 @@ jobs:
 
       - name: Read Flutter version
         id: flutter-ver
+        # Windows runners default to PowerShell, where the bash-style
+        # $(...) command substitution and $GITHUB_OUTPUT do not work. Without
+        # this the version output is empty and subosito installs the latest
+        # stable Flutter instead of the pinned version. See flutter-version.txt.
+        shell: bash
         run: echo "version=$(cat ${{ env.FLUTTER_VERSION_FILE }})" >> "$GITHUB_OUTPUT"
 
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,11 @@ jobs:
 
       - name: Read Flutter version
         id: flutter-ver
+        # Windows runners default to PowerShell, where the bash-style
+        # $(...) command substitution and $GITHUB_OUTPUT do not work. Without
+        # this the version output is empty and subosito installs the latest
+        # stable Flutter instead of the pinned version. See flutter-version.txt.
+        shell: bash
         run: echo "version=$(cat ${{ env.FLUTTER_VERSION_FILE }})" >> "$GITHUB_OUTPUT"
 
       - name: Setup Flutter


### PR DESCRIPTION
## Summary

The `Build Windows` CI job has been failing on `main` with a Dart compile error:

> `material_design_icons_flutter-7.0.7296/lib/icon_map.dart`: error: The class 'IconData' can't be extended outside of its library because it's a final class.

### Root cause

The `Read Flutter version` step uses bash syntax (`$(cat ...)` and `$GITHUB_OUTPUT`) with no `shell:` override. Windows runners default to **PowerShell**, so the step silently produced an empty `version` output, and `subosito/flutter-action` fell back to the **latest stable Flutter (3.44.0)** instead of the pinned **3.41.4** used by every other platform.

Flutter 3.44.0 makes the framework's `IconData` a `final` class, which `material_design_icons_flutter` 7.0.7296 illegally extends — so the Windows-only Flutter upgrade broke the Dart `kernel_snapshot` step. This is **unrelated** to the upcoming `windows-latest` -> VS 2026 image migration (the runner was still VS 2022 / MSVC 14.44).

### Fix

Add `shell: bash` to the `build-windows` `Read Flutter version` step in `ci.yaml` and `release.yml` so the pinned version is honored on Windows. This matches the pattern already used in `native-plugin-tests.yml`. The macOS/Linux jobs already default to bash and were unaffected.

### Follow-ups (not in this PR)

- `material_design_icons_flutter` (newest published is 7.0.7296, ~2 years stale) blocks any future intentional upgrade to Flutter 3.44+ and will need replacing.
- The `windows-latest` -> `windows-2025-vs2026` migration (~June 2026) is a separate, future concern; pinning `windows-2022` would defer it.

## Test plan

- [x] Both workflow files validated as well-formed YAML locally
- [ ] CI `Build Windows` job passes on this PR (the definitive check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
