### PR TITLE
fix(sync): deletion correctness — no resurrection, no FK-787 sync failures

### DIFF
--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -669,9 +669,11 @@ class SyncRepository {
     );
   }
 
-  /// Remove every tombstone for a single record (all entity types share the
-  /// deletion log). Called when a remote edit newer than the deletion revives
-  /// the record, so the obsolete tombstone stops re-deleting it on later syncs.
+  /// Remove the tombstone(s) for one record of [entityType]. The deletion log
+  /// is a single table shared across entity types and recordIds are only unique
+  /// within an entity type, so the delete matches BOTH [entityType] and
+  /// [recordId]. Called when a remote edit newer than the deletion revives the
+  /// record, so the obsolete tombstone stops re-deleting it on later syncs.
   Future<void> removeDeletion({
     required String entityType,
     required String recordId,

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -669,6 +669,29 @@ class SyncRepository {
     );
   }
 
+  /// Remove every tombstone for a single record (all entity types share the
+  /// deletion log). Called when a remote edit newer than the deletion revives
+  /// the record, so the obsolete tombstone stops re-deleting it on later syncs.
+  Future<void> removeDeletion({
+    required String entityType,
+    required String recordId,
+  }) async {
+    try {
+      await (_db.delete(_db.deletionLog)..where(
+            (t) =>
+                t.entityType.equals(entityType) & t.recordId.equals(recordId),
+          ))
+          .go();
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to remove deletion: $entityType/$recordId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Clear old deletions (older than given days)
   Future<void> clearOldDeletions({int olderThanDays = 90}) async {
     try {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -548,6 +548,60 @@ class SyncDataSerializer {
     });
   }
 
+  /// Repairs every foreign key left dangling after a sync apply: a nullable
+  /// reference is cleared; a non-nullable orphan is deleted (a manual cascade).
+  /// Applying a remote deletion of a parent can leave a local row pointing at
+  /// it via a non-cascading FK, which would otherwise fail the deferred-FK
+  /// COMMIT and abort the whole sync. Must run inside
+  /// [applyInDeferredFkTransaction] so COMMIT sees a consistent graph. Loops
+  /// because deleting an orphan can in turn dangle its own children.
+  Future<void> repairDanglingForeignKeys() async {
+    for (var pass = 0; pass < 5; pass++) {
+      final violations = await _db
+          .customSelect('PRAGMA foreign_key_check')
+          .get();
+      if (violations.isEmpty) return;
+
+      for (final v in violations) {
+        final table = v.read<String>('table');
+        final rowid = v.data['rowid'] as int?;
+        if (rowid == null) continue; // WITHOUT ROWID tables: not in sync schema
+        final fkid = v.read<int>('fkid');
+
+        final fkList = await _db
+            .customSelect('PRAGMA foreign_key_list("$table")')
+            .get();
+        final fk = fkList.where((f) => f.read<int>('id') == fkid).toList();
+        if (fk.isEmpty) continue;
+        final column = fk.first.read<String>('from');
+
+        final info = await _db
+            .customSelect('PRAGMA table_info("$table")')
+            .get();
+        final col = info
+            .where((c) => c.read<String>('name') == column)
+            .toList();
+        final notNull = col.isNotEmpty && col.first.read<int>('notnull') == 1;
+
+        if (notNull) {
+          _log.warning(
+            'Sync repair: deleting orphaned $table row (no parent for "$column")',
+          );
+          await _db.customStatement('DELETE FROM "$table" WHERE rowid = ?', [
+            rowid,
+          ]);
+        } else {
+          _log.warning('Sync repair: clearing dangling $table."$column"');
+          await _db.customStatement(
+            'UPDATE "$table" SET "$column" = NULL WHERE rowid = ?',
+            [rowid],
+          );
+        }
+      }
+    }
+    _log.error('Foreign-key repair did not converge after 5 passes');
+  }
+
   Future<Map<String, dynamic>?> fetchRecord(
     String entityType,
     String recordId,

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -599,7 +599,17 @@ class SyncDataSerializer {
         }
       }
     }
-    _log.error('Foreign-key repair did not converge after 5 passes');
+    // Still inconsistent after the cap: fail now with a targeted error rather
+    // than letting the deferred-FK COMMIT throw a context-free 787.
+    final remaining = await _db.customSelect('PRAGMA foreign_key_check').get();
+    _log.error(
+      'Foreign-key repair did not converge after 5 passes; '
+      '${remaining.length} violation(s) remain',
+    );
+    throw StateError(
+      'Sync foreign-key repair did not converge: '
+      '${remaining.length} dangling reference(s) remain after 5 passes',
+    );
   }
 
   Future<Map<String, dynamic>?> fetchRecord(

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart' show SyncRecord;
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
@@ -117,7 +118,7 @@ enum ConflictResolution { keepLocal, keepRemote, keepBoth }
 /// deletion is tracked in the deletion log. [nullable] distinguishes a cascade
 /// child (NOT NULL -> the row cannot exist without the parent) from a set-null
 /// reference (nullable -> the row survives with the reference cleared).
-typedef _ParentRef = ({String field, String parent, bool nullable});
+typedef ParentRef = ({String field, String parent, bool nullable});
 
 /// Core sync service that orchestrates cloud sync operations
 class SyncService {
@@ -745,6 +746,13 @@ class SyncService {
       recordsFailed += result.recordsFailed;
     }
 
+    // Integrity backstop: applying a remote deletion of a parent can leave a
+    // local row pointing at it via a non-cascading FK, which would fail the
+    // deferred-FK COMMIT and abort the whole sync. Clear or delete any such
+    // dangling reference before the transaction commits. (The merge guard
+    // above stops a peer's orphan from being re-added, so this does not loop.)
+    await _serializer.repairDanglingForeignKeys();
+
     return _MergeResult(
       recordsApplied: recordsApplied,
       conflictsFound: conflictsFound,
@@ -831,24 +839,49 @@ class SyncService {
     );
   }
 
-  /// Synced child -> parent FK relationships whose parent deletion is tracked
-  /// in the deletion log (dives, diveSites, trips). Used by [_mergeEntity] to
-  /// keep a peer's live child from dangling its FK against a parent we have
-  /// deleted. Covered by the resurrection tests in
-  /// sync_deletion_propagation_test.dart. (diverId is intentionally absent:
-  /// diver deletion goes through DiverMergeRepository, which repoints FKs
-  /// rather than orphaning them.)
-  static const Map<String, List<_ParentRef>> _parentRefs = {
+  /// Every synced child -> parent FK whose parent can be deleted (and thus
+  /// tombstoned in the deletion log). Used by [_mergeEntity] to keep a peer's
+  /// live child from dangling its FK against a parent we have deleted -- which
+  /// would otherwise fail the deferred-FK COMMIT and abort the whole sync.
+  /// NOT NULL (nullable: false) children are skipped; nullable references are
+  /// cleared so the row survives detached.
+  ///
+  /// Generated from every `references(<deletable parent>, ...)` in the schema;
+  /// completeness (and column nullability) is asserted against the live schema
+  /// by sync_parent_refs_completeness_test.dart, so a new FK to a deletable
+  /// parent fails that test until it is added here. (diverId is intentionally
+  /// absent: diver deletion goes through DiverMergeRepository, which repoints
+  /// FKs rather than orphaning them.)
+  @visibleForTesting
+  static const Map<String, List<ParentRef>> parentRefs = {
     'dives': [
       (field: 'siteId', parent: 'diveSites', nullable: true),
       (field: 'tripId', parent: 'trips', nullable: true),
+      (field: 'courseId', parent: 'courses', nullable: true),
+      (field: 'computerId', parent: 'diveComputers', nullable: true),
+      (field: 'diveCenterId', parent: 'diveCenters', nullable: true),
     ],
-    'diveProfiles': [(field: 'diveId', parent: 'dives', nullable: false)],
-    'diveTanks': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveProfiles': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'computerId', parent: 'diveComputers', nullable: true),
+    ],
+    'diveTanks': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'equipmentId', parent: 'equipment', nullable: true),
+    ],
     'diveWeights': [(field: 'diveId', parent: 'dives', nullable: false)],
-    'diveEquipment': [(field: 'diveId', parent: 'dives', nullable: false)],
-    'diveBuddies': [(field: 'diveId', parent: 'dives', nullable: false)],
-    'diveTags': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveEquipment': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'equipmentId', parent: 'equipment', nullable: false),
+    ],
+    'diveBuddies': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'buddyId', parent: 'buddies', nullable: false),
+    ],
+    'diveTags': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'tagId', parent: 'tags', nullable: false),
+    ],
     'diveProfileEvents': [(field: 'diveId', parent: 'dives', nullable: false)],
     'gasSwitches': [(field: 'diveId', parent: 'dives', nullable: false)],
     'diveCustomFields': [(field: 'diveId', parent: 'dives', nullable: false)],
@@ -856,15 +889,34 @@ class SyncService {
       (field: 'diveId', parent: 'dives', nullable: false),
     ],
     'tideRecords': [(field: 'diveId', parent: 'dives', nullable: false)],
-    'diveDataSources': [(field: 'diveId', parent: 'dives', nullable: false)],
-    'sightings': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveDataSources': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'computerId', parent: 'diveComputers', nullable: true),
+    ],
+    'sightings': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+      (field: 'speciesId', parent: 'species', nullable: false),
+    ],
     'media': [
       (field: 'diveId', parent: 'dives', nullable: true),
       (field: 'siteId', parent: 'diveSites', nullable: true),
+      (field: 'signerId', parent: 'buddies', nullable: true),
     ],
-    'siteSpecies': [(field: 'siteId', parent: 'diveSites', nullable: false)],
+    'siteSpecies': [
+      (field: 'siteId', parent: 'diveSites', nullable: false),
+      (field: 'speciesId', parent: 'species', nullable: false),
+    ],
     'liveaboardDetails': [(field: 'tripId', parent: 'trips', nullable: false)],
     'itineraryDays': [(field: 'tripId', parent: 'trips', nullable: false)],
+    'certifications': [(field: 'courseId', parent: 'courses', nullable: true)],
+    'courses': [(field: 'instructorId', parent: 'buddies', nullable: true)],
+    'equipmentSetItems': [
+      (field: 'setId', parent: 'equipmentSets', nullable: false),
+      (field: 'equipmentId', parent: 'equipment', nullable: false),
+    ],
+    'serviceRecords': [
+      (field: 'equipmentId', parent: 'equipment', nullable: false),
+    ],
   };
 
   Future<_MergeResult> _mergeEntity({
@@ -884,7 +936,7 @@ class SyncService {
     var failed = 0;
 
     final selfTombstones = allTombstones[entityType] ?? const <String, int>{};
-    final parentRefs = _parentRefs[entityType] ?? const <_ParentRef>[];
+    final entityParentRefs = parentRefs[entityType] ?? const <ParentRef>[];
 
     for (final record in records) {
       String? recordId;
@@ -910,7 +962,7 @@ class SyncService {
         // (e.g. a photo whose dive was deleted keeps the photo, sans dive link).
         var recordToApply = record;
         var droppedByParent = false;
-        for (final ref in parentRefs) {
+        for (final ref in entityParentRefs) {
           final parentId = record[ref.field];
           if (parentId is String &&
               (allTombstones[ref.parent]?.containsKey(parentId) ?? false)) {

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -113,6 +113,12 @@ class SyncConflict {
 /// Resolution choice for a conflict
 enum ConflictResolution { keepLocal, keepRemote, keepBoth }
 
+/// A foreign-key reference from a synced child record to a parent whose
+/// deletion is tracked in the deletion log. [nullable] distinguishes a cascade
+/// child (NOT NULL -> the row cannot exist without the parent) from a set-null
+/// reference (nullable -> the row survives with the reference cleared).
+typedef _ParentRef = ({String field, String parent, bool nullable});
+
 /// Core sync service that orchestrates cloud sync operations
 class SyncService {
   final SyncRepository _syncRepository;
@@ -601,6 +607,14 @@ class SyncService {
     conflictsFound += deletionResult.conflictsFound;
     recordsFailed += deletionResult.recordsFailed;
 
+    // Local tombstones (including any just applied from this payload's
+    // deletions) guard the merge below: a remote LIVE record must not
+    // resurrect a record we have deleted unless the remote edit is newer than
+    // our deletion. Loaded after _applyRemoteDeletions so a tombstone arriving
+    // in the same payload also protects against a self-contradictory payload
+    // that carries both a delete and a stale live copy of the same record.
+    final tombstonesByEntity = await _deletionMap();
+
     final data = remotePayload.data;
 
     final mergeOrder =
@@ -724,6 +738,7 @@ class SyncService {
         hasUpdatedAt: entry.hasUpdatedAt,
         lastSyncMs: lastSyncMs,
         pendingRecordIds: pendingByEntity[entry.type] ?? const <String>{},
+        allTombstones: tombstonesByEntity,
       );
       recordsApplied += result.recordsApplied;
       conflictsFound += result.conflictsFound;
@@ -816,12 +831,49 @@ class SyncService {
     );
   }
 
+  /// Synced child -> parent FK relationships whose parent deletion is tracked
+  /// in the deletion log (dives, diveSites, trips). Used by [_mergeEntity] to
+  /// keep a peer's live child from dangling its FK against a parent we have
+  /// deleted. Covered by the resurrection tests in
+  /// sync_deletion_propagation_test.dart. (diverId is intentionally absent:
+  /// diver deletion goes through DiverMergeRepository, which repoints FKs
+  /// rather than orphaning them.)
+  static const Map<String, List<_ParentRef>> _parentRefs = {
+    'dives': [
+      (field: 'siteId', parent: 'diveSites', nullable: true),
+      (field: 'tripId', parent: 'trips', nullable: true),
+    ],
+    'diveProfiles': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveTanks': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveWeights': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveEquipment': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveBuddies': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveTags': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveProfileEvents': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'gasSwitches': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveCustomFields': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'tankPressureProfiles': [
+      (field: 'diveId', parent: 'dives', nullable: false),
+    ],
+    'tideRecords': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'diveDataSources': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'sightings': [(field: 'diveId', parent: 'dives', nullable: false)],
+    'media': [
+      (field: 'diveId', parent: 'dives', nullable: true),
+      (field: 'siteId', parent: 'diveSites', nullable: true),
+    ],
+    'siteSpecies': [(field: 'siteId', parent: 'diveSites', nullable: false)],
+    'liveaboardDetails': [(field: 'tripId', parent: 'trips', nullable: false)],
+    'itineraryDays': [(field: 'tripId', parent: 'trips', nullable: false)],
+  };
+
   Future<_MergeResult> _mergeEntity({
     required String entityType,
     required List<Map<String, dynamic>> records,
     required bool hasUpdatedAt,
     required int? lastSyncMs,
     required Set<String> pendingRecordIds,
+    required Map<String, Map<String, int>> allTombstones,
   }) async {
     if (records.isEmpty) {
       return const _MergeResult(recordsApplied: 0, conflictsFound: 0);
@@ -830,6 +882,9 @@ class SyncService {
     var applied = 0;
     var conflicts = 0;
     var failed = 0;
+
+    final selfTombstones = allTombstones[entityType] ?? const <String, int>{};
+    final parentRefs = _parentRefs[entityType] ?? const <_ParentRef>[];
 
     for (final record in records) {
       String? recordId;
@@ -848,8 +903,50 @@ class SyncService {
           continue;
         }
 
+        // Parent-deletion guard: a record pointing at a locally-tombstoned
+        // parent would otherwise dangle its FK (failing the deferred-FK commit)
+        // or resurrect an orphan. A NOT NULL (cascade) child is skipped; a
+        // nullable (set-null) reference is cleared so the row survives detached
+        // (e.g. a photo whose dive was deleted keeps the photo, sans dive link).
+        var recordToApply = record;
+        var droppedByParent = false;
+        for (final ref in parentRefs) {
+          final parentId = record[ref.field];
+          if (parentId is String &&
+              (allTombstones[ref.parent]?.containsKey(parentId) ?? false)) {
+            if (ref.nullable) {
+              recordToApply = {...recordToApply, ref.field: null};
+            } else {
+              droppedByParent = true;
+              break;
+            }
+          }
+        }
+        if (droppedByParent) continue;
+
+        // Local-deletion guard: if we deleted this record, a remote LIVE copy
+        // must not resurrect it unless the remote edit is newer than our
+        // deletion (a genuine revival). Without this, a peer that has not yet
+        // seen our delete re-introduces the record on every sync.
+        final deletedAt = selfTombstones[recordId];
+        if (deletedAt != null) {
+          final remoteUpdatedAt = hasUpdatedAt
+              ? _extractUpdatedAtMillis(record)
+              : null;
+          if (remoteUpdatedAt == null || remoteUpdatedAt <= deletedAt) {
+            // No newer remote edit -- the deletion wins; stay deleted.
+            continue;
+          }
+          // Remote edit is newer than the deletion: revive the record and drop
+          // the now-obsolete tombstone so it stops re-deleting it.
+          await _syncRepository.removeDeletion(
+            entityType: entityType,
+            recordId: recordId,
+          );
+        }
+
         if (!hasUpdatedAt) {
-          await _serializer.upsertRecord(entityType, record);
+          await _serializer.upsertRecord(entityType, recordToApply);
           applied += 1;
           continue;
         }
@@ -873,7 +970,7 @@ class SyncService {
         // remote HLC wins; an exact tie or a local-newer HLC keeps local.
         if (localHlc != null && remoteHlc != null) {
           if (remoteHlc.compareTo(localHlc) > 0) {
-            await _serializer.upsertRecord(entityType, record);
+            await _serializer.upsertRecord(entityType, recordToApply);
             applied += 1;
           }
           continue;
@@ -900,7 +997,7 @@ class SyncService {
         if (remoteUpdatedAt == null ||
             localUpdatedAt == null ||
             remoteUpdatedAt >= localUpdatedAt) {
-          await _serializer.upsertRecord(entityType, record);
+          await _serializer.upsertRecord(entityType, recordToApply);
           applied += 1;
         }
       } catch (e, stackTrace) {
@@ -928,6 +1025,23 @@ class SyncService {
     final map = <String, Set<String>>{};
     for (final record in records) {
       map.putIfAbsent(record.entityType, () => <String>{}).add(record.recordId);
+    }
+    return map;
+  }
+
+  /// Local deletion tombstones as entityType -> (recordId -> latest deletedAt).
+  /// Used by [_mergeEntity] to keep a remote live copy from resurrecting a
+  /// record we have deleted.
+  Future<Map<String, Map<String, int>>> _deletionMap() async {
+    final deletions = await _syncRepository.getAllDeletions();
+    final map = <String, Map<String, int>>{};
+    for (final d in deletions) {
+      final byId = map.putIfAbsent(d.entityType, () => <String, int>{});
+      final existing = byId[d.recordId];
+      // Keep the most recent deletion if duplicate tombstones exist.
+      if (existing == null || d.deletedAt > existing) {
+        byId[d.recordId] = d.deletedAt;
+      }
     }
     return map;
   }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -732,6 +732,39 @@ class SyncService {
           (type: 'media', records: data.media, hasUpdatedAt: false),
         ];
 
+    // Precompute the locally-tombstoned parents this payload will REVIVE (a
+    // remote edit strictly newer than our deletion). A child must not be
+    // dropped/cleared for a parent that is coming back. The merge order does
+    // not guarantee a parent is processed before its children, and a revival
+    // only clears the tombstone in the DB (not the in-memory snapshot used by
+    // the guard below), so this is computed up front to stay order-independent.
+    final recordsByType = {for (final e in mergeOrder) e.type: e};
+    final revivedParents = <String, Set<String>>{};
+    final parentTypes = <String>{
+      for (final refs in parentRefs.values)
+        for (final ref in refs) ref.parent,
+    };
+    for (final parentType in parentTypes) {
+      final tombs = tombstonesByEntity[parentType];
+      final entry = recordsByType[parentType];
+      if (tombs == null ||
+          tombs.isEmpty ||
+          entry == null ||
+          !entry.hasUpdatedAt) {
+        continue;
+      }
+      for (final rec in entry.records) {
+        final id = _recordIdForEntity(parentType, rec);
+        if (id == null) continue;
+        final deletedAt = tombs[id];
+        if (deletedAt == null) continue;
+        final remoteUpdatedAt = _extractUpdatedAtMillis(rec);
+        if (remoteUpdatedAt != null && remoteUpdatedAt > deletedAt) {
+          revivedParents.putIfAbsent(parentType, () => <String>{}).add(id);
+        }
+      }
+    }
+
     for (final entry in mergeOrder) {
       final result = await _mergeEntity(
         entityType: entry.type,
@@ -740,6 +773,7 @@ class SyncService {
         lastSyncMs: lastSyncMs,
         pendingRecordIds: pendingByEntity[entry.type] ?? const <String>{},
         allTombstones: tombstonesByEntity,
+        revivedParents: revivedParents,
       );
       recordsApplied += result.recordsApplied;
       conflictsFound += result.conflictsFound;
@@ -926,6 +960,7 @@ class SyncService {
     required int? lastSyncMs,
     required Set<String> pendingRecordIds,
     required Map<String, Map<String, int>> allTombstones,
+    required Map<String, Set<String>> revivedParents,
   }) async {
     if (records.isEmpty) {
       return const _MergeResult(recordsApplied: 0, conflictsFound: 0);
@@ -965,7 +1000,10 @@ class SyncService {
         for (final ref in entityParentRefs) {
           final parentId = record[ref.field];
           if (parentId is String &&
-              (allTombstones[ref.parent]?.containsKey(parentId) ?? false)) {
+              (allTombstones[ref.parent]?.containsKey(parentId) ?? false) &&
+              // A parent being revived in this same payload is NOT gone; keep
+              // the child's reference intact regardless of merge order.
+              (revivedParents[ref.parent]?.contains(parentId) != true)) {
             if (ref.nullable) {
               recordToApply = {...recordToApply, ref.field: null};
             } else {

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -35,8 +35,8 @@ void main() {
       cloud = FakeCloudStorageProvider();
     });
 
-    tearDown(() {
-      DatabaseService.instance.resetForTesting();
+    tearDown(() async {
+      await tearDownTestDatabase();
     });
 
     SyncService buildService() => SyncService(
@@ -243,8 +243,8 @@ void main() {
       cloud = FakeCloudStorageProvider();
     });
 
-    tearDown(() {
-      DatabaseService.instance.resetForTesting();
+    tearDown(() async {
+      await tearDownTestDatabase();
     });
 
     SyncService buildService() => SyncService(

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -483,5 +483,76 @@ void main() {
         reason: 'the dangling dive link is cleared, not resurrected',
       );
     });
+
+    test(
+      'applying a peer deletion of a SITE a local dive still references does '
+      'not fail the sync; the dive survives with a cleared site link',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+
+        await serializer.upsertRecord('diveSites', {
+          'id': 'site-x',
+          'name': 'Reef',
+          'description': '',
+          'notes': '',
+          'isShared': false,
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-x', diveNumber: 1),
+        );
+        final diveJson = await serializer.fetchRecord('dives', 'dive-x');
+        await serializer.upsertRecord('dives', {
+          ...diveJson!,
+          'siteId': 'site-x',
+        });
+
+        await buildService()
+            .performSync(); // push current state, advance lastSync
+
+        // A peer deletes the site while our local dive still references it
+        // (dives.siteId is a non-cascading FK, so it would dangle at COMMIT).
+        const data = SyncData();
+        final checksum = sha256
+            .convert(utf8.encode(jsonEncode(data.toJson())))
+            .toString();
+        final payload = SyncPayload(
+          version: syncFormatVersion,
+          exportedAt: 9000,
+          deviceId: 'peer-dev',
+          checksum: checksum,
+          data: data,
+          deletions: {
+            'diveSites': [const SyncDeletion(id: 'site-x', deletedAt: 8000)],
+          },
+        );
+        await cloud.uploadFile(
+          Uint8List.fromList(utf8.encode(serializer.serializePayload(payload))),
+          'submersion_sync_peer-dev.json',
+        );
+
+        final result = await buildService().performSync();
+
+        expect(
+          result.status,
+          isNot(SyncResultStatus.error),
+          reason: 'a deleted parent must not abort the whole sync (787)',
+        );
+        expect(
+          await serializer.fetchRecord('diveSites', 'site-x'),
+          isNull,
+          reason: 'the site deletion still applies',
+        );
+        final dive = await serializer.fetchRecord('dives', 'dive-x');
+        expect(dive, isNotNull, reason: 'the dive itself must survive');
+        expect(
+          dive!['siteId'],
+          isNull,
+          reason: 'the dangling site link is cleared, not left to crash COMMIT',
+        );
+      },
+    );
   });
 }

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -554,5 +554,97 @@ void main() {
         );
       },
     );
+
+    test('a parent revived in the same payload keeps its children; the FK is '
+        'not cleared by the stale tombstone snapshot (any merge order)', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+
+      // Local: a site + a dive referencing it; capture the dive JSON.
+      await serializer.upsertRecord('diveSites', {
+        'id': 'site-r',
+        'name': 'Reef',
+        'description': '',
+        'notes': '',
+        'isShared': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-r', diveNumber: 7),
+      );
+      final diveBase = await serializer.fetchRecord('dives', 'dive-r');
+      await serializer.upsertRecord('dives', {
+        ...diveBase!,
+        'siteId': 'site-r',
+      });
+      final diveJson = await serializer.fetchRecord('dives', 'dive-r');
+      await buildService().performSync(); // push, advance lastSync
+
+      // Locally delete (tombstone) the site. Remove the dive first so the
+      // non-cascading FK lets the site row go; the tombstone predates the peer
+      // edit below.
+      await serializer.deleteRecord('dives', 'dive-r');
+      await serializer.deleteRecord('diveSites', 'site-r');
+      await SyncRepository().logDeletion(
+        entityType: 'diveSites',
+        recordId: 'site-r',
+        deletedAt: 5000,
+      );
+
+      // Peer payload: the site is EDITED (updatedAt 9000 > deletion 5000, so it
+      // revives) AND a dive still references it. `dives` merges before
+      // `diveSites`, so the child is processed while the parent still looks
+      // tombstoned -- the precomputed revived set must keep the FK.
+      final peerData = SyncData(
+        diveSites: [
+          {
+            'id': 'site-r',
+            'name': 'Reef (renamed)',
+            'description': '',
+            'notes': '',
+            'isShared': false,
+            'createdAt': 1000,
+            'updatedAt': 9000,
+          },
+        ],
+        dives: [
+          {...diveJson!, 'siteId': 'site-r', 'updatedAt': 9000},
+        ],
+      );
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(peerData.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 9000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: peerData,
+        deletions: const {},
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(utf8.encode(serializer.serializePayload(payload))),
+        'submersion_sync_peer-dev.json',
+      );
+
+      final result = await buildService().performSync();
+
+      expect(result.status, isNot(SyncResultStatus.error));
+      expect(
+        await serializer.fetchRecord('diveSites', 'site-r'),
+        isNotNull,
+        reason: 'the site is revived by the newer remote edit',
+      );
+      final revivedDive = await serializer.fetchRecord('dives', 'dive-r');
+      expect(revivedDive, isNotNull);
+      expect(
+        revivedDive!['siteId'],
+        'site-r',
+        reason:
+            'the FK must be preserved when the parent is revived in the '
+            'same payload, regardless of merge order',
+      );
+    });
   });
 }

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -2,15 +2,19 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart' show MediaCompanion;
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/features/universal_import/data/repositories/csv_preset_repository.dart';
 
 import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
 import '../../../helpers/sync_test_helpers.dart';
 import '../../../helpers/test_database.dart';
 
@@ -222,6 +226,261 @@ void main() {
         reason:
             'the local row was created (8000) after last sync (4000), so '
             'a stale remote tombstone must not delete it',
+      );
+    });
+  });
+
+  /// A device that has deleted a record must not have it resurrected by a peer
+  /// that still holds a live copy it has not yet seen deleted. This is the
+  /// other direction of deletion propagation: applying a remote *live* record
+  /// against a *local tombstone* (vs. applying a remote tombstone against a
+  /// local live row, covered above).
+  group('Local deletion is not resurrected by a peer live copy', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Future<void> uploadPeerDive(
+      SyncDataSerializer serializer,
+      Map<String, dynamic> diveJson,
+    ) async {
+      final peerData = SyncData(dives: [diveJson]);
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(peerData.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 2000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: peerData,
+        deletions: const {},
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(utf8.encode(serializer.serializePayload(payload))),
+        'submersion_sync_peer-dev.json',
+      );
+    }
+
+    test('a deleted dive is NOT resurrected by a peer copy older than the '
+        'deletion', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+
+      // Device A creates dive #43 and syncs it (so it is no longer "pending"
+      // -- a pending record is skipped on merge, which would mask the bug).
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-43', diveNumber: 43),
+      );
+      await buildService().performSync();
+      final diveJson = await serializer.fetchRecord('dives', 'dive-43');
+      expect(diveJson, isNotNull);
+
+      // A deletes #43 (writes a tombstone, removes the local row).
+      await diveRepo.deleteDive('dive-43');
+      expect(await serializer.fetchRecord('dives', 'dive-43'), isNull);
+
+      // A peer that has not seen the delete still has the live dive, with an
+      // updatedAt far older than our (just-now) deletion.
+      await uploadPeerDive(serializer, {...diveJson!, 'updatedAt': 1000});
+
+      await buildService().performSync();
+
+      expect(
+        await serializer.fetchRecord('dives', 'dive-43'),
+        isNull,
+        reason:
+            "a peer's stale live copy must not resurrect a locally-deleted dive",
+      );
+    });
+
+    test('a peer edit newer than the local deletion revives the dive and '
+        'drops the tombstone', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-44', diveNumber: 44),
+      );
+      await buildService().performSync();
+      final diveJson = await serializer.fetchRecord('dives', 'dive-44');
+      await diveRepo.deleteDive('dive-44');
+
+      // Peer edited the dive AFTER our deletion (updatedAt in the far future).
+      await uploadPeerDive(serializer, {
+        ...diveJson!,
+        'updatedAt': 99999999999999,
+      });
+
+      await buildService().performSync();
+
+      expect(
+        await serializer.fetchRecord('dives', 'dive-44'),
+        isNotNull,
+        reason: 'a peer edit newer than the deletion is a genuine revival',
+      );
+      final remaining = await SyncRepository().getAllDeletions();
+      expect(
+        remaining.any((d) => d.recordId == 'dive-44'),
+        isFalse,
+        reason: 'a revived record should drop its now-obsolete tombstone',
+      );
+    });
+
+    test('a deleted dive WITH child records is not resurrected and does not '
+        'orphan its children', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-50', diveNumber: 50),
+      );
+      await serializer.upsertRecord('diveProfiles', {
+        'id': 'prof-50',
+        'diveId': 'dive-50',
+        'isPrimary': true,
+        'timestamp': 0,
+        'depth': 5.0,
+      });
+      await buildService().performSync();
+      final diveJson = await serializer.fetchRecord('dives', 'dive-50');
+      final profJson = await serializer.fetchRecord('diveProfiles', 'prof-50');
+      expect(profJson, isNotNull);
+
+      // Deleting the dive cascades the child away locally.
+      await diveRepo.deleteDive('dive-50');
+      expect(await serializer.fetchRecord('dives', 'dive-50'), isNull);
+      expect(await serializer.fetchRecord('diveProfiles', 'prof-50'), isNull);
+
+      // Peer still has the live dive AND its live child profile.
+      final peerData = SyncData(
+        dives: [
+          {...diveJson!, 'updatedAt': 1000},
+        ],
+        diveProfiles: [profJson!],
+      );
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(peerData.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 2000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: peerData,
+        deletions: const {},
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(utf8.encode(serializer.serializePayload(payload))),
+        'submersion_sync_peer-dev.json',
+      );
+
+      final result = await buildService().performSync();
+
+      expect(
+        result.status,
+        isNot(SyncResultStatus.error),
+        reason: 'a peer copy of a deleted dive+children must not error sync',
+      );
+      expect(
+        await serializer.fetchRecord('dives', 'dive-50'),
+        isNull,
+        reason: 'the dive stays deleted',
+      );
+      expect(
+        await serializer.fetchRecord('diveProfiles', 'prof-50'),
+        isNull,
+        reason: 'the orphaned child must not be resurrected either',
+      );
+    });
+
+    test('a photo whose dive was deleted is preserved (set-null), not lost '
+        'and not resurrected with a dangling link', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final db = DatabaseService.instance.database;
+
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-60', diveNumber: 60),
+      );
+      await db
+          .into(db.media)
+          .insert(
+            MediaCompanion.insert(
+              id: 'media-60',
+              diveId: const Value('dive-60'),
+              filePath: '/photo.jpg',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          );
+      await buildService().performSync();
+      final diveJson = await serializer.fetchRecord('dives', 'dive-60');
+      final mediaJson = await serializer.fetchRecord('media', 'media-60');
+      expect(mediaJson, isNotNull);
+
+      // Deleting the dive set-nulls the photo's diveId locally; the photo
+      // survives (Media.diveId is nullable / onDelete: setNull).
+      await diveRepo.deleteDive('dive-60');
+      expect(await serializer.fetchRecord('dives', 'dive-60'), isNull);
+      final localMedia = await serializer.fetchRecord('media', 'media-60');
+      expect(
+        localMedia,
+        isNotNull,
+        reason: 'the photo must survive the delete',
+      );
+      expect(localMedia!['diveId'], isNull);
+
+      // Peer still has the live dive AND the photo still linked to it.
+      final peerData = SyncData(
+        dives: [
+          {...diveJson!, 'updatedAt': 1000},
+        ],
+        media: [mediaJson!],
+      );
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(peerData.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 2000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: peerData,
+        deletions: const {},
+      );
+      await cloud.uploadFile(
+        Uint8List.fromList(utf8.encode(serializer.serializePayload(payload))),
+        'submersion_sync_peer-dev.json',
+      );
+
+      final result = await buildService().performSync();
+
+      expect(result.status, isNot(SyncResultStatus.error));
+      expect(await serializer.fetchRecord('dives', 'dive-60'), isNull);
+      final afterMedia = await serializer.fetchRecord('media', 'media-60');
+      expect(
+        afterMedia,
+        isNotNull,
+        reason: 'the photo must NOT be lost when its dive is deleted',
+      );
+      expect(
+        afterMedia!['diveId'],
+        isNull,
+        reason: 'the dangling dive link is cleared, not resurrected',
       );
     });
   });

--- a/test/core/services/sync/sync_parent_refs_completeness_test.dart
+++ b/test/core/services/sync/sync_parent_refs_completeness_test.dart
@@ -1,0 +1,162 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Guards `SyncService.parentRefs` against the live schema. The merge applies
+/// remote records inside a deferred-FK transaction; if a synced child has a
+/// foreign key to a deletable parent that is NOT listed in `parentRefs`, a
+/// peer's live child of a locally-deleted parent dangles its FK and the whole
+/// sync fails at COMMIT (SqliteException 787). This test fails the moment such
+/// an FK exists without a guard, or with the wrong nullability (skip vs.
+/// clear-the-reference).
+void main() {
+  // SQL table name -> sync entityType, for every entity the merge applies
+  // (mirrors SyncService's mergeOrder).
+  const syncedTables = <String, String>{
+    'dives': 'dives',
+    'diver_settings': 'diverSettings',
+    'buddies': 'buddies',
+    'dive_centers': 'diveCenters',
+    'trips': 'trips',
+    'liveaboard_detail_records': 'liveaboardDetails',
+    'trip_itinerary_days': 'itineraryDays',
+    'equipment': 'equipment',
+    'equipment_sets': 'equipmentSets',
+    'equipment_set_items': 'equipmentSetItems',
+    'dive_types': 'diveTypes',
+    'tank_presets': 'tankPresets',
+    'dive_computers': 'diveComputers',
+    'species': 'species',
+    'tags': 'tags',
+    'courses': 'courses',
+    'dive_sites': 'diveSites',
+    'dive_tanks': 'diveTanks',
+    'dive_weights': 'diveWeights',
+    'dive_equipment': 'diveEquipment',
+    'dive_tags': 'diveTags',
+    'dive_buddies': 'diveBuddies',
+    'dive_profiles': 'diveProfiles',
+    'dive_profile_events': 'diveProfileEvents',
+    'gas_switches': 'gasSwitches',
+    'dive_custom_fields': 'diveCustomFields',
+    'dive_data_sources': 'diveDataSources',
+    'site_species': 'siteSpecies',
+    'csv_presets': 'csvPresets',
+    'view_configs': 'viewConfigs',
+    'field_presets': 'fieldPresets',
+    'tank_pressure_profiles': 'tankPressureProfiles',
+    'tide_records': 'tideRecords',
+    'sightings': 'sightings',
+    'certifications': 'certifications',
+    'service_records': 'serviceRecords',
+    'media': 'media',
+  };
+
+  // Parent table -> entityType for parents a user can delete (and thus
+  // tombstone). Divers are excluded: diver deletion goes through
+  // DiverMergeRepository, which repoints FKs rather than orphaning rows.
+  const deletableParents = <String, String>{
+    'dives': 'dives',
+    'dive_sites': 'diveSites',
+    'trips': 'trips',
+    'courses': 'courses',
+    'equipment': 'equipment',
+    'equipment_sets': 'equipmentSets',
+    'buddies': 'buddies',
+    'tags': 'tags',
+    'dive_types': 'diveTypes',
+    'tank_presets': 'tankPresets',
+    'dive_centers': 'diveCenters',
+    'species': 'species',
+    'dive_computers': 'diveComputers',
+  };
+
+  String camel(String snake) {
+    final parts = snake.split('_');
+    return parts.first +
+        parts
+            .skip(1)
+            .map((p) => p.isEmpty ? p : p[0].toUpperCase() + p.substring(1))
+            .join();
+  }
+
+  test('parentRefs covers every synced FK to a deletable parent', () async {
+    final db = await setUpTestDatabase();
+    addTearDown(tearDownTestDatabase);
+
+    final missing = <String>[];
+    final wrongNullable = <String>[];
+
+    for (final entry in syncedTables.entries) {
+      final table = entry.key;
+      final childEntity = entry.value;
+
+      final cols = await db
+          .customSelect(
+            'SELECT * FROM pragma_table_info(?)',
+            variables: [Variable.withString(table)],
+          )
+          .get();
+      expect(
+        cols,
+        isNotEmpty,
+        reason: 'synced table "$table" does not exist (typo in this test?)',
+      );
+      final notNull = {
+        for (final c in cols)
+          c.read<String>('name'): (c.data['notnull'] as int? ?? 0) == 1,
+      };
+
+      final fks = await db
+          .customSelect(
+            'SELECT * FROM pragma_foreign_key_list(?)',
+            variables: [Variable.withString(table)],
+          )
+          .get();
+
+      for (final fk in fks) {
+        final parentTable = fk.read<String>('table');
+        final parentEntity = deletableParents[parentTable];
+        if (parentEntity == null) continue; // parent not user-deletable
+
+        final field = camel(fk.read<String>('from'));
+        final nullable = !(notNull[fk.read<String>('from')] ?? false);
+
+        final refs = SyncService.parentRefs[childEntity] ?? const [];
+        final match = refs
+            .where((r) => r.field == field && r.parent == parentEntity)
+            .toList();
+
+        if (match.isEmpty) {
+          missing.add(
+            '$childEntity.$field -> $parentEntity (nullable=$nullable)',
+          );
+        } else if (match.first.nullable != nullable) {
+          wrongNullable.add(
+            '$childEntity.$field -> $parentEntity: parentRefs says '
+            'nullable=${match.first.nullable}, schema says $nullable',
+          );
+        }
+      }
+    }
+
+    expect(
+      missing,
+      isEmpty,
+      reason:
+          'SyncService.parentRefs is missing FK guards. A deleted parent would '
+          'dangle these children and fail the deferred-FK COMMIT:\n'
+          '${missing.join('\n')}',
+    );
+    expect(
+      wrongNullable,
+      isEmpty,
+      reason:
+          'Nullability mismatch (decides skip vs. clear-the-reference):\n'
+          '${wrongNullable.join('\n')}',
+    );
+  });
+}

--- a/test/core/services/sync/sync_parent_refs_completeness_test.dart
+++ b/test/core/services/sync/sync_parent_refs_completeness_test.dart
@@ -16,6 +16,7 @@ void main() {
   // SQL table name -> sync entityType, for every entity the merge applies
   // (mirrors SyncService's mergeOrder).
   const syncedTables = <String, String>{
+    'divers': 'divers',
     'dives': 'dives',
     'diver_settings': 'diverSettings',
     'buddies': 'buddies',
@@ -52,6 +53,7 @@ void main() {
     'sightings': 'sightings',
     'certifications': 'certifications',
     'service_records': 'serviceRecords',
+    'settings': 'settings',
     'media': 'media',
   };
 


### PR DESCRIPTION
## Summary

Fixes cross-device deletion bugs in iCloud sync where deleting a record on one device either **reappeared** after sync or made every sync **fail** with a foreign-key error.

Reported:
- *"I deleted dive #43 from macOS… it still has dive #43 [on iPhone], and… dive #43 reappears [on macOS]."*
- *`SqliteException(787): FOREIGN KEY constraint failed … COMMIT TRANSACTION`* on macOS **and** iOS.

## Root cause

The merge had no awareness of deletions, and the apply transaction defers FK checks to `COMMIT`. Three failure modes, all closed here:

1. **Resurrection** — a peer's still-live copy of a record you deleted was re-inserted (and re-propagated back), so the delete never stuck.
2. **Merge-side orphan (787)** — a peer's live *child* of a parent you deleted was re-inserted and dangled its FK, aborting the whole sync at `COMMIT`.
3. **Deletion-apply orphan (787)** — applying a peer's *deletion* of a parent (site, trip, dive computer, …) while this device still referenced it via a non-cascading FK left that reference dangling.

## Fix

- **Self-tombstone guard** (`_mergeEntity`): a record carrying a local tombstone isn't re-applied unless the peer's edit is strictly newer (a genuine revival, which drops the tombstone).
- **Parent-deletion guard** (`SyncService.parentRefs`): generated from every `references(<deletable parent>)` in the schema (dives, sites, trips, equipment, courses, buddies, species, tags, dive computers, dive centers, …). NOT NULL children are skipped; nullable references are cleared (a photo whose dive was deleted is kept, detached). `sync_parent_refs_completeness_test.dart` reflects the live schema and fails if any FK is ever left unguarded.
- **Integrity repair** (`SyncDataSerializer.repairDanglingForeignKeys`): a final pass inside the apply transaction that clears nullable dangling refs and deletes non-nullable orphans, so `COMMIT` always sees a consistent graph. Complements the merge guard (which stops orphans being re-added, so the repair doesn't loop).
- Plus `SyncRepository.removeDeletion` and a `_deletionMap` snapshot taken after remote deletions apply.

## Tests

`sync_deletion_propagation_test.dart`: resurrection (stays deleted), revival (newer peer edit wins + tombstone dropped), dive-with-children (no FK error, children not orphaned), photo preserved on dive delete, and a peer site-deletion while a local dive references it (previously a hard 787; now succeeds with the link cleared). Plus the schema-completeness guard.

- `flutter test` — 8258 passing
- `flutter analyze` — no issues
- `dart format` — clean

## Manual verification still recommended

A real two-device iCloud round-trip: delete a dive (and separately a site/equipment) on one device, confirm it stays deleted on both, sync doesn't error, and photos are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
