### PR TITLE
fix(trips): include dives logged on the last day of a trip

### DIFF
--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -385,7 +385,15 @@ class TripRepository {
     try {
       _log.info('Scanning for candidate dives: $startDate - $endDate');
       final startMs = startDate.millisecondsSinceEpoch;
-      final endMs = endDate.millisecondsSinceEpoch;
+      final endMs = DateTime(
+        endDate.year,
+        endDate.month,
+        endDate.day,
+        23,
+        59,
+        59,
+        999,
+      ).millisecondsSinceEpoch;
 
       final rows = await _db
           .customSelect(

--- a/test/features/trips/data/repositories/trip_repository_dive_scan_test.dart
+++ b/test/features/trips/data/repositories/trip_repository_dive_scan_test.dart
@@ -204,6 +204,29 @@ void main() {
       expect(candidates.first.isUnassigned, isFalse);
     });
 
+    test('includes dive logged at noon on the end day', () async {
+      final startDate = DateTime(2024, 6, 1);
+      final endDate = DateTime(2024, 6, 7);
+
+      await insertTrip(id: tripId, startDate: startDate, endDate: endDate);
+
+      await insertDive(
+        id: 'dive-end-day-noon',
+        dateTime: DateTime(2024, 6, 7, 12, 0, 0),
+        dId: diverId,
+      );
+
+      final candidates = await repository.findCandidateDivesForTrip(
+        tripId: tripId,
+        startDate: startDate,
+        endDate: endDate,
+        diverId: diverId,
+      );
+
+      expect(candidates, hasLength(1));
+      expect(candidates.first.dive.id, equals('dive-end-day-noon'));
+    });
+
     test('excludes dives from other divers', () async {
       final startDate = DateTime(2024, 6, 1);
       final endDate = DateTime(2024, 6, 7);


### PR DESCRIPTION
Fixes #237

## Summary

- `findCandidateDivesForTrip` converted `endDate` directly to milliseconds, but `endDate` is midnight at the start of the end day — any dive logged during that day had a timestamp greater than `endMs` and was excluded by the `<= endMs` SQL filter
- Extended `endMs` to `23:59:59.999` on the end day so the full end day is included in the candidate scan
- Added a regression test: dive logged at noon on the end day is now returned as a candidate

## Test plan

- [ ] `flutter test test/features/trips/data/repositories/trip_repository_dive_scan_test.dart` — all 7 tests pass including the new end-day regression test
- [ ] `flutter test test/features/trips/` — all 409 trip tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)