### PR TITLE
fix(sync): Reset Sync State adopts a fresh device identity

### DIFF
--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -1,12 +1,16 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/sync_clock.dart';
 
 /// Handles sync initialization and checks on app launch
 class SyncInitializer {
   static final _log = LoggerService.forClass(SyncInitializer);
+
+  final _uuid = const Uuid();
 
   static const _lastProviderKey = 'sync_last_provider';
 
@@ -139,6 +143,28 @@ class SyncInitializer {
     final token = await _syncRepository.rotateInstanceToken();
     await _prefs.setString(_dbInstanceTokenKey, token);
     await _prefs.setString(_deviceIdSentinelKey, deviceId);
+  }
+
+  /// Mint a brand-new sync identity for this installation: a fresh device id
+  /// persisted to the database and mirrored into the launch anchors, with a
+  /// freshly rotated instance token.
+  ///
+  /// This is the recovery path for a cloned identity -- two installs syncing
+  /// as the same device after cross-device backup/restore choreography. Each
+  /// twin lists the shared per-device sync file as "its own", sees no peers,
+  /// and silently overwrites the other's uploads. [reconcileDeviceIdentity]
+  /// deliberately preserves the anchored identity (correct for same-device
+  /// restores), so a clone survives every restore and reset; only minting a
+  /// new id -- and anchoring it so the next launch does not revert it -- can
+  /// split the twins. Returns the new device id.
+  Future<String> adoptFreshIdentity() async {
+    final newId = _uuid.v4();
+    await _syncRepository.setDeviceId(newId);
+    await _establishAnchors(newId);
+    // Drop the in-memory clock so HLC stamps re-seed under the new node id.
+    SyncClock.instance.reset();
+    _log.info('Adopted a fresh sync identity');
+    return newId;
   }
 
   /// Check sync status on app launch

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -698,9 +698,9 @@ class CloudSyncPage extends ConsumerWidget {
       builder: (context) => AlertDialog(
         title: const Text('Reset Sync State?'),
         content: const Text(
-          'This will clear all sync history and start fresh. '
-          'Your data will not be deleted, but you may need to resolve '
-          'conflicts on the next sync.',
+          'This will clear all sync history and give this device a new '
+          'sync identity. Your data will not be deleted, but you may need '
+          'to resolve conflicts on the next sync.',
         ),
         actions: [
           TextButton(

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -327,8 +327,15 @@ class SyncNotifier extends StateNotifier<SyncState> {
   }
 
   /// Reset sync state
+  ///
+  /// Also adopts a brand-new device identity. Reset is the user-facing
+  /// recovery for sync gone wrong, and the worst such state -- two installs
+  /// syncing as the same device after cross-device restores -- is only
+  /// fixable with a fresh identity. Restore detection deliberately preserves
+  /// the anchored identity, so a clone survives everything short of this.
   Future<void> resetSyncState() async {
     await _syncService.resetSyncState();
+    await _ref.read(syncInitializerProvider).adoptFreshIdentity();
     await refreshState();
   }
 

--- a/test/core/services/sync/sync_initializer_reconcile_test.dart
+++ b/test/core/services/sync/sync_initializer_reconcile_test.dart
@@ -258,4 +258,56 @@ void main() {
       expect(status, DeviceIdentityStatus.seeded);
     });
   });
+
+  group('adoptFreshIdentity', () {
+    test('mints a new device id, persists it, and re-anchors it', () async {
+      await initializer.reconcileDeviceIdentity();
+      final oldId = await repository.getDeviceId();
+      final oldToken = prefs.getString('sync_db_instance_token');
+
+      final newId = await initializer.adoptFreshIdentity();
+
+      expect(newId, isNot(oldId));
+      expect(await repository.getDeviceId(), newId);
+      expect(prefs.getString('sync_device_id_sentinel'), newId);
+      expect(prefs.getString('sync_db_instance_token'), isNotNull);
+      expect(prefs.getString('sync_db_instance_token'), isNot(oldToken));
+    });
+
+    test('a later launch reconcile keeps the fresh identity', () async {
+      // Restore detection deliberately preserves the anchored identity, so a
+      // regenerated id must be fully re-anchored or the next launch would
+      // read it as a restore and revert it.
+      await initializer.reconcileDeviceIdentity();
+      final newId = await initializer.adoptFreshIdentity();
+
+      final status = await initializer.reconcileDeviceIdentity();
+
+      expect(status, DeviceIdentityStatus.unchanged);
+      expect(await repository.getDeviceId(), newId);
+      expect(prefs.getString('sync_device_id_sentinel'), newId);
+    });
+  });
+
+  group('SyncNotifier.resetSyncState', () {
+    test('adopts a fresh device identity', () async {
+      // The twin-device trap: two installs syncing as the same device write
+      // the same per-device file and each lists zero peers. Reset Sync State
+      // is the user-facing recovery, so it must shed the identity, not just
+      // the baseline.
+      await initializer.reconcileDeviceIdentity();
+      final oldId = await repository.getDeviceId();
+
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(syncStateProvider.notifier).resetSyncState();
+
+      final newId = await repository.getDeviceId();
+      expect(newId, isNot(oldId));
+      expect(prefs.getString('sync_device_id_sentinel'), newId);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- **The bug (field-discovered during S3 sync verification):** two installs can end up syncing as the *same* device after cross-device backup/restore choreography. Each twin then writes the same per-device sync file (`submersion_sync_<deviceId>.json`), excludes that filename as "its own" when listing peers, sees zero peers, reports "Sync completed successfully" — and silently overwrites the other's upload forever. Observed live between an iPhone and a Mac: one file in the bucket whose size ping-ponged with each device's sync.
- **Why it was unrecoverable:** the PR #309 restore-detection deliberately *preserves* the anchored identity (correct for same-device restores), so a cloned identity survived every existing recovery path — Reset Sync State never touched the device id, and Reset Database was reverted by the SharedPreferences sentinel on the next launch. The app had identity preservation but no identity divorce.
- **The fix:** `SyncInitializer.adoptFreshIdentity()` mints a new device id, persists it, re-anchors the sentinel + instance token (so the next launch's reconcile keeps it instead of reverting it), and resets the in-memory HLC clock so stamps re-seed under the new node id. `SyncNotifier.resetSyncState()` now calls it, making the existing user-facing "Reset Sync State" the recovery tool for twinned devices; the confirmation dialog copy now says a new sync identity is issued.

Side effects considered: the old per-device file is orphaned in cloud storage (harmless — peers still merge it by HLC/updatedAt, and its records lose to anything newer); tombstone clearing on reset is pre-existing behavior, unchanged.

## Test Plan

- New tests in `sync_initializer_reconcile_test.dart` (real in-memory DB + mock prefs): fresh id minted/persisted/re-anchored with rotated token; a subsequent launch reconcile reports `unchanged` and keeps the new identity (the revert trap); `SyncNotifier.resetSyncState` adopts a fresh identity through the provider graph.
- Full gates: `dart format` clean, `flutter analyze` clean, `flutter test test/core/services/sync` (154) and `flutter test test/features/settings` (458) all passing.
- [x] Manual: on a twinned pair, run Reset Sync State on one device, Sync Now on both → second per-device file appears and dives converge both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)