### PR TITLE
fix(sync): re-baseline sync after a database restore

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -124,9 +124,21 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     }
   }
 
-  void _maybeSyncOnLaunch() {
+  Future<void> _maybeSyncOnLaunch() async {
     final settings = ref.read(syncBehaviorProvider);
     if (!settings.autoSyncEnabled || !settings.syncOnLaunch) return;
+    // Wait for the launch reconcile (watched in build) to finish before the
+    // first sync reads sync state. A restore-triggered rebaseline may still be
+    // in flight; syncing mid-rebaseline would read a rewound lastSync/tombstone
+    // set and defeat the "rebaseline before anything reads sync state"
+    // guarantee. Reconcile is launch-safe (resolves with a status, never
+    // throws), but guard anyway so a failure can't block launch sync forever.
+    try {
+      await ref.read(reconcileDeviceIdentityProvider.future);
+    } catch (_) {
+      // Already logged inside reconcileDeviceIdentity; proceed with the sync.
+    }
+    if (!mounted) return;
     ref.read(syncStateProvider.notifier).performSync();
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -171,6 +171,10 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     final themePreset = ref.watch(themePresetProvider);
     final localeSetting = ref.watch(localeProvider);
 
+    // Detect a database restore and re-baseline sync before anything reads
+    // sync state, so a rewound baseline can't stall sync or resurrect deletes.
+    ref.watch(reconcileDeviceIdentityProvider);
+
     // Restore the last used cloud sync provider on app startup
     ref.watch(restoreLastProviderProvider);
 

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -160,6 +160,31 @@ class SyncRepository {
     return metadata.deviceId;
   }
 
+  /// Get this database's instance token, or null if none has been set yet
+  /// (rows predating the column, or a freshly created/restored database).
+  Future<String?> getInstanceToken() async {
+    final metadata = await getOrCreateMetadata();
+    return metadata.instanceToken;
+  }
+
+  /// Generate and persist a fresh instance token, returning it.
+  ///
+  /// Rotating the token on each launch is what lets a later restore of an older
+  /// backup be detected even when the device id is unchanged: the backup
+  /// carries a superseded token that no longer matches the copy mirrored
+  /// outside the database. See [SyncInitializer.reconcileDeviceIdentity].
+  Future<String> rotateInstanceToken() async {
+    await getOrCreateMetadata();
+    final token = _uuid.v4();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(
+      _db.syncMetadata,
+    )..where((t) => t.id.equals(_globalMetadataId))).write(
+      SyncMetadataCompanion(instanceToken: Value(token), updatedAt: Value(now)),
+    );
+    return token;
+  }
+
   /// Get the last sync timestamp
   Future<DateTime?> getLastSyncTime() async {
     final metadata = await getOrCreateMetadata();

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -806,13 +806,27 @@ class SyncRepository {
   /// identity across a database restore, which would otherwise replace it with
   /// the (possibly stale, possibly foreign) device id captured in the backup.
   Future<void> setDeviceId(String deviceId) async {
-    await getOrCreateMetadata();
-    final now = DateTime.now().millisecondsSinceEpoch;
-    await (_db.update(
-      _db.syncMetadata,
-    )..where((t) => t.id.equals(_globalMetadataId))).write(
-      SyncMetadataCompanion(deviceId: Value(deviceId), updatedAt: Value(now)),
-    );
+    if (deviceId.trim().isEmpty) {
+      // A blank device id would corrupt sync identity (per-device file name and
+      // HLC node id), so reject it rather than persist it.
+      throw ArgumentError.value(
+        deviceId,
+        'deviceId',
+        'device id must not be empty',
+      );
+    }
+    try {
+      await getOrCreateMetadata();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await (_db.update(
+        _db.syncMetadata,
+      )..where((t) => t.id.equals(_globalMetadataId))).write(
+        SyncMetadataCompanion(deviceId: Value(deviceId), updatedAt: Value(now)),
+      );
+    } catch (e, stackTrace) {
+      _log.error('Failed to set device id', error: e, stackTrace: stackTrace);
+      rethrow;
+    }
   }
 
   /// Re-baseline sync after a database restore.

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -776,4 +776,40 @@ class SyncRepository {
       rethrow;
     }
   }
+
+  /// Overwrite the stored device id. Used to preserve this installation's sync
+  /// identity across a database restore, which would otherwise replace it with
+  /// the (possibly stale, possibly foreign) device id captured in the backup.
+  Future<void> setDeviceId(String deviceId) async {
+    await getOrCreateMetadata();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(
+      _db.syncMetadata,
+    )..where((t) => t.id.equals(_globalMetadataId))).write(
+      SyncMetadataCompanion(deviceId: Value(deviceId), updatedAt: Value(now)),
+    );
+  }
+
+  /// Re-baseline sync after a database restore.
+  ///
+  /// A restore replaces the entire database, so `sync_metadata` (device id,
+  /// HLC clock, last-sync timestamp, cursors) and the deletion log all revert
+  /// to the backup's stale snapshot. The merge gates on the persisted
+  /// `lastSync` (`localUpdatedAt > lastSyncMs` reads almost every restored row
+  /// as a conflict), so a rewound baseline stalls sync and lets a peer's
+  /// still-live copy keep resurrecting deletes.
+  ///
+  /// Preserve the live device identity (captured by the caller *before* the
+  /// restore) and clear the sync baseline so the next sync performs a clean
+  /// full reconcile of the restored data instead of replaying a stale position.
+  Future<void> rebaselineAfterRestore({String? preserveDeviceId}) async {
+    if (preserveDeviceId != null && preserveDeviceId.isNotEmpty) {
+      await setDeviceId(preserveDeviceId);
+    }
+    await resetSyncState();
+    // Drop the in-memory clock so it re-seeds from the restored rows under this
+    // device's id on the next write. (issue() advances physical time to now()
+    // regardless, so local writes are never ordered behind the restored data.)
+    SyncClock.instance.reset();
+  }
 }

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1315,6 +1315,12 @@ class SyncMetadata extends Table {
   /// (nullable: rows written before HLC rollout fall back to updatedAt).
   TextColumn get hlc => text().nullable()();
 
+  /// Opaque per-database token, rotated on each launch and mirrored outside the
+  /// database. A mismatch between this and the mirrored copy means the on-disk
+  /// database was replaced (restore/overwrite), even when the device id is
+  /// unchanged. Nullable: rows predating this column read as "no token yet".
+  TextColumn get instanceToken => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -1550,7 +1556,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 77;
+  static const int currentSchemaVersion = 78;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1631,6 +1637,7 @@ class AppDatabase extends _$AppDatabase {
     75,
     76,
     77,
+    78,
   ];
 
   /// Returns the number of migration steps that will execute when upgrading
@@ -3797,6 +3804,22 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 77) await reportProgress();
+        if (from < 78) {
+          // Add the nullable per-database instance token to sync_metadata. Used
+          // to detect a database restore/overwrite that leaves the device id
+          // unchanged (a same-device backup). Nullable so existing rows read as
+          // "no token yet" and are treated like a first-run seed.
+          final cols = await customSelect(
+            "PRAGMA table_info('sync_metadata')",
+          ).get();
+          final existing = cols.map((c) => c.read<String>('name')).toSet();
+          if (cols.isNotEmpty && !existing.contains('instance_token')) {
+            await customStatement(
+              'ALTER TABLE sync_metadata ADD COLUMN instance_token TEXT',
+            );
+          }
+        }
+        if (from < 78) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -11,9 +11,16 @@ class SyncInitializer {
   static const _lastProviderKey = 'sync_last_provider';
 
   /// Mirrors the in-DB sync device id outside the database (which a restore
-  /// would otherwise rewind silently). A mismatch on launch is the signal that
+  /// would otherwise rewind silently). A mismatch on launch is one signal that
   /// the database was replaced by a restore. See [reconcileDeviceIdentity].
   static const _deviceIdSentinelKey = 'sync_device_id_sentinel';
+
+  /// Mirrors the database instance token outside the database. The token is
+  /// rotated each launch, so a restored backup carries a stale token that no
+  /// longer matches this copy -- the primary restore signal, and the one that
+  /// catches a same-device backup (whose device id is unchanged). See
+  /// [reconcileDeviceIdentity].
+  static const _dbInstanceTokenKey = 'sync_db_instance_token';
 
   final SyncRepository _syncRepository;
   final SharedPreferences _prefs;
@@ -47,51 +54,74 @@ class SyncInitializer {
     }
   }
 
-  /// Reconcile this installation's sync identity against the device id mirrored
+  /// Reconcile this installation's sync identity against the anchors mirrored
   /// outside the database, detecting (and recovering from) a database restore.
   ///
   /// All sync bookkeeping (device id, HLC clock, last-sync timestamp, cursors,
   /// deletion log) lives inside the database, so a whole-DB restore rewinds it
   /// to the backup's snapshot -- which stalls sync and lets a peer's still-live
-  /// copy keep resurrecting deletes. The device id mirrored in SharedPreferences
-  /// survives the restore, so a mismatch between it and the restored in-DB
-  /// device id is the signal that a restore happened.
+  /// copy keep resurrecting deletes. Two values mirrored in SharedPreferences
+  /// survive the restore and reveal it:
   ///
-  /// - No sentinel yet: record the current id ([DeviceIdentityStatus.seeded]).
-  ///   A restore that predates the sentinel cannot be detected this way; such a
-  ///   device needs a one-time manual Reset Sync State to recover.
-  /// - Sentinel matches: nothing to do ([DeviceIdentityStatus.unchanged]).
-  /// - Sentinel differs: a restore swapped the database. Re-baseline sync,
-  ///   preserving the live identity from the sentinel
+  /// - the **instance token** (rotated each launch) -- the primary signal. A
+  ///   restored backup carries a stale token that no longer matches the mirror,
+  ///   so this catches even a same-device backup whose device id is unchanged.
+  /// - the **device id** -- a secondary signal; a restored foreign backup also
+  ///   changes the in-DB device id. It additionally names the identity to
+  ///   preserve through the re-baseline.
+  ///
+  /// Outcomes:
+  /// - No anchors yet: establish them ([DeviceIdentityStatus.seeded]). A restore
+  ///   predating the anchors cannot be detected and needs a one-time manual
+  ///   Reset Sync State to recover.
+  /// - On-disk DB is the one we last wrote: rotate the token and continue
+  ///   ([DeviceIdentityStatus.unchanged]).
+  /// - On-disk DB is not the one we last wrote: a restore swapped it.
+  ///   Re-baseline sync, preserving the live device identity
   ///   ([DeviceIdentityStatus.rebaselined]).
   ///
   /// Never throws: a reconcile failure must not block app launch.
   Future<DeviceIdentityStatus> reconcileDeviceIdentity() async {
     try {
       final deviceId = await _syncRepository.getDeviceId();
-      final sentinel = _prefs.getString(_deviceIdSentinelKey);
+      final dbToken = await _syncRepository.getInstanceToken();
+      final mirroredToken = _prefs.getString(_dbInstanceTokenKey);
+      final sentinelDeviceId = _prefs.getString(_deviceIdSentinelKey);
 
-      if (sentinel == null) {
-        await _prefs.setString(_deviceIdSentinelKey, deviceId);
-        _log.info('Seeded sync device-id sentinel');
+      // First run (or first launch after this detection shipped): nothing to
+      // compare against. Establish the anchors. A restore that predates them
+      // cannot be detected and needs a manual Reset Sync State.
+      if (mirroredToken == null || sentinelDeviceId == null) {
+        await _establishAnchors(deviceId);
+        _log.info('Seeded sync restore-detection anchors');
         return DeviceIdentityStatus.seeded;
       }
 
-      if (sentinel == deviceId) {
-        return DeviceIdentityStatus.unchanged;
+      // The on-disk DB must be the one we last wrote. The instance token is the
+      // primary signal (it catches a same-device backup, whose device id is
+      // unchanged); a device-id change is a secondary signal kept as a belt.
+      final restoreDetected =
+          dbToken == null ||
+          dbToken != mirroredToken ||
+          sentinelDeviceId != deviceId;
+
+      if (restoreDetected) {
+        _log.warning(
+          'On-disk database is not the one we last wrote (restore/overwrite '
+          'detected); re-baselining sync and restoring the live identity',
+        );
+        await _syncRepository.rebaselineAfterRestore(
+          preserveDeviceId: sentinelDeviceId,
+        );
+        // Re-establish anchors on the restored DB, mirroring the preserved id.
+        await _establishAnchors(sentinelDeviceId);
+        return DeviceIdentityStatus.rebaselined;
       }
 
-      // The database carries a different device id than the one we persisted
-      // outside it: the DB was replaced by a restore. Restore the live identity
-      // and clear the rewound baseline so the next sync fully reconciles.
-      _log.warning(
-        'Sync device id changed under us (database restore detected); '
-        're-baselining sync and restoring the live identity',
-      );
-      await _syncRepository.rebaselineAfterRestore(preserveDeviceId: sentinel);
-      // The sentinel already holds the live id we just restored, so it stays
-      // authoritative; no rewrite is needed.
-      return DeviceIdentityStatus.rebaselined;
+      // Normal launch: rotate the token so a backup taken of this state becomes
+      // distinguishable from the live DB on a future restore.
+      await _establishAnchors(deviceId);
+      return DeviceIdentityStatus.unchanged;
     } catch (e, stackTrace) {
       _log.error(
         'Device-identity reconcile failed; continuing launch',
@@ -100,6 +130,15 @@ class SyncInitializer {
       );
       return DeviceIdentityStatus.error;
     }
+  }
+
+  /// Rotate the database instance token and mirror it -- plus [deviceId] --
+  /// into SharedPreferences, so the next launch can tell whether the on-disk DB
+  /// is still the one we last wrote.
+  Future<void> _establishAnchors(String deviceId) async {
+    final token = await _syncRepository.rotateInstanceToken();
+    await _prefs.setString(_dbInstanceTokenKey, token);
+    await _prefs.setString(_deviceIdSentinelKey, deviceId);
   }
 
   /// Check sync status on app launch

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -10,6 +10,11 @@ class SyncInitializer {
 
   static const _lastProviderKey = 'sync_last_provider';
 
+  /// Mirrors the in-DB sync device id outside the database (which a restore
+  /// would otherwise rewind silently). A mismatch on launch is the signal that
+  /// the database was replaced by a restore. See [reconcileDeviceIdentity].
+  static const _deviceIdSentinelKey = 'sync_device_id_sentinel';
+
   final SyncRepository _syncRepository;
   final SharedPreferences _prefs;
 
@@ -39,6 +44,61 @@ class SyncInitializer {
       await _prefs.remove(_lastProviderKey);
     } else {
       await _prefs.setString(_lastProviderKey, provider.name);
+    }
+  }
+
+  /// Reconcile this installation's sync identity against the device id mirrored
+  /// outside the database, detecting (and recovering from) a database restore.
+  ///
+  /// All sync bookkeeping (device id, HLC clock, last-sync timestamp, cursors,
+  /// deletion log) lives inside the database, so a whole-DB restore rewinds it
+  /// to the backup's snapshot -- which stalls sync and lets a peer's still-live
+  /// copy keep resurrecting deletes. The device id mirrored in SharedPreferences
+  /// survives the restore, so a mismatch between it and the restored in-DB
+  /// device id is the signal that a restore happened.
+  ///
+  /// - No sentinel yet: record the current id ([DeviceIdentityStatus.seeded]).
+  ///   A restore that predates the sentinel cannot be detected this way; such a
+  ///   device needs a one-time manual Reset Sync State to recover.
+  /// - Sentinel matches: nothing to do ([DeviceIdentityStatus.unchanged]).
+  /// - Sentinel differs: a restore swapped the database. Re-baseline sync,
+  ///   preserving the live identity from the sentinel
+  ///   ([DeviceIdentityStatus.rebaselined]).
+  ///
+  /// Never throws: a reconcile failure must not block app launch.
+  Future<DeviceIdentityStatus> reconcileDeviceIdentity() async {
+    try {
+      final deviceId = await _syncRepository.getDeviceId();
+      final sentinel = _prefs.getString(_deviceIdSentinelKey);
+
+      if (sentinel == null) {
+        await _prefs.setString(_deviceIdSentinelKey, deviceId);
+        _log.info('Seeded sync device-id sentinel');
+        return DeviceIdentityStatus.seeded;
+      }
+
+      if (sentinel == deviceId) {
+        return DeviceIdentityStatus.unchanged;
+      }
+
+      // The database carries a different device id than the one we persisted
+      // outside it: the DB was replaced by a restore. Restore the live identity
+      // and clear the rewound baseline so the next sync fully reconciles.
+      _log.warning(
+        'Sync device id changed under us (database restore detected); '
+        're-baselining sync and restoring the live identity',
+      );
+      await _syncRepository.rebaselineAfterRestore(preserveDeviceId: sentinel);
+      // The sentinel already holds the live id we just restored, so it stays
+      // authoritative; no rewrite is needed.
+      return DeviceIdentityStatus.rebaselined;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Device-identity reconcile failed; continuing launch',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return DeviceIdentityStatus.error;
     }
   }
 
@@ -183,6 +243,25 @@ class SyncInitializer {
     final lower = filename.toLowerCase();
     return lower.contains('conflicted copy') || lower.contains('conflict');
   }
+}
+
+/// Outcome of [SyncInitializer.reconcileDeviceIdentity].
+enum DeviceIdentityStatus {
+  /// No sentinel existed yet; the current device id was recorded. First run, or
+  /// first launch after this detection shipped. A restore predating the
+  /// sentinel cannot be detected and needs a manual Reset Sync State.
+  seeded,
+
+  /// The sentinel already matched the in-DB device id. Normal launch, no-op.
+  unchanged,
+
+  /// The in-DB device id no longer matched the sentinel: a restore replaced the
+  /// database. Sync was re-baselined and the live identity restored.
+  rebaselined,
+
+  /// The reconcile could not run (e.g. the metadata lookup failed). Launch
+  /// continues regardless.
+  error,
 }
 
 /// Status of the sync check

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -286,16 +286,20 @@ class SyncInitializer {
 
 /// Outcome of [SyncInitializer.reconcileDeviceIdentity].
 enum DeviceIdentityStatus {
-  /// No sentinel existed yet; the current device id was recorded. First run, or
-  /// first launch after this detection shipped. A restore predating the
-  /// sentinel cannot be detected and needs a manual Reset Sync State.
+  /// No anchors existed yet; the instance token and device id were recorded.
+  /// First run, or first launch after this detection shipped. A restore
+  /// predating the anchors cannot be detected and needs a manual Reset Sync
+  /// State.
   seeded,
 
-  /// The sentinel already matched the in-DB device id. Normal launch, no-op.
+  /// The anchors still matched the on-disk database. Normal launch; the
+  /// instance token was rotated for next time.
   unchanged,
 
-  /// The in-DB device id no longer matched the sentinel: a restore replaced the
-  /// database. Sync was re-baselined and the live identity restored.
+  /// The on-disk database no longer matched the mirrored anchors -- a changed
+  /// instance token (the primary signal, which catches a same-device backup),
+  /// or a changed device id: a restore replaced the database. Sync was
+  /// re-baselined and the live identity restored.
   rebaselined,
 
   /// The reconcile could not run (e.g. the metadata lookup failed). Launch

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -54,6 +55,7 @@ class BackupService {
   final BackupDatabaseAdapter _dbAdapter;
   final BackupPreferences _preferences;
   final CloudStorageProvider? _cloudProvider;
+  final SyncRepository _syncRepository;
   final _log = LoggerService.forClass(BackupService);
   final _uuid = const Uuid();
 
@@ -64,9 +66,11 @@ class BackupService {
     required BackupDatabaseAdapter dbAdapter,
     required BackupPreferences preferences,
     CloudStorageProvider? cloudProvider,
+    SyncRepository? syncRepository,
   }) : _dbAdapter = dbAdapter,
        _preferences = preferences,
-       _cloudProvider = cloudProvider;
+       _cloudProvider = cloudProvider,
+       _syncRepository = syncRepository ?? SyncRepository();
 
   // ===========================================================================
   // Backup
@@ -278,8 +282,10 @@ class BackupService {
       throw const BackupException('Backup file not found locally or in cloud');
     }
 
-    // Restore using DatabaseService (handles close/copy/reinitialize)
-    await _dbAdapter.restore(sourcePath);
+    // Restore using DatabaseService (handles close/copy/reinitialize), then
+    // re-baseline sync so the restored data syncs cleanly instead of replaying
+    // the backup's stale sync position.
+    await _replaceDatabaseAndRebaselineSync(sourcePath);
 
     _log.info('Restore completed from: ${record.filename}');
   }
@@ -302,10 +308,50 @@ class BackupService {
     // in their configured backup location and in the history list.
     await performBackup();
 
-    // Restore using DatabaseService
-    await _dbAdapter.restore(filePath);
+    // Restore using DatabaseService, then re-baseline sync (see
+    // _replaceDatabaseAndRebaselineSync).
+    await _replaceDatabaseAndRebaselineSync(filePath);
 
     _log.info('Restore from file completed: ${p.basename(filePath)}');
+  }
+
+  /// Replace the database with [sourcePath], then re-baseline sync.
+  ///
+  /// A restore swaps in the backup's entire database — including its stale sync
+  /// metadata (device id, HLC clock, last-sync timestamp, cursors) and deletion
+  /// log. Without re-baselining, the rewound `lastSync` makes the merge treat
+  /// almost every restored row as a conflict, so sync stalls and deletes
+  /// resurrect from a peer's still-live copy. This preserves the live device
+  /// identity (captured before the swap) and clears the sync position so the
+  /// next sync cleanly reconciles the restored data.
+  Future<void> _replaceDatabaseAndRebaselineSync(String sourcePath) async {
+    String? liveDeviceId;
+    try {
+      liveDeviceId = await _syncRepository.getDeviceId();
+    } catch (e, st) {
+      _log.warning(
+        "Could not capture device id before restore; sync will adopt the "
+        "backup's device id",
+        error: e,
+        stackTrace: st,
+      );
+    }
+
+    await _dbAdapter.restore(sourcePath);
+
+    try {
+      await _syncRepository.rebaselineAfterRestore(
+        preserveDeviceId: liveDeviceId,
+      );
+    } catch (e, st) {
+      // Non-fatal: the data restore itself succeeded. If re-baselining failed,
+      // the user can recover by running "Reset Sync State" manually.
+      _log.error(
+        'Failed to re-baseline sync after restore',
+        error: e,
+        stackTrace: st,
+      );
+    }
   }
 
   // ===========================================================================

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -325,13 +325,20 @@ class BackupService {
   /// identity (captured before the swap) and clears the sync position so the
   /// next sync cleanly reconciles the restored data.
   Future<void> _replaceDatabaseAndRebaselineSync(String sourcePath) async {
-    String? liveDeviceId;
+    String liveDeviceId;
     try {
       liveDeviceId = await _syncRepository.getDeviceId();
     } catch (e, st) {
+      // Fall back to a fresh device id rather than letting the restore adopt
+      // the backup's id. Adopting it would make this install impersonate the
+      // device that produced the backup (colliding per-device sync file and
+      // HLC node identity). A fresh id keeps this install distinct; the
+      // launch-time reconcile realigns it to the mirrored identity if one
+      // exists.
+      liveDeviceId = const Uuid().v4();
       _log.warning(
-        "Could not capture device id before restore; sync will adopt the "
-        "backup's device id",
+        "Could not capture device id before restore; preserving a fresh "
+        "device id instead of adopting the backup's",
         error: e,
         stackTrace: st,
       );

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -415,10 +415,12 @@ final syncLaunchCheckProvider = FutureProvider<SyncCheckResult>((ref) async {
 
 /// Reconcile the sync device identity on app launch.
 ///
-/// Detects a database restore (the in-DB device id no longer matches the id
-/// mirrored outside the database) and re-baselines sync so a rewound baseline
-/// can't stall sync or resurrect deletes. Runs unconditionally at startup,
-/// independent of whether a cloud provider is configured.
+/// Detects a database restore -- the on-disk database no longer matches the
+/// anchors mirrored outside it: a rotated instance token (the primary signal,
+/// which catches a same-device backup) or the device id -- and re-baselines
+/// sync so a rewound baseline can't stall sync or resurrect deletes. Runs
+/// unconditionally at startup, independent of whether a cloud provider is
+/// configured. See [SyncInitializer.reconcileDeviceIdentity].
 final reconcileDeviceIdentityProvider = FutureProvider<DeviceIdentityStatus>((
   ref,
 ) async {

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -413,6 +413,19 @@ final syncLaunchCheckProvider = FutureProvider<SyncCheckResult>((ref) async {
   return initializer.checkSyncOnLaunch(provider);
 });
 
+/// Reconcile the sync device identity on app launch.
+///
+/// Detects a database restore (the in-DB device id no longer matches the id
+/// mirrored outside the database) and re-baselines sync so a rewound baseline
+/// can't stall sync or resurrect deletes. Runs unconditionally at startup,
+/// independent of whether a cloud provider is configured.
+final reconcileDeviceIdentityProvider = FutureProvider<DeviceIdentityStatus>((
+  ref,
+) async {
+  final initializer = ref.watch(syncInitializerProvider);
+  return initializer.reconcileDeviceIdentity();
+});
+
 /// Restore last used provider on app launch
 final restoreLastProviderProvider = FutureProvider<void>((ref) async {
   final initializer = ref.watch(syncInitializerProvider);

--- a/test/core/data/repositories/sync_repository_rebaseline_test.dart
+++ b/test/core/data/repositories/sync_repository_rebaseline_test.dart
@@ -71,4 +71,17 @@ void main() {
       },
     );
   });
+
+  group('setDeviceId validation', () {
+    test('rejects an empty or blank device id', () async {
+      // A blank id would corrupt the per-device sync file name and HLC node id.
+      await expectLater(repo.setDeviceId(''), throwsArgumentError);
+      await expectLater(repo.setDeviceId('   '), throwsArgumentError);
+    });
+
+    test('persists a valid device id', () async {
+      await repo.setDeviceId('device-XYZ');
+      expect(await repo.getDeviceId(), 'device-XYZ');
+    });
+  });
 }

--- a/test/core/data/repositories/sync_repository_rebaseline_test.dart
+++ b/test/core/data/repositories/sync_repository_rebaseline_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for the restore-breaks-sync bug.
+///
+/// A database restore replaces the whole DB, so `sync_metadata` (device id,
+/// HLC clock, last-sync timestamp, cursors) and the deletion log revert to the
+/// backup's stale snapshot. The merge gates on the persisted `lastSync`
+/// (`localUpdatedAt > lastSyncMs` flags spurious conflicts), so a rewound
+/// baseline stalls sync and lets a peer's still-live copy keep resurrecting
+/// deletes. [SyncRepository.rebaselineAfterRestore] clears that baseline while
+/// preserving the live device identity, so the next sync does a clean full
+/// reconcile of the restored data.
+void main() {
+  late SyncRepository repo;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repo = SyncRepository();
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  group('rebaselineAfterRestore', () {
+    test('clears the rewound baseline (lastSync + tombstones) and preserves '
+        'the live device id', () async {
+      // The state a restored DB lands in: a metadata row already exists (the
+      // backup has one) carrying a stale lastSync, plus a leftover tombstone
+      // from the backup snapshot.
+      await repo.getOrCreateMetadata();
+      await repo.updateLastSyncTime(DateTime.fromMillisecondsSinceEpoch(1000));
+      await repo.logDeletion(entityType: 'dives', recordId: 'old-tombstone');
+      expect(await repo.getLastSyncTime(), isNotNull);
+      expect(await repo.getAllDeletions(), isNotEmpty);
+
+      await repo.rebaselineAfterRestore(preserveDeviceId: 'device-LIVE');
+
+      expect(
+        await repo.getLastSyncTime(),
+        isNull,
+        reason:
+            'lastSync must be cleared so the next sync does a full reconcile '
+            'instead of replaying a rewound baseline',
+      );
+      expect(
+        await repo.getAllDeletions(),
+        isEmpty,
+        reason: "the backup's stale tombstones must be cleared",
+      );
+      expect(
+        await repo.getDeviceId(),
+        'device-LIVE',
+        reason:
+            'the live device identity must survive the restore rather than be '
+            "replaced by the backup's device id",
+      );
+    });
+
+    test(
+      'keeps the current device id when no preserve id is supplied',
+      () async {
+        final original = await repo.getDeviceId();
+        await repo.rebaselineAfterRestore();
+        expect(await repo.getDeviceId(), original);
+        expect(await repo.getLastSyncTime(), isNull);
+      },
+    );
+  });
+}

--- a/test/core/database/migration_v78_instance_token_test.dart
+++ b/test/core/database/migration_v78_instance_token_test.dart
@@ -1,0 +1,85 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Migration 78 adds a nullable `instance_token` column to sync_metadata. The
+/// token is rotated each launch and mirrored outside the DB so a restore that
+/// leaves the device id unchanged (a same-device backup) is still detectable.
+/// This exercises the actual onUpgrade ALTER TABLE path (the rest of the suite
+/// only covers the fresh createAll schema).
+void main() {
+  test(
+    'v78 schema includes a nullable instance_token on sync_metadata',
+    () async {
+      final db = AppDatabase(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('sync_metadata')")
+          .get();
+      final col = cols.firstWhere(
+        (c) => c.read<String>('name') == 'instance_token',
+      );
+      expect(
+        col.read<int>('notnull'),
+        0,
+        reason: 'instance_token must be nullable',
+      );
+    },
+  );
+
+  test('v77 -> v78 upgrade adds instance_token to sync_metadata', () async {
+    // Minimal pre-v78 sync_metadata at user_version = 77 so the v78 ALTER runs.
+    final native = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 77');
+        rawDb.execute('''
+          CREATE TABLE sync_metadata (
+            id TEXT NOT NULL PRIMARY KEY,
+            device_id TEXT NOT NULL
+          )
+        ''');
+      },
+    );
+    final db = AppDatabase(native);
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('sync_metadata')")
+        .get();
+    expect(cols.any((c) => c.read<String>('name') == 'instance_token'), isTrue);
+  });
+
+  test('v77 -> v78 upgrade preserves existing sync_metadata rows', () async {
+    final native = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 77');
+        rawDb.execute('''
+          CREATE TABLE sync_metadata (
+            id TEXT NOT NULL PRIMARY KEY,
+            device_id TEXT NOT NULL
+          )
+        ''');
+        rawDb.execute(
+          "INSERT INTO sync_metadata (id, device_id) "
+          "VALUES ('global', 'dev-keep')",
+        );
+      },
+    );
+    final db = AppDatabase(native);
+    addTearDown(db.close);
+
+    final row = await db
+        .customSelect(
+          "SELECT device_id, instance_token FROM sync_metadata "
+          "WHERE id = 'global'",
+        )
+        .getSingle();
+    expect(row.read<String>('device_id'), 'dev-keep');
+    expect(
+      row.read<String?>('instance_token'),
+      isNull,
+      reason: 'migrated rows start with a null instance token (first-run seed)',
+    );
+  });
+}

--- a/test/core/services/sync/sync_initializer_reconcile_test.dart
+++ b/test/core/services/sync/sync_initializer_reconcile_test.dart
@@ -157,6 +157,75 @@ void main() {
       );
     });
 
+    test('detects a same-device restore from the instance token alone', () async {
+      // Seed the anchors (device-id sentinel + instance token).
+      expect(
+        await initializer.reconcileDeviceIdentity(),
+        DeviceIdentityStatus.seeded,
+      );
+      final liveId = await repository.getDeviceId();
+
+      // A same-device hand-restore: the device id is unchanged (it is this
+      // device's own backup), so the device-id sentinel still matches. The only
+      // signal is that the restored DB carries a different instance token than
+      // the copy mirrored in prefs -- plus a rewound baseline.
+      await repository.rotateInstanceToken();
+      await repository.updateLastSyncTime(
+        DateTime.fromMillisecondsSinceEpoch(1000),
+      );
+      await repository.logDeletion(
+        entityType: 'dives',
+        recordId: 'old-tombstone',
+      );
+
+      final status = await initializer.reconcileDeviceIdentity();
+
+      expect(
+        status,
+        DeviceIdentityStatus.rebaselined,
+        reason:
+            'a token mismatch must trigger a rebaseline even when the device '
+            'id is unchanged (the same-device-backup blind spot)',
+      );
+      expect(
+        await repository.getDeviceId(),
+        liveId,
+        reason: 'the unchanged same-device identity is preserved',
+      );
+      expect(await repository.getLastSyncTime(), isNull);
+      expect(await repository.getAllDeletions(), isEmpty);
+
+      // The anchors are re-aligned, so the next launch is a plain no-op.
+      expect(
+        await initializer.reconcileDeviceIdentity(),
+        DeviceIdentityStatus.unchanged,
+      );
+    });
+
+    test('rotates the instance token on a normal launch', () async {
+      expect(
+        await initializer.reconcileDeviceIdentity(),
+        DeviceIdentityStatus.seeded,
+      );
+      final t1 = await repository.getInstanceToken();
+      expect(t1, isNotNull);
+
+      expect(
+        await initializer.reconcileDeviceIdentity(),
+        DeviceIdentityStatus.unchanged,
+      );
+      final t2 = await repository.getInstanceToken();
+
+      expect(t2, isNotNull);
+      expect(
+        t2,
+        isNot(t1),
+        reason:
+            'each launch rotates the token so a backup of this state becomes '
+            'detectable once the live token advances past it',
+      );
+    });
+
     test('returns error and never throws when the lookup fails', () async {
       final throwingInitializer = SyncInitializer(
         syncRepository: _ThrowingSyncRepository(),

--- a/test/core/services/sync/sync_initializer_reconcile_test.dart
+++ b/test/core/services/sync/sync_initializer_reconcile_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_initializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// A repository whose [getDeviceId] always throws, to exercise the launch-safe
+/// error branch of [SyncInitializer.reconcileDeviceIdentity].
+class _ThrowingSyncRepository extends SyncRepository {
+  @override
+  Future<String> getDeviceId() async {
+    throw StateError('boom');
+  }
+}
+
+/// Tests for the launch-time device-identity reconciliation that recovers a
+/// database restore.
+///
+/// All sync bookkeeping (device id, HLC clock, last-sync timestamp, cursors,
+/// deletion log) lives inside the database, so a whole-DB restore silently
+/// rewinds it to the backup's snapshot. The device id mirrored in
+/// SharedPreferences (the "sentinel") survives the restore, so a launch-time
+/// mismatch between the sentinel and the restored in-DB device id is the signal
+/// that a restore happened -- and the cue to re-baseline sync.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SyncRepository repository;
+  late SharedPreferences prefs;
+  late SyncInitializer initializer;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    repository = SyncRepository();
+    initializer = SyncInitializer(syncRepository: repository, prefs: prefs);
+  });
+
+  tearDown(() async {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  group('reconcileDeviceIdentity', () {
+    test(
+      'seeds the sentinel on first run without touching the baseline',
+      () async {
+        // Materialize metadata so updateLastSyncTime() (a bare UPDATE) sticks.
+        await repository.getOrCreateMetadata();
+        await repository.updateLastSyncTime(
+          DateTime.fromMillisecondsSinceEpoch(5000),
+        );
+        final before = await repository.getDeviceId();
+
+        final status = await initializer.reconcileDeviceIdentity();
+
+        expect(
+          status,
+          DeviceIdentityStatus.seeded,
+          reason: 'the first run has no sentinel to compare against',
+        );
+        expect(
+          await repository.getDeviceId(),
+          before,
+          reason: 'seeding must not change this installation identity',
+        );
+        expect(
+          await repository.getLastSyncTime(),
+          isNotNull,
+          reason: 'seeding must not wipe a legitimate baseline',
+        );
+
+        // The sentinel now exists and matches, so a second run is a no-op.
+        expect(
+          await initializer.reconcileDeviceIdentity(),
+          DeviceIdentityStatus.unchanged,
+        );
+      },
+    );
+
+    test(
+      'is a no-op when the sentinel already matches the device id',
+      () async {
+        // First run seeds the sentinel from the current device id.
+        await initializer.reconcileDeviceIdentity();
+        await repository.updateLastSyncTime(
+          DateTime.fromMillisecondsSinceEpoch(5000),
+        );
+        await repository.logDeletion(entityType: 'dives', recordId: 'keep-me');
+
+        final status = await initializer.reconcileDeviceIdentity();
+
+        expect(status, DeviceIdentityStatus.unchanged);
+        expect(
+          await repository.getLastSyncTime(),
+          isNotNull,
+          reason: 'a matching identity must not trigger a rebaseline',
+        );
+        expect(
+          await repository.getAllDeletions(),
+          isNotEmpty,
+          reason: 'a matching identity must leave the deletion log intact',
+        );
+      },
+    );
+
+    test('rebaselines and restores the live identity after a restore', () async {
+      // Establish this install's identity and seed the out-of-DB sentinel.
+      await repository.setDeviceId('live-device');
+      expect(
+        await initializer.reconcileDeviceIdentity(),
+        DeviceIdentityStatus.seeded,
+      );
+
+      // A restore swaps the whole DB: the in-DB device id becomes the backup's,
+      // with a rewound baseline (stale lastSync) and a leftover tombstone.
+      await repository.setDeviceId('backup-device');
+      await repository.updateLastSyncTime(
+        DateTime.fromMillisecondsSinceEpoch(1000),
+      );
+      await repository.logDeletion(
+        entityType: 'dives',
+        recordId: 'old-tombstone',
+      );
+
+      final status = await initializer.reconcileDeviceIdentity();
+
+      expect(status, DeviceIdentityStatus.rebaselined);
+      expect(
+        await repository.getDeviceId(),
+        'live-device',
+        reason:
+            'the live identity from the sentinel must replace the '
+            "backup's device id",
+      );
+      expect(
+        await repository.getLastSyncTime(),
+        isNull,
+        reason:
+            'the rewound baseline must be cleared so the next sync does a '
+            'full reconcile',
+      );
+      expect(
+        await repository.getAllDeletions(),
+        isEmpty,
+        reason: "the backup's stale tombstones must be cleared",
+      );
+
+      // The sentinel now matches the restored identity, so the next launch is a
+      // no-op rather than a second rebaseline.
+      expect(
+        await initializer.reconcileDeviceIdentity(),
+        DeviceIdentityStatus.unchanged,
+      );
+    });
+
+    test('returns error and never throws when the lookup fails', () async {
+      final throwingInitializer = SyncInitializer(
+        syncRepository: _ThrowingSyncRepository(),
+        prefs: prefs,
+      );
+
+      // Must not throw -- a reconcile failure cannot be allowed to crash launch.
+      final status = await throwingInitializer.reconcileDeviceIdentity();
+
+      expect(status, DeviceIdentityStatus.error);
+    });
+  });
+}

--- a/test/core/services/sync/sync_initializer_reconcile_test.dart
+++ b/test/core/services/sync/sync_initializer_reconcile_test.dart
@@ -1,9 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_initializer.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 
 import '../../../helpers/test_database.dart';
 
@@ -21,10 +24,12 @@ class _ThrowingSyncRepository extends SyncRepository {
 ///
 /// All sync bookkeeping (device id, HLC clock, last-sync timestamp, cursors,
 /// deletion log) lives inside the database, so a whole-DB restore silently
-/// rewinds it to the backup's snapshot. The device id mirrored in
-/// SharedPreferences (the "sentinel") survives the restore, so a launch-time
-/// mismatch between the sentinel and the restored in-DB device id is the signal
-/// that a restore happened -- and the cue to re-baseline sync.
+/// rewinds it to the backup's snapshot. Two anchors mirrored in
+/// SharedPreferences survive the restore and reveal it: a per-database instance
+/// token rotated each launch (the primary signal -- it catches a same-device
+/// backup, whose device id is unchanged) and the device id (a secondary signal
+/// that also names the identity to preserve). A launch-time mismatch on either
+/// is the cue to re-baseline sync.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -236,6 +241,21 @@ void main() {
       final status = await throwingInitializer.reconcileDeviceIdentity();
 
       expect(status, DeviceIdentityStatus.error);
+    });
+  });
+
+  group('reconcileDeviceIdentityProvider', () {
+    test('runs the reconcile and seeds anchors on first run', () async {
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(
+        reconcileDeviceIdentityProvider.future,
+      );
+
+      expect(status, DeviceIdentityStatus.seeded);
     });
   });
 }

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -65,6 +65,22 @@ class _SpySyncRepository extends SyncRepository {
   }
 }
 
+/// A spy whose [getDeviceId] throws, to exercise the restore path's fallback
+/// when the live device id cannot be captured before the swap.
+class _CaptureFailSyncRepository extends SyncRepository {
+  int rebaselineCalls = 0;
+  String? preservedDeviceId;
+
+  @override
+  Future<String> getDeviceId() async => throw StateError('cannot read id');
+
+  @override
+  Future<void> rebaselineAfterRestore({String? preserveDeviceId}) async {
+    rebaselineCalls++;
+    preservedDeviceId = preserveDeviceId;
+  }
+}
+
 /// Fake cloud storage provider for testing
 class FakeCloudStorageProvider implements CloudStorageProvider {
   final List<String> uploadedFiles = [];
@@ -228,6 +244,41 @@ void main() {
           reason:
               'the live device identity captured before the restore must be '
               "preserved, not overwritten by the backup's device id",
+        );
+      });
+
+      test('preserves a fresh device id when the live id cannot be captured '
+          '(never adopts the backup id)', () async {
+        final spy = _CaptureFailSyncRepository();
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: spy,
+        );
+
+        final src = File(
+          '${Directory.systemTemp.path}/restore_src_'
+          '${DateTime.now().microsecondsSinceEpoch}.db',
+        );
+        await src.writeAsString('db');
+        addTearDown(() async {
+          if (await src.exists()) await src.delete();
+        });
+
+        await service.restoreFromFile(src.path);
+
+        expect(spy.rebaselineCalls, 1);
+        expect(
+          spy.preservedDeviceId,
+          isNotNull,
+          reason:
+              'a capture failure must still preserve a device id, not pass '
+              'null (which would let the restore adopt the backup id)',
+        );
+        expect(
+          spy.preservedDeviceId,
+          isNotEmpty,
+          reason: 'the fallback must be a fresh, non-empty device id',
         );
       });
     });

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
@@ -46,6 +47,22 @@ class FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake database does not support direct queries');
+}
+
+/// Spy sync repository: records the post-restore re-baseline without touching a
+/// database, so the restore wiring can be asserted in isolation.
+class _SpySyncRepository extends SyncRepository {
+  int rebaselineCalls = 0;
+  String? preservedDeviceId;
+
+  @override
+  Future<String> getDeviceId() async => 'live-device-id';
+
+  @override
+  Future<void> rebaselineAfterRestore({String? preserveDeviceId}) async {
+    rebaselineCalls++;
+    preservedDeviceId = preserveDeviceId;
+  }
 }
 
 /// Fake cloud storage provider for testing
@@ -169,6 +186,50 @@ void main() {
       preferences = BackupPreferences(prefs);
       fakeCloud = FakeCloudStorageProvider();
       fakeDb = FakeBackupDatabaseAdapter();
+    });
+
+    group('restore re-baselines sync', () {
+      test('restoreFromFile replaces the DB and re-baselines sync, preserving '
+          'the live device id', () async {
+        final spy = _SpySyncRepository();
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: spy,
+        );
+
+        final src = File(
+          '${Directory.systemTemp.path}/restore_src_'
+          '${DateTime.now().microsecondsSinceEpoch}.db',
+        );
+        await src.writeAsString('db');
+        addTearDown(() async {
+          if (await src.exists()) await src.delete();
+        });
+
+        await service.restoreFromFile(src.path);
+
+        expect(
+          fakeDb.restoreCallCount,
+          1,
+          reason: 'the database is replaced from the restore source',
+        );
+        expect(
+          spy.rebaselineCalls,
+          1,
+          reason:
+              'sync must be re-baselined after the DB is replaced, otherwise '
+              "the backup's stale sync position stalls sync and resurrects "
+              'deletes',
+        );
+        expect(
+          spy.preservedDeviceId,
+          'live-device-id',
+          reason:
+              'the live device identity captured before the restore must be '
+              "preserved, not overwritten by the backup's device id",
+        );
+      });
     });
 
     group('pruneOldBackups', () {


### PR DESCRIPTION
## Problem

Reported symptom: after restoring a database backup on the macOS client, changes stopped syncing, and deleting a dive on macOS made it reappear (the iPhone client still had it).

## Root cause

All sync bookkeeping lives **inside the database** — in the `sync_metadata` table (device id, the Hybrid Logical Clock, `lastSyncTimestamp`, cursors) plus the deletion/tombstone log. A restore replaces the whole DB file, so it silently rewinds every one of those values to the backup's stale snapshot.

The conflict merge gates on the persisted `lastSync` (`localUpdatedAt > lastSyncMs` flags almost every restored row as a conflict). With a rewound baseline:

- nearly every restored row looks "locally modified since last sync," so the merge treats normal data as conflicts and sync stalls; and
- the peer device still holds a live copy of anything deleted before the backup, so those deletes get resurrected on the restored device.

That is exactly the reported behavior: changes stop propagating, and deletes come back from the other device.

## Fix — part 1: re-baseline on the in-app restore path

Re-baseline sync as part of the in-app restore, in `BackupService` via a new `_replaceDatabaseAndRebaselineSync(...)`:

1. **Capture the live device id before the swap.** The restored DB carries the *backup's* device id; adopting that would make this device impersonate whatever device produced the backup. We read the current device id first, then re-apply it after the restore so this device keeps its own stable identity.
2. **Restore the DB** (unchanged behavior).
3. **Clear the sync baseline** — `rebaselineAfterRestore()` preserves the device id, then runs the existing `resetSyncState()` (nulls `lastSync`, clears cursors/`remoteFileId`, clears the deletion log) and resets the in-memory HLC. The next sync then does a clean full reconcile of the restored data instead of misreading it as a pile of conflicts.

### Why reset the HLC too

The Hybrid Logical Clock is re-seeded on next use from `max(persisted hlc, max row hlc)` forced to this device id, and `issue()` advances the physical component to `now()`. Resetting the in-memory clock after a restore avoids carrying a stale in-memory physical time from before the swap; it self-heals from the restored rows on the next issue.

## Fix — part 2: launch-time auto-detection (covers out-of-band restores)

Part 1 only covers restores performed through `BackupService`. A restore done any other way — an OS-level file replacement, a Time Machine / Finder recovery, a migration, or a restore performed *before* this PR shipped — still swaps the whole DB and rewinds the baseline. So `SyncInitializer.reconcileDeviceIdentity()` (wired via `reconcileDeviceIdentityProvider` in `app.dart`, watched at startup) reconciles, on **every launch**, the on-disk DB against two values mirrored *outside* the DB in `SharedPreferences` (which a restore can't touch):

- **Instance token (primary).** A per-database token (`sync_metadata.instance_token`, schema v78) that is **rotated every launch** and mirrored to prefs. On launch, if the on-disk token no longer matches the mirror, the DB is a restored backup carrying a superseded token. Because the token rotates, this catches a **same-device backup** — this device's own older backup, whose device id is unchanged. It is equality-compared, so there are no clock/ordering assumptions and no skew failure mode.
- **Device id (secondary).** A restored *foreign* backup also changes the in-DB device id; a mismatch against the mirrored device id is a second trigger, and it additionally names the identity to **preserve** through the re-baseline (so the device keeps its own sync identity rather than adopting the backup's).

On a mismatch from either signal, the reconcile calls `rebaselineAfterRestore(preserveDeviceId:)` and re-establishes both anchors on the restored DB. On a clean launch it just rotates the token. The reconcile is launch-safe — it never throws, so a sync-bookkeeping problem can't block app startup.

| Out-of-band overwrite with… | Caught by |
|---|---|
| A **different device's** DB/backup | token mismatch + device-id mismatch |
| This **same device's** older backup | token mismatch (device id is unchanged) |
| A **fresh/empty** DB | token mismatch + device-id mismatch |

## New API

- `SyncRepository.setDeviceId(String)` — re-applies a known device id to `sync_metadata`.
- `SyncRepository.rebaselineAfterRestore({String? preserveDeviceId})` — optional device-id preservation + `resetSyncState()` + `SyncClock.instance.reset()`.
- `SyncRepository.getInstanceToken()` / `rotateInstanceToken()` — read / rotate the per-database token.
- `SyncInitializer.reconcileDeviceIdentity()` → `DeviceIdentityStatus` (`seeded` / `unchanged` / `rebaselined` / `error`).

## Schema

- v78: nullable `sync_metadata.instance_token`, added via an idempotent `PRAGMA table_info`-guarded migration. Existing rows read `NULL` (treated as a first-run seed), so no backfill. `database.g.dart` is gitignored and regenerated by setup/CI.

## Tests

- `sync_repository_rebaseline_test.dart` — `rebaselineAfterRestore` clears the rewound baseline (lastSync + tombstones) and preserves the live device id; keeps the current device id when no preserve id is supplied.
- `backup_service_test.dart` — `restoreFromFile` replaces the DB **and** re-baselines sync, preserving the live device id (spy `SyncRepository`).
- `sync_initializer_reconcile_test.dart` — seeds on first run without touching the baseline; no-op (and rotates the token) when the anchors match; rebaselines and restores the live identity after a device-id change; **detects a same-device restore from the instance token alone**; rotates the token each launch; returns `error` and never throws when the lookup fails.
- `migration_v78_instance_token_test.dart` — v78 schema has a nullable `instance_token`; the v77→v78 upgrade adds it and preserves existing rows.
- `dart format` clean; `flutter analyze` clean.

## Note for already-affected devices

Launch-time auto-detection recovers any restore where the anchors were already planted (i.e. any restore from this PR forward). A device that was *already* restored **before** this shipped has no pre-restore anchor to compare against, so it cannot be auto-recovered — it needs a one-time **Settings → Cloud Sync → Reset Sync State**. From that reset onward it is protected like any other device. (This is the irreducible limit: detecting a restore needs an out-of-DB anchor written *before* the restore.)
