### PR TITLE
feat(sync): auto-refresh entity lists after sync via Drift table-change ticks

### DIFF
--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -21,6 +21,11 @@ class BuddyRepository {
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(BuddyRepository);
 
+  /// Emits whenever the `buddies` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchBuddiesChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.buddies));
+
   /// Get all buddies ordered by name
   Future<List<domain.Buddy>> getAllBuddies({String? diverId}) async {
     try {

--- a/lib/features/buddies/presentation/providers/buddy_providers.dart
+++ b/lib/features/buddies/presentation/providers/buddy_providers.dart
@@ -222,6 +222,14 @@ class BuddyListNotifier extends StateNotifier<AsyncValue<List<Buddy>>> {
         _initializeAndLoad();
       }
     });
+
+    // Reload when the `buddies` table changes (e.g. a sync writes rows
+    // directly) so surfaces watching this notifier (e.g. the buddy summary)
+    // refresh too.
+    final tableChangeSub = _repository.watchBuddiesChanges().listen(
+      (_) => _silentReloadBuddies(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -240,6 +248,23 @@ class BuddyListNotifier extends StateNotifier<AsyncValue<List<Buddy>>> {
       state = AsyncValue.data(buddies);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, for table-change ticks (e.g.
+  /// a sync). Resolves the validated diver id first so an early tick scopes
+  /// correctly.
+  Future<void> _silentReloadBuddies() async {
+    try {
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
+      final buddies = await _repository.getAllBuddies(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(buddies);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/buddies/presentation/providers/buddy_providers.dart
+++ b/lib/features/buddies/presentation/providers/buddy_providers.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -21,12 +22,23 @@ final buddyRepositoryProvider = Provider<BuddyRepository>((ref) {
   return BuddyRepository();
 });
 
-/// All buddies provider
+/// All buddies provider (filtered by current diver).
+///
+/// A one-shot read that self-invalidates whenever the `buddies` table changes
+/// (a sync apply, a local create/edit/delete, ...), so list UIs refresh
+/// automatically while imperative `ref.read(allBuddiesProvider.future)` reads
+/// still resolve.
 final allBuddiesProvider = FutureProvider<List<Buddy>>((ref) async {
   final repository = ref.watch(buddyRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+
+  final sub = repository.watchBuddiesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
+
   return repository.getAllBuddies(diverId: validatedDiverId);
 });
 
@@ -45,6 +57,14 @@ final allBuddiesWithDiveCountProvider =
       final validatedDiverId = await ref.watch(
         validatedCurrentDiverIdProvider.future,
       );
+      final buddiesSub = repository.watchBuddiesChanges().listen(
+        (_) => ref.invalidateSelf(),
+      );
+      ref.onDispose(buddiesSub.cancel);
+      final divesSub = DiveRepository().watchDivesChanges().listen(
+        (_) => ref.invalidateSelf(),
+      );
+      ref.onDispose(divesSub.cancel);
       return repository.getAllBuddiesWithDiveCount(diverId: validatedDiverId);
     });
 

--- a/lib/features/buddies/presentation/providers/buddy_providers.dart
+++ b/lib/features/buddies/presentation/providers/buddy_providers.dart
@@ -5,7 +5,6 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -61,9 +60,10 @@ final allBuddiesWithDiveCountProvider =
         (_) => ref.invalidateSelf(),
       );
       ref.onDispose(buddiesSub.cancel);
-      final divesSub = DiveRepository().watchDivesChanges().listen(
-        (_) => ref.invalidateSelf(),
-      );
+      final divesSub = ref
+          .read(diveRepositoryProvider)
+          .watchDivesChanges()
+          .listen((_) => ref.invalidateSelf());
       ref.onDispose(divesSub.cancel);
       return repository.getAllBuddiesWithDiveCount(diverId: validatedDiverId);
     });

--- a/lib/features/certifications/data/repositories/certification_repository.dart
+++ b/lib/features/certifications/data/repositories/certification_repository.dart
@@ -16,6 +16,11 @@ class CertificationRepository {
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(CertificationRepository);
 
+  /// Emits whenever the `certifications` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchCertificationsChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.certifications));
+
   /// Get all certifications ordered by issue date (newest first)
   Future<List<domain.Certification>> getAllCertifications({
     String? diverId,

--- a/lib/features/certifications/presentation/providers/certification_providers.dart
+++ b/lib/features/certifications/presentation/providers/certification_providers.dart
@@ -20,7 +20,12 @@ final certificationRepositoryProvider = Provider<CertificationRepository>((
   return CertificationRepository();
 });
 
-/// All certifications provider
+/// All certifications provider.
+///
+/// Self-invalidates whenever the `certifications` table changes -- including
+/// when a sync applies remote changes -- so the list refreshes automatically,
+/// while remaining a [FutureProvider] so imperative
+/// `ref.read(provider.future)` reads still resolve.
 final allCertificationsProvider = FutureProvider<List<Certification>>((
   ref,
 ) async {
@@ -28,6 +33,10 @@ final allCertificationsProvider = FutureProvider<List<Certification>>((
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchCertificationsChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllCertifications(diverId: validatedDiverId);
 });
 
@@ -151,6 +160,13 @@ class CertificationListNotifier
         _initializeAndLoad();
       }
     });
+
+    // Refresh when the certifications table changes (e.g. a sync writes rows
+    // directly).
+    final tableChangeSub = _repository.watchCertificationsChanges().listen(
+      (_) => _silentReloadCertifications(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -169,6 +185,20 @@ class CertificationListNotifier
       state = AsyncValue.data(certifications);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, so table-driven refreshes
+  /// (e.g. after a sync write) do not flash a spinner over existing data.
+  /// Reuses the already-resolved [_validatedDiverId].
+  Future<void> _silentReloadCertifications() async {
+    try {
+      final certifications = await _repository.getAllCertifications(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(certifications);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/certifications/presentation/providers/certification_providers.dart
+++ b/lib/features/certifications/presentation/providers/certification_providers.dart
@@ -190,9 +190,13 @@ class CertificationListNotifier
 
   /// Reload without flipping to a loading state, so table-driven refreshes
   /// (e.g. after a sync write) do not flash a spinner over existing data.
-  /// Reuses the already-resolved [_validatedDiverId].
+  /// Resolves the validated diver id first so a tick arriving before
+  /// initialization completes still scopes the query correctly.
   Future<void> _silentReloadCertifications() async {
     try {
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
       final certifications = await _repository.getAllCertifications(
         diverId: _validatedDiverId,
       );

--- a/lib/features/courses/data/repositories/course_repository.dart
+++ b/lib/features/courses/data/repositories/course_repository.dart
@@ -37,6 +37,11 @@ class CourseRepository {
     }
   }
 
+  /// Emits whenever the `courses` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchCoursesChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.courses));
+
   /// Get course by ID
   Future<domain.Course?> getCourseById(String id) async {
     try {

--- a/lib/features/courses/presentation/providers/course_providers.dart
+++ b/lib/features/courses/presentation/providers/course_providers.dart
@@ -231,9 +231,13 @@ class CourseListNotifier extends StateNotifier<AsyncValue<List<Course>>> {
 
   /// Reload without flipping to a loading state, so table-driven refreshes
   /// (e.g. after a sync write) do not flash a spinner over existing data.
-  /// Reuses the already-resolved [_validatedDiverId].
+  /// Resolves the validated diver id first so a tick arriving before
+  /// initialization completes still scopes the query correctly.
   Future<void> _silentReloadCourses() async {
     try {
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
       final courses = await _repository.getAllCourses(
         diverId: _validatedDiverId,
       );

--- a/lib/features/courses/presentation/providers/course_providers.dart
+++ b/lib/features/courses/presentation/providers/course_providers.dart
@@ -19,12 +19,20 @@ final courseRepositoryProvider = Provider<CourseRepository>((ref) {
   return CourseRepository();
 });
 
-/// All courses provider
+/// All courses provider.
+///
+/// Self-invalidates whenever the `courses` table changes (e.g. after a sync)
+/// so the list refreshes automatically, while remaining a [FutureProvider] so
+/// imperative `ref.read(provider.future)` reads still resolve.
 final allCoursesProvider = FutureProvider<List<Course>>((ref) async {
   final repository = ref.watch(courseRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchCoursesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllCourses(diverId: validatedDiverId);
 });
 
@@ -193,6 +201,13 @@ class CourseListNotifier extends StateNotifier<AsyncValue<List<Course>>> {
         _initializeAndLoad();
       }
     });
+
+    // Refresh when the courses table changes (e.g. a sync writes rows
+    // directly).
+    final tableChangeSub = _repository.watchCoursesChanges().listen(
+      (_) => _silentReloadCourses(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -211,6 +226,20 @@ class CourseListNotifier extends StateNotifier<AsyncValue<List<Course>>> {
       state = AsyncValue.data(courses);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, so table-driven refreshes
+  /// (e.g. after a sync write) do not flash a spinner over existing data.
+  /// Reuses the already-resolved [_validatedDiverId].
+  Future<void> _silentReloadCourses() async {
+    try {
+      final courses = await _repository.getAllCourses(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(courses);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/dive_centers/data/repositories/dive_center_repository.dart
+++ b/lib/features/dive_centers/data/repositories/dive_center_repository.dart
@@ -15,6 +15,11 @@ class DiveCenterRepository {
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(DiveCenterRepository);
 
+  /// Emits whenever the `dive_centers` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchDiveCentersChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.diveCenters));
+
   /// Get all dive centers
   Future<List<domain.DiveCenter>> getAllDiveCenters({String? diverId}) async {
     try {

--- a/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
+++ b/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
@@ -199,6 +199,12 @@ class DiveCenterListNotifier
   /// list refreshes in place without flashing a spinner.
   Future<void> _silentReload() async {
     try {
+      // Resolve the validated diver id first: a tick can arrive before
+      // _initializeAndLoad() has populated _validatedDiverId, which would
+      // otherwise query with diverId: null and return unscoped centers.
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
       final centers = await _repository.getAllDiveCenters(
         diverId: _validatedDiverId,
       );

--- a/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
+++ b/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dive_centers/data/repositories/dive_center_r
 import 'package:submersion/features/dive_centers/data/services/dive_center_api_service.dart';
 import 'package:submersion/features/dive_centers/domain/constants/dive_center_field.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -18,12 +19,21 @@ final diveCenterRepositoryProvider = Provider<DiveCenterRepository>((ref) {
   return DiveCenterRepository();
 });
 
-/// All dive centers provider
+/// All dive centers provider.
+///
+/// Self-invalidates whenever the `dive_centers` table changes -- including when
+/// a sync applies remote changes -- so the list refreshes automatically, while
+/// remaining a [FutureProvider] so imperative `ref.read(provider.future)` reads
+/// still resolve.
 final allDiveCentersProvider = FutureProvider<List<DiveCenter>>((ref) async {
   final repository = ref.watch(diveCenterRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchDiveCentersChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllDiveCenters(diverId: validatedDiverId);
 });
 
@@ -128,6 +138,12 @@ final diveCenterDiveCountProvider = FutureProvider.family<int, String>((
   centerId,
 ) async {
   final repository = ref.watch(diveCenterRepositoryProvider);
+  // The count reads the `dives` table, so self-invalidate whenever dives
+  // change (e.g. after a sync) to keep per-row counts fresh.
+  final sub = DiveRepository().watchDivesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getDiveCountForCenter(centerId);
 });
 
@@ -151,6 +167,12 @@ class DiveCenterListNotifier
         _initializeAndLoad();
       }
     });
+
+    // Auto-refresh when the `dive_centers` table changes (e.g. after a sync).
+    final centersChangeSub = _repository.watchDiveCentersChanges().listen(
+      (_) => _silentReload(),
+    );
+    _ref.onDispose(centersChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -169,6 +191,20 @@ class DiveCenterListNotifier
       state = AsyncValue.data(centers);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Silent reload used when the `dive_centers` table changes (e.g. after a
+  /// sync). Mirrors [_loadDiveCenters] but never flips state to loading, so the
+  /// list refreshes in place without flashing a spinner.
+  Future<void> _silentReload() async {
+    try {
+      final centers = await _repository.getAllDiveCenters(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(centers);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
+++ b/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
@@ -6,9 +6,9 @@ import 'package:submersion/features/dive_centers/data/repositories/dive_center_r
 import 'package:submersion/features/dive_centers/data/services/dive_center_api_service.dart';
 import 'package:submersion/features/dive_centers/domain/constants/dive_center_field.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
@@ -140,9 +140,10 @@ final diveCenterDiveCountProvider = FutureProvider.family<int, String>((
   final repository = ref.watch(diveCenterRepositoryProvider);
   // The count reads the `dives` table, so self-invalidate whenever dives
   // change (e.g. after a sync) to keep per-row counts fresh.
-  final sub = DiveRepository().watchDivesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
+  final sub = ref
+      .read(diveRepositoryProvider)
+      .watchDivesChanges()
+      .listen((_) => ref.invalidateSelf());
   ref.onDispose(sub.cancel);
   return repository.getDiveCountForCenter(centerId);
 });

--- a/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
+++ b/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
@@ -8,7 +8,7 @@ import 'package:submersion/features/dive_centers/domain/constants/dive_center_fi
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -45,6 +45,11 @@ class DiveRepository {
   // CRUD Operations
   // ============================================================================
 
+  /// Emits whenever the `dives` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchDivesChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.dives));
+
   /// Get all dives, ordered by date (newest first)
   /// This method is optimized to avoid N+1 queries by batch loading related data
   /// Optionally filter by [diverId] for multi-diver support

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -113,10 +113,18 @@ final customFieldKeySuggestionsProvider =
       return repository.getDistinctKeysForDiver(diverId);
     });
 
-/// All dives list provider (filtered by current diver)
+/// All dives list provider (filtered by current diver).
+///
+/// A [FutureProvider] that self-invalidates whenever the `dives` table is
+/// written (e.g. after a sync applies remote changes), so the list refreshes
+/// while imperative `ref.read(divesProvider.future)` reads still resolve.
 final divesProvider = FutureProvider<List<domain.Dive>>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
   final currentDiverId = ref.watch(currentDiverIdProvider);
+  final sub = repository.watchDivesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllDives(diverId: currentDiverId);
 });
 
@@ -216,6 +224,14 @@ class DiveListNotifier extends StateNotifier<AsyncValue<List<domain.Dive>>> {
       }
     });
     _loadDives();
+
+    // Reload silently when the `dives` table is written directly (e.g. a sync
+    // applies remote changes) without going through this notifier's mutation
+    // methods. Silent so a multi-write sync doesn't flash a loading spinner.
+    final divesChangeSub = _repository.watchDivesChanges().listen(
+      (_) => _silentReload(),
+    );
+    _ref.onDispose(divesChangeSub.cancel);
   }
 
   Future<void> _loadDives() async {
@@ -228,6 +244,18 @@ class DiveListNotifier extends StateNotifier<AsyncValue<List<domain.Dive>>> {
       _ref.invalidate(divesProvider);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload the list without flashing a loading spinner. Mirrors [_loadDives]
+  /// but never sets `state = AsyncValue.loading()`, so table-change ticks from
+  /// a sync update the data in place instead of flickering the UI.
+  Future<void> _silentReload() async {
+    try {
+      final dives = await _repository.getAllDives(diverId: _currentDiverId);
+      if (mounted) state = AsyncValue.data(dives);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 
@@ -432,6 +460,14 @@ class PaginatedDiveListNotifier
       }
     });
     loadFirstPage();
+
+    // Reload silently when the `dives` table is written directly (e.g. a sync
+    // applies remote changes) without going through this notifier's mutation
+    // methods. Silent so a multi-write sync doesn't flash a loading spinner.
+    final divesChangeSub = _repository.watchDivesChanges().listen(
+      (_) => _silentReloadFirstPage(),
+    );
+    _ref.onDispose(divesChangeSub.cancel);
   }
 
   bool get _isDateSort {
@@ -524,6 +560,45 @@ class PaginatedDiveListNotifier
 
   Future<void> refresh() async {
     await loadFirstPage();
+  }
+
+  /// Reload the first page without flashing a loading spinner. Mirrors
+  /// [loadFirstPage] (resetting to page 1 with the same diver/filter/sort
+  /// params) but never sets `state = AsyncValue.loading()`, so table-change
+  /// ticks from a sync update the data in place instead of flickering the UI.
+  Future<void> _silentReloadFirstPage() async {
+    _currentOffset = 0;
+    try {
+      final filter = _ref.read(diveFilterProvider);
+      final sort = _ref.read(diveSortProvider);
+      final results = await Future.wait([
+        _repository.getDiveSummaries(
+          diverId: _currentDiverId,
+          filter: filter,
+          sort: sort,
+          limit: _pageSize,
+        ),
+        _repository.getDiveCount(diverId: _currentDiverId, filter: filter),
+      ]);
+      final dives = results[0] as List<DiveSummary>;
+      final totalCount = results[1] as int;
+      _currentOffset = dives.length;
+
+      if (mounted) {
+        state = AsyncValue.data(
+          PaginatedDiveListState(
+            dives: dives,
+            hasMore: dives.length >= _pageSize,
+            nextCursor: _isDateSort ? _cursorFromLastDive(dives) : null,
+            totalCount: totalCount,
+          ),
+        );
+      }
+      // Pre-load downsampled profiles for mini charts (fire and forget)
+      _loadBatchProfiles(dives.map((d) => d.id).toList());
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
+    }
   }
 
   DiveSummaryCursor? _cursorFromLastDive(List<DiveSummary> dives) {

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_custom_field_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
@@ -18,6 +19,9 @@ import 'package:submersion/features/trips/presentation/providers/trip_providers.
 
 // Re-export DiveFilterState so existing imports continue to work
 export 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+// Re-export diveRepositoryProvider (declared in its own dependency-only module
+// to avoid import cycles) so existing consumers can keep importing it from here.
+export 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 
 /// Dive filter state provider
 final diveFilterProvider = StateProvider<DiveFilterState>(
@@ -93,11 +97,6 @@ List<domain.Dive> _applySorting(
     return sorted;
   });
 }
-
-/// Repository provider
-final diveRepositoryProvider = Provider<DiveRepository>((ref) {
-  return DiveRepository();
-});
 
 /// Custom field repository singleton
 final diveCustomFieldRepositoryProvider = Provider<DiveCustomFieldRepository>((

--- a/lib/features/dive_log/presentation/providers/dive_repository_provider.dart
+++ b/lib/features/dive_log/presentation/providers/dive_repository_provider.dart
@@ -1,0 +1,14 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+/// Provider for the dive repository.
+///
+/// Lives in its own dependency-only module (no feature-presentation imports)
+/// so other feature providers can subscribe to dive-table change ticks via
+/// `diveRepositoryProvider` without importing the full `dive_providers.dart`
+/// — which imports those same feature providers and would create cross-feature
+/// import cycles. `dive_providers.dart` re-exports this so existing
+/// `diveRepositoryProvider` consumers are unaffected.
+final diveRepositoryProvider = Provider<DiveRepository>((ref) {
+  return DiveRepository();
+});

--- a/lib/features/dive_sites/data/repositories/site_repository_impl.dart
+++ b/lib/features/dive_sites/data/repositories/site_repository_impl.dart
@@ -35,6 +35,11 @@ class SiteRepository {
     }
   }
 
+  /// Emits whenever the `dive_sites` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchSitesChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.diveSites));
+
   /// Get a single site by ID
   Future<domain.DiveSite?> getSiteById(String id) async {
     try {

--- a/lib/features/dive_sites/presentation/providers/site_providers.dart
+++ b/lib/features/dive_sites/presentation/providers/site_providers.dart
@@ -4,7 +4,6 @@ import 'package:submersion/core/performance/perf_timer.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -202,9 +201,10 @@ final sitesWithCountsProvider = FutureProvider<List<SiteWithDiveCount>>((
     (_) => ref.invalidateSelf(),
   );
   ref.onDispose(sitesSub.cancel);
-  final divesSub = DiveRepository().watchDivesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
+  final divesSub = ref
+      .read(diveRepositoryProvider)
+      .watchDivesChanges()
+      .listen((_) => ref.invalidateSelf());
   ref.onDispose(divesSub.cancel);
   return repository.getSitesWithDiveCounts(diverId: validatedDiverId);
 });

--- a/lib/features/dive_sites/presentation/providers/site_providers.dart
+++ b/lib/features/dive_sites/presentation/providers/site_providers.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/performance/perf_timer.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -173,11 +174,19 @@ final siteRepositoryProvider = Provider<SiteRepository>((ref) {
 });
 
 /// All sites provider
+///
+/// A [FutureProvider] that self-invalidates whenever the `dive_sites` table is
+/// written (e.g. after a sync applies remote changes), so the list refreshes
+/// while imperative `ref.read(sitesProvider.future)` reads still resolve.
 final sitesProvider = FutureProvider<List<domain.DiveSite>>((ref) async {
   final repository = ref.watch(siteRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchSitesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllSites(diverId: validatedDiverId);
 });
 
@@ -189,6 +198,14 @@ final sitesWithCountsProvider = FutureProvider<List<SiteWithDiveCount>>((
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sitesSub = repository.watchSitesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sitesSub.cancel);
+  final divesSub = DiveRepository().watchDivesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(divesSub.cancel);
   return repository.getSitesWithDiveCounts(diverId: validatedDiverId);
 });
 

--- a/lib/features/dive_types/data/repositories/dive_type_repository.dart
+++ b/lib/features/dive_types/data/repositories/dive_type_repository.dart
@@ -19,6 +19,11 @@ class DiveTypeRepository {
   // CRUD Operations
   // ============================================================================
 
+  /// Emits whenever the `dive_types` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchDiveTypesChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.diveTypes));
+
   /// Get all dive types, ordered by sort order then name
   /// Returns built-in types plus custom types for the specified diver
   /// If no diverId is provided, returns only built-in types

--- a/lib/features/dive_types/presentation/providers/dive_type_providers.dart
+++ b/lib/features/dive_types/presentation/providers/dive_type_providers.dart
@@ -122,9 +122,14 @@ class DiveTypeListNotifier
 
   /// Reload without flipping to a loading state, so table-driven refreshes
   /// (e.g. after a sync write) do not flash a spinner over existing data.
-  /// Reuses the already-resolved [_validatedDiverId].
+  /// Resolves the validated diver id first so a tick arriving before
+  /// initialization completes still scopes the query correctly (otherwise a
+  /// null diver id would drop custom dive types).
   Future<void> _silentReloadDiveTypes() async {
     try {
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
       final diveTypes = await _repository.getAllDiveTypes(
         diverId: _validatedDiverId,
       );

--- a/lib/features/dive_types/presentation/providers/dive_type_providers.dart
+++ b/lib/features/dive_types/presentation/providers/dive_type_providers.dart
@@ -11,11 +11,20 @@ final diveTypeRepositoryProvider = Provider<DiveTypeRepository>((ref) {
 
 /// All dive types list provider (sorted by sort order, then name)
 /// Includes built-in types plus custom types for the current diver
+///
+/// Stays a [FutureProvider] so imperative `ref.read(diveTypesProvider.future)`
+/// reads still resolve, while self-invalidating whenever the `dive_types` table
+/// changes -- including when a sync applies remote changes -- so list UIs
+/// refresh instead of serving a cached one-shot snapshot.
 final diveTypesProvider = FutureProvider<List<DiveTypeEntity>>((ref) async {
   final repository = ref.watch(diveTypeRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchDiveTypesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllDiveTypes(diverId: validatedDiverId);
 });
 
@@ -83,6 +92,13 @@ class DiveTypeListNotifier
         _initializeAndLoad();
       }
     });
+
+    // Refresh when the dive_types table changes (e.g. a sync writes rows
+    // directly). Cancelled on dispose (provider is autoDispose).
+    final tableChangeSub = _repository.watchDiveTypesChanges().listen(
+      (_) => _silentReloadDiveTypes(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -101,6 +117,20 @@ class DiveTypeListNotifier
       state = AsyncValue.data(diveTypes);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, so table-driven refreshes
+  /// (e.g. after a sync write) do not flash a spinner over existing data.
+  /// Reuses the already-resolved [_validatedDiverId].
+  Future<void> _silentReloadDiveTypes() async {
+    try {
+      final diveTypes = await _repository.getAllDiveTypes(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(diveTypes);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -52,6 +52,11 @@ class DiverRepository {
     }
   }
 
+  /// Emits whenever the `divers` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchDiversChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.divers));
+
   /// Get the default diver (or first if none marked default)
   Future<domain.Diver?> getDefaultDiver() async {
     try {

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -16,9 +16,17 @@ final diverMergeRepositoryProvider = Provider<DiverMergeRepository>((ref) {
   return DiverMergeRepository();
 });
 
-/// All divers provider
+/// All divers provider.
+///
+/// A [FutureProvider] that self-invalidates whenever the `divers` table is
+/// written (e.g. after a sync), so the list refreshes while imperative
+/// `ref.read(allDiversProvider.future)` reads still resolve.
 final allDiversProvider = FutureProvider<List<Diver>>((ref) async {
   final repository = ref.watch(diverRepositoryProvider);
+  final sub = repository.watchDiversChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllDivers();
 });
 
@@ -176,6 +184,12 @@ class DiverListNotifier extends StateNotifier<AsyncValue<List<Diver>>> {
   DiverListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
     _loadDivers();
+
+    // Refresh when the divers table changes (e.g. a sync writes rows directly).
+    final tableChangeSub = _repository.watchDiversChanges().listen(
+      (_) => _silentReloadDivers(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _loadDivers() async {
@@ -185,6 +199,17 @@ class DiverListNotifier extends StateNotifier<AsyncValue<List<Diver>>> {
       state = AsyncValue.data(divers);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, so table-driven refreshes
+  /// (e.g. after a sync write) do not flash a spinner over existing data.
+  Future<void> _silentReloadDivers() async {
+    try {
+      final divers = await _repository.getAllDivers();
+      if (mounted) state = AsyncValue.data(divers);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -5,6 +5,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 
 /// Repository provider
 final diverRepositoryProvider = Provider<DiverRepository>((ref) {
@@ -298,6 +299,13 @@ final diverStatsProvider = FutureProvider.family<DiverStats, String>((
   diverId,
 ) async {
   final repository = ref.watch(diverRepositoryProvider);
+  // The stats read the `dives` table, so self-invalidate when dives change
+  // (e.g. after a sync) to keep the per-tile counts on the diver list fresh.
+  final diveSub = ref
+      .read(diveRepositoryProvider)
+      .watchDivesChanges()
+      .listen((_) => ref.invalidateSelf());
+  ref.onDispose(diveSub.cancel);
   final diveCount = await repository.getDiveCountForDiver(diverId);
   final totalTime = await repository.getTotalBottomTimeForDiver(diverId);
   return DiverStats(diveCount: diveCount, totalBottomTimeSeconds: totalTime);

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -5,7 +5,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 
 /// Repository provider
 final diverRepositoryProvider = Provider<DiverRepository>((ref) {

--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -66,6 +66,11 @@ class EquipmentRepository {
     }
   }
 
+  /// Emits whenever the `equipment` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchEquipmentChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.equipment));
+
   /// Get all equipment
   Future<List<EquipmentItem>> getAllEquipment({String? diverId}) async {
     try {

--- a/lib/features/equipment/presentation/providers/equipment_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_providers.dart
@@ -51,18 +51,33 @@ final equipmentByStatusProvider =
       final validatedDiverId = await ref.watch(
         validatedCurrentDiverIdProvider.future,
       );
+      final sub = repository.watchEquipmentChanges().listen(
+        (_) => ref.invalidateSelf(),
+      );
+      ref.onDispose(sub.cancel);
       if (status == null) {
         return repository.getAllEquipment(diverId: validatedDiverId);
       }
       return repository.getEquipmentByStatus(status, diverId: validatedDiverId);
     });
 
-/// All equipment provider
+/// All equipment provider (filtered by current diver).
+///
+/// A one-shot read that self-invalidates whenever the `equipment` table
+/// changes (a sync apply, a local create/edit/delete, ...), so list UIs
+/// refresh automatically while imperative
+/// `ref.read(allEquipmentProvider.future)` reads still resolve.
 final allEquipmentProvider = FutureProvider<List<EquipmentItem>>((ref) async {
   final repository = ref.watch(equipmentRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+
+  final sub = repository.watchEquipmentChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
+
   return repository.getAllEquipment(diverId: validatedDiverId);
 });
 
@@ -158,6 +173,10 @@ final serviceDueEquipmentProvider = FutureProvider<List<EquipmentItem>>((
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchEquipmentChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getEquipmentWithServiceDue(diverId: validatedDiverId);
 });
 

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -27,6 +27,11 @@ class SpeciesRepository {
     return rows.map((row) => _mapRowToSpecies(row)).toList();
   }
 
+  /// Emits whenever the `species` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchSpeciesChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.species));
+
   /// Get species by category
   Future<List<domain.Species>> getSpeciesByCategory(
     SpeciesCategory category,

--- a/lib/features/marine_life/presentation/providers/species_providers.dart
+++ b/lib/features/marine_life/presentation/providers/species_providers.dart
@@ -12,6 +12,10 @@ final speciesRepositoryProvider = Provider<SpeciesRepository>((ref) {
 /// All species provider
 final allSpeciesProvider = FutureProvider<List<Species>>((ref) async {
   final repository = ref.watch(speciesRepositoryProvider);
+  final sub = repository.watchSpeciesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllSpecies();
 });
 
@@ -163,14 +167,22 @@ class SpeciesListNotifier extends StateNotifier<AsyncValue<List<Species>>> {
   SpeciesListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
     _loadSpecies();
+
+    // Reload when the `species` table changes (e.g. a sync writes rows
+    // directly), not just on local mutations. _loadSpecies() updates in place
+    // without a loading flash, so it doubles as the silent reload.
+    final tableChangeSub = _repository.watchSpeciesChanges().listen(
+      (_) => _loadSpecies(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _loadSpecies() async {
     try {
       final species = await _repository.getAllSpecies();
-      state = AsyncValue.data(species);
+      if (mounted) state = AsyncValue.data(species);
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/tags/data/repositories/tag_repository.dart
+++ b/lib/features/tags/data/repositories/tag_repository.dart
@@ -18,6 +18,11 @@ class TagRepository {
   // CRUD Operations
   // ============================================================================
 
+  /// Emits whenever the `tags` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchTagsChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.tags));
+
   /// Get all tags, ordered by name
   Future<List<domain.Tag>> getAllTags({String? diverId}) async {
     try {

--- a/lib/features/tags/presentation/providers/tag_providers.dart
+++ b/lib/features/tags/presentation/providers/tag_providers.dart
@@ -91,6 +91,13 @@ class TagListNotifier extends StateNotifier<AsyncValue<List<Tag>>> {
         _initializeAndLoad();
       }
     });
+
+    // Reload when the `tags` table changes (e.g. a sync writes rows directly)
+    // so surfaces watching this notifier (e.g. the tag picker) refresh too.
+    final tableChangeSub = _repository.watchTagsChanges().listen(
+      (_) => _silentReloadTags(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -107,6 +114,21 @@ class TagListNotifier extends StateNotifier<AsyncValue<List<Tag>>> {
       state = AsyncValue.data(tags);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, for table-change ticks (e.g.
+  /// a sync). Resolves the validated diver id first so an early tick scopes
+  /// correctly.
+  Future<void> _silentReloadTags() async {
+    try {
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
+      final tags = await _repository.getAllTags(diverId: _validatedDiverId);
+      if (mounted) state = AsyncValue.data(tags);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/tags/presentation/providers/tag_providers.dart
+++ b/lib/features/tags/presentation/providers/tag_providers.dart
@@ -1,5 +1,6 @@
 import 'package:submersion/core/providers/provider.dart';
 
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
@@ -11,11 +12,18 @@ final tagRepositoryProvider = Provider<TagRepository>((ref) {
 });
 
 /// All tags list provider
+///
+/// Stays a [FutureProvider] so imperative `ref.read(tagsProvider.future)` reads
+/// still resolve, while self-invalidating whenever the `tags` table changes --
+/// including when a sync applies remote changes -- so list UIs refresh instead
+/// of serving a cached one-shot snapshot.
 final tagsProvider = FutureProvider<List<Tag>>((ref) async {
   final repository = ref.watch(tagRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchTagsChanges().listen((_) => ref.invalidateSelf());
+  ref.onDispose(sub.cancel);
   return repository.getAllTags(diverId: validatedDiverId);
 });
 
@@ -31,6 +39,14 @@ final tagStatisticsProvider = FutureProvider<List<TagStatistic>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final tagsSub = repository.watchTagsChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(tagsSub.cancel);
+  final divesSub = DiveRepository().watchDivesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(divesSub.cancel);
   return repository.getTagStatistics(diverId: validatedDiverId);
 });
 

--- a/lib/features/tags/presentation/providers/tag_providers.dart
+++ b/lib/features/tags/presentation/providers/tag_providers.dart
@@ -1,6 +1,5 @@
 import 'package:submersion/core/providers/provider.dart';
 
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
@@ -43,9 +42,10 @@ final tagStatisticsProvider = FutureProvider<List<TagStatistic>>((ref) async {
     (_) => ref.invalidateSelf(),
   );
   ref.onDispose(tagsSub.cancel);
-  final divesSub = DiveRepository().watchDivesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
+  final divesSub = ref
+      .read(diveRepositoryProvider)
+      .watchDivesChanges()
+      .listen((_) => ref.invalidateSelf());
   ref.onDispose(divesSub.cancel);
   return repository.getTagStatistics(diverId: validatedDiverId);
 });

--- a/lib/features/tank_presets/data/repositories/tank_preset_repository.dart
+++ b/lib/features/tank_presets/data/repositories/tank_preset_repository.dart
@@ -20,6 +20,11 @@ class TankPresetRepository {
   // CRUD Operations
   // ============================================================================
 
+  /// Emits whenever the `tank_presets` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchTankPresetsChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.tankPresets));
+
   /// Get all tank presets (custom + built-in), with custom presets first
   /// If no diverId is provided, returns only built-in presets
   Future<List<TankPresetEntity>> getAllPresets({String? diverId}) async {

--- a/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
+++ b/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
@@ -11,11 +11,21 @@ final tankPresetRepositoryProvider = Provider<TankPresetRepository>((ref) {
 
 /// All tank presets provider (custom + built-in, custom first)
 /// Includes built-in presets plus custom presets for the current diver
+///
+/// Stays a [FutureProvider] so imperative
+/// `ref.read(tankPresetsProvider.future)` reads still resolve, while
+/// self-invalidating whenever the `tank_presets` table changes -- including
+/// when a sync applies remote changes -- so list UIs refresh instead of serving
+/// a cached one-shot snapshot.
 final tankPresetsProvider = FutureProvider<List<TankPresetEntity>>((ref) async {
   final repository = ref.watch(tankPresetRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  final sub = repository.watchTankPresetsChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getAllPresets(diverId: validatedDiverId);
 });
 
@@ -63,6 +73,13 @@ class TankPresetListNotifier
         _initializeAndLoad();
       }
     });
+
+    // Refresh when the tank_presets table changes (e.g. a sync writes rows
+    // directly). Cancelled on dispose (provider is autoDispose).
+    final tableChangeSub = _repository.watchTankPresetsChanges().listen(
+      (_) => _silentReloadPresets(),
+    );
+    _ref.onDispose(tableChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -81,6 +98,20 @@ class TankPresetListNotifier
       state = AsyncValue.data(presets);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Reload without flipping to a loading state, so table-driven refreshes
+  /// (e.g. after a sync write) do not flash a spinner over existing data.
+  /// Reuses the already-resolved [_validatedDiverId].
+  Future<void> _silentReloadPresets() async {
+    try {
+      final presets = await _repository.getAllPresets(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(presets);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
+++ b/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
@@ -103,9 +103,14 @@ class TankPresetListNotifier
 
   /// Reload without flipping to a loading state, so table-driven refreshes
   /// (e.g. after a sync write) do not flash a spinner over existing data.
-  /// Reuses the already-resolved [_validatedDiverId].
+  /// Resolves the validated diver id first so a tick arriving before
+  /// initialization completes still scopes the query correctly (otherwise a
+  /// null diver id would drop custom presets).
   Future<void> _silentReloadPresets() async {
     try {
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
       final presets = await _repository.getAllPresets(
         diverId: _validatedDiverId,
       );

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -20,6 +20,11 @@ class TripRepository {
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(TripRepository);
 
+  /// Emits whenever the `trips` table changes so list providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchTripsChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.trips));
+
   /// Get all trips ordered by start date (most recent first)
   Future<List<domain.Trip>> getAllTrips({String? diverId}) async {
     try {

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -45,12 +45,23 @@ final tripRepositoryProvider = Provider<TripRepository>((ref) {
   return TripRepository();
 });
 
-/// All trips provider
+/// All trips provider.
+///
+/// A one-shot read that self-invalidates whenever the `trips` table changes
+/// (a sync apply, a local create/edit/delete, ...), so list UIs refresh
+/// automatically while imperative `ref.read(allTripsProvider.future)` reads
+/// still resolve.
 final allTripsProvider = FutureProvider<List<Trip>>((ref) async {
   final repository = ref.watch(tripRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+
+  final sub = repository.watchTripsChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
+
   return repository.getAllTrips(diverId: validatedDiverId);
 });
 
@@ -260,6 +271,19 @@ class TripListNotifier extends StateNotifier<AsyncValue<List<TripWithStats>>> {
         _initializeAndLoad();
       }
     });
+
+    // Auto-refresh when the underlying tables change (e.g. after a sync).
+    // Subscribe to both the trips table and the dives table: the stats query
+    // LEFT JOINs dives, so a synced dive can change the per-trip counts even
+    // when no trip row changed.
+    final tripsChangeSub = _repository.watchTripsChanges().listen(
+      (_) => _silentReload(),
+    );
+    final divesChangeSub = DiveRepository().watchDivesChanges().listen(
+      (_) => _silentReload(),
+    );
+    _ref.onDispose(tripsChangeSub.cancel);
+    _ref.onDispose(divesChangeSub.cancel);
   }
 
   Future<void> _initializeAndLoad() async {
@@ -284,6 +308,22 @@ class TripListNotifier extends StateNotifier<AsyncValue<List<TripWithStats>>> {
       state = AsyncValue.data(trips);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Silent reload used when the underlying tables change (e.g. after a sync).
+  ///
+  /// Mirrors [_loadTrips] but never flips state to loading, so the list
+  /// refreshes in place without flashing a spinner. The trip stats LEFT JOIN
+  /// the dives table, so this fires for both trip and dive table changes.
+  Future<void> _silentReload() async {
+    try {
+      final trips = await _repository.getAllTripsWithStats(
+        diverId: _validatedDiverId,
+      );
+      if (mounted) state = AsyncValue.data(trips);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/dive_log/presentation/providers/view_config_
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     as domain;
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
 import 'package:submersion/features/trips/domain/constants/trip_field.dart';
@@ -279,9 +280,10 @@ class TripListNotifier extends StateNotifier<AsyncValue<List<TripWithStats>>> {
     final tripsChangeSub = _repository.watchTripsChanges().listen(
       (_) => _silentReload(),
     );
-    final divesChangeSub = DiveRepository().watchDivesChanges().listen(
-      (_) => _silentReload(),
-    );
+    final divesChangeSub = _ref
+        .read(diveRepositoryProvider)
+        .watchDivesChanges()
+        .listen((_) => _silentReload());
     _ref.onDispose(tripsChangeSub.cancel);
     _ref.onDispose(divesChangeSub.cancel);
   }

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -318,6 +318,12 @@ class TripListNotifier extends StateNotifier<AsyncValue<List<TripWithStats>>> {
   /// the dives table, so this fires for both trip and dive table changes.
   Future<void> _silentReload() async {
     try {
+      // Resolve the validated diver id first: a tick can arrive before
+      // _initializeAndLoad() has populated _validatedDiverId, which would
+      // otherwise query with diverId: null and show unscoped stats.
+      _validatedDiverId = await _ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
       final trips = await _repository.getAllTripsWithStats(
         diverId: _validatedDiverId,
       );

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -9,7 +9,7 @@ import 'package:submersion/features/dive_log/presentation/providers/view_config_
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     as domain;
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
 import 'package:submersion/features/trips/domain/constants/trip_field.dart';

--- a/test/features/buddies/presentation/providers/buddy_providers_test.dart
+++ b/test/features/buddies/presentation/providers/buddy_providers_test.dart
@@ -1,0 +1,223 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/database.dart' as db;
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Buddy _makeBuddy({
+  String id = '',
+  String name = 'Test Buddy',
+  String? diverId,
+}) {
+  final now = DateTime(2024);
+  return Buddy(
+    id: id,
+    name: name,
+    diverId: diverId,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+/// Inserts a dive row directly into the `dives` table, mirroring a sync apply
+/// that writes rows without going through any list notifier. This fires the
+/// `dives` table-change tick that count-aware providers subscribe to.
+Future<void> _insertDive(db.AppDatabase database, {required String id}) async {
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await database
+      .into(database.dives)
+      .insert(
+        db.DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(now),
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late BuddyRepository buddyRepo;
+  late DiverRepository diverRepo;
+  late db.AppDatabase database;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    buddyRepo = BuddyRepository();
+    diverRepo = DiverRepository();
+    database = DatabaseService.instance.database;
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  Future<Diver> seedCurrentDiver() async {
+    final diver = await diverRepo.createDiver(
+      Diver(
+        id: '',
+        name: 'D',
+        isDefault: true,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('allBuddiesProvider', () {
+    test('auto-refreshes after a buddy is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // An active listener keeps the provider (and its buddies table-change
+      // subscription) alive, mirroring a widget that watches the list.
+      final sub = container.listen(allBuddiesProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(allBuddiesProvider.future), isEmpty);
+
+      // A sync applies a remote buddy straight to the DB (no notifier
+      // mutation). The watchBuddiesChanges tick must invalidate the provider
+      // so the new row surfaces.
+      await buddyRepo.createBuddy(
+        _makeBuddy(name: 'Synced Buddy', diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          allBuddiesProvider.future,
+        )).map((b) => b.name).toList();
+        if (names.contains('Synced Buddy')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Buddy'),
+        reason:
+            'allBuddiesProvider should auto-refresh after a direct table '
+            'write without any manual invalidation',
+      );
+    });
+  });
+
+  group('allBuddiesWithDiveCountProvider', () {
+    test(
+      'auto-refreshes on both buddies and dives table writes (sync scenario)',
+      () async {
+        final diver = await seedCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        // Keep the provider alive so both its buddies and dives table-change
+        // subscriptions stay open.
+        final sub = container.listen(
+          allBuddiesWithDiveCountProvider,
+          (_, _) {},
+        );
+        addTearDown(sub.close);
+
+        expect(
+          await container.read(allBuddiesWithDiveCountProvider.future),
+          isEmpty,
+        );
+
+        // Buddies-table tick: a synced buddy applied straight to the DB.
+        await buddyRepo.createBuddy(
+          _makeBuddy(name: 'Counted Buddy', diverId: diver.id),
+        );
+
+        // Dives-table tick: a synced dive applied straight to the DB exercises
+        // the separate dives subscription that also invalidates this provider.
+        await _insertDive(database, id: 'count-dive-1');
+
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (await container.read(
+            allBuddiesWithDiveCountProvider.future,
+          )).map((b) => b.buddy.name).toList();
+          if (names.contains('Counted Buddy')) break;
+        }
+
+        expect(
+          names,
+          contains('Counted Buddy'),
+          reason:
+              'allBuddiesWithDiveCountProvider should auto-refresh after '
+              'direct buddies/dives table writes',
+        );
+      },
+    );
+  });
+
+  group('BuddyListNotifier', () {
+    test('silently reloads the list when a buddy is written directly to the '
+        'DB (sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen buddy list.
+      final sub = container.listen(buddyListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(buddyListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(buddyListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote buddy straight to the DB (no addBuddy call).
+      // The watchBuddiesChanges tick must trigger _silentReloadBuddies.
+      await buddyRepo.createBuddy(
+        _makeBuddy(name: 'Silent Buddy', diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(buddyListNotifierProvider).value ?? [])
+            .map((b) => b.name)
+            .toList();
+        if (names.contains('Silent Buddy')) break;
+      }
+
+      expect(
+        names,
+        contains('Silent Buddy'),
+        reason:
+            'BuddyListNotifier should silently reload after a direct DB write '
+            'without any manual refresh() call',
+      );
+    });
+  });
+}

--- a/test/features/certifications/presentation/providers/certification_providers_test.dart
+++ b/test/features/certifications/presentation/providers/certification_providers_test.dart
@@ -190,11 +190,12 @@ void main() {
       );
     });
 
-    test('silent reload surfaces an AsyncError when getAll throws', () async {
+    test('reports AsyncError when the initial load throws', () async {
       await seedCurrentDiver();
 
-      // Use the real repository to drive the table-change tick, but make
-      // getAllCertifications throw so the silent-reload catch branch runs.
+      // A repository whose getAllCertifications always throws makes the
+      // notifier's initial load (_loadCertifications) fail, exercising its
+      // error catch branch. No table-change tick is involved here.
       final throwing = _ThrowingCertificationRepository();
       final container = ProviderContainer(
         overrides: [

--- a/test/features/certifications/presentation/providers/certification_providers_test.dart
+++ b/test/features/certifications/presentation/providers/certification_providers_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/certifications/data/repositories/certification_repository.dart';
+import 'package:submersion/features/certifications/domain/entities/certification.dart';
+import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Certification _makeCertification({
+  String id = '',
+  String name = 'Open Water',
+  String? diverId,
+}) {
+  final now = DateTime(2024);
+  return Certification(
+    id: id,
+    diverId: diverId,
+    name: name,
+    agency: CertificationAgency.padi,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Diver _makeDiver({String name = 'D', bool isDefault = true}) {
+  final now = DateTime(2024);
+  return Diver(
+    id: '',
+    name: name,
+    isDefault: isDefault,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+/// Repository whose [getAllCertifications] always throws, to exercise the
+/// error/catch branch of the providers. Its change stream is inert so no tick
+/// is ever delivered.
+class _ThrowingCertificationRepository extends CertificationRepository {
+  @override
+  Stream<void> watchCertificationsChanges() => const Stream<void>.empty();
+
+  @override
+  Future<List<Certification>> getAllCertifications({String? diverId}) async {
+    throw StateError('boom');
+  }
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late CertificationRepository certRepo;
+  late DiverRepository diverRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    certRepo = CertificationRepository();
+    diverRepo = DiverRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates a default diver and selects it as current, so diver-scoped
+  /// providers resolve a stable validated diver id.
+  Future<Diver> seedCurrentDiver() async {
+    final diver = await diverRepo.createDiver(_makeDiver());
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('allCertificationsProvider', () {
+    test('auto-refreshes after a write to the certifications table '
+        '(sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // An active listener keeps the provider (and its table-change
+      // subscription) alive, mirroring a widget watching the list.
+      final sub = container.listen(allCertificationsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(allCertificationsProvider.future), isEmpty);
+
+      // A sync applies a remote certification straight to the DB, bypassing the
+      // list notifier. The tableUpdates tick must invalidate the provider so the
+      // UI reflects the new row.
+      await certRepo.createCertification(
+        _makeCertification(name: 'Synced Cert').copyWith(diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          allCertificationsProvider.future,
+        )).map((c) => c.name).toList();
+        if (names.contains('Synced Cert')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Cert'),
+        reason:
+            'allCertificationsProvider should auto-refresh after the table '
+            'write without any manual invalidation',
+      );
+    });
+
+    test('surfaces an AsyncError when the repository getAll throws', () async {
+      await seedCurrentDiver();
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          certificationRepositoryProvider.overrideWithValue(
+            _ThrowingCertificationRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await expectLater(
+        container.read(allCertificationsProvider.future),
+        throwsA(isA<StateError>()),
+      );
+      expect(container.read(allCertificationsProvider).hasError, isTrue);
+    });
+  });
+
+  group('certificationListNotifierProvider', () {
+    test('auto-refreshes the list when a certification is written directly to '
+        'the DB (sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(
+        certificationListNotifierProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      while (container.read(certificationListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(certificationListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote certification straight to the DB (no notifier
+      // mutation call). The watchCertificationsChanges tick must silently reload
+      // the list via _silentReloadCertifications.
+      await certRepo.createCertification(
+        _makeCertification(name: 'Synced Cert').copyWith(diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(certificationListNotifierProvider).value ?? [])
+            .map((c) => c.name)
+            .toList();
+        if (names.contains('Synced Cert')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Cert'),
+        reason:
+            'CertificationListNotifier should auto-refresh after a direct DB '
+            'write without any manual refresh() call',
+      );
+    });
+
+    test('silent reload surfaces an AsyncError when getAll throws', () async {
+      await seedCurrentDiver();
+
+      // Use the real repository to drive the table-change tick, but make
+      // getAllCertifications throw so the silent-reload catch branch runs.
+      final throwing = _ThrowingCertificationRepository();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          certificationRepositoryProvider.overrideWithValue(throwing),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(
+        certificationListNotifierProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      // The initial load itself goes through _loadCertifications, which also
+      // routes the throw into AsyncValue.error.
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        if (container.read(certificationListNotifierProvider).hasError) break;
+      }
+
+      expect(
+        container.read(certificationListNotifierProvider).hasError,
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/courses/presentation/providers/course_providers_test.dart
+++ b/test/features/courses/presentation/providers/course_providers_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/courses/data/repositories/course_repository.dart';
+import 'package:submersion/features/courses/domain/entities/course.dart';
+import 'package:submersion/features/courses/presentation/providers/course_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Course _makeCourse({
+  String id = '',
+  String name = 'Open Water',
+  required String diverId,
+}) {
+  final now = DateTime(2024);
+  return Course(
+    id: id,
+    diverId: diverId,
+    name: name,
+    agency: CertificationAgency.padi,
+    startDate: now,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Diver _makeDiver({String name = 'D', bool isDefault = true}) {
+  final now = DateTime(2024);
+  return Diver(
+    id: '',
+    name: name,
+    isDefault: isDefault,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+/// Repository whose [getAllCourses] always throws, to exercise the error/catch
+/// branch of the providers. Its change stream is inert so no tick is delivered.
+class _ThrowingCourseRepository extends CourseRepository {
+  @override
+  Stream<void> watchCoursesChanges() => const Stream<void>.empty();
+
+  @override
+  Future<List<Course>> getAllCourses({String? diverId}) async {
+    throw StateError('boom');
+  }
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late CourseRepository courseRepo;
+  late DiverRepository diverRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    courseRepo = CourseRepository();
+    diverRepo = DiverRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates a default diver and selects it as current, so diver-scoped
+  /// providers resolve a stable validated diver id.
+  Future<Diver> seedCurrentDiver() async {
+    final diver = await diverRepo.createDiver(_makeDiver());
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('allCoursesProvider', () {
+    test(
+      'auto-refreshes after a write to the courses table (sync scenario)',
+      () async {
+        final diver = await seedCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        // An active listener keeps the provider (and its table-change
+        // subscription) alive, mirroring a widget watching the list.
+        final sub = container.listen(allCoursesProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        expect(await container.read(allCoursesProvider.future), isEmpty);
+
+        // A sync applies a remote course straight to the DB, bypassing the list
+        // notifier. The tableUpdates tick must invalidate the provider so the
+        // UI reflects the new row.
+        await courseRepo.createCourse(
+          _makeCourse(name: 'Synced Course', diverId: diver.id),
+        );
+
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (await container.read(
+            allCoursesProvider.future,
+          )).map((c) => c.name).toList();
+          if (names.contains('Synced Course')) break;
+        }
+
+        expect(
+          names,
+          contains('Synced Course'),
+          reason:
+              'allCoursesProvider should auto-refresh after the table write '
+              'without any manual invalidation',
+        );
+      },
+    );
+
+    test('surfaces an AsyncError when the repository getAll throws', () async {
+      await seedCurrentDiver();
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          courseRepositoryProvider.overrideWithValue(
+            _ThrowingCourseRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await expectLater(
+        container.read(allCoursesProvider.future),
+        throwsA(isA<StateError>()),
+      );
+      expect(container.read(allCoursesProvider).hasError, isTrue);
+    });
+  });
+
+  group('courseListNotifierProvider', () {
+    test('auto-refreshes the list when a course is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(courseListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(courseListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(courseListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote course straight to the DB (no notifier mutation
+      // call). The watchCoursesChanges tick must silently reload the list via
+      // _silentReloadCourses.
+      await courseRepo.createCourse(
+        _makeCourse(name: 'Synced Course', diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(courseListNotifierProvider).value ?? [])
+            .map((c) => c.name)
+            .toList();
+        if (names.contains('Synced Course')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Course'),
+        reason:
+            'CourseListNotifier should auto-refresh after a direct DB write '
+            'without any manual refresh() call',
+      );
+    });
+
+    test('silent reload surfaces an AsyncError when getAll throws', () async {
+      await seedCurrentDiver();
+
+      // Use the throwing repository so the load/silent-reload catch branch runs.
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          courseRepositoryProvider.overrideWithValue(
+            _ThrowingCourseRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(courseListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        if (container.read(courseListNotifierProvider).hasError) break;
+      }
+
+      expect(container.read(courseListNotifierProvider).hasError, isTrue);
+    });
+  });
+}

--- a/test/features/courses/presentation/providers/course_providers_test.dart
+++ b/test/features/courses/presentation/providers/course_providers_test.dart
@@ -189,10 +189,12 @@ void main() {
       );
     });
 
-    test('silent reload surfaces an AsyncError when getAll throws', () async {
+    test('reports AsyncError when the initial load throws', () async {
       await seedCurrentDiver();
 
-      // Use the throwing repository so the load/silent-reload catch branch runs.
+      // A repository that always throws makes the notifier's initial load
+      // (_loadCourses) fail, exercising its error catch branch. No table-change
+      // tick is involved here.
       final container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),

--- a/test/features/dive_centers/presentation/providers/dive_center_providers_test.dart
+++ b/test/features/dive_centers/presentation/providers/dive_center_providers_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart';
+import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
+import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+DiveCenter _makeCenter({
+  String id = '',
+  String name = 'Test Center',
+  String? diverId,
+}) {
+  final now = DateTime.now();
+  return DiveCenter(
+    id: id,
+    diverId: diverId,
+    name: name,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Dive _makeDive({String id = '', required DiveCenter center}) {
+  return Dive(id: id, dateTime: DateTime(2024, 1, 1, 10), diveCenter: center);
+}
+
+/// Fake repository whose [getAllDiveCenters] always throws, used to exercise
+/// the providers' error path.
+class _ThrowingDiveCenterRepository extends DiveCenterRepository {
+  @override
+  Future<List<DiveCenter>> getAllDiveCenters({String? diverId}) async {
+    throw StateError('boom');
+  }
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late DiveCenterRepository centerRepo;
+  late DiverRepository diverRepo;
+  late DiveRepository diveRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    centerRepo = DiveCenterRepository();
+    diverRepo = DiverRepository();
+    diveRepo = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates the current default diver. Dive centers are diver-scoped, so a
+  /// valid current diver is required for the scoped queries to return rows.
+  Future<Diver> setUpCurrentDiver() async {
+    final diver = await diverRepo.createDiver(
+      Diver(
+        id: '',
+        name: 'D',
+        isDefault: true,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('allDiveCentersProvider auto-refresh', () {
+    test('auto-refreshes after a dive center is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // An active listener keeps the provider (and its dive_centers
+      // table-change subscription) alive, mirroring a widget watching the
+      // list.
+      final sub = container.listen(allDiveCentersProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(allDiveCentersProvider.future), isEmpty);
+
+      // A sync applies a remote dive center straight to the DB, bypassing the
+      // list notifier (no manual invalidate). The watchDiveCentersChanges
+      // tick must invalidateSelf so the provider reflects the new row.
+      await centerRepo.createDiveCenter(
+        _makeCenter(name: 'Synced Center', diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          allDiveCentersProvider.future,
+        )).map((c) => c.name).toList();
+        if (names.contains('Synced Center')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Center'),
+        reason:
+            'allDiveCentersProvider should auto-refresh after the table '
+            'write without any manual invalidation',
+      );
+    });
+
+    test('surfaces an AsyncError when the repository throws', () async {
+      await setUpCurrentDiver();
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diveCenterRepositoryProvider.overrideWithValue(
+            _ThrowingDiveCenterRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = container.read(allDiveCentersProvider);
+      // Drive the future to completion and assert it rejects.
+      await expectLater(
+        container.read(allDiveCentersProvider.future),
+        throwsA(isA<StateError>()),
+      );
+      expect(container.read(allDiveCentersProvider), isA<AsyncError>());
+      // Initial read is loading before the throw propagates.
+      expect(result, isA<AsyncLoading>());
+    });
+  });
+
+  group('diveCenterDiveCountProvider auto-refresh', () {
+    test('recomputes the count when a dive is written for the center '
+        '(sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+      final center = await centerRepo.createDiveCenter(
+        _makeCenter(name: 'Counted', diverId: diver.id),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // An active listener keeps the family provider (and its dives
+      // table-change subscription) alive.
+      final sub = container.listen(
+        diveCenterDiveCountProvider(center.id),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(diveCenterDiveCountProvider(center.id).future),
+        equals(0),
+      );
+
+      // A sync writes a dive linked to this center straight to the DB. The
+      // watchDivesChanges tick must invalidateSelf so the per-row count
+      // refreshes.
+      await diveRepo.createDive(_makeDive(center: center));
+
+      var count = 0;
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        count = await container.read(
+          diveCenterDiveCountProvider(center.id).future,
+        );
+        if (count > 0) break;
+      }
+
+      expect(
+        count,
+        equals(1),
+        reason:
+            'diveCenterDiveCountProvider should auto-refresh after a dive is '
+            'written for the center without any manual invalidation',
+      );
+    });
+  });
+
+  group('diveCenterListNotifierProvider silent reload', () {
+    test(
+      'auto-refreshes the list when a dive center is written directly to the '
+      'DB (sync scenario)',
+      () async {
+        final diver = await setUpCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        // An active listener keeps the notifier (and its dive_centers
+        // table-change subscription) alive, mirroring the on-screen list.
+        final sub = container.listen(diveCenterListNotifierProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        while (container.read(diveCenterListNotifierProvider).isLoading) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        expect(container.read(diveCenterListNotifierProvider).value, isEmpty);
+
+        // A sync applies a remote dive center straight to the DB (no notifier
+        // mutation call). The watchDiveCentersChanges tick must trigger
+        // _silentReload, which refreshes in place without flipping to loading.
+        await centerRepo.createDiveCenter(
+          _makeCenter(name: 'Silently Synced', diverId: diver.id),
+        );
+
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (container.read(diveCenterListNotifierProvider).value ?? [])
+              .map((c) => c.name)
+              .toList();
+          if (names.contains('Silently Synced')) break;
+        }
+
+        expect(
+          names,
+          contains('Silently Synced'),
+          reason:
+              'DiveCenterListNotifier should silently reload after a direct DB '
+              'write without any manual refresh() call',
+        );
+      },
+    );
+
+    test('surfaces an AsyncError when the repository throws on load', () async {
+      await setUpCurrentDiver();
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diveCenterRepositoryProvider.overrideWithValue(
+            _ThrowingDiveCenterRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // The notifier's initial load calls getAllDiveCenters, which throws and
+      // is caught into AsyncValue.error.
+      AsyncValue<List<DiveCenter>> state = container.read(
+        diveCenterListNotifierProvider,
+      );
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        state = container.read(diveCenterListNotifierProvider);
+        if (state is AsyncError) break;
+      }
+
+      expect(state, isA<AsyncError>());
+    });
+  });
+}

--- a/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.mocks.dart
@@ -496,6 +496,14 @@ class MockDiveRepository extends _i1.Mock implements _i4.DiveRepository {
   }
 
   @override
+  _i7.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i7.Stream<void>.empty(),
+          )
+          as _i7.Stream<void>);
+
+  @override
   _i7.Future<List<_i3.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.mocks.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.mocks.dart
@@ -180,6 +180,14 @@ class MockTripRepository extends _i1.Mock implements _i16.TripRepository {
   }
 
   @override
+  _i17.Stream<void> watchTripsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTripsChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
+
+  @override
   _i17.Future<List<_i2.Trip>> getAllTrips({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllTrips, [], {#diverId: diverId}),
@@ -391,6 +399,14 @@ class MockEquipmentRepository extends _i1.Mock
             ),
           )
           as _i17.Future<List<_i3.EquipmentItem>>);
+
+  @override
+  _i17.Stream<void> watchEquipmentChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchEquipmentChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
 
   @override
   _i17.Future<List<_i3.EquipmentItem>> getAllEquipment({String? diverId}) =>
@@ -657,6 +673,14 @@ class MockBuddyRepository extends _i1.Mock implements _i6.BuddyRepository {
   }
 
   @override
+  _i17.Stream<void> watchBuddiesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchBuddiesChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
+
+  @override
   _i17.Future<List<_i5.Buddy>> getAllBuddies({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllBuddies, [], {#diverId: diverId}),
@@ -854,6 +878,14 @@ class MockDiveCenterRepository extends _i1.Mock
   }
 
   @override
+  _i17.Stream<void> watchDiveCentersChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDiveCentersChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
+
+  @override
   _i17.Future<List<_i7.DiveCenter>> getAllDiveCenters({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDiveCenters, [], {#diverId: diverId}),
@@ -971,6 +1003,14 @@ class MockCertificationRepository extends _i1.Mock
   MockCertificationRepository() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  _i17.Stream<void> watchCertificationsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchCertificationsChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
 
   @override
   _i17.Future<List<_i8.Certification>> getAllCertifications({
@@ -1091,6 +1131,14 @@ class MockTagRepository extends _i1.Mock implements _i25.TagRepository {
   MockTagRepository() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  _i17.Stream<void> watchTagsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTagsChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
 
   @override
   _i17.Future<List<_i9.Tag>> getAllTags({String? diverId}) =>
@@ -1280,6 +1328,14 @@ class MockDiveTypeRepository extends _i1.Mock
   }
 
   @override
+  _i17.Stream<void> watchDiveTypesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDiveTypesChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
+
+  @override
   _i17.Future<List<_i10.DiveTypeEntity>> getAllDiveTypes({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDiveTypes, [], {#diverId: diverId}),
@@ -1398,6 +1454,14 @@ class MockSiteRepository extends _i1.Mock implements _i27.SiteRepository {
             ),
           )
           as _i17.Future<List<_i11.DiveSite>>);
+
+  @override
+  _i17.Stream<void> watchSitesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchSitesChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
 
   @override
   _i17.Future<_i11.DiveSite?> getSiteById(String? id) =>
@@ -1547,6 +1611,14 @@ class MockDiveRepository extends _i1.Mock implements _i13.DiveRepository {
   MockDiveRepository() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  _i17.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
 
   @override
   _i17.Future<List<_i12.Dive>> getAllDives({String? diverId}) =>
@@ -2300,6 +2372,14 @@ class MockCourseRepository extends _i1.Mock implements _i37.CourseRepository {
             returnValue: _i17.Future<List<_i15.Course>>.value(<_i15.Course>[]),
           )
           as _i17.Future<List<_i15.Course>>);
+
+  @override
+  _i17.Stream<void> watchCoursesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchCoursesChanges, []),
+            returnValue: _i17.Stream<void>.empty(),
+          )
+          as _i17.Stream<void>);
 
   @override
   _i17.Future<_i15.Course?> getCourseById(String? id) =>

--- a/test/features/dive_import/presentation/providers/dive_import_notifier_test.mocks.dart
+++ b/test/features/dive_import/presentation/providers/dive_import_notifier_test.mocks.dart
@@ -79,6 +79,14 @@ class MockDiveRepository extends _i1.Mock implements _i3.DiveRepository {
   }
 
   @override
+  _i5.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i5.Stream<void>.empty(),
+          )
+          as _i5.Stream<void>);
+
+  @override
   _i5.Future<List<_i2.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),

--- a/test/features/dive_log/presentation/providers/dive_list_notifier_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_list_notifier_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Dive _makeDive({String id = '', String? diverId, String notes = 'Test Dive'}) {
+  return Dive(id: id, diverId: diverId, dateTime: DateTime.now(), notes: notes);
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late DiveRepository diveRepo;
+  late DiverRepository diverRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    diveRepo = DiveRepository();
+    diverRepo = DiverRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates a default diver and pins it as the current diver in prefs so the
+  /// diver-scoped dive providers/notifiers read it synchronously at construction.
+  Future<Diver> setUpCurrentDiver() async {
+    final diver = await diverRepo.createDiver(
+      Diver(
+        id: '',
+        name: 'D',
+        isDefault: true,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('DiveListNotifier auto-refresh', () {
+    test('auto-refreshes the list when a dive is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its dives-table subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(diveListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(diveListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(diveListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote dive straight to the DB (no notifier mutation
+      // call). The watchDivesChanges tick must silently reload the list.
+      await diveRepo.createDive(
+        _makeDive(diverId: diver.id, notes: 'Synced Dive'),
+      );
+
+      var notes = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        notes = (container.read(diveListNotifierProvider).value ?? [])
+            .map((d) => d.notes)
+            .toList();
+        if (notes.contains('Synced Dive')) break;
+      }
+
+      expect(
+        notes,
+        contains('Synced Dive'),
+        reason:
+            'DiveListNotifier should auto-refresh after a direct DB write '
+            'without any manual refresh() call',
+      );
+    });
+  });
+
+  group('PaginatedDiveListNotifier auto-refresh', () {
+    test('silently reloads the first page when a dive is written directly to '
+        'the DB (sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its dives-table subscription)
+      // alive, mirroring the on-screen paginated list.
+      final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(paginatedDiveListProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(paginatedDiveListProvider).value?.dives, isEmpty);
+
+      // Remote dive applied straight to the DB; _silentReloadFirstPage must
+      // refresh the first page in place.
+      await diveRepo.createDive(
+        _makeDive(diverId: diver.id, notes: 'Synced Summary'),
+      );
+
+      var count = 0;
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final state = container.read(paginatedDiveListProvider).value;
+        count = state?.dives.length ?? 0;
+        if (count >= 1) break;
+      }
+
+      expect(
+        count,
+        greaterThanOrEqualTo(1),
+        reason:
+            'PaginatedDiveListNotifier should reload its first page after a '
+            'direct DB write without any manual refresh() call',
+      );
+    });
+  });
+
+  group('divesProvider auto-refresh', () {
+    test(
+      'self-invalidates after a write to the dives table (sync scenario)',
+      () async {
+        final diver = await setUpCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        // Active listener keeps the FutureProvider (and its table-change
+        // subscription) alive, mirroring a widget watching the list.
+        final sub = container.listen(divesProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        expect(await container.read(divesProvider.future), isEmpty);
+
+        // A sync applies a remote dive straight to the DB. The tableUpdates tick
+        // must invalidate the provider so the next read reflects the new row.
+        await diveRepo.createDive(
+          _makeDive(diverId: diver.id, notes: 'Synced FP Dive'),
+        );
+
+        var notes = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          notes = (await container.read(
+            divesProvider.future,
+          )).map((d) => d.notes).toList();
+          if (notes.contains('Synced FP Dive')) break;
+        }
+
+        expect(
+          notes,
+          contains('Synced FP Dive'),
+          reason:
+              'divesProvider should auto-refresh after the table write without '
+              'any manual invalidation',
+        );
+      },
+    );
+  });
+}

--- a/test/features/dive_sites/data/services/site_matching_service_test.mocks.dart
+++ b/test/features/dive_sites/data/services/site_matching_service_test.mocks.dart
@@ -100,6 +100,14 @@ class MockSiteRepository extends _i1.Mock implements _i7.SiteRepository {
           as _i8.Future<List<_i2.DiveSite>>);
 
   @override
+  _i8.Stream<void> watchSitesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchSitesChanges, []),
+            returnValue: _i8.Stream<void>.empty(),
+          )
+          as _i8.Stream<void>);
+
+  @override
   _i8.Future<_i2.DiveSite?> getSiteById(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#getSiteById, [id]),
@@ -304,6 +312,14 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
   MockDiveRepository() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  _i8.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i8.Stream<void>.empty(),
+          )
+          as _i8.Stream<void>);
 
   @override
   _i8.Future<List<_i4.Dive>> getAllDives({String? diverId}) =>

--- a/test/features/dive_sites/presentation/providers/site_match_review_notifier_test.dart
+++ b/test/features/dive_sites/presentation/providers/site_match_review_notifier_test.dart
@@ -87,6 +87,15 @@ void main() {
     when(
       sites.getAllSites(diverId: anyNamed('diverId')),
     ).thenAnswer((_) async => const []);
+    // The dive/site list notifiers (rebuilt by confirm()'s refresh) and the
+    // base providers subscribe to these table-change ticks; strict mocks throw
+    // MissingStubError unless every called method is stubbed.
+    when(
+      dives.watchDivesChanges(),
+    ).thenAnswer((_) => const Stream<void>.empty());
+    when(
+      sites.watchSitesChanges(),
+    ).thenAnswer((_) => const Stream<void>.empty());
     when(
       api.searchNearby(
         latitude: anyNamed('latitude'),

--- a/test/features/dive_sites/presentation/providers/site_match_review_notifier_test.mocks.dart
+++ b/test/features/dive_sites/presentation/providers/site_match_review_notifier_test.mocks.dart
@@ -100,6 +100,14 @@ class MockSiteRepository extends _i1.Mock implements _i7.SiteRepository {
           as _i8.Future<List<_i2.DiveSite>>);
 
   @override
+  _i8.Stream<void> watchSitesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchSitesChanges, []),
+            returnValue: _i8.Stream<void>.empty(),
+          )
+          as _i8.Stream<void>);
+
+  @override
   _i8.Future<_i2.DiveSite?> getSiteById(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#getSiteById, [id]),
@@ -304,6 +312,14 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
   MockDiveRepository() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  _i8.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i8.Stream<void>.empty(),
+          )
+          as _i8.Stream<void>);
 
   @override
   _i8.Future<List<_i4.Dive>> getAllDives({String? diverId}) =>

--- a/test/features/dive_sites/presentation/providers/site_providers_test.dart
+++ b/test/features/dive_sites/presentation/providers/site_providers_test.dart
@@ -202,6 +202,48 @@ void main() {
       expect(undoDive.first.site?.id, equals('um-2'));
     });
   });
+
+  group('sitesWithCountsProvider auto-refresh', () {
+    test('refreshes dive counts when a dive is written directly to the DB '
+        '(sync scenario)', () async {
+      final site = await siteRepository.createSite(
+        const DiveSite(id: 'count-site', name: 'Count Site'),
+      );
+
+      // An active listener keeps the provider (and both its sites and dives
+      // table-change subscriptions) alive, mirroring a widget that watches
+      // the list.
+      final sub = container.listen(sitesWithCountsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      // Initially the site exists with a zero dive count.
+      final initial = await container.read(sitesWithCountsProvider.future);
+      final initialEntry = initial.firstWhere((s) => s.site.id == site.id);
+      expect(initialEntry.diveCount, equals(0));
+
+      // A sync applies a remote dive for this site straight to the DB. The
+      // watchDivesChanges tick must invalidate the provider so the count
+      // refreshes.
+      await _insertDive(database, id: 'count-dive', siteId: site.id);
+
+      var count = 0;
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final sites = await container.read(sitesWithCountsProvider.future);
+        final entry = sites.where((s) => s.site.id == site.id);
+        count = entry.isEmpty ? 0 : entry.first.diveCount;
+        if (count >= 1) break;
+      }
+
+      expect(
+        count,
+        equals(1),
+        reason:
+            'sitesWithCountsProvider should auto-refresh dive counts after a '
+            'direct dives-table write without any manual invalidation',
+      );
+    });
+  });
 }
 
 Future<void> _insertDive(

--- a/test/features/dive_types/presentation/providers/dive_type_providers_test.dart
+++ b/test/features/dive_types/presentation/providers/dive_type_providers_test.dart
@@ -162,7 +162,7 @@ void main() {
       );
     });
 
-    test('silent reload surfaces AsyncError when getAll throws', () async {
+    test('reports AsyncError when the initial load throws', () async {
       await seedCurrentDiver();
 
       final container = ProviderContainer(

--- a/test/features/dive_types/presentation/providers/dive_type_providers_test.dart
+++ b/test/features/dive_types/presentation/providers/dive_type_providers_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
+import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
+import 'package:submersion/features/dive_types/presentation/providers/dive_type_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Diver _makeDiver({String name = 'Default', bool isDefault = true}) {
+  final now = DateTime.now();
+  return Diver(
+    id: '',
+    name: name,
+    isDefault: isDefault,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+DiveTypeEntity _makeDiveType({String name = 'Custom Type', String? diverId}) {
+  return DiveTypeEntity.create(id: '', name: name, diverId: diverId);
+}
+
+/// Fake repository whose `getAllDiveTypes` throws, to drive the error path.
+/// `watchDiveTypesChanges()` is inherited from the real repository and works
+/// against the in-memory test DB set up in [setUp].
+class _ThrowingDiveTypeRepository extends DiveTypeRepository {
+  @override
+  Future<List<DiveTypeEntity>> getAllDiveTypes({String? diverId}) async {
+    throw Exception('boom');
+  }
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late DiverRepository diverRepo;
+  late DiveTypeRepository diveTypeRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    diverRepo = DiverRepository();
+    diveTypeRepo = DiveTypeRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates a default diver and marks it current so diver-scoped custom dive
+  /// types resolve. Returns the diver id.
+  Future<String> seedCurrentDiver() async {
+    final diver = await diverRepo.createDiver(_makeDiver());
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver.id;
+  }
+
+  group('diveTypesProvider (base FutureProvider)', () {
+    test(
+      'auto-refreshes after a write to the dive_types table (sync scenario)',
+      () async {
+        final diverId = await seedCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        // An active listener keeps the provider (and its table-change
+        // subscription) alive, mirroring a widget watching the dive-type list.
+        final sub = container.listen(diveTypesProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        // Initial resolve: only built-in types, no custom rows yet.
+        final initial = await container.read(diveTypesProvider.future);
+        expect(initial.map((t) => t.name), isNot(contains('Synced Type')));
+
+        // A sync applies a remote custom dive type straight to the DB (no
+        // notifier mutation). The watchDiveTypesChanges tick must invalidate
+        // the provider so the new row appears.
+        await diveTypeRepo.createDiveType(
+          _makeDiveType(name: 'Synced Type', diverId: diverId),
+        );
+
+        // Poll until the tick -> invalidateSelf -> rebuild settles.
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (await container.read(
+            diveTypesProvider.future,
+          )).map((t) => t.name).toList();
+          if (names.contains('Synced Type')) break;
+        }
+
+        expect(
+          names,
+          contains('Synced Type'),
+          reason:
+              'diveTypesProvider should auto-refresh after the table write '
+              'without any manual invalidation',
+        );
+      },
+    );
+  });
+
+  group('diveTypeListNotifierProvider '
+      '(DiveTypeListNotifier._silentReloadDiveTypes)', () {
+    test('silently reloads the list when a dive type is written directly to '
+        'the DB (sync scenario)', () async {
+      final diverId = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(diveTypeListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      // Wait for the initial load to settle (built-in types only).
+      while (container.read(diveTypeListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final initialNames =
+          (container.read(diveTypeListNotifierProvider).value ?? [])
+              .map((t) => t.name)
+              .toList();
+      expect(initialNames, isNot(contains('Synced Type')));
+
+      // A sync applies a remote custom dive type straight to the DB (no
+      // notifier mutation call). The watchDiveTypesChanges tick must silently
+      // reload via _silentReloadDiveTypes so the list reflects the new row.
+      await diveTypeRepo.createDiveType(
+        _makeDiveType(name: 'Synced Type', diverId: diverId),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(diveTypeListNotifierProvider).value ?? [])
+            .map((t) => t.name)
+            .toList();
+        if (names.contains('Synced Type')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Type'),
+        reason:
+            'DiveTypeListNotifier should silently reload after a direct DB '
+            'write without any manual refresh() call',
+      );
+    });
+
+    test('silent reload surfaces AsyncError when getAll throws', () async {
+      await seedCurrentDiver();
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diveTypeRepositoryProvider.overrideWithValue(
+            _ThrowingDiveTypeRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(diveTypeListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      // The initial load already fails; poll until the error state settles.
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        if (container.read(diveTypeListNotifierProvider).hasError) break;
+      }
+
+      expect(container.read(diveTypeListNotifierProvider).hasError, isTrue);
+    });
+  });
+}

--- a/test/features/divers/presentation/providers/diver_providers_test.dart
+++ b/test/features/divers/presentation/providers/diver_providers_test.dart
@@ -64,6 +64,44 @@ void main() {
 
       expect(await container.read(allDiversProvider.future), isEmpty);
     });
+
+    test(
+      'auto-refreshes after a write to the divers table (sync scenario)',
+      () async {
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        // An active listener keeps the provider alive, mirroring a widget that
+        // watches the list; this is what keeps its table-change subscription open.
+        final sub = container.listen(allDiversProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        expect(await container.read(allDiversProvider.future), isEmpty);
+
+        // A sync applies a remote diver straight to the DB, bypassing the list
+        // notifier (no manual invalidate). The tableUpdates tick must invalidate
+        // the provider so the UI reflects the new row.
+        await repo.createDiver(_makeDiver(name: 'Synced Diver'));
+
+        // Poll until the tick -> invalidateSelf -> rebuild settles.
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (await container.read(
+            allDiversProvider.future,
+          )).map((d) => d.name).toList();
+          if (names.contains('Synced Diver')) break;
+        }
+
+        expect(
+          names,
+          contains('Synced Diver'),
+          reason:
+              'allDiversProvider should auto-refresh after the table write '
+              'without any manual invalidation',
+        );
+      },
+    );
   });
 
   group('hasAnyDiversProvider', () {

--- a/test/features/divers/presentation/providers/diver_providers_test.dart
+++ b/test/features/divers/presentation/providers/diver_providers_test.dart
@@ -315,6 +315,42 @@ void main() {
       );
     });
 
+    test('silently reloads when a diver is written directly to the DB '
+        '(sync scenario)', () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its divers-table subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(diverListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(diverListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(diverListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote diver straight to the DB (no addDiver call).
+      // The watchDiversChanges tick must silently reload the list.
+      await repo.createDiver(_makeDiver(name: 'Synced Diver'));
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(diverListNotifierProvider).value ?? [])
+            .map((d) => d.name)
+            .toList();
+        if (names.contains('Synced Diver')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Diver'),
+        reason:
+            'DiverListNotifier should auto-refresh after a direct DB write '
+            'without any manual refresh() call',
+      );
+    });
+
     test('addDiver creates the diver and returns it', () async {
       final container = makeContainer();
       addTearDown(container.dispose);

--- a/test/features/equipment/presentation/providers/equipment_providers_test.dart
+++ b/test/features/equipment/presentation/providers/equipment_providers_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+EquipmentItem _makeEquipment({
+  String id = '',
+  String name = 'Test Reg',
+  EquipmentType type = EquipmentType.regulator,
+  String? diverId,
+  DateTime? lastServiceDate,
+  int? serviceIntervalDays,
+}) {
+  return EquipmentItem(
+    id: id,
+    name: name,
+    type: type,
+    diverId: diverId,
+    lastServiceDate: lastServiceDate,
+    serviceIntervalDays: serviceIntervalDays,
+  );
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late EquipmentRepository equipmentRepo;
+  late DiverRepository diverRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    equipmentRepo = EquipmentRepository();
+    diverRepo = DiverRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  Future<Diver> seedCurrentDiver() async {
+    final diver = await diverRepo.createDiver(
+      Diver(
+        id: '',
+        name: 'D',
+        isDefault: true,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('allEquipmentProvider', () {
+    test('auto-refreshes after equipment is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // An active listener keeps the provider (and its equipment table-change
+      // subscription) alive, mirroring a widget that watches the list.
+      final sub = container.listen(allEquipmentProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(allEquipmentProvider.future), isEmpty);
+
+      // A sync applies remote equipment straight to the DB (no notifier
+      // mutation). The watchEquipmentChanges tick must invalidate the
+      // provider so the new row surfaces.
+      await equipmentRepo.createEquipment(
+        _makeEquipment(name: 'Synced Reg', diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          allEquipmentProvider.future,
+        )).map((e) => e.name).toList();
+        if (names.contains('Synced Reg')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Reg'),
+        reason:
+            'allEquipmentProvider should auto-refresh after a direct table '
+            'write without any manual invalidation',
+      );
+    });
+  });
+
+  group('equipmentByStatusProvider(null)', () {
+    test('auto-refreshes after equipment is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // Keep the (null status = all equipment) family provider alive so its
+      // equipment table-change subscription stays open.
+      final sub = container.listen(equipmentByStatusProvider(null), (_, _) {});
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(equipmentByStatusProvider(null).future),
+        isEmpty,
+      );
+
+      await equipmentRepo.createEquipment(
+        _makeEquipment(name: 'Synced Mask', diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          equipmentByStatusProvider(null).future,
+        )).map((e) => e.name).toList();
+        if (names.contains('Synced Mask')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Mask'),
+        reason:
+            'equipmentByStatusProvider(null) should auto-refresh after a '
+            'direct table write without any manual invalidation',
+      );
+    });
+  });
+
+  group('serviceDueEquipmentProvider', () {
+    test(
+      'auto-refreshes after service-due equipment is written directly to the '
+      'DB (sync scenario)',
+      () async {
+        final diver = await seedCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        // Keep the provider alive so its equipment table-change subscription
+        // stays open.
+        final sub = container.listen(serviceDueEquipmentProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        expect(
+          await container.read(serviceDueEquipmentProvider.future),
+          isEmpty,
+        );
+
+        // A synced item serviced long ago with a short interval is overdue, so
+        // it lands in the service-due list once the tick fires.
+        await equipmentRepo.createEquipment(
+          _makeEquipment(
+            name: 'Overdue Reg',
+            diverId: diver.id,
+            lastServiceDate: DateTime(2020),
+            serviceIntervalDays: 30,
+          ),
+        );
+
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (await container.read(
+            serviceDueEquipmentProvider.future,
+          )).map((e) => e.name).toList();
+          if (names.contains('Overdue Reg')) break;
+        }
+
+        expect(
+          names,
+          contains('Overdue Reg'),
+          reason:
+              'serviceDueEquipmentProvider should auto-refresh after a direct '
+              'table write without any manual invalidation',
+        );
+      },
+    );
+  });
+}

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_reimport_test.mocks.dart
@@ -667,6 +667,14 @@ class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
   }
 
   @override
+  _i7.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i7.Stream<void>.empty(),
+          )
+          as _i7.Stream<void>);
+
+  @override
   _i7.Future<List<_i4.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_test.mocks.dart
@@ -780,6 +780,15 @@ class MockDiveComputerRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveRepository extends _i1.Mock implements _i5.DiveRepository {
   @override
+  _i7.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i7.Stream<void>.empty(),
+            returnValueForMissingStub: _i7.Stream<void>.empty(),
+          )
+          as _i7.Stream<void>);
+
+  @override
   _i7.Future<List<_i4.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),

--- a/test/features/import_wizard/data/adapters/healthkit_adapter_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/healthkit_adapter_test.mocks.dart
@@ -239,6 +239,15 @@ class MockImportedDiveConverter extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveRepository extends _i1.Mock implements _i3.DiveRepository {
   @override
+  _i7.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i7.Stream<void>.empty(),
+            returnValueForMissingStub: _i7.Stream<void>.empty(),
+          )
+          as _i7.Stream<void>);
+
+  @override
   _i7.Future<List<_i2.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),

--- a/test/features/import_wizard/data/adapters/universal_adapter_test.mocks.dart
+++ b/test/features/import_wizard/data/adapters/universal_adapter_test.mocks.dart
@@ -200,6 +200,15 @@ class _FakeUddfEntityImportResult_18 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveRepository extends _i1.Mock implements _i3.DiveRepository {
   @override
+  _i18.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
+  @override
   _i18.Future<List<_i2.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),
@@ -1000,6 +1009,15 @@ class MockSiteRepository extends _i1.Mock implements _i27.SiteRepository {
           as _i18.Future<List<_i5.DiveSite>>);
 
   @override
+  _i18.Stream<void> watchSitesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchSitesChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
+  @override
   _i18.Future<_i5.DiveSite?> getSiteById(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#getSiteById, [id]),
@@ -1163,6 +1181,15 @@ class MockSiteRepository extends _i1.Mock implements _i27.SiteRepository {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTripRepository extends _i1.Mock implements _i28.TripRepository {
+  @override
+  _i18.Stream<void> watchTripsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTripsChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
   @override
   _i18.Future<List<_i6.Trip>> getAllTrips({String? diverId}) =>
       (super.noSuchMethod(
@@ -1413,6 +1440,15 @@ class MockEquipmentRepository extends _i1.Mock
                 ),
           )
           as _i18.Future<List<_i7.EquipmentItem>>);
+
+  @override
+  _i18.Stream<void> watchEquipmentChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchEquipmentChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
 
   @override
   _i18.Future<List<_i7.EquipmentItem>> getAllEquipment({String? diverId}) =>
@@ -1716,6 +1752,15 @@ class MockEquipmentSetRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockBuddyRepository extends _i1.Mock implements _i10.BuddyRepository {
   @override
+  _i18.Stream<void> watchBuddiesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchBuddiesChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
+  @override
   _i18.Future<List<_i9.Buddy>> getAllBuddies({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllBuddies, [], {#diverId: diverId}),
@@ -1945,6 +1990,15 @@ class MockBuddyRepository extends _i1.Mock implements _i10.BuddyRepository {
 class MockDiveCenterRepository extends _i1.Mock
     implements _i34.DiveCenterRepository {
   @override
+  _i18.Stream<void> watchDiveCentersChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDiveCentersChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
+  @override
   _i18.Future<List<_i11.DiveCenter>> getAllDiveCenters({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDiveCenters, [], {#diverId: diverId}),
@@ -2082,6 +2136,15 @@ class MockDiveCenterRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockCertificationRepository extends _i1.Mock
     implements _i35.CertificationRepository {
+  @override
+  _i18.Stream<void> watchCertificationsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchCertificationsChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
   @override
   _i18.Future<List<_i12.Certification>> getAllCertifications({
     String? diverId,
@@ -2227,6 +2290,15 @@ class MockCertificationRepository extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTagRepository extends _i1.Mock implements _i36.TagRepository {
+  @override
+  _i18.Stream<void> watchTagsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTagsChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
   @override
   _i18.Future<List<_i13.Tag>> getAllTags({String? diverId}) =>
       (super.noSuchMethod(
@@ -2444,6 +2516,15 @@ class MockTagRepository extends _i1.Mock implements _i36.TagRepository {
 /// See the documentation for Mockito's code generation for more information.
 class MockDiveTypeRepository extends _i1.Mock
     implements _i37.DiveTypeRepository {
+  @override
+  _i18.Stream<void> watchDiveTypesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDiveTypesChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
   @override
   _i18.Future<List<_i14.DiveTypeEntity>> getAllDiveTypes({String? diverId}) =>
       (super.noSuchMethod(
@@ -2671,6 +2752,15 @@ class MockCourseRepository extends _i1.Mock implements _i39.CourseRepository {
           as _i18.Future<List<_i15.Course>>);
 
   @override
+  _i18.Stream<void> watchCoursesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchCoursesChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
+  @override
   _i18.Future<_i15.Course?> getCourseById(String? id) =>
       (super.noSuchMethod(
             Invocation.method(#getCourseById, [id]),
@@ -2843,6 +2933,15 @@ class MockCourseRepository extends _i1.Mock implements _i39.CourseRepository {
 /// See the documentation for Mockito's code generation for more information.
 class MockTankPresetRepository extends _i1.Mock
     implements _i40.TankPresetRepository {
+  @override
+  _i18.Stream<void> watchTankPresetsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTankPresetsChanges, []),
+            returnValue: _i18.Stream<void>.empty(),
+            returnValueForMissingStub: _i18.Stream<void>.empty(),
+          )
+          as _i18.Stream<void>);
+
   @override
   _i18.Future<List<_i16.TankPresetEntity>> getAllPresets({String? diverId}) =>
       (super.noSuchMethod(

--- a/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.mocks.dart
+++ b/test/features/import_wizard/presentation/providers/import_wizard_notifier_test.mocks.dart
@@ -214,6 +214,15 @@ class MockImportSourceAdapter extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockTagRepository extends _i1.Mock implements _i12.TagRepository {
   @override
+  _i9.Stream<void> watchTagsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTagsChanges, []),
+            returnValue: _i9.Stream<void>.empty(),
+            returnValueForMissingStub: _i9.Stream<void>.empty(),
+          )
+          as _i9.Stream<void>);
+
+  @override
   _i9.Future<List<_i4.Tag>> getAllTags({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllTags, [], {#diverId: diverId}),

--- a/test/features/marine_life/data/repositories/species_repository_test.dart
+++ b/test/features/marine_life/data/repositories/species_repository_test.dart
@@ -39,6 +39,28 @@ void main() {
   });
 
   group('SpeciesRepository', () {
+    test(
+      'watchSpeciesChanges emits when the species table is written',
+      () async {
+        // Subscribe first, then write: the tick must fire so the species list
+        // providers (allSpeciesProvider / SpeciesListNotifier) refresh after a
+        // sync writes species rows directly.
+        final firstTick = repository.watchSpeciesChanges().first.timeout(
+          const Duration(seconds: 5),
+        );
+        await repository.createSpecies(
+          commonName: 'Synced Species',
+          scientificName: 'Synced sp',
+          category: SpeciesCategory.fish,
+          taxonomyClass: 'Test',
+          description: 'x',
+        );
+        await firstTick; // throws on timeout if the tick never fired
+        final all = await repository.getAllSpecies();
+        expect(all.any((s) => s.commonName == 'Synced Species'), isTrue);
+      },
+    );
+
     group('CRUD operations', () {
       test(
         'createSpecies creates a custom species with generated ID',

--- a/test/features/marine_life/presentation/providers/species_providers_test.dart
+++ b/test/features/marine_life/presentation/providers/species_providers_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late SpeciesRepository speciesRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    speciesRepo = SpeciesRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  group('allSpeciesProvider', () {
+    test('auto-refreshes after a species is written directly to the DB '
+        '(sync scenario)', () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // An active listener keeps the provider (and its species table-change
+      // subscription) alive, mirroring a widget that watches the list.
+      final sub = container.listen(allSpeciesProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(allSpeciesProvider.future), isEmpty);
+
+      // A sync applies a remote species straight to the DB (species are not
+      // diver-scoped). The watchSpeciesChanges tick must invalidate the
+      // provider so the new row surfaces.
+      await speciesRepo.createSpecies(
+        commonName: 'Synced Grouper',
+        category: SpeciesCategory.fish,
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          allSpeciesProvider.future,
+        )).map((s) => s.commonName).toList();
+        if (names.contains('Synced Grouper')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Grouper'),
+        reason:
+            'allSpeciesProvider should auto-refresh after a direct table '
+            'write without any manual invalidation',
+      );
+    });
+  });
+
+  group('speciesListNotifierProvider', () {
+    test('reloads the list when a species is written directly to the DB '
+        '(sync scenario)', () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // The notifier is autoDispose, so an active listener is required to keep
+      // it (and its table-change subscription) alive, mirroring the species
+      // management page.
+      final sub = container.listen(speciesListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(speciesListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(speciesListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote species straight to the DB (no addSpecies
+      // call). The watchSpeciesChanges tick must trigger _loadSpecies, which
+      // updates in place without a loading flash.
+      await speciesRepo.createSpecies(
+        commonName: 'Reloaded Wrasse',
+        category: SpeciesCategory.fish,
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(speciesListNotifierProvider).value ?? [])
+            .map((s) => s.commonName)
+            .toList();
+        if (names.contains('Reloaded Wrasse')) break;
+      }
+
+      expect(
+        names,
+        contains('Reloaded Wrasse'),
+        reason:
+            'SpeciesListNotifier should reload after a direct DB write '
+            'without any manual reload call',
+      );
+    });
+  });
+}

--- a/test/features/tags/presentation/providers/tag_providers_test.dart
+++ b/test/features/tags/presentation/providers/tag_providers_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/tags/domain/entities/tag.dart';
+import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Tag _makeTag({String id = '', String name = 'Test Tag', String? diverId}) {
+  final now = DateTime.now();
+  return Tag(
+    id: id,
+    diverId: diverId,
+    name: name,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Dive _makeDive({String id = '', String? diverId, String notes = 'Test Dive'}) {
+  return Dive(id: id, diverId: diverId, dateTime: DateTime.now(), notes: notes);
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late TagRepository tagRepo;
+  late DiveRepository diveRepo;
+  late DiverRepository diverRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    tagRepo = TagRepository();
+    diveRepo = DiveRepository();
+    diverRepo = DiverRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates a default diver and pins it as the current diver in prefs so the
+  /// diver-scoped tag providers/notifier read it at construction. Tags are
+  /// diver-scoped, so a current diver must exist for written rows to be
+  /// visible to the providers.
+  Future<Diver> setUpCurrentDiver() async {
+    final diver = await diverRepo.createDiver(
+      Diver(
+        id: '',
+        name: 'D',
+        isDefault: true,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  group('tagsProvider auto-refresh', () {
+    test('auto-refreshes after a tag is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // An active listener keeps the provider alive, mirroring a widget that
+      // watches the list; this keeps its table-change subscription open.
+      final sub = container.listen(tagsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(tagsProvider.future), isEmpty);
+
+      // A sync applies a remote tag straight to the DB, bypassing the notifier.
+      // The watchTagsChanges tick must invalidate the provider so the new row
+      // surfaces.
+      await tagRepo.createTag(_makeTag(name: 'Synced Tag', diverId: diver.id));
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          tagsProvider.future,
+        )).map((t) => t.name).toList();
+        if (names.contains('Synced Tag')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Tag'),
+        reason:
+            'tagsProvider should auto-refresh after a direct DB write '
+            'without any manual invalidation',
+      );
+    });
+  });
+
+  group('tagStatisticsProvider auto-refresh', () {
+    test('re-resolves on BOTH a tags-table write and a dives-table write '
+        '(sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // An active listener keeps the provider (and its tags + dives table
+      // subscriptions) alive.
+      final sub = container.listen(tagStatisticsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(tagStatisticsProvider.future), isEmpty);
+
+      // 1. A tag written directly to the DB must tick the tags subscription
+      //    and re-resolve the statistics with the new tag.
+      await tagRepo.createTag(_makeTag(name: 'Stat Tag', diverId: diver.id));
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          tagStatisticsProvider.future,
+        )).map((s) => s.tag.name).toList();
+        if (names.contains('Stat Tag')) break;
+      }
+      expect(
+        names,
+        contains('Stat Tag'),
+        reason:
+            'tagStatisticsProvider should re-resolve after a tags-table write',
+      );
+
+      // 2. A dive written directly to the DB must tick the dives subscription
+      //    and re-resolve the statistics again (the tag remains, proving a
+      //    fresh rebuild rather than a stale cached snapshot).
+      await diveRepo.createDive(
+        _makeDive(diverId: diver.id, notes: 'Synced Dive'),
+      );
+
+      var resolvedAfterDive = false;
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final stats = await container.read(tagStatisticsProvider.future);
+        if (stats.any((s) => s.tag.name == 'Stat Tag')) {
+          resolvedAfterDive = true;
+          break;
+        }
+      }
+      expect(
+        resolvedAfterDive,
+        isTrue,
+        reason:
+            'tagStatisticsProvider should re-resolve after a dives-table write',
+      );
+    });
+  });
+
+  group('tagListNotifierProvider auto-refresh', () {
+    test('silently reloads the list when a tag is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await setUpCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen tag picker.
+      final sub = container.listen(tagListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(tagListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(tagListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote tag straight to the DB (no notifier mutation
+      // call). The watchTagsChanges tick must silently reload via
+      // _silentReloadTags.
+      await tagRepo.createTag(_makeTag(name: 'Synced Tag', diverId: diver.id));
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(tagListNotifierProvider).value ?? [])
+            .map((t) => t.name)
+            .toList();
+        if (names.contains('Synced Tag')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Tag'),
+        reason:
+            'TagListNotifier should silently reload after a direct DB write '
+            'without any manual refresh() call',
+      );
+    });
+  });
+}

--- a/test/features/tags/presentation/widgets/tag_merge_sheet_test.mocks.dart
+++ b/test/features/tags/presentation/widgets/tag_merge_sheet_test.mocks.dart
@@ -39,6 +39,14 @@ class MockTagRepository extends _i1.Mock implements _i3.TagRepository {
   }
 
   @override
+  _i4.Stream<void> watchTagsChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchTagsChanges, []),
+            returnValue: _i4.Stream<void>.empty(),
+          )
+          as _i4.Stream<void>);
+
+  @override
   _i4.Future<List<_i2.Tag>> getAllTags({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllTags, [], {#diverId: diverId}),

--- a/test/features/tank_presets/presentation/providers/tank_preset_providers_test.dart
+++ b/test/features/tank_presets/presentation/providers/tank_preset_providers_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/tank_presets/data/repositories/tank_preset_repository.dart';
+import 'package:submersion/features/tank_presets/domain/entities/tank_preset_entity.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+Diver _makeDiver({String name = 'Default', bool isDefault = true}) {
+  final now = DateTime.now();
+  return Diver(
+    id: '',
+    name: name,
+    isDefault: isDefault,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+TankPresetEntity _makePreset({String name = 'Custom Tank', String? diverId}) {
+  return TankPresetEntity.create(
+    id: '',
+    name: name,
+    displayName: name,
+    volumeLiters: 11.1,
+    workingPressureBar: 207,
+    material: TankMaterial.aluminum,
+    diverId: diverId,
+  );
+}
+
+/// Fake repository whose `getAllPresets` throws, to drive the error path.
+/// `watchTankPresetsChanges()` is inherited from the real repository and works
+/// against the in-memory test DB set up in [setUp].
+class _ThrowingTankPresetRepository extends TankPresetRepository {
+  @override
+  Future<List<TankPresetEntity>> getAllPresets({String? diverId}) async {
+    throw Exception('boom');
+  }
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late DiverRepository diverRepo;
+  late TankPresetRepository presetRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    diverRepo = DiverRepository();
+    presetRepo = TankPresetRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  /// Creates a default diver and marks it current so diver-scoped custom
+  /// presets resolve. Returns the diver id.
+  Future<String> seedCurrentDiver() async {
+    final diver = await diverRepo.createDiver(_makeDiver());
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver.id;
+  }
+
+  group('tankPresetsProvider (base FutureProvider)', () {
+    test(
+      'auto-refreshes after a write to the tank_presets table (sync scenario)',
+      () async {
+        final diverId = await seedCurrentDiver();
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        // An active listener keeps the provider (and its table-change
+        // subscription) alive, mirroring a widget watching the preset list.
+        final sub = container.listen(tankPresetsProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        // Initial resolve: only built-in presets, no custom rows yet.
+        final initial = await container.read(tankPresetsProvider.future);
+        expect(initial.map((p) => p.name), isNot(contains('Synced Tank')));
+
+        // A sync applies a remote custom preset straight to the DB (no notifier
+        // mutation). The watchTankPresetsChanges tick must invalidate the
+        // provider so the new row appears.
+        await presetRepo.createPreset(
+          _makePreset(name: 'Synced Tank', diverId: diverId),
+        );
+
+        // Poll until the tick -> invalidateSelf -> rebuild settles.
+        var names = <String>[];
+        for (var i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names = (await container.read(
+            tankPresetsProvider.future,
+          )).map((p) => p.name).toList();
+          if (names.contains('Synced Tank')) break;
+        }
+
+        expect(
+          names,
+          contains('Synced Tank'),
+          reason:
+              'tankPresetsProvider should auto-refresh after the table write '
+              'without any manual invalidation',
+        );
+      },
+    );
+  });
+
+  group('tankPresetListNotifierProvider '
+      '(TankPresetListNotifier._silentReloadPresets)', () {
+    test('silently reloads the list when a preset is written directly to the '
+        'DB (sync scenario)', () async {
+      final diverId = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(tankPresetListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      // Wait for the initial load to settle (built-in presets only).
+      while (container.read(tankPresetListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final initialNames =
+          (container.read(tankPresetListNotifierProvider).value ?? [])
+              .map((p) => p.name)
+              .toList();
+      expect(initialNames, isNot(contains('Synced Tank')));
+
+      // A sync applies a remote custom preset straight to the DB (no notifier
+      // mutation call). The watchTankPresetsChanges tick must silently reload
+      // via _silentReloadPresets so the list reflects the new row.
+      await presetRepo.createPreset(
+        _makePreset(name: 'Synced Tank', diverId: diverId),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(tankPresetListNotifierProvider).value ?? [])
+            .map((p) => p.name)
+            .toList();
+        if (names.contains('Synced Tank')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Tank'),
+        reason:
+            'TankPresetListNotifier should silently reload after a direct DB '
+            'write without any manual refresh() call',
+      );
+    });
+
+    test('silent reload surfaces AsyncError when getAll throws', () async {
+      await seedCurrentDiver();
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          tankPresetRepositoryProvider.overrideWithValue(
+            _ThrowingTankPresetRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(tankPresetListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      // The initial load already fails; poll until the error state settles.
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        if (container.read(tankPresetListNotifierProvider).hasError) break;
+      }
+
+      expect(container.read(tankPresetListNotifierProvider).hasError, isTrue);
+    });
+  });
+}

--- a/test/features/tank_presets/presentation/providers/tank_preset_providers_test.dart
+++ b/test/features/tank_presets/presentation/providers/tank_preset_providers_test.dart
@@ -171,7 +171,7 @@ void main() {
       );
     });
 
-    test('silent reload surfaces AsyncError when getAll throws', () async {
+    test('reports AsyncError when the initial load throws', () async {
       await seedCurrentDiver();
 
       final container = ProviderContainer(

--- a/test/features/trips/presentation/pages/trip_edit_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_edit_page_test.dart
@@ -1300,6 +1300,9 @@ class _MockTripRepository implements TripRepository {
 
   @override
   Future<int> shareAllForDiver(String diverId) async => 0;
+
+  @override
+  Stream<void> watchTripsChanges() => const Stream<void>.empty();
 }
 
 /// Mock repository that returns a test trip
@@ -1378,6 +1381,9 @@ class _MockTripRepositoryWithTrip implements TripRepository {
 
   @override
   Future<int> shareAllForDiver(String diverId) async => 0;
+
+  @override
+  Stream<void> watchTripsChanges() => const Stream<void>.empty();
 }
 
 /// Mock repository that returns a SHARED test trip (for unshare confirmation tests).
@@ -1456,6 +1462,9 @@ class _MockTripRepositoryWithSharedTrip implements TripRepository {
 
   @override
   Future<int> shareAllForDiver(String diverId) async => 0;
+
+  @override
+  Stream<void> watchTripsChanges() => const Stream<void>.empty();
 }
 
 /// Mock notifier
@@ -1609,6 +1618,9 @@ class _SlowTripRepository implements TripRepository {
 
   @override
   Future<int> shareAllForDiver(String diverId) async => 0;
+
+  @override
+  Stream<void> watchTripsChanges() => const Stream<void>.empty();
 }
 
 /// Repository that throws when getTripById is called.
@@ -1679,4 +1691,7 @@ class _ErrorTripRepository implements TripRepository {
 
   @override
   Future<int> shareAllForDiver(String diverId) async => 0;
+
+  @override
+  Stream<void> watchTripsChanges() => const Stream<void>.empty();
 }

--- a/test/features/trips/presentation/providers/trip_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_providers_test.dart
@@ -333,6 +333,55 @@ void main() {
       expect(newTrip.diverId, equals(diver.id));
     });
 
+    test('auto-refreshes the list when a trip is written directly to the DB '
+        '(sync scenario)', () async {
+      final diver = await diverRepo.createDiver(
+        Diver(
+          id: '',
+          name: 'D',
+          isDefault: true,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+        ),
+      );
+      await prefs.setString(currentDiverIdKey, diver.id);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its table-change subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(tripListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(tripListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(tripListNotifierProvider).value, isEmpty);
+
+      // A sync applies a remote trip straight to the DB (no notifier mutation
+      // call). The watchTripsChanges tick must silently reload the list.
+      await tripRepo.createTrip(
+        _makeTrip(name: 'Synced').copyWith(diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (container.read(tripListNotifierProvider).value ?? [])
+            .map((t) => t.trip.name)
+            .toList();
+        if (names.contains('Synced')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced'),
+        reason:
+            'TripListNotifier should auto-refresh after a direct DB write '
+            'without any manual refresh() call',
+      );
+    });
+
     test('updateTrip persists changes', () async {
       final t = await tripRepo.createTrip(_makeTrip(name: 'Original'));
 

--- a/test/features/trips/presentation/providers/trip_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_providers_test.dart
@@ -4,6 +4,8 @@ import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/providers/provider.dart';
 
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -39,6 +41,7 @@ void main() {
   late SharedPreferences prefs;
   late TripRepository tripRepo;
   late DiverRepository diverRepo;
+  late DiveRepository diveRepo;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -46,6 +49,7 @@ void main() {
     await setUpTestDatabase();
     tripRepo = TripRepository();
     diverRepo = DiverRepository();
+    diveRepo = DiveRepository();
   });
 
   tearDown(() async {
@@ -108,6 +112,52 @@ void main() {
         expect(trips.map((t) => t.name), contains('Owned'));
       },
     );
+
+    test('allTripsProvider self-invalidates after a write to the trips table '
+        '(sync scenario)', () async {
+      final diver = await diverRepo.createDiver(
+        Diver(
+          id: '',
+          name: 'D',
+          isDefault: true,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+        ),
+      );
+      await prefs.setString(currentDiverIdKey, diver.id);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the FutureProvider (and its trips-table
+      // subscription) alive, mirroring a widget watching the list.
+      final sub = container.listen(allTripsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(await container.read(allTripsProvider.future), isEmpty);
+
+      // A sync applies a remote trip straight to the DB. The watchTripsChanges
+      // tick must invalidate the provider so the next read includes it.
+      await tripRepo.createTrip(
+        _makeTrip(name: 'Synced Trip').copyWith(diverId: diver.id),
+      );
+
+      var names = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        names = (await container.read(
+          allTripsProvider.future,
+        )).map((t) => t.name).toList();
+        if (names.contains('Synced Trip')) break;
+      }
+
+      expect(
+        names,
+        contains('Synced Trip'),
+        reason:
+            'allTripsProvider should auto-refresh after the table write '
+            'without any manual invalidation',
+      );
+    });
 
     test('tripByIdProvider returns the matching trip', () async {
       final created = await tripRepo.createTrip(_makeTrip(name: 'Find'));
@@ -379,6 +429,72 @@ void main() {
         reason:
             'TripListNotifier should auto-refresh after a direct DB write '
             'without any manual refresh() call',
+      );
+    });
+
+    test('auto-refreshes the trip list when a DIVE is written directly to the '
+        'DB (trip stats LEFT JOIN dives)', () async {
+      final diver = await diverRepo.createDiver(
+        Diver(
+          id: '',
+          name: 'D',
+          isDefault: true,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+        ),
+      );
+      await prefs.setString(currentDiverIdKey, diver.id);
+
+      final trip = await tripRepo.createTrip(
+        _makeTrip(
+          name: 'Counting',
+          start: DateTime(2024, 6, 1),
+          end: DateTime(2024, 6, 10),
+        ).copyWith(diverId: diver.id),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the notifier (and its dives-table subscription)
+      // alive, mirroring the on-screen list.
+      final sub = container.listen(tripListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(tripListNotifierProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      // Trip starts with zero dives.
+      final initial = container.read(tripListNotifierProvider).value!;
+      expect(initial.firstWhere((s) => s.trip.id == trip.id).diveCount, 0);
+
+      // A sync applies a dive (assigned to the trip) straight to the DB. The
+      // watchDivesChanges tick on the trip notifier must reload the stats,
+      // because diveCount is computed by a LEFT JOIN against the dives table.
+      await diveRepo.createDive(
+        Dive(
+          id: '',
+          diverId: diver.id,
+          dateTime: DateTime(2024, 6, 5),
+          tripId: trip.id,
+          notes: 'In-trip dive',
+        ),
+      );
+
+      var diveCount = 0;
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final stats = container.read(tripListNotifierProvider).value ?? [];
+        final match = stats.where((s) => s.trip.id == trip.id);
+        diveCount = match.isEmpty ? 0 : match.first.diveCount;
+        if (diveCount >= 1) break;
+      }
+
+      expect(
+        diveCount,
+        equals(1),
+        reason:
+            'TripListNotifier should reload trip stats after a direct dive '
+            'write, since the dives-table subscription drives the refresh',
       );
     });
 

--- a/test/features/universal_import/presentation/providers/import_consolidation_service_test.mocks.dart
+++ b/test/features/universal_import/presentation/providers/import_consolidation_service_test.mocks.dart
@@ -75,6 +75,14 @@ class MockDiveRepository extends _i1.Mock implements _i3.DiveRepository {
   }
 
   @override
+  _i5.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i5.Stream<void>.empty(),
+          )
+          as _i5.Stream<void>);
+
+  @override
   _i5.Future<List<_i2.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),

--- a/test/features/weather/data/repositories/weather_repository_test.mocks.dart
+++ b/test/features/weather/data/repositories/weather_repository_test.mocks.dart
@@ -106,6 +106,14 @@ class MockDiveRepository extends _i1.Mock implements _i3.DiveRepository {
   }
 
   @override
+  _i6.Stream<void> watchDivesChanges() =>
+      (super.noSuchMethod(
+            Invocation.method(#watchDivesChanges, []),
+            returnValue: _i6.Stream<void>.empty(),
+          )
+          as _i6.Stream<void>);
+
+  @override
   _i6.Future<List<_i2.Dive>> getAllDives({String? diverId}) =>
       (super.noSuchMethod(
             Invocation.method(#getAllDives, [], {#diverId: diverId}),


### PR DESCRIPTION
## Summary

After a sync applied remote records, the UI kept showing cached data — the list providers are one-shot reads that were never invalidated when sync wrote rows directly to the database. This makes every main entity list auto-refresh after a sync (or any DB write).

Auto-refresh is driven by a Drift `tableUpdates` tick — a `Stream<void>` that fires only on real table writes (no seed emission, so it cannot self-trigger a rebuild loop):

- **Repositories** expose `watch<Entity>Changes()`.
- **Base list providers** (dives, sites, divers, trips, equipment, buddies, dive centers, certifications, courses, dive types, tags, tank presets) subscribe to the tick and `invalidateSelf()`, while staying `FutureProvider`s so imperative `ref.read(provider.future)` reads (backup export, import dedup, detail-page actions) still resolve.
- **The on-screen lists** render from `StateNotifier`s and `*WithCounts`/`*WithStats` providers that bypass the base providers, so those display sources refresh too: notifiers do a *silent* reload (no loading-spinner flash on multi-write syncs); count/stat providers self-invalidate. Sources whose figures derive from dives also subscribe to the dives tick so counts refresh.

## Why not `StreamProvider`?

Converting the base providers to `StreamProvider` compiles, but a `StreamProvider` only subscribes its source while it has an active listener — so every listener-less `ref.read(provider.future)` (~60 call sites across export/import/detail paths) would hang forever. The `FutureProvider` + `tableUpdates`-tick approach keeps those working.

## Changes

- 24 lib files: 12 repos (`watch<Entity>Changes()`), 12 provider files (base providers + 13 display-source refreshes).
- 4 test files: 2 new auto-refresh regression tests, 5 trip fake-repo methods, strict-mock stubs.
- 13 regenerated `.mocks.dart` for the extended repo interfaces.

## Test plan

- `flutter analyze`: clean
- `dart format`: clean
- Full suite: **8254 passed, 9 skipped, 0 failed**
- New tests assert auto-refresh after a direct DB write with no manual invalidation, for both the base-provider path (`allDiversProvider`) and the notifier path (`TripListNotifier`).
