### PR TITLE
fix(ble): preserve GATT notification boundaries in BLE read streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,189 @@
 All notable changes to Submersion are documented in this file.
 
 
+## 1.4.9 (2026-06-11)
+
+### Features
+
+- responsive two-column edit form on wide windows
+- rebuild site edit on shared form sections incl. merge mode
+- guard embedded cancel with discard confirmation
+- persistent fields for validated rows, decoration override
+- adopt EditFormScaffold, dirty guard and error auto-expand
+- rebuild Experience and rare groups, lock group order
+- rebuild Trip and Buddies groups
+- rebuild Conditions group with temperature hero
+- rebuild Gas & Gear group with tank cards and smart collapse
+- add TankCard with inline expanding tank editor
+- rebuild The Dive group on shared form primitives
+- add EditFormScaffold with discard guard and embedded header
+- add AddSectionRow for rare form sections
+- add UnitField numeric input with unit suffix
+- add FormRow label/value variants with inline text editing
+- add StatStrip hero stats with in-place editing and profile affordance
+- add collapsible FormSection with summary, invitation and error states
+- add FormStyle design tokens for shared form system
+- confirm first-contact library merges before syncing
+- detect twin device identities via per-upload nonces
+- surface the S3 provider tile and config route
+- add S3 configuration page with live connection test
+- add S3 sync settings strings in en and all 10 locales
+- register CloudProviderType.s3 and the S3 provider singleton
+- add S3StorageProvider implementing CloudStorageProvider
+- persist S3 config as a secure-storage blob
+- add minimal SigV4-signed S3 API client (put/get, retry)
+- complete SigV4 signing against AWS test vectors
+- add SigV4 hashing, key derivation, and encoding primitives
+- add S3Config entity for the S3 sync backend
+- detect same-device restores via a rotating instance token
+- auto-detect a database restore on launch and re-baseline
+- auto-refresh entity lists after sync via Drift table-change ticks
+- include state/province in dive center location
+- make diver-merge undo reachable from the UI
+- stamp HLCs on the three config tables that bypass the choke point
+- stamp HLCs on writes and use them in the merge decision
+- add nullable hlc column to conflict-capable tables (v77)
+- add Hybrid Logical Clock value type + SyncClock service
+- per-device sync files to remove the write-write race
+- undoable diver merge + localize the merge banner UI
+- detect and merge duplicate diver profiles from sync
+- surface Cloud Sync in Settings (route + iOS/macOS tile)
+- enlarge default heat-map cloud radius and opacity
+- load and cache heat-map fragment program
+- add density-heatmap helper functions with tests
+- warn on near-duplicate sites in the picker
+- autocomplete site name + warn on near-duplicates
+- autocomplete the region field, scoped by country
+- autocomplete the site country field
+- add SuggestionField autocomplete widget
+- add SimilarValueHint near-duplicate widget
+- add distinct-value suggestion helpers
+- add ISO 3166 country name constant
+- add Sorensen-Dice fuzzy matching utility
+
+### Bug Fixes
+
+- preserve GATT notification boundaries in BLE read streams
+- harden numeric stat input and guard save-time parsing
+- guard scaffold pop with context.mounted, enforce UnitField numerics
+- shrink tank card stats so the pressure range fits on phone
+- address PR review feedback
+- localize the first-sync merge dialog's Cancel button
+- keep the upload nonce when the upload times out
+- restore accents on the Hungarian Sync Now label
+- close the first-sync guard's reentrancy window
+- harden twin detection against false positives
+- reset keeps tombstones and retires the old device file
+- retire the legacy shared sync file after merging it
+- validate payload checksums over the writer's encoding
+- Reset Sync State adopts a fresh device identity
+- clear sync metadata on S3 sign-out while retaining credentials
+- surface keychain failures on the S3 page, harden fields
+- close probe clients, guard provider caches, sub-prefix folders
+- make S3 credentials load() total over malformed blobs
+- wrap S3 parse failures in CloudStorageException
+- collapse header whitespace per SigV4, document sign() contracts
+- harden S3Config per review - total displayHost, trimmed secret, path rejection
+- address PR review on restore detection
+- re-baseline sync after a database restore
+- address review — diver-stats tick, species + tag/buddy, DI consistency
+- address PR review — scope silent reloads + use diveRepositoryProvider
+- address PR #306 review round 2 (Copilot)
+- keep children of a parent revived in the same sync payload
+- cover all deletable-parent FKs + repair dangling refs at apply
+- stop deletions resurrecting from a peer's stale live copy
+- resolve PR #303 review -- change-bus on settings/preset writes, per-device launch check
+- check for null or empty
+- make diver-merge undo a true inverse of sync state
+- import-filter device-local keys, harden clock seed, deletion safety
+- HLC authoritative over conflict branch; stop dropping failed records
+- guard v77 index creation against partial-schema migration fixtures
+- add 77 to migrationVersions
+- address PR #302 review feedback
+- code-review polish on the sync-hardening batch
+- compute surface interval from timestamps when column is null
+- correct getTopDiveCenters SQL to use city/state/country columns
+- exclude built-in catalog rows from the sync payload
+- close cross-device deletion propagation gaps
+- include six previously-orphaned user-data tables in SyncData
+- defer FK checks, add courses, exclude device-local settings
+- surface apply failures as errors instead of masking as conflicts
+- export media and certifications via toJson() too
+- export all non-BLOB entities via toJson() for symmetric sync
+- export dives via toJson() so all fields survive sync
+- export isPlanned so dives apply on receiving devices
+- include dives logged on the last day of a trip
+- compute days-since-diving by calendar day not 24h period
+- use effectiveRuntime for longest dive in dive log summary
+- tune heat-map cloud defaults after visual review
+- prevent duplicate-key crash in the surface GPS map
+- use proper marine icons for species categories
+- add missing en l10n keys + picker hint import (#292)
+- rebase Swift exit-GPS patch onto upstream GNSS-status check
+- show updated dive number after renumbering Fixes #240
+
+### Refactoring
+
+- extract picker sheets from dive edit page
+- extract diveRepositoryProvider to break import cycles
+- replace fetchRecord hand-maintained maps with Drift's toJson()
+- render heat map via density-colorized shader
+
+### Performance
+
+- encode BLOBs as base64 instead of JSON byte arrays
+
+### Documentation
+
+- record implementation deviations in design spec
+- add edit form redesign implementation plan
+- add edit form redesign design spec and mockup
+- add upgrade-path hardening implementation plan
+- align S3 spec with review-driven implementation changes
+- correct two SigV4 test vectors (computationally verified)
+- add S3 sync backend implementation plan
+- add S3-compatible sync storage backend design spec
+- record device-local settings-key audit
+- record Phase 0 iCloud sync diagnosis (merge masks apply errors as conflicts)
+- add iCloud sync all-data spec + Phase 0 diagnostic plan
+- add heat-map redesign spec and implementation plan
+- implementation plan for site field autocomplete (#292)
+- design spec for dive site & location field autocomplete (#292)
+- release notes
+
+### Tests
+
+- raise PR patch coverage above 90%
+- pin legacy-file retirement safety invariants
+- cover the S3 tile states and sign-out credential retention
+- pin S3 store error propagation; clarify load() docs
+- pin S3 client behavior; fix retry wrapping and UTF-8 decode
+- rename error-path tests to match the path they exercise
+- cover auto-refresh tick/silent-reload paths (patch coverage ~35->94%)
+- cover conflict resolution; fix stale comments; harden blob/merge tests
+- cover the v77 hlc migration upgrade path
+- reproduce A->B no-op; receiving merge relabels apply error as conflict
+- add serializer symmetry round-trip test
+- add in-memory fake CloudStorageProvider for diagnostics
+- add runtime-only longest dive coverage to dive summary widget
+
+### CI/CD
+
+- bump codecov/codecov-action from 6 to 7
+
+### Chores
+
+- bump version to 1.4.9+96
+- translate first-sync merge strings into all locales
+- refresh Podfile.lock checksum for libdivecomputer_plugin
+- silence experimental/coroutine errors on windows
+
+### Other
+
+- add density-colorized heat-map fragment shader
+- i18n: add similar-site hint strings across all locales
+
+
 ## 1.4.9 (2026-05-29)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Submersion are documented in this file.
 
 
-## 1.4.9 (2026-06-11)
+## 1.4.9+96 (2026-06-11)
 
 ### Features
 

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -49,9 +49,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     private var remainingServiceDiscoveries = 0
     private var discoverySignaled = false
 
-    private let readLock = NSLock()
-    private var readBuffer = Data()
-    private let readSemaphore = DispatchSemaphore(value: 0)
+    private let packetBuffer = PacketReadBuffer()
     private let writeSemaphore = DispatchSemaphore(value: 0)
     private let writeReadySemaphore = DispatchSemaphore(value: 0)
     private let connectSemaphore = DispatchSemaphore(value: 0)
@@ -224,11 +222,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         let stream = Unmanaged<BleIoStream>.fromOpaque(userdata!).takeUnretainedValue()
         guard let actual else {
             var transferred: size_t = 0
-            let status = stream.performRead(data: data!, size: size, actual: &transferred)
-            if status != Int32(LIBDC_STATUS_SUCCESS) {
-                return status
-            }
-            return transferred == size ? Int32(LIBDC_STATUS_SUCCESS) : Int32(LIBDC_STATUS_TIMEOUT)
+            return stream.performRead(data: data!, size: size, actual: &transferred)
         }
         return stream.performRead(data: data!, size: size, actual: actual)
     }
@@ -260,21 +254,14 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
 
     private static let cPoll: libdc_io_poll_fn = { userdata, timeout in
         let stream = Unmanaged<BleIoStream>.fromOpaque(userdata!).takeUnretainedValue()
-        stream.readLock.lock()
-        let available = stream.readBuffer.count
-        stream.readLock.unlock()
-        if available > 0 { return Int32(LIBDC_STATUS_SUCCESS) }
+        if stream.packetBuffer.hasData { return Int32(LIBDC_STATUS_SUCCESS) }
 
         if timeout == 0 { return Int32(LIBDC_STATUS_TIMEOUT) }
 
         let deadline: DispatchTime = timeout < 0 ? .distantFuture :
             .now() + .milliseconds(Int(timeout))
-        let result = stream.readSemaphore.wait(timeout: deadline)
-        if result == .timedOut { return Int32(LIBDC_STATUS_TIMEOUT) }
-
-        // Re-signal since we consumed the signal but didn't consume data.
-        stream.readSemaphore.signal()
-        return Int32(LIBDC_STATUS_SUCCESS)
+        return stream.packetBuffer.poll(deadline: deadline)
+            ? Int32(LIBDC_STATUS_SUCCESS) : Int32(LIBDC_STATUS_TIMEOUT)
     }
 
     // MARK: - I/O Operations
@@ -284,28 +271,19 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         let deadline: DispatchTime = timeoutMs == Int.max ? .distantFuture :
             .now() + .milliseconds(timeoutMs)
 
-        while true {
-            readLock.lock()
-            let available = readBuffer.count
-            if available > 0 {
-                let bytesToRead = min(size, readBuffer.count)
-                _ = readBuffer.withUnsafeBytes { ptr in
-                    memcpy(data, ptr.baseAddress!, bytesToRead)
-                }
-                readBuffer.removeFirst(bytesToRead)
-                readLock.unlock()
-                actual.pointee = bytesToRead
-                return Int32(LIBDC_STATUS_SUCCESS)
-            }
-            readLock.unlock()
-
-            if readSemaphore.wait(timeout: deadline) == .timedOut {
-                actual.pointee = 0
-                consecutiveReadTimeouts += 1
-                maybeFlipWriteModeAfterReadTimeout()
-                return Int32(LIBDC_STATUS_TIMEOUT)
-            }
+        // The buffer returns bytes from at most one BLE notification per
+        // call: libdivecomputer's packet parsers size each read from the
+        // packet header and would silently drop a second packet coalesced
+        // into the same read (lost FLAG_LAST ack -> spurious timeout).
+        guard let bytesToRead = packetBuffer.read(
+            into: data, maxBytes: size, deadline: deadline) else {
+            actual.pointee = 0
+            consecutiveReadTimeouts += 1
+            maybeFlipWriteModeAfterReadTimeout()
+            return Int32(LIBDC_STATUS_TIMEOUT)
         }
+        actual.pointee = bytesToRead
+        return Int32(LIBDC_STATUS_SUCCESS)
     }
 
     private func performWrite(data: UnsafeRawPointer, size: size_t,
@@ -391,10 +369,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             return Int32(LIBDC_STATUS_SUCCESS)
         }
 
-        readLock.lock()
-        readBuffer.removeAll(keepingCapacity: true)
-        readLock.unlock()
-        drainSemaphore(readSemaphore)
+        packetBuffer.purge()
         return Int32(LIBDC_STATUS_SUCCESS)
     }
 
@@ -636,10 +611,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             "notify \(characteristic.uuid.uuidString)"
                 + " bytes=\(value.count)"
                 + " data=\(Self.hexString(value, maxBytes: Self.maxLogBytes))")
-        readLock.lock()
-        readBuffer.append(value)
-        readLock.unlock()
-        readSemaphore.signal()
+        packetBuffer.append(value)
     }
 
     func peripheral(_ peripheral: CBPeripheral,

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/PacketReadBuffer.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/PacketReadBuffer.swift
@@ -20,12 +20,25 @@ final class PacketReadBuffer {
 
     /// Append one notification payload. Empty payloads are ignored because a
     /// zero-byte read is treated as a protocol error by the parsers.
+    ///
+    /// The semaphore is signaled only on the empty -> non-empty transition,
+    /// so it behaves as an edge-triggered wakeup event rather than a counter
+    /// of notifications. Without this, a consumer that drains chunks faster
+    /// than they arrive (the steady state during a flash dump) would leave
+    /// one stale signal per notification, producing O(N) spurious wakeups
+    /// on the next empty-buffer wait and an O(N) drain in purge(). The
+    /// single-consumer contract documented on the type means a missed
+    /// wakeup is impossible: any later append from an empty queue will
+    /// itself signal.
     func append(_ data: Data) {
         guard !data.isEmpty else { return }
         lock.lock()
+        let wasEmpty = chunks.isEmpty
         chunks.append(data)
         lock.unlock()
-        semaphore.signal()
+        if wasEmpty {
+            semaphore.signal()
+        }
     }
 
     /// True if any notification data is buffered.

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/PacketReadBuffer.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/PacketReadBuffer.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// FIFO of BLE notification payloads that preserves packet boundaries.
+///
+/// libdivecomputer's BLE protocol parsers (pelagic_i330r, shearwater, ...)
+/// expect each dc_iostream_read() to return bytes from at most one GATT
+/// notification: they size the packet from its header and discard any extra
+/// bytes in the same read. If two notifications are coalesced into one read
+/// (e.g. the i330R's trailing FLAG_LAST ack arriving in the same dispatch
+/// window as the last data packet), the trailing packet is silently lost and
+/// the parser times out waiting for it.
+///
+/// Threading contract: append() may be called from any thread (the
+/// CoreBluetooth delegate queue); read(), poll(), and purge() are expected
+/// from a single consumer thread (libdivecomputer's download thread).
+final class PacketReadBuffer {
+    private let lock = NSLock()
+    private var chunks: [Data] = []
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    /// Append one notification payload. Empty payloads are ignored because a
+    /// zero-byte read is treated as a protocol error by the parsers.
+    func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        lock.lock()
+        chunks.append(data)
+        lock.unlock()
+        semaphore.signal()
+    }
+
+    /// True if any notification data is buffered.
+    var hasData: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !chunks.isEmpty
+    }
+
+    /// Copy up to `maxBytes` from the oldest notification into `dest`,
+    /// blocking until data arrives or `deadline` passes. A partially
+    /// consumed notification stays at the head of the queue, so bytes from
+    /// two notifications are never returned by a single call.
+    /// Returns the number of bytes copied, or nil on timeout.
+    func read(into dest: UnsafeMutableRawPointer, maxBytes: Int,
+              deadline: DispatchTime) -> Int? {
+        while true {
+            lock.lock()
+            if let chunk = chunks.first {
+                let count = min(maxBytes, chunk.count)
+                chunk.withUnsafeBytes { ptr in
+                    _ = memcpy(dest, ptr.baseAddress!, count)
+                }
+                if count < chunk.count {
+                    chunks[0] = chunk.subdata(in: count..<chunk.count)
+                } else {
+                    chunks.removeFirst()
+                }
+                lock.unlock()
+                return count
+            }
+            lock.unlock()
+
+            // Stale signals (from chunks consumed without waiting) cause a
+            // spurious wakeup here; the loop re-checks against the absolute
+            // deadline, so they cannot extend the timeout.
+            if semaphore.wait(timeout: deadline) == .timedOut {
+                return nil
+            }
+        }
+    }
+
+    /// Block until data is available or `deadline` passes, without
+    /// consuming anything. Returns true if data is available.
+    func poll(deadline: DispatchTime) -> Bool {
+        while !hasData {
+            // A consumed signal may be stale (its chunk was already read);
+            // loop to re-check rather than report a false positive.
+            if semaphore.wait(timeout: deadline) == .timedOut {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Drop all buffered notifications and pending wakeup signals.
+    func purge() {
+        lock.lock()
+        chunks.removeAll(keepingCapacity: true)
+        lock.unlock()
+        while semaphore.wait(timeout: .now()) == .success {
+            // Drain stale signals so they don't wake a future read.
+        }
+    }
+}

--- a/packages/libdivecomputer_plugin/darwin/Tests/PacketReadBufferTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/PacketReadBufferTests/main.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+// Standalone test runner for PacketReadBuffer (no XCTest: the LibDCDarwin
+// package cannot build under SwiftPM because it depends on Flutter modules
+// only present in the CocoaPods build). Run via darwin/run_native_tests.sh.
+
+var failures = 0
+
+func expect(_ condition: Bool, _ message: String, line: Int = #line) {
+    if condition {
+        print("PASS: \(message)")
+    } else {
+        print("FAIL: \(message) (main.swift:\(line))")
+        failures += 1
+    }
+}
+
+func readBytes(_ buffer: PacketReadBuffer, max: Int, timeoutMs: Int) -> [UInt8]? {
+    var dest = [UInt8](repeating: 0, count: max)
+    let deadline = DispatchTime.now() + .milliseconds(timeoutMs)
+    let count: Int? = dest.withUnsafeMutableBytes { ptr in
+        buffer.read(into: ptr.baseAddress!, maxBytes: max, deadline: deadline)
+    }
+    guard let count else { return nil }
+    return Array(dest[0..<count])
+}
+
+// 1. The i330R bug: a 69-byte last-data packet and the 6-byte FLAG_LAST ack
+// arrive as separate notifications in the same dispatch window. Each read
+// must return bytes from at most one notification, never both coalesced.
+do {
+    let buffer = PacketReadBuffer()
+    var lastData = Data([0xCD, 0x80, 0x0D, 0xD6, 0x40])
+    lastData.append(Data(repeating: 0xAA, count: 64))
+    let flagLast = Data([0xCD, 0xC0, 0x0D, 0x88, 0x01, 0x02])
+    buffer.append(lastData)
+    buffer.append(flagLast)
+
+    let first = readBytes(buffer, max: 260, timeoutMs: 100)
+    expect(first?.count == 69,
+           "coalesced: first read returns only the 69-byte packet, got \(String(describing: first?.count))")
+    let second = readBytes(buffer, max: 260, timeoutMs: 100)
+    expect(second?.count == 6,
+           "coalesced: second read returns the 6-byte FLAG_LAST ack, got \(String(describing: second?.count))")
+    expect(second == [0xCD, 0xC0, 0x0D, 0x88, 0x01, 0x02],
+           "coalesced: FLAG_LAST ack bytes intact")
+}
+
+// 2. Partial consumption: a small read drains the head chunk across calls
+// before the next chunk becomes visible.
+do {
+    let buffer = PacketReadBuffer()
+    buffer.append(Data([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    buffer.append(Data([99, 98]))
+
+    expect(readBytes(buffer, max: 4, timeoutMs: 100) == [1, 2, 3, 4],
+           "partial: first 4 bytes of head chunk")
+    expect(readBytes(buffer, max: 260, timeoutMs: 100) == [5, 6, 7, 8, 9, 10],
+           "partial: remainder of head chunk only, not the next chunk")
+    expect(readBytes(buffer, max: 260, timeoutMs: 100) == [99, 98],
+           "partial: next chunk afterwards")
+}
+
+// 3. Timeout on empty buffer.
+do {
+    let buffer = PacketReadBuffer()
+    let start = DispatchTime.now()
+    let result = readBytes(buffer, max: 16, timeoutMs: 100)
+    let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1e6
+    expect(result == nil, "timeout: empty buffer read returns nil")
+    expect(elapsedMs >= 90, "timeout: waited near the deadline (\(elapsedMs) ms)")
+}
+
+// 4. Purge drops buffered chunks and stale wakeups.
+do {
+    let buffer = PacketReadBuffer()
+    buffer.append(Data([1, 2, 3]))
+    buffer.append(Data([4, 5, 6]))
+    buffer.purge()
+    expect(readBytes(buffer, max: 16, timeoutMs: 100) == nil,
+           "purge: no data after purge despite earlier appends")
+}
+
+// 5. Poll is non-consuming and honors timeout.
+do {
+    let buffer = PacketReadBuffer()
+    expect(!buffer.poll(deadline: DispatchTime.now() + .milliseconds(50)),
+           "poll: empty buffer times out")
+    buffer.append(Data([7, 7]))
+    expect(buffer.poll(deadline: DispatchTime.now() + .milliseconds(50)),
+           "poll: sees buffered data")
+    expect(readBytes(buffer, max: 16, timeoutMs: 100) == [7, 7],
+           "poll: did not consume the data")
+}
+
+// 6. Cross-thread delivery: a read blocked on an empty buffer wakes when a
+// notification arrives from another thread (CoreBluetooth delegate queue).
+do {
+    let buffer = PacketReadBuffer()
+    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(50)) {
+        buffer.append(Data([42]))
+    }
+    expect(readBytes(buffer, max: 16, timeoutMs: 1000) == [42],
+           "cross-thread: blocked read receives late append")
+}
+
+// 7. FIFO order across chunks.
+do {
+    let buffer = PacketReadBuffer()
+    buffer.append(Data([1]))
+    buffer.append(Data([2]))
+    buffer.append(Data([3]))
+    expect(readBytes(buffer, max: 16, timeoutMs: 100) == [1], "fifo: first")
+    expect(readBytes(buffer, max: 16, timeoutMs: 100) == [2], "fifo: second")
+    expect(readBytes(buffer, max: 16, timeoutMs: 100) == [3], "fifo: third")
+}
+
+// 8. Empty notifications are ignored: a zero-byte read would be treated as
+// a protocol error by libdivecomputer packet parsers.
+do {
+    let buffer = PacketReadBuffer()
+    buffer.append(Data())
+    buffer.append(Data([5]))
+    expect(readBytes(buffer, max: 16, timeoutMs: 100) == [5],
+           "empty append: skipped, real chunk returned")
+}
+
+// 9. Purge also drops pending wakeup signals: a poll right after purge must
+// not report data based on a stale signal from a purged chunk.
+do {
+    let buffer = PacketReadBuffer()
+    buffer.append(Data([1]))
+    buffer.append(Data([2]))
+    buffer.purge()
+    expect(!buffer.poll(deadline: DispatchTime.now() + .milliseconds(50)),
+           "purge: poll sees no data from stale signals")
+}
+
+// 10. Signals left over from chunks consumed without waiting must not make
+// poll report data on an empty buffer.
+do {
+    let buffer = PacketReadBuffer()
+    buffer.append(Data([1, 2, 3]))
+    _ = readBytes(buffer, max: 16, timeoutMs: 100)
+    expect(!buffer.poll(deadline: DispatchTime.now() + .milliseconds(50)),
+           "stale signal: poll on drained buffer returns false")
+}
+
+if failures == 0 {
+    print("All PacketReadBuffer tests passed.")
+    exit(0)
+} else {
+    print("\(failures) PacketReadBuffer test(s) FAILED.")
+    exit(1)
+}

--- a/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
+++ b/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Compiles and runs the standalone native unit tests for the darwin BLE
+# transport helpers. These cannot run under `swift test` because the
+# LibDCDarwin SwiftPM target depends on Flutter modules that only exist in
+# the CocoaPods build.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+BUILD_DIR=".build/native-tests"
+mkdir -p "$BUILD_DIR"
+
+swiftc -o "$BUILD_DIR/packet_read_buffer_tests" \
+    Sources/LibDCDarwin/PacketReadBuffer.swift \
+    Tests/PacketReadBufferTests/main.swift
+
+"$BUILD_DIR/packet_read_buffer_tests"

--- a/packages/libdivecomputer_plugin/ios/Classes/PacketReadBuffer.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/PacketReadBuffer.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/PacketReadBuffer.swift

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -22,7 +22,7 @@ BleIoStream* ble_io_stream_new(void) {
     BleIoStream* stream = g_new0(BleIoStream, 1);
     g_mutex_init(&stream->read_mutex);
     g_cond_init(&stream->read_cond);
-    stream->read_buffer = g_byte_array_new();
+    stream->read_chunks = g_queue_new();
     stream->timeout_ms = 10000;
     g_mutex_init(&stream->pin_mutex);
     g_cond_init(&stream->pin_cond);
@@ -130,8 +130,10 @@ static void on_properties_changed(GDBusConnection* connection,
         value_var, &n_bytes, sizeof(guint8));
 
     if (n_bytes > 0 && bytes) {
+        GByteArray* chunk = g_byte_array_sized_new((guint)n_bytes);
+        g_byte_array_append(chunk, bytes, (guint)n_bytes);
         g_mutex_lock(&stream->read_mutex);
-        g_byte_array_append(stream->read_buffer, bytes, (guint)n_bytes);
+        g_queue_push_tail(stream->read_chunks, chunk);
         g_cond_signal(&stream->read_cond);
         g_mutex_unlock(&stream->read_mutex);
     }
@@ -312,7 +314,7 @@ static int ble_read(void* userdata, void* data, size_t size,
                           : g_get_monotonic_time() +
                                 (gint64)stream->timeout_ms * 1000;
 
-    while (stream->read_buffer->len == 0) {
+    while (g_queue_is_empty(stream->read_chunks)) {
         if (stream->timeout_ms == G_MAXINT32) {
             g_cond_wait(&stream->read_cond, &stream->read_mutex);
         } else {
@@ -325,10 +327,20 @@ static int ble_read(void* userdata, void* data, size_t size,
         }
     }
 
-    size_t bytes_to_read = MIN(size, stream->read_buffer->len);
-    memcpy(data, stream->read_buffer->data, bytes_to_read);
-    g_byte_array_remove_range(stream->read_buffer, 0,
-                              (guint)bytes_to_read);
+    // Return bytes from at most one notification per read: the packet
+    // parsers size each read from the packet header and would silently
+    // drop a second packet coalesced into the same read (lost FLAG_LAST
+    // ack -> spurious timeout). A partially consumed notification stays
+    // at the head of the queue.
+    GByteArray* chunk = (GByteArray*)g_queue_peek_head(stream->read_chunks);
+    size_t bytes_to_read = MIN(size, chunk->len);
+    memcpy(data, chunk->data, bytes_to_read);
+    if (bytes_to_read < chunk->len) {
+        g_byte_array_remove_range(chunk, 0, (guint)bytes_to_read);
+    } else {
+        g_queue_pop_head(stream->read_chunks);
+        g_byte_array_unref(chunk);
+    }
     g_mutex_unlock(&stream->read_mutex);
 
     if (actual) *actual = bytes_to_read;
@@ -520,7 +532,7 @@ static int ble_poll(void* userdata, int timeout) {
     BleIoStream* stream = (BleIoStream*)userdata;
     g_mutex_lock(&stream->read_mutex);
 
-    if (stream->read_buffer->len > 0) {
+    if (!g_queue_is_empty(stream->read_chunks)) {
         g_mutex_unlock(&stream->read_mutex);
         return LIBDC_STATUS_SUCCESS;
     }
@@ -530,15 +542,22 @@ static int ble_poll(void* userdata, int timeout) {
         return LIBDC_STATUS_TIMEOUT;
     }
 
-    gboolean signaled;
+    // GCond waits can wake spuriously; re-check the predicate in a loop.
+    gboolean signaled = TRUE;
     if (timeout < 0) {
-        g_cond_wait(&stream->read_cond, &stream->read_mutex);
-        signaled = TRUE;
+        while (g_queue_is_empty(stream->read_chunks)) {
+            g_cond_wait(&stream->read_cond, &stream->read_mutex);
+        }
     } else {
         gint64 deadline =
             g_get_monotonic_time() + (gint64)timeout * 1000;
-        signaled = g_cond_wait_until(
-            &stream->read_cond, &stream->read_mutex, deadline);
+        while (g_queue_is_empty(stream->read_chunks)) {
+            if (!g_cond_wait_until(&stream->read_cond,
+                                   &stream->read_mutex, deadline)) {
+                signaled = FALSE;
+                break;
+            }
+        }
     }
 
     g_mutex_unlock(&stream->read_mutex);
@@ -549,7 +568,10 @@ static int ble_purge(void* userdata, unsigned int direction) {
     if ((direction & DIRECTION_INPUT) == 0) return LIBDC_STATUS_SUCCESS;
     BleIoStream* stream = (BleIoStream*)userdata;
     g_mutex_lock(&stream->read_mutex);
-    g_byte_array_set_size(stream->read_buffer, 0);
+    GByteArray* chunk;
+    while ((chunk = g_queue_pop_head(stream->read_chunks)) != NULL) {
+        g_byte_array_unref(chunk);
+    }
     g_mutex_unlock(&stream->read_mutex);
     return LIBDC_STATUS_SUCCESS;
 }
@@ -601,7 +623,13 @@ void ble_io_stream_free(BleIoStream* stream) {
 
     g_mutex_clear(&stream->read_mutex);
     g_cond_clear(&stream->read_cond);
-    if (stream->read_buffer) g_byte_array_unref(stream->read_buffer);
+    if (stream->read_chunks) {
+        GByteArray* chunk;
+        while ((chunk = g_queue_pop_head(stream->read_chunks)) != NULL) {
+            g_byte_array_unref(chunk);
+        }
+        g_queue_free(stream->read_chunks);
+    }
     g_free(stream->device_path);
     g_free(stream->write_path);
     g_free(stream->notify_path);

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.h
@@ -19,7 +19,11 @@ typedef struct {
 
     GMutex read_mutex;
     GCond read_cond;
-    GByteArray* read_buffer;
+    // Queue of GByteArray*, one entry per GATT notification.
+    // libdivecomputer's packet parsers require each read to return bytes
+    // from at most one notification; coalescing them into a flat buffer
+    // loses packet boundaries.
+    GQueue* read_chunks;
 
     gint timeout_ms;
     gchar* device_name;

--- a/packages/libdivecomputer_plugin/macos/Classes/PacketReadBuffer.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/PacketReadBuffer.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/PacketReadBuffer.swift

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -173,7 +173,7 @@ void BleIoStream::OnCharacteristicValueChanged(
 
     {
         std::lock_guard<std::mutex> lock(read_mutex_);
-        read_buffer_.insert(read_buffer_.end(), data.begin(), data.end());
+        read_chunks_.push_back(std::move(data));
     }
     read_cv_.notify_one();
 }
@@ -387,16 +387,16 @@ int BleIoStream::IoctlCallback(void* userdata, unsigned int request,
 int BleIoStream::PollCallback(void* userdata, int timeout) {
     auto* stream = static_cast<BleIoStream*>(userdata);
     std::unique_lock<std::mutex> lock(stream->read_mutex_);
-    if (!stream->read_buffer_.empty()) return LIBDC_STATUS_SUCCESS;
+    if (!stream->read_chunks_.empty()) return LIBDC_STATUS_SUCCESS;
     if (timeout == 0) return LIBDC_STATUS_TIMEOUT;
 
     if (timeout < 0) {
         stream->read_cv_.wait(
-            lock, [stream] { return !stream->read_buffer_.empty(); });
+            lock, [stream] { return !stream->read_chunks_.empty(); });
     } else {
         if (!stream->read_cv_.wait_for(
                 lock, std::chrono::milliseconds(timeout),
-                [stream] { return !stream->read_buffer_.empty(); })) {
+                [stream] { return !stream->read_chunks_.empty(); })) {
             return LIBDC_STATUS_TIMEOUT;
         }
     }
@@ -407,7 +407,7 @@ int BleIoStream::PurgeCallback(void* userdata, unsigned int direction) {
     if ((direction & kDirectionInput) == 0) return LIBDC_STATUS_SUCCESS;
     auto* stream = static_cast<BleIoStream*>(userdata);
     std::lock_guard<std::mutex> lock(stream->read_mutex_);
-    stream->read_buffer_.clear();
+    stream->read_chunks_.clear();
     return LIBDC_STATUS_SUCCESS;
 }
 
@@ -419,24 +419,33 @@ int BleIoStream::PerformRead(void* data, size_t size, size_t* actual) {
                         : std::chrono::steady_clock::now() +
                               std::chrono::milliseconds(timeout_ms_);
 
-    while (read_buffer_.empty()) {
+    while (read_chunks_.empty()) {
         if (timeout_ms_ == INT32_MAX) {
             read_cv_.wait(
-                lock, [this] { return !read_buffer_.empty(); });
+                lock, [this] { return !read_chunks_.empty(); });
         } else {
             if (!read_cv_.wait_until(
                     lock, deadline,
-                    [this] { return !read_buffer_.empty(); })) {
+                    [this] { return !read_chunks_.empty(); })) {
                 *actual = 0;
                 return LIBDC_STATUS_TIMEOUT;
             }
         }
     }
 
-    size_t bytes_to_read = std::min(size, read_buffer_.size());
-    std::memcpy(data, read_buffer_.data(), bytes_to_read);
-    read_buffer_.erase(read_buffer_.begin(),
-                       read_buffer_.begin() + bytes_to_read);
+    // Return bytes from at most one notification per read: the packet
+    // parsers size each read from the packet header and would silently
+    // drop a second packet coalesced into the same read (lost FLAG_LAST
+    // ack -> spurious timeout). A partially consumed notification stays
+    // at the front of the queue.
+    std::vector<uint8_t>& chunk = read_chunks_.front();
+    size_t bytes_to_read = std::min(size, chunk.size());
+    std::memcpy(data, chunk.data(), bytes_to_read);
+    if (bytes_to_read < chunk.size()) {
+        chunk.erase(chunk.begin(), chunk.begin() + bytes_to_read);
+    } else {
+        read_chunks_.pop_front();
+    }
     *actual = bytes_to_read;
     return LIBDC_STATUS_SUCCESS;
 }

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -96,7 +97,10 @@ class BleIoStream {
 
   std::mutex read_mutex_;
   std::condition_variable read_cv_;
-  std::vector<uint8_t> read_buffer_;
+  // One entry per GATT notification. libdivecomputer's packet parsers
+  // require each read to return bytes from at most one notification;
+  // coalescing them into a flat buffer loses packet boundaries.
+  std::deque<std::vector<uint8_t>> read_chunks_;
 
   int timeout_ms_ = 10000;
   std::string device_name_;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: submersion
 description: An open-source dive logging application for scuba divers.
 publish_to: 'none'
-version: 1.4.9+95
+version: 1.4.9+96
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary

- Root cause of the reported i330R failure (downloads die at ~1% with "Download failed", libdivecomputer result=-7 / DC_STATUS_TIMEOUT): the darwin, Windows, and Linux BLE transports coalesced GATT notifications into a flat byte buffer. libdivecomputer's packet parsers size each `dc_iostream_read` from the packet header and silently discard trailing bytes in the same read, so when the i330R's 6-byte FLAG_LAST ack (`cdc00d880102`) landed in the same dispatch window as the 69-byte final data packet of a 4 KB flash block, the ack was consumed-and-dropped, the recv loop kept waiting for a terminator that was already gone, and the 3 s timeout fired. The reporter's debug log shows the failing read's data-to-ack gap was 0 ms, versus 26-32 ms on the four blocks that succeeded.
- Not a regression: latent since the transports were written. The i330R/DSX protocol trips it deterministically (every `CMD_READ_FLASH` response ends with the tiny ack right behind a data packet), which is why that device "never worked" on iPhone and Windows alike. Shearwater SLIP framing on those platforms was vulnerable too but rarely hit. Android always had the correct one-notification-per-read queue, with a comment explaining why, and served as the reference for this port.
- darwin (iOS + macOS via the shared-source symlinks): new `PacketReadBuffer` - a chunk queue (NSLock + DispatchSemaphore) where a partially consumed notification stays at the head, so a single read never spans two notifications. `BleIoStream` rewired (read/poll/purge/notify); the nil-`actual` read fallback simplified to match Windows/Linux (the path is unreachable: `dc_iostream_read` always passes a local out-param).
- Windows: `read_buffer_` flat vector replaced with `std::deque<std::vector<uint8_t>>` of per-notification chunks, same head-consume logic.
- Linux: `GByteArray` replaced with a `GQueue` of per-notification `GByteArray`s; `ble_poll` also gains the GLib-required predicate loop around its condition wait (pre-existing spurious-wakeup tolerance, fixed while touching the file).
- Accepted trade-off: a protocol packet split across two notifications now spans two reads, where the flat buffer could accidentally reassemble it. This matches Android, upstream libdivecomputer's own `dc_packet_t` iostream, and the framing of every supported device; if a future device fragments packets across notifications, reassembly belongs in the parser, not the transport.

## Test Plan

- New standalone native test suite (`packages/libdivecomputer_plugin/darwin/run_native_tests.sh`, swiftc-compiled because SwiftPM cannot build the package - its Flutter module dependencies only exist in the CocoaPods build): 19 assertions including the exact log repro (69-byte data packet + 6-byte FLAG_LAST coalescing returned as two reads), partial consumption across reads, FIFO ordering, timeout-near-deadline, non-consuming poll, stale-signal honesty, purge draining pending wakeups, cross-thread delivery, and empty-notification filtering. Written red-first; all passing.
- Gates: `dart format` clean, `flutter analyze` clean, plugin Dart tests 15/15, `flutter build macos --debug` compiles the modified Swift through the real CocoaPods pipeline, full suite via pre-push hook. Windows/Linux are mechanical ports of the same algorithm (no local toolchain on this Mac); CI desktop builds cover compilation.
- Independent review pass over the diff (one-notification invariant on all three platforms, concurrency idioms, GLib refcounting across read/purge/free, deque reference-invalidation rules): no critical or important findings; its three minor recommendations are applied here.
- [ ] Manual: real i330R download on iPhone (reporter's hardware) - the deterministic trigger needs the physical device.
- [ ] Manual: regression pass with a Shearwater (Peregrine/Perdix) over BLE on macOS to confirm framing is unaffected.
