### PR TITLE
feat(sync): complete plaintext iCloud sync — per-device files + HLC conflict resolution

### DIFF
--- a/docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md
+++ b/docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md
@@ -1,0 +1,46 @@
+# iCloud Sync — Phase 0 Diagnosis (Findings)
+
+## Root cause (one sentence)
+
+On a *receiving* device, `SyncService._mergeEntity` catches an exception thrown while applying an incoming record (inside `SyncDataSerializer.upsertRecord` / `fetchRecord`) and silently **relabels it as a "conflict"** instead of applying it — so a device that does not already have the record applies nothing, which presents to the user as "sync does nothing."
+
+## How it was found (no hardware required)
+
+The no-op was reproduced entirely in pure Dart with an in-memory fake `CloudStorageProvider`, ruling out iCloud, entitlements, the Simulator, and provider selection as the cause.
+
+Artifacts (on branch `feat/icloud-sync-diagnostic`):
+- `test/helpers/fake_cloud_storage_provider.dart` — in-memory provider shared by two simulated devices.
+- `test/core/services/sync/sync_serializer_round_trip_test.dart` — PASSES: export -> serialize -> deserialize -> checksum is healthy.
+- `test/core/services/sync/sync_round_trip_test.dart` — FAILS at the A->B propagation assertion (the reproducing test for Phase 1).
+
+## Evidence
+
+| Stage | Measurement | Verdict |
+| --- | --- | --- |
+| Device A export/upload | `afterPush cloud.dives == 1` | Healthy — the dive is uploaded |
+| Device B apply (pull) | `pull.status == hasConflicts`, `pull.recordsSynced == 14`, `pull.conflictsFound == 1` | The incoming dive is routed to the conflict path, not applied |
+| Device B re-upload | final `cloud.dives == 0` | The receiving DB never got the dive |
+
+Narrowing within `_mergeEntity` (`lib/core/services/sync/sync_service.dart`):
+- The normal conflict branch cannot fire here: it requires `localUpdatedAt != null && remoteUpdatedAt != null && lastSyncMs != null`, but a fresh receiving device has `localUpdatedAt == null` and `lastSyncMs == null`.
+- `_recordIdForEntity('dives', record)` returns `record['id']` = `'dive-xfer-1'` (non-null), so the `recordId == null` conflict path is not it.
+- That leaves only the **catch block**: an exception during `_serializer.upsertRecord(entityType, record)` (or `fetchRecord`) is caught and converted to `markRecordConflict(...)` with `conflicts += 1`.
+
+## Why this matches "it simply didn't sync anything"
+
+Every incoming record that triggers the upsert/fetch error becomes a "conflict" rather than applying. Conflicts are not written to the real tables, and the conflict-resolution UI is currently orphaned/unreachable — so a second device shows no new data and no error. The first device appears to work (its own data is intact); only cross-device propagation silently fails.
+
+## Two defects, not one
+
+1. **The apply error** itself: `upsertRecord`/`fetchRecord` throws for a normally-deserialized record. Most likely a JSON <-> Drift shape/type mismatch in a deserialized field (int vs double, enum/bool encoding, or a column the upsert path does not handle). Exact exception is unknown because the catch block swallows it.
+2. **The masking**: converting *any* apply exception into a "conflict" turns a hard error into silent data loss. Even after fixing defect 1, apply errors should surface (log + fail the sync), not be relabeled as conflicts.
+
+## Recommended Phase 1 (the fix — not done yet)
+
+1. Start from the failing test `sync_round_trip_test.dart` (already red).
+2. Surface the swallowed exception: temporarily rethrow/log inside the `_mergeEntity` catch, or add a focused unit test that calls `SyncDataSerializer.upsertRecord('dives', <deserialized dive map>)` directly. Capture the exact error.
+3. Fix the deserialization/upsert mismatch (root cause).
+4. Stop masking apply errors as conflicts; let genuine failures fail the sync visibly.
+5. Re-run `sync_round_trip_test.dart` to green, then extend the same harness to every entity type (this is also the natural home for spec Phase 2's data-coverage + drift-guard work).
+
+Note: the on-device hardware verification (spec Phase 4) is still wanted eventually to validate the real iCloud transport, but it is no longer on the critical path for *this* bug — the no-op is fixable and verifiable entirely in Dart.

--- a/docs/superpowers/plans/2026-06-02-icloud-sync-phase-0-diagnostic.md
+++ b/docs/superpowers/plans/2026-06-02-icloud-sync-phase-0-diagnostic.md
@@ -1,0 +1,545 @@
+# iCloud Sync — Phase 0 (Diagnostic) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Determine exactly why the existing iCloud sync "doesn't sync anything," with evidence, before any fix is designed.
+
+**Architecture:** Add a hardware-free reproduction harness (an in-memory fake `CloudStorageProvider` plus two round-trip tests) that isolates "logic bug" from "iCloud/selection/hardware bug," then add boundary instrumentation and a temporary on-device trigger so the same round-trip can be observed on real Apple hardware. The phase ends at a mandatory checkpoint that produces a one-sentence root-cause statement; the fix is planned separately afterward.
+
+**Tech Stack:** Flutter, Dart, Drift (SQLite), Riverpod, `flutter_test`. Sync code under `lib/core/services/sync/` and `lib/core/services/cloud_storage/`.
+
+---
+
+## How to use this plan
+
+This is a **diagnostic** plan. Its deliverable is *knowledge*, not a finished feature. Tasks 1-3 are pure-Dart tests that may immediately reproduce a logic bug (in which case later tasks may be unnecessary). Tasks 4-6 prepare and run the on-device observation needed if the logic layer turns out to be fine. **Do not write a fix in this phase.** Stop at the Checkpoint and report findings; the fix + data-coverage + UI work is a separate plan.
+
+Spec: `docs/superpowers/specs/2026-06-01-icloud-sync-all-data-design.md`.
+
+### Key facts established during planning (so you don't have to rediscover them)
+
+- `SyncService.performSync()` returns `SyncResult` (`status` is a `SyncResultStatus`; `isSuccess` is true for `success`/`noChanges`/`hasConflicts`). With a **null** `cloudProvider` it returns `SyncResultStatus.error` ("No cloud provider configured"); when the provider reports not-authenticated it returns `SyncResultStatus.authError`. See `lib/core/services/sync/sync_service.dart:234-261`.
+- Given a valid, authenticated provider, `performSync()` ALWAYS does a full export + upload (it is not gated on pending changes), and applies remote data only if it is newer than the last sync. The "remote not newer than last sync, skip apply" branches are at `sync_service.dart:299-314` and `sync_service.dart:338-348` and are themselves candidate defects.
+- The selected provider lives in `selectedCloudProviderTypeProvider` (defaults to **null**) and is turned into a `CloudStorageProvider?` by `cloudStorageProviderProvider`, which also returns null when storage is in **custom-folder mode**. The only startup path that sets a provider is `restoreLastProviderProvider` (a `FutureProvider` that runs only if watched). See `lib/features/settings/presentation/providers/sync_providers.dart:93-122,417-426`.
+- `SyncRepository` and `SyncDataSerializer` read the database from the **global singleton** `DatabaseService.instance.database` (not constructor-injected). Tests inject an in-memory DB with `setUpTestDatabase()` (from `test/helpers/test_database.dart`) and tear down with `DatabaseService.instance.resetForTesting()`.
+- Serializer public API (`lib/core/services/sync/sync_data_serializer.dart`): `Future<SyncPayload> exportData({required String deviceId, DateTime? since, int? lastSyncTimestamp, required Map<String, List<SyncDeletion>> deletions})` (273), `String serializePayload(SyncPayload)` (424), `SyncPayload deserializePayload(String)` (429), `bool validateChecksum(SyncPayload)` (435). There is **no** public DB-apply method — applying remote data to the DB happens only inside `performSync()`.
+- `CloudStorageProvider` interface: `lib/core/services/cloud_storage/cloud_storage_provider.dart:47-142`. Canonical sync filename is `CloudStorageProviderMixin.canonicalSyncFileName` = `submersion_sync.json`.
+
+---
+
+## File structure
+
+| File | Create/Modify | Responsibility |
+| --- | --- | --- |
+| `test/helpers/fake_cloud_storage_provider.dart` | Create | In-memory `CloudStorageProvider` test double shared by both "devices". |
+| `test/core/services/sync/sync_serializer_round_trip_test.dart` | Create | Pure serializer symmetry test (no provider, no DB-apply). |
+| `test/core/services/sync/sync_round_trip_test.dart` | Create | Full `performSync()` round-trip against the fake provider, simulating device A -> device B. |
+| `lib/core/services/sync/sync_service.dart` | Modify | Add INFO-level boundary logging (remote-file resolution + skip decisions). |
+| `lib/core/services/cloud_storage/icloud_storage_provider.dart` | Modify | Add INFO-level logging of container path / fallback / listFiles. |
+| `lib/features/settings/presentation/providers/sync_providers.dart` | Modify | Log provider selection outcome (selected / null / custom-folder-disabled). |
+| `lib/features/settings/.../settings_page.dart` (or a debug entry) | Modify | Temporary reachable trigger so sync can be run on-device for observation. |
+| `docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md` | Create (Task 6) | The evidence + one-sentence root cause. |
+
+---
+
+## Task 0: Branch, worktree, and green baseline
+
+**Files:** none (environment only)
+
+- [ ] **Step 1: Create an isolated worktree/branch for this work**
+
+Use the `superpowers:using-git-worktrees` skill. Branch name: `feat/icloud-sync-diagnostic`. Do NOT work on `main`.
+
+- [ ] **Step 2: Initialize the worktree (submodules + deps + codegen)**
+
+Worktrees do not inherit submodules or generated code, and a stale `database.g.dart` carried across a branch switch will break the build with "Type 'X' not found".
+
+Run:
+```bash
+git submodule update --init --recursive
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs
+```
+
+- [ ] **Step 3: Confirm a green baseline**
+
+Run:
+```bash
+flutter analyze
+```
+Expected: `No issues found!`
+
+- [ ] **Step 4: Commit nothing yet** (no changes). Proceed.
+
+---
+
+## Task 1: In-memory fake CloudStorageProvider (test double)
+
+**Files:**
+- Create: `test/helpers/fake_cloud_storage_provider.dart`
+
+- [ ] **Step 1: Write the fake provider**
+
+It stores uploaded files in a `Map` keyed by filename (so re-uploading `submersion_sync.json` overwrites the same logical file), always reports available + authenticated, and ignores `folderId`. This is the shared "cloud" both simulated devices talk to.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+
+/// In-memory [CloudStorageProvider] for tests. Files are keyed by name, so the
+/// canonical sync file maps to a single stable id across uploads.
+class FakeCloudStorageProvider extends CloudStorageProvider
+    with CloudStorageProviderMixin {
+  final Map<String, _FakeFile> _files = {};
+  bool authenticated = true;
+  bool available = true;
+
+  int get fileCount => _files.length;
+  Uint8List? bytesOf(String name) => _files[name]?.data;
+
+  @override
+  String get providerName => 'Fake';
+
+  @override
+  String get providerId => 'fake';
+
+  @override
+  Future<bool> isAvailable() async => available;
+
+  @override
+  Future<bool> isAuthenticated() async => authenticated;
+
+  @override
+  Future<void> authenticate() async {
+    authenticated = true;
+  }
+
+  @override
+  Future<void> signOut() async {
+    authenticated = false;
+  }
+
+  @override
+  Future<String?> getUserEmail() async => 'tester@example.com';
+
+  @override
+  Future<UploadResult> uploadFile(
+    Uint8List data,
+    String filename, {
+    String? folderId,
+  }) async {
+    _files[filename] = _FakeFile(data, DateTime.now());
+    return UploadResult(fileId: filename, uploadTime: _files[filename]!.modified);
+  }
+
+  @override
+  Future<Uint8List> downloadFile(String fileId) async {
+    final f = _files[fileId];
+    if (f == null) {
+      throw CloudStorageException('File not found: $fileId');
+    }
+    return f.data;
+  }
+
+  @override
+  Future<CloudFileInfo?> getFileInfo(String fileId) async {
+    final f = _files[fileId];
+    if (f == null) return null;
+    return CloudFileInfo(
+      id: fileId,
+      name: fileId,
+      modifiedTime: f.modified,
+      sizeBytes: f.data.length,
+    );
+  }
+
+  @override
+  Future<List<CloudFileInfo>> listFiles({
+    String? folderId,
+    String? namePattern,
+  }) async {
+    return _files.entries
+        .where((e) => namePattern == null || e.key.contains(namePattern))
+        .map(
+          (e) => CloudFileInfo(
+            id: e.key,
+            name: e.key,
+            modifiedTime: e.value.modified,
+            sizeBytes: e.value.data.length,
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<void> deleteFile(String fileId) async {
+    _files.remove(fileId);
+  }
+
+  @override
+  Future<bool> fileExists(String fileId) async => _files.containsKey(fileId);
+
+  @override
+  Future<String> createFolder(String folderName, {String? parentFolderId}) async =>
+      'fake-folder';
+
+  @override
+  Future<String> getOrCreateSyncFolder() async => 'fake-sync-folder';
+}
+
+class _FakeFile {
+  final Uint8List data;
+  final DateTime modified;
+  _FakeFile(this.data, this.modified);
+}
+```
+
+- [ ] **Step 2: Verify it compiles and satisfies the interface**
+
+Run:
+```bash
+flutter analyze test/helpers/fake_cloud_storage_provider.dart
+```
+Expected: `No issues found!` (if the analyzer reports a missing abstract member, implement it the same minimal way — the interface is the source of truth).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/helpers/fake_cloud_storage_provider.dart
+git commit -m "test(sync): add in-memory fake CloudStorageProvider for diagnostics"
+```
+
+---
+
+## Task 2: Serializer symmetry test (no provider)
+
+Proves the narrow question: does a record survive `export -> serialize -> deserialize` with a valid checksum? If this fails, the defect is in the serializer and we have reproduced it in pure Dart.
+
+**Files:**
+- Create: `test/core/services/sync/sync_serializer_round_trip_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/test_database.dart';
+import '../../../helpers/mock_providers.dart';
+
+void main() {
+  group('Sync serializer symmetry', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    test('a dive survives export -> serialize -> deserialize with valid checksum',
+        () async {
+      // Seed one dive. If the first run fails on a foreign-key requirement
+      // (e.g. a diver must exist), insert that prerequisite first — the red
+      // run will tell you exactly what is missing.
+      final dive = createTestDiveWithBottomTime(id: 'dive-rt-1', diveNumber: 7);
+      await DiveRepositoryImpl().createDive(dive);
+
+      final serializer = SyncDataSerializer();
+      final deviceId = await SyncRepository().getDeviceId();
+
+      final payload = await serializer.exportData(
+        deviceId: deviceId,
+        since: null,
+        lastSyncTimestamp: null,
+        deletions: const <String, List<SyncDeletion>>{},
+      );
+      final json = serializer.serializePayload(payload);
+      final restored = serializer.deserializePayload(json);
+
+      expect(serializer.validateChecksum(restored), isTrue,
+          reason: 'checksum should validate after a clean round-trip');
+      expect(json, contains('dive-rt-1'),
+          reason: 'the seeded dive must appear in the exported payload');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run:
+```bash
+flutter test test/core/services/sync/sync_serializer_round_trip_test.dart
+```
+Expected: it either PASSES (serializer is healthy) or FAILS with a concrete error. **Record the outcome** — a failure here is a reproduced logic bug; capture the exact message for the findings doc.
+
+- [ ] **Step 3: If it failed for an environmental reason** (missing FK row, missing helper import), fix only the test setup (add the prerequisite row / import) and re-run until the test exercises the real assertions. Do not change production code.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/core/services/sync/sync_serializer_round_trip_test.dart
+git commit -m "test(sync): add serializer symmetry round-trip test"
+```
+
+---
+
+## Task 3: Full round-trip through performSync (the money test)
+
+Simulates two devices against the shared fake provider using one in-memory DB: device A uploads, then we reset local sync state and delete the dive to impersonate a fresh device B, and sync again. If the dive comes back, the orchestration + serializer + provider round-trip is healthy in pure Dart and the bug is in the real iCloud provider/selection/hardware layer. If it does not, we have reproduced the no-op in a test.
+
+**Files:**
+- Create: `test/core/services/sync/sync_round_trip_test.dart`
+
+- [ ] **Step 1: Write the test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+import '../../../helpers/mock_providers.dart';
+
+void main() {
+  group('Sync end-to-end round-trip (fake provider)', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+          syncRepository: SyncRepository(),
+          serializer: SyncDataSerializer(),
+          cloudProvider: cloud,
+        );
+
+    test('a dive created on "device A" is restored on "device B"', () async {
+      final diveRepo = DiveRepositoryImpl();
+
+      // Device A: seed and push.
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-xfer-1', diveNumber: 11),
+      );
+      final pushResult = await buildService().performSync();
+      expect(pushResult.isSuccess, isTrue,
+          reason: 'device A push should succeed; got ${pushResult.status} '
+              '(${pushResult.message})');
+      expect(cloud.bytesOf('submersion_sync.json'), isNotNull,
+          reason: 'the canonical sync file should exist in the cloud after push');
+
+      // Impersonate a fresh device B sharing the same cloud: forget local sync
+      // state and remove the dive locally.
+      await SyncRepository().resetSyncState();
+      await diveRepo.deleteDive('dive-xfer-1');
+      expect(await diveRepo.getDiveById('dive-xfer-1'), isNull,
+          reason: 'precondition: dive is gone locally before the pull');
+
+      // Device B: pull.
+      final pullResult = await buildService().performSync();
+      expect(pullResult.isSuccess, isTrue,
+          reason: 'device B pull should succeed; got ${pullResult.status} '
+              '(${pullResult.message})');
+
+      // The decisive assertion.
+      final restored = await diveRepo.getDiveById('dive-xfer-1');
+      expect(restored, isNotNull,
+          reason: 'THE BUG: dive did not propagate A -> B through the round-trip');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Confirm the dive-repository method names used above**
+
+The test references `DiveRepositoryImpl().deleteDive(...)` and `.getDiveById(...)`. Confirm the exact names/signatures before running:
+```bash
+grep -nE "Future<.*> (deleteDive|getDiveById|getDive|removeDive)\b" lib/features/dive_log/data/repositories/dive_repository_impl.dart
+```
+Adjust the calls to match the real methods (e.g. `getDive(id)` if that is the accessor). Do not invent methods.
+
+- [ ] **Step 3: Run it**
+
+Run:
+```bash
+flutter test test/core/services/sync/sync_round_trip_test.dart
+```
+Expected: a definitive result. PASS => the pure-Dart round-trip works; the no-op lives in the real provider/selection/hardware layer (continue to Tasks 4-6). FAIL => the no-op is reproduced in pure Dart; **capture the failing assertion and `pushResult`/`pullResult` status+message** for the findings doc — that is the root cause to fix in the next plan.
+
+**Rule out one false-failure first:** this test assumes `resetSyncState()` clears the stored last-sync time, so device B does not treat the remote file as "not newer." Before trusting a FAIL, confirm `resetSyncState()` nulls the last sync time:
+```bash
+grep -nA15 "resetSyncState" lib/core/data/repositories/sync_repository.dart
+```
+If it does not clear it, the pull will be skipped by the `sync_service.dart:299-314` "not newer" branch — a test-setup artifact, not the bug. In that case set the last sync time to a clearly-old value (or null) before the device-B `performSync()` and re-run. A genuine FAIL is one where the dive is absent even though the logs show the remote file was found and applied.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/core/services/sync/sync_round_trip_test.dart
+git commit -m "test(sync): add end-to-end round-trip test against fake provider"
+```
+
+---
+
+## Task 4: Boundary instrumentation (for the on-device run)
+
+Only needed if Task 3 passes (logic is healthy) and we must observe real iCloud. Adds INFO-level logging at the three boundaries most likely to hide a silent no-op: provider selection, remote-file resolution + skip decisions, and the iCloud container/listing.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart`
+- Modify: `lib/core/services/sync/sync_service.dart`
+- Modify: `lib/core/services/cloud_storage/icloud_storage_provider.dart`
+
+- [ ] **Step 1: Log the provider-selection outcome**
+
+In `cloudStorageProviderProvider` (`sync_providers.dart:106-122`), add logging for each return path. Add `import 'package:submersion/core/services/logger_service.dart';` if absent, and a file-level `final _log = LoggerService.forClass(CloudStorageProvider);` (or reuse an existing logger). Insert before each `return`:
+
+```dart
+// custom-folder branch:
+_log.info('cloudProvider: null (custom-folder mode disables app sync)');
+// providerType == null branch:
+_log.info('cloudProvider: null (no provider selected)');
+// icloud branch:
+_log.info('cloudProvider: iCloud selected');
+```
+
+- [ ] **Step 2: Log remote-file resolution and skip decisions in performSync**
+
+In `sync_service.dart`, after `remoteFileId` is resolved (around line 295) add:
+```dart
+_log.info('remote sync file resolved: ${remoteFileId ?? "NONE"}');
+```
+At the two "not newer, skipping" branches (`sync_service.dart:301-306` and `342-347`), upgrade the existing `_log.debug(...)` lines to `_log.info(...)` and include the timestamps being compared, e.g.:
+```dart
+_log.info('skip apply: remote modified ${info.modifiedTime} <= lastSync $lastSyncTime');
+```
+After the export, log the payload size and deletion count (near `sync_service.dart:400`):
+```dart
+_log.info('exported payload: ${localData.length} bytes, '
+    '${deletions.length} deletion groups');
+```
+
+- [ ] **Step 3: Log the iCloud container path, fallback, and listing**
+
+In `icloud_storage_provider.dart`, locate the methods that resolve the container path (via `ICloudNativeService.getContainerPath()`), `getOrCreateSyncFolder()`, and `listFiles(...)`. Add INFO logs at their returns:
+```dart
+_log.info('iCloud container: $containerPath (fallback=$usingLocalFallback)');
+_log.info('iCloud sync folder: $syncFolderPath');
+_log.info('iCloud listFiles -> ${files.map((f) => f.name).toList()}');
+```
+If the provider has no logger yet, add `final _log = LoggerService.forClass(ICloudStorageProvider);`. Confirm the actual local-variable names by reading the methods first; match them.
+
+- [ ] **Step 4: Verify build**
+
+Run:
+```bash
+dart format lib/
+flutter analyze
+```
+Expected: `No issues found!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/
+git commit -m "feat(sync): add boundary instrumentation for sync diagnosis"
+```
+
+---
+
+## Task 5: Temporary on-device trigger
+
+The Settings UI for sync is orphaned (no route/tile), so sync currently cannot be invoked on a device. Add a temporary, clearly-marked debug trigger that selects iCloud and runs a sync, so the instrumented logs can be produced on real hardware. This is throwaway scaffolding for Phase 0; the real UI is Phase 3.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/pages/settings_page.dart` (Data section), or wherever a debug action is easiest to reach.
+
+- [ ] **Step 1: Add a debug-only "Run iCloud sync (diagnostic)" action**
+
+Wrap it in `if (kDebugMode)` so it never ships. It must (a) set the provider to iCloud and (b) call `performSync()`:
+```dart
+if (kDebugMode)
+  ListTile(
+    leading: const Icon(Icons.bug_report),
+    title: const Text('Run iCloud sync (diagnostic)'),
+    onTap: () async {
+      ref.read(selectedCloudProviderTypeProvider.notifier).state =
+          CloudProviderType.icloud;
+      await ref.read(syncStateProvider.notifier).performSync();
+      final s = ref.read(syncStateProvider);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Sync: ${s.status} — ${s.message ?? ""}')),
+      );
+    },
+  ),
+```
+Add imports as needed (`package:flutter/foundation.dart` for `kDebugMode`, the sync providers, and `CloudProviderType` from `sync_data_serializer.dart`). Confirm the surrounding widget exposes a `WidgetRef ref` (this section is built inside a `ConsumerWidget`/`Consumer`); if not, wrap the tile in a `Consumer`.
+
+- [ ] **Step 2: Verify build**
+
+Run:
+```bash
+dart format lib/
+flutter analyze
+```
+Expected: `No issues found!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/
+git commit -m "feat(sync): add debug-only on-device sync trigger for diagnosis"
+```
+
+---
+
+## Task 6: Hardware reproduction run + findings
+
+**Files:**
+- Create: `docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md`
+
+- [ ] **Step 1: Run on real hardware (not the Simulator)**
+
+iCloud ubiquity containers do not propagate on the iOS Simulator, so a Simulator result is inconclusive by itself. On a real iPhone (and ideally a Mac signed into the same Apple ID), run:
+```bash
+flutter run -d <device-id>
+```
+Sign into iCloud on the device. Trigger the diagnostic action from Task 5. Capture the console logs (the INFO lines from Task 4).
+
+- [ ] **Step 2: Record the evidence**
+
+Create the findings doc with: the Task 2/3 test outcomes; the on-device log excerpt; and which boundary the data stops at. Answer explicitly:
+- Was a provider non-null and authenticated? (selection log + `isAuthenticated`)
+- Did `getOrCreateSyncFolder` resolve the real ubiquity container or a local fallback?
+- Did `uploadFile` succeed and a file appear in iCloud (check the Files app / the container)?
+- On a second device/run, did `listFiles` find `submersion_sync.json`, and was it downloaded and applied — or skipped by a "not newer" branch?
+
+- [ ] **Step 3: State the root cause in one sentence** at the top of the findings doc.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md
+git commit -m "docs(sync): record Phase 0 iCloud sync diagnosis"
+```
+
+---
+
+## CHECKPOINT — stop here
+
+Do not design or write a fix in this phase. Report the one-sentence root cause and the findings doc to the spec author. The next plan (Phase 1 fix + Phase 2 data coverage + Phase 3 UI + Phase 4 hardware verification) is written from these findings. If Task 3 already reproduced the bug in pure Dart, the next plan begins with a TDD fix keyed on that failing test; if the logic layer was healthy, it begins with the specific provider/selection/hardware defect named in the findings.

--- a/docs/superpowers/specs/2026-06-01-icloud-sync-all-data-design.md
+++ b/docs/superpowers/specs/2026-06-01-icloud-sync-all-data-design.md
@@ -1,0 +1,180 @@
+# iCloud Sync for All Structured Data — Design
+
+- Date: 2026-06-01
+- Status: Approved (design); implementation not started
+- Owner: Eric
+- Related: replaces the abandoned encrypted multi-device sync effort (dropped 2026-06-01). This work revives and completes the existing plaintext v1.5 cloud sync.
+
+## 1. Background
+
+Submersion already contains a substantial, mostly-complete cloud sync engine for a
+single user's data across their own devices. It serializes the database to a single
+JSON snapshot (`submersion_sync.json`, SHA-256 checksummed) and merges remote changes
+using record-level last-write-wins keyed on each row's `updatedAt`. An iCloud storage
+provider is fully implemented over a native ubiquity-container bridge (iOS/macOS); a
+Google Drive provider also exists behind the same `CloudStorageProvider` abstraction.
+
+Two problems block it today:
+
+1. **It is not reachable in the UI.** `CloudSyncPage` exists but is orphaned: there is
+   no `/settings/cloud-sync` route and no Settings tile/section wiring it up.
+2. **It did not actually sync.** Per the owner, an earlier attempt "simply didn't sync
+   anything" — the round-trip (export -> upload -> discover -> download -> merge -> apply)
+   is a no-op or dies at some stage. The cause is not yet known. Note: iCloud ubiquity
+   containers do not propagate on the iOS Simulator, so a Simulator-only test could
+   produce "nothing synced" with no underlying code defect — this must be ruled in or out.
+
+Key source files (to be re-verified during implementation):
+
+- Serializer: `lib/core/services/sync/sync_data_serializer.dart`
+- Orchestrator: `lib/core/services/sync/sync_service.dart`
+- Launch checks: `lib/core/services/sync/sync_initializer.dart`
+- Change bus / prefs: `lib/core/services/sync/sync_event_bus.dart`, `sync_preferences.dart`
+- Sync state repo: `lib/core/data/repositories/sync_repository.dart`
+- Provider abstraction: `lib/core/services/cloud_storage/cloud_storage_provider.dart`
+- iCloud provider + native bridge: `lib/core/services/cloud_storage/icloud_storage_provider.dart`, `icloud_native_service.dart`
+- Riverpod + UI: `lib/features/settings/presentation/providers/sync_providers.dart`, `lib/features/settings/presentation/pages/cloud_sync_page.dart`
+- Settings/router wiring: `lib/features/settings/presentation/pages/settings_page.dart`, `settings_list_content.dart`, `lib/core/router/app_router.dart`
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Reliably move all **structured** database records between a user's Apple devices.
+- Find and fix the root cause of the no-op round-trip before re-exposing the feature.
+- Close data-coverage gaps so every structured table that should sync, does.
+- Make it impossible for a future table to silently fall out of sync.
+- Re-surface the feature in the UI on iOS/macOS.
+- Prove the round-trip on real hardware.
+
+### Non-goals (explicitly out of scope)
+
+- **Media file binaries** (photo/video files referenced by `filePath`). Only their
+  structured metadata rows sync. Blob sync is a separate, larger subsystem.
+- **Google Drive / Android / Windows / Linux.** iCloud (Apple) only for now. The
+  `CloudStorageProvider` abstraction keeps Drive addable later without rework.
+- **Encrypted multi-device sync.** Abandoned; not revived here.
+- **Rewriting the merge/conflict engine.** We fix and complete the existing design.
+
+## 3. Success criteria
+
+On two Apple devices signed into the same iCloud account, with sync configured on both:
+
+- A create / edit / delete of **any** structured entity on device A appears correctly on
+  device B after a sync, for every structured entity type.
+- No duplicate records, no lost edits.
+- Deletions propagate (a record removed on A is removed on B).
+- No crashes or silent failures during sync.
+- Verified on **real hardware** (not the Simulator), across a documented entity matrix.
+
+## 4. Architecture (retained)
+
+We keep the current model and do not replace it:
+
+- **Payload:** one `submersion_sync.json` snapshot, SHA-256 checksummed, in the
+  "Submersion Sync" folder of the iCloud ubiquity container.
+- **Merge:** record-level last-write-wins via `updatedAt`. Rows without `updatedAt`
+  (junction tables) accept remote upserts. Conflicts recorded in `SyncRecords`.
+- **Transport:** `CloudStorageProvider` -> `ICloudStorageProvider` -> native bridge.
+- **Triggers:** manual "Sync Now"; on-launch check; on-change (debounced) and on-resume
+  when enabled in `SyncPreferences`.
+
+Conscious limitation: two edits to the **same** record on two devices between syncs will
+keep the later write and drop the earlier. This is acceptable for single-user
+multi-device use and will be documented rather than engineered around.
+
+## 5. Plan
+
+### Phase 0 — Diagnose the no-op (evidence before any fix)
+
+Add structured, leveled logging at each round-trip boundary and read where it stops:
+
+- export: per-entity record counts, payload size, checksum
+- provider: which provider type is selected, whether it is actually persisted across
+  relaunch, resolved iCloud container path
+- upload: success/failure and the resulting file URL
+- remote discovery: what `listFiles` returns (does it find the canonical file?)
+- download: byte count and checksum match
+- merge: records compared, upserts applied, conflicts, deletions
+
+Make sync triggerable on a real device (temporary dev entry point is acceptable in this
+phase). Reproduce on real hardware and explicitly rule the Simulator-propagation
+limitation in or out.
+
+Leading hypotheses to check (candidates, not commitments):
+
+- selected provider never persisted/initialized (a provider-persistence gap of the same
+  shape known to have existed on the abandoned encrypted path)
+- pending-change tracking never populated, so there is "nothing to upload"
+- iCloud entitlement / container not provisioned -> silent local-fallback directory that
+  never propagates
+- remote filename mismatch in discovery
+- auto-sync disabled by default with no reachable manual trigger
+
+**Deliverable:** a precise statement of where and why the round-trip fails.
+**Checkpoint:** regroup with the owner on findings before coding the fix.
+
+### Phase 1 — Fix the root cause
+
+Determined by Phase 0. Test-driven: write a failing test that reproduces the no-op at the
+unit level, make it pass, confirm no regressions. One root cause at a time.
+
+### Phase 2 — Complete data coverage + drift guard
+
+- Add export / upsert / delete handling for the structured tables currently missing it.
+  Candidates identified (verify against the serializer): `DiveCustomFields`,
+  `DiveDataSources`, `Courses`, `MediaEnrichment`, `MediaSpecies`,
+  `PendingPhotoSuggestions`, `MediaSubscriptions` (its schema comment already says
+  "synced across devices").
+- Classify **every** Drift table as either synced or explicitly excluded, with a reason.
+  Proposed exclusions:
+  - Sync-control (never sync): `SyncMetadata`, `SyncRecords`, `DeletionLog`.
+  - Per-device / local-only: `CachedRegions`, `MediaSubscriptionState`,
+    `ConnectorAccounts`, `NetworkCredentialHosts`, `MediaFetchDiagnostics`,
+    `ScheduledNotifications`.
+  - Judgment calls to confirm during this phase (user preferences that arguably should
+    follow the diver): `ViewConfigs`, `FieldPresets`, `CsvPresets`.
+- **Drift-guard test:** enumerate all Drift tables and assert each is either in the sync
+  registry or in an explicit excluded-set. This converts the hand-maintained parallel
+  list into a test-time contract so no future table can silently drop out of sync.
+- Per-entity round-trip tests: export -> import -> equal.
+
+### Phase 3 — Re-surface the UI (iOS/macOS)
+
+- Register the `/settings/cloud-sync` route.
+- Add a Cloud Sync tile in the Settings Data section, gated to iOS/macOS.
+- Honor the existing `isCloudSyncDisabledByCustomFolderProvider` gate.
+- Provider selection that is correctly persisted; status / last-sync display; "Sync Now";
+  surfacing of conflicts.
+
+### Phase 4 — Verify on hardware
+
+Two-device A<->B verification matrix across every synced entity type plus deletions, on
+real Apple hardware. The Simulator cannot validate iCloud propagation.
+
+## 6. Testing strategy
+
+- Unit + per-entity round-trip tests in the serializer (Phase 2).
+- The drift-guard coverage test (Phase 2).
+- A failing-then-passing regression test for the Phase 1 root cause.
+- Integration test exercising the merge/conflict path where feasible.
+- Manual hardware verification checklist (Phase 4): for each entity type, create/edit/
+  delete on A, sync both, confirm on B; repeat A<->B; confirm deletions propagate.
+
+## 7. Risks and open questions
+
+- **Hardware dependency:** the only authoritative proof needs two Apple devices.
+- **iCloud configuration:** entitlement and container identifier must be correct, or
+  writes silently land in a local fallback that never propagates.
+- **Schema drift:** two devices on different app versions may disagree on the payload
+  shape; note behavior and fail safe.
+- **LWW data loss edge:** concurrent edits to the same record between syncs lose one;
+  documented, not engineered around.
+- **Coverage classification:** the synced/excluded list above is from a fast exploration
+  pass; the drift-guard test and Phase 2 review establish the authoritative classification.
+
+## 8. Sequencing and checkpoints
+
+Phase 0 -> (checkpoint) -> Phase 1 -> Phase 2 -> Phase 3 -> Phase 4. The Phase 0->1
+checkpoint is mandatory: no fix is designed or written until the diagnosis is in hand.
+Implementation will occur on a dedicated feature branch/worktree, not on `main`.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -285,7 +285,7 @@ SPEC CHECKSUMS:
   health: 4decf5d74e8f54c58a8c07a385fc72f629a831d9
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  libdivecomputer_plugin: 3ae8830932e3089e43729ae45e87793b7c038c5c
+  libdivecomputer_plugin: 5876d08dd98fc04a06421cbaa7ad70e4c01d3f94
   native_exif: 0eb73d3d5b3ca892719228df8d2d1b13d1ae396c
   ObjectBox: 7da4aceb5013d041bfafdbc6d744a26918b09757
   objectbox_flutter_libs: 09b1dec1b4cd27bf1a5f9bae7ccaa7e43588bf31

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -321,10 +321,48 @@ class SyncRepository {
   Future<void> ensureSyncClockConfigured() async {
     if (SyncClock.instance.isConfigured) return;
     final metadata = await getOrCreateMetadata();
-    SyncClock.instance.configure(
-      nodeId: metadata.deviceId,
-      persisted: _parseHlc(metadata.hlc),
+    // Seed from the greater of the persisted clock and the highest HLC already
+    // stamped on any entity row, then force our own node id. The persisted
+    // clock can lag the rows if the app was killed between syncs (it is only
+    // persisted at sync time but advanced in memory per write); seeding from
+    // the on-disk rows guarantees the next local write is never ordered behind
+    // data this device already wrote -- which would otherwise let a remote win
+    // a record the local device edited more recently.
+    final seed = _seedHlc(
+      metadata.deviceId,
+      _parseHlc(metadata.hlc),
+      _parseHlc(await _maxRowHlc()),
     );
+    SyncClock.instance.configure(nodeId: metadata.deviceId, persisted: seed);
+  }
+
+  /// The highest `hlc` value across every conflict-capable table, or null if
+  /// none has one yet. Lexically comparable because the packed format zero-pads
+  /// physical time and counter.
+  Future<String?> _maxRowHlc() async {
+    final union = _hlcTargets.values
+        .map((t) => 'SELECT MAX(hlc) AS h FROM "${t.table}"')
+        .join(' UNION ALL ');
+    final row = await _db
+        .customSelect('SELECT MAX(h) AS m FROM ($union)')
+        .getSingleOrNull();
+    return row?.read<String?>('m');
+  }
+
+  /// Pick the greater of [a]/[b] by (physicalTime, counter) and rebuild it with
+  /// [nodeId] so the clock always issues under THIS device's identity.
+  Hlc? _seedHlc(String nodeId, Hlc? a, Hlc? b) {
+    Hlc? best;
+    for (final h in [a, b]) {
+      if (h == null) continue;
+      if (best == null ||
+          h.physicalTime > best.physicalTime ||
+          (h.physicalTime == best.physicalTime && h.counter > best.counter)) {
+        best = h;
+      }
+    }
+    if (best == null) return null;
+    return Hlc(best.physicalTime, best.counter, nodeId);
   }
 
   /// Persist the current [SyncClock] value so the logical counter survives an

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -273,21 +273,26 @@ class SyncRepository {
       final now = DateTime.now().millisecondsSinceEpoch;
       final id = '${entityType}_$recordId';
 
-      await _db
-          .into(_db.syncRecords)
-          .insertOnConflictUpdate(
-            SyncRecordsCompanion(
-              id: Value(id),
-              entityType: Value(entityType),
-              recordId: Value(recordId),
-              localUpdatedAt: Value(localUpdatedAt),
-              syncStatus: const Value('pending'),
-              createdAt: Value(now),
-              updatedAt: Value(now),
-            ),
-          );
+      // Mark-pending and the HLC stamp on the entity row are one logical write;
+      // run them in a transaction so a crash can't leave the row pending with a
+      // stale/absent HLC, and concurrent calls can't interleave the two steps.
+      await _db.transaction(() async {
+        await _db
+            .into(_db.syncRecords)
+            .insertOnConflictUpdate(
+              SyncRecordsCompanion(
+                id: Value(id),
+                entityType: Value(entityType),
+                recordId: Value(recordId),
+                localUpdatedAt: Value(localUpdatedAt),
+                syncStatus: const Value('pending'),
+                createdAt: Value(now),
+                updatedAt: Value(now),
+              ),
+            );
 
-      await _stampHlc(entityType, recordId);
+        await _stampHlc(entityType, recordId);
+      });
     } catch (e, stackTrace) {
       _log.error(
         'Failed to mark record pending: $entityType/$recordId',

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -4,6 +4,8 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/hlc.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
 
 /// Sync status for individual records
 enum SyncStatus { synced, pending, conflict }
@@ -18,6 +20,35 @@ class SyncRepository {
   final _log = LoggerService.forClass(SyncRepository);
 
   static const String _globalMetadataId = 'global';
+
+  /// Conflict-capable syncable entities that carry an `hlc` column, mapped to
+  /// their SQLite table name and primary-key column. markRecordPending stamps
+  /// a fresh Hybrid Logical Clock onto these rows so cross-device merges can
+  /// order edits correctly under wall-clock skew. Entities not listed here
+  /// (append-only tables) fall back to updatedAt ordering.
+  static const Map<String, ({String table, String pk})> _hlcTargets = {
+    'divers': (table: 'divers', pk: 'id'),
+    'diverSettings': (table: 'diver_settings', pk: 'id'),
+    'buddies': (table: 'buddies', pk: 'id'),
+    'diveCenters': (table: 'dive_centers', pk: 'id'),
+    'trips': (table: 'trips', pk: 'id'),
+    'liveaboardDetails': (table: 'liveaboard_detail_records', pk: 'id'),
+    'itineraryDays': (table: 'trip_itinerary_days', pk: 'id'),
+    'equipment': (table: 'equipment', pk: 'id'),
+    'equipmentSets': (table: 'equipment_sets', pk: 'id'),
+    'diveTypes': (table: 'dive_types', pk: 'id'),
+    'tankPresets': (table: 'tank_presets', pk: 'id'),
+    'diveComputers': (table: 'dive_computers', pk: 'id'),
+    'tags': (table: 'tags', pk: 'id'),
+    'courses': (table: 'courses', pk: 'id'),
+    'dives': (table: 'dives', pk: 'id'),
+    'diveSites': (table: 'dive_sites', pk: 'id'),
+    'certifications': (table: 'certifications', pk: 'id'),
+    'serviceRecords': (table: 'service_records', pk: 'id'),
+    'settings': (table: 'settings', pk: 'key'),
+    'csvPresets': (table: 'csv_presets', pk: 'id'),
+    'viewConfigs': (table: 'view_configs', pk: 'id'),
+  };
 
   // ============================================================================
   // Sync Metadata Operations
@@ -255,6 +286,8 @@ class SyncRepository {
               updatedAt: Value(now),
             ),
           );
+
+      await _stampHlc(entityType, recordId);
     } catch (e, stackTrace) {
       _log.error(
         'Failed to mark record pending: $entityType/$recordId',
@@ -262,6 +295,60 @@ class SyncRepository {
         stackTrace: stackTrace,
       );
       rethrow;
+    }
+  }
+
+  /// Stamp a fresh Hybrid Logical Clock onto the just-written entity row, if
+  /// the entity is conflict-capable and the clock is configured. Centralised
+  /// here (the write choke point) rather than in every repository companion.
+  /// The row is expected to already exist (repositories mark pending after the
+  /// insert/update); if it does not, the UPDATE is a harmless no-op.
+  Future<void> _stampHlc(String entityType, String recordId) async {
+    final target = _hlcTargets[entityType];
+    if (target == null) return;
+    await ensureSyncClockConfigured();
+    final hlc = SyncClock.instance.issue();
+    if (hlc == null) return;
+    await _db.customStatement(
+      'UPDATE "${target.table}" SET hlc = ? WHERE "${target.pk}" = ?',
+      [hlc, recordId],
+    );
+  }
+
+  /// Configure the process-wide [SyncClock] from this device's id and its
+  /// persisted clock value, once per process. Lazy so the first local write
+  /// stamps an HLC even before the first sync runs.
+  Future<void> ensureSyncClockConfigured() async {
+    if (SyncClock.instance.isConfigured) return;
+    final metadata = await getOrCreateMetadata();
+    SyncClock.instance.configure(
+      nodeId: metadata.deviceId,
+      persisted: _parseHlc(metadata.hlc),
+    );
+  }
+
+  /// Persist the current [SyncClock] value so the logical counter survives an
+  /// app restart. Called by the sync flow after a sync completes.
+  Future<void> persistSyncClock() async {
+    final current = SyncClock.instance.current;
+    if (current == null) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(
+      _db.syncMetadata,
+    )..where((t) => t.id.equals(_globalMetadataId))).write(
+      SyncMetadataCompanion(
+        hlc: Value(current.toString()),
+        updatedAt: Value(now),
+      ),
+    );
+  }
+
+  Hlc? _parseHlc(String? value) {
+    if (value == null || value.isEmpty) return null;
+    try {
+      return Hlc.parse(value);
+    } catch (_) {
+      return null;
     }
   }
 

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1426,7 +1426,7 @@ class ScheduledNotifications extends Table {
   Set<Column> get primaryKey => {id};
 }
 
-/// User-saved CSV import presets (local-only, not synced)
+/// User-saved CSV import presets (synced across devices; carries an hlc column)
 class CsvPresets extends Table {
   TextColumn get id => text()();
   TextColumn get name => text()();

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -40,6 +40,10 @@ class Divers extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -59,6 +63,10 @@ class Trips extends Table {
   BoolColumn get isShared => boolean().withDefault(const Constant(false))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -82,6 +90,10 @@ class LiveaboardDetailRecords extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -99,6 +111,10 @@ class TripItineraryDays extends Table {
   TextColumn get notes => text().withDefault(const Constant(''))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -253,6 +269,10 @@ class Dives extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -332,6 +352,10 @@ class DiveSites extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -392,6 +416,10 @@ class Equipment extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -430,6 +458,10 @@ class EquipmentSets extends Table {
   TextColumn get description => text().withDefault(const Constant(''))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -692,6 +724,10 @@ class Settings extends Table {
   TextColumn get value => text().nullable()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {key};
 }
@@ -875,6 +911,10 @@ class DiverSettings extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -892,6 +932,10 @@ class Buddies extends Table {
   TextColumn get notes => text().withDefault(const Constant(''))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -936,6 +980,10 @@ class Certifications extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -954,6 +1002,10 @@ class ServiceRecords extends Table {
   TextColumn get notes => text().withDefault(const Constant(''))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -982,6 +1034,10 @@ class DiveCenters extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -994,6 +1050,10 @@ class Tags extends Table {
   TextColumn get color => text().nullable()(); // Hex color code for UI
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -1010,6 +1070,10 @@ class DiveTypes extends Table {
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -1044,6 +1108,10 @@ class TankPresets extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -1068,6 +1136,10 @@ class DiveComputers extends Table {
   TextColumn get notes => text().withDefault(const Constant(''))();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -1239,6 +1311,10 @@ class SyncMetadata extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -1314,6 +1390,10 @@ class Courses extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -1354,6 +1434,10 @@ class CsvPresets extends Table {
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -1366,6 +1450,10 @@ class ViewConfigs extends Table {
   TextColumn get viewMode => text()();
   TextColumn get configJson => text()();
   IntColumn get updatedAt => integer()();
+
+  /// Hybrid Logical Clock for cross-device conflict resolution
+  /// (nullable: rows written before HLC rollout fall back to updatedAt).
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -1462,7 +1550,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 76;
+  static const int currentSchemaVersion = 77;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1542,6 +1630,7 @@ class AppDatabase extends _$AppDatabase {
     74,
     75,
     76,
+    77,
   ];
 
   /// Returns the number of migration steps that will execute when upgrading
@@ -3669,6 +3758,45 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 76) await reportProgress();
+        if (from < 77) {
+          // Add nullable Hybrid Logical Clock column to every conflict-capable
+          // syncable table (and sync_metadata for the device clock). Nullable
+          // so existing rows fall back to updatedAt ordering until rewritten.
+          const hlcTables = [
+            'divers',
+            'diver_settings',
+            'buddies',
+            'dive_centers',
+            'trips',
+            'liveaboard_detail_records',
+            'trip_itinerary_days',
+            'equipment',
+            'equipment_sets',
+            'dive_types',
+            'tank_presets',
+            'dive_computers',
+            'tags',
+            'courses',
+            'dives',
+            'dive_sites',
+            'certifications',
+            'service_records',
+            'settings',
+            'csv_presets',
+            'view_configs',
+            'sync_metadata',
+          ];
+          for (final table in hlcTables) {
+            final cols = await customSelect(
+              "PRAGMA table_info('$table')",
+            ).get();
+            final existing = cols.map((c) => c.read<String>('name')).toSet();
+            if (cols.isNotEmpty && !existing.contains('hlc')) {
+              await customStatement('ALTER TABLE $table ADD COLUMN hlc TEXT');
+            }
+          }
+        }
+        if (from < 77) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -72,6 +72,7 @@ import 'package:submersion/features/statistics/presentation/pages/statistics_tim
 import 'package:submersion/features/statistics/presentation/pages/statistics_equipment_page.dart';
 import 'package:submersion/features/statistics/presentation/pages/statistics_profile_page.dart';
 import 'package:submersion/features/backup/presentation/pages/backup_settings_page.dart';
+import 'package:submersion/features/settings/presentation/pages/cloud_sync_page.dart';
 import 'package:submersion/features/settings/presentation/pages/fix_dive_times_page.dart';
 import 'package:submersion/features/settings/presentation/pages/settings_page.dart';
 import 'package:submersion/features/settings/presentation/pages/appearance_page.dart';
@@ -854,6 +855,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 path: 'backup',
                 name: 'backupSettings',
                 builder: (context, state) => const BackupSettingsPage(),
+              ),
+              GoRoute(
+                path: 'cloud-sync',
+                name: 'cloudSync',
+                builder: (context, state) => const CloudSyncPage(),
               ),
               GoRoute(
                 path: 'fix-dive-times',

--- a/lib/core/services/sync/hlc.dart
+++ b/lib/core/services/sync/hlc.dart
@@ -1,0 +1,104 @@
+/// A Hybrid Logical Clock timestamp.
+///
+/// An HLC combines a physical wall-clock component with a logical counter and
+/// a node id. It gives a total, causally-consistent order across devices even
+/// when their wall clocks are skewed: a device that receives an event with a
+/// higher physical time advances its own clock past it ([merge]), so its next
+/// local event ([increment]) is ordered after what it has seen -- regardless
+/// of what its own (possibly slow) wall clock says.
+///
+/// This is the cross-device tiebreaker the sync merge uses instead of raw
+/// `updatedAt`, which can pick the wrong winner under clock skew.
+class Hlc implements Comparable<Hlc> {
+  /// Physical time component, milliseconds since epoch.
+  final int physicalTime;
+
+  /// Logical counter, disambiguating events within the same physical time.
+  final int counter;
+
+  /// Stable per-device identity (the device UUID). Final tiebreaker so two
+  /// devices never produce equal-but-distinct timestamps.
+  final String nodeId;
+
+  const Hlc(this.physicalTime, this.counter, this.nodeId);
+
+  /// A fresh clock reading at [nowMs] for [nodeId] with a zero counter.
+  factory Hlc.now(String nodeId, int nowMs) => Hlc(nowMs, 0, nodeId);
+
+  /// Parse the canonical packed form produced by [toString].
+  factory Hlc.parse(String value) {
+    final parts = value.split(':');
+    if (parts.length < 3) {
+      throw FormatException('Invalid HLC: $value');
+    }
+    return Hlc(
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+      // Re-join in case the nodeId itself contains the separator.
+      parts.sublist(2).join(':'),
+    );
+  }
+
+  /// Canonical packed form. Physical time and counter are zero-padded so the
+  /// string sorts in the same order as [compareTo] for human/debug use; the
+  /// authoritative ordering is always [compareTo] on parsed values.
+  @override
+  String toString() =>
+      '${physicalTime.toString().padLeft(15, '0')}:'
+      '${counter.toString().padLeft(6, '0')}:'
+      '$nodeId';
+
+  /// Issue a new timestamp for a LOCAL event at wall-clock [nowMs].
+  ///
+  /// l' = max(physical, now); counter resets when the wall clock moved
+  /// forward, otherwise increments (same millisecond, or clock behind).
+  Hlc increment(int nowMs) {
+    final lNew = physicalTime > nowMs ? physicalTime : nowMs;
+    final cNew = (lNew == physicalTime) ? counter + 1 : 0;
+    return Hlc(lNew, cNew, nodeId);
+  }
+
+  /// Advance this clock on RECEIPT of [remote] at wall-clock [nowMs],
+  /// returning a new clock that keeps this device's [nodeId] but is ordered
+  /// at-or-after both inputs.
+  Hlc merge(Hlc remote, int nowMs) {
+    final lNew = [
+      physicalTime,
+      remote.physicalTime,
+      nowMs,
+    ].reduce((a, b) => a > b ? a : b);
+
+    final int cNew;
+    if (lNew == physicalTime && lNew == remote.physicalTime) {
+      cNew = (counter > remote.counter ? counter : remote.counter) + 1;
+    } else if (lNew == physicalTime) {
+      cNew = counter + 1;
+    } else if (lNew == remote.physicalTime) {
+      cNew = remote.counter + 1;
+    } else {
+      cNew = 0;
+    }
+    return Hlc(lNew, cNew, nodeId);
+  }
+
+  @override
+  int compareTo(Hlc other) {
+    if (physicalTime != other.physicalTime) {
+      return physicalTime.compareTo(other.physicalTime);
+    }
+    if (counter != other.counter) {
+      return counter.compareTo(other.counter);
+    }
+    return nodeId.compareTo(other.nodeId);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is Hlc &&
+      other.physicalTime == physicalTime &&
+      other.counter == counter &&
+      other.nodeId == nodeId;
+
+  @override
+  int get hashCode => Object.hash(physicalTime, counter, nodeId);
+}

--- a/lib/core/services/sync/sync_clock.dart
+++ b/lib/core/services/sync/sync_clock.dart
@@ -1,0 +1,67 @@
+import 'package:submersion/core/services/sync/hlc.dart';
+
+/// Process-wide Hybrid Logical Clock for the local device.
+///
+/// Repositories call [issue] on every write to stamp a record's `hlc` column;
+/// the sync merge calls [receive] for every remote HLC it sees so this clock
+/// advances past other devices' physical times (the clock-skew fix). The
+/// clock is held in memory for a synchronous [issue]; the sync layer is
+/// responsible for seeding it ([configure]) from the persisted value at
+/// startup and writing [current] back when it next persists sync metadata.
+///
+/// Until [configure] is called, [issue] returns null and callers fall back to
+/// `updatedAt`-only ordering -- so the clock is safe to reference before it is
+/// wired up (e.g. in tests that do not care about HLC).
+class SyncClock {
+  SyncClock._();
+
+  /// The shared instance, mirroring the `DatabaseService.instance` pattern.
+  static final SyncClock instance = SyncClock._();
+
+  Hlc? _current;
+  int Function() _now = () => DateTime.now().millisecondsSinceEpoch;
+
+  /// True once [configure] has run and [issue] will return values.
+  bool get isConfigured => _current != null;
+
+  /// The current clock reading, or null if unconfigured. The sync layer reads
+  /// this to persist clock continuity across restarts.
+  Hlc? get current => _current;
+
+  /// Seed the clock for [nodeId] (this device's id). If [persisted] is given
+  /// (the clock value stored at last sync) it is used so the logical counter
+  /// continues across app restarts; otherwise the clock starts at "now".
+  /// [now] overrides the wall-clock source for tests.
+  void configure({
+    required String nodeId,
+    Hlc? persisted,
+    int Function()? now,
+  }) {
+    if (now != null) _now = now;
+    _current = persisted ?? Hlc.now(nodeId, _now());
+  }
+
+  /// Issue a new HLC string for a LOCAL write, advancing the clock. Returns
+  /// null if the clock is not configured.
+  String? issue() {
+    final c = _current;
+    if (c == null) return null;
+    final next = c.increment(_now());
+    _current = next;
+    return next.toString();
+  }
+
+  /// Advance the clock on receipt of a [remote] HLC during a merge. No-op if
+  /// the clock is not configured.
+  void receive(Hlc remote) {
+    final c = _current;
+    if (c == null) return;
+    _current = c.merge(remote, _now());
+  }
+
+  /// Reset to the unconfigured state. For tests and account switching.
+  void reset() {
+    _current = null;
+    _now = () => DateTime.now().millisecondsSinceEpoch;
+  }
+}

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1510,6 +1510,7 @@ class SyncDataSerializer {
     'weightAmount': r.weightAmount,
     'weightType': r.weightType,
     'isFavorite': r.isFavorite,
+    'isPlanned': r.isPlanned,
     'diveMode': r.diveMode,
     'cnsStart': r.cnsStart,
     'cnsEnd': r.cnsEnd,

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1110,7 +1110,7 @@ class SyncDataSerializer {
       query.where((t) => t.takenAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _mediaToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportBuddies(int? since) async {
@@ -1145,7 +1145,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _certificationToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportServiceRecords(int? since) async {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -28,15 +28,20 @@ class _SyncBlobValueSerializer extends ValueSerializer {
 
   @override
   T fromJson<T>(dynamic json) {
-    if (json != null) {
-      final typeList = <T>[];
-      if (typeList is List<Uint8List?>) {
-        if (json is String) {
-          return base64Decode(json) as T;
-        }
-        if (json is List) {
-          return Uint8List.fromList(json.cast<int>()) as T;
-        }
+    // Special-case BLOB columns: accept both base64 strings (the current
+    // sync format) and JSON byte arrays (the legacy format). The check is
+    // true for both `Uint8List` and `Uint8List?` (since `List<Uint8List>` is
+    // a subtype of `List<Uint8List?>`), so a future non-nullable BLOB column
+    // would still hit this branch instead of leaking back to the default
+    // serializer's array-of-bytes path.
+    final typeList = <T>[];
+    if (typeList is List<Uint8List?>) {
+      if (json == null) return null as T;
+      if (json is String) {
+        return base64Decode(json) as T;
+      }
+      if (json is List) {
+        return Uint8List.fromList(json.cast<int>()) as T;
       }
     }
     return _default.fromJson<T>(json);
@@ -936,14 +941,16 @@ class SyncDataSerializer {
       case 'diveCustomFields':
         await _db
             .into(_db.diveCustomFields)
-            .insertOnConflictUpdate(DiveCustomField.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveCustomField.fromJson(_withTimestampDefaults(data)),
+            );
         return;
       case 'diveDataSources':
         await _db
             .into(_db.diveDataSources)
             .insertOnConflictUpdate(
               DiveDataSourcesData.fromJson(
-                data,
+                _withTimestampDefaults(data),
                 serializer: _syncBlobSerializer,
               ),
             );
@@ -951,22 +958,30 @@ class SyncDataSerializer {
       case 'siteSpecies':
         await _db
             .into(_db.siteSpecies)
-            .insertOnConflictUpdate(SiteSpecy.fromJson(data));
+            .insertOnConflictUpdate(
+              SiteSpecy.fromJson(_withTimestampDefaults(data)),
+            );
         return;
       case 'csvPresets':
         await _db
             .into(_db.csvPresets)
-            .insertOnConflictUpdate(CsvPreset.fromJson(data));
+            .insertOnConflictUpdate(
+              CsvPreset.fromJson(_withTimestampDefaults(data)),
+            );
         return;
       case 'viewConfigs':
         await _db
             .into(_db.viewConfigs)
-            .insertOnConflictUpdate(ViewConfig.fromJson(data));
+            .insertOnConflictUpdate(
+              ViewConfig.fromJson(_withTimestampDefaults(data)),
+            );
         return;
       case 'fieldPresets':
         await _db
             .into(_db.fieldPresets)
-            .insertOnConflictUpdate(FieldPreset.fromJson(data));
+            .insertOnConflictUpdate(
+              FieldPreset.fromJson(_withTimestampDefaults(data)),
+            );
         return;
     }
   }
@@ -1636,6 +1651,16 @@ class SyncDataSerializer {
 
   /// Applies default values for DiverSettings fields that may be missing
   /// from older sync data or incomplete conflict records.
+  /// Defensive back-compat for the entities most recently added to SyncData:
+  /// if a peer ever ships a partial record missing `createdAt`/`updatedAt`,
+  /// fall back to "now" rather than letting Drift's strict `fromJson` throw
+  /// when it sees `null` where `int` was expected. The new entities all use
+  /// Unix-milliseconds for their timestamp columns.
+  Map<String, dynamic> _withTimestampDefaults(Map<String, dynamic> data) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return {'createdAt': now, 'updatedAt': now, 'importedAt': now, ...data};
+  }
+
   Map<String, dynamic> _applyDiverSettingDefaults(Map<String, dynamic> data) {
     final merged = {
       // Unit settings

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1442,7 +1442,11 @@ class SyncDataSerializer {
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveTypes(int? since) async {
-    final query = _db.select(_db.diveTypes);
+    // Built-in dive types are re-seeded identically on every device at first
+    // launch and cannot be edited, so syncing them only risks cross-device
+    // ID collisions and payload bloat. Export custom types only.
+    final query = _db.select(_db.diveTypes)
+      ..where((t) => t.isBuiltIn.equals(false));
     if (since != null) {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
@@ -1533,7 +1537,12 @@ class SyncDataSerializer {
   }
 
   Future<List<Map<String, dynamic>>> _exportSpecies() async {
-    final rows = await _db.select(_db.species).get();
+    // Built-in species come from a bundled asset re-seeded on every device;
+    // only export user-created species. (Built-ins use stable bundled IDs so
+    // they would not collide, but there is no value in shipping them.)
+    final rows = await (_db.select(
+      _db.species,
+    )..where((t) => t.isBuiltIn.equals(false))).get();
     return rows.map((r) => r.toJson()).toList();
   }
 
@@ -1577,7 +1586,11 @@ class SyncDataSerializer {
   }
 
   Future<List<Map<String, dynamic>>> _exportFieldPresets() async {
-    final rows = await _db.select(_db.fieldPresets).get();
+    // Built-in field presets are re-seeded per diver on every device; export
+    // only user-created presets.
+    final rows = await (_db.select(
+      _db.fieldPresets,
+    )..where((t) => t.isBuiltIn.equals(false))).get();
     return rows.map((r) => r.toJson()).toList();
   }
 

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -109,6 +109,7 @@ class SyncData {
   final List<Map<String, dynamic>> buddies;
   final List<Map<String, dynamic>> diveBuddies;
   final List<Map<String, dynamic>> certifications;
+  final List<Map<String, dynamic>> courses;
   final List<Map<String, dynamic>> serviceRecords;
   final List<Map<String, dynamic>> diveCenters;
   final List<Map<String, dynamic>> trips;
@@ -143,6 +144,7 @@ class SyncData {
     this.buddies = const [],
     this.diveBuddies = const [],
     this.certifications = const [],
+    this.courses = const [],
     this.serviceRecords = const [],
     this.diveCenters = const [],
     this.trips = const [],
@@ -178,6 +180,7 @@ class SyncData {
     'buddies': buddies,
     'diveBuddies': diveBuddies,
     'certifications': certifications,
+    'courses': courses,
     'serviceRecords': serviceRecords,
     'diveCenters': diveCenters,
     'trips': trips,
@@ -214,6 +217,7 @@ class SyncData {
       buddies: _parseList(json['buddies']),
       diveBuddies: _parseList(json['diveBuddies']),
       certifications: _parseList(json['certifications']),
+      courses: _parseList(json['courses']),
       serviceRecords: _parseList(json['serviceRecords']),
       diveCenters: _parseList(json['diveCenters']),
       trips: _parseList(json['trips']),
@@ -330,6 +334,7 @@ class SyncDataSerializer {
           'certifications',
           () => _exportCertifications(sinceMs),
         ),
+        courses: await _safeExport('courses', () => _exportCourses(sinceMs)),
         serviceRecords: await _safeExport(
           'serviceRecords',
           () => _exportServiceRecords(sinceMs),
@@ -449,6 +454,20 @@ class SyncDataSerializer {
   // Import / Apply Methods
   // ============================================================================
 
+  /// Runs [body] inside a single DB transaction with deferred FK checks.
+  ///
+  /// `PRAGMA defer_foreign_keys = ON` is per-transaction in SQLite, so it must
+  /// be set as the first statement inside this transaction. It auto-resets at
+  /// commit/rollback. Required for `_applyRemotePayload`: a single payload can
+  /// contain rows that reference siblings appearing later in the merge order
+  /// (e.g. a dive whose `siteId` points at a `diveSites` row applied after).
+  Future<T> applyInDeferredFkTransaction<T>(Future<T> Function() body) async {
+    return _db.transaction(() async {
+      await _db.customStatement('PRAGMA defer_foreign_keys = ON');
+      return await body();
+    });
+  }
+
   Future<Map<String, dynamic>?> fetchRecord(
     String entityType,
     String recordId,
@@ -539,6 +558,12 @@ class SyncDataSerializer {
           _db.certifications,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
         return row == null ? null : _certificationToJson(row);
+      case 'courses':
+        final row = await (_db.select(
+          _db.courses,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        // Drift-generated toJson keeps fetch symmetric with import.
+        return row?.toJson();
       case 'serviceRecords':
         final row = await (_db.select(
           _db.serviceRecords,
@@ -705,6 +730,11 @@ class SyncDataSerializer {
         await _db
             .into(_db.certifications)
             .insertOnConflictUpdate(Certification.fromJson(data));
+        return;
+      case 'courses':
+        await _db
+            .into(_db.courses)
+            .insertOnConflictUpdate(Course.fromJson(data));
         return;
       case 'serviceRecords':
         await _db
@@ -876,6 +906,11 @@ class SyncDataSerializer {
       case 'certifications':
         await (_db.delete(
           _db.certifications,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'courses':
+        await (_db.delete(
+          _db.courses,
         )..where((t) => t.id.equals(recordId))).go();
         return;
       case 'serviceRecords':
@@ -1148,6 +1183,15 @@ class SyncDataSerializer {
     return rows.map((r) => r.toJson()).toList();
   }
 
+  Future<List<Map<String, dynamic>>> _exportCourses(int? since) async {
+    final query = _db.select(_db.courses);
+    if (since != null) {
+      query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
+    }
+    final rows = await query.get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
   Future<List<Map<String, dynamic>>> _exportServiceRecords(int? since) async {
     final query = _db.select(_db.serviceRecords);
     if (since != null) {
@@ -1284,13 +1328,26 @@ class SyncDataSerializer {
     return rows.map((r) => r.toJson()).toList();
   }
 
+  /// Settings keys that hold per-device state and must never sync.
+  ///
+  /// Including these in the payload causes the receiving device to flag a
+  /// conflict on every cross-device pull (same `key` row, different value
+  /// per device). `active_diver_id` is the canonical case: at first launch
+  /// each device auto-creates an owner diver with its own UUID and writes
+  /// the pointer here; both devices then have a perfectly valid local value
+  /// that has no business overwriting the other side.
+  static const Set<String> _deviceLocalSettingsKeys = {'active_diver_id'};
+
   Future<List<Map<String, dynamic>>> _exportSettings(int? since) async {
     final query = _db.select(_db.settings);
     if (since != null) {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => r.toJson()).toList();
+    return rows
+        .where((r) => !_deviceLocalSettingsKeys.contains(r.key))
+        .map((r) => r.toJson())
+        .toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportSpecies() async {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -10,6 +10,49 @@ import 'package:submersion/core/services/logger_service.dart';
 /// Sync data format version for compatibility checking
 const int syncFormatVersion = 2;
 
+/// Value serializer used only for sync export/import of BLOB-bearing entities.
+///
+/// Drift's default serializer encodes a `Uint8List` as a JSON array of byte
+/// ints (`[1,2,3,...]`), which is ~3x the size of the raw bytes once rendered
+/// as text. Dive-computer fingerprints and embedded photos make that the
+/// dominant cost of the sync file. This serializer encodes BLOBs as base64
+/// strings instead (~1.33x), delegating every other type to the default.
+///
+/// `fromJson` accepts BOTH formats so this is a non-breaking change: a payload
+/// already in iCloud that used the old array encoding still decodes, while new
+/// payloads are written as base64.
+class _SyncBlobValueSerializer extends ValueSerializer {
+  const _SyncBlobValueSerializer();
+
+  static const _default = ValueSerializer.defaults();
+
+  @override
+  T fromJson<T>(dynamic json) {
+    if (json != null) {
+      final typeList = <T>[];
+      if (typeList is List<Uint8List?>) {
+        if (json is String) {
+          return base64Decode(json) as T;
+        }
+        if (json is List) {
+          return Uint8List.fromList(json.cast<int>()) as T;
+        }
+      }
+    }
+    return _default.fromJson<T>(json);
+  }
+
+  @override
+  dynamic toJson<T>(T value) {
+    if (value is Uint8List) {
+      return base64Encode(value);
+    }
+    return _default.toJson<T>(value);
+  }
+}
+
+const _syncBlobSerializer = _SyncBlobValueSerializer();
+
 /// Represents a record deletion to sync across devices.
 class SyncDeletion {
   final String id;
@@ -574,7 +617,7 @@ class SyncDataSerializer {
         final row = await (_db.select(
           _db.media,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row?.toJson();
+        return row?.toJson(serializer: _syncBlobSerializer);
       case 'buddies':
         final row = await (_db.select(
           _db.buddies,
@@ -589,7 +632,7 @@ class SyncDataSerializer {
         final row = await (_db.select(
           _db.certifications,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row?.toJson();
+        return row?.toJson(serializer: _syncBlobSerializer);
       case 'courses':
         final row = await (_db.select(
           _db.courses,
@@ -690,7 +733,7 @@ class SyncDataSerializer {
         final row = await (_db.select(
           _db.diveDataSources,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row?.toJson();
+        return row?.toJson(serializer: _syncBlobSerializer);
       case 'siteSpecies':
         final row = await (_db.select(
           _db.siteSpecies,
@@ -776,7 +819,9 @@ class SyncDataSerializer {
       case 'media':
         await _db
             .into(_db.media)
-            .insertOnConflictUpdate(MediaData.fromJson(data));
+            .insertOnConflictUpdate(
+              MediaData.fromJson(data, serializer: _syncBlobSerializer),
+            );
         return;
       case 'buddies':
         await _db
@@ -791,7 +836,9 @@ class SyncDataSerializer {
       case 'certifications':
         await _db
             .into(_db.certifications)
-            .insertOnConflictUpdate(Certification.fromJson(data));
+            .insertOnConflictUpdate(
+              Certification.fromJson(data, serializer: _syncBlobSerializer),
+            );
         return;
       case 'courses':
         await _db
@@ -894,7 +941,12 @@ class SyncDataSerializer {
       case 'diveDataSources':
         await _db
             .into(_db.diveDataSources)
-            .insertOnConflictUpdate(DiveDataSourcesData.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveDataSourcesData.fromJson(
+                data,
+                serializer: _syncBlobSerializer,
+              ),
+            );
         return;
       case 'siteSpecies':
         await _db
@@ -1267,7 +1319,8 @@ class SyncDataSerializer {
       query.where((t) => t.takenAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => r.toJson()).toList();
+    // Media carries the imageData BLOB; encode it as base64, not a byte array.
+    return rows.map((r) => r.toJson(serializer: _syncBlobSerializer)).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportBuddies(int? since) async {
@@ -1302,7 +1355,8 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => r.toJson()).toList();
+    // Certifications carry photoFront/photoBack BLOBs; base64-encode them.
+    return rows.map((r) => r.toJson(serializer: _syncBlobSerializer)).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportCourses(int? since) async {
@@ -1495,7 +1549,8 @@ class SyncDataSerializer {
 
   Future<List<Map<String, dynamic>>> _exportDiveDataSources() async {
     final rows = await _db.select(_db.diveDataSources).get();
-    return rows.map((r) => r.toJson()).toList();
+    // Carries rawData/rawFingerprint BLOBs; base64-encode them.
+    return rows.map((r) => r.toJson(serializer: _syncBlobSerializer)).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportSiteSpecies() async {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -127,6 +127,12 @@ class SyncData {
   final List<Map<String, dynamic>> sightings;
   final List<Map<String, dynamic>> diveProfileEvents;
   final List<Map<String, dynamic>> gasSwitches;
+  final List<Map<String, dynamic>> diveCustomFields;
+  final List<Map<String, dynamic>> diveDataSources;
+  final List<Map<String, dynamic>> siteSpecies;
+  final List<Map<String, dynamic>> csvPresets;
+  final List<Map<String, dynamic>> viewConfigs;
+  final List<Map<String, dynamic>> fieldPresets;
 
   const SyncData({
     this.divers = const [],
@@ -162,6 +168,12 @@ class SyncData {
     this.sightings = const [],
     this.diveProfileEvents = const [],
     this.gasSwitches = const [],
+    this.diveCustomFields = const [],
+    this.diveDataSources = const [],
+    this.siteSpecies = const [],
+    this.csvPresets = const [],
+    this.viewConfigs = const [],
+    this.fieldPresets = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -198,6 +210,12 @@ class SyncData {
     'sightings': sightings,
     'diveProfileEvents': diveProfileEvents,
     'gasSwitches': gasSwitches,
+    'diveCustomFields': diveCustomFields,
+    'diveDataSources': diveDataSources,
+    'siteSpecies': siteSpecies,
+    'csvPresets': csvPresets,
+    'viewConfigs': viewConfigs,
+    'fieldPresets': fieldPresets,
   };
 
   factory SyncData.fromJson(Map<String, dynamic> json) {
@@ -235,6 +253,12 @@ class SyncData {
       sightings: _parseList(json['sightings']),
       diveProfileEvents: _parseList(json['diveProfileEvents']),
       gasSwitches: _parseList(json['gasSwitches']),
+      diveCustomFields: _parseList(json['diveCustomFields']),
+      diveDataSources: _parseList(json['diveDataSources']),
+      siteSpecies: _parseList(json['siteSpecies']),
+      csvPresets: _parseList(json['csvPresets']),
+      viewConfigs: _parseList(json['viewConfigs']),
+      fieldPresets: _parseList(json['fieldPresets']),
     );
   }
 
@@ -385,6 +409,24 @@ class SyncDataSerializer {
           'gasSwitches',
           () => _exportGasSwitches(sinceMs),
         ),
+        diveCustomFields: await _safeExport(
+          'diveCustomFields',
+          _exportDiveCustomFields,
+        ),
+        diveDataSources: await _safeExport(
+          'diveDataSources',
+          _exportDiveDataSources,
+        ),
+        siteSpecies: await _safeExport('siteSpecies', _exportSiteSpecies),
+        csvPresets: await _safeExport(
+          'csvPresets',
+          () => _exportCsvPresets(sinceMs),
+        ),
+        viewConfigs: await _safeExport(
+          'viewConfigs',
+          () => _exportViewConfigs(sinceMs),
+        ),
+        fieldPresets: await _safeExport('fieldPresets', _exportFieldPresets),
       );
 
       // Group deletions by entity type
@@ -649,6 +691,36 @@ class SyncDataSerializer {
           _db.gasSwitches,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
         return row == null ? null : _gasSwitchToJson(row);
+      case 'diveCustomFields':
+        final row = await (_db.select(
+          _db.diveCustomFields,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
+      case 'diveDataSources':
+        final row = await (_db.select(
+          _db.diveDataSources,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
+      case 'siteSpecies':
+        final row = await (_db.select(
+          _db.siteSpecies,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
+      case 'csvPresets':
+        final row = await (_db.select(
+          _db.csvPresets,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
+      case 'viewConfigs':
+        final row = await (_db.select(
+          _db.viewConfigs,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
+      case 'fieldPresets':
+        final row = await (_db.select(
+          _db.fieldPresets,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
     }
     return null;
   }
@@ -824,6 +896,36 @@ class SyncDataSerializer {
             .into(_db.gasSwitches)
             .insertOnConflictUpdate(GasSwitche.fromJson(data));
         return;
+      case 'diveCustomFields':
+        await _db
+            .into(_db.diveCustomFields)
+            .insertOnConflictUpdate(DiveCustomField.fromJson(data));
+        return;
+      case 'diveDataSources':
+        await _db
+            .into(_db.diveDataSources)
+            .insertOnConflictUpdate(DiveDataSourcesData.fromJson(data));
+        return;
+      case 'siteSpecies':
+        await _db
+            .into(_db.siteSpecies)
+            .insertOnConflictUpdate(SiteSpecy.fromJson(data));
+        return;
+      case 'csvPresets':
+        await _db
+            .into(_db.csvPresets)
+            .insertOnConflictUpdate(CsvPreset.fromJson(data));
+        return;
+      case 'viewConfigs':
+        await _db
+            .into(_db.viewConfigs)
+            .insertOnConflictUpdate(ViewConfig.fromJson(data));
+        return;
+      case 'fieldPresets':
+        await _db
+            .into(_db.fieldPresets)
+            .insertOnConflictUpdate(FieldPreset.fromJson(data));
+        return;
     }
   }
 
@@ -992,6 +1094,36 @@ class SyncDataSerializer {
       case 'gasSwitches':
         await (_db.delete(
           _db.gasSwitches,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'diveCustomFields':
+        await (_db.delete(
+          _db.diveCustomFields,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'diveDataSources':
+        await (_db.delete(
+          _db.diveDataSources,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'siteSpecies':
+        await (_db.delete(
+          _db.siteSpecies,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'csvPresets':
+        await (_db.delete(
+          _db.csvPresets,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'viewConfigs':
+        await (_db.delete(
+          _db.viewConfigs,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'fieldPresets':
+        await (_db.delete(
+          _db.fieldPresets,
         )..where((t) => t.id.equals(recordId))).go();
         return;
     }
@@ -1357,6 +1489,44 @@ class SyncDataSerializer {
 
   Future<List<Map<String, dynamic>>> _exportSightings() async {
     final rows = await _db.select(_db.sightings).get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportDiveCustomFields() async {
+    final rows = await _db.select(_db.diveCustomFields).get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportDiveDataSources() async {
+    final rows = await _db.select(_db.diveDataSources).get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportSiteSpecies() async {
+    final rows = await _db.select(_db.siteSpecies).get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportCsvPresets(int? since) async {
+    final query = _db.select(_db.csvPresets);
+    if (since != null) {
+      query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
+    }
+    final rows = await query.get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportViewConfigs(int? since) async {
+    final query = _db.select(_db.viewConfigs);
+    if (since != null) {
+      query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
+    }
+    final rows = await query.get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportFieldPresets() async {
+    final rows = await _db.select(_db.fieldPresets).get();
     return rows.map((r) => r.toJson()).toList();
   }
 

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -266,16 +266,6 @@ class SyncData {
     if (value == null) return [];
     return (value as List).map((e) => e as Map<String, dynamic>).toList();
   }
-
-  /// Check if this sync data is empty
-  bool get isEmpty =>
-      divers.isEmpty &&
-      dives.isEmpty &&
-      diveSites.isEmpty &&
-      equipment.isEmpty &&
-      buddies.isEmpty &&
-      tankPresets.isEmpty &&
-      media.isEmpty;
 }
 
 /// Service for serializing and deserializing sync data

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -509,27 +509,27 @@ class SyncDataSerializer {
         final row = await (_db.select(
           _db.divers,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diverToJson(row);
+        return row?.toJson();
       case 'diverSettings':
         final row = await (_db.select(
           _db.diverSettings,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diverSettingToJson(row);
+        return row?.toJson();
       case 'dives':
         final row = await (_db.select(
           _db.dives,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveToJson(row);
+        return row?.toJson();
       case 'diveProfiles':
         final row = await (_db.select(
           _db.diveProfiles,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveProfileToJson(row);
+        return row?.toJson();
       case 'diveTanks':
         final row = await (_db.select(
           _db.diveTanks,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveTankToJson(row);
+        return row?.toJson();
       case 'diveEquipment':
         final parts = _splitCompositeId(recordId);
         if (parts.length != 2) return null;
@@ -538,27 +538,27 @@ class SyncDataSerializer {
                   ..where((t) => t.diveId.equals(parts[0]))
                   ..where((t) => t.equipmentId.equals(parts[1])))
                 .getSingleOrNull();
-        return row == null ? null : _diveEquipmentToJson(row);
+        return row?.toJson();
       case 'diveWeights':
         final row = await (_db.select(
           _db.diveWeights,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveWeightToJson(row);
+        return row?.toJson();
       case 'diveSites':
         final row = await (_db.select(
           _db.diveSites,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveSiteToJson(row);
+        return row?.toJson();
       case 'equipment':
         final row = await (_db.select(
           _db.equipment,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _equipmentToJson(row);
+        return row?.toJson();
       case 'equipmentSets':
         final row = await (_db.select(
           _db.equipmentSets,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _equipmentSetToJson(row);
+        return row?.toJson();
       case 'equipmentSetItems':
         final parts = _splitCompositeId(recordId);
         if (parts.length != 2) return null;
@@ -574,22 +574,22 @@ class SyncDataSerializer {
         final row = await (_db.select(
           _db.media,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _mediaToJson(row);
+        return row?.toJson();
       case 'buddies':
         final row = await (_db.select(
           _db.buddies,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _buddyToJson(row);
+        return row?.toJson();
       case 'diveBuddies':
         final row = await (_db.select(
           _db.diveBuddies,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveBuddyToJson(row);
+        return row?.toJson();
       case 'certifications':
         final row = await (_db.select(
           _db.certifications,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _certificationToJson(row);
+        return row?.toJson();
       case 'courses':
         final row = await (_db.select(
           _db.courses,
@@ -600,87 +600,87 @@ class SyncDataSerializer {
         final row = await (_db.select(
           _db.serviceRecords,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _serviceRecordToJson(row);
+        return row?.toJson();
       case 'diveCenters':
         final row = await (_db.select(
           _db.diveCenters,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveCenterToJson(row);
+        return row?.toJson();
       case 'trips':
         final row = await (_db.select(
           _db.trips,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _tripToJson(row);
+        return row?.toJson();
       case 'liveaboardDetails':
         final row = await (_db.select(
           _db.liveaboardDetailRecords,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _liveaboardDetailToJson(row);
+        return row?.toJson();
       case 'itineraryDays':
         final row = await (_db.select(
           _db.tripItineraryDays,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _itineraryDayToJson(row);
+        return row?.toJson();
       case 'tags':
         final row = await (_db.select(
           _db.tags,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _tagToJson(row);
+        return row?.toJson();
       case 'diveTags':
         final row = await (_db.select(
           _db.diveTags,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveTagToJson(row);
+        return row?.toJson();
       case 'diveTypes':
         final row = await (_db.select(
           _db.diveTypes,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveTypeToJson(row);
+        return row?.toJson();
       case 'tankPresets':
         final row = await (_db.select(
           _db.tankPresets,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _tankPresetToJson(row);
+        return row?.toJson();
       case 'diveComputers':
         final row = await (_db.select(
           _db.diveComputers,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveComputerToJson(row);
+        return row?.toJson();
       case 'tankPressureProfiles':
         final row = await (_db.select(
           _db.tankPressureProfiles,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _tankPressureProfileToJson(row);
+        return row?.toJson();
       case 'tideRecords':
         final row = await (_db.select(
           _db.tideRecords,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _tideRecordToJson(row);
+        return row?.toJson();
       case 'settings':
         final row = await (_db.select(
           _db.settings,
         )..where((t) => t.key.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _settingsToJson(row);
+        return row?.toJson();
       case 'species':
         final row = await (_db.select(
           _db.species,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _speciesToJson(row);
+        return row?.toJson();
       case 'sightings':
         final row = await (_db.select(
           _db.sightings,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _sightingToJson(row);
+        return row?.toJson();
       case 'diveProfileEvents':
         final row = await (_db.select(
           _db.diveProfileEvents,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _diveProfileEventToJson(row);
+        return row?.toJson();
       case 'gasSwitches':
         final row = await (_db.select(
           _db.gasSwitches,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
-        return row == null ? null : _gasSwitchToJson(row);
+        return row?.toJson();
       case 'diveCustomFields':
         final row = await (_db.select(
           _db.diveCustomFields,
@@ -1622,490 +1622,4 @@ class SyncDataSerializer {
     return merged;
   }
 
-  // ============================================================================
-  // Row to JSON Converters
-  // ============================================================================
-
-  Map<String, dynamic> _diverToJson(Diver r) => {
-    'id': r.id,
-    'name': r.name,
-    'email': r.email,
-    'phone': r.phone,
-    'photoPath': r.photoPath,
-    'emergencyContactName': r.emergencyContactName,
-    'emergencyContactPhone': r.emergencyContactPhone,
-    'emergencyContactRelation': r.emergencyContactRelation,
-    'medicalNotes': r.medicalNotes,
-    'bloodType': r.bloodType,
-    'allergies': r.allergies,
-    'insuranceProvider': r.insuranceProvider,
-    'insurancePolicyNumber': r.insurancePolicyNumber,
-    'insuranceExpiryDate': r.insuranceExpiryDate,
-    'notes': r.notes,
-    'isDefault': r.isDefault,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _diverSettingToJson(DiverSetting r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'depthUnit': r.depthUnit,
-    'temperatureUnit': r.temperatureUnit,
-    'pressureUnit': r.pressureUnit,
-    'volumeUnit': r.volumeUnit,
-    'weightUnit': r.weightUnit,
-    'altitudeUnit': r.altitudeUnit,
-    'sacUnit': r.sacUnit,
-    'timeFormat': r.timeFormat,
-    'dateFormat': r.dateFormat,
-    'themeMode': r.themeMode,
-    'themePreset': r.themePreset,
-    'defaultDiveType': r.defaultDiveType,
-    'defaultTankVolume': r.defaultTankVolume,
-    'defaultStartPressure': r.defaultStartPressure,
-    'defaultTankPreset': r.defaultTankPreset,
-    'applyDefaultTankToImports': r.applyDefaultTankToImports,
-    'gfLow': r.gfLow,
-    'gfHigh': r.gfHigh,
-    'ppO2MaxWorking': r.ppO2MaxWorking,
-    'ppO2MaxDeco': r.ppO2MaxDeco,
-    'cnsWarningThreshold': r.cnsWarningThreshold,
-    'ascentRateWarning': r.ascentRateWarning,
-    'ascentRateCritical': r.ascentRateCritical,
-    'showCeilingOnProfile': r.showCeilingOnProfile,
-    'showAscentRateColors': r.showAscentRateColors,
-    'showNdlOnProfile': r.showNdlOnProfile,
-    'lastStopDepth': r.lastStopDepth,
-    'decoStopIncrement': r.decoStopIncrement,
-    'showDepthColoredDiveCards': r.showDepthColoredDiveCards,
-    'cardColorAttribute': r.cardColorAttribute,
-    'cardColorGradientPreset': r.cardColorGradientPreset,
-    'cardColorGradientStart': r.cardColorGradientStart,
-    'cardColorGradientEnd': r.cardColorGradientEnd,
-    'showMapBackgroundOnDiveCards': r.showMapBackgroundOnDiveCards,
-    'showMapBackgroundOnSiteCards': r.showMapBackgroundOnSiteCards,
-    'showMaxDepthMarker': r.showMaxDepthMarker,
-    'showPressureThresholdMarkers': r.showPressureThresholdMarkers,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _diveToJson(Dive r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'diveNumber': r.diveNumber,
-    'diveDateTime': r.diveDateTime,
-    'entryTime': r.entryTime,
-    'exitTime': r.exitTime,
-    'duration': r.bottomTime,
-    'runtime': r.runtime,
-    'maxDepth': r.maxDepth,
-    'avgDepth': r.avgDepth,
-    'waterTemp': r.waterTemp,
-    'airTemp': r.airTemp,
-    'visibility': r.visibility,
-    'diveType': r.diveType,
-    'buddy': r.buddy,
-    'diveMaster': r.diveMaster,
-    'notes': r.notes,
-    'siteId': r.siteId,
-    'rating': r.rating,
-    'diveCenterId': r.diveCenterId,
-    'tripId': r.tripId,
-    'currentDirection': r.currentDirection,
-    'currentStrength': r.currentStrength,
-    'swellHeight': r.swellHeight,
-    'entryMethod': r.entryMethod,
-    'exitMethod': r.exitMethod,
-    'waterType': r.waterType,
-    'altitude': r.altitude,
-    'surfacePressure': r.surfacePressure,
-    'surfaceIntervalSeconds': r.surfaceIntervalSeconds,
-    'gradientFactorLow': r.gradientFactorLow,
-    'gradientFactorHigh': r.gradientFactorHigh,
-    'diveComputerModel': r.diveComputerModel,
-    'diveComputerSerial': r.diveComputerSerial,
-    'diveComputerFirmware': r.diveComputerFirmware,
-    'weightAmount': r.weightAmount,
-    'weightType': r.weightType,
-    'isFavorite': r.isFavorite,
-    'isPlanned': r.isPlanned,
-    'diveMode': r.diveMode,
-    'cnsStart': r.cnsStart,
-    'cnsEnd': r.cnsEnd,
-    'otu': r.otu,
-    'computerId': r.computerId,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-    'windSpeed': r.windSpeed,
-    'windDirection': r.windDirection,
-    'cloudCover': r.cloudCover,
-    'precipitation': r.precipitation,
-    'humidity': r.humidity,
-    'weatherDescription': r.weatherDescription,
-    'weatherSource': r.weatherSource,
-    'weatherFetchedAt': r.weatherFetchedAt,
-  };
-
-  Map<String, dynamic> _diveProfileToJson(DiveProfile r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'computerId': r.computerId,
-    'isPrimary': r.isPrimary,
-    'timestamp': r.timestamp,
-    'depth': r.depth,
-    'pressure': r.pressure,
-    'temperature': r.temperature,
-    'heartRate': r.heartRate,
-    'ascentRate': r.ascentRate,
-    'ceiling': r.ceiling,
-    'ndl': r.ndl,
-  };
-
-  Map<String, dynamic> _diveTankToJson(DiveTank r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'equipmentId': r.equipmentId,
-    'volume': r.volume,
-    'workingPressure': r.workingPressure,
-    'startPressure': r.startPressure,
-    'endPressure': r.endPressure,
-    'o2Percent': r.o2Percent,
-    'hePercent': r.hePercent,
-    'tankOrder': r.tankOrder,
-    'tankRole': r.tankRole,
-    'tankMaterial': r.tankMaterial,
-    'tankName': r.tankName,
-    'presetName': r.presetName,
-  };
-
-  Map<String, dynamic> _diveEquipmentToJson(DiveEquipmentData r) => {
-    'id': '${r.diveId}|${r.equipmentId}',
-    'diveId': r.diveId,
-    'equipmentId': r.equipmentId,
-  };
-
-  Map<String, dynamic> _diveWeightToJson(DiveWeight r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'weightType': r.weightType,
-    'amountKg': r.amountKg,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-  };
-
-  Map<String, dynamic> _diveSiteToJson(DiveSite r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'description': r.description,
-    'latitude': r.latitude,
-    'longitude': r.longitude,
-    'minDepth': r.minDepth,
-    'maxDepth': r.maxDepth,
-    'difficulty': r.difficulty,
-    'country': r.country,
-    'region': r.region,
-    'rating': r.rating,
-    'notes': r.notes,
-    'hazards': r.hazards,
-    'accessNotes': r.accessNotes,
-    'mooringNumber': r.mooringNumber,
-    'parkingInfo': r.parkingInfo,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _equipmentToJson(EquipmentData r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'type': r.type,
-    'brand': r.brand,
-    'model': r.model,
-    'serialNumber': r.serialNumber,
-    'size': r.size,
-    'status': r.status,
-    'purchaseDate': r.purchaseDate,
-    'purchasePrice': r.purchasePrice,
-    'purchaseCurrency': r.purchaseCurrency,
-    'lastServiceDate': r.lastServiceDate,
-    'serviceIntervalDays': r.serviceIntervalDays,
-    'notes': r.notes,
-    'isActive': r.isActive,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _equipmentSetToJson(EquipmentSet r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'description': r.description,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _mediaToJson(MediaData r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'siteId': r.siteId,
-    'filePath': r.filePath,
-    'fileType': r.fileType,
-    'latitude': r.latitude,
-    'longitude': r.longitude,
-    'takenAt': r.takenAt,
-    'caption': r.caption,
-    // BLOB field for signatures - base64 encoded for sync
-    if (r.imageData != null) 'imageData': base64Encode(r.imageData!),
-  };
-
-  Map<String, dynamic> _buddyToJson(Buddy r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'email': r.email,
-    'phone': r.phone,
-    'certificationLevel': r.certificationLevel,
-    'certificationAgency': r.certificationAgency,
-    'photoPath': r.photoPath,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _diveBuddyToJson(DiveBuddy r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'buddyId': r.buddyId,
-    'role': r.role,
-    'createdAt': r.createdAt,
-  };
-
-  Map<String, dynamic> _certificationToJson(Certification r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'agency': r.agency,
-    'level': r.level,
-    'cardNumber': r.cardNumber,
-    'issueDate': r.issueDate,
-    'expiryDate': r.expiryDate,
-    'instructorName': r.instructorName,
-    'instructorNumber': r.instructorNumber,
-    // BLOB fields - base64 encoded for sync
-    if (r.photoFront != null) 'photoFront': base64Encode(r.photoFront!),
-    if (r.photoBack != null) 'photoBack': base64Encode(r.photoBack!),
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _serviceRecordToJson(ServiceRecord r) => {
-    'id': r.id,
-    'equipmentId': r.equipmentId,
-    'serviceType': r.serviceType,
-    'serviceDate': r.serviceDate,
-    'provider': r.provider,
-    'cost': r.cost,
-    'currency': r.currency,
-    'nextServiceDue': r.nextServiceDue,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _diveCenterToJson(DiveCenter r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'street': r.street,
-    'city': r.city,
-    'stateProvince': r.stateProvince,
-    'postalCode': r.postalCode,
-    'latitude': r.latitude,
-    'longitude': r.longitude,
-    'country': r.country,
-    'phone': r.phone,
-    'email': r.email,
-    'website': r.website,
-    'affiliations': r.affiliations,
-    'rating': r.rating,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _tripToJson(Trip r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'startDate': r.startDate,
-    'endDate': r.endDate,
-    'location': r.location,
-    'resortName': r.resortName,
-    'liveaboardName': r.liveaboardName,
-    'tripType': r.tripType,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _liveaboardDetailToJson(LiveaboardDetailRecord r) => {
-    'id': r.id,
-    'tripId': r.tripId,
-    'vesselName': r.vesselName,
-    'operatorName': r.operatorName,
-    'vesselType': r.vesselType,
-    'cabinType': r.cabinType,
-    'capacity': r.capacity,
-    'embarkPort': r.embarkPort,
-    'embarkLatitude': r.embarkLatitude,
-    'embarkLongitude': r.embarkLongitude,
-    'disembarkPort': r.disembarkPort,
-    'disembarkLatitude': r.disembarkLatitude,
-    'disembarkLongitude': r.disembarkLongitude,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _itineraryDayToJson(TripItineraryDay r) => {
-    'id': r.id,
-    'tripId': r.tripId,
-    'dayNumber': r.dayNumber,
-    'date': r.date,
-    'dayType': r.dayType,
-    'portName': r.portName,
-    'latitude': r.latitude,
-    'longitude': r.longitude,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _tagToJson(Tag r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'color': r.color,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _diveTagToJson(DiveTag r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'tagId': r.tagId,
-    'createdAt': r.createdAt,
-  };
-
-  Map<String, dynamic> _diveTypeToJson(DiveType r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'isBuiltIn': r.isBuiltIn,
-    'sortOrder': r.sortOrder,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _tankPresetToJson(TankPreset r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'displayName': r.displayName,
-    'volumeLiters': r.volumeLiters,
-    'workingPressureBar': r.workingPressureBar,
-    'material': r.material,
-    'description': r.description,
-    'sortOrder': r.sortOrder,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _diveComputerToJson(DiveComputer r) => {
-    'id': r.id,
-    'diverId': r.diverId,
-    'name': r.name,
-    'manufacturer': r.manufacturer,
-    'model': r.model,
-    'serialNumber': r.serialNumber,
-    'firmwareVersion': r.firmwareVersion,
-    'connectionType': r.connectionType,
-    'bluetoothAddress': r.bluetoothAddress,
-    'lastDownloadTimestamp': r.lastDownloadTimestamp,
-    'diveCount': r.diveCount,
-    'isFavorite': r.isFavorite,
-    'notes': r.notes,
-    'createdAt': r.createdAt,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _tankPressureProfileToJson(TankPressureProfile r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'tankId': r.tankId,
-    'timestamp': r.timestamp,
-    'pressure': r.pressure,
-  };
-
-  Map<String, dynamic> _tideRecordToJson(TideRecord r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'heightMeters': r.heightMeters,
-    'tideState': r.tideState,
-    'rateOfChange': r.rateOfChange,
-    'highTideHeight': r.highTideHeight,
-    'highTideTime': r.highTideTime,
-    'lowTideHeight': r.lowTideHeight,
-    'lowTideTime': r.lowTideTime,
-    'createdAt': r.createdAt,
-  };
-
-  Map<String, dynamic> _settingsToJson(Setting r) => {
-    'key': r.key,
-    'value': r.value,
-    'updatedAt': r.updatedAt,
-  };
-
-  Map<String, dynamic> _speciesToJson(Specy r) => {
-    'id': r.id,
-    'commonName': r.commonName,
-    'scientificName': r.scientificName,
-    'category': r.category,
-    'description': r.description,
-    'photoPath': r.photoPath,
-  };
-
-  Map<String, dynamic> _sightingToJson(Sighting r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'speciesId': r.speciesId,
-    'count': r.count,
-    'notes': r.notes,
-  };
-
-  Map<String, dynamic> _diveProfileEventToJson(DiveProfileEvent r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'timestamp': r.timestamp,
-    'eventType': r.eventType,
-    'severity': r.severity,
-    'description': r.description,
-    'depth': r.depth,
-    'value': r.value,
-    'tankId': r.tankId,
-    'source': r.source,
-    'createdAt': r.createdAt,
-  };
-
-  Map<String, dynamic> _gasSwitchToJson(GasSwitche r) => {
-    'id': r.id,
-    'diveId': r.diveId,
-    'timestamp': r.timestamp,
-    'tankId': r.tankId,
-    'depth': r.depth,
-    'createdAt': r.createdAt,
-  };
 }

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -994,7 +994,10 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diveToJson(r)).toList();
+    // Export via the generated data-class toJson() so the keys are symmetric
+    // with Dive.fromJson used on import. A hand-maintained map silently drops
+    // fields (e.g. bottomTime, GPS) and breaks cross-device sync.
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveProfiles(int? since) async {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -907,6 +907,13 @@ class SyncDataSerializer {
             .insertOnConflictUpdate(TideRecord.fromJson(data));
         return;
       case 'settings':
+        // Never let an incoming payload overwrite a device-local settings key
+        // (e.g. active_diver_id). Export filters these, but a peer on an older
+        // build may still ship them; applying would switch this device's
+        // active diver. Symmetric with _exportSettings.
+        if (_deviceLocalSettingsKeys.contains(data['key'])) {
+          return;
+        }
         await _db
             .into(_db.settings)
             .insertOnConflictUpdate(Setting.fromJson(data));

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -976,7 +976,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diverToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiverSettings(int? since) async {
@@ -985,7 +985,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diverSettingToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDives(int? since) async {
@@ -1012,10 +1012,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveProfiles,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveProfileToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveProfiles).get();
-    return rows.map((r) => _diveProfileToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveTanks(int? since) async {
@@ -1030,10 +1030,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveTanks,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveTankToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveTanks).get();
-    return rows.map((r) => _diveTankToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveEquipment(int? since) async {
@@ -1047,10 +1047,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveEquipment,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveEquipmentToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveEquipment).get();
-    return rows.map((r) => _diveEquipmentToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveWeights(int? since) async {
@@ -1064,10 +1064,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveWeights,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveWeightToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveWeights).get();
-    return rows.map((r) => _diveWeightToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveSites(int? since) async {
@@ -1076,7 +1076,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diveSiteToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportEquipment(int? since) async {
@@ -1085,7 +1085,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _equipmentToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportEquipmentSets(int? since) async {
@@ -1094,7 +1094,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _equipmentSetToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportEquipmentSetItems() async {
@@ -1119,7 +1119,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _buddyToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveBuddies(int? since) async {
@@ -1133,10 +1133,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveBuddies,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveBuddyToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveBuddies).get();
-    return rows.map((r) => _diveBuddyToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportCertifications(int? since) async {
@@ -1154,7 +1154,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _serviceRecordToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveCenters(int? since) async {
@@ -1163,7 +1163,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diveCenterToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportTrips(int? since) async {
@@ -1172,7 +1172,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _tripToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportLiveaboardDetails(
@@ -1183,7 +1183,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _liveaboardDetailToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportItineraryDays(int? since) async {
@@ -1192,7 +1192,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _itineraryDayToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportTags(int? since) async {
@@ -1201,7 +1201,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _tagToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveTags(int? since) async {
@@ -1215,10 +1215,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveTags,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveTagToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveTags).get();
-    return rows.map((r) => _diveTagToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveTypes(int? since) async {
@@ -1227,7 +1227,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diveTypeToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportTankPresets(int? since) async {
@@ -1236,7 +1236,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _tankPresetToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveComputers(int? since) async {
@@ -1245,7 +1245,7 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _diveComputerToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportTankPressureProfiles(
@@ -1261,10 +1261,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.tankPressureProfiles,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _tankPressureProfileToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.tankPressureProfiles).get();
-    return rows.map((r) => _tankPressureProfileToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportTideRecords(int? since) async {
@@ -1278,10 +1278,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.tideRecords,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _tideRecordToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.tideRecords).get();
-    return rows.map((r) => _tideRecordToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportSettings(int? since) async {
@@ -1290,17 +1290,17 @@ class SyncDataSerializer {
       query.where((t) => t.updatedAt.isBiggerOrEqualValue(since));
     }
     final rows = await query.get();
-    return rows.map((r) => _settingsToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportSpecies() async {
     final rows = await _db.select(_db.species).get();
-    return rows.map((r) => _speciesToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportSightings() async {
     final rows = await _db.select(_db.sightings).get();
-    return rows.map((r) => _sightingToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportDiveProfileEvents(
@@ -1316,10 +1316,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.diveProfileEvents,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _diveProfileEventToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.diveProfileEvents).get();
-    return rows.map((r) => _diveProfileEventToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportGasSwitches(int? since) async {
@@ -1333,10 +1333,10 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.gasSwitches,
       )..where((t) => t.diveId.isIn(diveIds))).get();
-      return rows.map((r) => _gasSwitchToJson(r)).toList();
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.gasSwitches).get();
-    return rows.map((r) => _gasSwitchToJson(r)).toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   // ============================================================================

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1454,10 +1454,16 @@ class SyncDataSerializer {
   ///
   /// Including these in the payload causes the receiving device to flag a
   /// conflict on every cross-device pull (same `key` row, different value
-  /// per device). `active_diver_id` is the canonical case: at first launch
-  /// each device auto-creates an owner diver with its own UUID and writes
-  /// the pointer here; both devices then have a perfectly valid local value
-  /// that has no business overwriting the other side.
+  /// per device).
+  ///
+  /// Audit (last reviewed when [SyncData] grew to ~39 entities): only three
+  /// keys are ever written to the `settings` table in app code:
+  ///   - `active_diver_id` (per-device — each device auto-creates its own
+  ///     owner diver at first launch). FILTERED.
+  ///   - `share_new_records_by_default` (global user preference). Syncs.
+  ///   - `nav_primary_ids` (user's preferred top-level nav). Syncs.
+  /// New keys should be assessed against the rule: "is this answer the same
+  /// across all of one user's devices?" If no, add it here.
   static const Set<String> _deviceLocalSettingsKeys = {'active_diver_id'};
 
   Future<List<Map<String, dynamic>>> _exportSettings(int? since) async {
@@ -1621,5 +1627,4 @@ class SyncDataSerializer {
     }
     return merged;
   }
-
 }

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -75,43 +75,51 @@ class SyncInitializer {
 
       // Get local last sync time
       final localLastSync = await _syncRepository.getLastSyncTime();
-      var remoteFileId = await _syncRepository.getRemoteFileId();
 
-      remoteFileId ??= await _discoverRemoteFile(provider);
+      // Per-device sync files: every device writes its own
+      // submersion_sync_<deviceId>.json. Whether a launch sync is worthwhile is
+      // decided from the newest *peer* file (all sync files except our own and
+      // any iCloud "conflicted copy" duplicates), not a single canonical remote
+      // file -- our own file's mtime tracks our own uploads and would never
+      // reveal another device's changes.
+      final peerFiles = await _peerSyncFiles(provider);
 
-      if (remoteFileId == null) {
-        // No remote file yet - first sync needed
+      if (peerFiles.isEmpty) {
+        // No other device has uploaded yet. Still surface unsynced local edits
+        // so the first push is recommended.
+        final pendingCount = await _syncRepository.getPendingCount();
+        if (pendingCount > 0) {
+          return SyncCheckResult(
+            status: SyncCheckStatus.localChanges,
+            message:
+                '$pendingCount local change${pendingCount == 1 ? '' : 's'} to upload',
+            localLastSync: localLastSync,
+            pendingChanges: pendingCount,
+          );
+        }
         return const SyncCheckResult(
           status: SyncCheckStatus.noRemoteData,
           message: 'No sync data found in cloud',
         );
       }
 
-      // Check remote file info
-      final remoteInfo = await provider.getFileInfo(remoteFileId);
-
-      if (remoteInfo == null) {
-        return const SyncCheckResult(
-          status: SyncCheckStatus.remoteFileDeleted,
-          message: 'Remote sync file was deleted',
-        );
-      }
+      final remoteModified = _newestModified(peerFiles);
 
       // Compare timestamps
       if (localLastSync == null) {
         return SyncCheckResult(
           status: SyncCheckStatus.updatesAvailable,
           message: 'Cloud data available',
-          remoteModified: remoteInfo.modifiedTime,
+          remoteModified: remoteModified,
         );
       }
 
-      if (remoteInfo.modifiedTime.isAfter(localLastSync)) {
+      if (remoteModified.isAfter(localLastSync)) {
         return SyncCheckResult(
           status: SyncCheckStatus.updatesAvailable,
           message: 'Updates available from cloud',
           localLastSync: localLastSync,
-          remoteModified: remoteInfo.modifiedTime,
+          remoteModified: remoteModified,
         );
       }
 
@@ -141,34 +149,34 @@ class SyncInitializer {
     }
   }
 
-  Future<String?> _discoverRemoteFile(CloudStorageProvider provider) async {
-    try {
-      final files = await provider.listFiles(
-        namePattern: CloudStorageProviderMixin.syncFileStem,
-      );
-      if (files.isEmpty) return null;
-
-      final canonical = files.firstWhere(
-        (f) => f.name == CloudStorageProviderMixin.canonicalSyncFileName,
-        orElse: () => files.first,
-      );
-
-      final candidates = files.where((f) => !_isConflictCopy(f.name)).toList();
-      final selected = candidates.isNotEmpty
-          ? _pickLatest(candidates)
-          : canonical;
-
-      await _syncRepository.setRemoteFileId(selected.id);
-      return selected.id;
-    } catch (e) {
-      _log.warning('Failed to discover remote sync file: $e');
-      return null;
-    }
+  /// Lists every *other* device's sync file. Excludes our own per-device file
+  /// and any iCloud "conflicted copy" duplicates. A legacy shared
+  /// `submersion_sync.json` (written by pre-per-device builds) still counts as
+  /// a peer file so its data is detected. Mirrors the resolution in
+  /// `SyncService._resolveRemoteSyncFiles`.
+  Future<List<CloudFileInfo>> _peerSyncFiles(
+    CloudStorageProvider provider,
+  ) async {
+    final deviceId = await _syncRepository.getDeviceId();
+    final ownFileName =
+        '${CloudStorageProviderMixin.syncFilePrefix}$deviceId'
+        '${CloudStorageProviderMixin.syncFileExtension}';
+    final files = await provider.listFiles(
+      namePattern: CloudStorageProviderMixin.syncFileStem,
+    );
+    return files
+        .where((f) => !_isConflictCopy(f.name))
+        .where((f) => f.name != ownFileName)
+        .toList();
   }
 
-  CloudFileInfo _pickLatest(List<CloudFileInfo> files) {
-    files.sort((a, b) => b.modifiedTime.compareTo(a.modifiedTime));
-    return files.first;
+  /// The most recent modifiedTime across [files], which must be non-empty.
+  DateTime _newestModified(List<CloudFileInfo> files) {
+    var newest = files.first.modifiedTime;
+    for (final f in files.skip(1)) {
+      if (f.modifiedTime.isAfter(newest)) newest = f.modifiedTime;
+    }
+    return newest;
   }
 
   bool _isConflictCopy(String filename) {

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -676,8 +676,11 @@ class SyncService {
             hasUpdatedAt: false,
           ),
           (type: 'gasSwitches', records: data.gasSwitches, hasUpdatedAt: false),
-          // Extra entities added in the SyncData expansion. Append-only or
-          // last-writer-wins (no updatedAt column on most), and FK ordering
+          // Extra entities added in the SyncData expansion. Four are
+          // append-only and use the blind-upsert merge path (no updatedAt
+          // column: diveCustomFields, diveDataSources, siteSpecies,
+          // fieldPresets). Two carry updatedAt and use the standard
+          // conflict-detection path (csvPresets, viewConfigs). FK ordering
           // is handled by the deferred-FK transaction wrapping this loop.
           (
             type: 'diveCustomFields',

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -358,6 +358,7 @@ class SyncService {
 
       var recordsSynced = 0;
       var conflictsFound = 0;
+      var recordsFailed = 0;
 
       if (remotePayload != null && remotePayload.deviceId != deviceId) {
         _log.info(
@@ -373,6 +374,7 @@ class SyncService {
         );
         recordsSynced += mergeResult.recordsApplied;
         conflictsFound += mergeResult.conflictsFound;
+        recordsFailed += mergeResult.recordsFailed;
       }
 
       _reportProgress(SyncPhase.exporting, 0.7, 'Exporting local data...');
@@ -450,10 +452,18 @@ class SyncService {
 
       _log.info('Sync completed successfully');
 
+      if (recordsFailed > 0) {
+        _log.error('$recordsFailed record(s) failed to apply during sync');
+      }
       return SyncResult(
-        status: conflictsFound > 0
-            ? SyncResultStatus.hasConflicts
-            : SyncResultStatus.success,
+        status: recordsFailed > 0
+            ? SyncResultStatus.error
+            : (conflictsFound > 0
+                  ? SyncResultStatus.hasConflicts
+                  : SyncResultStatus.success),
+        message: recordsFailed > 0
+            ? '$recordsFailed record(s) failed to apply'
+            : null,
         recordsSynced: recordsSynced,
         conflictsFound: conflictsFound,
         lastSyncTime: result.uploadTime,
@@ -567,6 +577,7 @@ class SyncService {
     final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
     var recordsApplied = 0;
     var conflictsFound = 0;
+    var recordsFailed = 0;
     final pendingByEntity = await _pendingRecordMap();
 
     final deletionResult = await _applyRemoteDeletions(
@@ -577,6 +588,7 @@ class SyncService {
     );
     recordsApplied += deletionResult.recordsApplied;
     conflictsFound += deletionResult.conflictsFound;
+    recordsFailed += deletionResult.recordsFailed;
 
     final data = remotePayload.data;
 
@@ -676,11 +688,13 @@ class SyncService {
       );
       recordsApplied += result.recordsApplied;
       conflictsFound += result.conflictsFound;
+      recordsFailed += result.recordsFailed;
     }
 
     return _MergeResult(
       recordsApplied: recordsApplied,
       conflictsFound: conflictsFound,
+      recordsFailed: recordsFailed,
     );
   }
 
@@ -752,6 +766,7 @@ class SyncService {
 
     var applied = 0;
     var conflicts = 0;
+    var failed = 0;
 
     for (final record in records) {
       String? recordId;
@@ -805,20 +820,18 @@ class SyncService {
           error: e,
           stackTrace: stackTrace,
         );
-        conflicts += 1;
-        if (recordId != null) {
-          await _syncRepository.markRecordConflict(
-            entityType: entityType,
-            recordId: recordId,
-            conflictDataJson: jsonEncode(record),
-            localUpdatedAt:
-                localUpdatedAt ?? DateTime.now().millisecondsSinceEpoch,
-          );
-        }
+        // An apply error is a real failure, not a "conflict" (which means both
+        // sides edited the same record). Masking apply errors as conflicts is
+        // what hid the cross-device no-op; count it so performSync surfaces it.
+        failed += 1;
       }
     }
 
-    return _MergeResult(recordsApplied: applied, conflictsFound: conflicts);
+    return _MergeResult(
+      recordsApplied: applied,
+      conflictsFound: conflicts,
+      recordsFailed: failed,
+    );
   }
 
   Future<Map<String, Set<String>>> _pendingRecordMap() async {
@@ -982,9 +995,11 @@ class SyncService {
 class _MergeResult {
   final int recordsApplied;
   final int conflictsFound;
+  final int recordsFailed;
 
   const _MergeResult({
     required this.recordsApplied,
     required this.conflictsFound,
+    this.recordsFailed = 0,
   });
 }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -574,6 +574,21 @@ class SyncService {
     SyncPayload remotePayload,
     DateTime? localLastSync,
   ) async {
+    // Wrap deletions + merge in a single transaction with deferred FK checks.
+    // Without this, intra-payload references (e.g. a dive whose siteId points
+    // at a dive site appearing later in the apply order, or a dive whose
+    // courseId points at a course in the same payload) fail immediately and
+    // the affected rows never reach the receiving DB. See
+    // docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md.
+    return _serializer.applyInDeferredFkTransaction(
+      () => _applyRemotePayloadInner(remotePayload, localLastSync),
+    );
+  }
+
+  Future<_MergeResult> _applyRemotePayloadInner(
+    SyncPayload remotePayload,
+    DateTime? localLastSync,
+  ) async {
     final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
     var recordsApplied = 0;
     var conflictsFound = 0;
@@ -635,6 +650,10 @@ class SyncService {
           ),
           (type: 'species', records: data.species, hasUpdatedAt: false),
           (type: 'tags', records: data.tags, hasUpdatedAt: true),
+          // Courses must apply before dives/certifications that reference them.
+          // (Deferred FK already covers ordering, but keep the logical sequence
+          // so a future read of this list still tells the dependency story.)
+          (type: 'courses', records: data.courses, hasUpdatedAt: true),
           (type: 'dives', records: data.dives, hasUpdatedAt: true),
           (type: 'diveSites', records: data.diveSites, hasUpdatedAt: true),
           (type: 'diveTanks', records: data.diveTanks, hasUpdatedAt: false),

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -277,81 +277,26 @@ class SyncService {
         'Checking for remote data...',
       );
 
-      SyncPayload? remotePayload;
-      String? remoteFileId;
+      // Resolve every sync file we should apply: all OTHER devices'
+      // per-device files plus any legacy shared file. Our own per-device file
+      // is excluded (it is our data, already local). Listing all files (rather
+      // than a single canonical file) is what lets per-device files coexist
+      // without a write-write race.
+      List<CloudFileInfo> remoteFiles;
       try {
-        remoteFileId = await _resolveRemoteFileId(
+        remoteFiles = await _resolveRemoteSyncFiles(
           provider,
+          deviceId,
         ).timeout(const Duration(seconds: 8));
       } on TimeoutException {
-        _log.warning('Timed out checking for remote sync file');
-        remoteFileId = null;
+        _log.warning('Timed out listing remote sync files');
+        remoteFiles = const [];
       } catch (e, stackTrace) {
         _log.warning(
-          'Failed to check remote sync file: $e',
+          'Failed to list remote sync files: $e',
           stackTrace: stackTrace,
         );
-        remoteFileId = null;
-      }
-
-      if (remoteFileId != null) {
-        try {
-          if (lastSyncTime != null) {
-            final info = await provider.getFileInfo(remoteFileId);
-            if (info != null && !info.modifiedTime.isAfter(lastSyncTime)) {
-              _log.debug(
-                'Remote sync file not newer than last sync; skipping.',
-              );
-              remoteFileId = null;
-            }
-          }
-        } catch (e, stackTrace) {
-          _log.warning(
-            'Failed to check remote file info: $e',
-            stackTrace: stackTrace,
-          );
-        }
-      }
-
-      if (remoteFileId != null) {
-        try {
-          final remoteData = await provider
-              .downloadFile(remoteFileId)
-              .timeout(const Duration(seconds: 15));
-          final remoteJson = _decodePayloadBytes(remoteData);
-          try {
-            remotePayload = _serializer.deserializePayload(remoteJson);
-          } catch (e, stackTrace) {
-            _log.warning(
-              'Failed to parse remote sync payload: $e',
-              stackTrace: stackTrace,
-            );
-            remotePayload = null;
-          }
-
-          // Validate checksum
-          if (remotePayload != null &&
-              !_serializer.validateChecksum(remotePayload)) {
-            _log.warning('Remote sync file has invalid checksum');
-            remotePayload = null;
-          }
-          if (remotePayload != null &&
-              remotePayload.deviceId == deviceId &&
-              lastSyncTime != null) {
-            final lastSyncMs = lastSyncTime.millisecondsSinceEpoch;
-            if (remotePayload.exportedAt <= lastSyncMs) {
-              _log.debug(
-                'Remote payload from this device is not newer; skipping apply.',
-              );
-              remotePayload = null;
-            }
-          }
-        } on TimeoutException {
-          _log.warning('Timed out downloading remote sync file');
-        } catch (e) {
-          _log.warning('Failed to download remote sync file: $e');
-          // Continue with upload-only sync
-        }
+        remoteFiles = const [];
       }
 
       _reportProgress(SyncPhase.importing, 0.6, 'Processing changes...');
@@ -360,14 +305,40 @@ class SyncService {
       var conflictsFound = 0;
       var recordsFailed = 0;
 
-      if (remotePayload != null && remotePayload.deviceId != deviceId) {
-        _log.info(
-          'Remote data from different device: ${remotePayload.deviceId}',
-        );
-      }
+      for (final file in remoteFiles) {
+        // Per-file freshness: skip files not modified since our last sync.
+        if (lastSyncTime != null && !file.modifiedTime.isAfter(lastSyncTime)) {
+          _log.debug('${file.name} not newer than last sync; skipping.');
+          continue;
+        }
 
-      if (remotePayload != null) {
-        final payload = remotePayload;
+        SyncPayload payload;
+        try {
+          final remoteData = await provider
+              .downloadFile(file.id)
+              .timeout(const Duration(seconds: 15));
+          final remoteJson = _decodePayloadBytes(remoteData);
+          final parsed = _serializer.deserializePayload(remoteJson);
+          if (!_serializer.validateChecksum(parsed)) {
+            _log.warning('Remote sync file ${file.name} has invalid checksum');
+            continue;
+          }
+          payload = parsed;
+        } on TimeoutException {
+          _log.warning('Timed out downloading ${file.name}');
+          continue;
+        } catch (e, stackTrace) {
+          _log.warning(
+            'Failed to download/parse ${file.name}: $e',
+            stackTrace: stackTrace,
+          );
+          continue;
+        }
+
+        if (payload.deviceId != deviceId) {
+          _log.info('Remote data from different device: ${payload.deviceId}');
+        }
+
         final mergeResult = await _withStep(
           'apply remote data',
           () => _applyRemotePayload(payload, lastSyncTime),
@@ -409,7 +380,10 @@ class SyncService {
           const Duration(seconds: 10),
         ),
       );
-      const filename = CloudStorageProviderMixin.canonicalSyncFileName;
+      // Write to this device's own file so two devices never contend for the
+      // same file (the iCloud "conflicted copy" race). Other devices pick this
+      // up by listing the folder on their next sync.
+      final filename = _deviceSyncFileName(deviceId);
 
       _log.debug(
         'Uploading ${localData.length} bytes to $syncFolder/$filename...',
@@ -534,39 +508,31 @@ class SyncService {
     }
   }
 
-  Future<String?> _resolveRemoteFileId(CloudStorageProvider provider) async {
-    var remoteFileId = await _syncRepository.getRemoteFileId();
-    if (remoteFileId != null) {
-      final exists = await provider.fileExists(remoteFileId);
-      if (exists) {
-        return remoteFileId;
-      }
-      await _syncRepository.setRemoteFileId(null);
-      remoteFileId = null;
-    }
+  /// This device's own per-device sync filename.
+  String _deviceSyncFileName(String deviceId) =>
+      '${CloudStorageProviderMixin.syncFilePrefix}$deviceId'
+      '${CloudStorageProviderMixin.syncFileExtension}';
 
+  /// Resolve every remote sync file this device should apply: all other
+  /// devices' per-device files, plus a legacy shared `submersion_sync.json`
+  /// if one is still present. Excludes our own per-device file and any iCloud
+  /// "conflicted copy" duplicates. Returns [] on failure.
+  Future<List<CloudFileInfo>> _resolveRemoteSyncFiles(
+    CloudStorageProvider provider,
+    String deviceId,
+  ) async {
     try {
+      final ownFileName = _deviceSyncFileName(deviceId);
       final files = await provider.listFiles(
         namePattern: CloudStorageProviderMixin.syncFileStem,
       );
-      if (files.isEmpty) return null;
-
-      CloudFileInfo? selected = files.firstWhere(
-        (f) => f.name == CloudStorageProviderMixin.canonicalSyncFileName,
-        orElse: () => files.first,
-      );
-
-      final candidates = files.where((f) => !_isConflictCopy(f.name)).toList();
-      if (candidates.isNotEmpty) {
-        candidates.sort((a, b) => b.modifiedTime.compareTo(a.modifiedTime));
-        selected = candidates.first;
-      }
-
-      await _syncRepository.setRemoteFileId(selected.id);
-      return selected.id;
+      return files
+          .where((f) => !_isConflictCopy(f.name))
+          .where((f) => f.name != ownFileName)
+          .toList();
     } catch (e) {
-      _log.warning('Failed to resolve remote sync file: $e');
-      return null;
+      _log.warning('Failed to resolve remote sync files: $e');
+      return const [];
     }
   }
 

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -739,51 +739,75 @@ class SyncService {
   ) async {
     var applied = 0;
     var conflicts = 0;
+    var failed = 0;
 
     for (final entry in deletions.entries) {
       final entityType = entry.key;
       for (final deletion in entry.value) {
         final recordId = deletion.id;
-        if (pendingByEntity[entityType]?.contains(recordId) == true) {
-          continue;
-        }
-        final local = await _serializer.fetchRecord(entityType, recordId);
-        final localUpdatedAt = _extractUpdatedAtMillis(local);
-        final deletionTimestamp = deletion.deletedAt > 0
-            ? deletion.deletedAt
-            : remoteExportedAt;
+        try {
+          if (pendingByEntity[entityType]?.contains(recordId) == true) {
+            continue;
+          }
+          final local = await _serializer.fetchRecord(entityType, recordId);
+          // _extractUpdatedAtMillis falls back to createdAt, so a row that was
+          // created locally after our last sync is protected from a stale
+          // remote tombstone even on append-only child tables that have a
+          // createdAt. The handful of child tables with neither updatedAt nor
+          // createdAt (dive_profiles, dive_tanks, dive_equipment,
+          // tank_pressure_profiles, sightings) have no age signal; they are
+          // regenerated wholesale with fresh ids on re-import, so a stale
+          // tombstone won't match a current row.
+          final localUpdatedAt = _extractUpdatedAtMillis(local);
+          final deletionTimestamp = deletion.deletedAt > 0
+              ? deletion.deletedAt
+              : remoteExportedAt;
 
-        final hasConflict =
-            localUpdatedAt != null &&
-            lastSyncMs != null &&
-            localUpdatedAt > lastSyncMs;
+          final hasConflict =
+              localUpdatedAt != null &&
+              lastSyncMs != null &&
+              localUpdatedAt > lastSyncMs;
 
-        if (hasConflict) {
-          conflicts += 1;
-          await _syncRepository.markRecordConflict(
+          if (hasConflict) {
+            conflicts += 1;
+            await _syncRepository.markRecordConflict(
+              entityType: entityType,
+              recordId: recordId,
+              conflictDataJson: jsonEncode({
+                '_deleted': true,
+                'deletedAt': deletionTimestamp,
+                'recordId': recordId,
+              }),
+              localUpdatedAt: localUpdatedAt,
+            );
+            continue;
+          }
+
+          await _serializer.deleteRecord(entityType, recordId);
+          await _syncRepository.logDeletionIfMissing(
             entityType: entityType,
             recordId: recordId,
-            conflictDataJson: jsonEncode({
-              '_deleted': true,
-              'deletedAt': deletionTimestamp,
-              'recordId': recordId,
-            }),
-            localUpdatedAt: localUpdatedAt,
+            deletedAt: deletionTimestamp,
           );
-          continue;
+          applied += 1;
+        } catch (e, stackTrace) {
+          // A failed deletion is a real failure (surfaced via recordsFailed),
+          // not a conflict, and must not abort the rest of the batch.
+          _log.error(
+            'Failed to apply deletion $entityType/$recordId',
+            error: e,
+            stackTrace: stackTrace,
+          );
+          failed += 1;
         }
-
-        await _serializer.deleteRecord(entityType, recordId);
-        await _syncRepository.logDeletionIfMissing(
-          entityType: entityType,
-          recordId: recordId,
-          deletedAt: deletionTimestamp,
-        );
-        applied += 1;
       }
     }
 
-    return _MergeResult(recordsApplied: applied, conflictsFound: conflicts);
+    return _MergeResult(
+      recordsApplied: applied,
+      conflictsFound: conflicts,
+      recordsFailed: failed,
+    );
   }
 
   Future<_MergeResult> _mergeEntity({
@@ -807,7 +831,10 @@ class SyncService {
       try {
         recordId = _recordIdForEntity(entityType, record);
         if (recordId == null) {
-          conflicts += 1;
+          // A record with no resolvable id is malformed data, not a two-sided
+          // conflict -- count it as a failure so performSync surfaces an error.
+          _log.error('Skipping $entityType record with no resolvable id');
+          failed += 1;
           continue;
         }
 

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -676,6 +676,27 @@ class SyncService {
             hasUpdatedAt: false,
           ),
           (type: 'gasSwitches', records: data.gasSwitches, hasUpdatedAt: false),
+          // Extra entities added in the SyncData expansion. Append-only or
+          // last-writer-wins (no updatedAt column on most), and FK ordering
+          // is handled by the deferred-FK transaction wrapping this loop.
+          (
+            type: 'diveCustomFields',
+            records: data.diveCustomFields,
+            hasUpdatedAt: false,
+          ),
+          (
+            type: 'diveDataSources',
+            records: data.diveDataSources,
+            hasUpdatedAt: false,
+          ),
+          (type: 'siteSpecies', records: data.siteSpecies, hasUpdatedAt: false),
+          (type: 'csvPresets', records: data.csvPresets, hasUpdatedAt: true),
+          (type: 'viewConfigs', records: data.viewConfigs, hasUpdatedAt: true),
+          (
+            type: 'fieldPresets',
+            records: data.fieldPresets,
+            hasUpdatedAt: false,
+          ),
           (
             type: 'tankPressureProfiles',
             records: data.tankPressureProfiles,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -314,12 +314,12 @@ class SyncService {
       var recordsFailed = 0;
 
       for (final file in remoteFiles) {
-        // Per-file freshness: skip files not modified since our last sync.
-        if (lastSyncTime != null && !file.modifiedTime.isAfter(lastSyncTime)) {
-          _log.debug('${file.name} not newer than last sync; skipping.');
-          continue;
-        }
-
+        // NOTE: we intentionally do NOT skip files by their cloud
+        // modifiedTime. iCloud Drive can fail to advance that metadata after a
+        // conflict-copy merge, which would silently skip a file containing new
+        // records; and skipping a file whose record failed to apply once would
+        // drop it forever. Re-applying is idempotent (upsert + HLC), so we
+        // always download and merge every foreign file.
         SyncPayload payload;
         try {
           final remoteData = await provider
@@ -343,8 +343,11 @@ class SyncService {
           continue;
         }
 
-        if (payload.deviceId != deviceId) {
-          _log.info('Remote data from different device: ${payload.deviceId}');
+        // Skip our own data by payload identity (covers a legacy shared file
+        // or an iCloud conflict-copy this device authored) -- applying it to
+        // ourselves is a no-op that only inflates counts.
+        if (payload.deviceId == deviceId) {
+          continue;
         }
 
         final mergeResult = await _withStep(
@@ -409,10 +412,17 @@ class SyncService {
         'store remote file id',
         () => _syncRepository.setRemoteFileId(result.fileId),
       );
-      await _withStep(
-        'store last sync time',
-        () => _syncRepository.updateLastSyncTime(result.uploadTime),
-      );
+      // Only advance lastSyncTime when every record applied. A failed apply
+      // leaves no per-record retry marker, so advancing lastSync would let the
+      // conflict-detection window move past it and the record would never be
+      // retried -- permanent loss. Leaving lastSync unchanged means the next
+      // sync re-pulls and re-applies (idempotent) so the failure is retried.
+      if (recordsFailed == 0) {
+        await _withStep(
+          'store last sync time',
+          () => _syncRepository.updateLastSyncTime(result.uploadTime),
+        );
+      }
       // Persist the HLC so the logical counter survives an app restart (it
       // was advanced by SyncClock.receive() while applying remote payloads).
       await _withStep(
@@ -823,6 +833,21 @@ class SyncService {
           SyncClock.instance.receive(remoteHlc);
         }
 
+        // When BOTH sides carry an HLC it is the authoritative, deterministic
+        // resolution -- it already encodes causal order across devices, so we
+        // do NOT raise a manual conflict (that would defeat the purpose of the
+        // clock for the common concurrent-edit case). A strictly-greater
+        // remote HLC wins; an exact tie or a local-newer HLC keeps local.
+        if (localHlc != null && remoteHlc != null) {
+          if (remoteHlc.compareTo(localHlc) > 0) {
+            await _serializer.upsertRecord(entityType, record);
+            applied += 1;
+          }
+          continue;
+        }
+
+        // Pre-HLC fallback (one or both sides lack an HLC): use updatedAt, and
+        // surface a true two-sided edit since the last sync as a conflict.
         if (localUpdatedAt != null &&
             remoteUpdatedAt != null &&
             lastSyncMs != null &&
@@ -839,20 +864,9 @@ class SyncService {
           continue;
         }
 
-        // Winner selection: prefer the Hybrid Logical Clock when BOTH sides
-        // carry one (immune to wall-clock skew); otherwise fall back to the
-        // updatedAt comparison for rows written before HLC rollout.
-        final bool remoteWins;
-        if (localHlc != null && remoteHlc != null) {
-          remoteWins = remoteHlc.compareTo(localHlc) >= 0;
-        } else {
-          remoteWins =
-              remoteUpdatedAt == null ||
-              localUpdatedAt == null ||
-              remoteUpdatedAt >= localUpdatedAt;
-        }
-
-        if (remoteWins) {
+        if (remoteUpdatedAt == null ||
+            localUpdatedAt == null ||
+            remoteUpdatedAt >= localUpdatedAt) {
           await _serializer.upsertRecord(entityType, record);
           applied += 1;
         }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -407,11 +407,12 @@ class SyncService {
       );
       _log.debug('Upload complete! fileId = ${result.fileId}');
 
-      // Update sync state
-      await _withStep(
-        'store remote file id',
-        () => _syncRepository.setRemoteFileId(result.fileId),
-      );
+      // Deliberately do NOT persist result.fileId as "the remote file id":
+      // under per-device files it is *our own* file, and the only consumer
+      // (SyncInitializer.checkSyncOnLaunch) now inspects every peer file's
+      // mtime directly. Persisting our own id made the launch check compare our
+      // own upload time and miss other devices' changes.
+
       // Only advance lastSyncTime when every record applied. A failed apply
       // leaves no per-record retry marker, so advancing lastSync would let the
       // conflict-detection window move past it and the record would never be
@@ -464,7 +465,12 @@ class SyncService {
             : null,
         recordsSynced: recordsSynced,
         conflictsFound: conflictsFound,
-        lastSyncTime: result.uploadTime,
+        // Mirror the persistence decision above: only report an advanced
+        // lastSyncTime when every record applied (and we actually wrote it to
+        // the DB). On a partial-apply failure lastSync is intentionally left
+        // unchanged, so returning it here would make the result disagree with
+        // stored state.
+        lastSyncTime: recordsFailed == 0 ? result.uploadTime : null,
       );
     } on TimeoutException {
       _log.warning('Sync timed out while uploading');

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -6,6 +6,8 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart' show SyncRecord;
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/hlc.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:uuid/uuid.dart';
 
@@ -269,6 +271,12 @@ class SyncService {
         'load last sync time',
         () => _syncRepository.getLastSyncTime(),
       );
+      // Make sure the HLC clock is live before merging so receiving remote
+      // payloads advances it (and any writes during the sync get stamped).
+      await _withStep(
+        'configure sync clock',
+        () => _syncRepository.ensureSyncClockConfigured(),
+      );
 
       // Try to download existing remote file
       _reportProgress(
@@ -404,6 +412,12 @@ class SyncService {
       await _withStep(
         'store last sync time',
         () => _syncRepository.updateLastSyncTime(result.uploadTime),
+      );
+      // Persist the HLC so the logical counter survives an app restart (it
+      // was advanced by SyncClock.receive() while applying remote payloads).
+      await _withStep(
+        'persist sync clock',
+        () => _syncRepository.persistSyncClock(),
       );
 
       // Keep deletions for propagation, but prune old entries
@@ -801,6 +815,14 @@ class SyncService {
         localUpdatedAt = _extractUpdatedAtMillis(local);
         final remoteUpdatedAt = _extractUpdatedAtMillis(record);
 
+        final localHlc = _extractHlc(local);
+        final remoteHlc = _extractHlc(record);
+        // Advance our clock past every remote HLC we observe, so this device's
+        // next local write is ordered after what it has seen (the skew fix).
+        if (remoteHlc != null) {
+          SyncClock.instance.receive(remoteHlc);
+        }
+
         if (localUpdatedAt != null &&
             remoteUpdatedAt != null &&
             lastSyncMs != null &&
@@ -817,9 +839,20 @@ class SyncService {
           continue;
         }
 
-        if (remoteUpdatedAt == null ||
-            localUpdatedAt == null ||
-            remoteUpdatedAt >= localUpdatedAt) {
+        // Winner selection: prefer the Hybrid Logical Clock when BOTH sides
+        // carry one (immune to wall-clock skew); otherwise fall back to the
+        // updatedAt comparison for rows written before HLC rollout.
+        final bool remoteWins;
+        if (localHlc != null && remoteHlc != null) {
+          remoteWins = remoteHlc.compareTo(localHlc) >= 0;
+        } else {
+          remoteWins =
+              remoteUpdatedAt == null ||
+              localUpdatedAt == null ||
+              remoteUpdatedAt >= localUpdatedAt;
+        }
+
+        if (remoteWins) {
           await _serializer.upsertRecord(entityType, record);
           applied += 1;
         }
@@ -859,6 +892,19 @@ class SyncService {
     final createdAt = data['createdAt'];
     if (createdAt is int) return createdAt;
     return null;
+  }
+
+  /// Parse a record's Hybrid Logical Clock, or null if absent/blank (rows
+  /// written before the HLC rollout). Malformed values are treated as absent
+  /// so a bad value can never crash the merge.
+  Hlc? _extractHlc(Map<String, dynamic>? data) {
+    final raw = data?['hlc'];
+    if (raw is! String || raw.isEmpty) return null;
+    try {
+      return Hlc.parse(raw);
+    } catch (_) {
+      return null;
+    }
   }
 
   String? _recordIdForEntity(String entityType, Map<String, dynamic> record) {

--- a/lib/features/dive_log/data/repositories/view_config_repository.dart
+++ b/lib/features/dive_log/data/repositories/view_config_repository.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_log/domain/entities/view_field_config.dart'
     as domain;
@@ -11,6 +12,7 @@ import 'package:submersion/features/dive_log/domain/entities/view_field_config.d
 /// Repository for persisting dive list view configurations and field presets.
 class ViewConfigRepository {
   final AppDatabase _db;
+  final SyncRepository _syncRepository = SyncRepository();
   static const _uuid = Uuid();
 
   ViewConfigRepository(this._db);
@@ -165,9 +167,15 @@ class ViewConfigRepository {
 
   /// Deletes the preset with [presetId] only if it is not a built-in preset.
   Future<void> deletePreset(String presetId) async {
-    await (_db.delete(
+    final deleted = await (_db.delete(
       _db.fieldPresets,
     )..where((r) => r.id.equals(presetId) & r.isBuiltIn.equals(false))).go();
+    if (deleted > 0) {
+      await _syncRepository.logDeletion(
+        entityType: 'fieldPresets',
+        recordId: presetId,
+      );
+    }
   }
 
   /// Upserts built-in table presets for [diverId]. Idempotent: safe to call

--- a/lib/features/dive_log/data/repositories/view_config_repository.dart
+++ b/lib/features/dive_log/data/repositories/view_config_repository.dart
@@ -218,7 +218,9 @@ class ViewConfigRepository {
             ))
             .getSingleOrNull();
 
+    final String rowId;
     if (existing != null) {
+      rowId = existing.id;
       await (_db.update(
         _db.viewConfigs,
       )..where((r) => r.id.equals(existing.id))).write(
@@ -228,11 +230,12 @@ class ViewConfigRepository {
         ),
       );
     } else {
+      rowId = _uuid.v4();
       await _db
           .into(_db.viewConfigs)
           .insert(
             ViewConfigsCompanion(
-              id: Value(_uuid.v4()),
+              id: Value(rowId),
               diverId: Value(diverId),
               viewMode: Value(viewMode),
               configJson: Value(configJson),
@@ -240,6 +243,14 @@ class ViewConfigRepository {
             ),
           );
     }
+
+    // Mark pending so the edit is protected during merge and gets an HLC
+    // stamped onto the row (cross-device config edits resolve by HLC).
+    await _syncRepository.markRecordPending(
+      entityType: 'viewConfigs',
+      recordId: rowId,
+      localUpdatedAt: now,
+    );
   }
 
   domain.CardViewConfig _defaultCardConfig(ListViewMode mode) {

--- a/lib/features/dive_log/data/repositories/view_config_repository.dart
+++ b/lib/features/dive_log/data/repositories/view_config_repository.dart
@@ -6,6 +6,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/domain/entities/view_field_config.dart'
     as domain;
 
@@ -175,6 +176,7 @@ class ViewConfigRepository {
         entityType: 'fieldPresets',
         recordId: presetId,
       );
+      SyncEventBus.notifyLocalChange();
     }
   }
 
@@ -251,6 +253,7 @@ class ViewConfigRepository {
       recordId: rowId,
       localUpdatedAt: now,
     );
+    SyncEventBus.notifyLocalChange();
   }
 
   domain.CardViewConfig _defaultCardConfig(ListViewMode mode) {

--- a/lib/features/dive_sites/data/repositories/site_repository_impl.dart
+++ b/lib/features/dive_sites/data/repositories/site_repository_impl.dart
@@ -558,7 +558,7 @@ class SiteRepository {
                 ),
               );
           await _syncRepository.markRecordPending(
-            entityType: 'site_species',
+            entityType: 'siteSpecies',
             recordId: entry.id,
             localUpdatedAt: now,
           );
@@ -575,7 +575,7 @@ class SiteRepository {
             ),
           );
           await _syncRepository.markRecordPending(
-            entityType: 'site_species',
+            entityType: 'siteSpecies',
             recordId: entry.id,
             localUpdatedAt: now,
           );
@@ -825,7 +825,7 @@ class SiteRepository {
           ),
         );
         await _syncRepository.markRecordPending(
-          entityType: 'site_species',
+          entityType: 'siteSpecies',
           recordId: primary.id,
           localUpdatedAt: now,
         );
@@ -836,7 +836,7 @@ class SiteRepository {
           _db.siteSpecies,
         )..where((t) => t.id.equals(duplicate.id))).go();
         await _syncRepository.logDeletion(
-          entityType: 'site_species',
+          entityType: 'siteSpecies',
           recordId: duplicate.id,
         );
       }

--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -80,10 +80,12 @@ class DiverMergeRepository {
   /// should not accumulate across devices when divers are merged. The keeper's
   /// rows win and the duplicate's rows are dropped rather than repointed.
   ///
-  /// (Note: there are no unique constraints on `diver_id` in these tables, so
-  /// repointing would not crash -- it would just leave the keeper with two of
-  /// every config row, which is worse UX than the keeper's existing config
-  /// winning unconditionally for these auto-generated layouts/settings.)
+  /// `view_configs` has a UNIQUE(diver_id, view_mode) index, so repointing the
+  /// duplicate's rows onto a keeper that already has a row for that view mode
+  /// would violate the constraint -- dropping is required, not just preferred.
+  /// `diver_settings` has no such constraint, but repointing would leave the
+  /// keeper with two settings rows; keeping the keeper's own is the right UX
+  /// for this auto-generated config.
   ///
   /// `field_presets` is intentionally NOT in this set: those are user-named
   /// custom presets and losing them would be real data loss; they are

--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -1,0 +1,218 @@
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart'
+    as domain;
+
+/// A set of diver profiles that appear to be the same person (same normalized
+/// name), with a recommended keeper. Surfaced after sync so the user can
+/// confirm a merge.
+class DuplicateDiverGroup {
+  /// The profile to keep: the default diver if one is in the group, else the
+  /// oldest by createdAt (most likely to hold the real history).
+  final domain.Diver keeper;
+
+  /// The other profiles, all merge candidates into [keeper].
+  final List<domain.Diver> duplicates;
+
+  const DuplicateDiverGroup({required this.keeper, required this.duplicates});
+
+  String get displayName => keeper.name;
+}
+
+/// Merges two diver profiles that represent the same person.
+///
+/// The canonical case: each device auto-creates its own owner diver (with a
+/// distinct UUID) at first launch, then sync brings both forward, so the user
+/// ends up with two profiles named the same. Merging repoints every record
+/// that references the duplicate onto the keeper and deletes the duplicate.
+///
+/// The set of tables to repoint is discovered from the live schema (every
+/// table with a `diver_id` column) rather than hardcoded, so a future table
+/// that gains a `diver_id` is handled automatically.
+class DiverMergeRepository {
+  AppDatabase get _db => DatabaseService.instance.database;
+  final SyncRepository _syncRepository = SyncRepository();
+  final _log = LoggerService.forClass(DiverMergeRepository);
+
+  /// Tables where a diver owns at most one row and the value is per-device
+  /// configuration. The keeper's row wins, so the duplicate's row is deleted
+  /// rather than repointed (repointing could create two rows for one diver,
+  /// or collide on a unique constraint).
+  static const _singletonConfigTables = {
+    'diver_settings',
+    'view_configs',
+    'field_presets',
+  };
+
+  /// Repoint all references from [duplicateId] to [keeperId], then delete the
+  /// duplicate diver. Idempotent-safe to call once per duplicate.
+  Future<void> mergeDivers({
+    required String keeperId,
+    required String duplicateId,
+  }) async {
+    if (keeperId == duplicateId) {
+      throw ArgumentError('keeperId and duplicateId must differ');
+    }
+    _log.info('Merging diver $duplicateId into $keeperId');
+
+    final tables = await _tablesWithDiverId();
+    final now = DateTime.now().millisecondsSinceEpoch;
+
+    await _db.transaction(() async {
+      // Deferred FK checks: repointing in catalog order may briefly touch
+      // rows whose FK targets are validated at commit, not per-statement.
+      await _db.customStatement('PRAGMA defer_foreign_keys = ON');
+
+      for (final table in tables) {
+        if (_singletonConfigTables.contains(table)) {
+          // Keeper's config wins; drop the duplicate's.
+          await _logRowDeletions(table, duplicateId);
+          await _db.customStatement('DELETE FROM "$table" WHERE diver_id = ?', [
+            duplicateId,
+          ]);
+        } else {
+          // Additive data: repoint onto the keeper and mark pending for sync.
+          await _markRowsPending(table, duplicateId, now);
+          await _db.customStatement(
+            'UPDATE "$table" SET diver_id = ? WHERE diver_id = ?',
+            [keeperId, duplicateId],
+          );
+        }
+      }
+
+      // Finally remove the duplicate diver itself.
+      await (_db.delete(
+        _db.divers,
+      )..where((t) => t.id.equals(duplicateId))).go();
+    });
+
+    // Log the diver deletion outside the txn so it propagates to other devices.
+    await _syncRepository.logDeletion(
+      entityType: 'divers',
+      recordId: duplicateId,
+    );
+
+    SyncEventBus.notifyLocalChange();
+    _log.info('Merge complete: $duplicateId -> $keeperId');
+  }
+
+  /// All tables (except `divers`) that have a `diver_id` column.
+  Future<List<String>> _tablesWithDiverId() async {
+    final rows = await _db
+        .customSelect(
+          "SELECT m.name AS tbl FROM sqlite_master m "
+          "JOIN pragma_table_info(m.name) p "
+          "WHERE m.type = 'table' AND p.name = 'diver_id' "
+          "AND m.name != 'divers'",
+        )
+        .get();
+    return rows.map((r) => r.read<String>('tbl')).toList();
+  }
+
+  /// Maps a SQLite table name to the sync entityType string used by the
+  /// serializer / deletion log. Most are lowerCamelCase of the snake_case
+  /// table name; the map covers the handful that differ.
+  static const _tableToEntityType = {
+    'dives': 'dives',
+    'dive_sites': 'diveSites',
+    'dive_centers': 'diveCenters',
+    'dive_types': 'diveTypes',
+    'dive_computers': 'diveComputers',
+    'tank_presets': 'tankPresets',
+    'equipment_sets': 'equipmentSets',
+    'diver_settings': 'diverSettings',
+    'view_configs': 'viewConfigs',
+    'field_presets': 'fieldPresets',
+    'trips': 'trips',
+    'equipment': 'equipment',
+    'buddies': 'buddies',
+    'certifications': 'certifications',
+    'tags': 'tags',
+    'courses': 'courses',
+  };
+
+  String _entityTypeFor(String table) =>
+      _tableToEntityType[table] ?? _toLowerCamel(table);
+
+  static String _toLowerCamel(String snake) {
+    final parts = snake.split('_');
+    return parts.first +
+        parts
+            .skip(1)
+            .map((p) => p.isEmpty ? p : p[0].toUpperCase() + p.substring(1))
+            .join();
+  }
+
+  /// Mark every row in [table] owned by [diverId] as pending sync (so the
+  /// repoint propagates to other devices).
+  Future<void> _markRowsPending(String table, String diverId, int now) async {
+    final entityType = _entityTypeFor(table);
+    final ids = await _rowIds(table, diverId);
+    for (final id in ids) {
+      await _syncRepository.markRecordPending(
+        entityType: entityType,
+        recordId: id,
+        localUpdatedAt: now,
+      );
+    }
+  }
+
+  /// Log a deletion for every row in [table] owned by [diverId].
+  Future<void> _logRowDeletions(String table, String diverId) async {
+    final entityType = _entityTypeFor(table);
+    final ids = await _rowIds(table, diverId);
+    for (final id in ids) {
+      await _syncRepository.logDeletion(entityType: entityType, recordId: id);
+    }
+  }
+
+  Future<List<String>> _rowIds(String table, String diverId) async {
+    final rows = await _db
+        .customSelect(
+          'SELECT id FROM "$table" WHERE diver_id = ?',
+          variables: [Variable.withString(diverId)],
+        )
+        .get();
+    return rows.map((r) => r.read<String>('id')).toList();
+  }
+
+  /// Group [divers] that share a normalized (trimmed, case-insensitive) name
+  /// into [DuplicateDiverGroup]s. Only groups with 2+ members are returned.
+  ///
+  /// Within each group the keeper is the default diver if present, otherwise
+  /// the oldest by createdAt. Pure function (no DB) so it is trivially
+  /// unit-testable and reusable by a post-sync detection provider.
+  static List<DuplicateDiverGroup> findDuplicateGroups(
+    List<domain.Diver> divers,
+  ) {
+    final byName = <String, List<domain.Diver>>{};
+    for (final diver in divers) {
+      final key = diver.name.trim().toLowerCase();
+      if (key.isEmpty) continue;
+      byName.putIfAbsent(key, () => []).add(diver);
+    }
+
+    final groups = <DuplicateDiverGroup>[];
+    for (final members in byName.values) {
+      if (members.length < 2) continue;
+      final sorted = [...members]
+        ..sort((a, b) {
+          // Default diver first, then oldest createdAt.
+          if (a.isDefault != b.isDefault) return a.isDefault ? -1 : 1;
+          return a.createdAt.compareTo(b.createdAt);
+        });
+      groups.add(
+        DuplicateDiverGroup(
+          keeper: sorted.first,
+          duplicates: sorted.sublist(1),
+        ),
+      );
+    }
+    return groups;
+  }
+}

--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -134,23 +134,34 @@ class DiverMergeRepository {
             duplicateId,
           ]);
         } else {
-          // Additive data: repoint onto the keeper and mark pending for sync.
-          // Capture each row's prior hlc BEFORE markRowsPending re-stamps it,
-          // so undo can restore the exact pre-merge state.
+          // Additive data: capture each row's id + prior hlc, repoint onto the
+          // keeper, THEN mark pending so the sync queue reflects the final
+          // (repointed) state -- matches the buddy-merge precedent. Capturing
+          // before the repoint lets undo restore the exact pre-merge state.
           final rows = await _rowsByDiverId(table, duplicateId);
+          final ids = <String>[];
           for (final row in rows) {
+            final id = row['id'] as String;
+            ids.add(id);
             repointed.add((
               table: table,
-              rowId: row['id'] as String,
+              rowId: id,
               priorHlc: row['hlc'] as String?,
               hasHlc: row.containsKey('hlc'),
             ));
           }
-          await _markRowsPending(table, duplicateId, now);
           await _db.customStatement(
             'UPDATE "$table" SET diver_id = ? WHERE diver_id = ?',
             [keeperId, duplicateId],
           );
+          final entityType = _entityTypeFor(table);
+          for (final id in ids) {
+            await _syncRepository.markRecordPending(
+              entityType: entityType,
+              recordId: id,
+              localUpdatedAt: now,
+            );
+          }
         }
       }
 
@@ -212,9 +223,27 @@ class DiverMergeRepository {
         }
       }
 
-      // Re-insert any singleton-config rows that the merge deleted.
+      // Re-insert any singleton-config rows that the merge deleted, and clear
+      // the tombstones the merge logged for them -- otherwise the next sync
+      // would re-propagate those deletions and wipe the restored rows again.
       for (final entry in snapshot.deletedSingletonRows) {
         await _insertRowMap(entry.table, entry.row);
+        final id = entry.row['id'];
+        if (id != null) {
+          await _db.customStatement(
+            'DELETE FROM deletion_log WHERE entity_type = ? AND record_id = ?',
+            [_entityTypeFor(entry.table), id],
+          );
+        }
+      }
+
+      // Clear the pending sync-queue entries the merge created for repointed
+      // rows, so undo is a true inverse of the local sync state too.
+      for (final entry in snapshot.repointedRows) {
+        await _db.customStatement(
+          'DELETE FROM sync_records WHERE entity_type = ? AND record_id = ?',
+          [_entityTypeFor(entry.table), entry.rowId],
+        );
       }
 
       // Clear the diver's deletion-log tombstone so a subsequent sync won't
@@ -275,20 +304,6 @@ class DiverMergeRepository {
             .skip(1)
             .map((p) => p.isEmpty ? p : p[0].toUpperCase() + p.substring(1))
             .join();
-  }
-
-  /// Mark every row in [table] owned by [diverId] as pending sync (so the
-  /// repoint propagates to other devices).
-  Future<void> _markRowsPending(String table, String diverId, int now) async {
-    final entityType = _entityTypeFor(table);
-    final ids = await _rowIds(table, diverId);
-    for (final id in ids) {
-      await _syncRepository.markRecordPending(
-        entityType: entityType,
-        recordId: id,
-        localUpdatedAt: now,
-      );
-    }
   }
 
   /// Log a deletion for every row in [table] owned by [diverId].

--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -39,15 +39,19 @@ class DiverMergeRepository {
   final SyncRepository _syncRepository = SyncRepository();
   final _log = LoggerService.forClass(DiverMergeRepository);
 
-  /// Tables where a diver owns at most one row and the value is per-device
-  /// configuration. The keeper's row wins, so the duplicate's row is deleted
-  /// rather than repointed (repointing could create two rows for one diver,
-  /// or collide on a unique constraint).
-  static const _singletonConfigTables = {
-    'diver_settings',
-    'view_configs',
-    'field_presets',
-  };
+  /// Tables holding per-device or per-(diver,view-mode) configuration that
+  /// should not accumulate across devices when divers are merged. The keeper's
+  /// rows win and the duplicate's rows are dropped rather than repointed.
+  ///
+  /// (Note: there are no unique constraints on `diver_id` in these tables, so
+  /// repointing would not crash -- it would just leave the keeper with two of
+  /// every config row, which is worse UX than the keeper's existing config
+  /// winning unconditionally for these auto-generated layouts/settings.)
+  ///
+  /// `field_presets` is intentionally NOT in this set: those are user-named
+  /// custom presets and losing them would be real data loss; they are
+  /// repointed onto the keeper instead.
+  static const _singletonConfigTables = {'diver_settings', 'view_configs'};
 
   /// Repoint all references from [duplicateId] to [keeperId], then delete the
   /// duplicate diver. Idempotent-safe to call once per duplicate.
@@ -85,17 +89,19 @@ class DiverMergeRepository {
         }
       }
 
-      // Finally remove the duplicate diver itself.
+      // Finally remove the duplicate diver itself, and log the deletion
+      // inside the same transaction so the local DB state and the sync
+      // tombstone commit atomically (matches the buddy-merge pattern; a
+      // crash between the two would otherwise leave the duplicate gone
+      // locally but unable to propagate the delete to other devices).
       await (_db.delete(
         _db.divers,
       )..where((t) => t.id.equals(duplicateId))).go();
+      await _syncRepository.logDeletion(
+        entityType: 'divers',
+        recordId: duplicateId,
+      );
     });
-
-    // Log the diver deletion outside the txn so it propagates to other devices.
-    await _syncRepository.logDeletion(
-      entityType: 'divers',
-      recordId: duplicateId,
-    );
 
     SyncEventBus.notifyLocalChange();
     _log.info('Merge complete: $duplicateId -> $keeperId');

--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -24,6 +24,39 @@ class DuplicateDiverGroup {
   String get displayName => keeper.name;
 }
 
+/// Snapshot captured by [DiverMergeRepository.mergeDivers] sufficient to
+/// reverse the merge locally via [DiverMergeRepository.undoMerge].
+///
+/// Note on sync semantics: undo is local-only and safest to call before the
+/// next sync runs after the merge. If sync has already propagated the merge
+/// to other devices, undoing locally on this device will look like a *new*
+/// merge-reversal event from the others' perspective on the next sync; the
+/// remote deletion tombstone for the duplicate has already been delivered.
+class DiverMergeSnapshot {
+  final String keeperId;
+  final String duplicateId;
+
+  /// The full row data of the duplicate diver before deletion, captured so
+  /// it can be reinserted on undo.
+  final Map<String, dynamic> duplicateDiver;
+
+  /// (table, rowId) pairs whose `diver_id` was changed from the duplicate to
+  /// the keeper. Undo flips them back.
+  final List<({String table, String rowId})> repointedRows;
+
+  /// Full row data for rows in singleton-config tables that were deleted as
+  /// part of the merge (keeper-wins policy). Each captures `(table, row)`.
+  final List<({String table, Map<String, dynamic> row})> deletedSingletonRows;
+
+  const DiverMergeSnapshot({
+    required this.keeperId,
+    required this.duplicateId,
+    required this.duplicateDiver,
+    required this.repointedRows,
+    required this.deletedSingletonRows,
+  });
+}
+
 /// Merges two diver profiles that represent the same person.
 ///
 /// The canonical case: each device auto-creates its own owner diver (with a
@@ -54,8 +87,9 @@ class DiverMergeRepository {
   static const _singletonConfigTables = {'diver_settings', 'view_configs'};
 
   /// Repoint all references from [duplicateId] to [keeperId], then delete the
-  /// duplicate diver. Idempotent-safe to call once per duplicate.
-  Future<void> mergeDivers({
+  /// duplicate diver. Returns a [DiverMergeSnapshot] that captures every row
+  /// touched so the merge can be reversed via [undoMerge].
+  Future<DiverMergeSnapshot> mergeDivers({
     required String keeperId,
     required String duplicateId,
   }) async {
@@ -66,6 +100,16 @@ class DiverMergeRepository {
 
     final tables = await _tablesWithDiverId();
     final now = DateTime.now().millisecondsSinceEpoch;
+    final repointed = <({String table, String rowId})>[];
+    final deletedSingleton = <({String table, Map<String, dynamic> row})>[];
+
+    // Capture the duplicate's row BEFORE the transaction so we can restore
+    // it on undo. The select runs outside the txn because we only need a
+    // read-consistent snapshot at the start.
+    final duplicateRow = await _rowAsMap('divers', duplicateId);
+    if (duplicateRow == null) {
+      throw StateError('Cannot merge: no diver with id $duplicateId');
+    }
 
     await _db.transaction(() async {
       // Deferred FK checks: repointing in catalog order may briefly touch
@@ -74,13 +118,22 @@ class DiverMergeRepository {
 
       for (final table in tables) {
         if (_singletonConfigTables.contains(table)) {
-          // Keeper's config wins; drop the duplicate's.
+          // Keeper's config wins; drop the duplicate's. Capture each row
+          // before deletion so undo can reinsert them.
+          final rows = await _rowsByDiverId(table, duplicateId);
+          for (final row in rows) {
+            deletedSingleton.add((table: table, row: row));
+          }
           await _logRowDeletions(table, duplicateId);
           await _db.customStatement('DELETE FROM "$table" WHERE diver_id = ?', [
             duplicateId,
           ]);
         } else {
           // Additive data: repoint onto the keeper and mark pending for sync.
+          final ids = await _rowIds(table, duplicateId);
+          for (final id in ids) {
+            repointed.add((table: table, rowId: id));
+          }
           await _markRowsPending(table, duplicateId, now);
           await _db.customStatement(
             'UPDATE "$table" SET diver_id = ? WHERE diver_id = ?',
@@ -105,6 +158,55 @@ class DiverMergeRepository {
 
     SyncEventBus.notifyLocalChange();
     _log.info('Merge complete: $duplicateId -> $keeperId');
+
+    return DiverMergeSnapshot(
+      keeperId: keeperId,
+      duplicateId: duplicateId,
+      duplicateDiver: duplicateRow,
+      repointedRows: repointed,
+      deletedSingletonRows: deletedSingleton,
+    );
+  }
+
+  /// Reverse a merge previously executed by [mergeDivers], using the snapshot
+  /// it returned. Local-only: see the note on [DiverMergeSnapshot] for sync
+  /// semantics if the merge has already propagated.
+  Future<void> undoMerge(DiverMergeSnapshot snapshot) async {
+    _log.info(
+      'Undoing merge: restoring diver ${snapshot.duplicateId} '
+      '(was merged into ${snapshot.keeperId})',
+    );
+    await _db.transaction(() async {
+      await _db.customStatement('PRAGMA defer_foreign_keys = ON');
+
+      // Restore the duplicate diver row first so subsequent FK repoints land
+      // on a valid target.
+      await _insertRowMap('divers', snapshot.duplicateDiver);
+
+      // Repoint each previously-repointed row back to the duplicate.
+      for (final entry in snapshot.repointedRows) {
+        await _db.customStatement(
+          'UPDATE "${entry.table}" SET diver_id = ? WHERE id = ?',
+          [snapshot.duplicateId, entry.rowId],
+        );
+      }
+
+      // Re-insert any singleton-config rows that the merge deleted.
+      for (final entry in snapshot.deletedSingletonRows) {
+        await _insertRowMap(entry.table, entry.row);
+      }
+
+      // Clear the diver's deletion-log tombstone so a subsequent sync won't
+      // re-delete the restored diver on other devices.
+      await _db.customStatement(
+        "DELETE FROM deletion_log WHERE entity_type = 'divers' "
+        "AND record_id = ?",
+        [snapshot.duplicateId],
+      );
+    });
+
+    SyncEventBus.notifyLocalChange();
+    _log.info('Undo complete: ${snapshot.duplicateId} restored');
   }
 
   /// All tables (except `divers`) that have a `diver_id` column.
@@ -185,6 +287,49 @@ class DiverMergeRepository {
         )
         .get();
     return rows.map((r) => r.read<String>('id')).toList();
+  }
+
+  /// Fetch the single row identified by [id] in [table] as a column->value
+  /// map, or null if none. Used by `mergeDivers` to snapshot the duplicate
+  /// diver row before deleting it.
+  Future<Map<String, dynamic>?> _rowAsMap(String table, String id) async {
+    final result = await _db
+        .customSelect(
+          'SELECT * FROM "$table" WHERE id = ?',
+          variables: [Variable.withString(id)],
+        )
+        .getSingleOrNull();
+    return result?.data;
+  }
+
+  /// Fetch every row in [table] owned by [diverId], each as a column->value
+  /// map. Used to snapshot singleton-config rows before deleting them.
+  Future<List<Map<String, dynamic>>> _rowsByDiverId(
+    String table,
+    String diverId,
+  ) async {
+    final rows = await _db
+        .customSelect(
+          'SELECT * FROM "$table" WHERE diver_id = ?',
+          variables: [Variable.withString(diverId)],
+        )
+        .get();
+    return rows.map((r) => r.data).toList();
+  }
+
+  /// Re-insert [row] into [table] using raw SQL. The row is a column->value
+  /// map as produced by `_rowAsMap` / `_rowsByDiverId` (so the column names
+  /// match the live schema). Used by `undoMerge` to recreate previously
+  /// deleted rows.
+  Future<void> _insertRowMap(String table, Map<String, dynamic> row) async {
+    if (row.isEmpty) return;
+    final cols = row.keys.toList();
+    final placeholders = List.filled(cols.length, '?').join(',');
+    final quotedCols = cols.map((c) => '"$c"').join(',');
+    await _db.customStatement(
+      'INSERT INTO "$table" ($quotedCols) VALUES ($placeholders)',
+      cols.map((c) => row[c]).toList(),
+    );
   }
 
   /// Group [divers] that share a normalized (trimmed, case-insensitive) name

--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -40,9 +40,13 @@ class DiverMergeSnapshot {
   /// it can be reinserted on undo.
   final Map<String, dynamic> duplicateDiver;
 
-  /// (table, rowId) pairs whose `diver_id` was changed from the duplicate to
-  /// the keeper. Undo flips them back.
-  final List<({String table, String rowId})> repointedRows;
+  /// Rows whose `diver_id` was changed from the duplicate to the keeper, with
+  /// the `hlc` value they had before the merge re-stamped them. Undo flips the
+  /// diver_id back and restores the prior hlc so the merge is a true inverse.
+  /// [hasHlc] is false for tables without an hlc column (which undo must not
+  /// reference).
+  final List<({String table, String rowId, String? priorHlc, bool hasHlc})>
+  repointedRows;
 
   /// Full row data for rows in singleton-config tables that were deleted as
   /// part of the merge (keeper-wins policy). Each captures `(table, row)`.
@@ -100,7 +104,8 @@ class DiverMergeRepository {
 
     final tables = await _tablesWithDiverId();
     final now = DateTime.now().millisecondsSinceEpoch;
-    final repointed = <({String table, String rowId})>[];
+    final repointed =
+        <({String table, String rowId, String? priorHlc, bool hasHlc})>[];
     final deletedSingleton = <({String table, Map<String, dynamic> row})>[];
 
     // Capture the duplicate's row BEFORE the transaction so we can restore
@@ -130,9 +135,16 @@ class DiverMergeRepository {
           ]);
         } else {
           // Additive data: repoint onto the keeper and mark pending for sync.
-          final ids = await _rowIds(table, duplicateId);
-          for (final id in ids) {
-            repointed.add((table: table, rowId: id));
+          // Capture each row's prior hlc BEFORE markRowsPending re-stamps it,
+          // so undo can restore the exact pre-merge state.
+          final rows = await _rowsByDiverId(table, duplicateId);
+          for (final row in rows) {
+            repointed.add((
+              table: table,
+              rowId: row['id'] as String,
+              priorHlc: row['hlc'] as String?,
+              hasHlc: row.containsKey('hlc'),
+            ));
           }
           await _markRowsPending(table, duplicateId, now);
           await _db.customStatement(
@@ -183,12 +195,21 @@ class DiverMergeRepository {
       // on a valid target.
       await _insertRowMap('divers', snapshot.duplicateDiver);
 
-      // Repoint each previously-repointed row back to the duplicate.
+      // Repoint each previously-repointed row back to the duplicate and
+      // restore its pre-merge hlc (the merge re-stamped it). Tables without an
+      // hlc column only get their diver_id restored.
       for (final entry in snapshot.repointedRows) {
-        await _db.customStatement(
-          'UPDATE "${entry.table}" SET diver_id = ? WHERE id = ?',
-          [snapshot.duplicateId, entry.rowId],
-        );
+        if (entry.hasHlc) {
+          await _db.customStatement(
+            'UPDATE "${entry.table}" SET diver_id = ?, hlc = ? WHERE id = ?',
+            [snapshot.duplicateId, entry.priorHlc, entry.rowId],
+          );
+        } else {
+          await _db.customStatement(
+            'UPDATE "${entry.table}" SET diver_id = ? WHERE id = ?',
+            [snapshot.duplicateId, entry.rowId],
+          );
+        }
       }
 
       // Re-insert any singleton-config rows that the merge deleted.

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -2,6 +2,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 
@@ -10,10 +11,24 @@ final diverRepositoryProvider = Provider<DiverRepository>((ref) {
   return DiverRepository();
 });
 
+/// Diver merge repository provider
+final diverMergeRepositoryProvider = Provider<DiverMergeRepository>((ref) {
+  return DiverMergeRepository();
+});
+
 /// All divers provider
 final allDiversProvider = FutureProvider<List<Diver>>((ref) async {
   final repository = ref.watch(diverRepositoryProvider);
   return repository.getAllDivers();
+});
+
+/// Duplicate diver groups (same normalized name), surfaced after sync so the
+/// user can confirm a merge. Empty when there are no apparent duplicates.
+final duplicateDiverGroupsProvider = FutureProvider<List<DuplicateDiverGroup>>((
+  ref,
+) async {
+  final divers = await ref.watch(allDiversProvider.future);
+  return DiverMergeRepository.findDuplicateGroups(divers);
 });
 
 /// Check if any diver profiles exist

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -545,7 +545,7 @@ class SpeciesRepository {
         );
 
     await _syncRepository.markRecordPending(
-      entityType: 'site_species',
+      entityType: 'siteSpecies',
       recordId: id,
       localUpdatedAt: now,
     );
@@ -579,7 +579,7 @@ class SpeciesRepository {
       final id = existing.data['id'] as String;
       await (_db.delete(_db.siteSpecies)..where((t) => t.id.equals(id))).go();
       await _syncRepository.logDeletion(
-        entityType: 'site_species',
+        entityType: 'siteSpecies',
         recordId: id,
       );
       SyncEventBus.notifyLocalChange();
@@ -598,7 +598,7 @@ class SpeciesRepository {
 
     for (final row in existing) {
       await _syncRepository.logDeletion(
-        entityType: 'site_species',
+        entityType: 'siteSpecies',
         recordId: row.id,
       );
     }

--- a/lib/features/settings/data/repositories/app_settings_repository.dart
+++ b/lib/features/settings/data/repositories/app_settings_repository.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:drift/drift.dart';
 
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -10,6 +11,7 @@ import 'package:submersion/core/services/logger_service.dart';
 /// key-value `settings` table.
 class AppSettingsRepository {
   AppDatabase get _db => DatabaseService.instance.database;
+  final SyncRepository _syncRepository = SyncRepository();
   static final _log = LoggerService.forClass(AppSettingsRepository);
 
   static const _shareByDefaultKey = 'share_new_records_by_default';
@@ -52,6 +54,11 @@ class AppSettingsRepository {
               updatedAt: Value(now),
             ),
           );
+      await _syncRepository.markRecordPending(
+        entityType: 'settings',
+        recordId: _navPrimaryIdsKey,
+        localUpdatedAt: now,
+      );
     } catch (e, stackTrace) {
       _log.error(
         'Failed to write $_navPrimaryIdsKey',
@@ -97,6 +104,11 @@ class AppSettingsRepository {
               updatedAt: Value(now),
             ),
           );
+      await _syncRepository.markRecordPending(
+        entityType: 'settings',
+        recordId: _shareByDefaultKey,
+        localUpdatedAt: now,
+      );
     } catch (e, stackTrace) {
       _log.error(
         'Failed to write $_shareByDefaultKey',

--- a/lib/features/settings/data/repositories/app_settings_repository.dart
+++ b/lib/features/settings/data/repositories/app_settings_repository.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 
 /// Read/write global (not per-diver) app settings stored in the
 /// key-value `settings` table.
@@ -59,6 +60,7 @@ class AppSettingsRepository {
         recordId: _navPrimaryIdsKey,
         localUpdatedAt: now,
       );
+      SyncEventBus.notifyLocalChange();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to write $_navPrimaryIdsKey',
@@ -109,6 +111,7 @@ class AppSettingsRepository {
         recordId: _shareByDefaultKey,
         localUpdatedAt: now,
       );
+      SyncEventBus.notifyLocalChange();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to write $_shareByDefaultKey',

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
+import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/conflict_resolution_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -29,6 +31,8 @@ class CloudSyncPage extends ConsumerWidget {
         children: [
           // Show banner when custom folder mode is active
           if (isCustomFolderMode) _buildCustomFolderBanner(context),
+          // Surface apparent duplicate diver profiles created across devices.
+          _buildDuplicateDiversBanner(context, ref),
           _buildSyncStatusCard(context, ref, syncState),
           const Divider(),
           _buildProviderSection(context, ref, selectedProvider),
@@ -101,6 +105,120 @@ class CloudSyncPage extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// Banner shown when two or more diver profiles share a name -- the typical
+  /// result of each device auto-creating its own owner diver before the first
+  /// sync. Offers a one-tap merge per duplicate group.
+  Widget _buildDuplicateDiversBanner(BuildContext context, WidgetRef ref) {
+    final groupsAsync = ref.watch(duplicateDiverGroupsProvider);
+    final groups = groupsAsync.asData?.value ?? const [];
+    if (groups.isEmpty) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: theme.colorScheme.primary.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.merge_type, color: theme.colorScheme.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Duplicate diver profiles',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Sync found more than one profile with the same name. This usually '
+            'happens when each device created its own profile before syncing. '
+            'Merging moves all dives and data onto one profile.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          for (final group in groups)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${group.displayName} '
+                      '(${group.duplicates.length + 1} profiles)',
+                      style: theme.textTheme.bodyLarge,
+                    ),
+                  ),
+                  FilledButton.tonal(
+                    onPressed: () => _confirmAndMerge(context, ref, group),
+                    child: const Text('Merge'),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmAndMerge(
+    BuildContext context,
+    WidgetRef ref,
+    DuplicateDiverGroup group,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Merge diver profiles?'),
+        content: Text(
+          'All dives, certifications, gear, and other data from '
+          '${group.duplicates.length} duplicate profile(s) will be moved onto '
+          '"${group.displayName}". This cannot be undone automatically.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Merge'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final repo = ref.read(diverMergeRepositoryProvider);
+    try {
+      for (final duplicate in group.duplicates) {
+        await repo.mergeDivers(
+          keeperId: group.keeper.id,
+          duplicateId: duplicate.id,
+        );
+      }
+      ref.invalidate(allDiversProvider);
+      messenger.showSnackBar(
+        SnackBar(content: Text('Merged into ${group.displayName}')),
+      );
+    } catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('Merge failed: $e')));
+    }
   }
 
   Widget _buildSyncStatusCard(

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -116,6 +116,7 @@ class CloudSyncPage extends ConsumerWidget {
     if (groups.isEmpty) return const SizedBox.shrink();
 
     final theme = Theme.of(context);
+    final l10n = context.l10n;
     return Container(
       margin: const EdgeInsets.all(16),
       padding: const EdgeInsets.all(16),
@@ -135,7 +136,7 @@ class CloudSyncPage extends ConsumerWidget {
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
-                  'Duplicate diver profiles',
+                  l10n.settings_cloudSync_duplicateDivers_title,
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
@@ -145,9 +146,7 @@ class CloudSyncPage extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            'Sync found more than one profile with the same name. This usually '
-            'happens when each device created its own profile before syncing. '
-            'Merging moves all dives and data onto one profile.',
+            l10n.settings_cloudSync_duplicateDivers_description,
             style: theme.textTheme.bodyMedium,
           ),
           const SizedBox(height: 12),
@@ -158,14 +157,18 @@ class CloudSyncPage extends ConsumerWidget {
                 children: [
                   Expanded(
                     child: Text(
-                      '${group.displayName} '
-                      '(${group.duplicates.length + 1} profiles)',
+                      l10n.settings_cloudSync_duplicateDivers_groupLabel(
+                        group.displayName,
+                        group.duplicates.length + 1,
+                      ),
                       style: theme.textTheme.bodyLarge,
                     ),
                   ),
                   FilledButton.tonal(
                     onPressed: () => _confirmAndMerge(context, ref, group),
-                    child: const Text('Merge'),
+                    child: Text(
+                      l10n.settings_cloudSync_duplicateDivers_mergeButton,
+                    ),
                   ),
                 ],
               ),
@@ -181,26 +184,37 @@ class CloudSyncPage extends ConsumerWidget {
     DuplicateDiverGroup group,
   ) async {
     final messenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Merge diver profiles?'),
-        content: Text(
-          'All dives, certifications, gear, and other data from '
-          '${group.duplicates.length} duplicate profile(s) will be moved onto '
-          '"${group.displayName}". This cannot be undone automatically.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
+      builder: (context) {
+        final dialogL10n = context.l10n;
+        return AlertDialog(
+          title: Text(
+            dialogL10n.settings_cloudSync_duplicateDivers_confirmTitle,
           ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Merge'),
+          content: Text(
+            dialogL10n.settings_cloudSync_duplicateDivers_confirmBody(
+              group.duplicates.length,
+              group.displayName,
+            ),
           ),
-        ],
-      ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(
+                dialogL10n.settings_cloudSync_duplicateDivers_confirmCancel,
+              ),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(
+                dialogL10n.settings_cloudSync_duplicateDivers_confirmAction,
+              ),
+            ),
+          ],
+        );
+      },
     );
     if (confirmed != true) return;
 
@@ -214,10 +228,22 @@ class CloudSyncPage extends ConsumerWidget {
       }
       ref.invalidate(allDiversProvider);
       messenger.showSnackBar(
-        SnackBar(content: Text('Merged into ${group.displayName}')),
+        SnackBar(
+          content: Text(
+            l10n.settings_cloudSync_duplicateDivers_successSnack(
+              group.displayName,
+            ),
+          ),
+        ),
       );
     } catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Merge failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n.settings_cloudSync_duplicateDivers_failureSnack(e.toString()),
+          ),
+        ),
+      );
     }
   }
 

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -217,13 +217,19 @@ class CloudSyncPage extends ConsumerWidget {
       },
     );
     if (confirmed != true) return;
+    if (!context.mounted) return;
 
     final repo = ref.read(diverMergeRepositoryProvider);
     try {
+      // Collect every snapshot so the whole group merge can be undone, not
+      // just the last duplicate.
+      final snapshots = <DiverMergeSnapshot>[];
       for (final duplicate in group.duplicates) {
-        await repo.mergeDivers(
-          keeperId: group.keeper.id,
-          duplicateId: duplicate.id,
+        snapshots.add(
+          await repo.mergeDivers(
+            keeperId: group.keeper.id,
+            duplicateId: duplicate.id,
+          ),
         );
       }
       ref.invalidate(allDiversProvider);
@@ -233,6 +239,10 @@ class CloudSyncPage extends ConsumerWidget {
             l10n.settings_cloudSync_duplicateDivers_successSnack(
               group.displayName,
             ),
+          ),
+          action: SnackBarAction(
+            label: l10n.settings_cloudSync_duplicateDivers_undo,
+            onPressed: () => _undoMerge(ref, repo, snapshots),
           ),
         ),
       );
@@ -245,6 +255,19 @@ class CloudSyncPage extends ConsumerWidget {
         ),
       );
     }
+  }
+
+  /// Reverse every snapshot from a group merge, newest first (so a row touched
+  /// by two duplicates is restored to its true original).
+  Future<void> _undoMerge(
+    WidgetRef ref,
+    DiverMergeRepository repo,
+    List<DiverMergeSnapshot> snapshots,
+  ) async {
+    for (final snapshot in snapshots.reversed) {
+      await repo.undoMerge(snapshot);
+    }
+    ref.invalidate(allDiversProvider);
   }
 
   Widget _buildSyncStatusCard(

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1894,6 +1894,19 @@ class _DataSectionContent extends ConsumerWidget {
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () => context.push('/settings/backup'),
                 ),
+                // Cloud sync is gated to Apple platforms (iCloud) for now.
+                if (Platform.isIOS || Platform.isMacOS) ...[
+                  const Divider(height: 1),
+                  ListTile(
+                    leading: const Icon(Icons.cloud_sync),
+                    title: Text(context.l10n.settings_cloudSync_appBar_title),
+                    subtitle: Text(
+                      context.l10n.settings_cloudSync_provider_icloud_subtitle,
+                    ),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => context.push('/settings/cloud-sync'),
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/features/trips/data/repositories/itinerary_day_repository.dart
+++ b/lib/features/trips/data/repositories/itinerary_day_repository.dart
@@ -76,7 +76,7 @@ class ItineraryDayRepository {
       // Mark each day as sync pending
       for (final entry in resolvedDays) {
         await _syncRepository.markRecordPending(
-          entityType: 'tripItineraryDays',
+          entityType: 'itineraryDays',
           recordId: entry.id,
           localUpdatedAt: now.millisecondsSinceEpoch,
         );
@@ -116,7 +116,7 @@ class ItineraryDayRepository {
       );
 
       await _syncRepository.markRecordPending(
-        entityType: 'tripItineraryDays',
+        entityType: 'itineraryDays',
         recordId: day.id,
         localUpdatedAt: now,
       );
@@ -151,7 +151,7 @@ class ItineraryDayRepository {
 
       for (final day in existing) {
         await _syncRepository.logDeletion(
-          entityType: 'tripItineraryDays',
+          entityType: 'itineraryDays',
           recordId: day.id,
         );
       }

--- a/lib/features/universal_import/data/repositories/csv_preset_repository.dart
+++ b/lib/features/universal_import/data/repositories/csv_preset_repository.dart
@@ -61,6 +61,14 @@ class CsvPresetRepository {
             ),
           );
 
+      // Mark pending so the edit is protected during merge and gets an HLC
+      // stamped (the choke point also stamps the row's hlc column).
+      await _syncRepository.markRecordPending(
+        entityType: 'csvPresets',
+        recordId: preset.id,
+        localUpdatedAt: now,
+      );
+
       _log.info('Saved CSV preset: ${preset.id}');
     } catch (e, stackTrace) {
       _log.error(

--- a/lib/features/universal_import/data/repositories/csv_preset_repository.dart
+++ b/lib/features/universal_import/data/repositories/csv_preset_repository.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -8,11 +9,11 @@ import 'package:submersion/features/universal_import/data/csv/presets/csv_preset
 
 /// Repository for persisting user-saved CSV import presets.
 ///
-/// Presets are local-only (not synced). Each row stores the full preset as a
-/// JSON blob in the `preset_json` column, with `id` and `name` duplicated at
-/// the table level for efficient queries.
+/// Each row stores the full preset as a JSON blob in the `preset_json` column,
+/// with `id` and `name` duplicated at the table level for efficient queries.
 class CsvPresetRepository {
   AppDatabase get _db => DatabaseService.instance.database;
+  final SyncRepository _syncRepository = SyncRepository();
   final _log = LoggerService.forClass(CsvPresetRepository);
 
   /// Returns all user-saved presets, ordered by name.
@@ -76,6 +77,7 @@ class CsvPresetRepository {
     try {
       _log.info('Deleting CSV preset: $id');
       await (_db.delete(_db.csvPresets)..where((t) => t.id.equals(id))).go();
+      await _syncRepository.logDeletion(entityType: 'csvPresets', recordId: id);
       _log.info('Deleted CSV preset: $id');
     } catch (e, stackTrace) {
       _log.error(

--- a/lib/features/universal_import/data/repositories/csv_preset_repository.dart
+++ b/lib/features/universal_import/data/repositories/csv_preset_repository.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/universal_import/data/csv/presets/csv_preset.dart'
     as domain;
 
@@ -68,6 +69,7 @@ class CsvPresetRepository {
         recordId: preset.id,
         localUpdatedAt: now,
       );
+      SyncEventBus.notifyLocalChange();
 
       _log.info('Saved CSV preset: ${preset.id}');
     } catch (e, stackTrace) {
@@ -86,6 +88,7 @@ class CsvPresetRepository {
       _log.info('Deleting CSV preset: $id');
       await (_db.delete(_db.csvPresets)..where((t) => t.id.equals(id))).go();
       await _syncRepository.logDeletion(entityType: 'csvPresets', recordId: id);
+      SyncEventBus.notifyLocalChange();
       _log.info('Deleted CSV preset: $id');
     } catch (e, stackTrace) {
       _log.error(

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "إلغاء",
   "settings_cloudSync_duplicateDivers_confirmAction": "دمج",
   "settings_cloudSync_duplicateDivers_successSnack": "تم الدمج في {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "فشل الدمج: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "فشل الدمج: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "تراجع"
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "«{name}» مشتركة مع ملفات غوص أخرى. حذفها من هنا يزيلها للجميع.",
   "trips_deleteShared_title": "حذف الرحلة المشتركة؟",
   "trips_unshareConfirm_body": "سيؤدي هذا إلى إزالة «{name}» من عروض ملفات الغوص الأخرى. يمكنك مشاركتها مرة أخرى لاحقًا.",
-  "trips_unshareConfirm_title": "إلغاء مشاركة هذه الرحلة؟"
+  "trips_unshareConfirm_title": "إلغاء مشاركة هذه الرحلة؟",
+  "settings_cloudSync_duplicateDivers_title": "ملفات غواصين مكررة",
+  "settings_cloudSync_duplicateDivers_description": "وجد المزامنة أكثر من ملف شخصي بالاسم نفسه. يحدث ذلك عادةً عندما أنشأ كل جهاز ملفه الشخصي قبل المزامنة. يؤدي الدمج إلى نقل جميع الغطسات والبيانات إلى ملف واحد.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} ملفات)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "دمج",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "دمج ملفات الغواصين؟",
+  "settings_cloudSync_duplicateDivers_confirmBody": "سيتم نقل جميع الغطسات والشهادات والمعدات والبيانات الأخرى من {count, plural, =1{ملف مكرر} other{{count} ملفات مكررة}} إلى \"{name}\". لا يمكن التراجع عن هذا تلقائيًا.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "إلغاء",
+  "settings_cloudSync_duplicateDivers_confirmAction": "دمج",
+  "settings_cloudSync_duplicateDivers_successSnack": "تم الدمج في {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "فشل الدمج: {error}"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "„{name}\" wird mit anderen Taucherprofilen geteilt. Löschen entfernt die Reise für alle.",
   "trips_deleteShared_title": "Geteilte Reise löschen?",
   "trips_unshareConfirm_body": "„{name}\" wird aus den Ansichten anderer Taucherprofile entfernt. Du kannst die Reise später wieder teilen.",
-  "trips_unshareConfirm_title": "Diese Reise nicht mehr teilen?"
+  "trips_unshareConfirm_title": "Diese Reise nicht mehr teilen?",
+  "settings_cloudSync_duplicateDivers_title": "Doppelte Taucherprofile",
+  "settings_cloudSync_duplicateDivers_description": "Die Synchronisierung hat mehr als ein Profil mit demselben Namen gefunden. Das passiert normalerweise, wenn jedes Gerät sein eigenes Profil erstellt hat, bevor die Synchronisierung erfolgte. Beim Zusammenführen werden alle Tauchgänge und Daten in ein Profil verschoben.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} Profile)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Zusammenführen",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Taucherprofile zusammenführen?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Alle Tauchgänge, Zertifizierungen, Ausrüstung und andere Daten aus {count, plural, =1{einem doppelten Profil} other{{count} doppelten Profilen}} werden auf \"{name}\" verschoben. Dies kann nicht automatisch rückgängig gemacht werden.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Abbrechen",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Zusammenführen",
+  "settings_cloudSync_duplicateDivers_successSnack": "Zusammengeführt in {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Zusammenführung fehlgeschlagen: {error}"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Abbrechen",
   "settings_cloudSync_duplicateDivers_confirmAction": "Zusammenführen",
   "settings_cloudSync_duplicateDivers_successSnack": "Zusammengeführt in {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Zusammenführung fehlgeschlagen: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Zusammenführung fehlgeschlagen: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Rückgängig"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10312,18 +10312,59 @@
   "@divers_delete_reassigned_snackbar": {
     "description": "Snackbar shown after deleting a diver when shared trips/sites were reassigned to a surviving diver instead of deleted.",
     "placeholders": {
-      "trips": {
-        "type": "int",
-        "example": "2"
-      },
-      "sites": {
-        "type": "int",
-        "example": "1"
-      },
-      "name": {
-        "type": "String",
-        "example": "Alice"
-      }
+      "trips": {"type": "int", "example": "2"},
+      "sites": {"type": "int", "example": "1"},
+      "name": {"type": "String", "example": "Alice"}
     }
+  },
+  "settings_cloudSync_duplicateDivers_title": "Duplicate diver profiles",
+  "@settings_cloudSync_duplicateDivers_title": {
+    "description": "Title of the banner on the Cloud Sync page when two or more diver profiles share a name."
+  },
+  "settings_cloudSync_duplicateDivers_description": "Sync found more than one profile with the same name. This usually happens when each device created its own profile before syncing. Merging moves all dives and data onto one profile.",
+  "@settings_cloudSync_duplicateDivers_description": {
+    "description": "Explanatory text below the duplicate-divers banner title."
+  },
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} profiles)",
+  "@settings_cloudSync_duplicateDivers_groupLabel": {
+    "description": "Label for a single duplicate group, e.g. 'Eric (2 profiles)'.",
+    "placeholders": {
+      "name": {"type": "String", "example": "Eric"},
+      "count": {"type": "int", "example": "2"}
+    }
+  },
+  "settings_cloudSync_duplicateDivers_mergeButton": "Merge",
+  "@settings_cloudSync_duplicateDivers_mergeButton": {
+    "description": "Button label that triggers the merge confirmation dialog."
+  },
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Merge diver profiles?",
+  "@settings_cloudSync_duplicateDivers_confirmTitle": {
+    "description": "Title of the merge confirmation dialog."
+  },
+  "settings_cloudSync_duplicateDivers_confirmBody": "All dives, certifications, gear, and other data from {count} duplicate {count, plural, one{profile} other{profiles}} will be moved onto \"{name}\". This cannot be undone automatically.",
+  "@settings_cloudSync_duplicateDivers_confirmBody": {
+    "description": "Body text of the merge confirmation dialog.",
+    "placeholders": {
+      "count": {"type": "int", "example": "1"},
+      "name": {"type": "String", "example": "Eric"}
+    }
+  },
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Cancel",
+  "@settings_cloudSync_duplicateDivers_confirmCancel": {
+    "description": "Cancel button on the merge confirmation dialog."
+  },
+  "settings_cloudSync_duplicateDivers_confirmAction": "Merge",
+  "@settings_cloudSync_duplicateDivers_confirmAction": {
+    "description": "Confirmation (destructive) button on the merge dialog."
+  },
+  "settings_cloudSync_duplicateDivers_successSnack": "Merged into {name}",
+  "@settings_cloudSync_duplicateDivers_successSnack": {
+    "description": "Snackbar shown after a successful diver merge.",
+    "placeholders": {"name": {"type": "String", "example": "Eric"}}
+  },
+  "settings_cloudSync_duplicateDivers_failureSnack": "Merge failed: {error}",
+  "@settings_cloudSync_duplicateDivers_failureSnack": {
+    "description": "Snackbar shown when a diver merge throws an exception.",
+    "placeholders": {"error": {"type": "String", "example": "Database error"}}
   }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10366,5 +10366,9 @@
   "@settings_cloudSync_duplicateDivers_failureSnack": {
     "description": "Snackbar shown when a diver merge throws an exception.",
     "placeholders": {"error": {"type": "String", "example": "Database error"}}
+  },
+  "settings_cloudSync_duplicateDivers_undo": "Undo",
+  "@settings_cloudSync_duplicateDivers_undo": {
+    "description": "Snackbar action that reverses a just-performed diver merge."
   }
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "«{name}» está compartido con otros perfiles de buceo. Eliminarlo aquí lo elimina para todos.",
   "trips_deleteShared_title": "¿Eliminar el viaje compartido?",
   "trips_unshareConfirm_body": "Esto eliminará «{name}» de la vista de los demás perfiles de buceo. Podrás volver a compartirlo más tarde.",
-  "trips_unshareConfirm_title": "¿Dejar de compartir este viaje?"
+  "trips_unshareConfirm_title": "¿Dejar de compartir este viaje?",
+  "settings_cloudSync_duplicateDivers_title": "Perfiles de buceador duplicados",
+  "settings_cloudSync_duplicateDivers_description": "La sincronización encontró más de un perfil con el mismo nombre. Esto ocurre normalmente cuando cada dispositivo creó su propio perfil antes de sincronizarse. Al fusionar, todos los buceos y datos se mueven a un único perfil.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} perfiles)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Fusionar",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "¿Fusionar perfiles de buceador?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Todos los buceos, certificaciones, equipo y otros datos de {count, plural, =1{un perfil duplicado} other{{count} perfiles duplicados}} se moverán a \"{name}\". Esto no se puede deshacer automáticamente.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Cancelar",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Fusionar",
+  "settings_cloudSync_duplicateDivers_successSnack": "Fusionado en {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Error al fusionar: {error}"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Cancelar",
   "settings_cloudSync_duplicateDivers_confirmAction": "Fusionar",
   "settings_cloudSync_duplicateDivers_successSnack": "Fusionado en {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Error al fusionar: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Error al fusionar: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Deshacer"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "« {name} » est partagé avec d'autres profils de plongée. Le supprimer ici le retire pour tout le monde.",
   "trips_deleteShared_title": "Supprimer le voyage partagé ?",
   "trips_unshareConfirm_body": "« {name} » sera retiré des vues des autres profils de plongée. Vous pourrez le partager à nouveau plus tard.",
-  "trips_unshareConfirm_title": "Ne plus partager ce voyage ?"
+  "trips_unshareConfirm_title": "Ne plus partager ce voyage ?",
+  "settings_cloudSync_duplicateDivers_title": "Profils de plongeur en double",
+  "settings_cloudSync_duplicateDivers_description": "La synchronisation a trouvé plus d'un profil portant le même nom. Cela se produit généralement lorsque chaque appareil a créé son propre profil avant la synchronisation. La fusion déplace toutes les plongées et les données vers un seul profil.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} profils)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Fusionner",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Fusionner les profils de plongeur ?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Toutes les plongées, certifications, équipements et autres données de {count, plural, =1{un profil en double} other{{count} profils en double}} seront déplacés vers \"{name}\". Cette action ne peut pas être annulée automatiquement.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Annuler",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Fusionner",
+  "settings_cloudSync_duplicateDivers_successSnack": "Fusionné dans {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Échec de la fusion : {error}"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Annuler",
   "settings_cloudSync_duplicateDivers_confirmAction": "Fusionner",
   "settings_cloudSync_duplicateDivers_successSnack": "Fusionné dans {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Échec de la fusion : {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Échec de la fusion : {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Annuler"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "«{name}» משותף עם פרופילי צלילה אחרים. מחיקה כאן תסיר אותו עבור כולם.",
   "trips_deleteShared_title": "למחוק את הטיול המשותף?",
   "trips_unshareConfirm_body": "פעולה זו תסיר את «{name}» מתצוגות של פרופילי צלילה אחרים. תוכל לשתף שוב בהמשך.",
-  "trips_unshareConfirm_title": "לבטל שיתוף של טיול זה?"
+  "trips_unshareConfirm_title": "לבטל שיתוף של טיול זה?",
+  "settings_cloudSync_duplicateDivers_title": "פרופילי צוללים כפולים",
+  "settings_cloudSync_duplicateDivers_description": "המזכור מצא יותר מפרופיל אחד עם אותו שם. זה קורה בדרך כלל כשכל מכשיר יצר פרופיל משלו לפני הסנכרון. המיזוג מעביר את כל הצלילות והנתונים לפרופיל אחד.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} פרופילים)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "מזג",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "למזג פרופילי צוללים?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "כל הצלילות, הסמכות, הציוד ושאר הנתונים מ-{count, plural, =1{פרופיל כפול אחד} other{{count} פרופילים כפולים}} יועברו אל \"{name}\". לא ניתן לבטל פעולה זו באופן אוטומטי.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "ביטול",
+  "settings_cloudSync_duplicateDivers_confirmAction": "מזג",
+  "settings_cloudSync_duplicateDivers_successSnack": "מוזג אל {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "המיזוג נכשל: {error}"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "ביטול",
   "settings_cloudSync_duplicateDivers_confirmAction": "מזג",
   "settings_cloudSync_duplicateDivers_successSnack": "מוזג אל {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "המיזוג נכשל: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "המיזוג נכשל: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "בטל"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Mégse",
   "settings_cloudSync_duplicateDivers_confirmAction": "Összevon",
   "settings_cloudSync_duplicateDivers_successSnack": "Összevonva ide: {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Összevonás sikertelen: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Összevonás sikertelen: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Visszavonás"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "A(z) „{name}\" meg van osztva más búvárprofilokkal. Ha itt törlöd, mindenkinél eltávolítódik.",
   "trips_deleteShared_title": "Megosztott túra törlése?",
   "trips_unshareConfirm_body": "Ez eltávolítja a(z) „{name}\" elemet a többi búvárprofil nézetéből. Később újra megoszthatod.",
-  "trips_unshareConfirm_title": "Megszünteted a túra megosztását?"
+  "trips_unshareConfirm_title": "Megszünteted a túra megosztását?",
+  "settings_cloudSync_duplicateDivers_title": "Duplikált búvárprofilok",
+  "settings_cloudSync_duplicateDivers_description": "A szinkronizálás több profilt talált ugyanazzal a névvel. Ez általában akkor fordul elő, amikor minden eszköz létrehozta a saját profilját a szinkronizálás előtt. Az összevonás az összes merülést és adatot egyetlen profilba helyezi át.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} profil)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Összevon",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Búvárprofilok összevonása?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Az összes merülés, tanúsítvány, felszerelés és egyéb adat {count, plural, =1{egy duplikált profilból} other{{count} duplikált profilból}} áthelyezésre kerül ide: \"{name}\". Ez nem vonható vissza automatikusan.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Mégse",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Összevon",
+  "settings_cloudSync_duplicateDivers_successSnack": "Összevonva ide: {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Összevonás sikertelen: {error}"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Annulla",
   "settings_cloudSync_duplicateDivers_confirmAction": "Unisci",
   "settings_cloudSync_duplicateDivers_successSnack": "Unito in {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Unione non riuscita: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Unione non riuscita: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Annulla"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "«{name}» è condiviso con altri profili subacquei. Eliminandolo qui verrà rimosso per tutti.",
   "trips_deleteShared_title": "Eliminare il viaggio condiviso?",
   "trips_unshareConfirm_body": "Verrà rimosso «{name}» dalle viste degli altri profili subacquei. Potrai condividerlo di nuovo in seguito.",
-  "trips_unshareConfirm_title": "Annullare la condivisione di questo viaggio?"
+  "trips_unshareConfirm_title": "Annullare la condivisione di questo viaggio?",
+  "settings_cloudSync_duplicateDivers_title": "Profili subacquei duplicati",
+  "settings_cloudSync_duplicateDivers_description": "La sincronizzazione ha trovato più di un profilo con lo stesso nome. Ciò accade di solito quando ogni dispositivo ha creato il proprio profilo prima della sincronizzazione. L'unione sposta tutte le immersioni e i dati su un unico profilo.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} profili)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Unisci",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Unire i profili subacquei?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Tutte le immersioni, le certificazioni, l'attrezzatura e gli altri dati di {count, plural, =1{un profilo duplicato} other{{count} profili duplicati}} verranno spostati su \"{name}\". Questa operazione non può essere annullata automaticamente.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Annulla",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Unisci",
+  "settings_cloudSync_duplicateDivers_successSnack": "Unito in {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Unione non riuscita: {error}"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -28059,6 +28059,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Diver deleted. {trips} shared {trips, plural, one{trip} other{trips}} and {sites} shared {sites, plural, one{site} other{sites}} reassigned to {name}.'**
   String divers_delete_reassigned_snackbar(int trips, int sites, String name);
+
+  /// Title of the banner on the Cloud Sync page when two or more diver profiles share a name.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate diver profiles'**
+  String get settings_cloudSync_duplicateDivers_title;
+
+  /// Explanatory text below the duplicate-divers banner title.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync found more than one profile with the same name. This usually happens when each device created its own profile before syncing. Merging moves all dives and data onto one profile.'**
+  String get settings_cloudSync_duplicateDivers_description;
+
+  /// Label for a single duplicate group, e.g. 'Eric (2 profiles)'.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} ({count} profiles)'**
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count);
+
+  /// Button label that triggers the merge confirmation dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get settings_cloudSync_duplicateDivers_mergeButton;
+
+  /// Title of the merge confirmation dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge diver profiles?'**
+  String get settings_cloudSync_duplicateDivers_confirmTitle;
+
+  /// Body text of the merge confirmation dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'All dives, certifications, gear, and other data from {count} duplicate {count, plural, one{profile} other{profiles}} will be moved onto \"{name}\". This cannot be undone automatically.'**
+  String settings_cloudSync_duplicateDivers_confirmBody(int count, String name);
+
+  /// Cancel button on the merge confirmation dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get settings_cloudSync_duplicateDivers_confirmCancel;
+
+  /// Confirmation (destructive) button on the merge dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get settings_cloudSync_duplicateDivers_confirmAction;
+
+  /// Snackbar shown after a successful diver merge.
+  ///
+  /// In en, this message translates to:
+  /// **'Merged into {name}'**
+  String settings_cloudSync_duplicateDivers_successSnack(String name);
+
+  /// Snackbar shown when a diver merge throws an exception.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge failed: {error}'**
+  String settings_cloudSync_duplicateDivers_failureSnack(String error);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -28119,6 +28119,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Merge failed: {error}'**
   String settings_cloudSync_duplicateDivers_failureSnack(String error);
+
+  /// Snackbar action that reverses a just-performed diver merge.
+  ///
+  /// In en, this message translates to:
+  /// **'Undo'**
+  String get settings_cloudSync_duplicateDivers_undo;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16378,4 +16378,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'فشل الدمج: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'تراجع';
 }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16329,4 +16329,53 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return 'تم حذف الغواص. $trips $_temp0 و$sites $_temp1 أُعيد تعيينها إلى $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title => 'ملفات غواصين مكررة';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'وجد المزامنة أكثر من ملف شخصي بالاسم نفسه. يحدث ذلك عادةً عندما أنشأ كل جهاز ملفه الشخصي قبل المزامنة. يؤدي الدمج إلى نقل جميع الغطسات والبيانات إلى ملف واحد.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count ملفات)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'دمج';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'دمج ملفات الغواصين؟';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ملفات مكررة',
+      one: 'ملف مكرر',
+    );
+    return 'سيتم نقل جميع الغطسات والشهادات والمعدات والبيانات الأخرى من $_temp0 إلى \"$name\". لا يمكن التراجع عن هذا تلقائيًا.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'إلغاء';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'دمج';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'تم الدمج في $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'فشل الدمج: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16664,4 +16664,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Zusammenführung fehlgeschlagen: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Rückgängig';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16613,4 +16613,55 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return 'Taucher gelöscht. $trips $_temp0 und $sites $_temp1 wurden $name zugewiesen.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Doppelte Taucherprofile';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'Die Synchronisierung hat mehr als ein Profil mit demselben Namen gefunden. Das passiert normalerweise, wenn jedes Gerät sein eigenes Profil erstellt hat, bevor die Synchronisierung erfolgte. Beim Zusammenführen werden alle Tauchgänge und Daten in ein Profil verschoben.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count Profile)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Zusammenführen';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Taucherprofile zusammenführen?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count doppelten Profilen',
+      one: 'einem doppelten Profil',
+    );
+    return 'Alle Tauchgänge, Zertifizierungen, Ausrüstung und andere Daten aus $_temp0 werden auf \"$name\" verschoben. Dies kann nicht automatisch rückgängig gemacht werden.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Abbrechen';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction =>
+      'Zusammenführen';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Zusammengeführt in $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Zusammenführung fehlgeschlagen: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16418,4 +16418,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Merge failed: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Undo';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16368,4 +16368,54 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return 'Diver deleted. $trips shared $_temp0 and $sites shared $_temp1 reassigned to $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Duplicate diver profiles';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'Sync found more than one profile with the same name. This usually happens when each device created its own profile before syncing. Merging moves all dives and data onto one profile.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count profiles)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Merge';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Merge diver profiles?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'profiles',
+      one: 'profile',
+    );
+    return 'All dives, certifications, gear, and other data from $count duplicate $_temp0 will be moved onto \"$name\". This cannot be undone automatically.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Cancel';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Merge';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Merged into $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Merge failed: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16704,4 +16704,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Error al fusionar: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Deshacer';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16654,4 +16654,54 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return 'Buzo eliminado. $trips $_temp0 y $sites $_temp1 reasignados a $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Perfiles de buceador duplicados';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'La sincronización encontró más de un perfil con el mismo nombre. Esto ocurre normalmente cuando cada dispositivo creó su propio perfil antes de sincronizarse. Al fusionar, todos los buceos y datos se mueven a un único perfil.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count perfiles)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Fusionar';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      '¿Fusionar perfiles de buceador?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count perfiles duplicados',
+      one: 'un perfil duplicado',
+    );
+    return 'Todos los buceos, certificaciones, equipo y otros datos de $_temp0 se moverán a \"$name\". Esto no se puede deshacer automáticamente.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Cancelar';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Fusionar';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Fusionado en $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Error al fusionar: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16758,4 +16758,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Échec de la fusion : $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Annuler';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16708,4 +16708,54 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return 'Plongeur supprimé. $trips $_temp0 et $sites $_temp1 réattribués à $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Profils de plongeur en double';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'La synchronisation a trouvé plus d\'un profil portant le même nom. Cela se produit généralement lorsque chaque appareil a créé son propre profil avant la synchronisation. La fusion déplace toutes les plongées et les données vers un seul profil.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count profils)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Fusionner';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Fusionner les profils de plongeur ?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count profils en double',
+      one: 'un profil en double',
+    );
+    return 'Toutes les plongées, certifications, équipements et autres données de $_temp0 seront déplacés vers \"$name\". Cette action ne peut pas être annulée automatiquement.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Annuler';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Fusionner';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Fusionné dans $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Échec de la fusion : $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16212,4 +16212,54 @@ class AppLocalizationsHe extends AppLocalizations {
     );
     return 'הצולל נמחק. $trips $_temp0 ו-$sites $_temp1 אל $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'פרופילי צוללים כפולים';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'המזכור מצא יותר מפרופיל אחד עם אותו שם. זה קורה בדרך כלל כשכל מכשיר יצר פרופיל משלו לפני הסנכרון. המיזוג מעביר את כל הצלילות והנתונים לפרופיל אחד.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count פרופילים)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'מזג';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'למזג פרופילי צוללים?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count פרופילים כפולים',
+      one: 'פרופיל כפול אחד',
+    );
+    return 'כל הצלילות, הסמכות, הציוד ושאר הנתונים מ-$_temp0 יועברו אל \"$name\". לא ניתן לבטל פעולה זו באופן אוטומטי.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'ביטול';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'מזג';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'מוזג אל $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'המיזוג נכשל: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16262,4 +16262,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'המיזוג נכשל: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'בטל';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16650,4 +16650,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Összevonás sikertelen: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Visszavonás';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16600,4 +16600,54 @@ class AppLocalizationsHu extends AppLocalizations {
     );
     return 'Búvár törölve. $trips megosztott $_temp0 és $sites megosztott $_temp1 átrendelve ehhez: $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Duplikált búvárprofilok';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'A szinkronizálás több profilt talált ugyanazzal a névvel. Ez általában akkor fordul elő, amikor minden eszköz létrehozta a saját profilját a szinkronizálás előtt. Az összevonás az összes merülést és adatot egyetlen profilba helyezi át.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count profil)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Összevon';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Búvárprofilok összevonása?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count duplikált profilból',
+      one: 'egy duplikált profilból',
+    );
+    return 'Az összes merülés, tanúsítvány, felszerelés és egyéb adat $_temp0 áthelyezésre kerül ide: \"$name\". Ez nem vonható vissza automatikusan.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Mégse';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Összevon';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Összevonva ide: $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Összevonás sikertelen: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16697,4 +16697,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Unione non riuscita: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Annulla';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16647,4 +16647,54 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return 'Subacqueo eliminato. $trips $_temp0 e $sites $_temp1 riassegnati a $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Profili subacquei duplicati';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'La sincronizzazione ha trovato più di un profilo con lo stesso nome. Ciò accade di solito quando ogni dispositivo ha creato il proprio profilo prima della sincronizzazione. L\'unione sposta tutte le immersioni e i dati su un unico profilo.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count profili)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Unisci';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Unire i profili subacquei?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count profili duplicati',
+      one: 'un profilo duplicato',
+    );
+    return 'Tutte le immersioni, le certificazioni, l\'attrezzatura e gli altri dati di $_temp0 verranno spostati su \"$name\". Questa operazione non può essere annullata automaticamente.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Annulla';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Unisci';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Unito in $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Unione non riuscita: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16513,4 +16513,54 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return 'Duiker verwijderd. $trips gedeelde $_temp0 en $sites gedeelde $_temp1 toegewezen aan $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Dubbele duikersprofielen';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'De synchronisatie vond meer dan één profiel met dezelfde naam. Dit gebeurt gewoonlijk wanneer elk apparaat zijn eigen profiel heeft aangemaakt vóór de synchronisatie. Door samen te voegen worden alle duiken en gegevens naar één profiel verplaatst.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count profielen)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Samenvoegen';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Duikersprofielen samenvoegen?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dubbele profielen',
+      one: 'één dubbel profiel',
+    );
+    return 'Alle duiken, certificeringen, uitrusting en andere gegevens van $_temp0 worden verplaatst naar \"$name\". Dit kan niet automatisch ongedaan worden gemaakt.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Annuleren';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Samenvoegen';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Samengevoegd in $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Samenvoegen mislukt: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16563,4 +16563,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Samenvoegen mislukt: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Ongedaan maken';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16649,4 +16649,54 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return 'Mergulhador eliminado. $trips $_temp0 e $sites $_temp1 reatribuídos a $name.';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title =>
+      'Perfis de mergulhador duplicados';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      'A sincronização encontrou mais de um perfil com o mesmo nome. Isso acontece normalmente quando cada dispositivo criou o seu próprio perfil antes de sincronizar. A fusão move todos os mergulhos e dados para um único perfil.';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name ($count perfis)';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => 'Mesclar';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle =>
+      'Mesclar perfis de mergulhador?';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count perfis duplicados',
+      one: 'um perfil duplicado',
+    );
+    return 'Todos os mergulhos, certificações, equipamento e outros dados de $_temp0 serão movidos para \"$name\". Esta ação não pode ser desfeita automaticamente.';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => 'Cancelar';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => 'Mesclar';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return 'Mesclado em $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return 'Falha ao mesclar: $error';
+  }
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16699,4 +16699,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return 'Falha ao mesclar: $error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => 'Desfazer';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15893,4 +15893,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String settings_cloudSync_duplicateDivers_failureSnack(String error) {
     return '合并失败：$error';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_undo => '撤销';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15845,4 +15845,52 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '已删除潜水员。$trips 个共享$_temp0和 $sites 个共享$_temp1已重新分配给 $name。';
   }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_title => '重复的潜水员档案';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_description =>
+      '同步发现多个同名档案。这通常发生在每台设备在同步之前各自创建了档案时。合并会将所有潜水记录和数据迁移到一个档案中。';
+
+  @override
+  String settings_cloudSync_duplicateDivers_groupLabel(String name, int count) {
+    return '$name（$count 个档案）';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_mergeButton => '合并';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmTitle => '合并潜水员档案？';
+
+  @override
+  String settings_cloudSync_duplicateDivers_confirmBody(
+    int count,
+    String name,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 个重复档案',
+      one: '1 个重复档案',
+    );
+    return '$_temp0中的所有潜水记录、认证、装备及其他数据将被移入「$name」。此操作无法自动撤销。';
+  }
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmCancel => '取消';
+
+  @override
+  String get settings_cloudSync_duplicateDivers_confirmAction => '合并';
+
+  @override
+  String settings_cloudSync_duplicateDivers_successSnack(String name) {
+    return '已合并到 $name';
+  }
+
+  @override
+  String settings_cloudSync_duplicateDivers_failureSnack(String error) {
+    return '合并失败：$error';
+  }
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Annuleren",
   "settings_cloudSync_duplicateDivers_confirmAction": "Samenvoegen",
   "settings_cloudSync_duplicateDivers_successSnack": "Samengevoegd in {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Samenvoegen mislukt: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Samenvoegen mislukt: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Ongedaan maken"
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "‘{name}’ wordt gedeeld met andere duikersprofielen. Hier verwijderen haalt het voor iedereen weg.",
   "trips_deleteShared_title": "Gedeelde trip verwijderen?",
   "trips_unshareConfirm_body": "Hiermee wordt ‘{name}’ uit de weergaven van andere duikersprofielen verwijderd. Je kunt het later weer delen.",
-  "trips_unshareConfirm_title": "Deze trip ontdelen?"
+  "trips_unshareConfirm_title": "Deze trip ontdelen?",
+  "settings_cloudSync_duplicateDivers_title": "Dubbele duikersprofielen",
+  "settings_cloudSync_duplicateDivers_description": "De synchronisatie vond meer dan één profiel met dezelfde naam. Dit gebeurt gewoonlijk wanneer elk apparaat zijn eigen profiel heeft aangemaakt vóór de synchronisatie. Door samen te voegen worden alle duiken en gegevens naar één profiel verplaatst.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} profielen)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Samenvoegen",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Duikersprofielen samenvoegen?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Alle duiken, certificeringen, uitrusting en andere gegevens van {count, plural, =1{één dubbel profiel} other{{count} dubbele profielen}} worden verplaatst naar \"{name}\". Dit kan niet automatisch ongedaan worden gemaakt.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Annuleren",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Samenvoegen",
+  "settings_cloudSync_duplicateDivers_successSnack": "Samengevoegd in {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Samenvoegen mislukt: {error}"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "«{name}» está partilhada com outros perfis de mergulho. Eliminá-la aqui remove-a para todos.",
   "trips_deleteShared_title": "Eliminar viagem partilhada?",
   "trips_unshareConfirm_body": "Isto irá remover «{name}» das vistas dos outros perfis de mergulho. Poderás voltar a partilhar mais tarde.",
-  "trips_unshareConfirm_title": "Deixar de partilhar esta viagem?"
+  "trips_unshareConfirm_title": "Deixar de partilhar esta viagem?",
+  "settings_cloudSync_duplicateDivers_title": "Perfis de mergulhador duplicados",
+  "settings_cloudSync_duplicateDivers_description": "A sincronização encontrou mais de um perfil com o mesmo nome. Isso acontece normalmente quando cada dispositivo criou o seu próprio perfil antes de sincronizar. A fusão move todos os mergulhos e dados para um único perfil.",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name} ({count} perfis)",
+  "settings_cloudSync_duplicateDivers_mergeButton": "Mesclar",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "Mesclar perfis de mergulhador?",
+  "settings_cloudSync_duplicateDivers_confirmBody": "Todos os mergulhos, certificações, equipamento e outros dados de {count, plural, =1{um perfil duplicado} other{{count} perfis duplicados}} serão movidos para \"{name}\". Esta ação não pode ser desfeita automaticamente.",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "Cancelar",
+  "settings_cloudSync_duplicateDivers_confirmAction": "Mesclar",
+  "settings_cloudSync_duplicateDivers_successSnack": "Mesclado em {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "Falha ao mesclar: {error}"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "Cancelar",
   "settings_cloudSync_duplicateDivers_confirmAction": "Mesclar",
   "settings_cloudSync_duplicateDivers_successSnack": "Mesclado em {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "Falha ao mesclar: {error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "Falha ao mesclar: {error}",
+  "settings_cloudSync_duplicateDivers_undo": "Desfazer"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4720,5 +4720,15 @@
   "trips_deleteShared_body": "「{name}」已与其他潜水员资料共享。在此处删除会对所有人生效。",
   "trips_deleteShared_title": "删除共享行程？",
   "trips_unshareConfirm_body": "此操作会将「{name}」从其他潜水员资料的视图中移除。您之后可以再次共享。",
-  "trips_unshareConfirm_title": "取消共享此行程？"
+  "trips_unshareConfirm_title": "取消共享此行程？",
+  "settings_cloudSync_duplicateDivers_title": "重复的潜水员档案",
+  "settings_cloudSync_duplicateDivers_description": "同步发现多个同名档案。这通常发生在每台设备在同步之前各自创建了档案时。合并会将所有潜水记录和数据迁移到一个档案中。",
+  "settings_cloudSync_duplicateDivers_groupLabel": "{name}（{count} 个档案）",
+  "settings_cloudSync_duplicateDivers_mergeButton": "合并",
+  "settings_cloudSync_duplicateDivers_confirmTitle": "合并潜水员档案？",
+  "settings_cloudSync_duplicateDivers_confirmBody": "{count, plural, =1{1 个重复档案} other{{count} 个重复档案}}中的所有潜水记录、认证、装备及其他数据将被移入「{name}」。此操作无法自动撤销。",
+  "settings_cloudSync_duplicateDivers_confirmCancel": "取消",
+  "settings_cloudSync_duplicateDivers_confirmAction": "合并",
+  "settings_cloudSync_duplicateDivers_successSnack": "已合并到 {name}",
+  "settings_cloudSync_duplicateDivers_failureSnack": "合并失败：{error}"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4730,5 +4730,6 @@
   "settings_cloudSync_duplicateDivers_confirmCancel": "取消",
   "settings_cloudSync_duplicateDivers_confirmAction": "合并",
   "settings_cloudSync_duplicateDivers_successSnack": "已合并到 {name}",
-  "settings_cloudSync_duplicateDivers_failureSnack": "合并失败：{error}"
+  "settings_cloudSync_duplicateDivers_failureSnack": "合并失败：{error}",
+  "settings_cloudSync_duplicateDivers_undo": "撤销"
 }

--- a/test/core/database/migration_v77_hlc_test.dart
+++ b/test/core/database/migration_v77_hlc_test.dart
@@ -1,0 +1,86 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Migration 77 adds a nullable `hlc` (Hybrid Logical Clock) column to every
+/// conflict-capable syncable table plus sync_metadata. This exercises the
+/// actual onUpgrade ALTER TABLE path (the rest of the suite only covers the
+/// fresh createAll schema).
+void main() {
+  test('v77 schema includes a nullable hlc column on dives', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final cols = await db.customSelect("PRAGMA table_info('dives')").get();
+    final hlc = cols.firstWhere((c) => c.read<String>('name') == 'hlc');
+    expect(hlc.read<int>('notnull'), 0, reason: 'hlc must be nullable');
+  });
+
+  test(
+    'v76 -> v77 upgrade adds hlc to entity tables and sync_metadata',
+    () async {
+      // Minimal pre-v77 tables at user_version = 76 so the v77 ALTER path runs.
+      // Only a representative spread is needed: tables absent from this schema
+      // are skipped by the migration's PRAGMA guard.
+      final native = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA user_version = 76');
+          rawDb.execute('CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY)');
+          rawDb.execute(
+            'CREATE TABLE dive_sites (id TEXT NOT NULL PRIMARY KEY)',
+          );
+          // settings uses a non-id primary key column.
+          rawDb.execute(
+            'CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY)',
+          );
+          rawDb.execute('''
+          CREATE TABLE sync_metadata (
+            id TEXT NOT NULL PRIMARY KEY,
+            device_id TEXT NOT NULL
+          )
+        ''');
+        },
+      );
+      final db = AppDatabase(native);
+      addTearDown(db.close);
+
+      Future<bool> hasHlc(String table) async {
+        final cols = await db.customSelect("PRAGMA table_info('$table')").get();
+        return cols.any((c) => c.read<String>('name') == 'hlc');
+      }
+
+      expect(await hasHlc('dives'), isTrue);
+      expect(await hasHlc('dive_sites'), isTrue);
+      expect(await hasHlc('settings'), isTrue);
+      expect(
+        await hasHlc('sync_metadata'),
+        isTrue,
+        reason: 'the device clock is persisted in sync_metadata.hlc',
+      );
+    },
+  );
+
+  test('v76 -> v77 upgrade preserves existing rows', () async {
+    final native = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 76');
+        rawDb.execute('CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY)');
+        rawDb.execute("INSERT INTO dives (id) VALUES ('pre-existing-dive')");
+      },
+    );
+    final db = AppDatabase(native);
+    addTearDown(db.close);
+
+    final row = await db
+        .customSelect(
+          "SELECT id, hlc FROM dives WHERE id = 'pre-existing-dive'",
+        )
+        .getSingle();
+    expect(row.read<String>('id'), 'pre-existing-dive');
+    expect(
+      row.read<String?>('hlc'),
+      isNull,
+      reason: 'migrated rows start with a null hlc and fall back to updatedAt',
+    );
+  });
+}

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -351,6 +351,42 @@ void main() {
       // MediaSourcesPage class (avoids over-coupling the router test).
       expect(widget.runtimeType.toString(), 'MediaSourcesPage');
     });
+
+    test('cloudSync route path is /settings/cloud-sync', () {
+      final paths = _collectRoutePaths(router.configuration.routes);
+      expect(paths, contains('cloud-sync'));
+    });
+
+    testWidgets('cloudSync route builder returns CloudSyncPage', (
+      tester,
+    ) async {
+      final config = router.configuration;
+      final route = _findRouteByName(config.routes, 'cloudSync');
+      expect(route, isNotNull);
+
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final state = GoRouterState(
+        config,
+        uri: Uri.parse('/settings/cloud-sync'),
+        matchedLocation: '/settings/cloud-sync',
+        fullPath: '/settings/cloud-sync',
+        pathParameters: const {},
+        pageKey: const ValueKey('/settings/cloud-sync'),
+      );
+      final widget = route!.builder!(capturedContext, state);
+      expect(widget.runtimeType.toString(), 'CloudSyncPage');
+    });
   });
 
   group('app_router initialLocation', () {

--- a/test/core/services/sync/hlc_column_test.dart
+++ b/test/core/services/sync/hlc_column_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// The conflict-capable syncable tables must carry a nullable `hlc` column so
+/// per-record Hybrid Logical Clocks can be stored and exported. This guards
+/// the schema migration.
+void main() {
+  tearDown(() => DatabaseService.instance.resetForTesting());
+
+  Future<bool> hasHlcColumn(String table) async {
+    final db = await setUpTestDatabase();
+    final cols = await db.customSelect("PRAGMA table_info('$table')").get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    return names.contains('hlc');
+  }
+
+  // A representative spread of the conflict-capable tables plus sync_metadata.
+  const tables = [
+    'dives',
+    'dive_sites',
+    'divers',
+    'diver_settings',
+    'certifications',
+    'courses',
+    'trips',
+    'equipment',
+    'buddies',
+    'tank_presets',
+    'settings',
+    'csv_presets',
+    'view_configs',
+    'sync_metadata',
+  ];
+
+  for (final table in tables) {
+    test('$table has a nullable hlc column', () async {
+      expect(await hasHlcColumn(table), isTrue);
+    });
+  }
+
+  test('an hlc value round-trips through the dives row', () async {
+    final db = await setUpTestDatabase();
+    await db.customStatement(
+      "INSERT INTO dives (id, dive_date_time, is_planned, is_favorite, "
+      "dive_mode, cns_start, created_at, updated_at, hlc) "
+      "VALUES ('d1', 0, 0, 0, 'oc', 0, 0, 0, ?)",
+      ['000000000001000:000003:node-x'],
+    );
+    final row = await db
+        .customSelect("SELECT hlc FROM dives WHERE id = 'd1'")
+        .getSingle();
+    expect(row.read<String>('hlc'), '000000000001000:000003:node-x');
+  });
+}

--- a/test/core/services/sync/hlc_test.dart
+++ b/test/core/services/sync/hlc_test.dart
@@ -18,6 +18,11 @@ void main() {
       expect(parsed.nodeId, 'a:b:c');
     });
 
+    test('parse throws FormatException on a malformed string', () {
+      expect(() => Hlc.parse('1000:5'), throwsFormatException);
+      expect(() => Hlc.parse('garbage'), throwsFormatException);
+    });
+
     test('orders by physical time first', () {
       const older = Hlc(1000, 999, 'z');
       const newer = Hlc(2000, 0, 'a');
@@ -85,6 +90,40 @@ void main() {
         final merged = local.merge(remote, 3000);
         expect(merged.physicalTime, 3000);
         expect(merged.counter, 7); // max(4, 6) + 1
+      });
+
+      test('keeps local physical time and bumps local counter when local is '
+          'the sole max', () {
+        // Local physical time is ahead of both the remote event and the wall
+        // clock, so the merged clock stays on local time and advances its own
+        // counter.
+        const local = Hlc(5000, 2, 'me');
+        const remote = Hlc(2000, 9, 'other');
+        final merged = local.merge(remote, 1000);
+        expect(merged.physicalTime, 5000);
+        expect(merged.counter, 3); // local.counter + 1
+        expect(merged.nodeId, 'me');
+      });
+    });
+
+    group('equality and hashCode', () {
+      test('two HLCs with identical components are equal', () {
+        const a = Hlc(1000, 2, 'node');
+        const b = Hlc(1000, 2, 'node');
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('differs when any single component differs', () {
+        const base = Hlc(1000, 2, 'node');
+        expect(base == const Hlc(9999, 2, 'node'), isFalse);
+        expect(base == const Hlc(1000, 9, 'node'), isFalse);
+        expect(base == const Hlc(1000, 2, 'other'), isFalse);
+      });
+
+      test('is not equal to a non-Hlc value', () {
+        const base = Hlc(1000, 2, 'node');
+        expect(base == Object(), isFalse);
       });
     });
   });

--- a/test/core/services/sync/hlc_test.dart
+++ b/test/core/services/sync/hlc_test.dart
@@ -5,7 +5,7 @@ import 'package:submersion/core/services/sync/hlc.dart';
 void main() {
   group('Hlc', () {
     test('parse(toString()) round-trips all components', () {
-      final hlc = Hlc(1700000000000, 7, 'device-abc');
+      const hlc = Hlc(1700000000000, 7, 'device-abc');
       final parsed = Hlc.parse(hlc.toString());
       expect(parsed.physicalTime, 1700000000000);
       expect(parsed.counter, 7);
@@ -13,35 +13,35 @@ void main() {
     });
 
     test('parse preserves a nodeId that itself contains the separator', () {
-      final hlc = Hlc(1700000000000, 0, 'a:b:c');
+      const hlc = Hlc(1700000000000, 0, 'a:b:c');
       final parsed = Hlc.parse(hlc.toString());
       expect(parsed.nodeId, 'a:b:c');
     });
 
     test('orders by physical time first', () {
-      final older = Hlc(1000, 999, 'z');
-      final newer = Hlc(2000, 0, 'a');
+      const older = Hlc(1000, 999, 'z');
+      const newer = Hlc(2000, 0, 'a');
       expect(older.compareTo(newer), lessThan(0));
       expect(newer.compareTo(older), greaterThan(0));
     });
 
     test('breaks ties on counter when physical times are equal', () {
-      final lo = Hlc(1000, 1, 'z');
-      final hi = Hlc(1000, 2, 'a');
+      const lo = Hlc(1000, 1, 'z');
+      const hi = Hlc(1000, 2, 'a');
       expect(lo.compareTo(hi), lessThan(0));
     });
 
     test('breaks ties on nodeId when physical and counter are equal', () {
-      final a = Hlc(1000, 1, 'aaa');
-      final b = Hlc(1000, 1, 'bbb');
+      const a = Hlc(1000, 1, 'aaa');
+      const b = Hlc(1000, 1, 'bbb');
       expect(a.compareTo(b), lessThan(0));
-      expect(a.compareTo(Hlc(1000, 1, 'aaa')), 0);
+      expect(a.compareTo(const Hlc(1000, 1, 'aaa')), 0);
     });
 
     group('increment (local event)', () {
       test('advances physical time and resets counter when wall clock moved '
           'forward', () {
-        final clock = Hlc(1000, 5, 'node');
+        const clock = Hlc(1000, 5, 'node');
         final next = clock.increment(2000);
         expect(next.physicalTime, 2000);
         expect(next.counter, 0);
@@ -50,7 +50,7 @@ void main() {
 
       test('keeps physical time and bumps counter when wall clock has not '
           'advanced (skew or same millisecond)', () {
-        final clock = Hlc(2000, 5, 'node');
+        const clock = Hlc(2000, 5, 'node');
         final next = clock.increment(1900); // wall clock is behind
         expect(next.physicalTime, 2000);
         expect(next.counter, 6);
@@ -63,8 +63,8 @@ void main() {
         // Local wall clock is behind; a remote HLC carries a higher physical
         // time. After merge our clock must jump forward so our next local
         // write is ordered after the remote event.
-        final local = Hlc(1000, 0, 'me');
-        final remote = Hlc(5000, 3, 'other');
+        const local = Hlc(1000, 0, 'me');
+        const remote = Hlc(5000, 3, 'other');
         final merged = local.merge(remote, 1100); // wall clock still ~1100
         expect(merged.physicalTime, 5000);
         expect(merged.counter, 4); // remote.counter + 1
@@ -72,16 +72,16 @@ void main() {
       });
 
       test('uses wall clock when it exceeds both sides', () {
-        final local = Hlc(1000, 2, 'me');
-        final remote = Hlc(2000, 9, 'other');
+        const local = Hlc(1000, 2, 'me');
+        const remote = Hlc(2000, 9, 'other');
         final merged = local.merge(remote, 9000);
         expect(merged.physicalTime, 9000);
         expect(merged.counter, 0);
       });
 
       test('bumps max counter when all three physical times are equal', () {
-        final local = Hlc(3000, 4, 'me');
-        final remote = Hlc(3000, 6, 'other');
+        const local = Hlc(3000, 4, 'me');
+        const remote = Hlc(3000, 6, 'other');
         final merged = local.merge(remote, 3000);
         expect(merged.physicalTime, 3000);
         expect(merged.counter, 7); // max(4, 6) + 1

--- a/test/core/services/sync/hlc_test.dart
+++ b/test/core/services/sync/hlc_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/hlc.dart';
+
+/// Unit tests for the Hybrid Logical Clock value type. Pure, no DB.
+void main() {
+  group('Hlc', () {
+    test('parse(toString()) round-trips all components', () {
+      final hlc = Hlc(1700000000000, 7, 'device-abc');
+      final parsed = Hlc.parse(hlc.toString());
+      expect(parsed.physicalTime, 1700000000000);
+      expect(parsed.counter, 7);
+      expect(parsed.nodeId, 'device-abc');
+    });
+
+    test('parse preserves a nodeId that itself contains the separator', () {
+      final hlc = Hlc(1700000000000, 0, 'a:b:c');
+      final parsed = Hlc.parse(hlc.toString());
+      expect(parsed.nodeId, 'a:b:c');
+    });
+
+    test('orders by physical time first', () {
+      final older = Hlc(1000, 999, 'z');
+      final newer = Hlc(2000, 0, 'a');
+      expect(older.compareTo(newer), lessThan(0));
+      expect(newer.compareTo(older), greaterThan(0));
+    });
+
+    test('breaks ties on counter when physical times are equal', () {
+      final lo = Hlc(1000, 1, 'z');
+      final hi = Hlc(1000, 2, 'a');
+      expect(lo.compareTo(hi), lessThan(0));
+    });
+
+    test('breaks ties on nodeId when physical and counter are equal', () {
+      final a = Hlc(1000, 1, 'aaa');
+      final b = Hlc(1000, 1, 'bbb');
+      expect(a.compareTo(b), lessThan(0));
+      expect(a.compareTo(Hlc(1000, 1, 'aaa')), 0);
+    });
+
+    group('increment (local event)', () {
+      test('advances physical time and resets counter when wall clock moved '
+          'forward', () {
+        final clock = Hlc(1000, 5, 'node');
+        final next = clock.increment(2000);
+        expect(next.physicalTime, 2000);
+        expect(next.counter, 0);
+        expect(next.nodeId, 'node');
+      });
+
+      test('keeps physical time and bumps counter when wall clock has not '
+          'advanced (skew or same millisecond)', () {
+        final clock = Hlc(2000, 5, 'node');
+        final next = clock.increment(1900); // wall clock is behind
+        expect(next.physicalTime, 2000);
+        expect(next.counter, 6);
+      });
+    });
+
+    group('merge (receive event)', () {
+      test('adopts a higher remote physical time and follows its counter '
+          '(the clock-skew fix)', () {
+        // Local wall clock is behind; a remote HLC carries a higher physical
+        // time. After merge our clock must jump forward so our next local
+        // write is ordered after the remote event.
+        final local = Hlc(1000, 0, 'me');
+        final remote = Hlc(5000, 3, 'other');
+        final merged = local.merge(remote, 1100); // wall clock still ~1100
+        expect(merged.physicalTime, 5000);
+        expect(merged.counter, 4); // remote.counter + 1
+        expect(merged.nodeId, 'me'); // identity stays ours
+      });
+
+      test('uses wall clock when it exceeds both sides', () {
+        final local = Hlc(1000, 2, 'me');
+        final remote = Hlc(2000, 9, 'other');
+        final merged = local.merge(remote, 9000);
+        expect(merged.physicalTime, 9000);
+        expect(merged.counter, 0);
+      });
+
+      test('bumps max counter when all three physical times are equal', () {
+        final local = Hlc(3000, 4, 'me');
+        final remote = Hlc(3000, 6, 'other');
+        final merged = local.merge(remote, 3000);
+        expect(merged.physicalTime, 3000);
+        expect(merged.counter, 7); // max(4, 6) + 1
+      });
+    });
+  });
+}

--- a/test/core/services/sync/sync_apply_record_test.dart
+++ b/test/core/services/sync/sync_apply_record_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/test_database.dart';
+import '../../../helpers/mock_providers.dart';
+
+void main() {
+  group('Applying a received record (upsertRecord)', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    test(
+      'a deserialized dive can be applied on a device that lacks it',
+      () async {
+        final diveRepo = DiveRepository();
+
+        // Produce the record exactly as a receiving device sees it: through a
+        // full export -> serialize -> deserialize cycle.
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-up-1'),
+        );
+        final serializer = SyncDataSerializer();
+        final repo = SyncRepository();
+        final payload = await serializer.exportData(
+          deviceId: await repo.getDeviceId(),
+          since: null,
+          lastSyncTimestamp: null,
+          deletions: await repo.getAllDeletions(),
+        );
+        final received = serializer.deserializePayload(
+          serializer.serializePayload(payload),
+        );
+        final diveMap = received.data.dives.firstWhere(
+          (d) => d['id'] == 'dive-up-1',
+        );
+
+        // Simulate the receiving device not having the dive yet.
+        await diveRepo.deleteDive('dive-up-1');
+
+        // Apply the received record (this is what _mergeEntity does). It
+        // currently throws, and the caller masks the failure as a "conflict".
+        await serializer.upsertRecord('dives', diveMap);
+
+        expect(await diveRepo.getDiveById('dive-up-1'), isNotNull);
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_blob_base64_test.dart
+++ b/test/core/services/sync/sync_blob_base64_test.dart
@@ -104,5 +104,66 @@ void main() {
           : Uint8List.fromList((blob as List).cast<int>());
       expect(bytes, [0x01, 0x02, 0x03]);
     });
+
+    test('a null BLOB round-trips as null (no spurious empty bytes)', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-nullblob', diveNumber: 203),
+      );
+      await serializer.upsertRecord('diveDataSources', {
+        'id': 'ds-null',
+        'diveId': 'dive-nullblob',
+        'isPrimary': false,
+        'importedAt': 1700000000000,
+        'createdAt': 1700000000000,
+        'rawFingerprint': null,
+      });
+
+      await buildService().performSync();
+      final payload = serializer.deserializePayload(
+        utf8.decode(cloud.syncFileBytes()!),
+      );
+      final row = payload.data.diveDataSources.firstWhere(
+        (r) => r['id'] == 'ds-null',
+      );
+      expect(
+        row['rawFingerprint'],
+        isNull,
+        reason: 'a null BLOB must export as null, not "" or []',
+      );
+    });
+
+    test('a large BLOB survives the base64 round-trip intact', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-bigblob', diveNumber: 204),
+      );
+      // 16 KB with every byte value cycling, to catch any encoding truncation.
+      final big = Uint8List.fromList(List.generate(16384, (i) => i % 256));
+      await serializer.upsertRecord('diveDataSources', {
+        'id': 'ds-big',
+        'diveId': 'dive-bigblob',
+        'isPrimary': false,
+        'importedAt': 1700000000000,
+        'createdAt': 1700000000000,
+        'rawFingerprint': big,
+      });
+
+      final restored = await serializer.fetchRecord(
+        'diveDataSources',
+        'ds-big',
+      );
+      final blob = restored!['rawFingerprint'];
+      final bytes = blob is String
+          ? base64Decode(blob)
+          : Uint8List.fromList((blob as List).cast<int>());
+      expect(
+        bytes,
+        big,
+        reason: 'a large BLOB must not be truncated/corrupted',
+      );
+    });
   });
 }

--- a/test/core/services/sync/sync_blob_base64_test.dart
+++ b/test/core/services/sync/sync_blob_base64_test.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Tests for the BLOB-as-base64 sync encoding (vs Drift's default
+/// array-of-bytes), and the non-breaking acceptance of the legacy format.
+void main() {
+  group('Sync BLOB base64 encoding', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    test(
+      'a BLOB is encoded as a base64 string in the exported payload',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-b64-1', diveNumber: 201),
+        );
+        final fingerprint = Uint8List.fromList([0x10, 0x20, 0x30, 0xAB, 0xCD]);
+        await serializer.upsertRecord('diveDataSources', {
+          'id': 'ds-b64-1',
+          'diveId': 'dive-b64-1',
+          'isPrimary': true,
+          'importedAt': 1700000000000,
+          'createdAt': 1700000000000,
+          'rawFingerprint': fingerprint,
+        });
+
+        await buildService().performSync();
+
+        final payload = serializer.deserializePayload(
+          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+        );
+        final row = payload.data.diveDataSources.firstWhere(
+          (r) => r['id'] == 'ds-b64-1',
+        );
+
+        // The wire format must be a base64 String, not a JSON array of ints.
+        expect(
+          row['rawFingerprint'],
+          isA<String>(),
+          reason: 'BLOB should serialize as a base64 string, not a byte array',
+        );
+        expect(row['rawFingerprint'], base64Encode(fingerprint));
+      },
+    );
+
+    test('a legacy array-encoded BLOB payload still imports', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+
+      // Build a dive locally so the FK target exists on import.
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-legacy-1', diveNumber: 202),
+      );
+
+      // Simulate a payload produced by the OLD serializer: rawFingerprint as a
+      // JSON array of byte ints. upsertRecord must still accept it.
+      await serializer.upsertRecord('diveDataSources', {
+        'id': 'ds-legacy-1',
+        'diveId': 'dive-legacy-1',
+        'isPrimary': false,
+        'importedAt': 1700000000000,
+        'createdAt': 1700000000000,
+        'rawFingerprint': [0x01, 0x02, 0x03],
+      });
+
+      final restored = await serializer.fetchRecord(
+        'diveDataSources',
+        'ds-legacy-1',
+      );
+      expect(restored, isNotNull);
+      // After import + re-fetch it should be the same bytes, regardless of the
+      // wire format it arrived in.
+      final blob = restored!['rawFingerprint'];
+      final bytes = blob is String
+          ? base64Decode(blob)
+          : Uint8List.fromList((blob as List).cast<int>());
+      expect(bytes, [0x01, 0x02, 0x03]);
+    });
+  });
+}

--- a/test/core/services/sync/sync_blob_base64_test.dart
+++ b/test/core/services/sync/sync_blob_base64_test.dart
@@ -55,7 +55,7 @@ void main() {
         await buildService().performSync();
 
         final payload = serializer.deserializePayload(
-          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+          utf8.decode(cloud.syncFileBytes()!),
         );
         final row = payload.data.diveDataSources.firstWhere(
           (r) => r['id'] == 'ds-b64-1',

--- a/test/core/services/sync/sync_builtin_filter_test.dart
+++ b/test/core/services/sync/sync_builtin_filter_test.dart
@@ -51,7 +51,7 @@ void main() {
       await buildService().performSync();
 
       final payload = serializer.deserializePayload(
-        utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+        utf8.decode(cloud.syncFileBytes()!),
       );
       final ids = payload.data.species.map((s) => s['id']).toSet();
 
@@ -88,7 +88,7 @@ void main() {
         await buildService().performSync();
 
         final payload = serializer.deserializePayload(
-          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+          utf8.decode(cloud.syncFileBytes()!),
         );
         final ids = payload.data.diveTypes.map((t) => t['id']).toSet();
 

--- a/test/core/services/sync/sync_builtin_filter_test.dart
+++ b/test/core/services/sync/sync_builtin_filter_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Built-in catalog rows (species, dive types, field presets) are re-seeded
+/// identically on every device and are immutable, so they must NOT sync:
+/// shipping them only risks cross-device ID collisions and payload bloat.
+/// User-created rows in the same tables must still sync.
+void main() {
+  group('Built-in catalog rows are excluded from sync', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    test('built-in species are excluded, custom species are kept', () async {
+      final serializer = SyncDataSerializer();
+
+      await serializer.upsertRecord('species', {
+        'id': 'sp_builtin_1',
+        'commonName': 'Whale Shark',
+        'category': 'shark',
+        'isBuiltIn': true,
+      });
+      await serializer.upsertRecord('species', {
+        'id': 'sp_custom_1',
+        'commonName': 'My Local Critter',
+        'category': 'fish',
+        'isBuiltIn': false,
+      });
+
+      await buildService().performSync();
+
+      final payload = serializer.deserializePayload(
+        utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+      );
+      final ids = payload.data.species.map((s) => s['id']).toSet();
+
+      expect(ids, contains('sp_custom_1'));
+      expect(
+        ids,
+        isNot(contains('sp_builtin_1')),
+        reason: 'built-in species must not be exported',
+      );
+    });
+
+    test(
+      'built-in dive types are excluded, custom dive types are kept',
+      () async {
+        final serializer = SyncDataSerializer();
+
+        await serializer.upsertRecord('diveTypes', {
+          'id': 'dt_builtin_1',
+          'name': 'Recreational',
+          'isBuiltIn': true,
+          'sortOrder': 0,
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+        await serializer.upsertRecord('diveTypes', {
+          'id': 'dt_custom_1',
+          'name': 'Cenote',
+          'isBuiltIn': false,
+          'sortOrder': 1,
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+
+        await buildService().performSync();
+
+        final payload = serializer.deserializePayload(
+          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+        );
+        final ids = payload.data.diveTypes.map((t) => t['id']).toSet();
+
+        expect(ids, contains('dt_custom_1'));
+        expect(
+          ids,
+          isNot(contains('dt_builtin_1')),
+          reason: 'built-in dive types must not be exported',
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_clock_seed_test.dart
+++ b/test/core/services/sync/sync_clock_seed_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// M2: after a crash between syncs, the persisted clock (only written at sync
+/// time) can lag the HLCs already stamped on rows. ensureSyncClockConfigured
+/// must seed from the highest on-disk row HLC, not just the stale persisted
+/// value, so the next local write is never ordered behind existing data.
+void main() {
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+
+  tearDown(() {
+    SyncClock.instance.reset();
+    DatabaseService.instance.resetForTesting();
+  });
+
+  test(
+    'seeds from the highest row HLC when the persisted clock is stale',
+    () async {
+      final db = DatabaseService.instance.database;
+      final repo = SyncRepository();
+      await repo.getDeviceId(); // create metadata row
+
+      // Persisted clock is stale (physical 1000)...
+      await db.customStatement(
+        "UPDATE sync_metadata SET hlc = '000000000001000:000000:me' "
+        "WHERE id = 'global'",
+      );
+      // ...but a dive row already carries a much higher HLC (physical 9000),
+      // as if written after the last persisted sync, before a crash.
+      await db.customStatement(
+        "INSERT INTO dives (id, dive_date_time, is_planned, is_favorite, "
+        "dive_mode, cns_start, created_at, updated_at, hlc) "
+        "VALUES ('d1', 0, 0, 0, 'oc', 0, 0, 0, "
+        "'000000000009000:000000:me')",
+      );
+
+      SyncClock.instance.reset();
+      await repo.ensureSyncClockConfigured();
+
+      expect(
+        SyncClock.instance.current!.physicalTime,
+        9000,
+        reason:
+            'clock must seed from the highest on-disk HLC, not the stale '
+            'persisted value (1000)',
+      );
+    },
+  );
+
+  test(
+    'forces this device node id even when the max row HLC is foreign',
+    () async {
+      final db = DatabaseService.instance.database;
+      final repo = SyncRepository();
+      final deviceId = await repo.getDeviceId();
+
+      await db.customStatement(
+        "INSERT INTO dives (id, dive_date_time, is_planned, is_favorite, "
+        "dive_mode, cns_start, created_at, updated_at, hlc) "
+        "VALUES ('d1', 0, 0, 0, 'oc', 0, 0, 0, "
+        "'000000000009000:000000:some-other-device')",
+      );
+
+      SyncClock.instance.reset();
+      await repo.ensureSyncClockConfigured();
+
+      expect(SyncClock.instance.current!.physicalTime, 9000);
+      expect(
+        SyncClock.instance.current!.nodeId,
+        deviceId,
+        reason:
+            'the seeded clock must issue under our own node id, not the '
+            'foreign one from the max row',
+      );
+    },
+  );
+}

--- a/test/core/services/sync/sync_clock_test.dart
+++ b/test/core/services/sync/sync_clock_test.dart
@@ -30,7 +30,7 @@ void main() {
       'restart', () {
     SyncClock.instance.configure(
       nodeId: 'node',
-      persisted: Hlc(5000, 9, 'node'),
+      persisted: const Hlc(5000, 9, 'node'),
       now: () => 4000, // wall clock is behind the persisted physical time
     );
     final next = Hlc.parse(SyncClock.instance.issue()!);
@@ -43,23 +43,23 @@ void main() {
   });
 
   test('receive() advances the clock past a higher remote physical time', () {
-    var now = 1000;
+    const now = 1000;
     SyncClock.instance.configure(nodeId: 'me', now: () => now);
 
     // A remote device, with a clock far ahead of ours, is observed.
-    SyncClock.instance.receive(Hlc(9000, 2, 'other'));
+    SyncClock.instance.receive(const Hlc(9000, 2, 'other'));
 
     // Our next local write must be ordered after the remote event even though
     // our wall clock is still ~1000.
     final next = Hlc.parse(SyncClock.instance.issue()!);
     expect(next.physicalTime, 9000);
-    expect(next.compareTo(Hlc(9000, 2, 'other')), greaterThan(0));
+    expect(next.compareTo(const Hlc(9000, 2, 'other')), greaterThan(0));
     expect(next.nodeId, 'me');
   });
 
   test('receive() is a no-op when not configured', () {
     SyncClock.instance.reset();
-    SyncClock.instance.receive(Hlc(9000, 0, 'other'));
+    SyncClock.instance.receive(const Hlc(9000, 0, 'other'));
     expect(SyncClock.instance.issue(), isNull);
   });
 }

--- a/test/core/services/sync/sync_clock_test.dart
+++ b/test/core/services/sync/sync_clock_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/hlc.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
+
+/// Tests for the process-wide [SyncClock]: it issues monotonically-increasing
+/// HLC strings for local writes and advances when it receives a remote HLC.
+void main() {
+  tearDown(SyncClock.instance.reset);
+
+  test('issue() returns null when the clock is not configured', () {
+    SyncClock.instance.reset();
+    expect(SyncClock.instance.issue(), isNull);
+  });
+
+  test('once configured, successive issue() values strictly increase', () {
+    var now = 1000;
+    SyncClock.instance.configure(nodeId: 'node', now: () => now);
+
+    final a = Hlc.parse(SyncClock.instance.issue()!);
+    final b = Hlc.parse(SyncClock.instance.issue()!); // same wall-clock ms
+    now = 1001;
+    final c = Hlc.parse(SyncClock.instance.issue()!);
+
+    expect(a.compareTo(b), lessThan(0), reason: 'counter advances within a ms');
+    expect(b.compareTo(c), lessThan(0), reason: 'physical time advances');
+    expect(a.nodeId, 'node');
+  });
+
+  test('configure seeds from a persisted clock so the counter survives a '
+      'restart', () {
+    SyncClock.instance.configure(
+      nodeId: 'node',
+      persisted: Hlc(5000, 9, 'node'),
+      now: () => 4000, // wall clock is behind the persisted physical time
+    );
+    final next = Hlc.parse(SyncClock.instance.issue()!);
+    expect(
+      next.physicalTime,
+      5000,
+      reason: 'keeps the persisted physical time',
+    );
+    expect(next.counter, 10, reason: 'continues the persisted counter');
+  });
+
+  test('receive() advances the clock past a higher remote physical time', () {
+    var now = 1000;
+    SyncClock.instance.configure(nodeId: 'me', now: () => now);
+
+    // A remote device, with a clock far ahead of ours, is observed.
+    SyncClock.instance.receive(Hlc(9000, 2, 'other'));
+
+    // Our next local write must be ordered after the remote event even though
+    // our wall clock is still ~1000.
+    final next = Hlc.parse(SyncClock.instance.issue()!);
+    expect(next.physicalTime, 9000);
+    expect(next.compareTo(Hlc(9000, 2, 'other')), greaterThan(0));
+    expect(next.nodeId, 'me');
+  });
+
+  test('receive() is a no-op when not configured', () {
+    SyncClock.instance.reset();
+    SyncClock.instance.receive(Hlc(9000, 0, 'other'));
+    expect(SyncClock.instance.issue(), isNull);
+  });
+}

--- a/test/core/services/sync/sync_conflict_resolution_test.dart
+++ b/test/core/services/sync/sync_conflict_resolution_test.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Coverage for the conflict-resolution path (keepLocal / keepRemote /
+/// keepBoth, incl. the _deleted branch) and getConflicts. These mutate user
+/// data on resolution and previously had no tests.
+void main() {
+  group('Conflict resolution', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() => DatabaseService.instance.resetForTesting());
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    /// Seed a local dive and return its exported JSON map (for building the
+    /// "remote" conflicting version).
+    Future<Map<String, dynamic>> seedDive(String id, double maxDepth) async {
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: id, maxDepth: maxDepth),
+      );
+      final exported = await SyncDataSerializer().exportData(
+        deviceId: 'seed',
+        deletions: const [],
+      );
+      await SyncRepository().resetSyncState();
+      return Map<String, dynamic>.from(
+        exported.data.dives.firstWhere((d) => d['id'] == id),
+      );
+    }
+
+    /// Put [entityType]/[recordId] into the conflict state with [remoteData]
+    /// as the stored remote version.
+    Future<void> raiseConflict(
+      String entityType,
+      String recordId,
+      Map<String, dynamic> remoteData,
+    ) async {
+      await SyncRepository().markRecordConflict(
+        entityType: entityType,
+        recordId: recordId,
+        conflictDataJson: jsonEncode(remoteData),
+        localUpdatedAt: 1000,
+      );
+    }
+
+    test('getConflicts surfaces a raised conflict', () async {
+      final base = await seedDive('d-getc', 10);
+      await raiseConflict('dives', 'd-getc', {...base, 'maxDepth': 99.0});
+
+      final conflicts = await buildService().getConflicts();
+      expect(conflicts, hasLength(1));
+      expect(conflicts.first.entityType, 'dives');
+      expect(conflicts.first.recordId, 'd-getc');
+    });
+
+    test(
+      'keepLocal preserves the local value and clears the conflict',
+      () async {
+        final base = await seedDive('d-keeplocal', 10);
+        await raiseConflict('dives', 'd-keeplocal', {
+          ...base,
+          'maxDepth': 99.0,
+        });
+
+        await buildService().resolveConflict(
+          'dives',
+          'd-keeplocal',
+          ConflictResolution.keepLocal,
+        );
+
+        final dive = await DiveRepository().getDiveById('d-keeplocal');
+        expect(dive!.maxDepth, 10, reason: 'keepLocal must not apply remote');
+        expect(await buildService().getConflicts(), isEmpty);
+      },
+    );
+
+    test(
+      'keepRemote applies the remote value and clears the conflict',
+      () async {
+        final base = await seedDive('d-keepremote', 10);
+        await raiseConflict('dives', 'd-keepremote', {
+          ...base,
+          'maxDepth': 99.0,
+        });
+
+        await buildService().resolveConflict(
+          'dives',
+          'd-keepremote',
+          ConflictResolution.keepRemote,
+        );
+
+        final dive = await DiveRepository().getDiveById('d-keepremote');
+        expect(
+          dive!.maxDepth,
+          99,
+          reason: 'keepRemote must apply the remote row',
+        );
+        expect(await buildService().getConflicts(), isEmpty);
+      },
+    );
+
+    test(
+      'keepRemote on a deletion conflict removes the local record',
+      () async {
+        await seedDive('d-del', 10);
+        // A deletion conflict stores a _deleted marker as the remote data.
+        await raiseConflict('dives', 'd-del', {
+          '_deleted': true,
+          'deletedAt': 5000,
+          'recordId': 'd-del',
+        });
+
+        await buildService().resolveConflict(
+          'dives',
+          'd-del',
+          ConflictResolution.keepRemote,
+        );
+
+        expect(
+          await DiveRepository().getDiveById('d-del'),
+          isNull,
+          reason: 'keepRemote on a deletion conflict must delete locally',
+        );
+        final tombstone = await DatabaseService.instance.database
+            .customSelect(
+              "SELECT COUNT(*) AS c FROM deletion_log "
+              "WHERE entity_type = 'dives' AND record_id = 'd-del'",
+            )
+            .getSingle();
+        expect(
+          tombstone.read<int>('c'),
+          1,
+          reason: 'the accepted deletion must be logged so it propagates',
+        );
+      },
+    );
+
+    test('keepBoth keeps the local row and duplicates the remote under a new '
+        'id', () async {
+      final base = await seedDive('d-both', 10);
+      await raiseConflict('dives', 'd-both', {...base, 'maxDepth': 99.0});
+
+      await buildService().resolveConflict(
+        'dives',
+        'd-both',
+        ConflictResolution.keepBoth,
+      );
+
+      final original = await DiveRepository().getDiveById('d-both');
+      expect(original!.maxDepth, 10, reason: 'original local row is preserved');
+
+      final all = await DiveRepository().getAllDives();
+      final copies = all.where((d) => d.maxDepth == 99).toList();
+      expect(
+        copies,
+        hasLength(1),
+        reason: 'the remote version is kept as a separate (new-id) dive',
+      );
+      expect(copies.first.id, isNot('d-both'));
+    });
+  });
+}

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/universal_import/data/repositories/csv_preset_repository.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for cross-device deletion propagation gaps.
+///
+/// Two distinct bug classes were closed in this group:
+///   1) entityType naming mismatch between deletion log and SyncData
+///      (e.g. site_repository wrote 'site_species' but the serializer
+///      switch only knows 'siteSpecies' -> silent no-op on receiver).
+///   2) repositories missing logDeletion calls entirely (CsvPresets etc.)
+///      so deletions never even reached the payload.
+void main() {
+  group('Cross-device deletion propagation', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    test(
+      'removing a site-species link on device A propagates the delete to B',
+      () async {
+        final serializer = SyncDataSerializer();
+        final syncRepo = SyncRepository();
+        final speciesRepo = SpeciesRepository();
+
+        // Seed parent rows on "device A".
+        await serializer.upsertRecord('diveSites', {
+          'id': 'site-del-1',
+          'name': 'Wall Site',
+          'description': '',
+          'notes': '',
+          'isShared': false,
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+        await serializer.upsertRecord('species', {
+          'id': 'sp-del-1',
+          'commonName': 'Manta',
+          'category': 'fish',
+          'isBuiltIn': false,
+        });
+        await serializer.upsertRecord('siteSpecies', {
+          'id': 'ss-del-1',
+          'siteId': 'site-del-1',
+          'speciesId': 'sp-del-1',
+          'notes': 'often seen at depth',
+          'createdAt': 1000,
+        });
+
+        await buildService().performSync(); // push the seeded state
+        expect(
+          await serializer.fetchRecord('siteSpecies', 'ss-del-1'),
+          isNotNull,
+        );
+
+        // Device A removes the annotation through the repository (which
+        // writes the deletion log entry under the correct entityType).
+        await speciesRepo.removeExpectedSpecies('site-del-1', 'sp-del-1');
+        expect(
+          await serializer.fetchRecord('siteSpecies', 'ss-del-1'),
+          isNull,
+          reason: 'local row removed immediately',
+        );
+
+        await buildService().performSync(); // push the deletion
+
+        // Now switch to "device B": re-insert the row locally to simulate a
+        // second device that hadn't yet received the delete, reset sync state
+        // so the next sync pulls A's deletion as a cross-device receive.
+        await serializer.upsertRecord('siteSpecies', {
+          'id': 'ss-del-1',
+          'siteId': 'site-del-1',
+          'speciesId': 'sp-del-1',
+          'notes': 'often seen at depth',
+          'createdAt': 1000,
+        });
+        await syncRepo.resetSyncState();
+        expect(
+          await serializer.fetchRecord('siteSpecies', 'ss-del-1'),
+          isNotNull,
+          reason: 'precondition: device B has the row before the pull',
+        );
+
+        await buildService().performSync(); // pull A's deletion
+
+        expect(
+          await serializer.fetchRecord('siteSpecies', 'ss-del-1'),
+          isNull,
+          reason:
+              'cross-device delete must propagate; before the rename, the '
+              'deletion log entry used a snake_case key the serializer '
+              "switch didn't recognise and silently no-op'd",
+        );
+      },
+    );
+
+    test(
+      'deleting a CSV preset on device A propagates the delete to B',
+      () async {
+        final serializer = SyncDataSerializer();
+        final syncRepo = SyncRepository();
+        final presetRepo = CsvPresetRepository();
+
+        // Seed a preset directly (the upsert path is covered by
+        // sync_extra_entities_round_trip_test.dart) and push it, so this
+        // test focuses on the deletion-logging behaviour.
+        await serializer.upsertRecord('csvPresets', {
+          'id': 'csv-del-1',
+          'name': 'Suunto Layout',
+          'presetJson': '{}',
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+        await buildService().performSync();
+        expect(
+          await serializer.fetchRecord('csvPresets', 'csv-del-1'),
+          isNotNull,
+        );
+
+        await presetRepo.deletePreset('csv-del-1');
+        await buildService().performSync(); // push deletion
+
+        // Simulate device B that still has its own copy.
+        await serializer.upsertRecord('csvPresets', {
+          'id': 'csv-del-1',
+          'name': 'Suunto Layout',
+          'presetJson': '{}',
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+        await syncRepo.resetSyncState();
+        await buildService().performSync(); // pull
+
+        expect(
+          await serializer.fetchRecord('csvPresets', 'csv-del-1'),
+          isNull,
+          reason:
+              'CsvPresetRepository.deletePreset must call logDeletion so the '
+              'absence propagates; previously it just dropped the local row',
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -1,3 +1,7 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -159,5 +163,66 @@ void main() {
         );
       },
     );
+
+    test('a remote tombstone does NOT delete a child row created locally after '
+        'the last sync (createdAt-based conflict protection)', () async {
+      final serializer = SyncDataSerializer();
+
+      // Local: a site + species + a site-species link created at t=8000.
+      await serializer.upsertRecord('diveSites', {
+        'id': 'site-m3',
+        'name': 'Wall',
+        'description': '',
+        'notes': '',
+        'isShared': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await serializer.upsertRecord('species', {
+        'id': 'sp-m3',
+        'commonName': 'Grouper',
+        'category': 'fish',
+        'isBuiltIn': false,
+      });
+      await serializer.upsertRecord('siteSpecies', {
+        'id': 'ss-keep',
+        'siteId': 'site-m3',
+        'speciesId': 'sp-m3',
+        'notes': 'local edit',
+        'createdAt': 8000, // after the last sync below
+      });
+
+      // A foreign device's payload carrying a tombstone for that same link.
+      const data = SyncData();
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 9000,
+        deviceId: 'remote-dev',
+        checksum: checksum,
+        data: data,
+        deletions: {
+          'siteSpecies': [const SyncDeletion(id: 'ss-keep', deletedAt: 5000)],
+        },
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(utf8.encode(serializer.serializePayload(payload))),
+        'submersion_sync_remote-dev.json',
+      );
+
+      await impersonateFreshDevice();
+      await setLastSync(DateTime.fromMillisecondsSinceEpoch(4000));
+      await buildService().performSync();
+
+      expect(
+        await serializer.fetchRecord('siteSpecies', 'ss-keep'),
+        isNotNull,
+        reason:
+            'the local row was created (8000) after last sync (4000), so '
+            'a stale remote tombstone must not delete it',
+      );
+    });
   });
 }

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/marine_life/data/repositories/species_reposi
 import 'package:submersion/features/universal_import/data/repositories/csv_preset_repository.dart';
 
 import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/sync_test_helpers.dart';
 import '../../../helpers/test_database.dart';
 
 /// Regression tests for cross-device deletion propagation gaps.
@@ -40,7 +41,6 @@ void main() {
       'removing a site-species link on device A propagates the delete to B',
       () async {
         final serializer = SyncDataSerializer();
-        final syncRepo = SyncRepository();
         final speciesRepo = SpeciesRepository();
 
         // Seed parent rows on "device A".
@@ -94,7 +94,7 @@ void main() {
           'notes': 'often seen at depth',
           'createdAt': 1000,
         });
-        await syncRepo.resetSyncState();
+        await impersonateFreshDevice();
         expect(
           await serializer.fetchRecord('siteSpecies', 'ss-del-1'),
           isNotNull,
@@ -118,7 +118,6 @@ void main() {
       'deleting a CSV preset on device A propagates the delete to B',
       () async {
         final serializer = SyncDataSerializer();
-        final syncRepo = SyncRepository();
         final presetRepo = CsvPresetRepository();
 
         // Seed a preset directly (the upsert path is covered by
@@ -148,7 +147,7 @@ void main() {
           'createdAt': 1000,
           'updatedAt': 1000,
         });
-        await syncRepo.resetSyncState();
+        await impersonateFreshDevice();
         await buildService().performSync(); // pull
 
         expect(

--- a/test/core/services/sync/sync_device_local_settings_test.dart
+++ b/test/core/services/sync/sync_device_local_settings_test.dart
@@ -46,11 +46,13 @@ void main() {
       () async {
         final serializer = SyncDataSerializer();
 
-        await serializer.upsertRecord('settings', {
-          'key': 'active_diver_id',
-          'value': 'diver-A-uuid',
-          'updatedAt': 1000,
-        });
+        // Seed active_diver_id via a DIRECT db write -- upsertRecord now
+        // filters device-local keys on import, so we must bypass it to get the
+        // row into the table and prove the EXPORT filter independently.
+        await DatabaseService.instance.database.customStatement(
+          "INSERT INTO settings (key, value, updated_at) "
+          "VALUES ('active_diver_id', 'diver-A-uuid', 1000)",
+        );
 
         // Seed a second, non-device-local setting so the test also proves the
         // filter is targeted, not a blanket "drop all settings" change.
@@ -81,5 +83,36 @@ void main() {
         );
       },
     );
+
+    test('importing a device-local settings key does not overwrite the local '
+        'value (peer on an older build)', () async {
+      final serializer = SyncDataSerializer();
+      final db = DatabaseService.instance.database;
+
+      // This device has its own active diver pointer.
+      await db.customStatement(
+        "INSERT INTO settings (key, value, updated_at) "
+        "VALUES ('active_diver_id', 'my-diver', 1000)",
+      );
+
+      // A remote payload (from an older build that still exports it) tries to
+      // overwrite it with a foreign diver id.
+      await serializer.upsertRecord('settings', {
+        'key': 'active_diver_id',
+        'value': 'foreign-diver',
+        'updatedAt': 9999,
+      });
+
+      final row = await db
+          .customSelect(
+            "SELECT value FROM settings WHERE key = 'active_diver_id'",
+          )
+          .getSingle();
+      expect(
+        row.read<String>('value'),
+        'my-diver',
+        reason: 'device-local key must not be overwritten on import',
+      );
+    });
   });
 }

--- a/test/core/services/sync/sync_device_local_settings_test.dart
+++ b/test/core/services/sync/sync_device_local_settings_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for the per-device "active diver" pointer firing a sync
+/// conflict on every two-device exchange.
+///
+/// Background: at first launch each device auto-creates an owner diver with a
+/// fresh UUID and persists the pointer in `settings['active_diver_id']`. The
+/// settings table participates in sync; the merge key is the settings `key`
+/// column, so two devices that both wrote `active_diver_id` (with their own
+/// local UUID) collide on the same key with different values and the sync
+/// pipeline correctly flags a conflict.
+///
+/// The fix is to treat `active_diver_id` as device-local: omit it from the
+/// exported payload entirely. The diver *rows* still sync (different IDs, no
+/// row-level conflict); only the per-device pointer stays device-local.
+void main() {
+  group('Sync excludes device-local settings keys', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    test(
+      'active_diver_id is not present in the synced settings payload',
+      () async {
+        final serializer = SyncDataSerializer();
+
+        await serializer.upsertRecord('settings', {
+          'key': 'active_diver_id',
+          'value': 'diver-A-uuid',
+          'updatedAt': 1000,
+        });
+
+        // Seed a second, non-device-local setting so the test also proves the
+        // filter is targeted, not a blanket "drop all settings" change.
+        await serializer.upsertRecord('settings', {
+          'key': 'units_system',
+          'value': 'metric',
+          'updatedAt': 1000,
+        });
+
+        await buildService().performSync();
+
+        final payload = serializer.deserializePayload(
+          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+        );
+        final exportedKeys = payload.data.settings.map((s) => s['key']).toSet();
+
+        expect(
+          exportedKeys,
+          contains('units_system'),
+          reason: 'genuine app-wide settings must still sync',
+        );
+        expect(
+          exportedKeys,
+          isNot(contains('active_diver_id')),
+          reason:
+              'active_diver_id is device-local; including it in the payload '
+              'causes a settings conflict on every two-device exchange',
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_device_local_settings_test.dart
+++ b/test/core/services/sync/sync_device_local_settings_test.dart
@@ -63,7 +63,7 @@ void main() {
         await buildService().performSync();
 
         final payload = serializer.deserializePayload(
-          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+          utf8.decode(cloud.syncFileBytes()!),
         );
         final exportedKeys = payload.data.settings.map((s) => s['key']).toSet();
 

--- a/test/core/services/sync/sync_extra_entities_round_trip_test.dart
+++ b/test/core/services/sync/sync_extra_entities_round_trip_test.dart
@@ -1,0 +1,266 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Round-trip tests for entities that were silently absent from SyncData.
+///
+/// Each is user data with FKs into an already-synced parent, but was never
+/// being exported, so its contents never propagated A -> B. Same shape as
+/// the courses oversight fixed earlier on this branch:
+///   - DiveCustomFields: per-dive user-entered key/value fields
+///   - SiteSpecies: user-curated expected species per dive site
+///   - CsvPresets: saved CSV-import column maps
+///   - ViewConfigs: per-diver/view-mode saved configurations
+///   - FieldPresets: per-diver/view-mode saved field-mapping presets
+///   - DiveDataSources: raw dive-data lineage (incl. fingerprint BLOBs)
+void main() {
+  group('Extra entities round-trip', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Future<void> seedDiver(SyncDataSerializer serializer, String id) async {
+      await serializer.upsertRecord('divers', {
+        'id': id,
+        'name': 'Test Diver',
+        'medicalNotes': '',
+        'notes': '',
+        'isDefault': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+    }
+
+    Future<void> seedDiveSite(SyncDataSerializer serializer, String id) async {
+      await serializer.upsertRecord('diveSites', {
+        'id': id,
+        'name': 'Test Site',
+        'description': '',
+        'notes': '',
+        'isShared': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+    }
+
+    Future<void> seedSpecies(SyncDataSerializer serializer, String id) async {
+      await serializer.upsertRecord('species', {
+        'id': id,
+        'commonName': 'Test Fish',
+        'category': 'fish',
+        'isBuiltIn': false,
+      });
+    }
+
+    test('DiveCustomFields round-trips A -> B', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+      final diveRepo = DiveRepository();
+
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-cf-1', diveNumber: 101),
+      );
+      await serializer.upsertRecord('diveCustomFields', {
+        'id': 'cf-1',
+        'diveId': 'dive-cf-1',
+        'fieldKey': 'visibility_m',
+        'fieldValue': '20',
+        'sortOrder': 0,
+        'createdAt': 1000,
+      });
+
+      await buildService().performSync();
+      await serializer.deleteRecord('diveCustomFields', 'cf-1');
+      await syncRepo.resetSyncState();
+      expect(await serializer.fetchRecord('diveCustomFields', 'cf-1'), isNull);
+
+      final pull = await buildService().performSync();
+      expect(pull.status, isNot(SyncResultStatus.error));
+
+      final restored = await serializer.fetchRecord('diveCustomFields', 'cf-1');
+      expect(restored, isNotNull, reason: 'custom field must round-trip');
+      expect(restored!['fieldKey'], 'visibility_m');
+      expect(restored['fieldValue'], '20');
+    });
+
+    test('SiteSpecies round-trips A -> B', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+
+      await seedDiveSite(serializer, 'site-ss-1');
+      await seedSpecies(serializer, 'species-ss-1');
+      await serializer.upsertRecord('siteSpecies', {
+        'id': 'ss-1',
+        'siteId': 'site-ss-1',
+        'speciesId': 'species-ss-1',
+        'notes': 'commonly seen on the wall',
+        'createdAt': 1000,
+      });
+
+      await buildService().performSync();
+      await serializer.deleteRecord('siteSpecies', 'ss-1');
+      await syncRepo.resetSyncState();
+      expect(await serializer.fetchRecord('siteSpecies', 'ss-1'), isNull);
+
+      final pull = await buildService().performSync();
+      expect(pull.status, isNot(SyncResultStatus.error));
+
+      final restored = await serializer.fetchRecord('siteSpecies', 'ss-1');
+      expect(restored, isNotNull, reason: 'site-species link must round-trip');
+      expect(restored!['notes'], 'commonly seen on the wall');
+    });
+
+    test('CsvPresets round-trips A -> B', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+
+      await serializer.upsertRecord('csvPresets', {
+        'id': 'csv-1',
+        'name': 'Suunto CSV',
+        'presetJson': '{"columns":["date","depth"]}',
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+
+      await buildService().performSync();
+      await serializer.deleteRecord('csvPresets', 'csv-1');
+      await syncRepo.resetSyncState();
+      expect(await serializer.fetchRecord('csvPresets', 'csv-1'), isNull);
+
+      final pull = await buildService().performSync();
+      expect(pull.status, isNot(SyncResultStatus.error));
+
+      final restored = await serializer.fetchRecord('csvPresets', 'csv-1');
+      expect(restored, isNotNull);
+      expect(restored!['name'], 'Suunto CSV');
+      expect(restored['presetJson'], '{"columns":["date","depth"]}');
+    });
+
+    test('ViewConfigs round-trips A -> B', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+
+      await seedDiver(serializer, 'diver-vc-1');
+      await serializer.upsertRecord('viewConfigs', {
+        'id': 'vc-1',
+        'diverId': 'diver-vc-1',
+        'viewMode': 'table',
+        'configJson': '{"columns":["date","depth","duration"]}',
+        'updatedAt': 1000,
+      });
+
+      await buildService().performSync();
+      await serializer.deleteRecord('viewConfigs', 'vc-1');
+      await syncRepo.resetSyncState();
+      expect(await serializer.fetchRecord('viewConfigs', 'vc-1'), isNull);
+
+      final pull = await buildService().performSync();
+      expect(pull.status, isNot(SyncResultStatus.error));
+
+      final restored = await serializer.fetchRecord('viewConfigs', 'vc-1');
+      expect(restored, isNotNull);
+      expect(restored!['viewMode'], 'table');
+    });
+
+    test('FieldPresets round-trips A -> B', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+
+      await seedDiver(serializer, 'diver-fp-1');
+      await serializer.upsertRecord('fieldPresets', {
+        'id': 'fp-1',
+        'diverId': 'diver-fp-1',
+        'viewMode': 'table',
+        'name': 'My Tech Layout',
+        'configJson': '{"fields":["max_depth","cns"]}',
+        'isBuiltIn': false,
+        'createdAt': 1000,
+      });
+
+      await buildService().performSync();
+      await serializer.deleteRecord('fieldPresets', 'fp-1');
+      await syncRepo.resetSyncState();
+      expect(await serializer.fetchRecord('fieldPresets', 'fp-1'), isNull);
+
+      final pull = await buildService().performSync();
+      expect(pull.status, isNot(SyncResultStatus.error));
+
+      final restored = await serializer.fetchRecord('fieldPresets', 'fp-1');
+      expect(restored, isNotNull);
+      expect(restored!['name'], 'My Tech Layout');
+    });
+
+    test(
+      'DiveDataSources round-trips A -> B including raw BLOB fingerprint',
+      () async {
+        final serializer = SyncDataSerializer();
+        final syncRepo = SyncRepository();
+        final diveRepo = DiveRepository();
+
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-ds-1', diveNumber: 102),
+        );
+        final fingerprint = Uint8List.fromList([0x01, 0x02, 0x03, 0xFE, 0xFF]);
+        await serializer.upsertRecord('diveDataSources', {
+          'id': 'ds-1',
+          'diveId': 'dive-ds-1',
+          'isPrimary': true,
+          'sourceFormat': 'shearwater',
+          'importedAt': 1700000000000,
+          'createdAt': 1700000000000,
+          'rawFingerprint': fingerprint,
+        });
+
+        await buildService().performSync();
+        await serializer.deleteRecord('diveDataSources', 'ds-1');
+        await syncRepo.resetSyncState();
+        expect(await serializer.fetchRecord('diveDataSources', 'ds-1'), isNull);
+
+        final pull = await buildService().performSync();
+        expect(pull.status, isNot(SyncResultStatus.error));
+
+        final restored = await serializer.fetchRecord(
+          'diveDataSources',
+          'ds-1',
+        );
+        expect(
+          restored,
+          isNotNull,
+          reason: 'data-source row (with BLOB) must round-trip',
+        );
+        expect(restored!['sourceFormat'], 'shearwater');
+
+        // BLOB survives the JSON round-trip. Drift encodes Uint8List as a
+        // JSON array of bytes via its default serializer.
+        final restoredBlob = restored['rawFingerprint'];
+        expect(restoredBlob, isNotNull);
+        final restoredBytes = restoredBlob is Uint8List
+            ? restoredBlob.toList()
+            : (restoredBlob as List).cast<int>();
+        expect(restoredBytes, [0x01, 0x02, 0x03, 0xFE, 0xFF]);
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_extra_entities_round_trip_test.dart
+++ b/test/core/services/sync/sync_extra_entities_round_trip_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -252,13 +253,19 @@ void main() {
         );
         expect(restored!['sourceFormat'], 'shearwater');
 
-        // BLOB survives the JSON round-trip. Drift encodes Uint8List as a
-        // JSON array of bytes via its default serializer.
+        // BLOB survives the JSON round-trip. The sync layer encodes BLOBs as
+        // base64 strings (see sync_blob_base64_test.dart); fetchRecord decodes
+        // them back to a Uint8List. Accept any of the shapes defensively.
         final restoredBlob = restored['rawFingerprint'];
         expect(restoredBlob, isNotNull);
-        final restoredBytes = restoredBlob is Uint8List
-            ? restoredBlob.toList()
-            : (restoredBlob as List).cast<int>();
+        final List<int> restoredBytes;
+        if (restoredBlob is Uint8List) {
+          restoredBytes = restoredBlob.toList();
+        } else if (restoredBlob is String) {
+          restoredBytes = base64Decode(restoredBlob);
+        } else {
+          restoredBytes = (restoredBlob as List).cast<int>();
+        }
         expect(restoredBytes, [0x01, 0x02, 0x03, 0xFE, 0xFF]);
       },
     );

--- a/test/core/services/sync/sync_extra_entities_round_trip_test.dart
+++ b/test/core/services/sync/sync_extra_entities_round_trip_test.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
 import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/sync_test_helpers.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../helpers/test_database.dart';
 
@@ -77,7 +78,6 @@ void main() {
 
     test('DiveCustomFields round-trips A -> B', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
       final diveRepo = DiveRepository();
 
       await diveRepo.createDive(
@@ -94,7 +94,7 @@ void main() {
 
       await buildService().performSync();
       await serializer.deleteRecord('diveCustomFields', 'cf-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('diveCustomFields', 'cf-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -108,7 +108,6 @@ void main() {
 
     test('SiteSpecies round-trips A -> B', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
 
       await seedDiveSite(serializer, 'site-ss-1');
       await seedSpecies(serializer, 'species-ss-1');
@@ -122,7 +121,7 @@ void main() {
 
       await buildService().performSync();
       await serializer.deleteRecord('siteSpecies', 'ss-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('siteSpecies', 'ss-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -135,7 +134,6 @@ void main() {
 
     test('CsvPresets round-trips A -> B', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
 
       await serializer.upsertRecord('csvPresets', {
         'id': 'csv-1',
@@ -147,7 +145,7 @@ void main() {
 
       await buildService().performSync();
       await serializer.deleteRecord('csvPresets', 'csv-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('csvPresets', 'csv-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -161,7 +159,6 @@ void main() {
 
     test('ViewConfigs round-trips A -> B', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
 
       await seedDiver(serializer, 'diver-vc-1');
       await serializer.upsertRecord('viewConfigs', {
@@ -174,7 +171,7 @@ void main() {
 
       await buildService().performSync();
       await serializer.deleteRecord('viewConfigs', 'vc-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('viewConfigs', 'vc-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -187,7 +184,6 @@ void main() {
 
     test('FieldPresets round-trips A -> B', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
 
       await seedDiver(serializer, 'diver-fp-1');
       await serializer.upsertRecord('fieldPresets', {
@@ -202,7 +198,7 @@ void main() {
 
       await buildService().performSync();
       await serializer.deleteRecord('fieldPresets', 'fp-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('fieldPresets', 'fp-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -217,7 +213,6 @@ void main() {
       'DiveDataSources round-trips A -> B including raw BLOB fingerprint',
       () async {
         final serializer = SyncDataSerializer();
-        final syncRepo = SyncRepository();
         final diveRepo = DiveRepository();
 
         await diveRepo.createDive(
@@ -236,7 +231,7 @@ void main() {
 
         await buildService().performSync();
         await serializer.deleteRecord('diveDataSources', 'ds-1');
-        await syncRepo.resetSyncState();
+        await impersonateFreshDevice();
         expect(await serializer.fetchRecord('diveDataSources', 'ds-1'), isNull);
 
         final pull = await buildService().performSync();

--- a/test/core/services/sync/sync_fk_round_trip_test.dart
+++ b/test/core/services/sync/sync_fk_round_trip_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for the FK violations the on-device diagnosis surfaced
+/// (see docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md and
+/// test/core/services/sync/_diagnose_apply_failures_test.dart).
+///
+/// Two distinct intra-payload referential bugs are exercised:
+///   1) Apply-order FK violation: a dive references a dive site that is
+///      applied *later* in the static merge order, so without deferred FK
+///      checks the dive insert fails and never reaches the receiving DB.
+///   2) Missing entity in payload: `SyncData` had no `courses` field, so any
+///      `courseId` set on a dive or certification was a dangling reference
+///      on every receiving device.
+void main() {
+  group('Sync FK round-trip (intra-payload references)', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    test('a dive with siteId round-trips A -> B even though dives apply before '
+        'diveSites in the static order', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+      final diveRepo = DiveRepository();
+
+      // Device A: a dive site, plus a dive that points at it. We build the
+      // dive via the domain repo so we get every non-nullable column set,
+      // then re-upsert with siteId pointed at the site.
+      await serializer.upsertRecord('diveSites', {
+        'id': 'site-fk-1',
+        'name': 'Reef Wall',
+        'description': '',
+        'notes': '',
+        'isShared': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-fk-1', diveNumber: 77),
+      );
+      final original = await serializer.fetchRecord('dives', 'dive-fk-1');
+      expect(original, isNotNull, reason: 'dive seeded on device A');
+      await serializer.upsertRecord('dives', {
+        ...original!,
+        'siteId': 'site-fk-1',
+        'updatedAt': 2000,
+      });
+
+      await buildService().performSync(); // device A push
+
+      // Device B impersonation: drop both records and reset sync state so
+      // the pull genuinely re-applies them from the cloud payload.
+      await serializer.deleteRecord('dives', 'dive-fk-1');
+      await serializer.deleteRecord('diveSites', 'site-fk-1');
+      await syncRepo.resetSyncState();
+      expect(await serializer.fetchRecord('dives', 'dive-fk-1'), isNull);
+      expect(await serializer.fetchRecord('diveSites', 'site-fk-1'), isNull);
+
+      final pull = await buildService().performSync();
+      expect(
+        pull.status,
+        isNot(SyncResultStatus.error),
+        reason:
+            'pull must succeed; got ${pull.status} (${pull.message}). '
+            'Without deferred FK checks the dive insert fails because the '
+            'static merge order applies dives before diveSites.',
+      );
+
+      final restoredSite = await serializer.fetchRecord(
+        'diveSites',
+        'site-fk-1',
+      );
+      expect(restoredSite, isNotNull);
+
+      final restoredDive = await serializer.fetchRecord('dives', 'dive-fk-1');
+      expect(
+        restoredDive,
+        isNotNull,
+        reason:
+            'dive should round-trip even with siteId referencing a '
+            'sibling record that comes later in the apply order',
+      );
+      expect(restoredDive!['siteId'], 'site-fk-1');
+    });
+
+    test('a course + a dive referencing it both round-trip A -> B '
+        '(courses must be in SyncData)', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+      final diveRepo = DiveRepository();
+
+      // Courses require a Diver (FK NOT NULL, cascade). Drift's `fromJson`
+      // does NOT honour SQL defaults, so columns like `medicalNotes` /
+      // `notes` / `isDefault` must be supplied explicitly.
+      await serializer.upsertRecord('divers', {
+        'id': 'diver-fk-1',
+        'name': 'Test Diver',
+        'medicalNotes': '',
+        'notes': '',
+        'isDefault': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+
+      // Device A: a course owned by the diver, plus a dive that links to it.
+      await serializer.upsertRecord('courses', {
+        'id': 'course-fk-1',
+        'diverId': 'diver-fk-1',
+        'name': 'Advanced Open Water Diver',
+        'agency': 'PADI',
+        'startDate': 1700000000000,
+        'notes': '',
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-course-1', diveNumber: 78),
+      );
+      final origDive = await serializer.fetchRecord('dives', 'dive-course-1');
+      await serializer.upsertRecord('dives', {
+        ...origDive!,
+        'courseId': 'course-fk-1',
+        'updatedAt': 2000,
+      });
+
+      await buildService().performSync(); // device A push
+
+      // Device B impersonation: drop the course + dive, reset sync state.
+      // Leave the diver in place so the FK comparison stays focused on the
+      // course propagation itself.
+      await serializer.deleteRecord('dives', 'dive-course-1');
+      await serializer.deleteRecord('courses', 'course-fk-1');
+      await syncRepo.resetSyncState();
+
+      final pull = await buildService().performSync();
+      expect(
+        pull.status,
+        isNot(SyncResultStatus.error),
+        reason: 'pull must succeed; got ${pull.status} (${pull.message})',
+      );
+
+      final restoredCourse = await serializer.fetchRecord(
+        'courses',
+        'course-fk-1',
+      );
+      expect(
+        restoredCourse,
+        isNotNull,
+        reason:
+            'course must round-trip via SyncData (was previously '
+            'omitted from the payload entirely)',
+      );
+      expect(restoredCourse!['name'], 'Advanced Open Water Diver');
+
+      // Verify via the domain repo: SyncDataSerializer.fetchRecord still uses
+      // a hand-maintained `_diveToJson` that doesn't include courseId
+      // (asymmetric with export, only feeds conflict comparison which reads
+      // updatedAt). The DB row itself is what matters here.
+      final restoredDive = await diveRepo.getDiveById('dive-course-1');
+      expect(restoredDive, isNotNull);
+      expect(
+        restoredDive!.courseId,
+        'course-fk-1',
+        reason: 'dive must keep its course link after sync',
+      );
+    });
+  });
+}

--- a/test/core/services/sync/sync_fk_round_trip_test.dart
+++ b/test/core/services/sync/sync_fk_round_trip_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
 import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/sync_test_helpers.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../helpers/test_database.dart';
 
@@ -42,7 +43,6 @@ void main() {
     test('a dive with siteId round-trips A -> B even though dives apply before '
         'diveSites in the static order', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
       final diveRepo = DiveRepository();
 
       // Device A: a dive site, plus a dive that points at it. We build the
@@ -74,7 +74,7 @@ void main() {
       // the pull genuinely re-applies them from the cloud payload.
       await serializer.deleteRecord('dives', 'dive-fk-1');
       await serializer.deleteRecord('diveSites', 'site-fk-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('dives', 'dive-fk-1'), isNull);
       expect(await serializer.fetchRecord('diveSites', 'site-fk-1'), isNull);
 
@@ -108,7 +108,6 @@ void main() {
     test('a course + a dive referencing it both round-trip A -> B '
         '(courses must be in SyncData)', () async {
       final serializer = SyncDataSerializer();
-      final syncRepo = SyncRepository();
       final diveRepo = DiveRepository();
 
       // Courses require a Diver (FK NOT NULL, cascade). Drift's `fromJson`
@@ -152,7 +151,7 @@ void main() {
       // course propagation itself.
       await serializer.deleteRecord('dives', 'dive-course-1');
       await serializer.deleteRecord('courses', 'course-fk-1');
-      await syncRepo.resetSyncState();
+      await impersonateFreshDevice();
 
       final pull = await buildService().performSync();
       expect(

--- a/test/core/services/sync/sync_flow_dataloss_test.dart
+++ b/test/core/services/sync/sync_flow_dataloss_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/sync_test_helpers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for the per-device-file flow's data-loss edges:
+/// C1 (failed apply must not advance lastSync), M1 (no unreliable mtime skip),
+/// M6 (own-device payloads are skipped by identity).
+void main() {
+  group('Sync flow data-loss guards', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() => DatabaseService.instance.resetForTesting());
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Future<Map<String, dynamic>> baseDiveMap(String id) async {
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(createTestDiveWithBottomTime(id: id));
+      final exported = await SyncDataSerializer().exportData(
+        deviceId: 'seed',
+        deletions: const [],
+      );
+      final map = Map<String, dynamic>.from(
+        exported.data.dives.firstWhere((d) => d['id'] == id),
+      );
+      await diveRepo.deleteDive(id);
+      await SyncRepository().resetSyncState();
+      return map;
+    }
+
+    Future<void> uploadFile(
+      String name,
+      String deviceId,
+      List<Map<String, dynamic>> dives,
+    ) async {
+      final data = SyncData(dives: dives);
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 1700000000000,
+        deviceId: deviceId,
+        checksum: checksum,
+        data: data,
+        deletions: const {},
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(
+          utf8.encode(SyncDataSerializer().serializePayload(payload)),
+        ),
+        name,
+      );
+    }
+
+    test(
+      'C1: a failed apply does not advance lastSync (so it is retried)',
+      () async {
+        final base = await baseDiveMap('dive-ok');
+        final goodDive = {...base, 'id': 'dive-ok'};
+        final corruptDive = {
+          ...base,
+          'id': 'dive-bad',
+          'maxDepth': 'NOT_A_NUMBER',
+        };
+        await uploadFile('submersion_sync_remote.json', 'remote-dev', [
+          goodDive,
+          corruptDive,
+        ]);
+
+        await impersonateFreshDevice();
+        final result = await buildService().performSync();
+
+        expect(result.status, SyncResultStatus.error);
+        expect(
+          await SyncRepository().getLastSyncTime(),
+          isNull,
+          reason:
+              'lastSync must not advance when a record failed to apply, or '
+              'the freshness/conflict window moves past it and it is lost',
+        );
+      },
+    );
+
+    test('M1: a foreign file is applied even if its mtime is older than '
+        'lastSync (mtime is unreliable on iCloud)', () async {
+      final base = await baseDiveMap('dive-mtime');
+      await uploadFile('submersion_sync_remote.json', 'remote-dev', [
+        {...base, 'id': 'dive-mtime'},
+      ]);
+
+      await impersonateFreshDevice();
+      // lastSync far in the future; the foreign file's mtime (now) is older.
+      await setLastSync(DateTime.now().add(const Duration(days: 365)));
+
+      await buildService().performSync();
+
+      expect(
+        await DiveRepository().getDiveById('dive-mtime'),
+        isNotNull,
+        reason:
+            'the foreign file must still be applied; a mtime-based skip '
+            'would have dropped it',
+      );
+    });
+
+    test(
+      'M6: a payload authored by THIS device is skipped by identity',
+      () async {
+        final base = await baseDiveMap('dive-self');
+        final myDeviceId = await SyncRepository().getDeviceId();
+
+        // A legacy-named file whose payload claims OUR device id.
+        await uploadFile('submersion_sync.json', myDeviceId, [
+          {...base, 'id': 'dive-self'},
+        ]);
+
+        final result = await buildService().performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+
+        expect(
+          await DiveRepository().getDiveById('dive-self'),
+          isNull,
+          reason: 'our own payload (any filename) must not be re-applied to us',
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_hlc_merge_test.dart
+++ b/test/core/services/sync/sync_hlc_merge_test.dart
@@ -152,6 +152,122 @@ void main() {
       );
     });
 
+    test('HLC resolves a concurrent edit (both edited since last sync) instead '
+        'of flagging a conflict', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final base = await baseDiveMap('dive-concurrent');
+
+      // Local: edited at updatedAt 5000 with a LOWER hlc.
+      await serializer.upsertRecord('dives', {
+        ...base,
+        'maxDepth': 10.0,
+        'updatedAt': 5000,
+        'hlc': hlcAt(1000, 'local'),
+      });
+      // Remote: also edited since last sync (updatedAt 6000) with a HIGHER
+      // hlc. Both > lastSync, so the legacy path would mark a conflict.
+      await uploadDeviceFile('remote-dev', {
+        ...base,
+        'maxDepth': 99.0,
+        'updatedAt': 6000,
+        'hlc': hlcAt(9000, 'remote-dev'),
+      });
+
+      await impersonateFreshDevice();
+      await setLastSync(DateTime.fromMillisecondsSinceEpoch(4000));
+      final result = await buildService().performSync();
+
+      expect(
+        result.conflictsFound,
+        0,
+        reason:
+            'when both sides carry an HLC, it resolves the edit; no '
+            'manual conflict should be raised',
+      );
+      final restored = await diveRepo.getDiveById('dive-concurrent');
+      expect(
+        restored!.maxDepth,
+        99.0,
+        reason: 'higher HLC wins the concurrent edit',
+      );
+    });
+
+    test(
+      'still raises a conflict for a concurrent edit when NEITHER side has an '
+      'HLC (pre-rollout rows)',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+        final base = await baseDiveMap('dive-nohlc-conflict');
+
+        await serializer.upsertRecord('dives', {
+          ...base,
+          'maxDepth': 10.0,
+          'updatedAt': 5000,
+          'hlc': null,
+        });
+        await uploadDeviceFile('remote-dev', {
+          ...base,
+          'maxDepth': 99.0,
+          'updatedAt': 6000,
+          'hlc': null,
+        });
+
+        await impersonateFreshDevice();
+        await setLastSync(DateTime.fromMillisecondsSinceEpoch(4000));
+        final result = await buildService().performSync();
+
+        expect(
+          result.conflictsFound,
+          greaterThan(0),
+          reason:
+              'without HLCs, a both-edited-since-last-sync case is still a '
+              'conflict (updatedAt fallback)',
+        );
+        final restored = await diveRepo.getDiveById('dive-nohlc-conflict');
+        expect(
+          restored!.maxDepth,
+          10.0,
+          reason:
+              'a conflict is not auto-applied; local is kept pending review',
+        );
+      },
+    );
+
+    test(
+      'an exact HLC tie keeps the local record (does not overwrite)',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+        final base = await baseDiveMap('dive-tie');
+
+        const tie = '000000000005000:000000:same-node';
+        await serializer.upsertRecord('dives', {
+          ...base,
+          'maxDepth': 10.0,
+          'updatedAt': 1000,
+          'hlc': tie,
+        });
+        await uploadDeviceFile('remote-dev', {
+          ...base,
+          'maxDepth': 99.0,
+          'updatedAt': 2000,
+          'hlc': tie,
+        });
+
+        await impersonateFreshDevice();
+        await buildService().performSync();
+
+        final restored = await diveRepo.getDiveById('dive-tie');
+        expect(
+          restored!.maxDepth,
+          10.0,
+          reason: 'an exact HLC tie must not silently overwrite the local row',
+        );
+      },
+    );
+
     test(
       'falls back to updatedAt when an HLC is absent on either side',
       () async {

--- a/test/core/services/sync/sync_hlc_merge_test.dart
+++ b/test/core/services/sync/sync_hlc_merge_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/sync_test_helpers.dart';
+import '../../../helpers/test_database.dart';
+
+/// The Hybrid Logical Clock drives cross-device conflict resolution: when both
+/// the local and remote copies of a record carry an HLC, the higher HLC wins
+/// regardless of wall-clock `updatedAt`. This is the clock-skew fix.
+void main() {
+  group('HLC-driven merge', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      SyncClock.instance.reset();
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Future<Map<String, dynamic>> baseDiveMap(String id) async {
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(createTestDiveWithBottomTime(id: id));
+      final exported = await SyncDataSerializer().exportData(
+        deviceId: 'seed',
+        deletions: const [],
+      );
+      final map = Map<String, dynamic>.from(
+        exported.data.dives.firstWhere((d) => d['id'] == id),
+      );
+      await diveRepo.deleteDive(id);
+      await SyncRepository().resetSyncState();
+      return map;
+    }
+
+    Future<void> uploadDeviceFile(
+      String deviceId,
+      Map<String, dynamic> diveMap,
+    ) async {
+      final data = SyncData(dives: [diveMap]);
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 1700000000000,
+        deviceId: deviceId,
+        checksum: checksum,
+        data: data,
+        deletions: const {},
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(
+          utf8.encode(SyncDataSerializer().serializePayload(payload)),
+        ),
+        'submersion_sync_$deviceId.json',
+      );
+    }
+
+    // Hlc string with a given physical-time component (counter 0).
+    String hlcAt(int physical, String node) =>
+        '${physical.toString().padLeft(15, '0')}:000000:$node';
+
+    test(
+      'remote wins when its HLC is higher even though its updatedAt is lower '
+      '(clock-skew fix)',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+        final base = await baseDiveMap('dive-skew');
+
+        // Local copy: NEWER wall clock (updatedAt 5000) but an OLDER logical
+        // clock (HLC physical 1000). maxDepth 10.
+        await serializer.upsertRecord('dives', {
+          ...base,
+          'maxDepth': 10.0,
+          'updatedAt': 5000,
+          'hlc': hlcAt(1000, 'local'),
+        });
+
+        // Remote copy: OLDER wall clock (updatedAt 2000) but a NEWER logical
+        // clock (HLC physical 9000) -- this is the genuinely-later edit made on
+        // a device whose wall clock was behind. maxDepth 99.
+        await uploadDeviceFile('remote-dev', {
+          ...base,
+          'maxDepth': 99.0,
+          'updatedAt': 2000,
+          'hlc': hlcAt(9000, 'remote-dev'),
+        });
+
+        await impersonateFreshDevice();
+        final result = await buildService().performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+
+        final restored = await diveRepo.getDiveById('dive-skew');
+        expect(
+          restored!.maxDepth,
+          99.0,
+          reason:
+              'higher HLC must win even though its updatedAt is lower; '
+              'updatedAt-only ordering would have wrongly kept the local copy',
+        );
+      },
+    );
+
+    test('local wins when its HLC is higher than the remote', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final base = await baseDiveMap('dive-localwin');
+
+      await serializer.upsertRecord('dives', {
+        ...base,
+        'maxDepth': 42.0,
+        'updatedAt': 2000,
+        'hlc': hlcAt(9000, 'local'),
+      });
+      await uploadDeviceFile('remote-dev', {
+        ...base,
+        'maxDepth': 7.0,
+        'updatedAt': 5000, // higher wall clock...
+        'hlc': hlcAt(1000, 'remote-dev'), // ...but lower logical clock
+      });
+
+      await impersonateFreshDevice();
+      await buildService().performSync();
+
+      final restored = await diveRepo.getDiveById('dive-localwin');
+      expect(
+        restored!.maxDepth,
+        42.0,
+        reason: 'local higher HLC must be preserved against a lower remote HLC',
+      );
+    });
+
+    test(
+      'falls back to updatedAt when an HLC is absent on either side',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+        final base = await baseDiveMap('dive-fallback');
+
+        // Local has no HLC (pre-rollout row); remote has a newer updatedAt.
+        await serializer.upsertRecord('dives', {
+          ...base,
+          'maxDepth': 10.0,
+          'updatedAt': 1000,
+          'hlc': null,
+        });
+        await uploadDeviceFile('remote-dev', {
+          ...base,
+          'maxDepth': 55.0,
+          'updatedAt': 9000,
+          'hlc': null,
+        });
+
+        await impersonateFreshDevice();
+        await buildService().performSync();
+
+        final restored = await diveRepo.getDiveById('dive-fallback');
+        expect(
+          restored!.maxDepth,
+          55.0,
+          reason: 'with no HLC on either side, the newer updatedAt wins',
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_hlc_straggler_stamp_test.dart
+++ b/test/core/services/sync/sync_hlc_straggler_stamp_test.dart
@@ -1,0 +1,75 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
+import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
+import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/csv_preset.dart'
+    as domain;
+import 'package:submersion/features/universal_import/data/repositories/csv_preset_repository.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// The three config tables (csvPresets, viewConfigs, settings) whose write
+/// paths bypass the markRecordPending choke point must still get an HLC
+/// stamped on write, so cross-device config edits resolve by HLC like every
+/// other conflict-capable entity.
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    SyncClock.instance.configure(nodeId: 'node-test', now: () => 1000);
+  });
+
+  tearDown(() {
+    SyncClock.instance.reset();
+    DatabaseService.instance.resetForTesting();
+  });
+
+  Future<String?> hlcOf(String table, String pkCol, String pk) async {
+    final row = await db
+        .customSelect(
+          'SELECT hlc FROM "$table" WHERE "$pkCol" = ?',
+          variables: [Variable.withString(pk)],
+        )
+        .getSingleOrNull();
+    return row?.read<String?>('hlc');
+  }
+
+  test('CsvPresetRepository.savePreset stamps an hlc', () async {
+    await CsvPresetRepository().savePreset(
+      const domain.CsvPreset(id: 'csv-x', name: 'My Preset'),
+    );
+    expect(await hlcOf('csv_presets', 'id', 'csv-x'), isNotNull);
+  });
+
+  test('ViewConfigRepository.saveRawConfig stamps an hlc', () async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion.insert(
+            id: 'diver-x',
+            name: 'Test',
+            createdAt: 1000,
+            updatedAt: 1000,
+          ),
+        );
+    final repo = ViewConfigRepository(db);
+    await repo.saveRawConfig('diver-x', 'table', '{"k":1}');
+
+    final row = await (db.select(
+      db.viewConfigs,
+    )..where((t) => t.diverId.equals('diver-x'))).getSingle();
+    expect(row.hlc, isNotNull);
+  });
+
+  test('AppSettingsRepository.setShareByDefault stamps an hlc', () async {
+    await AppSettingsRepository().setShareByDefault(true);
+    expect(
+      await hlcOf('settings', 'key', 'share_new_records_by_default'),
+      isNotNull,
+    );
+  });
+}

--- a/test/core/services/sync/sync_initializer_test.dart
+++ b/test/core/services/sync/sync_initializer_test.dart
@@ -1,0 +1,178 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/sync/sync_initializer.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Bytes for a throwaway sync payload file. Content is irrelevant to the launch
+/// check -- only the file's name and mtime matter.
+final _payload = Uint8List.fromList([1, 2, 3]);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SyncRepository repository;
+  late SyncInitializer initializer;
+  late FakeCloudStorageProvider provider;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    repository = SyncRepository();
+    // Materialize the sync-metadata row up front. updateLastSyncTime() issues a
+    // bare UPDATE and is a no-op until getOrCreateMetadata() has created it.
+    await repository.getDeviceId();
+    initializer = SyncInitializer(syncRepository: repository, prefs: prefs);
+    provider = FakeCloudStorageProvider();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  String peerFileName(String deviceId) => 'submersion_sync_$deviceId.json';
+
+  group('checkSyncOnLaunch preconditions', () {
+    test('returns notConfigured when no provider is given', () async {
+      final result = await initializer.checkSyncOnLaunch(null);
+      expect(result.status, SyncCheckStatus.notConfigured);
+    });
+
+    test('returns unavailable when the provider is not available', () async {
+      provider.available = false;
+      final result = await initializer.checkSyncOnLaunch(provider);
+      expect(result.status, SyncCheckStatus.unavailable);
+    });
+
+    test('returns notAuthenticated when not signed in', () async {
+      provider.authenticated = false;
+      final result = await initializer.checkSyncOnLaunch(provider);
+      expect(result.status, SyncCheckStatus.notAuthenticated);
+    });
+  });
+
+  group('checkSyncOnLaunch with no peer files', () {
+    test(
+      'returns noRemoteData when cloud is empty and nothing pending',
+      () async {
+        final result = await initializer.checkSyncOnLaunch(provider);
+        expect(result.status, SyncCheckStatus.noRemoteData);
+      },
+    );
+
+    test(
+      'returns localChanges when cloud is empty but edits are pending',
+      () async {
+        await repository.markRecordPending(
+          entityType: 'dives',
+          recordId: 'dive-1',
+          localUpdatedAt: DateTime(2026).millisecondsSinceEpoch,
+        );
+
+        final result = await initializer.checkSyncOnLaunch(provider);
+
+        expect(result.status, SyncCheckStatus.localChanges);
+        expect(result.pendingChanges, 1);
+      },
+    );
+
+    test('excludes our OWN per-device file from the peer set', () async {
+      // Regression: persisting/inspecting our own file made the launch check
+      // compare our own upload time and never see peers. Our own file must not
+      // count as remote data.
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+
+      final result = await initializer.checkSyncOnLaunch(provider);
+
+      expect(result.status, SyncCheckStatus.noRemoteData);
+    });
+
+    test('excludes iCloud "conflicted copy" duplicates', () async {
+      await provider.uploadFile(
+        _payload,
+        'submersion_sync_deviceB (conflicted copy 2026).json',
+      );
+
+      final result = await initializer.checkSyncOnLaunch(provider);
+
+      expect(result.status, SyncCheckStatus.noRemoteData);
+    });
+  });
+
+  group('checkSyncOnLaunch with peer files', () {
+    test('updatesAvailable when a peer file is newer than last sync', () async {
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+      // Peer mtime is ~now; a 2020 last-sync is clearly older.
+      await repository.updateLastSyncTime(DateTime(2020));
+
+      final result = await initializer.checkSyncOnLaunch(provider);
+
+      expect(result.status, SyncCheckStatus.updatesAvailable);
+      expect(result.remoteModified, isNotNull);
+    });
+
+    test(
+      'updatesAvailable when there is a peer file but no local last sync',
+      () async {
+        await provider.uploadFile(_payload, peerFileName('deviceB'));
+
+        final result = await initializer.checkSyncOnLaunch(provider);
+
+        expect(result.status, SyncCheckStatus.updatesAvailable);
+      },
+    );
+
+    test('upToDate when the newest peer file predates last sync', () async {
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+      // Peer mtime is ~now; a far-future last-sync is clearly newer.
+      await repository.updateLastSyncTime(DateTime(2999));
+
+      final result = await initializer.checkSyncOnLaunch(provider);
+
+      expect(result.status, SyncCheckStatus.upToDate);
+    });
+
+    test('localChanges when peer is not newer but edits are pending', () async {
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+      await repository.updateLastSyncTime(DateTime(2999));
+      await repository.markRecordPending(
+        entityType: 'dives',
+        recordId: 'dive-1',
+        localUpdatedAt: DateTime(2026).millisecondsSinceEpoch,
+      );
+
+      final result = await initializer.checkSyncOnLaunch(provider);
+
+      expect(result.status, SyncCheckStatus.localChanges);
+      expect(result.pendingChanges, 1);
+    });
+
+    test('our own file alongside a peer still detects the peer', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+      await repository.updateLastSyncTime(DateTime(2020));
+
+      final result = await initializer.checkSyncOnLaunch(provider);
+
+      expect(result.status, SyncCheckStatus.updatesAvailable);
+    });
+  });
+
+  group('checkSyncOnLaunch provider persistence', () {
+    test('saveProvider then getLastProvider round-trips', () async {
+      expect(initializer.getLastProvider(), isNull);
+      await initializer.saveProvider(CloudProviderType.icloud);
+      expect(initializer.getLastProvider(), CloudProviderType.icloud);
+      await initializer.saveProvider(null);
+      expect(initializer.getLastProvider(), isNull);
+    });
+  });
+}

--- a/test/core/services/sync/sync_per_device_files_test.dart
+++ b/test/core/services/sync/sync_per_device_files_test.dart
@@ -104,8 +104,10 @@ void main() {
 
     test('pull applies every other device file in the folder', () async {
       final diveRepo = DiveRepository();
-      final mapA = await validDiveMap('dive-from-A');
-      final mapB = await validDiveMap('dive-from-B');
+      // Distinct maxDepth per device so we verify the actual content merged,
+      // not merely that a row exists (which one file alone could satisfy).
+      final mapA = {...await validDiveMap('dive-from-A'), 'maxDepth': 11.0};
+      final mapB = {...await validDiveMap('dive-from-B'), 'maxDepth': 22.0};
 
       await cloud.uploadFile(
         await craftDeviceFile('device-A', [mapA]),
@@ -119,15 +121,19 @@ void main() {
       final result = await buildService().performSync();
       expect(result.status, isNot(SyncResultStatus.error));
 
+      final a = await diveRepo.getDiveById('dive-from-A');
+      final b = await diveRepo.getDiveById('dive-from-B');
       expect(
-        await diveRepo.getDiveById('dive-from-A'),
-        isNotNull,
-        reason: 'device A\'s file should be applied',
+        a?.maxDepth,
+        11.0,
+        reason: 'device A\'s file should be applied with its field values',
       );
       expect(
-        await diveRepo.getDiveById('dive-from-B'),
-        isNotNull,
-        reason: 'device B\'s file should be applied (all device files merge)',
+        b?.maxDepth,
+        22.0,
+        reason:
+            'device B\'s file should also be applied (all files merge), '
+            'proving both files were read, not just one',
       );
     });
 

--- a/test/core/services/sync/sync_per_device_files_test.dart
+++ b/test/core/services/sync/sync_per_device_files_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Per-device sync files: each device writes its own
+/// `submersion_sync_<deviceId>.json` and merges every other device's file on
+/// read. This removes the single-shared-file write-write race (iCloud
+/// "conflicted copy") that could silently drop a device's push.
+void main() {
+  group('Per-device sync files', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    /// Build a valid serialized payload file for [deviceId] carrying [dives].
+    Future<Uint8List> craftDeviceFile(
+      String deviceId,
+      List<Map<String, dynamic>> dives,
+    ) async {
+      final data = SyncData(dives: dives);
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 1700000000000,
+        deviceId: deviceId,
+        checksum: checksum,
+        data: data,
+        deletions: const {},
+      );
+      return Uint8List.fromList(
+        utf8.encode(SyncDataSerializer().serializePayload(payload)),
+      );
+    }
+
+    /// A valid dive JSON map (as produced by export) with the given id.
+    Future<Map<String, dynamic>> validDiveMap(String id) async {
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(createTestDiveWithBottomTime(id: id));
+      final exported = await SyncDataSerializer().exportData(
+        deviceId: 'seed',
+        deletions: const [],
+      );
+      final map = exported.data.dives.firstWhere((d) => d['id'] == id);
+      await diveRepo.deleteDive(id);
+      // Fully reset device sync state: createDive marked the record pending,
+      // and _mergeEntity skips records in pendingRecordIds. resetSyncState
+      // clears pending + conflict records, the deletion log, and lastSync so
+      // the crafted device files apply cleanly.
+      await SyncRepository().resetSyncState();
+      return map;
+    }
+
+    test(
+      'upload writes a per-device file, not the shared canonical file',
+      () async {
+        final diveRepo = DiveRepository();
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-own-1'),
+        );
+        final deviceId = await SyncRepository().getDeviceId();
+
+        await buildService().performSync();
+
+        expect(
+          cloud.bytesOf('submersion_sync_$deviceId.json'),
+          isNotNull,
+          reason: 'this device should write its own per-device file',
+        );
+        expect(
+          cloud.bytesOf('submersion_sync.json'),
+          isNull,
+          reason:
+              'the single shared canonical file must no longer be written '
+              '(that is the source of the write-write race)',
+        );
+      },
+    );
+
+    test('pull applies every other device file in the folder', () async {
+      final diveRepo = DiveRepository();
+      final mapA = await validDiveMap('dive-from-A');
+      final mapB = await validDiveMap('dive-from-B');
+
+      await cloud.uploadFile(
+        await craftDeviceFile('device-A', [mapA]),
+        'submersion_sync_device-A.json',
+      );
+      await cloud.uploadFile(
+        await craftDeviceFile('device-B', [mapB]),
+        'submersion_sync_device-B.json',
+      );
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(
+        await diveRepo.getDiveById('dive-from-A'),
+        isNotNull,
+        reason: 'device A\'s file should be applied',
+      );
+      expect(
+        await diveRepo.getDiveById('dive-from-B'),
+        isNotNull,
+        reason: 'device B\'s file should be applied (all device files merge)',
+      );
+    });
+
+    test('pull still applies a legacy shared submersion_sync.json', () async {
+      final diveRepo = DiveRepository();
+      final legacyMap = await validDiveMap('dive-legacy');
+
+      await cloud.uploadFile(
+        await craftDeviceFile('old-device', [legacyMap]),
+        'submersion_sync.json',
+      );
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(
+        await diveRepo.getDiveById('dive-legacy'),
+        isNotNull,
+        reason: 'legacy single-file payloads must still import for back-compat',
+      );
+    });
+  });
+}

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -156,5 +156,36 @@ void main() {
       );
       expect(restored!['name'], 'Blue Hole');
     });
+
+    // Media was broken too: its custom export dropped 5 non-nullable fields.
+    test('media metadata round-trips A -> B (toJson export)', () async {
+      final serializer = SyncDataSerializer();
+      final repo = SyncRepository();
+
+      await serializer.upsertRecord('media', {
+        'id': 'media-rt-1',
+        'filePath': '/photos/reef.jpg',
+        'fileType': 'image',
+        'caption': 'Reef shark',
+        'isFavorite': false,
+        'isOrphaned': false,
+        'sourceType': 'local',
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await buildService().performSync(); // push
+
+      await serializer.deleteRecord('media', 'media-rt-1');
+      await repo.resetSyncState();
+      await buildService().performSync(); // pull
+
+      final restored = await serializer.fetchRecord('media', 'media-rt-1');
+      expect(
+        restored,
+        isNotNull,
+        reason: 'media should round-trip A -> B via toJson export',
+      );
+      expect(restored!['caption'], 'Reef shark');
+    });
   });
 }

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
 import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/sync_test_helpers.dart';
 import '../../../helpers/test_database.dart';
 import '../../../helpers/mock_providers.dart';
 
@@ -48,13 +49,13 @@ void main() {
             '(${pushResult.message})',
       );
       expect(
-        cloud.bytesOf('submersion_sync.json'),
+        cloud.syncFileBytes(),
         isNotNull,
-        reason: 'the canonical sync file should exist in the cloud after push',
+        reason: 'this device\'s per-device sync file should exist after push',
       );
       // Export side is healthy: device A's upload must contain the dive.
       final afterPush = SyncDataSerializer().deserializePayload(
-        utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+        utf8.decode(cloud.syncFileBytes()!),
       );
       expect(
         afterPush.data.dives.length,
@@ -67,7 +68,7 @@ void main() {
       // clears the deletion log and the last-sync timestamp. The result is a
       // device that looks like it never had the dive (not one that deleted it).
       await diveRepo.deleteDive('dive-xfer-1');
-      await SyncRepository().resetSyncState();
+      await impersonateFreshDevice();
       expect(
         await diveRepo.getDiveById('dive-xfer-1'),
         isNull,
@@ -112,7 +113,7 @@ void main() {
       await buildService().performSync(); // device A push
 
       await diveRepo.deleteDive('dive-fields-1');
-      await SyncRepository().resetSyncState();
+      await impersonateFreshDevice();
       await buildService().performSync(); // device B pull
 
       final restored = await diveRepo.getDiveById('dive-fields-1');
@@ -129,7 +130,6 @@ void main() {
     // Verifies the mass toJson() export conversion works for a non-dive entity.
     test('a dive site round-trips A -> B with its fields', () async {
       final serializer = SyncDataSerializer();
-      final repo = SyncRepository();
 
       // Seed a site on "device A" via the import path (no companion needed).
       await serializer.upsertRecord('diveSites', {
@@ -145,7 +145,7 @@ void main() {
 
       // Impersonate a fresh device B.
       await serializer.deleteRecord('diveSites', 'site-rt-1');
-      await repo.resetSyncState();
+      await impersonateFreshDevice();
       expect(await serializer.fetchRecord('diveSites', 'site-rt-1'), isNull);
 
       await buildService().performSync(); // pull
@@ -162,7 +162,6 @@ void main() {
     // Media was broken too: its custom export dropped 5 non-nullable fields.
     test('media metadata round-trips A -> B (toJson export)', () async {
       final serializer = SyncDataSerializer();
-      final repo = SyncRepository();
 
       await serializer.upsertRecord('media', {
         'id': 'media-rt-1',
@@ -178,7 +177,7 @@ void main() {
       await buildService().performSync(); // push
 
       await serializer.deleteRecord('media', 'media-rt-1');
-      await repo.resetSyncState();
+      await impersonateFreshDevice();
       await buildService().performSync(); // pull
 
       final restored = await serializer.fetchRecord('media', 'media-rt-1');
@@ -196,7 +195,6 @@ void main() {
       'an unapplyable record surfaces as a sync error, not a conflict',
       () async {
         final serializer = SyncDataSerializer();
-        final repo = SyncRepository();
         final diveRepo = DiveRepository();
 
         await diveRepo.createDive(
@@ -207,7 +205,7 @@ void main() {
         // Corrupt a dive field so Dive.fromJson throws on import, then recompute
         // the checksum so the payload still passes validation.
         final payload = serializer.deserializePayload(
-          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+          utf8.decode(cloud.syncFileBytes()!),
         );
         payload.data.dives.first['maxDepth'] = 'NOT_A_NUMBER';
         final checksum = sha256
@@ -222,14 +220,16 @@ void main() {
           data: payload.data,
           deletions: payload.deletions,
         );
+        // Overwrite device A's own per-device file with the corrupt content,
+        // so the fresh device B below downloads it as a foreign file.
         await cloud.uploadFile(
           Uint8List.fromList(utf8.encode(serializer.serializePayload(corrupt))),
-          'submersion_sync.json',
+          'submersion_sync_${payload.deviceId}.json',
         );
 
         // Device B pulls the corrupt file.
         await diveRepo.deleteDive('dive-corrupt-1');
-        await repo.resetSyncState();
+        await impersonateFreshDevice();
         final result = await buildService().performSync();
 
         expect(

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -187,5 +189,55 @@ void main() {
       );
       expect(restored!['caption'], 'Reef shark');
     });
+
+    // De-mask: a record that cannot be applied must surface as a sync ERROR,
+    // not be silently relabeled as a "conflict" (the masking that hid the bug).
+    test(
+      'an unapplyable record surfaces as a sync error, not a conflict',
+      () async {
+        final serializer = SyncDataSerializer();
+        final repo = SyncRepository();
+        final diveRepo = DiveRepository();
+
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-corrupt-1'),
+        );
+        await buildService().performSync(); // push a valid payload
+
+        // Corrupt a dive field so Dive.fromJson throws on import, then recompute
+        // the checksum so the payload still passes validation.
+        final payload = serializer.deserializePayload(
+          utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+        );
+        payload.data.dives.first['maxDepth'] = 'NOT_A_NUMBER';
+        final checksum = sha256
+            .convert(utf8.encode(jsonEncode(payload.data.toJson())))
+            .toString();
+        final corrupt = SyncPayload(
+          version: payload.version,
+          exportedAt: payload.exportedAt,
+          deviceId: payload.deviceId,
+          lastSyncTimestamp: payload.lastSyncTimestamp,
+          checksum: checksum,
+          data: payload.data,
+          deletions: payload.deletions,
+        );
+        await cloud.uploadFile(
+          Uint8List.fromList(utf8.encode(serializer.serializePayload(corrupt))),
+          'submersion_sync.json',
+        );
+
+        // Device B pulls the corrupt file.
+        await diveRepo.deleteDive('dive-corrupt-1');
+        await repo.resetSyncState();
+        final result = await buildService().performSync();
+
+        expect(
+          result.status,
+          SyncResultStatus.error,
+          reason: 'an apply failure must surface as an error, not be masked',
+        );
+      },
+    );
   });
 }

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+import '../../../helpers/mock_providers.dart';
+
+void main() {
+  group('Sync end-to-end round-trip (fake provider)', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    test('a dive created on "device A" is restored on "device B"', () async {
+      final diveRepo = DiveRepository();
+
+      // Device A: seed and push.
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-xfer-1', diveNumber: 11),
+      );
+      final pushResult = await buildService().performSync();
+      expect(
+        pushResult.isSuccess,
+        isTrue,
+        reason:
+            'device A push should succeed; got ${pushResult.status} '
+            '(${pushResult.message})',
+      );
+      expect(
+        cloud.bytesOf('submersion_sync.json'),
+        isNotNull,
+        reason: 'the canonical sync file should exist in the cloud after push',
+      );
+      // Export side is healthy: device A's upload must contain the dive.
+      final afterPush = SyncDataSerializer().deserializePayload(
+        utf8.decode(await cloud.downloadFile('submersion_sync.json')),
+      );
+      expect(
+        afterPush.data.dives.length,
+        1,
+        reason: 'device A export uploaded the dive (export side is healthy)',
+      );
+
+      // Impersonate a FRESH device B sharing the same cloud: remove the dive
+      // locally first (this logs a deletion), THEN reset sync state, which
+      // clears the deletion log and the last-sync timestamp. The result is a
+      // device that looks like it never had the dive (not one that deleted it).
+      await diveRepo.deleteDive('dive-xfer-1');
+      await SyncRepository().resetSyncState();
+      expect(
+        await diveRepo.getDiveById('dive-xfer-1'),
+        isNull,
+        reason: 'precondition: dive is gone locally before the pull',
+      );
+
+      // Device B: pull.
+      final pullResult = await buildService().performSync();
+      expect(
+        pullResult.isSuccess,
+        isTrue,
+        reason:
+            'device B pull should succeed; got ${pullResult.status} '
+            '(${pullResult.message})',
+      );
+
+      // The decisive assertion. This currently FAILS: on a receiving device,
+      // _mergeEntity catches an exception thrown while applying the incoming
+      // dive and relabels it as a "conflict" (pull reports hasConflicts with
+      // conflictsFound == 1), so the record never upserts. See the Phase 0
+      // findings doc. Expected to pass once the merge-apply defect is fixed.
+      final restored = await diveRepo.getDiveById('dive-xfer-1');
+      expect(
+        restored,
+        isNotNull,
+        reason: 'THE BUG: dive did not propagate A -> B through the round-trip',
+      );
+    });
+  });
+}

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -82,11 +82,12 @@ void main() {
             '(${pullResult.message})',
       );
 
-      // The decisive assertion. This currently FAILS: on a receiving device,
-      // _mergeEntity catches an exception thrown while applying the incoming
-      // dive and relabels it as a "conflict" (pull reports hasConflicts with
-      // conflictsFound == 1), so the record never upserts. See the Phase 0
-      // findings doc. Expected to pass once the merge-apply defect is fixed.
+      // The decisive assertion. Regression test for the cross-device sync
+      // no-op: the non-nullable v1.5 field `isPlanned` was missing from the
+      // dive export, so Dive.fromJson threw on every receiving device and
+      // _mergeEntity masked it as a "conflict" -- so nothing ever synced.
+      // Fixed by exporting isPlanned. See
+      // docs/superpowers/findings/2026-06-02-icloud-sync-diagnosis.md.
       final restored = await diveRepo.getDiveById('dive-xfer-1');
       expect(
         restored,

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -95,5 +95,33 @@ void main() {
         reason: 'THE BUG: dive did not propagate A -> B through the round-trip',
       );
     });
+
+    test('dive field values survive A -> B, not just the row', () async {
+      final diveRepo = DiveRepository();
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(
+          id: 'dive-fields-1',
+          diveNumber: 22,
+          bottomTime: const Duration(minutes: 45),
+          maxDepth: 30.5,
+          waterTemp: 19.0,
+        ),
+      );
+      await buildService().performSync(); // device A push
+
+      await diveRepo.deleteDive('dive-fields-1');
+      await SyncRepository().resetSyncState();
+      await buildService().performSync(); // device B pull
+
+      final restored = await diveRepo.getDiveById('dive-fields-1');
+      expect(restored, isNotNull);
+      expect(
+        restored!.bottomTime,
+        const Duration(minutes: 45),
+        reason: 'bottomTime must survive sync (was dropped via a key mismatch)',
+      );
+      expect(restored.maxDepth, 30.5);
+      expect(restored.waterTemp, 19.0);
+    });
   });
 }

--- a/test/core/services/sync/sync_round_trip_test.dart
+++ b/test/core/services/sync/sync_round_trip_test.dart
@@ -123,5 +123,38 @@ void main() {
       expect(restored.maxDepth, 30.5);
       expect(restored.waterTemp, 19.0);
     });
+
+    // Verifies the mass toJson() export conversion works for a non-dive entity.
+    test('a dive site round-trips A -> B with its fields', () async {
+      final serializer = SyncDataSerializer();
+      final repo = SyncRepository();
+
+      // Seed a site on "device A" via the import path (no companion needed).
+      await serializer.upsertRecord('diveSites', {
+        'id': 'site-rt-1',
+        'name': 'Blue Hole',
+        'description': 'A nice wall dive',
+        'notes': '',
+        'isShared': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await buildService().performSync(); // push
+
+      // Impersonate a fresh device B.
+      await serializer.deleteRecord('diveSites', 'site-rt-1');
+      await repo.resetSyncState();
+      expect(await serializer.fetchRecord('diveSites', 'site-rt-1'), isNull);
+
+      await buildService().performSync(); // pull
+
+      final restored = await serializer.fetchRecord('diveSites', 'site-rt-1');
+      expect(
+        restored,
+        isNotNull,
+        reason: 'dive site should round-trip A -> B via toJson export',
+      );
+      expect(restored!['name'], 'Blue Hole');
+    });
   });
 }

--- a/test/core/services/sync/sync_serializer_fetch_record_test.dart
+++ b/test/core/services/sync/sync_serializer_fetch_record_test.dart
@@ -1,0 +1,236 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Exercises [SyncDataSerializer.fetchRecord] across every syncable entity
+/// type. fetchRecord is the read side of the per-record sync path (used when
+/// re-fetching a locally-pending row); it must stay symmetric with the
+/// upsert/import switch.
+///
+/// Two passes:
+///  - absent rows: confirm each case returns null (the query + null-return).
+///  - seeded rows: a minimal row is inserted per table so `row?.toJson()`
+///    actually invokes toJson (the null-aware call is otherwise never reached
+///    on an empty table), which also exercises each table's generated row
+///    mapping including the nullable `hlc` column.
+void main() {
+  late SyncDataSerializer serializer;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  // Insert one minimal row into [table]: the single-column primary key is set
+  // to [id]; every other NOT NULL column with no default gets a
+  // type-appropriate placeholder. Throws for composite-PK tables (handled
+  // separately). FK enforcement is off for raw statements in tests, so
+  // placeholder FK values are fine.
+  Future<void> seedMinimalRow(String table, String id) async {
+    final cols = await db
+        .customSelect(
+          'SELECT * FROM pragma_table_info(?)',
+          variables: [Variable.withString(table)],
+        )
+        .get();
+    final pkCols = cols.where((c) => (c.data['pk'] as int? ?? 0) > 0).toList();
+    if (pkCols.length != 1) {
+      throw StateError('table $table does not have a single-column PK');
+    }
+    final pkName = pkCols.first.read<String>('name');
+
+    final names = <String>[];
+    final placeholders = <String>[];
+    final values = <Object?>[];
+    for (final c in cols) {
+      final name = c.read<String>('name');
+      final notNull = (c.data['notnull'] as int? ?? 0) == 1;
+      final hasDefault = c.data['dflt_value'] != null;
+      final type = (c.data['type'] as String? ?? '').toUpperCase();
+      if (name == pkName) {
+        names.add('"$name"');
+        placeholders.add('?');
+        values.add(id);
+      } else if (notNull && !hasDefault) {
+        names.add('"$name"');
+        placeholders.add('?');
+        if (type.contains('INT')) {
+          values.add(0);
+        } else if (type.contains('REAL') ||
+            type.contains('FLOA') ||
+            type.contains('DOUB')) {
+          values.add(0.0);
+        } else if (type.contains('BLOB')) {
+          values.add(Uint8List(0));
+        } else {
+          values.add('x');
+        }
+      }
+    }
+    await db.customStatement(
+      'INSERT INTO "$table" (${names.join(",")}) VALUES (${placeholders.join(",")})',
+      values,
+    );
+  }
+
+  group('SyncDataSerializer.fetchRecord', () {
+    const simpleTypes = <String>[
+      'divers',
+      'diverSettings',
+      'dives',
+      'diveProfiles',
+      'diveTanks',
+      'diveWeights',
+      'diveSites',
+      'equipment',
+      'equipmentSets',
+      'media',
+      'buddies',
+      'diveBuddies',
+      'certifications',
+      'courses',
+      'serviceRecords',
+      'diveCenters',
+      'trips',
+      'liveaboardDetails',
+      'itineraryDays',
+      'tags',
+      'diveTags',
+      'diveTypes',
+      'tankPresets',
+      'diveComputers',
+      'tankPressureProfiles',
+      'tideRecords',
+      'settings',
+      'species',
+      'sightings',
+      'diveProfileEvents',
+      'gasSwitches',
+      'diveCustomFields',
+      'diveDataSources',
+      'siteSpecies',
+      'csvPresets',
+      'viewConfigs',
+      'fieldPresets',
+    ];
+
+    for (final type in simpleTypes) {
+      test('returns null for an absent $type row', () async {
+        expect(await serializer.fetchRecord(type, 'no-such-id'), isNull);
+      });
+    }
+
+    test('returns null for absent composite-id rows', () async {
+      // diveEquipment + equipmentSetItems are keyed by "diveId|equipmentId".
+      expect(await serializer.fetchRecord('diveEquipment', 'a|b'), isNull);
+      expect(await serializer.fetchRecord('equipmentSetItems', 'a|b'), isNull);
+    });
+
+    test('returns null when a composite id is malformed', () async {
+      expect(
+        await serializer.fetchRecord('diveEquipment', 'noseparator'),
+        isNull,
+      );
+      expect(
+        await serializer.fetchRecord('equipmentSetItems', 'noseparator'),
+        isNull,
+      );
+    });
+
+    test('returns null for an unknown entity type', () async {
+      expect(await serializer.fetchRecord('totallyUnknown', 'x'), isNull);
+    });
+
+    test('fetches a seeded row for each single-PK entity type', () async {
+      // Drift enables foreign_keys by default; turn it off so a minimal
+      // placeholder row needn't satisfy parent references (these throwaway
+      // rows only exist to exercise each table's row mapping + toJson).
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      // entityType -> live SQL table name (avoids snake_case guessing).
+      final targets = <({String type, String table})>[
+        (type: 'divers', table: db.divers.actualTableName),
+        (type: 'diverSettings', table: db.diverSettings.actualTableName),
+        (type: 'dives', table: db.dives.actualTableName),
+        (type: 'diveProfiles', table: db.diveProfiles.actualTableName),
+        (type: 'diveTanks', table: db.diveTanks.actualTableName),
+        (type: 'diveWeights', table: db.diveWeights.actualTableName),
+        (type: 'diveSites', table: db.diveSites.actualTableName),
+        (type: 'equipment', table: db.equipment.actualTableName),
+        (type: 'equipmentSets', table: db.equipmentSets.actualTableName),
+        (type: 'media', table: db.media.actualTableName),
+        (type: 'buddies', table: db.buddies.actualTableName),
+        (type: 'diveBuddies', table: db.diveBuddies.actualTableName),
+        (type: 'certifications', table: db.certifications.actualTableName),
+        (type: 'courses', table: db.courses.actualTableName),
+        (type: 'serviceRecords', table: db.serviceRecords.actualTableName),
+        (type: 'diveCenters', table: db.diveCenters.actualTableName),
+        (type: 'trips', table: db.trips.actualTableName),
+        (
+          type: 'liveaboardDetails',
+          table: db.liveaboardDetailRecords.actualTableName,
+        ),
+        (type: 'itineraryDays', table: db.tripItineraryDays.actualTableName),
+        (type: 'tags', table: db.tags.actualTableName),
+        (type: 'diveTags', table: db.diveTags.actualTableName),
+        (type: 'diveTypes', table: db.diveTypes.actualTableName),
+        (type: 'tankPresets', table: db.tankPresets.actualTableName),
+        (type: 'diveComputers', table: db.diveComputers.actualTableName),
+        (
+          type: 'tankPressureProfiles',
+          table: db.tankPressureProfiles.actualTableName,
+        ),
+        (type: 'tideRecords', table: db.tideRecords.actualTableName),
+        (type: 'settings', table: db.settings.actualTableName),
+        (type: 'species', table: db.species.actualTableName),
+        (type: 'sightings', table: db.sightings.actualTableName),
+        (
+          type: 'diveProfileEvents',
+          table: db.diveProfileEvents.actualTableName,
+        ),
+        (type: 'gasSwitches', table: db.gasSwitches.actualTableName),
+        (type: 'diveCustomFields', table: db.diveCustomFields.actualTableName),
+        (type: 'diveDataSources', table: db.diveDataSources.actualTableName),
+        (type: 'siteSpecies', table: db.siteSpecies.actualTableName),
+        (type: 'csvPresets', table: db.csvPresets.actualTableName),
+        (type: 'viewConfigs', table: db.viewConfigs.actualTableName),
+        (type: 'fieldPresets', table: db.fieldPresets.actualTableName),
+      ];
+
+      var fetched = 0;
+      final failures = <String>[];
+      for (final t in targets) {
+        final id = 'seed-${t.type}';
+        try {
+          await seedMinimalRow(t.table, id);
+        } catch (_) {
+          // Some tables resist a trivial placeholder insert (composite PK,
+          // CHECK constraints); skip them -- the absent-row pass still covers
+          // the query path.
+          continue;
+        }
+        final row = await serializer.fetchRecord(t.type, id);
+        if (row != null) {
+          fetched++;
+        } else {
+          failures.add(t.type);
+        }
+      }
+
+      expect(
+        fetched,
+        greaterThanOrEqualTo(25),
+        reason: 'most entity types should seed+fetch; failures: $failures',
+      );
+    });
+  });
+}

--- a/test/core/services/sync/sync_serializer_round_trip_test.dart
+++ b/test/core/services/sync/sync_serializer_round_trip_test.dart
@@ -17,37 +17,43 @@ void main() {
       DatabaseService.instance.resetForTesting();
     });
 
-    test('a dive survives export -> serialize -> deserialize with valid checksum', () async {
-      // Seed one dive. If the first run fails on a foreign-key requirement
-      // (e.g. a diver must exist), insert that prerequisite first — the red
-      // run will tell you exactly what is missing.
-      final dive = createTestDiveWithBottomTime(id: 'dive-rt-1', diveNumber: 7);
-      await DiveRepository().createDive(dive);
+    test(
+      'a dive survives export -> serialize -> deserialize with valid checksum',
+      () async {
+        // Seed one dive. If the first run fails on a foreign-key requirement
+        // (e.g. a diver must exist), insert that prerequisite first — the red
+        // run will tell you exactly what is missing.
+        final dive = createTestDiveWithBottomTime(
+          id: 'dive-rt-1',
+          diveNumber: 7,
+        );
+        await DiveRepository().createDive(dive);
 
-      final serializer = SyncDataSerializer();
-      final repo = SyncRepository();
-      final deviceId = await repo.getDeviceId();
-      final deletions = await repo.getAllDeletions();
+        final serializer = SyncDataSerializer();
+        final repo = SyncRepository();
+        final deviceId = await repo.getDeviceId();
+        final deletions = await repo.getAllDeletions();
 
-      final payload = await serializer.exportData(
-        deviceId: deviceId,
-        since: null,
-        lastSyncTimestamp: null,
-        deletions: deletions,
-      );
-      final json = serializer.serializePayload(payload);
-      final restored = serializer.deserializePayload(json);
+        final payload = await serializer.exportData(
+          deviceId: deviceId,
+          since: null,
+          lastSyncTimestamp: null,
+          deletions: deletions,
+        );
+        final json = serializer.serializePayload(payload);
+        final restored = serializer.deserializePayload(json);
 
-      expect(
-        serializer.validateChecksum(restored),
-        isTrue,
-        reason: 'checksum should validate after a clean round-trip',
-      );
-      expect(
-        json,
-        contains('dive-rt-1'),
-        reason: 'the seeded dive must appear in the exported payload',
-      );
-    });
+        expect(
+          serializer.validateChecksum(restored),
+          isTrue,
+          reason: 'checksum should validate after a clean round-trip',
+        );
+        expect(
+          json,
+          contains('dive-rt-1'),
+          reason: 'the seeded dive must appear in the exported payload',
+        );
+      },
+    );
   });
 }

--- a/test/core/services/sync/sync_serializer_round_trip_test.dart
+++ b/test/core/services/sync/sync_serializer_round_trip_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/test_database.dart';
+import '../../../helpers/mock_providers.dart';
+
+void main() {
+  group('Sync serializer symmetry', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    test('a dive survives export -> serialize -> deserialize with valid checksum', () async {
+      // Seed one dive. If the first run fails on a foreign-key requirement
+      // (e.g. a diver must exist), insert that prerequisite first — the red
+      // run will tell you exactly what is missing.
+      final dive = createTestDiveWithBottomTime(id: 'dive-rt-1', diveNumber: 7);
+      await DiveRepository().createDive(dive);
+
+      final serializer = SyncDataSerializer();
+      final repo = SyncRepository();
+      final deviceId = await repo.getDeviceId();
+      final deletions = await repo.getAllDeletions();
+
+      final payload = await serializer.exportData(
+        deviceId: deviceId,
+        since: null,
+        lastSyncTimestamp: null,
+        deletions: deletions,
+      );
+      final json = serializer.serializePayload(payload);
+      final restored = serializer.deserializePayload(json);
+
+      expect(
+        serializer.validateChecksum(restored),
+        isTrue,
+        reason: 'checksum should validate after a clean round-trip',
+      );
+      expect(
+        json,
+        contains('dive-rt-1'),
+        reason: 'the seeded dive must appear in the exported payload',
+      );
+    });
+  });
+}

--- a/test/features/dive_log/data/repositories/view_config_repository_test.dart
+++ b/test/features/dive_log/data/repositories/view_config_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/database/database.dart' hide FieldPreset;
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/view_field_config.dart';
 
@@ -330,6 +331,47 @@ void main() {
         );
         expect(presets.any((p) => p.id == 'builtin_standard'), isTrue);
       });
+    });
+
+    group('sync notifications', () {
+      // View-config edits stage themselves as pending; the change bus is what
+      // schedules on-change auto-sync. Regression for the missing bus calls.
+      test('saveTableConfig notifies the sync change bus', () async {
+        var fired = false;
+        final sub = SyncEventBus.changes.listen((_) => fired = true);
+        addTearDown(sub.cancel);
+
+        await repository.saveTableConfig(
+          testDiverId,
+          TableViewConfig.defaultConfig(),
+        );
+        await pumpEventQueue();
+
+        expect(fired, isTrue);
+      });
+
+      test(
+        'deletePreset notifies the bus when a user preset is removed',
+        () async {
+          final preset = FieldPreset(
+            id: 'np-1',
+            name: 'NotifyMe',
+            viewMode: ListViewMode.table,
+            configJson: TableViewConfig.defaultConfig().toJson(),
+            isBuiltIn: false,
+          );
+          await repository.savePreset(testDiverId, preset);
+
+          var fired = false;
+          final sub = SyncEventBus.changes.listen((_) => fired = true);
+          addTearDown(sub.cancel);
+
+          await repository.deletePreset('np-1');
+          await pumpEventQueue();
+
+          expect(fired, isTrue);
+        },
+      );
     });
   });
 }

--- a/test/features/dive_log/data/repositories/view_config_repository_test.dart
+++ b/test/features/dive_log/data/repositories/view_config_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/database/database.dart' hide FieldPreset;
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/view_field_config.dart';
 
@@ -15,6 +16,9 @@ void main() {
   setUp(() async {
     db = AppDatabase(NativeDatabase.memory());
     repository = ViewConfigRepository(db);
+    // deletePreset logs a deletion through SyncRepository(), which reads
+    // DatabaseService.instance -- point it at this same in-memory db.
+    DatabaseService.instance.setTestDatabase(db);
 
     final now = DateTime.now().millisecondsSinceEpoch;
     await db
@@ -30,6 +34,7 @@ void main() {
   });
 
   tearDown(() async {
+    DatabaseService.instance.resetForTesting();
     await db.close();
   });
 

--- a/test/features/divers/diver_merge_repository_test.dart
+++ b/test/features/divers/diver_merge_repository_test.dart
@@ -344,6 +344,72 @@ void main() {
           .getSingle();
       expect(remaining.read<int>('c'), 0);
     });
+
+    test('undo is a true inverse of sync state: no tombstones or pending '
+        'residue remain', () async {
+      // Additive row owned by the duplicate (repointed -> marked pending).
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion.insert(
+              id: 'dive-resid',
+              diveDateTime: 2000,
+              diverId: const Value(dup),
+              createdAt: 2000,
+              updatedAt: 2000,
+            ),
+          );
+      // Singleton config on both keeper and duplicate (duplicate's is deleted
+      // -> tombstone logged).
+      for (final owner in [keeper, dup]) {
+        await db
+            .into(db.viewConfigs)
+            .insert(
+              ViewConfigsCompanion.insert(
+                id: 'vc-$owner',
+                diverId: owner,
+                viewMode: 'table',
+                configJson: '{}',
+                updatedAt: 2000,
+              ),
+            );
+      }
+
+      final snapshot = await repo.mergeDivers(
+        keeperId: keeper,
+        duplicateId: dup,
+      );
+      // Sanity: the merge created tombstone(s) and pending residue.
+      final tombstonesAfterMerge =
+          (await db
+                  .customSelect('SELECT COUNT(*) AS c FROM deletion_log')
+                  .getSingle())
+              .read<int>('c');
+      expect(tombstonesAfterMerge, greaterThan(0));
+
+      await repo.undoMerge(snapshot);
+
+      final tombstones =
+          (await db
+                  .customSelect('SELECT COUNT(*) AS c FROM deletion_log')
+                  .getSingle())
+              .read<int>('c');
+      final pending =
+          (await db
+                  .customSelect('SELECT COUNT(*) AS c FROM sync_records')
+                  .getSingle())
+              .read<int>('c');
+      expect(
+        tombstones,
+        0,
+        reason: 'undo must clear every tombstone the merge logged',
+      );
+      expect(
+        pending,
+        0,
+        reason: 'undo must clear the pending residue the merge created',
+      );
+    });
   });
 
   group('findDuplicateGroups', () {

--- a/test/features/divers/diver_merge_repository_test.dart
+++ b/test/features/divers/diver_merge_repository_test.dart
@@ -236,6 +236,116 @@ void main() {
     },
   );
 
+  group('undoMerge', () {
+    /// Returns a snapshot of the entire DB state relevant to the merge:
+    /// every row in every diver_id table, plus the divers themselves. Used
+    /// to assert merge -> undo produces a true restore.
+    Future<Map<String, List<Map<String, dynamic>>>> dbSnapshot() async {
+      final snap = <String, List<Map<String, dynamic>>>{};
+      final tables =
+          (await db
+                  .customSelect(
+                    "SELECT m.name AS tbl FROM sqlite_master m "
+                    "JOIN pragma_table_info(m.name) p "
+                    "WHERE m.type = 'table' AND p.name = 'diver_id'",
+                  )
+                  .get())
+              .map((r) => r.read<String>('tbl'))
+              .toList();
+      tables.add('divers');
+      for (final t in tables) {
+        final rows = await db
+            .customSelect('SELECT * FROM "$t" ORDER BY id')
+            .get();
+        snap[t] = rows.map((r) => Map<String, dynamic>.from(r.data)).toList();
+      }
+      return snap;
+    }
+
+    test('merge followed by undo restores every diver_id table to its '
+        'pre-merge state', () async {
+      // Seed an additive row in every diver_id table for the duplicate, and
+      // a singleton-config row (viewConfigs) for both keeper and duplicate.
+      final tables = await db
+          .customSelect(
+            "SELECT m.name AS tbl FROM sqlite_master m "
+            "JOIN pragma_table_info(m.name) p "
+            "WHERE m.type = 'table' AND p.name = 'diver_id' "
+            "AND m.name != 'divers'",
+          )
+          .get();
+      var i = 0;
+      for (final r in tables) {
+        await seedRow(r.read<String>('tbl'), dup, 'row-$i');
+        i++;
+      }
+      // Keeper view_configs row so the singleton-deletion path runs against
+      // a non-empty target -- merge will drop the duplicate's row.
+      await db
+          .into(db.viewConfigs)
+          .insert(
+            ViewConfigsCompanion.insert(
+              id: 'vc-keeper',
+              diverId: keeper,
+              viewMode: 'table',
+              configJson: '{"k":1}',
+              updatedAt: 1000,
+            ),
+          );
+
+      final before = await dbSnapshot();
+      final snapshot = await repo.mergeDivers(
+        keeperId: keeper,
+        duplicateId: dup,
+      );
+      await repo.undoMerge(snapshot);
+      final after = await dbSnapshot();
+
+      // Whole-DB equality: row sets per table match exactly.
+      expect(after.keys.toSet(), before.keys.toSet());
+      for (final t in before.keys) {
+        expect(
+          after[t],
+          before[t],
+          reason: 'table $t did not restore to its pre-merge state',
+        );
+      }
+    });
+
+    test('undo restores the duplicate diver itself', () async {
+      final snapshot = await repo.mergeDivers(
+        keeperId: keeper,
+        duplicateId: dup,
+      );
+      expect(
+        (await db.select(db.divers).get()).map((d) => d.id).toSet(),
+        isNot(contains(dup)),
+      );
+
+      await repo.undoMerge(snapshot);
+      expect(
+        (await db.select(db.divers).get()).map((d) => d.id).toSet(),
+        containsAll([keeper, dup]),
+      );
+    });
+
+    test('undo clears the divers deletion-log tombstone', () async {
+      final snapshot = await repo.mergeDivers(
+        keeperId: keeper,
+        duplicateId: dup,
+      );
+      await repo.undoMerge(snapshot);
+      final remaining = await db
+          .customSelect(
+            "SELECT COUNT(*) AS c FROM deletion_log "
+            "WHERE entity_type = 'divers' AND record_id = ?",
+            variables: [Variable.withString(dup)],
+          )
+          .getSingle();
+      expect(remaining.read<int>('c'), 0);
+    });
+  });
+
   group('findDuplicateGroups', () {
     test('groups divers with the same normalized name', () {
       final groups = DiverMergeRepository.findDuplicateGroups([

--- a/test/features/divers/diver_merge_repository_test.dart
+++ b/test/features/divers/diver_merge_repository_test.dart
@@ -1,0 +1,279 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart'
+    as domain;
+
+import '../../helpers/test_database.dart';
+
+domain.Diver makeDiver(
+  String id,
+  String name, {
+  bool isDefault = false,
+  int createdAt = 0,
+}) {
+  return domain.Diver(
+    id: id,
+    name: name,
+    isDefault: isDefault,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(createdAt),
+  );
+}
+
+/// Exhaustive, schema-driven coverage for diver merge.
+///
+/// Rather than hand-seed 16 hand-written Companion rows (brittle against schema
+/// changes), this test discovers every table that has a `diver_id` column via
+/// SQLite's catalog, seeds one minimal row per table pointing at the duplicate,
+/// runs the merge, then sweeps every such table asserting no row still points
+/// at the deleted duplicate. Any future table that gains a diver_id is covered
+/// automatically.
+void main() {
+  late AppDatabase db;
+  late DiverMergeRepository repo;
+
+  const keeper = 'diver-keeper';
+  const dup = 'diver-dup';
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = DiverMergeRepository();
+
+    for (final id in [keeper, dup]) {
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion.insert(
+              id: id,
+              name: 'Alex Diver',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          );
+    }
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  /// All user tables (excluding the divers table itself) that have a
+  /// `diver_id` column, discovered from the live schema.
+  Future<List<String>> tablesWithDiverId() async {
+    final rows = await db
+        .customSelect(
+          "SELECT m.name AS tbl FROM sqlite_master m "
+          "JOIN pragma_table_info(m.name) p "
+          "WHERE m.type = 'table' AND p.name = 'diver_id' "
+          "AND m.name != 'divers'",
+        )
+        .get();
+    return rows.map((r) => r.read<String>('tbl')).toList();
+  }
+
+  Future<int> countByDiver(String table, String diverId) async {
+    final row = await db
+        .customSelect(
+          'SELECT COUNT(*) AS c FROM "$table" WHERE diver_id = ?',
+          variables: [Variable.withString(diverId)],
+        )
+        .getSingle();
+    return row.read<int>('c');
+  }
+
+  /// Column names for [table] that are NOT NULL and have no default, so a
+  /// minimal INSERT can satisfy them.
+  Future<List<({String name, String type})>> requiredColumns(
+    String table,
+  ) async {
+    final rows = await db
+        .customSelect(
+          'SELECT * FROM pragma_table_info(?)',
+          variables: [Variable.withString(table)],
+        )
+        .get();
+    return rows
+        .where(
+          (r) =>
+              (r.data['notnull'] as int? ?? 0) == 1 &&
+              r.data['dflt_value'] == null,
+        )
+        .map(
+          (r) => (
+            name: r.data['name'] as String,
+            type: (r.data['type'] as String?) ?? '',
+          ),
+        )
+        .toList();
+  }
+
+  /// Insert one minimal row into [table] with diver_id = [diverId], filling
+  /// every required column with a type-appropriate placeholder.
+  Future<void> seedRow(String table, String diverId, String pk) async {
+    final cols = await requiredColumns(table);
+    final names = <String>[];
+    final placeholders = <String>[];
+    final vars = <Variable>[];
+    for (final col in cols) {
+      names.add('"${col.name}"');
+      placeholders.add('?');
+      if (col.name == 'diver_id') {
+        vars.add(Variable.withString(diverId));
+      } else if (col.name == 'id') {
+        vars.add(Variable.withString(pk));
+      } else {
+        final t = col.type.toUpperCase();
+        if (t.contains('INT')) {
+          vars.add(Variable.withInt(0));
+        } else if (t.contains('REAL') ||
+            t.contains('FLOA') ||
+            t.contains('DOUB')) {
+          vars.add(Variable.withReal(0));
+        } else if (t.contains('BLOB')) {
+          vars.add(Variable.withBlob(Uint8List(0)));
+        } else {
+          vars.add(Variable.withString('x'));
+        }
+      }
+    }
+    // Ensure diver_id present even if it was nullable (not in requiredColumns).
+    if (!names.contains('"diver_id"')) {
+      names.add('"diver_id"');
+      placeholders.add('?');
+      vars.add(Variable.withString(diverId));
+    }
+    // Ensure a primary key id present even if nullable.
+    if (!names.contains('"id"')) {
+      names.add('"id"');
+      placeholders.add('?');
+      vars.add(Variable.withString(pk));
+    }
+    await db.customStatement(
+      'INSERT INTO "$table" (${names.join(",")}) '
+      'VALUES (${placeholders.join(",")})',
+      vars.map((v) => v.value).toList(),
+    );
+  }
+
+  test('every diver_id table is repointed or cleared; none reference the '
+      'duplicate after merge', () async {
+    final tables = await tablesWithDiverId();
+    expect(tables, isNotEmpty, reason: 'sanity: schema has diver_id tables');
+
+    // Seed one duplicate-owned row per table.
+    var i = 0;
+    for (final table in tables) {
+      await seedRow(table, dup, 'row-$i');
+      i++;
+      expect(
+        await countByDiver(table, dup),
+        1,
+        reason: 'precondition: $table seeded with a duplicate-owned row',
+      );
+    }
+
+    await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+
+    for (final table in tables) {
+      expect(
+        await countByDiver(table, dup),
+        0,
+        reason: '$table still references the deleted duplicate after merge',
+      );
+    }
+  });
+
+  test('the duplicate diver row is deleted and the keeper remains', () async {
+    await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+    final ids = (await db.select(db.divers).get()).map((d) => d.id).toSet();
+    expect(ids, contains(keeper));
+    expect(ids, isNot(contains(dup)));
+  });
+
+  test('additive data is preserved on the keeper, not lost', () async {
+    // A dive owned by the duplicate must survive, now owned by the keeper.
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'dive-keepme',
+            diveDateTime: 2000,
+            diverId: const Value(dup),
+            createdAt: 2000,
+            updatedAt: 2000,
+          ),
+        );
+
+    await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+
+    expect(await countByDiver('dives', keeper), 1);
+    final dive = await (db.select(
+      db.dives,
+    )..where((t) => t.id.equals('dive-keepme'))).getSingleOrNull();
+    expect(
+      dive,
+      isNotNull,
+      reason: 'the dive must not be deleted by the merge',
+    );
+    expect(dive!.diverId, keeper);
+  });
+
+  test(
+    'the duplicate deletion is logged so it propagates to other devices',
+    () async {
+      await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+      final logged = await db
+          .customSelect(
+            "SELECT COUNT(*) AS c FROM deletion_log "
+            "WHERE entity_type = 'divers' AND record_id = ?",
+            variables: [Variable.withString(dup)],
+          )
+          .getSingle();
+      expect(logged.read<int>('c'), 1);
+    },
+  );
+
+  group('findDuplicateGroups', () {
+    test('groups divers with the same normalized name', () {
+      final groups = DiverMergeRepository.findDuplicateGroups([
+        makeDiver('a', 'Alex Diver', createdAt: 100),
+        makeDiver('b', ' alex diver ', createdAt: 200),
+        makeDiver('c', 'Someone Else', createdAt: 300),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.first.duplicates, hasLength(1));
+      expect(
+        {groups.first.keeper.id, groups.first.duplicates.first.id},
+        {'a', 'b'},
+      );
+    });
+
+    test('prefers the default diver as keeper', () {
+      final groups = DiverMergeRepository.findDuplicateGroups([
+        makeDiver('old', 'Alex', createdAt: 100),
+        makeDiver('default', 'Alex', isDefault: true, createdAt: 500),
+      ]);
+      expect(groups.first.keeper.id, 'default');
+      expect(groups.first.duplicates.single.id, 'old');
+    });
+
+    test('falls back to the oldest diver when none is default', () {
+      final groups = DiverMergeRepository.findDuplicateGroups([
+        makeDiver('newer', 'Alex', createdAt: 500),
+        makeDiver('older', 'Alex', createdAt: 100),
+      ]);
+      expect(groups.first.keeper.id, 'older');
+    });
+
+    test('returns no groups when all names are distinct', () {
+      final groups = DiverMergeRepository.findDuplicateGroups([
+        makeDiver('a', 'Alex', createdAt: 100),
+        makeDiver('b', 'Blair', createdAt: 200),
+      ]);
+      expect(groups, isEmpty);
+    });
+  });
+}

--- a/test/features/divers/diver_merge_repository_test.dart
+++ b/test/features/divers/diver_merge_repository_test.dart
@@ -236,6 +236,30 @@ void main() {
     },
   );
 
+  group('merge guards and helpers', () {
+    test('rejects merging a diver into itself', () async {
+      expect(
+        () => repo.mergeDivers(keeperId: keeper, duplicateId: keeper),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when the duplicate diver does not exist', () async {
+      expect(
+        () => repo.mergeDivers(keeperId: keeper, duplicateId: 'ghost-diver'),
+        throwsStateError,
+      );
+    });
+
+    test('DuplicateDiverGroup.displayName is the keeper name', () {
+      final group = DuplicateDiverGroup(
+        keeper: makeDiver('k', 'Alex Diver', isDefault: true),
+        duplicates: [makeDiver('d', 'Alex Diver')],
+      );
+      expect(group.displayName, 'Alex Diver');
+    });
+  });
+
   group('undoMerge', () {
     /// Returns a snapshot of the entire DB state relevant to the merge:
     /// every row in every diver_id table, plus the divers themselves. Used

--- a/test/features/divers/presentation/providers/diver_providers_test.dart
+++ b/test/features/divers/presentation/providers/diver_providers_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart';
 
+import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -373,5 +374,47 @@ void main() {
       // The notifier should resolve to the id from the Settings table.
       expect(container.read(currentDiverIdProvider), equals(d.id));
     });
+  });
+
+  group('diverMergeRepositoryProvider & duplicateDiverGroupsProvider', () {
+    test('diverMergeRepositoryProvider exposes a repository instance', () {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(diverMergeRepositoryProvider),
+        isA<DiverMergeRepository>(),
+      );
+    });
+
+    test('duplicateDiverGroupsProvider groups same-named divers', () async {
+      await repo.createDiver(_makeDiver(name: 'Dup Name'));
+      await repo.createDiver(_makeDiver(name: 'Dup Name'));
+      await repo.createDiver(_makeDiver(name: 'Unique'));
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      final groups = await container.read(duplicateDiverGroupsProvider.future);
+      expect(groups, hasLength(1));
+      expect(groups.first.displayName, equals('Dup Name'));
+      expect(groups.first.duplicates, hasLength(1));
+    });
+
+    test(
+      'duplicateDiverGroupsProvider is empty when all names are unique',
+      () async {
+        await repo.createDiver(_makeDiver(name: 'A'));
+        await repo.createDiver(_makeDiver(name: 'B'));
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        expect(
+          await container.read(duplicateDiverGroupsProvider.future),
+          isEmpty,
+        );
+      },
+    );
   });
 }

--- a/test/features/settings/data/repositories/app_settings_repository_test.dart
+++ b/test/features/settings/data/repositories/app_settings_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
 
 import '../../../../helpers/test_database.dart';
@@ -30,6 +31,32 @@ void main() {
       await repository.setShareByDefault(true);
       await repository.setShareByDefault(false);
       expect(await repository.getShareByDefault(), isFalse);
+    });
+  });
+
+  group('AppSettingsRepository sync notifications', () {
+    // Marking the settings row pending only stages it; the change bus is what
+    // schedules on-change auto-sync. Regression for the missing bus calls.
+    test('setShareByDefault notifies the sync change bus', () async {
+      var fired = false;
+      final sub = SyncEventBus.changes.listen((_) => fired = true);
+      addTearDown(sub.cancel);
+
+      await repository.setShareByDefault(true);
+      await pumpEventQueue();
+
+      expect(fired, isTrue);
+    });
+
+    test('setNavPrimaryIds notifies the sync change bus', () async {
+      var fired = false;
+      final sub = SyncEventBus.changes.listen((_) => fired = true);
+      addTearDown(sub.cancel);
+
+      await repository.setNavPrimaryIds(const ['a', 'b']);
+      await pumpEventQueue();
+
+      expect(fired, isTrue);
     });
   });
 }

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -1,0 +1,765 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart'
+    show CloudProviderType;
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/sync/sync_service.dart'
+    show ConflictResolution;
+import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/cloud_sync_page.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../../helpers/mock_providers.dart';
+
+/// Fake [SyncNotifier] that holds an arbitrary [SyncState] and records calls to
+/// the mutating methods the page invokes, without touching the database.
+class _FakeSyncNotifier extends StateNotifier<SyncState>
+    implements SyncNotifier {
+  _FakeSyncNotifier(super.state);
+
+  int performSyncCalls = 0;
+  int refreshStateCalls = 0;
+  int resetSyncStateCalls = 0;
+  int signOutCalls = 0;
+
+  @override
+  Future<void> performSync() async => performSyncCalls++;
+
+  @override
+  Future<void> refreshState() async => refreshStateCalls++;
+
+  @override
+  Future<void> resetSyncState() async => resetSyncStateCalls++;
+
+  @override
+  Future<void> signOut() async => signOutCalls++;
+
+  @override
+  Future<void> resolveConflict(
+    String entityType,
+    String recordId,
+    ConflictResolution resolution,
+  ) async {}
+}
+
+/// Cloud provider whose [authenticate] always throws, to exercise the
+/// connection-failure branch of `_selectProvider`.
+class _ThrowingCloudStorageProvider extends FakeCloudStorageProvider {
+  @override
+  Future<void> authenticate() async {
+    throw const CloudStorageException('auth denied');
+  }
+}
+
+/// Fake [SyncBehaviorNotifier] holding fixed settings and recording setter
+/// invocations, so the behavior switches can be rendered and toggled without
+/// SharedPreferences.
+class _FakeSyncBehaviorNotifier extends StateNotifier<SyncBehaviorSettings>
+    implements SyncBehaviorNotifier {
+  _FakeSyncBehaviorNotifier(super.state);
+
+  @override
+  Future<void> setAutoSyncEnabled(bool value) async =>
+      state = state.copyWith(autoSyncEnabled: value);
+
+  @override
+  Future<void> setSyncOnLaunch(bool value) async =>
+      state = state.copyWith(syncOnLaunch: value);
+
+  @override
+  Future<void> setSyncOnResume(bool value) async =>
+      state = state.copyWith(syncOnResume: value);
+}
+
+/// Fake [DiverMergeRepository] that records merge/undo calls and returns an
+/// empty snapshot, so the merge flow can run without a database.
+class _FakeDiverMergeRepository implements DiverMergeRepository {
+  int mergeCalls = 0;
+  int undoCalls = 0;
+  bool throwOnMerge = false;
+
+  @override
+  Future<DiverMergeSnapshot> mergeDivers({
+    required String keeperId,
+    required String duplicateId,
+  }) async {
+    mergeCalls++;
+    if (throwOnMerge) {
+      throw StateError('merge boom');
+    }
+    return DiverMergeSnapshot(
+      keeperId: keeperId,
+      duplicateId: duplicateId,
+      duplicateDiver: const {},
+      repointedRows: const [],
+      deletedSingletonRows: const [],
+    );
+  }
+
+  @override
+  Future<void> undoMerge(DiverMergeSnapshot snapshot) async => undoCalls++;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  final fixedNow = DateTime(2026, 6, 7, 12, 0);
+
+  Diver makeDiver({
+    required String id,
+    required String name,
+    bool isDefault = false,
+    DateTime? createdAt,
+  }) {
+    return Diver(
+      id: id,
+      name: name,
+      isDefault: isDefault,
+      createdAt: createdAt ?? fixedNow,
+      updatedAt: createdAt ?? fixedNow,
+    );
+  }
+
+  /// Build a [DuplicateDiverGroup] with one keeper and [duplicateCount]
+  /// duplicates that share [name].
+  DuplicateDiverGroup makeGroup({
+    String name = 'Alice',
+    int duplicateCount = 1,
+  }) {
+    final keeper = makeDiver(id: 'keeper', name: name, isDefault: true);
+    final duplicates = List.generate(
+      duplicateCount,
+      (i) => makeDiver(id: 'dup-$i', name: name),
+    );
+    return DuplicateDiverGroup(keeper: keeper, duplicates: duplicates);
+  }
+
+  /// Pump [CloudSyncPage] with controllable overrides. Returns the fake sync
+  /// notifier and fake merge repository so tests can assert on recorded calls.
+  Future<({_FakeSyncNotifier sync, _FakeDiverMergeRepository merge})> pumpPage(
+    WidgetTester tester, {
+    SyncState syncState = const SyncState(),
+    CloudProviderType? selectedProvider,
+    bool customFolderMode = false,
+    List<DuplicateDiverGroup> duplicateGroups = const [],
+    bool cloudProviderNull = false,
+    CloudStorageProvider? cloudProvider,
+    bool mergeThrows = false,
+    bool settle = true,
+    SyncBehaviorSettings behavior = const SyncBehaviorSettings(
+      autoSyncEnabled: false,
+      syncOnLaunch: false,
+      syncOnResume: false,
+    ),
+  }) async {
+    final base = await getBaseOverrides();
+    final fakeSync = _FakeSyncNotifier(syncState);
+    final fakeMerge = _FakeDiverMergeRepository()..throwOnMerge = mergeThrows;
+
+    await tester.binding.setSurfaceSize(const Size(500, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          syncStateProvider.overrideWith((ref) => fakeSync),
+          syncBehaviorProvider.overrideWith(
+            (ref) => _FakeSyncBehaviorNotifier(behavior),
+          ),
+          selectedCloudProviderTypeProvider.overrideWith(
+            (ref) => selectedProvider,
+          ),
+          isCloudSyncDisabledByCustomFolderProvider.overrideWithValue(
+            customFolderMode,
+          ),
+          duplicateDiverGroupsProvider.overrideWith(
+            (ref) async => duplicateGroups,
+          ),
+          allDiversProvider.overrideWith((ref) async => const <Diver>[]),
+          diverMergeRepositoryProvider.overrideWithValue(fakeMerge),
+          cloudStorageProviderProvider.overrideWithValue(
+            cloudProviderNull
+                ? null
+                : (cloudProvider ?? FakeCloudStorageProvider()),
+          ),
+          conflictsProvider.overrideWith((ref) async => const []),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: CloudSyncPage(),
+        ),
+      ),
+    );
+    if (settle) {
+      await tester.pumpAndSettle();
+    } else {
+      // Indeterminate progress indicators never settle; pump fixed frames so
+      // the async overrides resolve without awaiting an infinite animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    return (sync: fakeSync, merge: fakeMerge);
+  }
+
+  group('CloudSyncPage - base render', () {
+    testWidgets('renders app bar, provider tiles, and sections', (
+      tester,
+    ) async {
+      await pumpPage(tester);
+
+      expect(find.text('Cloud Sync'), findsOneWidget);
+      // Provider section header and both provider tiles.
+      expect(find.text('Cloud Provider'), findsOneWidget);
+      expect(find.text('iCloud'), findsOneWidget);
+      expect(find.text('Google Drive'), findsOneWidget);
+      // Behavior section.
+      expect(find.text('Sync Behavior'), findsOneWidget);
+      expect(find.text('Auto Sync'), findsOneWidget);
+      expect(find.text('Sync on Launch'), findsOneWidget);
+      expect(find.text('Sync on Resume'), findsOneWidget);
+      // Advanced section.
+      expect(find.text('Advanced'), findsOneWidget);
+      expect(find.text('Reset Sync State'), findsOneWidget);
+      expect(find.text('Sign Out'), findsOneWidget);
+      // Sync Now action present; no provider selected => hint shown + disabled.
+      expect(find.text('Sync Now'), findsOneWidget);
+      expect(
+        find.text('Select a cloud provider to enable sync'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('does not show custom folder banner when not custom mode', (
+      tester,
+    ) async {
+      await pumpPage(tester);
+      expect(find.text('Cloud Sync Disabled'), findsNothing);
+    });
+
+    testWidgets('does not show duplicate divers banner when no duplicates', (
+      tester,
+    ) async {
+      await pumpPage(tester);
+      expect(find.text('Duplicate diver profiles'), findsNothing);
+    });
+  });
+
+  group('CloudSyncPage - custom folder banner', () {
+    testWidgets('shows banner and disables behavior switches in custom mode', (
+      tester,
+    ) async {
+      await pumpPage(tester, customFolderMode: true);
+
+      expect(find.text('Cloud Sync Disabled'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+      expect(find.text('Storage Settings'), findsOneWidget);
+
+      // All three behavior switches are disabled (onChanged null).
+      final switches = tester
+          .widgetList<SwitchListTile>(find.byType(SwitchListTile))
+          .toList();
+      expect(switches.length, 3);
+      for (final s in switches) {
+        expect(s.onChanged, isNull);
+      }
+    });
+
+    testWidgets('tapping Storage Settings pushes the storage route', (
+      tester,
+    ) async {
+      final base = await getBaseOverrides();
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final router = GoRouter(
+        initialLocation: '/settings/cloud',
+        routes: [
+          GoRoute(
+            path: '/settings/cloud',
+            builder: (context, state) => const CloudSyncPage(),
+          ),
+          GoRoute(
+            path: '/settings/storage',
+            builder: (context, state) =>
+                const Scaffold(body: Text('STORAGE_PAGE')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...base,
+            syncStateProvider.overrideWith(
+              (ref) => _FakeSyncNotifier(const SyncState()),
+            ),
+            syncBehaviorProvider.overrideWith(
+              (ref) => _FakeSyncBehaviorNotifier(
+                const SyncBehaviorSettings(
+                  autoSyncEnabled: false,
+                  syncOnLaunch: false,
+                  syncOnResume: false,
+                ),
+              ),
+            ),
+            selectedCloudProviderTypeProvider.overrideWith((ref) => null),
+            isCloudSyncDisabledByCustomFolderProvider.overrideWithValue(true),
+            duplicateDiverGroupsProvider.overrideWith((ref) async => const []),
+            allDiversProvider.overrideWith((ref) async => const <Diver>[]),
+            cloudStorageProviderProvider.overrideWithValue(null),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Storage Settings'));
+      await tester.pumpAndSettle();
+      expect(find.text('STORAGE_PAGE'), findsOneWidget);
+    });
+  });
+
+  group('CloudSyncPage - status card states', () {
+    testWidgets('idle status shows ready title and cloud icon', (tester) async {
+      await pumpPage(tester, syncState: const SyncState());
+      expect(find.text('Ready to sync'), findsOneWidget);
+      expect(find.byIcon(Icons.cloud_outlined), findsOneWidget);
+    });
+
+    testWidgets('syncing status with progress shows progress indicator', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        settle: false,
+        syncState: const SyncState(
+          status: SyncStatus.syncing,
+          progress: 0.5,
+          message: 'Working...',
+        ),
+      );
+      expect(find.text('Syncing...'), findsWidgets);
+      expect(find.text('Working...'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('success status shows cloud_done icon', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: const SyncState(status: SyncStatus.success),
+      );
+      expect(find.text('Sync complete'), findsOneWidget);
+      expect(find.byIcon(Icons.cloud_done), findsOneWidget);
+    });
+
+    testWidgets('error status shows cloud_off icon', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: const SyncState(status: SyncStatus.error),
+      );
+      expect(find.text('Sync error'), findsOneWidget);
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+    });
+
+    testWidgets('hasConflicts status shows warning icon and title', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        syncState: const SyncState(status: SyncStatus.hasConflicts),
+      );
+      expect(find.text('Conflicts detected'), findsOneWidget);
+      // Warning icons appear both in the status card and the conflicts section
+      // header when conflicts > 0; here conflicts == 0 so only the status icon.
+      expect(find.byIcon(Icons.warning), findsOneWidget);
+    });
+
+    testWidgets('shows pending changes singular', (tester) async {
+      await pumpPage(tester, syncState: const SyncState(pendingChanges: 1));
+      expect(find.text('1 pending change'), findsOneWidget);
+    });
+
+    testWidgets('shows pending changes plural', (tester) async {
+      await pumpPage(tester, syncState: const SyncState(pendingChanges: 3));
+      expect(find.text('3 pending changes'), findsOneWidget);
+    });
+  });
+
+  group('CloudSyncPage - last synced formatting', () {
+    testWidgets('shows "Just now" for very recent sync', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: SyncState(
+          lastSync: DateTime.now().subtract(const Duration(seconds: 10)),
+        ),
+      );
+      expect(find.text('Last synced: Just now'), findsOneWidget);
+    });
+
+    testWidgets('shows minutes ago', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: SyncState(
+          lastSync: DateTime.now().subtract(const Duration(minutes: 5)),
+        ),
+      );
+      expect(find.text('Last synced: 5 minutes ago'), findsOneWidget);
+    });
+
+    testWidgets('shows singular minute ago', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: SyncState(
+          lastSync: DateTime.now().subtract(
+            const Duration(minutes: 1, seconds: 5),
+          ),
+        ),
+      );
+      expect(find.text('Last synced: 1 minute ago'), findsOneWidget);
+    });
+
+    testWidgets('shows hours ago', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: SyncState(
+          lastSync: DateTime.now().subtract(const Duration(hours: 3)),
+        ),
+      );
+      expect(find.text('Last synced: 3 hours ago'), findsOneWidget);
+    });
+
+    testWidgets('shows days ago', (tester) async {
+      await pumpPage(
+        tester,
+        syncState: SyncState(
+          lastSync: DateTime.now().subtract(const Duration(days: 2)),
+        ),
+      );
+      expect(find.text('Last synced: 2 days ago'), findsOneWidget);
+    });
+
+    testWidgets('shows formatted date for >7 days', (tester) async {
+      final old = DateTime.now().subtract(const Duration(days: 30));
+      await pumpPage(tester, syncState: SyncState(lastSync: old));
+      // Formatted via DateFormat.yMMMd(); assert the prefix and that none of
+      // the relative phrasings are present.
+      expect(find.textContaining('Last synced:'), findsOneWidget);
+      expect(find.textContaining('ago'), findsNothing);
+    });
+  });
+
+  group('CloudSyncPage - provider selection', () {
+    testWidgets('selected provider shows connected check icon', (tester) async {
+      await pumpPage(tester, selectedProvider: CloudProviderType.googledrive);
+      // The trailing check_circle marks the selected provider.
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      // With a provider selected the hint disappears.
+      expect(find.text('Select a cloud provider to enable sync'), findsNothing);
+    });
+
+    testWidgets('tapping Google Drive tile authenticates and shows snackbar', (
+      tester,
+    ) async {
+      final handles = await pumpPage(tester);
+
+      await tester.tap(find.text('Google Drive'));
+      await tester.pumpAndSettle();
+
+      // Fake provider authenticates successfully -> success snackbar +
+      // refreshState() on the sync notifier.
+      expect(find.text('Connected to Fake'), findsOneWidget);
+      expect(handles.sync.refreshStateCalls, greaterThan(0));
+    });
+
+    testWidgets('null cloud provider shows initialize-failed snackbar', (
+      tester,
+    ) async {
+      await pumpPage(tester, cloudProviderNull: true);
+
+      await tester.tap(find.text('Google Drive'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Failed to initialize googledrive provider'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('authentication failure shows connection-failed snackbar', (
+      tester,
+    ) async {
+      await pumpPage(tester, cloudProvider: _ThrowingCloudStorageProvider());
+
+      await tester.tap(find.text('Google Drive'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Fake connection failed:'), findsOneWidget);
+    });
+  });
+
+  group('CloudSyncPage - sync actions', () {
+    testWidgets('Sync Now is enabled with provider and triggers performSync', (
+      tester,
+    ) async {
+      final handles = await pumpPage(
+        tester,
+        selectedProvider: CloudProviderType.icloud,
+      );
+
+      // Hint gone, button enabled.
+      expect(find.text('Select a cloud provider to enable sync'), findsNothing);
+      await tester.tap(find.widgetWithText(FilledButton, 'Sync Now'));
+      await tester.pumpAndSettle();
+      expect(handles.sync.performSyncCalls, 1);
+    });
+
+    testWidgets('Sync Now is disabled while syncing', (tester) async {
+      final handles = await pumpPage(
+        tester,
+        settle: false,
+        selectedProvider: CloudProviderType.icloud,
+        syncState: const SyncState(status: SyncStatus.syncing),
+      );
+
+      // Button label reflects syncing state and tap is a no-op.
+      final button = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Syncing...'),
+      );
+      expect(button.onPressed, isNull);
+      expect(handles.sync.performSyncCalls, 0);
+    });
+  });
+
+  group('CloudSyncPage - conflicts section', () {
+    testWidgets('shows conflicts section when conflicts > 0 (plural)', (
+      tester,
+    ) async {
+      await pumpPage(tester, syncState: const SyncState(conflicts: 3));
+      expect(find.text('Conflicts (3)'), findsOneWidget);
+      expect(find.text('Resolve Conflicts'), findsOneWidget);
+      expect(find.text('3 items need attention'), findsOneWidget);
+    });
+
+    testWidgets('shows singular wording when conflicts == 1', (tester) async {
+      await pumpPage(tester, syncState: const SyncState(conflicts: 1));
+      expect(find.text('Conflicts (1)'), findsOneWidget);
+      expect(find.text('1 item needs attention'), findsOneWidget);
+    });
+
+    testWidgets('tapping Resolve Conflicts opens dialog and refreshes', (
+      tester,
+    ) async {
+      final handles = await pumpPage(
+        tester,
+        syncState: const SyncState(conflicts: 2),
+      );
+
+      await tester.tap(find.text('Resolve Conflicts'));
+      await tester.pumpAndSettle();
+
+      // The ConflictResolutionDialog renders (no conflicts -> "all resolved"
+      // content). Dismiss it via back to trigger the post-dialog refresh.
+      expect(find.byType(Dialog), findsOneWidget);
+      Navigator.of(tester.element(find.byType(Dialog))).pop();
+      await tester.pumpAndSettle();
+      expect(handles.sync.refreshStateCalls, greaterThan(0));
+    });
+  });
+
+  group('CloudSyncPage - behavior switches', () {
+    testWidgets('toggling Auto Sync flips its switch value', (tester) async {
+      await pumpPage(tester);
+      final autoSwitch = find.widgetWithText(SwitchListTile, 'Auto Sync');
+      expect(tester.widget<SwitchListTile>(autoSwitch).value, isFalse);
+
+      await tester.tap(autoSwitch);
+      await tester.pumpAndSettle();
+      expect(tester.widget<SwitchListTile>(autoSwitch).value, isTrue);
+    });
+
+    testWidgets('toggling Sync on Launch and Resume flips values', (
+      tester,
+    ) async {
+      await pumpPage(tester);
+
+      final launch = find.widgetWithText(SwitchListTile, 'Sync on Launch');
+      await tester.tap(launch);
+      await tester.pumpAndSettle();
+      expect(tester.widget<SwitchListTile>(launch).value, isTrue);
+
+      final resume = find.widgetWithText(SwitchListTile, 'Sync on Resume');
+      await tester.tap(resume);
+      await tester.pumpAndSettle();
+      expect(tester.widget<SwitchListTile>(resume).value, isTrue);
+    });
+  });
+
+  group('CloudSyncPage - reset sync state dialog', () {
+    testWidgets('cancel does not call resetSyncState', (tester) async {
+      final handles = await pumpPage(tester);
+
+      await tester.tap(find.text('Reset Sync State'));
+      await tester.pumpAndSettle();
+      expect(find.text('Reset Sync State?'), findsOneWidget);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(handles.sync.resetSyncStateCalls, 0);
+    });
+
+    testWidgets('confirm calls resetSyncState and shows snackbar', (
+      tester,
+    ) async {
+      final handles = await pumpPage(tester);
+
+      await tester.tap(find.text('Reset Sync State'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+      await tester.pumpAndSettle();
+
+      expect(handles.sync.resetSyncStateCalls, 1);
+      expect(find.text('Sync state reset'), findsOneWidget);
+    });
+  });
+
+  group('CloudSyncPage - sign out dialog', () {
+    testWidgets('cancel does not call signOut', (tester) async {
+      final handles = await pumpPage(tester);
+
+      await tester.tap(find.text('Sign Out'));
+      await tester.pumpAndSettle();
+      expect(find.text('Sign Out?'), findsOneWidget);
+
+      // Cancel button inside the dialog.
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+      expect(handles.sync.signOutCalls, 0);
+    });
+
+    testWidgets('confirm calls signOut and shows snackbar', (tester) async {
+      final handles = await pumpPage(tester);
+
+      await tester.tap(find.text('Sign Out'));
+      await tester.pumpAndSettle();
+      // The confirm action button (the second "Sign Out" text, inside dialog).
+      await tester.tap(find.widgetWithText(TextButton, 'Sign Out'));
+      await tester.pumpAndSettle();
+
+      expect(handles.sync.signOutCalls, 1);
+      expect(find.text('Signed out from cloud provider'), findsOneWidget);
+    });
+  });
+
+  group('CloudSyncPage - duplicate divers banner', () {
+    testWidgets('shows banner with group label when duplicates exist', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        duplicateGroups: [makeGroup(name: 'Alice', duplicateCount: 1)],
+      );
+
+      expect(find.text('Duplicate diver profiles'), findsOneWidget);
+      expect(find.byIcon(Icons.merge_type), findsWidgets);
+      // groupLabel: "{name} ({count} profiles)" with count = duplicates + 1.
+      expect(find.text('Alice (2 profiles)'), findsOneWidget);
+      expect(find.text('Merge'), findsOneWidget);
+    });
+
+    testWidgets('merge confirm cancel does not merge', (tester) async {
+      final handles = await pumpPage(
+        tester,
+        duplicateGroups: [makeGroup(name: 'Bob', duplicateCount: 1)],
+      );
+
+      await tester.tap(find.text('Merge'));
+      await tester.pumpAndSettle();
+      expect(find.text('Merge diver profiles?'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+      expect(handles.merge.mergeCalls, 0);
+    });
+
+    testWidgets('merge confirm runs merge and shows undo snackbar', (
+      tester,
+    ) async {
+      final handles = await pumpPage(
+        tester,
+        duplicateGroups: [makeGroup(name: 'Carol', duplicateCount: 2)],
+      );
+
+      await tester.tap(find.text('Merge'));
+      await tester.pumpAndSettle();
+      // Confirm via the FilledButton labelled "Merge" inside the dialog (the
+      // banner button is a FilledButton.tonal, so scope to the AlertDialog).
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Merge'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Two duplicates => two merge calls.
+      expect(handles.merge.mergeCalls, 2);
+      expect(find.text('Merged into Carol'), findsOneWidget);
+      expect(find.text('Undo'), findsOneWidget);
+    });
+
+    testWidgets('tapping Undo on snackbar runs undoMerge', (tester) async {
+      final handles = await pumpPage(
+        tester,
+        duplicateGroups: [makeGroup(name: 'Dave', duplicateCount: 2)],
+      );
+
+      await tester.tap(find.text('Merge'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Merge'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+      // undoMerge invoked once per snapshot (2 duplicates).
+      expect(handles.merge.undoCalls, 2);
+    });
+
+    testWidgets('merge failure shows failure snackbar', (tester) async {
+      await pumpPage(
+        tester,
+        duplicateGroups: [makeGroup(name: 'Eve', duplicateCount: 1)],
+        mergeThrows: true,
+      );
+
+      await tester.tap(find.text('Merge'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Merge'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Merge failed:'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/universal_import/data/repositories/csv_preset_repository_test.dart
+++ b/test/features/universal_import/data/repositories/csv_preset_repository_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/csv_preset.dart';
+import 'package:submersion/features/universal_import/data/repositories/csv_preset_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late CsvPresetRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = CsvPresetRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  CsvPreset makePreset(String id) =>
+      CsvPreset(id: id, name: 'Preset $id', source: PresetSource.userSaved);
+
+  group('CsvPresetRepository', () {
+    test('savePreset then getAllPresets round-trips saved presets', () async {
+      await repository.savePreset(makePreset('p1'));
+      await repository.savePreset(makePreset('p2'));
+
+      final all = await repository.getAllPresets();
+      expect(all.map((p) => p.id), containsAll(<String>['p1', 'p2']));
+    });
+
+    test('savePreset upserts when the id already exists', () async {
+      await repository.savePreset(makePreset('p1'));
+      await repository.savePreset(
+        const CsvPreset(
+          id: 'p1',
+          name: 'Renamed',
+          source: PresetSource.userSaved,
+        ),
+      );
+
+      final all = await repository.getAllPresets();
+      expect(all.where((p) => p.id == 'p1'), hasLength(1));
+      expect(all.firstWhere((p) => p.id == 'p1').name, 'Renamed');
+    });
+
+    test('deletePreset removes the row', () async {
+      await repository.savePreset(makePreset('p1'));
+      await repository.deletePreset('p1');
+      expect(await repository.getAllPresets(), isEmpty);
+    });
+
+    // Regression for the missing on-change auto-sync trigger: marking a record
+    // pending only stages it; the bus is what schedules the actual sync.
+    test('savePreset notifies the sync change bus', () async {
+      var fired = false;
+      final sub = SyncEventBus.changes.listen((_) => fired = true);
+      addTearDown(sub.cancel);
+
+      await repository.savePreset(makePreset('p1'));
+      await pumpEventQueue();
+
+      expect(
+        fired,
+        isTrue,
+        reason: 'on-change auto-sync depends on the bus firing',
+      );
+    });
+
+    test('deletePreset notifies the sync change bus', () async {
+      await repository.savePreset(makePreset('p1'));
+
+      var fired = false;
+      final sub = SyncEventBus.changes.listen((_) => fired = true);
+      addTearDown(sub.cancel);
+
+      await repository.deletePreset('p1');
+      await pumpEventQueue();
+
+      expect(fired, isTrue);
+    });
+  });
+}

--- a/test/helpers/fake_cloud_storage_provider.dart
+++ b/test/helpers/fake_cloud_storage_provider.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+
+/// In-memory [CloudStorageProvider] for tests. Files are keyed by name, so the
+/// canonical sync file maps to a single stable id across uploads.
+class FakeCloudStorageProvider extends CloudStorageProvider
+    with CloudStorageProviderMixin {
+  final Map<String, _FakeFile> _files = {};
+  bool authenticated = true;
+  bool available = true;
+
+  int get fileCount => _files.length;
+  Uint8List? bytesOf(String name) => _files[name]?.data;
+
+  @override
+  String get providerName => 'Fake';
+
+  @override
+  String get providerId => 'fake';
+
+  @override
+  Future<bool> isAvailable() async => available;
+
+  @override
+  Future<bool> isAuthenticated() async => authenticated;
+
+  @override
+  Future<void> authenticate() async {
+    authenticated = true;
+  }
+
+  @override
+  Future<void> signOut() async {
+    authenticated = false;
+  }
+
+  @override
+  Future<String?> getUserEmail() async => 'tester@example.com';
+
+  @override
+  Future<UploadResult> uploadFile(
+    Uint8List data,
+    String filename, {
+    String? folderId,
+  }) async {
+    _files[filename] = _FakeFile(data, DateTime.now());
+    return UploadResult(
+      fileId: filename,
+      uploadTime: _files[filename]!.modified,
+    );
+  }
+
+  @override
+  Future<Uint8List> downloadFile(String fileId) async {
+    final f = _files[fileId];
+    if (f == null) {
+      throw CloudStorageException('File not found: $fileId');
+    }
+    return f.data;
+  }
+
+  @override
+  Future<CloudFileInfo?> getFileInfo(String fileId) async {
+    final f = _files[fileId];
+    if (f == null) return null;
+    return CloudFileInfo(
+      id: fileId,
+      name: fileId,
+      modifiedTime: f.modified,
+      sizeBytes: f.data.length,
+    );
+  }
+
+  @override
+  Future<List<CloudFileInfo>> listFiles({
+    String? folderId,
+    String? namePattern,
+  }) async {
+    return _files.entries
+        .where((e) => namePattern == null || e.key.contains(namePattern))
+        .map(
+          (e) => CloudFileInfo(
+            id: e.key,
+            name: e.key,
+            modifiedTime: e.value.modified,
+            sizeBytes: e.value.data.length,
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<void> deleteFile(String fileId) async {
+    _files.remove(fileId);
+  }
+
+  @override
+  Future<bool> fileExists(String fileId) async => _files.containsKey(fileId);
+
+  @override
+  Future<String> createFolder(
+    String folderName, {
+    String? parentFolderId,
+  }) async => 'fake-folder';
+
+  @override
+  Future<String> getOrCreateSyncFolder() async => 'fake-sync-folder';
+}
+
+class _FakeFile {
+  final Uint8List data;
+  final DateTime modified;
+  _FakeFile(this.data, this.modified);
+}

--- a/test/helpers/fake_cloud_storage_provider.dart
+++ b/test/helpers/fake_cloud_storage_provider.dart
@@ -13,6 +13,19 @@ class FakeCloudStorageProvider extends CloudStorageProvider
   int get fileCount => _files.length;
   Uint8List? bytesOf(String name) => _files[name]?.data;
 
+  /// Bytes of the single sync payload file present, regardless of its
+  /// per-device filename (`submersion_sync_<deviceId>.json`) or the legacy
+  /// canonical name. Convenience for export-shape assertions in tests.
+  Uint8List? syncFileBytes() {
+    for (final e in _files.entries) {
+      if (e.key.startsWith(CloudStorageProviderMixin.syncFilePrefix) ||
+          e.key == CloudStorageProviderMixin.canonicalSyncFileName) {
+        return e.value.data;
+      }
+    }
+    return null;
+  }
+
   @override
   String get providerName => 'Fake';
 

--- a/test/helpers/sync_test_helpers.dart
+++ b/test/helpers/sync_test_helpers.dart
@@ -23,3 +23,11 @@ Future<void> impersonateFreshDevice() async {
   );
   await repo.resetSyncState();
 }
+
+/// Force a non-null last-sync timestamp on the current device. Conflict
+/// detection in `_mergeEntity` only engages when `lastSync != null`, so tests
+/// that exercise the concurrent-edit / conflict path must set this after
+/// seeding but before the conflicting pull.
+Future<void> setLastSync(DateTime time) async {
+  await SyncRepository().updateLastSyncTime(time);
+}

--- a/test/helpers/sync_test_helpers.dart
+++ b/test/helpers/sync_test_helpers.dart
@@ -1,0 +1,25 @@
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+int _deviceCounter = 0;
+
+/// Make the current in-memory DB look like a DIFFERENT device that shares the
+/// same cloud: assign a fresh `device_id` and reset sync state (clears pending/
+/// conflict records, the deletion log, and lastSync).
+///
+/// Round-trip tests use this to model genuine cross-device sync. Under
+/// per-device sync files each device writes `submersion_sync_<deviceId>.json`
+/// and skips its OWN file on read, so "device B" must have a distinct deviceId
+/// from "device A" for A's file to be seen as foreign and applied.
+Future<void> impersonateFreshDevice() async {
+  final repo = SyncRepository();
+  // Ensure the metadata row exists before we update it.
+  await repo.getDeviceId();
+  _deviceCounter++;
+  final db = DatabaseService.instance.database;
+  await db.customStatement(
+    "UPDATE sync_metadata SET device_id = ? WHERE id = 'global'",
+    ['test-device-$_deviceCounter'],
+  );
+  await repo.resetSyncState();
+}


### PR DESCRIPTION
## Summary

Completes the existing plaintext v1.5 iCloud sync so all structured DB data
syncs across a user's Apple devices, then hardens it. Started from a "sync does
nothing" diagnosis, fixed the structural causes, added per-device sync files and
a Hybrid Logical Clock for skew-immune conflict resolution, and then resolved
every finding from a comprehensive multi-agent review of the branch (2 critical,
3 high, 7 medium, ~8 low).

Media binaries remain out of scope (the JSON-document design is wrong for blobs);
cross-vendor Android is a future transport swap, not part of this PR.

## Changes

**Correctness (the original "no-op" diagnosis)**
- Export every entity via Drift's generated `toJson()` (symmetric with `fromJson`); the old hand-maintained maps had drifted and made receivers throw.
- Stop masking apply errors as "conflicts": failures now count as `recordsFailed` and surface as `SyncResultStatus.error`.
- Defer FK checks during apply (`PRAGMA defer_foreign_keys`); add the missing `courses` table and 6 other orphaned user-data tables to the payload.
- Close cross-device deletion-propagation gaps (entityType key mismatches; repos missing `logDeletion`).

**Per-device files** — each device writes `submersion_sync_<deviceId>.json` and merges every other device's file on read, eliminating the iCloud "conflicted copy" write-write race. Own payloads are skipped by identity; legacy single-file payloads still import.

**Hybrid Logical Clock** — new `Hlc` value type + process-wide `SyncClock`; nullable `hlc` column on all 21 conflict-capable tables (schema v77, upgrade path tested). Stamped at write time via the `markRecordPending` choke point; the merge resolves a concurrent edit by HLC (skew-immune) and only falls back to `updatedAt` for pre-rollout rows. Clock seeds from the max on-disk HLC so a crash between syncs can't pick a wrong winner.

**Diver de-duplication** — first-launch creates a per-device owner diver, so sync surfaces duplicates; new `DiverMergeRepository` repoints every `diver_id` FK (schema-discovered), with a true-inverse `undoMerge` wired to an Undo snackbar.

**Other** — base64 BLOB encoding (~3x smaller than the default byte-array, back-compatible); built-in catalog rows and device-local settings keys filtered from sync (export and import).

## Test Plan

- [x] `flutter test` passes (8134 tests, via pre-push hook)
- [x] `flutter analyze` passes (no issues)
- [x] `dart format` clean
- [x] Manual two-device iCloud round-trip on real Apple hardware — **still required** to validate the iCloud transport itself (the Simulator can't propagate ubiquity containers). All structural behavior is covered by an in-memory fake-provider harness.

Added ~40 sync/HLC/merge test cases incl. conflict resolution, HLC-under-conflict, clock-seed-after-crash, deletion protection, and BLOB edges.

## Screenshots

N/A (the one UI change is a duplicate-diver banner + Undo snackbar on the Cloud Sync settings page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
