### PR TITLE
fix(stats): use effectiveRuntime for longest dive in Dive Log Summary

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_summary_widget.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_summary_widget.dart
@@ -268,20 +268,21 @@ class DiveSummaryWidget extends ConsumerWidget {
       );
     }
 
-    if (records.longestDive != null &&
-        records.longestDive!.bottomTime != null) {
-      final minutes = records.longestDive!.bottomTime!.inMinutes;
-      recordItems.add(
-        _buildRecordItem(
-          context,
-          units,
-          icon: Icons.timer,
-          title: context.l10n.diveLog_summary_record_longest,
-          value: '$minutes min',
-          diveId: records.longestDive!.diveId,
-          date: records.longestDive!.dateTime,
-        ),
-      );
+    if (records.longestDive != null) {
+      final effectiveRuntime = records.longestDive!.effectiveRuntime;
+      if (effectiveRuntime != null) {
+        recordItems.add(
+          _buildRecordItem(
+            context,
+            units,
+            icon: Icons.timer,
+            title: context.l10n.diveLog_summary_record_longest,
+            value: '${effectiveRuntime.inMinutes} min',
+            diveId: records.longestDive!.diveId,
+            date: records.longestDive!.dateTime,
+          ),
+        );
+      }
     }
 
     if (records.coldestDive != null && records.coldestDive!.waterTemp != null) {

--- a/test/features/dive_log/presentation/widgets/dive_summary_widget_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_summary_widget_test.dart
@@ -22,10 +22,10 @@ void main() {
       await tearDownTestDatabase();
     });
 
-    testWidgets('displays longest dive record with bottomTime', (tester) async {
-      // Create a dive with bottomTime to populate the records
+    testWidgets('displays longest dive using runtime when set', (tester) async {
       final dive = createTestDiveWithBottomTime(
-        bottomTime: const Duration(minutes: 45),
+        bottomTime: null,
+        runtime: const Duration(minutes: 123),
         maxDepth: 25.0,
         waterTemp: 22.0,
       );
@@ -54,7 +54,43 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Should show the longest dive duration
+      expect(find.text('123 min'), findsOneWidget);
+    });
+
+    testWidgets('displays longest dive using bottomTime when runtime is null', (
+      tester,
+    ) async {
+      final dive = createTestDiveWithBottomTime(
+        bottomTime: const Duration(minutes: 45),
+        runtime: null,
+        maxDepth: 25.0,
+        waterTemp: 22.0,
+      );
+      await repository.createDive(dive);
+
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            diveRepositoryProvider.overrideWithValue(repository),
+            diveStatisticsProvider.overrideWith((ref) async {
+              return repository.getStatistics();
+            }),
+            diveRecordsProvider.overrideWith((ref) async {
+              return repository.getRecords();
+            }),
+          ].cast(),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: DiveSummaryWidget()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
       expect(find.text('45 min'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary

- Fixes the Dive Log Summary page showing "Longest Dive" as 0 min when the dive has `runtime` set but no `bottomTime` (common for computer-imported dives)
- The root cause was `dive_summary_widget.dart` checking `bottomTime` directly, while the Home page personal records card correctly uses `effectiveRuntime` (`runtime ?? bottomTime`)
- Updated the widget to use `effectiveRuntime`, matching the pattern in `personal_records_card.dart`

Fixes #290

## Test plan

- [ ] Replaced the existing `bottomTime`-only widget test with two explicit cases: runtime-only (the bug scenario) and bottomTime fallback (runtime is null)
- [ ] All 3 tests in `dive_summary_widget_test.dart` pass
- [ ] Manually verify: open Dive Log Summary page and confirm Longest Dive matches the Home page personal records card

🤖 Generated with [Claude Code](https://claude.com/claude-code)