### PR TITLE
fix(import): persist recorded per-sample TTS so the divecomputer TTS source works

### DIFF
--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1008,6 +1008,7 @@ class UddfEntityImporter {
                   heartRate: p['heartRate'] as int?,
                   cns: asDoubleOrNull(p['cns']),
                   ndl: p['ndl'] as int?,
+                  tts: p['tts'] as int?,
                   rbt: p['rbt'] as int?,
                   decoType: p['decoType'] as int?,
                   setpoint: asDoubleOrNull(p['setpoint']),

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -290,7 +290,7 @@ ProfileAnalysisService _resolveAnalysisService(
     ttsCurve: useTts
         ? List<int>.generate(profile.length, (i) {
             final computerTts = profile[i].tts;
-            if (computerTts != null && computerTts > 0) return computerTts;
+            if (computerTts != null) return computerTts;
             if (analysis.ttsCurve != null && i < analysis.ttsCurve!.length) {
               return analysis.ttsCurve![i];
             }

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -450,6 +450,17 @@ class SubsurfaceXmlParser implements ImportParser {
     // Track which tank indices have pressure data across all samples
     final tankIndicesWithPressure = <int>{};
 
+    // Subsurface delta-encodes sample attributes: ndl, tts, rbt, cns and
+    // in_deco are only written when the value changes from the previous
+    // sample, so an omitted attribute means "unchanged", not "unknown".
+    // Carry the last seen value forward; samples before the first
+    // occurrence stay null.
+    int? lastNdl;
+    int? lastTts;
+    int? lastRbt;
+    double? lastCns;
+    bool inDeco = false;
+
     for (final sample in divecomputer.findElements('sample')) {
       final timestamp = _parseDurationSeconds(sample.getAttribute('time'));
       final depth = _parseDouble(sample.getAttribute('depth'));
@@ -459,14 +470,18 @@ class SubsurfaceXmlParser implements ImportParser {
       if (temp != null) point['temperature'] = temp;
       final heartRate = _parseInt(sample.getAttribute('heartbeat'));
       if (heartRate != null) point['heartRate'] = heartRate;
-      final ndl = _parseDurationSeconds(sample.getAttribute('ndl'));
+      final ndl = _parseDurationSeconds(sample.getAttribute('ndl')) ?? lastNdl;
       if (ndl != null) point['ndl'] = ndl;
-      final tts = _parseDurationSeconds(sample.getAttribute('tts'));
+      lastNdl = ndl;
+      final tts = _parseDurationSeconds(sample.getAttribute('tts')) ?? lastTts;
       if (tts != null) point['tts'] = tts;
-      final rbt = _parseDurationSeconds(sample.getAttribute('rbt'));
+      lastTts = tts;
+      final rbt = _parseDurationSeconds(sample.getAttribute('rbt')) ?? lastRbt;
       if (rbt != null) point['rbt'] = rbt;
-      final cns = _parseDouble(sample.getAttribute('cns'));
+      lastRbt = rbt;
+      final cns = _parseDouble(sample.getAttribute('cns')) ?? lastCns;
       if (cns != null) point['cns'] = cns;
+      lastCns = cns;
       final ppo2 = _parseDouble(sample.getAttribute('po2'));
       if (ppo2 != null) point['ppO2'] = ppo2;
       // Direct sample `setpoint` attribute is treated as bar — Subsurface
@@ -479,9 +494,9 @@ class SubsurfaceXmlParser implements ImportParser {
       // keep the direct-attribute path predictable.
       final setpoint = _parseDouble(sample.getAttribute('setpoint'));
       if (setpoint != null) point['setpoint'] = setpoint;
-      if (_parseInt(sample.getAttribute('in_deco')) == 1) {
-        point['decoType'] = 2;
-      }
+      final inDecoAttr = _parseInt(sample.getAttribute('in_deco'));
+      if (inDecoAttr != null) inDeco = inDecoAttr == 1;
+      if (inDeco) point['decoType'] = 2;
 
       // Read pressure0, pressure1, ... for each tank
       for (var tankIdx = 0; tankIdx < 10; tankIdx++) {

--- a/test/dives/001_short_deco_single_gas_switch.ssrf.xml
+++ b/test/dives/001_short_deco_single_gas_switch.ssrf.xml
@@ -1,0 +1,396 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+<site uuid='a1b2c3d4' name='Test Wall / Ideal Deco' gps='0.000000 0.000000'>
+</site>
+</divesites>
+<dives>
+<dive number='1' rating='5' divesiteid='a1b2c3d4' date='2026-06-02' time='10:00:00' duration='62:00 min'>
+  <cylinder size='24.0 l' workpressure='232.0 bar' description='Back gas (air)' />
+  <cylinder size='11.0 l' workpressure='232.0 bar' description='Deco EAN50' o2='50.0%' />
+  <divecomputer model='Submersion Test' deviceid='00000001' diveid='0a1b2c3d'>
+  <depth max='45.0 m' mean='20.2 m' />
+  <temperature water='20.0 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1030 g/l' />
+  <extradata key='Deco model' value='GF 50/75' />
+  <extradata key='Divemode' value='OC Technical' />
+  <event time='0:10 min' type='25' flags='2' name='gaschange' cylinder='0' />
+  <event time='25:10 min' type='25' flags='1' name='gaschange' cylinder='1' o2='50.0%' />
+  <sample time='0:10 min' depth='0.0 m' ndl='99:00 min' tts='3:00 min' />
+  <sample time='0:20 min' depth='3.2 m' tts='4:00 min' />
+  <sample time='0:30 min' depth='6.4 m' />
+  <sample time='0:40 min' depth='9.6 m' />
+  <sample time='0:50 min' depth='12.9 m' ndl='79:00 min' tts='5:00 min' />
+  <sample time='1:00 min' depth='16.1 m' ndl='44:00 min' />
+  <sample time='1:10 min' depth='19.3 m' ndl='27:00 min' />
+  <sample time='1:20 min' depth='22.5 m' ndl='17:00 min' tts='6:00 min' />
+  <sample time='1:30 min' depth='25.7 m' ndl='13:00 min' />
+  <sample time='1:40 min' depth='28.9 m' ndl='10:00 min' tts='7:00 min' />
+  <sample time='1:50 min' depth='32.1 m' ndl='7:00 min' />
+  <sample time='2:00 min' depth='35.4 m' ndl='5:00 min' />
+  <sample time='2:10 min' depth='38.6 m' ndl='4:00 min' tts='8:00 min' />
+  <sample time='2:20 min' depth='41.8 m' />
+  <sample time='2:30 min' depth='45.0 m' ndl='3:00 min' />
+  <sample time='2:40 min' depth='45.0 m' />
+  <sample time='2:50 min' depth='45.0 m' />
+  <sample time='3:00 min' depth='45.0 m' ndl='2:00 min' />
+  <sample time='3:10 min' depth='45.0 m' />
+  <sample time='3:20 min' depth='45.0 m' />
+  <sample time='3:30 min' depth='45.0 m' />
+  <sample time='3:40 min' depth='45.0 m' />
+  <sample time='3:50 min' depth='45.0 m' />
+  <sample time='4:00 min' depth='45.0 m' ndl='1:00 min' />
+  <sample time='4:10 min' depth='45.0 m' />
+  <sample time='4:20 min' depth='45.0 m' />
+  <sample time='4:30 min' depth='45.0 m' />
+  <sample time='4:40 min' depth='45.0 m' />
+  <sample time='4:50 min' depth='45.0 m' />
+  <sample time='5:00 min' depth='45.0 m' ndl='0:00 min' />
+  <sample time='5:10 min' depth='45.0 m' />
+  <sample time='5:20 min' depth='45.0 m' />
+  <sample time='5:30 min' depth='45.0 m' />
+  <sample time='5:40 min' depth='45.0 m' />
+  <sample time='5:50 min' depth='45.0 m' />
+  <sample time='6:00 min' depth='45.0 m' tts='9:00 min' in_deco='1' stopdepth='3.0 m' stoptime='4:00 min' />
+  <sample time='6:10 min' depth='45.0 m' />
+  <sample time='6:20 min' depth='45.0 m' tts='10:00 min' stoptime='5:00 min' />
+  <sample time='6:30 min' depth='45.0 m' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='6:40 min' depth='45.0 m' />
+  <sample time='6:50 min' depth='45.0 m' />
+  <sample time='7:00 min' depth='45.0 m' tts='11:00 min' />
+  <sample time='7:10 min' depth='45.0 m' stoptime='2:00 min' />
+  <sample time='7:20 min' depth='45.0 m' />
+  <sample time='7:30 min' depth='45.0 m' />
+  <sample time='7:40 min' depth='45.0 m' />
+  <sample time='7:50 min' depth='45.0 m' tts='12:00 min' />
+  <sample time='8:00 min' depth='45.0 m' stoptime='3:00 min' />
+  <sample time='8:10 min' depth='45.0 m' />
+  <sample time='8:20 min' depth='45.0 m' />
+  <sample time='8:30 min' depth='45.0 m' tts='13:00 min' />
+  <sample time='8:40 min' depth='45.0 m' />
+  <sample time='8:50 min' depth='45.0 m' tts='14:00 min' />
+  <sample time='9:00 min' depth='45.0 m' stoptime='4:00 min' />
+  <sample time='9:10 min' depth='45.0 m' />
+  <sample time='9:20 min' depth='45.0 m' tts='15:00 min' />
+  <sample time='9:30 min' depth='45.0 m' tts='16:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='9:40 min' depth='45.0 m' />
+  <sample time='9:50 min' depth='45.0 m' />
+  <sample time='10:00 min' depth='45.0 m' tts='17:00 min' />
+  <sample time='10:10 min' depth='45.0 m' />
+  <sample time='10:20 min' depth='45.0 m' />
+  <sample time='10:30 min' depth='45.0 m' tts='19:00 min' stoptime='2:00 min' />
+  <sample time='10:40 min' depth='45.0 m' />
+  <sample time='10:50 min' depth='45.0 m' tts='20:00 min' />
+  <sample time='11:00 min' depth='45.0 m' />
+  <sample time='11:10 min' depth='45.0 m' tts='21:00 min' />
+  <sample time='11:20 min' depth='45.0 m' />
+  <sample time='11:30 min' depth='45.0 m' tts='22:00 min' />
+  <sample time='11:40 min' depth='45.0 m' />
+  <sample time='11:50 min' depth='45.0 m' tts='23:00 min' stoptime='3:00 min' />
+  <sample time='12:00 min' depth='45.0 m' tts='24:00 min' />
+  <sample time='12:10 min' depth='45.0 m' />
+  <sample time='12:20 min' depth='45.0 m' tts='25:00 min' />
+  <sample time='12:30 min' depth='45.0 m' />
+  <sample time='12:40 min' depth='45.0 m' tts='26:00 min' />
+  <sample time='12:50 min' depth='45.0 m' tts='27:00 min' />
+  <sample time='13:00 min' depth='45.0 m' />
+  <sample time='13:10 min' depth='45.0 m' tts='28:00 min' />
+  <sample time='13:20 min' depth='45.0 m' tts='30:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='13:30 min' depth='45.0 m' />
+  <sample time='13:40 min' depth='45.0 m' tts='31:00 min' />
+  <sample time='13:50 min' depth='45.0 m' />
+  <sample time='14:00 min' depth='45.0 m' tts='33:00 min' />
+  <sample time='14:10 min' depth='45.0 m' />
+  <sample time='14:20 min' depth='45.0 m' tts='34:00 min' />
+  <sample time='14:30 min' depth='45.0 m' />
+  <sample time='14:40 min' depth='45.0 m' tts='35:00 min' />
+  <sample time='14:50 min' depth='45.0 m' />
+  <sample time='15:00 min' depth='45.0 m' tts='37:00 min' stoptime='2:00 min' />
+  <sample time='15:10 min' depth='45.0 m' />
+  <sample time='15:20 min' depth='45.0 m' />
+  <sample time='15:30 min' depth='45.0 m' tts='39:00 min' />
+  <sample time='15:40 min' depth='45.0 m' />
+  <sample time='15:50 min' depth='45.0 m' tts='40:00 min' />
+  <sample time='16:00 min' depth='45.0 m' />
+  <sample time='16:10 min' depth='45.0 m' tts='41:00 min' />
+  <sample time='16:20 min' depth='45.0 m' />
+  <sample time='16:30 min' depth='45.0 m' tts='42:00 min' />
+  <sample time='16:40 min' depth='45.0 m' tts='43:00 min' />
+  <sample time='16:50 min' depth='45.0 m' />
+  <sample time='17:00 min' depth='45.0 m' tts='44:00 min' />
+  <sample time='17:10 min' depth='45.0 m' tts='46:00 min' stoptime='3:00 min' />
+  <sample time='17:20 min' depth='45.0 m' />
+  <sample time='17:30 min' depth='45.0 m' tts='47:00 min' />
+  <sample time='17:40 min' depth='45.0 m' tts='48:00 min' />
+  <sample time='17:50 min' depth='45.0 m' tts='49:00 min' />
+  <sample time='18:00 min' depth='45.0 m' />
+  <sample time='18:10 min' depth='45.0 m' tts='50:00 min' />
+  <sample time='18:20 min' depth='45.0 m' tts='51:00 min' />
+  <sample time='18:30 min' depth='45.0 m' tts='52:00 min' />
+  <sample time='18:40 min' depth='45.0 m' tts='53:00 min' />
+  <sample time='18:50 min' depth='45.0 m' tts='55:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='19:00 min' depth='45.0 m' />
+  <sample time='19:10 min' depth='45.0 m' tts='56:00 min' />
+  <sample time='19:20 min' depth='45.0 m' />
+  <sample time='19:30 min' depth='45.0 m' tts='57:00 min' />
+  <sample time='19:40 min' depth='45.0 m' tts='58:00 min' />
+  <sample time='19:50 min' depth='45.0 m' tts='59:00 min' />
+  <sample time='20:00 min' depth='45.0 m' tts='60:00 min' />
+  <sample time='20:10 min' depth='45.0 m' />
+  <sample time='20:20 min' depth='45.0 m' tts='61:00 min' />
+  <sample time='20:30 min' depth='45.0 m' />
+  <sample time='20:40 min' depth='45.0 m' tts='62:00 min' />
+  <sample time='20:50 min' depth='45.0 m' tts='63:00 min' />
+  <sample time='21:00 min' depth='45.0 m' />
+  <sample time='21:10 min' depth='45.0 m' tts='64:00 min' />
+  <sample time='21:20 min' depth='45.0 m' tts='65:00 min' />
+  <sample time='21:30 min' depth='45.0 m' />
+  <sample time='21:40 min' depth='45.0 m' tts='66:00 min' />
+  <sample time='21:50 min' depth='45.0 m' tts='67:00 min' />
+  <sample time='22:00 min' depth='45.0 m' tts='69:00 min' stoptime='2:00 min' />
+  <sample time='22:10 min' depth='45.0 m' tts='70:00 min' />
+  <sample time='22:20 min' depth='45.0 m' tts='71:00 min' />
+  <sample time='22:30 min' depth='45.0 m' tts='72:00 min' />
+  <sample time='22:40 min' depth='43.5 m' />
+  <sample time='22:50 min' depth='42.0 m' />
+  <sample time='23:00 min' depth='40.5 m' />
+  <sample time='23:10 min' depth='39.0 m' />
+  <sample time='23:20 min' depth='37.5 m' />
+  <sample time='23:30 min' depth='36.0 m' tts='71:00 min' />
+  <sample time='23:40 min' depth='34.5 m' />
+  <sample time='23:50 min' depth='33.0 m' />
+  <sample time='24:00 min' depth='31.5 m' />
+  <sample time='24:10 min' depth='30.0 m' />
+  <sample time='24:20 min' depth='28.5 m' />
+  <sample time='24:30 min' depth='27.0 m' tts='70:00 min' />
+  <sample time='24:40 min' depth='25.5 m' />
+  <sample time='24:50 min' depth='24.0 m' />
+  <sample time='25:00 min' depth='22.5 m' />
+  <sample time='25:10 min' depth='21.0 m' tts='29:00 min' stoptime='1:00 min' />
+  <sample time='25:20 min' depth='19.5 m' />
+  <sample time='25:30 min' depth='18.0 m' tts='28:00 min' />
+  <sample time='25:40 min' depth='16.5 m' />
+  <sample time='25:50 min' depth='15.0 m' />
+  <sample time='26:00 min' depth='15.0 m' tts='27:00 min' />
+  <sample time='26:10 min' depth='15.0 m' stopdepth='12.0 m' stoptime='3:00 min' />
+  <sample time='26:20 min' depth='13.5 m' />
+  <sample time='26:30 min' depth='12.0 m' />
+  <sample time='26:40 min' depth='12.0 m' />
+  <sample time='26:50 min' depth='12.0 m' />
+  <sample time='27:00 min' depth='12.0 m' />
+  <sample time='27:10 min' depth='12.0 m' />
+  <sample time='27:20 min' depth='12.0 m' stoptime='2:00 min' />
+  <sample time='27:30 min' depth='12.0 m' />
+  <sample time='27:40 min' depth='12.0 m' />
+  <sample time='27:50 min' depth='12.0 m' />
+  <sample time='28:00 min' depth='12.0 m' />
+  <sample time='28:10 min' depth='12.0 m' tts='26:00 min' />
+  <sample time='28:20 min' depth='12.0 m' tts='27:00 min' stoptime='1:00 min' />
+  <sample time='28:30 min' depth='12.0 m' />
+  <sample time='28:40 min' depth='12.0 m' />
+  <sample time='28:50 min' depth='12.0 m' tts='26:00 min' />
+  <sample time='29:00 min' depth='12.0 m' tts='27:00 min' />
+  <sample time='29:10 min' depth='12.0 m' tts='26:00 min' />
+  <sample time='29:20 min' depth='12.0 m' tts='27:00 min' stopdepth='9.0 m' stoptime='5:00 min' />
+  <sample time='29:30 min' depth='10.5 m' tts='26:00 min' />
+  <sample time='29:40 min' depth='9.0 m' />
+  <sample time='29:50 min' depth='9.0 m' tts='25:00 min' />
+  <sample time='30:00 min' depth='9.0 m' />
+  <sample time='30:10 min' depth='9.0 m' />
+  <sample time='30:20 min' depth='9.0 m' stoptime='4:00 min' />
+  <sample time='30:30 min' depth='9.0 m' />
+  <sample time='30:40 min' depth='9.0 m' />
+  <sample time='30:50 min' depth='9.0 m' tts='24:00 min' />
+  <sample time='31:00 min' depth='9.0 m' />
+  <sample time='31:10 min' depth='9.0 m' tts='25:00 min' />
+  <sample time='31:20 min' depth='9.0 m' tts='24:00 min' stoptime='3:00 min' />
+  <sample time='31:30 min' depth='9.0 m' />
+  <sample time='31:40 min' depth='9.0 m' />
+  <sample time='31:50 min' depth='9.0 m' tts='23:00 min' />
+  <sample time='32:00 min' depth='9.0 m' tts='24:00 min' />
+  <sample time='32:10 min' depth='9.0 m' />
+  <sample time='32:20 min' depth='9.0 m' tts='23:00 min' stoptime='2:00 min' />
+  <sample time='32:30 min' depth='9.0 m' />
+  <sample time='32:40 min' depth='9.0 m' />
+  <sample time='32:50 min' depth='9.0 m' />
+  <sample time='33:00 min' depth='9.0 m' />
+  <sample time='33:10 min' depth='9.0 m' />
+  <sample time='33:20 min' depth='9.0 m' tts='22:00 min' stoptime='1:00 min' />
+  <sample time='33:30 min' depth='9.0 m' />
+  <sample time='33:40 min' depth='9.0 m' />
+  <sample time='33:50 min' depth='9.0 m' />
+  <sample time='34:00 min' depth='9.0 m' />
+  <sample time='34:10 min' depth='9.0 m' />
+  <sample time='34:20 min' depth='9.0 m' tts='21:00 min' stopdepth='6.0 m' stoptime='9:00 min' />
+  <sample time='34:30 min' depth='7.5 m' />
+  <sample time='34:40 min' depth='6.0 m' />
+  <sample time='34:50 min' depth='6.0 m' stoptime='8:00 min' />
+  <sample time='35:00 min' depth='6.0 m' />
+  <sample time='35:10 min' depth='6.0 m' />
+  <sample time='35:20 min' depth='6.0 m' />
+  <sample time='35:30 min' depth='6.0 m' />
+  <sample time='35:40 min' depth='6.0 m' />
+  <sample time='35:50 min' depth='6.0 m' stoptime='7:00 min' />
+  <sample time='36:00 min' depth='6.0 m' />
+  <sample time='36:10 min' depth='6.0 m' />
+  <sample time='36:20 min' depth='6.0 m' />
+  <sample time='36:30 min' depth='6.0 m' />
+  <sample time='36:40 min' depth='6.0 m' />
+  <sample time='36:50 min' depth='6.0 m' stoptime='6:00 min' />
+  <sample time='37:00 min' depth='6.0 m' />
+  <sample time='37:10 min' depth='6.0 m' />
+  <sample time='37:20 min' depth='6.0 m' />
+  <sample time='37:30 min' depth='6.0 m' tts='20:00 min' />
+  <sample time='37:40 min' depth='6.0 m' />
+  <sample time='37:50 min' depth='6.0 m' tts='21:00 min' stoptime='5:00 min' />
+  <sample time='38:00 min' depth='6.0 m' />
+  <sample time='38:10 min' depth='6.0 m' />
+  <sample time='38:20 min' depth='6.0 m' tts='20:00 min' />
+  <sample time='38:30 min' depth='6.0 m' />
+  <sample time='38:40 min' depth='6.0 m' />
+  <sample time='38:50 min' depth='6.0 m' tts='21:00 min' stoptime='4:00 min' />
+  <sample time='39:00 min' depth='6.0 m' />
+  <sample time='39:10 min' depth='6.0 m' tts='20:00 min' />
+  <sample time='39:20 min' depth='6.0 m' />
+  <sample time='39:30 min' depth='6.0 m' />
+  <sample time='39:40 min' depth='6.0 m' />
+  <sample time='39:50 min' depth='6.0 m' stoptime='3:00 min' />
+  <sample time='40:00 min' depth='6.0 m' />
+  <sample time='40:10 min' depth='6.0 m' />
+  <sample time='40:20 min' depth='6.0 m' />
+  <sample time='40:30 min' depth='6.0 m' />
+  <sample time='40:40 min' depth='6.0 m' />
+  <sample time='40:50 min' depth='6.0 m' stoptime='2:00 min' />
+  <sample time='41:00 min' depth='6.0 m' />
+  <sample time='41:10 min' depth='6.0 m' />
+  <sample time='41:20 min' depth='6.0 m' />
+  <sample time='41:30 min' depth='6.0 m' />
+  <sample time='41:40 min' depth='6.0 m' />
+  <sample time='41:50 min' depth='6.0 m' stoptime='1:00 min' />
+  <sample time='42:00 min' depth='6.0 m' />
+  <sample time='42:10 min' depth='6.0 m' />
+  <sample time='42:20 min' depth='6.0 m' />
+  <sample time='42:30 min' depth='6.0 m' />
+  <sample time='42:40 min' depth='6.0 m' tts='19:00 min' />
+  <sample time='42:50 min' depth='6.0 m' tts='20:00 min' stopdepth='3.0 m' stoptime='19:00 min' />
+  <sample time='43:00 min' depth='4.5 m' />
+  <sample time='43:10 min' depth='3.0 m' />
+  <sample time='43:20 min' depth='3.0 m' />
+  <sample time='43:30 min' depth='3.0 m' />
+  <sample time='43:40 min' depth='3.0 m' tts='19:00 min' stoptime='18:00 min' />
+  <sample time='43:50 min' depth='3.0 m' />
+  <sample time='44:00 min' depth='3.0 m' />
+  <sample time='44:10 min' depth='3.0 m' />
+  <sample time='44:20 min' depth='3.0 m' />
+  <sample time='44:30 min' depth='3.0 m' />
+  <sample time='44:40 min' depth='3.0 m' tts='18:00 min' stoptime='17:00 min' />
+  <sample time='44:50 min' depth='3.0 m' />
+  <sample time='45:00 min' depth='3.0 m' />
+  <sample time='45:10 min' depth='3.0 m' />
+  <sample time='45:20 min' depth='3.0 m' />
+  <sample time='45:30 min' depth='3.0 m' />
+  <sample time='45:40 min' depth='3.0 m' tts='17:00 min' stoptime='16:00 min' />
+  <sample time='45:50 min' depth='3.0 m' />
+  <sample time='46:00 min' depth='3.0 m' />
+  <sample time='46:10 min' depth='3.0 m' />
+  <sample time='46:20 min' depth='3.0 m' />
+  <sample time='46:30 min' depth='3.0 m' />
+  <sample time='46:40 min' depth='3.0 m' tts='16:00 min' stoptime='15:00 min' />
+  <sample time='46:50 min' depth='3.0 m' />
+  <sample time='47:00 min' depth='3.0 m' />
+  <sample time='47:10 min' depth='3.0 m' />
+  <sample time='47:20 min' depth='3.0 m' />
+  <sample time='47:30 min' depth='3.0 m' />
+  <sample time='47:40 min' depth='3.0 m' tts='15:00 min' stoptime='14:00 min' />
+  <sample time='47:50 min' depth='3.0 m' />
+  <sample time='48:00 min' depth='3.0 m' />
+  <sample time='48:10 min' depth='3.0 m' />
+  <sample time='48:20 min' depth='3.0 m' />
+  <sample time='48:30 min' depth='3.0 m' />
+  <sample time='48:40 min' depth='3.0 m' tts='14:00 min' stoptime='13:00 min' />
+  <sample time='48:50 min' depth='3.0 m' />
+  <sample time='49:00 min' depth='3.0 m' />
+  <sample time='49:10 min' depth='3.0 m' />
+  <sample time='49:20 min' depth='3.0 m' />
+  <sample time='49:30 min' depth='3.0 m' />
+  <sample time='49:40 min' depth='3.0 m' tts='13:00 min' stoptime='12:00 min' />
+  <sample time='49:50 min' depth='3.0 m' />
+  <sample time='50:00 min' depth='3.0 m' />
+  <sample time='50:10 min' depth='3.0 m' />
+  <sample time='50:20 min' depth='3.0 m' />
+  <sample time='50:30 min' depth='3.0 m' />
+  <sample time='50:40 min' depth='3.0 m' ndl='99:00 min' tts='1:00 min' in_deco='0' stopdepth='0.0 m' stoptime='0:00 min' />
+  <sample time='50:50 min' depth='3.0 m' />
+  <sample time='51:00 min' depth='3.0 m' />
+  <sample time='51:10 min' depth='3.0 m' />
+  <sample time='51:20 min' depth='3.0 m' />
+  <sample time='51:30 min' depth='3.0 m' />
+  <sample time='51:40 min' depth='3.0 m' />
+  <sample time='51:50 min' depth='3.0 m' />
+  <sample time='52:00 min' depth='3.0 m' />
+  <sample time='52:10 min' depth='3.0 m' />
+  <sample time='52:20 min' depth='3.0 m' />
+  <sample time='52:30 min' depth='3.0 m' />
+  <sample time='52:40 min' depth='3.0 m' />
+  <sample time='52:50 min' depth='3.0 m' />
+  <sample time='53:00 min' depth='3.0 m' />
+  <sample time='53:10 min' depth='3.0 m' />
+  <sample time='53:20 min' depth='3.0 m' />
+  <sample time='53:30 min' depth='3.0 m' />
+  <sample time='53:40 min' depth='3.0 m' />
+  <sample time='53:50 min' depth='3.0 m' />
+  <sample time='54:00 min' depth='3.0 m' />
+  <sample time='54:10 min' depth='3.0 m' />
+  <sample time='54:20 min' depth='3.0 m' />
+  <sample time='54:30 min' depth='3.0 m' />
+  <sample time='54:40 min' depth='3.0 m' />
+  <sample time='54:50 min' depth='3.0 m' />
+  <sample time='55:00 min' depth='3.0 m' />
+  <sample time='55:10 min' depth='3.0 m' />
+  <sample time='55:20 min' depth='3.0 m' />
+  <sample time='55:30 min' depth='3.0 m' />
+  <sample time='55:40 min' depth='3.0 m' />
+  <sample time='55:50 min' depth='3.0 m' />
+  <sample time='56:00 min' depth='3.0 m' />
+  <sample time='56:10 min' depth='3.0 m' />
+  <sample time='56:20 min' depth='3.0 m' />
+  <sample time='56:30 min' depth='3.0 m' />
+  <sample time='56:40 min' depth='3.0 m' />
+  <sample time='56:50 min' depth='3.0 m' />
+  <sample time='57:00 min' depth='3.0 m' />
+  <sample time='57:10 min' depth='3.0 m' />
+  <sample time='57:20 min' depth='3.0 m' />
+  <sample time='57:30 min' depth='3.0 m' />
+  <sample time='57:40 min' depth='3.0 m' />
+  <sample time='57:50 min' depth='3.0 m' />
+  <sample time='58:00 min' depth='3.0 m' />
+  <sample time='58:10 min' depth='3.0 m' />
+  <sample time='58:20 min' depth='3.0 m' />
+  <sample time='58:30 min' depth='3.0 m' />
+  <sample time='58:40 min' depth='3.0 m' />
+  <sample time='58:50 min' depth='3.0 m' />
+  <sample time='59:00 min' depth='3.0 m' />
+  <sample time='59:10 min' depth='3.0 m' />
+  <sample time='59:20 min' depth='3.0 m' />
+  <sample time='59:30 min' depth='3.0 m' />
+  <sample time='59:40 min' depth='3.0 m' />
+  <sample time='59:50 min' depth='3.0 m' />
+  <sample time='60:00 min' depth='3.0 m' />
+  <sample time='60:10 min' depth='3.0 m' />
+  <sample time='60:20 min' depth='3.0 m' />
+  <sample time='60:30 min' depth='3.0 m' />
+  <sample time='60:40 min' depth='3.0 m' />
+  <sample time='60:50 min' depth='3.0 m' />
+  <sample time='61:00 min' depth='3.0 m' />
+  <sample time='61:10 min' depth='3.0 m' />
+  <sample time='61:20 min' depth='3.0 m' />
+  <sample time='61:30 min' depth='3.0 m' />
+  <sample time='61:40 min' depth='3.0 m' />
+  <sample time='61:50 min' depth='1.5 m' />
+  <sample time='62:00 min' depth='0.0 m' tts='0:00 min' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -770,7 +770,7 @@ void main() {
     });
 
     test(
-      'persists UDDF sample cns, ndl, rbt and stores dive-level cns and otu in the source snapshot',
+      'persists UDDF sample cns, ndl, tts, rbt and stores dive-level cns and otu in the source snapshot',
       () async {
         when(mockDiveRepo.createDive(any)).thenAnswer(
           (invocation) async => invocation.positionalArguments[0] as Dive,
@@ -790,9 +790,16 @@ void main() {
                   'depth': 0.0,
                   'cns': 3.0,
                   'ndl': 1200,
+                  'tts': 300,
                   'rbt': 1500,
                 },
-                {'timestamp': 60, 'depth': 12.0, 'cns': 8.5, 'rbt': 900},
+                {
+                  'timestamp': 60,
+                  'depth': 12.0,
+                  'cns': 8.5,
+                  'tts': 480,
+                  'rbt': 900,
+                },
               ],
             },
           ],
@@ -812,9 +819,11 @@ void main() {
         expect(dive.profile, hasLength(2));
         expect(dive.profile[0].cns, 3.0);
         expect(dive.profile[0].ndl, 1200);
+        expect(dive.profile[0].tts, 300);
         expect(dive.profile[0].rbt, 1500);
         expect(dive.profile[1].cns, 8.5);
         expect(dive.profile[1].ndl, isNull);
+        expect(dive.profile[1].tts, 480);
         expect(dive.profile[1].rbt, 900);
 
         final capturedReadings = verify(

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -570,6 +570,62 @@ void main() {
       expect(profile[1]['decoType'], 2);
     });
 
+    test('carries delta-encoded ndl, tts, cns, and in_deco forward across '
+        'samples that omit them', () async {
+      // Subsurface only writes these attributes when the value changes
+      // from the previous sample; omission means "unchanged".
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='6:00 min'>
+  <divecomputer model='Test'>
+  <depth max='20.0 m' mean='15.0 m' />
+  <sample time='1:00 min' depth='20.0 m' />
+  <sample time='2:00 min' depth='20.0 m' ndl='0:00 min' tts='8:00 min' cns='12%' in_deco='1' />
+  <sample time='3:00 min' depth='18.0 m' />
+  <sample time='4:00 min' depth='15.0 m' tts='5:00 min' />
+  <sample time='5:00 min' depth='6.0 m' tts='0:00 min' in_deco='0' />
+  <sample time='6:00 min' depth='3.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+
+      // Before the first occurrence the values are genuinely unknown
+      expect(profile[0]['tts'], isNull);
+      expect(profile[0]['ndl'], isNull);
+      expect(profile[0]['cns'], isNull);
+      expect(profile[0]['decoType'], isNull);
+
+      // Explicit values
+      expect(profile[1]['tts'], 480);
+      expect(profile[1]['ndl'], 0);
+      expect(profile[1]['cns'], 12.0);
+      expect(profile[1]['decoType'], 2);
+
+      // Omitted attributes hold the previous value
+      expect(profile[2]['tts'], 480);
+      expect(profile[2]['ndl'], 0);
+      expect(profile[2]['cns'], 12.0);
+      expect(profile[2]['decoType'], 2);
+
+      expect(profile[3]['tts'], 300);
+
+      // Explicit tts=0 with in_deco=0 ends the obligation
+      expect(profile[4]['tts'], 0);
+      expect(profile[4]['decoType'], isNull);
+
+      // And the zero/cleared state also carries forward
+      expect(profile[5]['tts'], 0);
+      expect(profile[5]['decoType'], isNull);
+    });
+
     test('maps sample po2 to ppO2', () async {
       final result = await parser.parse(
         xmlBytes('''


### PR DESCRIPTION
## Summary
The Subsurface XML parser extracts tts from each sample, but the entity importer dropped it when mapping to DiveProfilePoint (ndl, rbt, cns and decoType were kept). As a result no imported dive ever carried recorded TTS, the profile overlay found nothing to display, and switching the TTS source between calculated and divecomputer changed nothing.

## Changes

Import tts is imported correctly.

## Open things

 - [x] Dont use calculated tts values when no imported value exist for some samples
 - [x] Unittests

## Test Plan

- [X] `flutter test` passes
- [X] `flutter analyze` passes
- [X] Manual testing on: Windows

## Screenshots

This fixes the rendering of the TTS curve when "DC" is selected - using the imported values instead of calculated ones. (Calculated ones are still a topic to discuss in another ticket as they dont take future gas switches into account and as they affect all deco calculations, heatmap, deco status, ... )

Screenshot calculated:
<img width="2050" height="848" alt="image" src="https://github.com/user-attachments/assets/a8207790-d85a-4dfd-b60a-e82ecae367c9" />


Screenshot DC:
<img width="2056" height="877" alt="image" src="https://github.com/user-attachments/assets/5009b9e8-570d-4179-9fa6-c15046d2fba2" />

Before this change, both graphs looked the same as tts wasnt inported and handled correctly.


Fixes #320

## Notes
Please review carefully as this PR touches how TTS values are imported and rendered.
