### PR TITLE
fix(dashboard): days-since-diving uses calendar days, not 24h periods

### DIFF
--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -87,9 +87,11 @@ final daysSinceLastDiveProvider = FutureProvider<int?>((ref) async {
   final recentDives = await ref.watch(recentDivesProvider.future);
   if (recentDives.isEmpty) return null;
 
-  final lastDiveDate = recentDives.first.dateTime;
+  final lastDive = recentDives.first.effectiveEntryTime;
   final now = DateTime.now();
-  return now.difference(lastDiveDate).inDays;
+  final diveDay = DateTime(lastDive.year, lastDive.month, lastDive.day);
+  final today = DateTime(now.year, now.month, now.day);
+  return today.difference(diveDay).inDays;
 });
 
 /// Monthly dive count provider (dives in current month)

--- a/test/features/dashboard/presentation/providers/dashboard_providers_test.dart
+++ b/test/features/dashboard/presentation/providers/dashboard_providers_test.dart
@@ -1,11 +1,89 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 
 import '../../../../helpers/mock_providers.dart';
 
+Dive _diveWithEntryTime(DateTime entryTime) => Dive(
+  id: 'test-${entryTime.millisecondsSinceEpoch}',
+  dateTime: entryTime,
+  entryTime: entryTime,
+  tanks: const [],
+  profile: const [],
+  equipment: const [],
+  notes: '',
+  photoIds: const [],
+  sightings: const [],
+  weights: const [],
+  tags: const [],
+);
+
 void main() {
+  group('daysSinceLastDiveProvider', () {
+    test('returns 0 for a dive that occurred earlier today', () async {
+      final now = DateTime.now();
+      final todayDive = _diveWithEntryTime(
+        DateTime(now.year, now.month, now.day, 8, 0),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          recentDivesProvider.overrideWith((ref) async => [todayDive]),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final days = await container.read(daysSinceLastDiveProvider.future);
+      expect(days, 0);
+    });
+
+    test(
+      'returns 1 for a dive at 11:55 pm yesterday (issue #263 regression)',
+      () async {
+        final yesterday = DateTime.now().subtract(const Duration(days: 1));
+        final lateDive = _diveWithEntryTime(
+          DateTime(yesterday.year, yesterday.month, yesterday.day, 23, 55),
+        );
+        final container = ProviderContainer(
+          overrides: [
+            recentDivesProvider.overrideWith((ref) async => [lateDive]),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final days = await container.read(daysSinceLastDiveProvider.future);
+        expect(days, 1);
+      },
+    );
+
+    test('returns 2 for a dive two calendar days ago', () async {
+      final twoDaysAgo = DateTime.now().subtract(const Duration(days: 2));
+      final oldDive = _diveWithEntryTime(
+        DateTime(twoDaysAgo.year, twoDaysAgo.month, twoDaysAgo.day, 12, 0),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          recentDivesProvider.overrideWith((ref) async => [oldDive]),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final days = await container.read(daysSinceLastDiveProvider.future);
+      expect(days, 2);
+    });
+
+    test('returns null when there are no dives', () async {
+      final container = ProviderContainer(
+        overrides: [recentDivesProvider.overrideWith((ref) async => [])],
+      );
+      addTearDown(container.dispose);
+
+      final days = await container.read(daysSinceLastDiveProvider.future);
+      expect(days, isNull);
+    });
+  });
+
   group('personalRecordsProvider', () {
     test('finds longest dive by effectiveRuntime', () async {
       final dives = [


### PR DESCRIPTION
## Summary

- `Duration.inDays` counts whole 24-hour blocks, causing a dive logged at 10:30 pm to show **"Today!"** the next morning — even when clearly a different calendar day
- Fix strips the time component from both the dive timestamp and `DateTime.now()` before diffing, so `inDays` correctly counts calendar days
- Also switches from `dive.dateTime` to `dive.effectiveEntryTime` so the metric is consistent with the sort order the repository uses to determine the most recent dive

Fixes submersion-app/submersion#263

## Test plan

- [x] `flutter test test/features/dashboard/presentation/providers/dashboard_providers_test.dart` — 4 new unit tests cover: today (0), 11:55 pm yesterday (1), two days ago (2), no dives (null)
- [x] Run app on macOS and verify the dashboard "Days since diving" stat shows the correct calendar-day count for a recent dive

🤖 Generated with [Claude Code](https://claude.com/claude-code)