### PR TITLE
feat(sync): smoother database restore: auto-resume merge; unmissable replace-adopt

### DIFF
--- a/docs/superpowers/plans/2026-06-15-smoother-restore-sync.md
+++ b/docs/superpowers/plans/2026-06-15-smoother-restore-sync.md
@@ -1,0 +1,1523 @@
+# Smoother Restore Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a database restore, resume cloud sync without the user having to find and tap "Sync Now" — auto-resume the restoring device (Merge), and make the other devices' replace-adopt pause unmissable instead of silent.
+
+**Architecture:** Carry the restore dialog's consent forward. A Merge restore persists a post-restore sync intent (mirrors the existing `pendingReplace`) that `_initialize` consumes on next launch via a gate-bypassing `performSync(auto:false)`; a durable per-provider "established" anchor (SharedPreferences, survives restore) stops a wiped cursor from re-arming the first-contact gate. For the destructive Replace-adopt path on other devices, detect the foreign epoch proactively on launch (independent of auto-sync toggles) and surface a global modal dialog + persistent banner; the adopt itself stays confirmed and unchanged.
+
+**Tech Stack:** Flutter, Riverpod (`StateNotifier`), Drift, SharedPreferences, go_router, Flutter gen-l10n. Tests use `flutter_test`, hand-written fakes, `SharedPreferences.setMockInitialValues`, and `ProviderContainer` overrides.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md`
+
+**Branch:** `feat/smoother-restore-sync` (already created from the post-#330 `origin/main`).
+
+---
+
+## File Structure
+
+**New files:**
+- `lib/core/services/sync/post_restore_sync_store.dart` — Merge restore "sync once on next launch" intent (SharedPreferences bool).
+- `lib/core/services/sync/established_provider_store.dart` — set of providerIds this install has successfully synced to (SharedPreferences string list).
+- `lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart` — reusable adopt dialog, shared by the Cloud Sync page and the app root.
+- `test/core/services/sync/post_restore_sync_store_test.dart`
+- `test/core/services/sync/established_provider_store_test.dart`
+- `test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+
+**Modified files:**
+- `lib/features/settings/presentation/providers/sync_providers.dart` — store providers; `SyncState.postRestoreSyncing`; `firstSyncMergeInfo` anchor short-circuit; success-path anchor write + intent clear; `_initialize` merge-intent + proactive-replace branches; `_runPostRestoreSync`; `_detectReplacedLibraryForSurfacing`; `resetSyncState` clears anchor + intent.
+- `lib/features/backup/data/services/backup_service.dart` — set the Merge intent on restore.
+- `lib/features/backup/presentation/providers/backup_providers.dart` — inject `PostRestoreSyncStore` into `backupServiceProvider`.
+- `lib/features/settings/presentation/pages/cloud_sync_page.dart` — call the extracted dialog; remove the in-page `_showAdoptDialog`.
+- `lib/core/router/app_router.dart` — add a root navigator key.
+- `lib/app.dart` — app-root `ref.listen` surfacing (notice SnackBar + adopt dialog + persistent banner).
+- `lib/l10n/arb/app_en.arb` + 10 locale ARBs — three new strings.
+- `test/features/backup/data/services/backup_service_test.dart` — Merge sets intent / Replace does not.
+
+---
+
+## Task 1: PostRestoreSyncStore
+
+**Files:**
+- Create: `lib/core/services/sync/post_restore_sync_store.dart`
+- Test: `test/core/services/sync/post_restore_sync_store_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/services/sync/post_restore_sync_store_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PostRestoreSyncStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    store = PostRestoreSyncStore(await SharedPreferences.getInstance());
+  });
+
+  test('defaults to not pending', () {
+    expect(store.pending, isFalse);
+  });
+
+  test('setPending then clear round-trips', () async {
+    await store.setPending();
+    expect(store.pending, isTrue);
+    await store.clear();
+    expect(store.pending, isFalse);
+  });
+
+  test('survives a new store instance over the same prefs (restore)', () async {
+    await store.setPending();
+    final reopened = PostRestoreSyncStore(await SharedPreferences.getInstance());
+    expect(reopened.pending, isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/post_restore_sync_store_test.dart`
+Expected: FAIL — `Target of URI doesn't exist: '.../post_restore_sync_store.dart'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/services/sync/post_restore_sync_store.dart
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences flag set when a Merge restore completes, consumed once on
+/// the next launch to force a sync that bypasses the first-contact gate.
+///
+/// Deliberately OUTSIDE the database (mirrors the pending-replace intent in
+/// LibraryEpochStore): the restore rewinds the in-DB sync cursor, and the
+/// Merge path mints no epoch, so this is the only durable signal that the
+/// just-restored data still owes the cloud one reconciling sync.
+class PostRestoreSyncStore {
+  static const _pendingKey = 'sync_post_restore_pending';
+
+  final SharedPreferences _prefs;
+
+  PostRestoreSyncStore(this._prefs);
+
+  bool get pending => _prefs.getBool(_pendingKey) ?? false;
+
+  Future<void> setPending() async {
+    await _prefs.setBool(_pendingKey, true);
+  }
+
+  Future<void> clear() async {
+    await _prefs.remove(_pendingKey);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/services/sync/post_restore_sync_store_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/sync/post_restore_sync_store.dart test/core/services/sync/post_restore_sync_store_test.dart
+git commit -m "feat(sync): add PostRestoreSyncStore for the Merge-restore sync intent"
+```
+
+---
+
+## Task 2: EstablishedProviderStore
+
+**Files:**
+- Create: `lib/core/services/sync/established_provider_store.dart`
+- Test: `test/core/services/sync/established_provider_store_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/services/sync/established_provider_store_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late EstablishedProviderStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    store = EstablishedProviderStore(await SharedPreferences.getInstance());
+  });
+
+  test('unknown provider is not established', () {
+    expect(store.contains('s3'), isFalse);
+  });
+
+  test('add marks a provider established and is idempotent', () async {
+    await store.add('s3');
+    await store.add('s3');
+    expect(store.contains('s3'), isTrue);
+  });
+
+  test('is scoped per provider', () async {
+    await store.add('s3');
+    expect(store.contains('s3'), isTrue);
+    expect(store.contains('icloud'), isFalse);
+  });
+
+  test('survives a new store instance over the same prefs (restore)', () async {
+    await store.add('s3');
+    final reopened =
+        EstablishedProviderStore(await SharedPreferences.getInstance());
+    expect(reopened.contains('s3'), isTrue);
+  });
+
+  test('clear forgets all providers', () async {
+    await store.add('s3');
+    await store.clear();
+    expect(store.contains('s3'), isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/established_provider_store_test.dart`
+Expected: FAIL — URI does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/services/sync/established_provider_store.dart
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences set of cloud providerIds this install has completed a
+/// successful sync against.
+///
+/// Lives outside the database so a restore (which rewinds the in-DB sync
+/// cursor) cannot make an established device look like a brand-new one to the
+/// first-contact gate. Same survive-the-restore role as the device-id / epoch
+/// anchors. Keyed on the providerId used by `getLastSyncTime(forProvider:)`,
+/// so the gate stays correct across backend switches.
+class EstablishedProviderStore {
+  static const _key = 'sync_established_providers';
+
+  final SharedPreferences _prefs;
+
+  EstablishedProviderStore(this._prefs);
+
+  bool contains(String providerId) =>
+      (_prefs.getStringList(_key) ?? const <String>[]).contains(providerId);
+
+  Future<void> add(String providerId) async {
+    final current = _prefs.getStringList(_key) ?? const <String>[];
+    if (current.contains(providerId)) return;
+    await _prefs.setStringList(_key, [...current, providerId]);
+  }
+
+  Future<void> clear() async {
+    await _prefs.remove(_key);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/services/sync/established_provider_store_test.dart`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/sync/established_provider_store.dart test/core/services/sync/established_provider_store_test.dart
+git commit -m "feat(sync): add EstablishedProviderStore anchor (survives restore)"
+```
+
+---
+
+## Task 3: Wire the two store providers
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (imports near line 16-24; provider block near line 46-55)
+
+- [ ] **Step 1: Add the imports**
+
+In the import block (after the existing `library_moved_store.dart` import, around line 19), add:
+
+```dart
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+```
+
+- [ ] **Step 2: Add the providers**
+
+After `libraryMovedStoreProvider` (around line 55), add:
+
+```dart
+/// Merge-restore "sync once on next launch" intent.
+final postRestoreSyncStoreProvider = Provider<PostRestoreSyncStore>((ref) {
+  return PostRestoreSyncStore(ref.watch(sharedPreferencesProvider));
+});
+
+/// Providers this install has successfully synced to (survives restore).
+final establishedProviderStoreProvider =
+    Provider<EstablishedProviderStore>((ref) {
+  return EstablishedProviderStore(ref.watch(sharedPreferencesProvider));
+});
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `flutter analyze lib/features/settings/presentation/providers/sync_providers.dart`
+Expected: No new errors (unused providers warning is acceptable until later tasks use them; if `analyze` reports them as errors, proceed — they are referenced in Tasks 5-8).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart
+git commit -m "feat(sync): expose post-restore intent and established-provider store providers"
+```
+
+---
+
+## Task 4: Add `SyncState.postRestoreSyncing`
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (the `SyncState` class, lines 172-260)
+
+- [ ] **Step 1: Add the field**
+
+After `final bool firstSyncAwaitingConfirmation;` (line 180), add:
+
+```dart
+  /// True while the one forced post-restore sync is running. Drives the
+  /// app-root "Syncing your restored library..." notice; never persisted.
+  final bool postRestoreSyncing;
+```
+
+- [ ] **Step 2: Add the constructor default**
+
+In the `const SyncState({...})` constructor (after `this.firstSyncAwaitingConfirmation = false,`, line 213), add:
+
+```dart
+    this.postRestoreSyncing = false,
+```
+
+- [ ] **Step 3: Add the copyWith param + assignment**
+
+In `copyWith`, after the `bool? firstSyncAwaitingConfirmation,` parameter (line 228), add:
+
+```dart
+    bool? postRestoreSyncing,
+```
+
+In the returned `SyncState(...)`, after the `firstSyncAwaitingConfirmation:` assignment (line 244-245), add:
+
+```dart
+      postRestoreSyncing: postRestoreSyncing ?? this.postRestoreSyncing,
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `flutter analyze lib/features/settings/presentation/providers/sync_providers.dart`
+Expected: No new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart
+git commit -m "feat(sync): add SyncState.postRestoreSyncing flag"
+```
+
+---
+
+## Task 5: `firstSyncMergeInfo` skips established providers
+
+This is the root-cause fix: an established device must not be treated as first-contact after a restore wipes its cursor — while a genuinely new device still is.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (`firstSyncMergeInfo`, lines 369-397)
+- Test: `test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/settings/presentation/providers/sync_providers_restore_test.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/changeset_test_helpers.dart';
+import '../../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferences prefs;
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  Future<ProviderContainer> makeContainer() async {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(cloud),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(syncStateProvider);
+    await container.read(syncStateProvider.notifier).refreshState();
+    return container;
+  }
+
+  Future<void> seedLocalDive(String id) async {
+    await DiveRepository().createDive(createTestDiveWithBottomTime(id: id));
+  }
+
+  group('firstSyncMergeInfo established-provider short-circuit', () {
+    test('genuine new device with peers + local dives still gates', () async {
+      final container = await makeContainer();
+      await seedLocalDive('d1');
+      await seedPeerManifest(cloud, 'peer-device');
+
+      final info =
+          await container.read(syncStateProvider.notifier).firstSyncMergeInfo();
+      expect(info, isNotNull,
+          reason: 'a brand-new device must still confirm before merging');
+    });
+
+    test('established provider short-circuits the gate (restore case)',
+        () async {
+      await EstablishedProviderStore(prefs).add(cloud.providerId);
+      final container = await makeContainer();
+      await seedLocalDive('d1');
+      await seedPeerManifest(cloud, 'peer-device');
+
+      final info =
+          await container.read(syncStateProvider.notifier).firstSyncMergeInfo();
+      expect(info, isNull,
+          reason:
+              'a device that already synced here is not first-contact, even '
+              'after a restore wiped its in-DB cursor');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify the second case fails**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+Expected: FIRST test passes; SECOND test FAILS (`info` is non-null because the anchor is ignored).
+
+- [ ] **Step 3: Add the short-circuit**
+
+In `firstSyncMergeInfo`, immediately after `if (provider == null) return null;` (line 372), add:
+
+```dart
+      // An established device is never first-contact: a restore wipes the
+      // in-DB cursor (lastSyncTime), but this anchor survives, so the gate
+      // must not re-fire for a device that already merged here.
+      if (_ref.read(establishedProviderStoreProvider).contains(
+        provider.providerId,
+      )) {
+        return null;
+      }
+```
+
+- [ ] **Step 4: Run test to verify both pass**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart test/features/settings/presentation/providers/sync_providers_restore_test.dart
+git commit -m "fix(sync): established provider is not first-contact (restore no longer re-gates)"
+```
+
+---
+
+## Task 6: Record the anchor + clear the intent on a successful sync
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (`performSync` success block, lines 676-689)
+- Test: same file as Task 5
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `group(...)` in `sync_providers_restore_test.dart`:
+
+```dart
+    test('a successful sync anchors the provider and clears the intent',
+        () async {
+      await PostRestoreSyncStore(prefs).setPending();
+      final container = await makeContainer();
+      await seedLocalDive('d1');
+
+      await container.read(syncStateProvider.notifier).performSync();
+
+      expect(EstablishedProviderStore(prefs).contains(cloud.providerId), isTrue,
+          reason: 'a clean sync marks this provider established');
+      expect(PostRestoreSyncStore(prefs).pending, isFalse,
+          reason: 'the post-restore intent is consumed once a sync succeeds');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart --name "anchors the provider"`
+Expected: FAIL — provider not anchored / intent still pending.
+
+- [ ] **Step 3: Add anchor write + intent clear**
+
+In `performSync`, inside `if (result.isSuccess) {`, immediately after the `state = state.copyWith(... progress: 1.0,);` block and before `await _surfaceOldBackendCleanupOffer();` (line 689), add:
+
+```dart
+          // Mark this provider established and consume any post-restore intent:
+          // a future restore that wipes the in-DB cursor must not make this
+          // device look like first-contact again, and the Merge restore's
+          // one-shot intent is now satisfied.
+          final syncedProvider = _ref.read(cloudStorageProviderProvider);
+          if (syncedProvider != null) {
+            await _ref
+                .read(establishedProviderStoreProvider)
+                .add(syncedProvider.providerId);
+          }
+          await _ref.read(postRestoreSyncStoreProvider).clear();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart test/features/settings/presentation/providers/sync_providers_restore_test.dart
+git commit -m "feat(sync): anchor the provider and clear the post-restore intent on sync success"
+```
+
+---
+
+## Task 7: `_initialize` consumes the Merge intent (forced gate-bypassing sync)
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (`_initialize`, lines 291-301; add `_runPostRestoreSync`)
+- Test: same file as Task 5
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `sync_providers_restore_test.dart` (new group):
+
+```dart
+  group('post-restore launch sync', () {
+    test('a pending intent forces a sync that bypasses the first-contact gate',
+        () async {
+      // Arrange the EXACT condition that used to defer: peers + local dives +
+      // null cursor + a pending post-restore intent.
+      await PostRestoreSyncStore(prefs).setPending();
+      await seedPeerManifest(cloud, 'peer-device');
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+        ],
+      );
+      addTearDown(container.dispose);
+      await DiveRepository()
+          .createDive(createTestDiveWithBottomTime(id: 'd1'));
+
+      // Construct the notifier (runs _initialize) and let it finish.
+      container.read(syncStateProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      // Allow the forced sync (and its internal post-success refresh delay) to
+      // complete.
+      await Future<void>.delayed(const Duration(seconds: 3));
+
+      final state = container.read(syncStateProvider);
+      expect(state.firstSyncAwaitingConfirmation, isFalse,
+          reason: 'THE BUG: the forced post-restore sync must not defer');
+      expect(PostRestoreSyncStore(prefs).pending, isFalse,
+          reason: 'a successful forced sync consumes the intent');
+      expect(state.postRestoreSyncing, isFalse,
+          reason: 'the syncing flag is lowered when the forced sync finishes');
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart --name "bypasses the first-contact gate"`
+Expected: FAIL — `firstSyncAwaitingConfirmation` is true and/or intent still pending (the intent is not yet consumed by `_initialize`).
+
+- [ ] **Step 3: Rewrite `_initialize` and add `_runPostRestoreSync`**
+
+Replace the existing `_initialize` (lines 291-301):
+
+```dart
+  Future<void> _initialize() async {
+    // Load initial state
+    if (!mounted) return;
+    await refreshState();
+    if (!mounted) return;
+
+    // A Replace restore persists its cloud side as a pending intent; execute
+    // it as soon as the app is back up, regardless of auto-sync settings.
+    if (_ref.read(libraryEpochStoreProvider).pendingReplace != null) {
+      unawaited(performSync());
+      return;
+    }
+
+    final provider = _ref.read(cloudStorageProviderProvider);
+    if (provider == null) return;
+
+    // A Merge restore persists a post-restore intent: the restore dialog's
+    // Merge choice is the consent, so force one sync that bypasses the
+    // first-contact gate (auto:false) regardless of the auto-sync toggles.
+    if (_ref.read(postRestoreSyncStoreProvider).pending) {
+      unawaited(_runPostRestoreSync());
+      return;
+    }
+
+    // On the other devices, surface a Replace-everywhere adoption proactively
+    // (even with auto-sync off) so a paused device is never hidden behind a
+    // manual Sync Now. See Task 12.
+    unawaited(_detectReplacedLibraryForSurfacing());
+  }
+
+  /// Force the one consented post-restore sync. `performSync(auto:false)` skips
+  /// the first-contact gate; the success path clears the intent (Task 6).
+  Future<void> _runPostRestoreSync() async {
+    if (!mounted) return;
+    state = state.copyWith(postRestoreSyncing: true);
+    await performSync();
+    if (mounted) state = state.copyWith(postRestoreSyncing: false);
+  }
+```
+
+NOTE: `_detectReplacedLibraryForSurfacing` is added in Task 12. To keep the tree compiling between commits, add this temporary stub now, directly below `_runPostRestoreSync` (Task 12 replaces its body):
+
+```dart
+  Future<void> _detectReplacedLibraryForSurfacing() async {
+    // Implemented in Task 12.
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart test/features/settings/presentation/providers/sync_providers_restore_test.dart
+git commit -m "feat(sync): force a gate-bypassing sync after a Merge restore"
+```
+
+---
+
+## Task 8: `resetSyncState` clears the anchor and the intent
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (`resetSyncState`, lines 767-777)
+- Test: same file as Task 5
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `sync_providers_restore_test.dart`:
+
+```dart
+  test('resetSyncState clears the anchor and the post-restore intent',
+      () async {
+    await EstablishedProviderStore(prefs).add(cloud.providerId);
+    await PostRestoreSyncStore(prefs).setPending();
+    final container = await makeContainer();
+
+    await container.read(syncStateProvider.notifier).resetSyncState();
+
+    expect(EstablishedProviderStore(prefs).contains(cloud.providerId), isFalse,
+        reason: 'an explicit reset is a true fresh start, so re-arm the gate');
+    expect(PostRestoreSyncStore(prefs).pending, isFalse);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart --name "resetSyncState clears"`
+Expected: FAIL — anchor still present after reset.
+
+- [ ] **Step 3: Add the clears**
+
+In `resetSyncState`, after `await _ref.read(libraryEpochStoreProvider).clearPendingReplace();` (line 774), add:
+
+```dart
+    await _ref.read(postRestoreSyncStoreProvider).clear();
+    await _ref.read(establishedProviderStoreProvider).clear();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart test/features/settings/presentation/providers/sync_providers_restore_test.dart
+git commit -m "feat(sync): Reset Sync State clears the established anchor and post-restore intent"
+```
+
+---
+
+## Task 9: BackupService sets the Merge intent on restore
+
+**Files:**
+- Modify: `lib/features/backup/data/services/backup_service.dart` (constructor lines 58-83; `restoreFromBackup` line 312-314; `restoreFromFile` line 344-346)
+- Modify: `lib/features/backup/presentation/providers/backup_providers.dart` (`backupServiceProvider`, lines 26-33)
+- Test: `test/features/backup/data/services/backup_service_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add these tests to the relevant `group` in `backup_service_test.dart` (mirror the existing `restoreFromFile` test's construction; use a real `PostRestoreSyncStore` over mock prefs). Add the import at the top:
+
+```dart
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+```
+
+Then add:
+
+```dart
+  test('Merge restore sets the post-restore sync intent', () async {
+    SharedPreferences.setMockInitialValues({});
+    final intentPrefs = await SharedPreferences.getInstance();
+    final intentStore = PostRestoreSyncStore(intentPrefs);
+    final service = BackupService(
+      dbAdapter: fakeDb,
+      preferences: preferences,
+      syncRepository: _SpySyncRepository(),
+      postRestoreSyncStore: intentStore,
+    );
+    final src = File(
+      '${Directory.systemTemp.path}/restore_merge_'
+      '${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    await src.writeAsString('db');
+    addTearDown(() async {
+      if (await src.exists()) await src.delete();
+    });
+
+    await service.restoreFromFile(src.path); // mode defaults to merge
+
+    expect(intentStore.pending, isTrue,
+        reason: 'a Merge restore must arm the post-restore sync intent');
+  });
+
+  test('Replace restore does NOT set the merge intent', () async {
+    SharedPreferences.setMockInitialValues({});
+    final intentPrefs = await SharedPreferences.getInstance();
+    final intentStore = PostRestoreSyncStore(intentPrefs);
+    final service = BackupService(
+      dbAdapter: fakeDb,
+      preferences: preferences,
+      syncRepository: _SpySyncRepository(),
+      epochStore: LibraryEpochStore(intentPrefs),
+      postRestoreSyncStore: intentStore,
+    );
+    final src = File(
+      '${Directory.systemTemp.path}/restore_replace_'
+      '${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    await src.writeAsString('db');
+    addTearDown(() async {
+      if (await src.exists()) await src.delete();
+    });
+
+    await service.restoreFromFile(src.path, mode: RestoreMode.replace);
+
+    expect(intentStore.pending, isFalse,
+        reason: 'Replace uses pendingReplace, not the merge intent');
+  });
+```
+
+Ensure these imports exist at the top of the test file (add any missing):
+
+```dart
+import 'package:submersion/core/services/sync/library_epoch_store.dart';
+import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/backup/data/services/backup_service_test.dart --name "post-restore sync intent"`
+Expected: FAIL — `BackupService` has no `postRestoreSyncStore` named parameter.
+
+- [ ] **Step 3: Add the dependency and set the intent**
+
+In `backup_service.dart`, add the import (after the `library_epoch_store.dart` import, line 17):
+
+```dart
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+```
+
+Add the field after `_epochStore` (line 66):
+
+```dart
+  /// Set on a Merge restore so the next launch forces one reconciling sync.
+  /// Nullable so existing constructions keep working.
+  final PostRestoreSyncStore? _postRestoreSyncStore;
+```
+
+Add the constructor parameter after `LibraryEpochStore? epochStore,` (line 78):
+
+```dart
+    PostRestoreSyncStore? postRestoreSyncStore,
+```
+
+Add the initializer after `_epochStore = epochStore;` — change that line to:
+
+```dart
+       _epochStore = epochStore,
+       _postRestoreSyncStore = postRestoreSyncStore;
+```
+
+In `restoreFromBackup`, replace lines 312-314:
+
+```dart
+    if (mode == RestoreMode.replace) {
+      await _mintPendingReplace();
+    } else {
+      await _postRestoreSyncStore?.setPending();
+    }
+```
+
+In `restoreFromFile`, replace lines 344-346 identically:
+
+```dart
+    if (mode == RestoreMode.replace) {
+      await _mintPendingReplace();
+    } else {
+      await _postRestoreSyncStore?.setPending();
+    }
+```
+
+- [ ] **Step 4: Wire the provider**
+
+In `backup_providers.dart`, add the import (after line 6):
+
+```dart
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+```
+
+In `backupServiceProvider` (line 27-32), add the argument after `epochStore: ...`:
+
+```dart
+    postRestoreSyncStore:
+        PostRestoreSyncStore(ref.watch(sharedPreferencesProvider)),
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `flutter test test/features/backup/data/services/backup_service_test.dart`
+Expected: PASS (existing + 2 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/backup/data/services/backup_service.dart lib/features/backup/presentation/providers/backup_providers.dart test/features/backup/data/services/backup_service_test.dart
+git commit -m "feat(backup): arm the post-restore sync intent on a Merge restore"
+```
+
+---
+
+## Task 10: Localization strings (en + 10 locales)
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` and `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`
+
+Three new keys (no placeholders): `settings_cloudSync_postRestore_syncing`, `settings_cloudSync_postRestore_synced`, `settings_cloudSync_replace_reviewAction`. (The spec named two; the persistent banner's action label requires the third, "Review".)
+
+- [ ] **Step 1: Add to the English template**
+
+In `lib/l10n/arb/app_en.arb`, add near the other `settings_cloudSync_` keys (these are simple strings; no `@`-metadata block needed):
+
+```json
+  "settings_cloudSync_postRestore_syncing": "Syncing your restored library with the cloud…",
+  "settings_cloudSync_postRestore_synced": "Restored library synced.",
+  "settings_cloudSync_replace_reviewAction": "Review",
+```
+
+- [ ] **Step 2: Add translations to each locale ARB**
+
+Add the same three keys with translated values to each locale file:
+
+`app_ar.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "تتم مزامنة مكتبتك المستعادة مع السحابة…",
+  "settings_cloudSync_postRestore_synced": "تمت مزامنة المكتبة المستعادة.",
+  "settings_cloudSync_replace_reviewAction": "مراجعة",
+```
+
+`app_de.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "Wiederhergestellte Bibliothek wird mit der Cloud synchronisiert…",
+  "settings_cloudSync_postRestore_synced": "Wiederhergestellte Bibliothek synchronisiert.",
+  "settings_cloudSync_replace_reviewAction": "Überprüfen",
+```
+
+`app_es.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "Sincronizando tu biblioteca restaurada con la nube…",
+  "settings_cloudSync_postRestore_synced": "Biblioteca restaurada sincronizada.",
+  "settings_cloudSync_replace_reviewAction": "Revisar",
+```
+
+`app_fr.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "Synchronisation de votre bibliothèque restaurée avec le cloud…",
+  "settings_cloudSync_postRestore_synced": "Bibliothèque restaurée synchronisée.",
+  "settings_cloudSync_replace_reviewAction": "Examiner",
+```
+
+`app_he.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "מסנכרן את הספרייה המשוחזרת שלך עם הענן…",
+  "settings_cloudSync_postRestore_synced": "הספרייה המשוחזרת סונכרנה.",
+  "settings_cloudSync_replace_reviewAction": "סקירה",
+```
+
+`app_hu.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "A visszaállított könyvtár szinkronizálása a felhővel…",
+  "settings_cloudSync_postRestore_synced": "A visszaállított könyvtár szinkronizálva.",
+  "settings_cloudSync_replace_reviewAction": "Áttekintés",
+```
+
+`app_it.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "Sincronizzazione della libreria ripristinata con il cloud…",
+  "settings_cloudSync_postRestore_synced": "Libreria ripristinata sincronizzata.",
+  "settings_cloudSync_replace_reviewAction": "Rivedi",
+```
+
+`app_nl.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "Je herstelde bibliotheek wordt met de cloud gesynchroniseerd…",
+  "settings_cloudSync_postRestore_synced": "Herstelde bibliotheek gesynchroniseerd.",
+  "settings_cloudSync_replace_reviewAction": "Controleren",
+```
+
+`app_pt.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "A sincronizar a sua biblioteca restaurada com a nuvem…",
+  "settings_cloudSync_postRestore_synced": "Biblioteca restaurada sincronizada.",
+  "settings_cloudSync_replace_reviewAction": "Rever",
+```
+
+`app_zh.arb`:
+```json
+  "settings_cloudSync_postRestore_syncing": "正在将恢复的资料库与云同步…",
+  "settings_cloudSync_postRestore_synced": "已同步恢复的资料库。",
+  "settings_cloudSync_replace_reviewAction": "查看",
+```
+
+- [ ] **Step 3: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: regenerates `lib/l10n/arb/app_localizations*.dart`. Then verify:
+
+Run: `flutter analyze lib/l10n/arb/app_localizations.dart`
+Expected: the three getters exist (no errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/l10n/arb/
+git commit -m "feat(l10n): post-restore sync notice + replace review action in all locales"
+```
+
+---
+
+## Task 11: Extract the adopt dialog into a reusable widget
+
+**Files:**
+- Create: `lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart`
+- Modify: `lib/features/settings/presentation/pages/cloud_sync_page.dart` (`_onSyncNowPressed` line 1003; remove `_showAdoptDialog` lines 1043-1079)
+- Test: `test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart`
+
+- [ ] **Step 1: Create the reusable dialog (copy the existing logic verbatim)**
+
+```dart
+// lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Confirm and run adoption of a replaced cloud library. Shared by the Cloud
+/// Sync page and the app-root surfacing so the destructive adopt has exactly
+/// one implementation. The safety backup runs here (not in SyncNotifier)
+/// because backup providers import sync providers; this widget layer may
+/// import both.
+Future<void> showAdoptReplacedLibraryDialog(
+  BuildContext context,
+  WidgetRef ref,
+  LibraryEpochMarker marker,
+) async {
+  final l10n = context.l10n;
+  final date = marker.replacedAt > 0
+      ? DateFormat.yMMMd().add_jm().format(
+          DateTime.fromMillisecondsSinceEpoch(marker.replacedAt),
+        )
+      : '?';
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(l10n.settings_cloudSync_adopt_dialogTitle),
+      content: Text(
+        l10n.settings_cloudSync_adopt_dialogContent(marker.displayName, date),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text(l10n.settings_cloudSync_adopt_notNow),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: Text(l10n.settings_cloudSync_adopt_confirm),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+  // Safety backup of this device's current data BEFORE it is overwritten.
+  await ref.read(backupServiceProvider).performBackup(isAutomatic: true);
+  await ref.read(syncStateProvider.notifier).adoptReplacedLibrary();
+}
+```
+
+- [ ] **Step 2: Point the Cloud Sync page at it**
+
+In `cloud_sync_page.dart`, add the import near the other widget/feature imports:
+
+```dart
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
+```
+
+In `_onSyncNowPressed`, replace the call on line 1003:
+
+```dart
+      await _showAdoptDialog(context, ref, replaceInfo);
+```
+
+with:
+
+```dart
+      await showAdoptReplacedLibraryDialog(context, ref, replaceInfo);
+```
+
+Then delete the now-unused private method `_showAdoptDialog` (lines 1043-1079). If `intl`'s `DateFormat` import in `cloud_sync_page.dart` becomes unused after deletion, remove that import too (verify with analyze in Step 4).
+
+- [ ] **Step 3: Write the dialog widget test**
+
+```dart
+// test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  testWidgets('renders the replacing device name and the two actions',
+      (tester) async {
+    const marker = LibraryEpochMarker(
+      epochId: 'e1',
+      replacedAt: 1764000000000,
+      deviceId: 'replacer',
+      deviceName: 'Eric Mac',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) => ElevatedButton(
+                  onPressed: () =>
+                      showAdoptReplacedLibraryDialog(context, ref, marker),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Adopt Restored Library?'), findsOneWidget);
+    expect(find.textContaining('Eric Mac'), findsOneWidget);
+    // Cancelling must not throw / must close cleanly.
+    expect(find.text('Not now'), findsOneWidget);
+    await tester.tap(find.text('Not now'));
+    await tester.pumpAndSettle();
+    expect(find.text('Adopt Restored Library?'), findsNothing);
+  });
+}
+```
+
+(If the `settings_cloudSync_adopt_notNow` English value is not exactly "Not now", read it from `lib/l10n/arb/app_en.arb` and update the `find.text` matcher to match.)
+
+- [ ] **Step 4: Run tests + analyze**
+
+Run: `flutter test test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart`
+Expected: PASS.
+Run: `flutter analyze lib/features/settings/presentation/pages/cloud_sync_page.dart lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart`
+Expected: No errors (no unused imports).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart lib/features/settings/presentation/pages/cloud_sync_page.dart test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart
+git commit -m "refactor(sync): extract reusable adopt-replaced-library dialog"
+```
+
+---
+
+## Task 12: Proactive replace detection on launch
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (replace the `_detectReplacedLibraryForSurfacing` stub from Task 7)
+- Test: same file as Task 5
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `sync_providers_restore_test.dart` (mirror how `sync_providers_epoch_test.dart` seeds a foreign epoch marker via `cloud.seedFile(libraryEpochFileName, ...)`; add the needed imports `dart:convert`, `dart:typed_data`, and `library_epoch.dart`):
+
+```dart
+  test('a foreign epoch with local dives arms replaceAwaitingAdoption without '
+      'syncing', () async {
+    const foreign = LibraryEpochMarker(
+      epochId: 'foreign-epoch',
+      replacedAt: 1764000000000,
+      deviceId: 'mac-device',
+      deviceName: 'Eric Mac',
+    );
+    cloud.seedFile(
+      libraryEpochFileName,
+      Uint8List.fromList(utf8.encode(jsonEncode(foreign.toJson()))),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(cloud),
+      ],
+    );
+    addTearDown(container.dispose);
+    await DiveRepository().createDive(createTestDiveWithBottomTime(id: 'd1'));
+
+    final notifier = container.read(syncStateProvider.notifier);
+    await notifier.refreshState();
+    await notifier.detectReplacedLibraryForSurfacing();
+
+    final state = container.read(syncStateProvider);
+    expect(state.replaceAwaitingAdoption, isTrue);
+    expect(state.replaceMarker?.epochId, 'foreign-epoch');
+  });
+```
+
+Add at the top of the file (if not present):
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart --name "arms replaceAwaitingAdoption"`
+Expected: FAIL — the method is a no-op stub and is private (rename below makes it callable).
+
+- [ ] **Step 3: Implement the detection**
+
+Replace the Task-7 stub with this (rename it to public so it is directly testable and callable from `_initialize`):
+
+```dart
+  /// On a device that did NOT restore, surface a Replace-everywhere adoption
+  /// proactively — even with auto-sync off — so the pause is never hidden
+  /// behind a manual Sync Now. Detection only; the destructive adopt stays
+  /// behind the confirmation dialog.
+  Future<void> detectReplacedLibraryForSurfacing() async {
+    final marker = await libraryReplaceInfo();
+    if (marker == null || !mounted) return;
+    final diveCount = await _ref.read(diveRepositoryProvider).getDiveCount();
+    if (!mounted) return;
+    if (diveCount == 0) {
+      // Nothing local to lose: let the existing empty-device auto-adopt path
+      // in performSync handle it.
+      unawaited(performSync());
+    } else {
+      state = state.copyWith(
+        replaceAwaitingAdoption: true,
+        replaceMarker: marker,
+      );
+    }
+  }
+```
+
+In `_initialize`, update the final call to use the public name:
+
+```dart
+    unawaited(detectReplacedLibraryForSurfacing());
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_restore_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/settings/presentation/providers/sync_providers.dart test/features/settings/presentation/providers/sync_providers_restore_test.dart
+git commit -m "feat(sync): detect a replaced library on launch regardless of auto-sync toggles"
+```
+
+---
+
+## Task 13: Add a root navigator key to GoRouter
+
+**Files:**
+- Modify: `lib/core/router/app_router.dart` (lines 124-125)
+
+- [ ] **Step 1: Define and pass the key**
+
+Above `final appRouterProvider = Provider<GoRouter>((ref) {` (line 124), add:
+
+```dart
+/// Root navigator key, so app-wide modals (e.g. the replaced-library adopt
+/// dialog surfaced from the app root) can be shown above the shell.
+final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
+```
+
+Inside `GoRouter(` (line 125), add as the first argument:
+
+```dart
+    navigatorKey: rootNavigatorKey,
+```
+
+(If a `ShellRoute` is present, leave its own `navigatorKey`/parentNavigatorKey untouched; the root key belongs only to the top-level `GoRouter`.)
+
+- [ ] **Step 2: Verify it compiles and routing still works**
+
+Run: `flutter analyze lib/core/router/app_router.dart`
+Expected: No errors.
+Run: `flutter test` (smoke — routing-dependent widget tests must still pass)
+Expected: No new failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/core/router/app_router.dart
+git commit -m "feat(router): expose a root navigator key for app-wide dialogs"
+```
+
+---
+
+## Task 14: App-root surfacing (notice + adopt dialog + persistent banner)
+
+This is wired with global keys (`_scaffoldMessengerKey`, `rootNavigatorKey`); it is verified manually (Step 4) because app-root global-key surfacing is impractical to unit-test.
+
+**Files:**
+- Modify: `lib/app.dart` (imports; add a session flag; add `ref.listen` in `build`; add handler methods)
+
+- [ ] **Step 1: Add imports + session flag**
+
+Add imports (near the existing feature imports):
+
+```dart
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
+```
+
+(`rootNavigatorKey` comes from the already-imported `app_router.dart`.)
+
+In `_SubmersionAppState`, after `final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();` (line 68), add:
+
+```dart
+  bool _adoptDialogShownThisSession = false;
+```
+
+- [ ] **Step 2: Add the listener in `build`**
+
+In `build`, immediately after `ref.watch(reconcileDeviceIdentityProvider);` (line 188), add:
+
+```dart
+    // Turn transient sync state into unmissable, screen-independent UI:
+    // the post-restore "syncing" notice, and the replaced-library adopt prompt.
+    ref.listen<SyncState>(syncStateProvider, _onSyncStateChanged);
+```
+
+- [ ] **Step 3: Add the handler methods**
+
+Add these methods to `_SubmersionAppState` (e.g. after `_maybeSyncOnResume`, line 149):
+
+```dart
+  void _onSyncStateChanged(SyncState? prev, SyncState next) {
+    final ctx = _scaffoldMessengerKey.currentContext;
+    final l10n = ctx != null ? AppLocalizations.of(ctx) : null;
+    final messenger = _scaffoldMessengerKey.currentState;
+
+    // Post-restore merge notice (start).
+    if (next.postRestoreSyncing && !(prev?.postRestoreSyncing ?? false)) {
+      messenger?.showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n?.settings_cloudSync_postRestore_syncing ??
+                'Syncing your restored library with the cloud…',
+          ),
+        ),
+      );
+    }
+    // Post-restore merge notice (done).
+    if ((prev?.postRestoreSyncing ?? false) &&
+        !next.postRestoreSyncing &&
+        (next.status == SyncStatus.success ||
+            next.status == SyncStatus.hasConflicts)) {
+      messenger?.showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n?.settings_cloudSync_postRestore_synced ??
+                'Restored library synced.',
+          ),
+        ),
+      );
+    }
+    // Replaced-library adopt: persistent banner + once-per-session modal.
+    if (next.replaceAwaitingAdoption &&
+        !(prev?.replaceAwaitingAdoption ?? false)) {
+      _surfaceReplaceAdoption(next.replaceMarker);
+    }
+    if (!next.replaceAwaitingAdoption &&
+        (prev?.replaceAwaitingAdoption ?? false)) {
+      messenger?.clearMaterialBanners();
+    }
+  }
+
+  void _surfaceReplaceAdoption(LibraryEpochMarker? marker) {
+    if (marker == null) return;
+    final ctx = _scaffoldMessengerKey.currentContext;
+    final l10n = ctx != null ? AppLocalizations.of(ctx) : null;
+    final messenger = _scaffoldMessengerKey.currentState;
+
+    // Persistent banner: rides across every screen until adopted.
+    messenger?.clearMaterialBanners();
+    messenger?.showMaterialBanner(
+      MaterialBanner(
+        content: Text(
+          l10n?.settings_cloudSync_replace_banner(marker.displayName) ??
+              'Sync paused: the library was replaced from a backup. Tap Review.',
+        ),
+        leading: const Icon(Icons.restore_page_outlined),
+        actions: [
+          TextButton(
+            onPressed: () => _openAdoptDialog(marker),
+            child: Text(l10n?.settings_cloudSync_replace_reviewAction ?? 'Review'),
+          ),
+        ],
+      ),
+    );
+
+    // Modal once per session.
+    if (!_adoptDialogShownThisSession) {
+      _adoptDialogShownThisSession = true;
+      _openAdoptDialog(marker);
+    }
+  }
+
+  void _openAdoptDialog(LibraryEpochMarker marker) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final navContext = rootNavigatorKey.currentContext;
+      if (navContext == null) return;
+      showAdoptReplacedLibraryDialog(navContext, ref, marker);
+    });
+  }
+```
+
+- [ ] **Step 4: Verify (analyze + manual)**
+
+Run: `flutter analyze lib/app.dart`
+Expected: No errors.
+
+Manual verification (two real devices or two app data dirs sharing one cloud), document results in the PR:
+1. **Merge restore (restoring device):** with Auto Sync OFF, restore a backup, relaunch. Expect a "Syncing your restored library…" SnackBar, then "Restored library synced.", and the Cloud Sync page shows no "First sync needs confirmation" banner.
+2. **Replace-everywhere (other device):** on device B (which has local dives), after device A does a Replace restore, launch device B with Auto Sync OFF. Expect the adopt dialog to appear over whatever screen B is on, plus a persistent banner. Dismiss the dialog → banner remains; tap Review → dialog returns. Confirm → safety backup is created, local data is replaced, banner clears.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/app.dart
+git commit -m "feat(sync): surface post-restore notice and replaced-library adopt at the app root"
+```
+
+---
+
+## Task 15: Two-device convergence integration test
+
+**Files:**
+- Create: `test/core/services/sync/restore_resume_convergence_test.dart`
+
+This asserts the end-to-end Merge outcome that the original bug broke: after a restore-style rebaseline, a device with the established anchor + pending intent converges with a peer without manual intervention. Model it on `test/core/services/sync/changeset_sync_convergence_test.dart` (Device A publishes to a shared fake cloud; Device B, anchored + intent-armed, syncs and pulls A's dive).
+
+- [ ] **Step 1: Write the test**
+
+```dart
+// test/core/services/sync/restore_resume_convergence_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('an established device pulls a peer dive after a restore-style rebaseline',
+      () async {
+    final cloud = FakeCloudStorageProvider();
+
+    // Device A: create a dive and publish.
+    await setUpTestDatabase();
+    var svc = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+    await DiveRepository()
+        .createDive(createTestDiveWithBottomTime(id: 'a1', diveNumber: 1));
+    expect((await svc.performSync()).status, SyncResultStatus.success);
+    await tearDownTestDatabase();
+
+    // Device B: fresh DB, same cloud, marked established (as if it had synced
+    // here before a restore wiped its cursor). A direct performSync mirrors the
+    // forced post-restore sync (auto:false, no gate).
+    SharedPreferences.setMockInitialValues({});
+    await EstablishedProviderStore(await SharedPreferences.getInstance())
+        .add(cloud.providerId);
+    await setUpTestDatabase();
+    svc = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+    expect((await svc.performSync()).status, SyncResultStatus.success);
+
+    final row = await DatabaseService.instance.database
+        .customSelect("SELECT id FROM dives WHERE id = 'a1'")
+        .getSingleOrNull();
+    expect(row, isNotNull,
+        reason: 'device B must converge with A without a manual Sync Now');
+    await tearDownTestDatabase();
+  });
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `flutter test test/core/services/sync/restore_resume_convergence_test.dart`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/core/services/sync/restore_resume_convergence_test.dart
+git commit -m "test(sync): restore-resume two-device convergence"
+```
+
+---
+
+## Task 16: Final verification
+
+- [ ] **Step 1: Format**
+
+Run: `dart format lib/ test/`
+Expected: reformats only touched files (commit if anything changed).
+
+- [ ] **Step 2: Analyze (whole project)**
+
+Run: `flutter analyze`
+Expected: No issues (matches the project's pre-push hook).
+
+- [ ] **Step 3: Full test suite**
+
+Run: `flutter test`
+Expected: All pass.
+
+- [ ] **Step 4: Commit any formatting**
+
+```bash
+git add -u
+git commit -m "style: dart format" # only if Step 1 changed files
+```
+
+- [ ] **Step 5: Push and open the PR (only when the user asks)**
+
+```bash
+git push -u origin feat/smoother-restore-sync
+gh pr create --base main --title "feat(sync): smoother database restore (auto-resume merge, unmissable replace-adopt)" --body "Implements docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** D1 auto-resume + notice → Tasks 7, 14. D2 force one sync regardless of toggles → Task 7 (`_initialize` `performSync(auto:false)`). D3 unmissable confirm → Tasks 11-14. D4 mirror intent + root anchor → Tasks 1-9. Localization → Task 10. Edge cases: intent cleared on success / retained on failure → Task 6; Reset clears anchor+intent → Task 8; branch precedence (Replace before Merge) → Task 7 `_initialize`; per-provider anchor scoping → Task 2. Testing → Tasks 1-12, 15. Verification → Task 16. All spec sections map to a task.
+
+**Placeholder scan:** No "TBD"/"handle errors"/"similar to" — the only deferred reference (`_detectReplacedLibraryForSurfacing` used in Task 7 before Task 12) is resolved by an explicit compiling stub in Task 7.
+
+**Type consistency:** `PostRestoreSyncStore` (`pending`/`setPending`/`clear`), `EstablishedProviderStore` (`contains`/`add`/`clear`), provider names (`postRestoreSyncStoreProvider`, `establishedProviderStoreProvider`), `SyncState.postRestoreSyncing`, `detectReplacedLibraryForSurfacing` (public in Task 12, called in Task 7 via stub then renamed), `showAdoptReplacedLibraryDialog`, and `rootNavigatorKey` are used consistently across tasks.

--- a/docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md
+++ b/docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md
@@ -1,0 +1,223 @@
+# Smoother Restore: Resume Sync Without a Manual "Sync Now"
+
+- **Date:** 2026-06-15
+- **Status:** Approved (design); implementation pending
+- **Branch:** feat/incremental-sync
+- **Related:** [restore-replace-mode](2026-06-11-restore-replace-mode-design.md), [incremental-sync-changeset-log](2026-06-14-incremental-sync-changeset-log-design.md)
+
+## Problem
+
+When cloud sync is enabled and the user restores a database, syncing silently stops until the user manually opens Cloud Sync settings and taps **Sync Now**. Users are typically unaware this is required, so their devices quietly fall out of sync.
+
+This shows up in two distinct ways:
+
+1. **On the device that restored** (Merge restore): the Cloud Sync page shows *"First sync needs confirmation. Tap Sync Now to review."* Auto-sync silently defers.
+2. **On the other devices** (after a Replace-everywhere restore elsewhere): each shows *"Sync is paused: the library was replaced from a backup on '<device>'. Tap Sync Now to review."* Sync pauses until the user manually adopts.
+
+Both are real and both leave the user with no signal that action is needed beyond a banner buried in settings.
+
+## Root cause
+
+Two separate gates, firing in two different restore modes.
+
+### Gate 1 — first-contact confirmation (restoring device, Merge mode)
+
+- A restore calls `_replaceDatabaseAndRebaselineSync` (`backup_service.dart`) -> `rebaselineAfterRestore` (`sync_repository.dart`) -> `resetSyncState`, which nulls `lastSyncTimestamp` / `lastSyncProvider`. This is deliberate: it forces a clean re-publish and re-pull after restore.
+- `firstSyncMergeInfo()` (`sync_providers.dart`) treats `lastSyncTime == null` + local dives present + peer files in the cloud as "first contact with an existing library," and returns non-null.
+- `performSync(auto: true)` (`sync_providers.dart`) sees that and **defers without syncing**, setting `firstSyncAwaitingConfirmation = true`. Every automatic trigger (sync-on-launch, sync-on-resume, post-write debounce) hits this and quietly backs off.
+- Only a manual **Sync Now** + confirming the "Combine Libraries?" dialog completes a sync and rewrites `lastSyncTime`, clearing the state.
+
+**The conflation:** the gate's "have I synced here before?" signal (`lastSyncTime`) is exactly the value a restore is designed to wipe. So a restored device is indistinguishable from a fresh install — even though it had an established sync relationship, and even though the restore flow already asked the user to choose Merge vs. Replace. That Merge/Replace choice is already consent to combine; the gate then re-requests the same consent, silently, in a different place.
+
+### Gate 2 — library-replacement adopt (other devices, Replace mode)
+
+- A Replace-everywhere restore mints a new library epoch and re-seeds the cloud (`executeLibraryReplace`, `sync_service.dart`).
+- Other devices detect the unfamiliar epoch on their next sync (`_runEpochGate`, `sync_service.dart`) and, if they hold local dives, set `replaceAwaitingAdoption = true` and **pause** (`performSync`, `sync_providers.dart`). Devices with zero dives already auto-adopt.
+- Adopting (`adoptReplacedLibrary`, `sync_service.dart`) is **destructive**: it deletes every local record not in the restored library and replaces local data, after taking a safety backup.
+- Two gaps make the pause silent: detection only happens *if a sync runs* (so it is coupled to the auto-sync toggles), and the only surface is the settings-page banner.
+
+The restoring device in **Replace** mode is already smooth: `_initialize` (`sync_providers.dart`) executes the pending replace via `performSync()` (auto=false) on next launch, regardless of toggles. Only the Merge restoring-device path and the other-device adopt path need work.
+
+## Decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | After a Merge/Replace restore, what should sync do on the restoring device? | **Auto-resume + notice.** The restore dialog's Merge/Replace choice is the consent; carry it forward and show a brief, non-blocking notice. |
+| D2 | Should restore proactively trigger a sync, or rely on existing triggers? | **Force one sync after restore**, regardless of the auto-sync toggles. |
+| D3 | When another device did Replace-everywhere, how should the other devices behave? | **Unmissable confirm.** Keep the destructive adopt behind a confirmation, but surface it impossible-to-miss (global dialog + persistent banner), not a silent settings banner. |
+| D4 | Implementation approach | **Mirror the replace intent + fix the root gate** (Approach 2): a post-restore sync intent that mirrors `pendingReplace`, plus a durable per-provider "established" anchor so a wiped cursor never again impersonates first-contact. |
+
+## Guiding principle
+
+Consent is captured at restore time; downstream syncs honor it instead of silently re-gating. The Merge case can act on that consent automatically (non-destructive). The Replace-adopt case must still confirm (destructive) — but loudly, not silently.
+
+## Design
+
+### Building blocks
+
+| Block | What it is | New/Modified |
+|-------|-----------|--------------|
+| Post-restore sync intent | A persisted flag set when a **Merge** restore completes, consumed once on next launch to force a gate-bypassing sync. Mirrors `pendingReplace`. | New store `post_restore_sync_store.dart` |
+| "Established provider" anchor | A persisted set of `providerId`s this install has successfully synced to. Survives restore (SharedPreferences). Teaches `firstSyncMergeInfo()` that an established device is not first-contact. | New store + hook in the post-sync success path |
+| Global sync surfacing | App-root listener that turns transient sync state into unmissable UI: a one-time SnackBar for the Merge notice, and a modal adopt dialog + persistent banner for the replace-adopt pause — independent of the current screen. | New root widget/listener; extract the existing adopt dialog so it is reusable |
+
+### Gate 1 — Merge restore -> auto-resume + notice
+
+**Intent store** (`lib/core/services/sync/post_restore_sync_store.dart`): a thin SharedPreferences wrapper.
+
+```dart
+class PostRestoreSyncStore {
+  bool get pending;            // key: sync_post_restore_pending
+  Future<void> setPending();
+  Future<void> clear();
+}
+```
+
+Kept separate from `pendingReplace` on purpose: `pendingReplace` carries a `LibraryEpochMarker` and means "execute a destructive cloud replace under a new epoch." A merge restore changes no epoch and must not trip replace logic. Two single-purpose flags cannot be cross-wired at the `_initialize` branch.
+
+**Set it** in `backup_service.dart`, symmetric with where Replace mints its intent:
+
+```dart
+if (mode == RestoreMode.replace) {
+  await _mintPendingReplace(...);            // existing
+} else {
+  await _postRestoreSyncStore.setPending();  // new: Merge consent
+}
+```
+
+**Established-provider anchor**: persist the set of `providerId`s with a completed successful sync, written in the notifier's sync-success path (the `result.isSuccess` branch of `performSync`, where the active provider is known and `_ref` is available) so the anchor lands whenever `lastSyncTime` advances. Keyed on the same `providerId` that `getLastSyncTime(forProvider:)` uses, so scoping is consistent. Because it lives in SharedPreferences, a DB restore cannot rewind it.
+
+`firstSyncMergeInfo()` gains one early return:
+
+```dart
+final provider = _ref.read(cloudStorageProviderProvider);
+if (provider == null) return null;
+if (_establishedProviderStore.contains(provider.providerId)) return null; // not first-contact
+// existing lastSyncTime / dive-count / peers checks unchanged
+```
+
+A genuinely new device has no anchor -> the safety gate still fires exactly as today. A restored-but-established device skips it.
+
+**Consume on launch** — `_initialize` (`sync_providers.dart`) gains two branches after the existing Replace branch:
+
+```dart
+// Merge restore: restore dialog was the consent. One gate-bypassing sync,
+// regardless of toggles.
+if (mounted && provider != null && _postRestoreSyncStore.pending) {
+  state = state.copyWith(postRestoreSyncing: true);  // drives the notice
+  unawaited(_runPostRestoreSync());                  // performSync(auto:false); clear intent on success
+  return;
+}
+// Other devices: proactively detect a replaced library (Gate 2).
+if (mounted && provider != null) {
+  unawaited(_detectReplacedLibraryForSurfacing());
+}
+```
+
+`performSync(auto: false)` is the mechanism: it skips the `if (auto)` first-contact check and runs irrespective of the toggles — the same path Replace already relies on.
+
+**Notice (UI layer, not the notifier):** the notifier only sets `postRestoreSyncing`; the app-root listener turns that into a non-blocking SnackBar via the existing `_scaffoldMessengerKey` ("Syncing your restored library with the cloud...", then a brief "Restored library synced" on completion). The notifier stays UI-free.
+
+**Intent lifecycle:** cleared on a *successful* post-restore sync. If it errors (offline), it stays for the next launch to retry — and established devices sync normally anyway via the anchor. Dormant if no provider is configured. **Reset Sync State** clears both the anchor and this intent, so an explicit reset remains a true fresh start that re-arms the gate.
+
+### Gate 2 — Replace adopt on other devices -> unmissable confirm
+
+**Proactive detection, decoupled from the toggles.** `_detectReplacedLibraryForSurfacing()` (called from `_initialize` and on resume) reuses the existing `libraryReplaceInfo()` epoch-marker read:
+
+```dart
+Future<void> _detectReplacedLibraryForSurfacing() async {
+  final marker = await libraryReplaceInfo();  // null if we are the replacer or epoch matches
+  if (marker == null || !mounted) return;
+  final diveCount = await _ref.read(diveRepositoryProvider).getDiveCount();
+  if (!mounted) return;
+  if (diveCount == 0) {
+    unawaited(performSync());                 // nothing to lose -> existing auto-adopt path
+  } else {
+    state = state.copyWith(                   // arm the unmissable surface; do NOT sync
+      replaceAwaitingAdoption: true,
+      replaceMarker: marker,
+    );
+  }
+}
+```
+
+The pause is now detected on every launch/resume even with Auto Sync off. The network read is already timeout-guarded (8s) and runs `unawaited`, so it never blocks startup.
+
+**Global surfacing.** Extract the adopt dialog out of `cloud_sync_page.dart` into a reusable `showAdoptReplacedLibraryDialog(context, ref, marker)` (e.g. `lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart`). It preserves the exact existing behavior: the "Adopt Restored Library?" dialog (`settings_cloudSync_adopt_dialogTitle/Content`) and, on confirm, safety backup (`performBackup(isAutomatic: true)`) then `adoptReplacedLibrary()`.
+
+The app root adds `ref.listen(syncStateProvider, ...)`:
+
+- When `replaceAwaitingAdoption` first flips true this session -> show that modal dialog via the root navigator (wherever the user is).
+- Drive a persistent `MaterialBanner` through `_scaffoldMessengerKey` using the existing `settings_cloudSync_replace_banner(deviceName)` string, with a **Review** action that reopens the dialog. The banner rides across all screens until the user adopts.
+
+**Adopt semantics unchanged.** `adoptReplacedLibrary()` still takes the safety backup and replaces local data — the human stays in the loop for the destructive operation. Only the visibility and timing of detection change. The settings-page banner stays as a secondary surface; centralizing the actual dialog in the root listener (guarded by a one-shot session flag) prevents two dialogs stacking when the user is on the settings page.
+
+**Anti-nag rule:** the modal shows at most once per app session; if dismissed, the persistent banner remains visible so it is never lost, and a fresh cold launch may prompt again.
+
+### Data flows
+
+```
+MERGE restore (restoring device)
+  restore completes -> set postRestoreSyncIntent
+  app restarts -> _initialize(): intent present?
+    -> performSync(auto:false)        // bypasses first-contact gate, ignores toggles
+    -> global SnackBar "Syncing your restored library..."
+    -> clear intent on success
+  (belt-and-suspenders) firstSyncMergeInfo() returns null because providerId is anchored
+
+REPLACE restore (the other devices)
+  app launch/resume -> _initialize(): not the replacer + libraryReplaceInfo() finds foreign epoch?
+    diveCount == 0 -> performSync() auto-adopts (nothing to lose)
+    diveCount  > 0 -> state.replaceAwaitingAdoption = true, replaceMarker = E
+  app-root listener sees the flag (once/session)
+    -> modal "Adopt Restored Library?" dialog
+    -> persistent MaterialBanner "Sync paused: library replaced on <device>. Review."
+  user confirms -> safety backup -> adoptReplacedLibrary()  (unchanged, destructive, confirmed)
+```
+
+## Edge cases and error handling
+
+- **Forced post-restore sync fails (offline):** intent is not cleared (only success clears it), so the next launch retries; meanwhile an established device still syncs normally via the anchor. The SnackBar never claims false success — on failure it defers to the existing sync-error surfacing.
+- **Branch precedence:** `_initialize` checks `pendingReplace` first and returns, so a Replace intent can never be shadowed by the merge branch. The two are mutually exclusive per restore (mode is exclusive).
+- **No provider configured at restore:** intent lies dormant; consumed only once a provider exists.
+- **Anchor scoping:** keyed on the same `providerId` as `getLastSyncTime(forProvider:)`, so a backend switch still gates genuine first-contact with the new backend, and the anchor cannot suppress the gate for a different cloud.
+- **Reset Sync State:** clears the anchor and the post-restore intent — an explicit reset stays a true fresh start that re-arms the gate.
+- **Gate 2 dialog stacking / nag:** one-shot session flag in the root listener — modal shows once per session, persistent banner lingers, the settings-page path calls the same dialog function so two cannot stack.
+- **Disposal safety:** every async helper re-checks `mounted` after awaits (the notifier's existing discipline for launch-triggered syncs that outlive the container); SnackBar/banner go through a post-frame callback so the global messenger is mounted.
+
+## Localization
+
+Two new strings only — the Merge notice start/done (e.g. `settings_cloudSync_postRestore_syncing`, `settings_cloudSync_postRestore_synced`). Gate 2 reuses the existing `settings_cloudSync_replace_banner` and `settings_cloudSync_adopt_dialog*` keys verbatim. New strings are translated into all 10 non-en locales and regenerated via gen-l10n.
+
+## Testing (TDD, >=80%)
+
+**Gate 1**
+- Merge restore sets the intent; Replace restore does not (sets `pendingReplace` instead).
+- `_initialize` with the intent forces `performSync(auto: false)` and **does not defer even when peers + local dives + null cursor coexist** (the exact bug, asserted gone).
+- Intent cleared on success, retained on failure, dormant with no provider.
+
+**Anchor / root fix**
+- `firstSyncMergeInfo()` returns null when the provider is anchored, non-null when not (**regression guard: a genuinely new device is still gated**).
+- Anchor written on sync success, survives a simulated restore, per-provider scoped.
+- Reset Sync State clears the anchor.
+
+**Gate 2**
+- Proactive detection arms `replaceAwaitingAdoption` (dives > 0) or auto-adopts (dives == 0) **with Auto Sync off**.
+- Root listener shows the dialog once per session; persistent banner shown; Review reopens the dialog.
+- The extracted adopt dialog preserves safety-backup-then-adopt behavior.
+- No double-dialog when on the settings page.
+
+**Convergence**
+- Extend the existing 2-device convergence tests: merge-restore converges with no manual Sync Now; replace-restore surfaces and adopts on the other device.
+
+The two highest-value guards: (1) `firstSyncMergeInfo()` still returns non-null for a genuinely new device — the gate doing its real job; (2) the forced post-restore sync demonstrably syncs under the precise condition that previously deferred. A test asserting "the old bug condition now syncs instead of deferring" proves the fix and blocks a future regression.
+
+## Verification
+
+`dart format` + whole-project `flutter analyze` + `flutter test` before commit. Final Mac + iPhone two-device hardware pass reproducing both screenshots' silent stops and confirming them gone, consistent with how the rest of incremental-sync has been verified.
+
+## Non-goals
+
+- No change to merge/conflict resolution, HLC ordering, or tombstone semantics — the merge itself is already correct (HLC-versioned tombstones prevent resurrection); this work only changes when and how consent is collected and surfaced.
+- No change to what `adoptReplacedLibrary()` does (still destructive, still safety-backed-up, still confirmed).
+- No restructure of the restore confirmation dialog (that was Approach 3, not chosen).

--- a/docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md
+++ b/docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md
@@ -1,8 +1,8 @@
 # Smoother Restore: Resume Sync Without a Manual "Sync Now"
 
 - **Date:** 2026-06-15
-- **Status:** Approved (design); implementation pending
-- **Branch:** feat/incremental-sync
+- **Status:** Implemented
+- **Branch:** feat/smoother-restore-sync
 - **Related:** [restore-replace-mode](2026-06-11-restore-replace-mode-design.md), [incremental-sync-changeset-log](2026-06-14-incremental-sync-changeset-log-design.md)
 
 ## Problem

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -203,8 +203,8 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     messenger?.showMaterialBanner(
       MaterialBanner(
         content: Text(
-          l10n?.settings_cloudSync_replace_banner(marker.displayName) ??
-              'Sync paused: the library was replaced from a backup. Tap Review.',
+          l10n?.settings_cloudSync_replace_globalBanner(marker.displayName) ??
+              'Sync is paused — the library was replaced from a backup.',
         ),
         leading: const Icon(Icons.restore_page_outlined),
         actions: [

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,11 +11,13 @@ import 'package:submersion/core/router/app_router.dart';
 import 'package:submersion/features/auto_update/presentation/providers/update_menu_channel.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
 import 'package:submersion/features/universal_import/presentation/providers/universal_import_providers.dart';
 import 'package:submersion/shared/services/file_share_handler.dart';
 import 'package:submersion/shared/services/incoming_file_handler.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
 
 const Locale _defaultFallbackLocale = Locale('en');
 const Set<String> _invalidSystemLocaleLanguageCodes = {'c', 'posix'};
@@ -66,6 +68,7 @@ class SubmersionApp extends ConsumerStatefulWidget {
 class _SubmersionAppState extends ConsumerState<SubmersionApp>
     with WidgetsBindingObserver {
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+  bool _adoptDialogShownThisSession = false;
   late final FileShareHandler _fileShareHandler;
   late final AppLifecycleListener _lifecycleListener;
 
@@ -148,6 +151,88 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     ref.read(syncStateProvider.notifier).performSync(auto: true);
   }
 
+  void _onSyncStateChanged(SyncState? prev, SyncState next) {
+    final ctx = _scaffoldMessengerKey.currentContext;
+    final l10n = ctx != null ? AppLocalizations.of(ctx) : null;
+    final messenger = _scaffoldMessengerKey.currentState;
+
+    // Post-restore merge notice (start).
+    if (next.postRestoreSyncing && !(prev?.postRestoreSyncing ?? false)) {
+      messenger?.showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n?.settings_cloudSync_postRestore_syncing ??
+                'Syncing your restored library with the cloud…',
+          ),
+        ),
+      );
+    }
+    // Post-restore merge notice (done).
+    if ((prev?.postRestoreSyncing ?? false) &&
+        !next.postRestoreSyncing &&
+        (next.status == SyncStatus.success ||
+            next.status == SyncStatus.hasConflicts)) {
+      messenger?.showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n?.settings_cloudSync_postRestore_synced ??
+                'Restored library synced.',
+          ),
+        ),
+      );
+    }
+    // Replaced-library adopt: persistent banner + once-per-session modal.
+    if (next.replaceAwaitingAdoption &&
+        !(prev?.replaceAwaitingAdoption ?? false)) {
+      _surfaceReplaceAdoption(next.replaceMarker);
+    }
+    if (!next.replaceAwaitingAdoption &&
+        (prev?.replaceAwaitingAdoption ?? false)) {
+      messenger?.clearMaterialBanners();
+    }
+  }
+
+  void _surfaceReplaceAdoption(LibraryEpochMarker? marker) {
+    if (marker == null) return;
+    final ctx = _scaffoldMessengerKey.currentContext;
+    final l10n = ctx != null ? AppLocalizations.of(ctx) : null;
+    final messenger = _scaffoldMessengerKey.currentState;
+
+    // Persistent banner: rides across every screen until adopted.
+    messenger?.clearMaterialBanners();
+    messenger?.showMaterialBanner(
+      MaterialBanner(
+        content: Text(
+          l10n?.settings_cloudSync_replace_banner(marker.displayName) ??
+              'Sync paused: the library was replaced from a backup. Tap Review.',
+        ),
+        leading: const Icon(Icons.restore_page_outlined),
+        actions: [
+          TextButton(
+            onPressed: () => _openAdoptDialog(marker),
+            child: Text(
+              l10n?.settings_cloudSync_replace_reviewAction ?? 'Review',
+            ),
+          ),
+        ],
+      ),
+    );
+
+    // Modal once per session; the banner persists if it is dismissed.
+    if (!_adoptDialogShownThisSession) {
+      _adoptDialogShownThisSession = true;
+      _openAdoptDialog(marker);
+    }
+  }
+
+  void _openAdoptDialog(LibraryEpochMarker marker) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final navContext = rootNavigatorKey.currentContext;
+      if (navContext == null) return;
+      showAdoptReplacedLibraryDialog(navContext, ref, marker);
+    });
+  }
+
   Future<void> _handleIncomingFile(Uint8List bytes, String fileName) async {
     final router = ref.read(appRouterProvider);
     final location = router.routeInformationProvider.value.uri.path;
@@ -186,6 +271,10 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     // Detect a database restore and re-baseline sync before anything reads
     // sync state, so a rewound baseline can't stall sync or resurrect deletes.
     ref.watch(reconcileDeviceIdentityProvider);
+
+    // Turn transient sync state into unmissable, screen-independent UI: the
+    // post-restore "syncing" notice, and the replaced-library adopt prompt.
+    ref.listen<SyncState>(syncStateProvider, _onSyncStateChanged);
 
     // Restore the last used cloud sync provider on app startup
     ref.watch(restoreLastProviderProvider);

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -272,12 +272,14 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     // sync state, so a rewound baseline can't stall sync or resurrect deletes.
     ref.watch(reconcileDeviceIdentityProvider);
 
+    // Restore the last used cloud sync provider BEFORE listening to sync state:
+    // listening instantiates SyncNotifier, whose _initialize needs the restored
+    // provider to run the post-restore intent / replaced-library surfacing.
+    ref.watch(restoreLastProviderProvider);
+
     // Turn transient sync state into unmissable, screen-independent UI: the
     // post-restore "syncing" notice, and the replaced-library adopt prompt.
     ref.listen<SyncState>(syncStateProvider, _onSyncStateChanged);
-
-    // Restore the last used cloud sync provider on app startup
-    ref.watch(restoreLastProviderProvider);
 
     return MaterialApp.router(
       scaffoldMessengerKey: _scaffoldMessengerKey,

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -121,8 +121,13 @@ import 'package:submersion/features/import_wizard/data/adapters/universal_adapte
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/main_scaffold.dart';
 
+/// Root navigator key, so app-wide modals (e.g. the replaced-library adopt
+/// dialog surfaced from the app root) can be shown above the shell.
+final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
+
 final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
+    navigatorKey: rootNavigatorKey,
     initialLocation: '/dashboard',
     redirect: (context, state) async {
       // Skip redirect logic during database migration to prevent deadlock

--- a/lib/core/services/sync/established_provider_store.dart
+++ b/lib/core/services/sync/established_provider_store.dart
@@ -1,0 +1,30 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences set of cloud providerIds this install has completed a
+/// successful sync against.
+///
+/// Lives outside the database so a restore (which rewinds the in-DB sync
+/// cursor) cannot make an established device look like a brand-new one to the
+/// first-contact gate. Same survive-the-restore role as the device-id / epoch
+/// anchors. Keyed on the providerId used by `getLastSyncTime(forProvider:)`,
+/// so the gate stays correct across backend switches.
+class EstablishedProviderStore {
+  static const _key = 'sync_established_providers';
+
+  final SharedPreferences _prefs;
+
+  EstablishedProviderStore(this._prefs);
+
+  bool contains(String providerId) =>
+      (_prefs.getStringList(_key) ?? const <String>[]).contains(providerId);
+
+  Future<void> add(String providerId) async {
+    final current = _prefs.getStringList(_key) ?? const <String>[];
+    if (current.contains(providerId)) return;
+    await _prefs.setStringList(_key, [...current, providerId]);
+  }
+
+  Future<void> clear() async {
+    await _prefs.remove(_key);
+  }
+}

--- a/lib/core/services/sync/post_restore_sync_store.dart
+++ b/lib/core/services/sync/post_restore_sync_store.dart
@@ -1,0 +1,26 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences flag set when a Merge restore completes, consumed once on
+/// the next launch to force a sync that bypasses the first-contact gate.
+///
+/// Deliberately OUTSIDE the database (mirrors the pending-replace intent in
+/// LibraryEpochStore): the restore rewinds the in-DB sync cursor, and the
+/// Merge path mints no epoch, so this is the only durable signal that the
+/// just-restored data still owes the cloud one reconciling sync.
+class PostRestoreSyncStore {
+  static const _pendingKey = 'sync_post_restore_pending';
+
+  final SharedPreferences _prefs;
+
+  PostRestoreSyncStore(this._prefs);
+
+  bool get pending => _prefs.getBool(_pendingKey) ?? false;
+
+  Future<void> setPending() async {
+    await _prefs.setBool(_pendingKey, true);
+  }
+
+  Future<void> clear() async {
+    await _prefs.remove(_pendingKey);
+  }
+}

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -15,6 +15,7 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
@@ -64,6 +65,10 @@ class BackupService {
   /// Library epoch persistence for restore Replace mode. Nullable so existing
   /// constructions keep working; Replace mode is a no-op without it.
   final LibraryEpochStore? _epochStore;
+
+  /// Set on a Merge restore so the next launch forces one reconciling sync.
+  /// Nullable so existing constructions keep working.
+  final PostRestoreSyncStore? _postRestoreSyncStore;
   final _log = LoggerService.forClass(BackupService);
   final _uuid = const Uuid();
 
@@ -76,11 +81,13 @@ class BackupService {
     CloudStorageProvider? cloudProvider,
     SyncRepository? syncRepository,
     LibraryEpochStore? epochStore,
+    PostRestoreSyncStore? postRestoreSyncStore,
   }) : _dbAdapter = dbAdapter,
        _preferences = preferences,
        _cloudProvider = cloudProvider,
        _syncRepository = syncRepository ?? SyncRepository(),
-       _epochStore = epochStore;
+       _epochStore = epochStore,
+       _postRestoreSyncStore = postRestoreSyncStore;
 
   // ===========================================================================
   // Backup
@@ -311,6 +318,10 @@ class BackupService {
     await _replaceDatabaseAndRebaselineSync(sourcePath);
     if (mode == RestoreMode.replace) {
       await _mintPendingReplace();
+    } else {
+      // Merge: the restore dialog's choice is the consent. Arm a one-shot
+      // intent so the next launch forces a gate-bypassing reconciling sync.
+      await _postRestoreSyncStore?.setPending();
     }
 
     _log.info('Restore completed from: ${record.filename}');
@@ -343,6 +354,10 @@ class BackupService {
     await _replaceDatabaseAndRebaselineSync(filePath);
     if (mode == RestoreMode.replace) {
       await _mintPendingReplace();
+    } else {
+      // Merge: the restore dialog's choice is the consent. Arm a one-shot
+      // intent so the next launch forces a gate-bypassing reconciling sync.
+      await _postRestoreSyncStore?.setPending();
     }
 
     _log.info('Restore from file completed: ${p.basename(filePath)}');

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
@@ -29,6 +30,9 @@ final backupServiceProvider = Provider<BackupService>((ref) {
     preferences: ref.watch(backupPreferencesProvider),
     cloudProvider: ref.watch(cloudStorageProviderProvider),
     epochStore: LibraryEpochStore(ref.watch(sharedPreferencesProvider)),
+    postRestoreSyncStore: PostRestoreSyncStore(
+      ref.watch(sharedPreferencesProvider),
+    ),
   );
 });
 

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -8,12 +8,12 @@ import 'package:intl/intl.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
-import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_moved.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/conflict_resolution_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -1000,7 +1000,7 @@ class CloudSyncPage extends ConsumerWidget {
     final replaceInfo = await notifier.libraryReplaceInfo();
     if (replaceInfo != null) {
       if (!context.mounted) return;
-      await _showAdoptDialog(context, ref, replaceInfo);
+      await showAdoptReplacedLibraryDialog(context, ref, replaceInfo);
       return;
     }
     final info = await notifier.firstSyncMergeInfo();
@@ -1035,47 +1035,6 @@ class CloudSyncPage extends ConsumerWidget {
     if (confirmed == true) {
       await notifier.performSync();
     }
-  }
-
-  /// Confirm and run adoption of a replaced cloud library. The safety backup
-  /// runs here (not in SyncNotifier) because backup providers import sync
-  /// providers; the page is the layer that may import both.
-  Future<void> _showAdoptDialog(
-    BuildContext context,
-    WidgetRef ref,
-    LibraryEpochMarker marker,
-  ) async {
-    final l10n = context.l10n;
-    final date = marker.replacedAt > 0
-        ? DateFormat.yMMMd().add_jm().format(
-            DateTime.fromMillisecondsSinceEpoch(marker.replacedAt),
-          )
-        : '?';
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.settings_cloudSync_adopt_dialogTitle),
-        content: Text(
-          l10n.settings_cloudSync_adopt_dialogContent(marker.displayName, date),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(l10n.settings_cloudSync_adopt_notNow),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(l10n.settings_cloudSync_adopt_confirm),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true) return;
-    // Safety backup of this device's current data BEFORE it is overwritten.
-    // Marked automatic: it is system-initiated, like the pre-migration
-    // safety backups, so the history list labels it accordingly.
-    await ref.read(backupServiceProvider).performBackup(isAutomatic: true);
-    await ref.read(syncStateProvider.notifier).adoptReplacedLibrary();
   }
 
   Future<void> _confirmResetSyncState(

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -193,6 +193,10 @@ class SyncState {
   final bool isAuthenticated;
   final bool firstSyncAwaitingConfirmation;
 
+  /// True while the one forced post-restore sync is running. Drives the
+  /// app-root "Syncing your restored library..." notice; never persisted.
+  final bool postRestoreSyncing;
+
   /// True when the cloud library was replaced from a backup under an epoch
   /// this device has not accepted; sync is paused until the user adopts.
   final bool replaceAwaitingAdoption;
@@ -225,6 +229,7 @@ class SyncState {
     this.conflicts = 0,
     this.isAuthenticated = false,
     this.firstSyncAwaitingConfirmation = false,
+    this.postRestoreSyncing = false,
     this.replaceAwaitingAdoption = false,
     this.replaceMarker,
     this.movedMarker,
@@ -240,6 +245,7 @@ class SyncState {
     int? conflicts,
     bool? isAuthenticated,
     bool? firstSyncAwaitingConfirmation,
+    bool? postRestoreSyncing,
     bool? replaceAwaitingAdoption,
     Object? replaceMarker = _markerSentinel,
     Object? movedMarker = _movedSentinel,
@@ -257,6 +263,7 @@ class SyncState {
       isAuthenticated: isAuthenticated ?? this.isAuthenticated,
       firstSyncAwaitingConfirmation:
           firstSyncAwaitingConfirmation ?? this.firstSyncAwaitingConfirmation,
+      postRestoreSyncing: postRestoreSyncing ?? this.postRestoreSyncing,
       replaceAwaitingAdoption:
           replaceAwaitingAdoption ?? this.replaceAwaitingAdoption,
       replaceMarker: identical(replaceMarker, _markerSentinel)

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -365,17 +365,17 @@ class SyncNotifier extends StateNotifier<SyncState> {
   Future<void> _detectReplacedLibraryForSurfacing() async {
     final marker = await libraryReplaceInfo();
     if (marker == null || !mounted) return;
+    // Surface only -- never sync from here. Only devices that HOLD dives pause
+    // and need the unmissable prompt; an empty device has nothing to lose and
+    // auto-adopts through performSync's own awaiting-adoption path on its next
+    // sync. Syncing from a detection hook would also race other launch-time
+    // syncs (and test setups), so detection stays pure: read marker, set state.
     final diveCount = await _ref.read(diveRepositoryProvider).getDiveCount();
-    if (!mounted) return;
-    if (diveCount == 0) {
-      // Nothing local to lose: let performSync's empty-device path auto-adopt.
-      unawaited(performSync());
-    } else {
-      state = state.copyWith(
-        replaceAwaitingAdoption: true,
-        replaceMarker: marker,
-      );
-    }
+    if (!mounted || diveCount == 0) return;
+    state = state.copyWith(
+      replaceAwaitingAdoption: true,
+      replaceMarker: marker,
+    );
   }
 
   void _listenForChanges() {

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -391,6 +391,14 @@ class SyncNotifier extends StateNotifier<SyncState> {
     try {
       final provider = _ref.read(cloudStorageProviderProvider);
       if (provider == null) return null;
+      // An established device is never first-contact: a restore wipes the
+      // in-DB cursor (lastSyncTime), but this anchor survives, so the gate
+      // must not re-fire for a device that already merged here.
+      if (_ref
+          .read(establishedProviderStoreProvider)
+          .contains(provider.providerId)) {
+        return null;
+      }
       // Scoped: first contact is per-backend. A cursor minted against a
       // backend the user switched away from must not mask the first,
       // library-combining sync against the new one.

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -715,6 +715,17 @@ class SyncNotifier extends StateNotifier<SyncState> {
             conflicts: result.conflictsFound,
             progress: 1.0,
           );
+          // Mark this provider established and consume any post-restore intent:
+          // a future restore that wipes the in-DB cursor must not make this
+          // device look like first-contact again, and the Merge restore's
+          // one-shot intent is now satisfied.
+          final syncedProvider = _ref.read(cloudStorageProviderProvider);
+          if (syncedProvider != null) {
+            await _ref
+                .read(establishedProviderStoreProvider)
+                .add(syncedProvider.providerId);
+          }
+          await _ref.read(postRestoreSyncStoreProvider).clear();
           await _surfaceOldBackendCleanupOffer();
           // A straggler syncing into a backend another device moved away from
           // learns of the move here -- the moment it is actively writing into

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -325,15 +325,20 @@ class SyncNotifier extends StateNotifier<SyncState> {
     await refreshState();
     if (!mounted) return;
 
+    // Every post-restore intent below needs a cloud provider. Without one, a
+    // persisted Replace intent would drive performSync() into a "no provider
+    // configured" error state on launch -- even for users who never enabled
+    // cloud sync. Keep the intent dormant until a provider exists; it survives
+    // in libraryEpochStore for a later launch that has one.
+    final provider = _ref.read(cloudStorageProviderProvider);
+    if (provider == null) return;
+
     // A Replace restore persists its cloud side as a pending intent; execute
     // it as soon as the app is back up, regardless of auto-sync settings.
     if (_ref.read(libraryEpochStoreProvider).pendingReplace != null) {
       unawaited(performSync());
       return;
     }
-
-    final provider = _ref.read(cloudStorageProviderProvider);
-    if (provider == null) return;
 
     // A Merge restore persists a post-restore intent: the restore dialog's
     // Merge choice is the consent, so force one sync that bypasses the

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -348,10 +348,24 @@ class SyncNotifier extends StateNotifier<SyncState> {
     if (mounted) state = state.copyWith(postRestoreSyncing: false);
   }
 
-  /// Surface a replaced cloud library on launch. Full body added in a later
-  /// step; the launch path already calls it so the wiring is exercised.
+  /// On a device that did NOT restore, surface a Replace-everywhere adoption
+  /// proactively -- even with auto-sync off -- so the pause is never hidden
+  /// behind a manual Sync Now. Detection only; the destructive adopt stays
+  /// behind the confirmation dialog.
   Future<void> _detectReplacedLibraryForSurfacing() async {
-    // Implemented in Task 12.
+    final marker = await libraryReplaceInfo();
+    if (marker == null || !mounted) return;
+    final diveCount = await _ref.read(diveRepositoryProvider).getDiveCount();
+    if (!mounted) return;
+    if (diveCount == 0) {
+      // Nothing local to lose: let performSync's empty-device path auto-adopt.
+      unawaited(performSync());
+    } else {
+      state = state.copyWith(
+        replaceAwaitingAdoption: true,
+        replaceMarker: marker,
+      );
+    }
   }
 
   void _listenForChanges() {

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -845,6 +845,8 @@ class SyncNotifier extends StateNotifier<SyncState> {
     // Reset is the manual escape hatch: drop any stuck replace intent and
     // un-pause an awaiting-adoption state.
     await _ref.read(libraryEpochStoreProvider).clearPendingReplace();
+    await _ref.read(postRestoreSyncStoreProvider).clear();
+    await _ref.read(establishedProviderStoreProvider).clear();
     state = state.copyWith(replaceAwaitingAdoption: false, replaceMarker: null);
     await refreshState();
   }

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -313,12 +313,45 @@ class SyncNotifier extends StateNotifier<SyncState> {
     // Load initial state
     if (!mounted) return;
     await refreshState();
+    if (!mounted) return;
+
     // A Replace restore persists its cloud side as a pending intent; execute
     // it as soon as the app is back up, regardless of auto-sync settings.
-    if (mounted &&
-        _ref.read(libraryEpochStoreProvider).pendingReplace != null) {
+    if (_ref.read(libraryEpochStoreProvider).pendingReplace != null) {
       unawaited(performSync());
+      return;
     }
+
+    final provider = _ref.read(cloudStorageProviderProvider);
+    if (provider == null) return;
+
+    // A Merge restore persists a post-restore intent: the restore dialog's
+    // Merge choice is the consent, so force one sync that bypasses the
+    // first-contact gate (auto:false) regardless of the auto-sync toggles.
+    if (_ref.read(postRestoreSyncStoreProvider).pending) {
+      unawaited(_runPostRestoreSync());
+      return;
+    }
+
+    // On the other devices, surface a Replace-everywhere adoption proactively
+    // (even with auto-sync off) so a paused device is never hidden behind a
+    // manual Sync Now.
+    unawaited(_detectReplacedLibraryForSurfacing());
+  }
+
+  /// Force the one consented post-restore sync. `performSync(auto:false)` skips
+  /// the first-contact gate; the success path clears the intent.
+  Future<void> _runPostRestoreSync() async {
+    if (!mounted) return;
+    state = state.copyWith(postRestoreSyncing: true);
+    await performSync();
+    if (mounted) state = state.copyWith(postRestoreSyncing: false);
+  }
+
+  /// Surface a replaced cloud library on launch. Full body added in a later
+  /// step; the launch path already calls it so the wiring is exercised.
+  Future<void> _detectReplacedLibraryForSurfacing() async {
+    // Implemented in Task 12.
   }
 
   void _listenForChanges() {

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -310,7 +310,17 @@ class SyncNotifier extends StateNotifier<SyncState> {
   SyncService get _syncService => _ref.read(syncServiceProvider);
 
   Future<void> _initialize() async {
-    // Load initial state
+    if (!mounted) return;
+    // Restore the saved provider before reading sync state: restoreLastProvider
+    // is async, so without awaiting it _initialize can race ahead and read a
+    // null provider, skipping the post-restore intent and replaced-library
+    // surfacing for the whole session. Mirrors _maybeSyncOnLaunch awaiting
+    // reconcileDeviceIdentityProvider.
+    try {
+      await _ref.read(restoreLastProviderProvider.future);
+    } catch (_) {
+      // Non-fatal: proceed with whatever provider state exists.
+    }
     if (!mounted) return;
     await refreshState();
     if (!mounted) return;

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -13,10 +13,12 @@ import 'package:submersion/core/services/cloud_storage/google_drive_storage_prov
 import 'package:submersion/core/services/cloud_storage/icloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/library_moved.dart';
 import 'package:submersion/core/services/sync/library_moved_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/core/services/sync/sync_initializer.dart';
@@ -52,6 +54,18 @@ final libraryEpochStoreProvider = Provider<LibraryEpochStore>((ref) {
 /// old-backend cleanup target) for backend switches.
 final libraryMovedStoreProvider = Provider<LibraryMovedStore>((ref) {
   return LibraryMovedStore(ref.watch(sharedPreferencesProvider));
+});
+
+/// Merge-restore "sync once on next launch" intent.
+final postRestoreSyncStoreProvider = Provider<PostRestoreSyncStore>((ref) {
+  return PostRestoreSyncStore(ref.watch(sharedPreferencesProvider));
+});
+
+/// Providers this install has successfully synced to (survives restore).
+final establishedProviderStoreProvider = Provider<EstablishedProviderStore>((
+  ref,
+) {
+  return EstablishedProviderStore(ref.watch(sharedPreferencesProvider));
 });
 
 /// Behavior settings for auto-sync

--- a/lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart
+++ b/lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Confirm and run adoption of a replaced cloud library. Shared by the Cloud
+/// Sync page and the app-root surfacing so the destructive adopt has exactly
+/// one implementation. The safety backup runs here (not in SyncNotifier)
+/// because backup providers import sync providers; this widget layer may
+/// import both.
+Future<void> showAdoptReplacedLibraryDialog(
+  BuildContext context,
+  WidgetRef ref,
+  LibraryEpochMarker marker,
+) async {
+  final l10n = context.l10n;
+  final date = marker.replacedAt > 0
+      ? DateFormat.yMMMd().add_jm().format(
+          DateTime.fromMillisecondsSinceEpoch(marker.replacedAt),
+        )
+      : '?';
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(l10n.settings_cloudSync_adopt_dialogTitle),
+      content: Text(
+        l10n.settings_cloudSync_adopt_dialogContent(marker.displayName, date),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text(l10n.settings_cloudSync_adopt_notNow),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: Text(l10n.settings_cloudSync_adopt_confirm),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+  // Safety backup of this device's current data BEFORE it is overwritten.
+  await ref.read(backupServiceProvider).performBackup(isAutomatic: true);
+  await ref.read(syncStateProvider.notifier).adoptReplacedLibrary();
+}

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "ar",
+  "settings_cloudSync_postRestore_syncing": "تتم مزامنة مكتبتك المستعادة مع السحابة…",
+  "settings_cloudSync_postRestore_synced": "تمت مزامنة المكتبة المستعادة.",
+  "settings_cloudSync_replace_reviewAction": "مراجعة",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "ar",
+  "settings_cloudSync_replace_globalBanner": "المزامنة متوقفة مؤقتًا — تم استبدال المكتبة من نسخة احتياطية على \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "تتم مزامنة مكتبتك المستعادة مع السحابة…",
   "settings_cloudSync_postRestore_synced": "تمت مزامنة المكتبة المستعادة.",
   "settings_cloudSync_replace_reviewAction": "مراجعة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "de",
+  "settings_cloudSync_replace_globalBanner": "Synchronisierung pausiert — die Bibliothek wurde aus einem Backup auf \"{deviceName}\" ersetzt.",
   "settings_cloudSync_postRestore_syncing": "Wiederhergestellte Bibliothek wird mit der Cloud synchronisiert…",
   "settings_cloudSync_postRestore_synced": "Wiederhergestellte Bibliothek synchronisiert.",
   "settings_cloudSync_replace_reviewAction": "Überprüfen",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "de",
+  "settings_cloudSync_postRestore_syncing": "Wiederhergestellte Bibliothek wird mit der Cloud synchronisiert…",
+  "settings_cloudSync_postRestore_synced": "Wiederhergestellte Bibliothek synchronisiert.",
+  "settings_cloudSync_replace_reviewAction": "Überprüfen",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,9 +1,11 @@
 {
   "@@locale": "en",
+  "settings_cloudSync_replace_globalBanner": "Sync is paused — the library was replaced from a backup on \"{deviceName}\".",
+  "@settings_cloudSync_replace_globalBanner": {"placeholders": {"deviceName": {"type": "String"}}},
   "settings_cloudSync_postRestore_syncing": "Syncing your restored library with the cloud…",
   "settings_cloudSync_postRestore_synced": "Restored library synced.",
   "settings_cloudSync_replace_reviewAction": "Review",
-  "@@last_modified": "2026-02-10",
+  "@@last_modified": "2026-06-15",
   "accessibility_dialog_keyboardShortcutsTitle": "Keyboard Shortcuts",
   "accessibility_keyLabel_backspace": "Backspace",
   "accessibility_keyLabel_delete": "Delete",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,5 +1,8 @@
 {
   "@@locale": "en",
+  "settings_cloudSync_postRestore_syncing": "Syncing your restored library with the cloud…",
+  "settings_cloudSync_postRestore_synced": "Restored library synced.",
+  "settings_cloudSync_replace_reviewAction": "Review",
   "@@last_modified": "2026-02-10",
   "accessibility_dialog_keyboardShortcutsTitle": "Keyboard Shortcuts",
   "accessibility_keyLabel_backspace": "Backspace",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "es",
+  "settings_cloudSync_postRestore_syncing": "Sincronizando tu biblioteca restaurada con la nube…",
+  "settings_cloudSync_postRestore_synced": "Biblioteca restaurada sincronizada.",
+  "settings_cloudSync_replace_reviewAction": "Revisar",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "es",
+  "settings_cloudSync_replace_globalBanner": "Sincronización en pausa: la biblioteca se reemplazó desde una copia de seguridad en \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "Sincronizando tu biblioteca restaurada con la nube…",
   "settings_cloudSync_postRestore_synced": "Biblioteca restaurada sincronizada.",
   "settings_cloudSync_replace_reviewAction": "Revisar",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "fr",
+  "settings_cloudSync_replace_globalBanner": "Synchronisation en pause — la bibliothèque a été remplacée depuis une sauvegarde sur \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "Synchronisation de votre bibliothèque restaurée avec le cloud…",
   "settings_cloudSync_postRestore_synced": "Bibliothèque restaurée synchronisée.",
   "settings_cloudSync_replace_reviewAction": "Examiner",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "fr",
+  "settings_cloudSync_postRestore_syncing": "Synchronisation de votre bibliothèque restaurée avec le cloud…",
+  "settings_cloudSync_postRestore_synced": "Bibliothèque restaurée synchronisée.",
+  "settings_cloudSync_replace_reviewAction": "Examiner",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "he",
+  "settings_cloudSync_replace_globalBanner": "הסנכרון מושהה — הספרייה הוחלפה מגיבוי במכשיר \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "מסנכרן את הספרייה המשוחזרת שלך עם הענן…",
   "settings_cloudSync_postRestore_synced": "הספרייה המשוחזרת סונכרנה.",
   "settings_cloudSync_replace_reviewAction": "סקירה",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "he",
+  "settings_cloudSync_postRestore_syncing": "מסנכרן את הספרייה המשוחזרת שלך עם הענן…",
+  "settings_cloudSync_postRestore_synced": "הספרייה המשוחזרת סונכרנה.",
+  "settings_cloudSync_replace_reviewAction": "סקירה",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "hu",
+  "settings_cloudSync_replace_globalBanner": "A szinkronizálás szünetel — a könyvtárat egy biztonsági másolatból cserélték itt: \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "A visszaállított könyvtár szinkronizálása a felhővel…",
   "settings_cloudSync_postRestore_synced": "A visszaállított könyvtár szinkronizálva.",
   "settings_cloudSync_replace_reviewAction": "Áttekintés",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "hu",
+  "settings_cloudSync_postRestore_syncing": "A visszaállított könyvtár szinkronizálása a felhővel…",
+  "settings_cloudSync_postRestore_synced": "A visszaállított könyvtár szinkronizálva.",
+  "settings_cloudSync_replace_reviewAction": "Áttekintés",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "it",
+  "settings_cloudSync_replace_globalBanner": "Sincronizzazione in pausa: la libreria è stata sostituita da un backup su \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "Sincronizzazione della libreria ripristinata con il cloud…",
   "settings_cloudSync_postRestore_synced": "Libreria ripristinata sincronizzata.",
   "settings_cloudSync_replace_reviewAction": "Rivedi",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "it",
+  "settings_cloudSync_postRestore_syncing": "Sincronizzazione della libreria ripristinata con il cloud…",
+  "settings_cloudSync_postRestore_synced": "Libreria ripristinata sincronizzata.",
+  "settings_cloudSync_replace_reviewAction": "Rivedi",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -116,6 +116,24 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @settings_cloudSync_postRestore_syncing.
+  ///
+  /// In en, this message translates to:
+  /// **'Syncing your restored library with the cloud…'**
+  String get settings_cloudSync_postRestore_syncing;
+
+  /// No description provided for @settings_cloudSync_postRestore_synced.
+  ///
+  /// In en, this message translates to:
+  /// **'Restored library synced.'**
+  String get settings_cloudSync_postRestore_synced;
+
+  /// No description provided for @settings_cloudSync_replace_reviewAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Review'**
+  String get settings_cloudSync_replace_reviewAction;
+
   /// Title of the keyboard shortcuts help dialog
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -116,6 +116,12 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @settings_cloudSync_replace_globalBanner.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync is paused — the library was replaced from a backup on \"{deviceName}\".'**
+  String settings_cloudSync_replace_globalBanner(String deviceName);
+
   /// No description provided for @settings_cloudSync_postRestore_syncing.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -9,6 +9,17 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'تتم مزامنة مكتبتك المستعادة مع السحابة…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'تمت مزامنة المكتبة المستعادة.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'مراجعة';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'اختصارات لوحة المفاتيح';
 

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -9,6 +9,11 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'المزامنة متوقفة مؤقتًا — تم استبدال المكتبة من نسخة احتياطية على \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'تتم مزامنة مكتبتك المستعادة مع السحابة…';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -9,6 +9,17 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'Wiederhergestellte Bibliothek wird mit der Cloud synchronisiert…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Wiederhergestellte Bibliothek synchronisiert.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Überprüfen';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'Tastenkombinationen';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -9,6 +9,11 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Synchronisierung pausiert — die Bibliothek wurde aus einem Backup auf \"$deviceName\" ersetzt.';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'Wiederhergestellte Bibliothek wird mit der Cloud synchronisiert…';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -9,6 +9,17 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'Syncing your restored library with the cloud…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Restored library synced.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Review';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'Keyboard Shortcuts';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -9,6 +9,11 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Sync is paused — the library was replaced from a backup on \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'Syncing your restored library with the cloud…';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -9,6 +9,17 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'Sincronizando tu biblioteca restaurada con la nube…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Biblioteca restaurada sincronizada.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Revisar';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle => 'Atajos de teclado';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -9,6 +9,11 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Sincronización en pausa: la biblioteca se reemplazó desde una copia de seguridad en \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'Sincronizando tu biblioteca restaurada con la nube…';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -9,6 +9,11 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Synchronisation en pause — la bibliothèque a été remplacée depuis une sauvegarde sur \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'Synchronisation de votre bibliothèque restaurée avec le cloud…';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -9,6 +9,17 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'Synchronisation de votre bibliothèque restaurée avec le cloud…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Bibliothèque restaurée synchronisée.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Examiner';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'Raccourcis clavier';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -9,6 +9,17 @@ class AppLocalizationsHe extends AppLocalizations {
   AppLocalizationsHe([String locale = 'he']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'מסנכרן את הספרייה המשוחזרת שלך עם הענן…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'הספרייה המשוחזרת סונכרנה.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'סקירה';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle => 'קיצורי מקלדת';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -9,6 +9,11 @@ class AppLocalizationsHe extends AppLocalizations {
   AppLocalizationsHe([String locale = 'he']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'הסנכרון מושהה — הספרייה הוחלפה מגיבוי במכשיר \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'מסנכרן את הספרייה המשוחזרת שלך עם הענן…';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -9,6 +9,11 @@ class AppLocalizationsHu extends AppLocalizations {
   AppLocalizationsHu([String locale = 'hu']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'A szinkronizálás szünetel — a könyvtárat egy biztonsági másolatból cserélték itt: \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'A visszaállított könyvtár szinkronizálása a felhővel…';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -9,6 +9,17 @@ class AppLocalizationsHu extends AppLocalizations {
   AppLocalizationsHu([String locale = 'hu']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'A visszaállított könyvtár szinkronizálása a felhővel…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'A visszaállított könyvtár szinkronizálva.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Áttekintés';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'Billentyuparancsok';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -9,6 +9,11 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Sincronizzazione in pausa: la libreria è stata sostituita da un backup su \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'Sincronizzazione della libreria ripristinata con il cloud…';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -9,6 +9,17 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'Sincronizzazione della libreria ripristinata con il cloud…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Libreria ripristinata sincronizzata.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Rivedi';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'Scorciatoie da tastiera';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -9,6 +9,11 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Synchronisatie onderbroken — de bibliotheek is vervangen vanaf een back-up op \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'Je herstelde bibliotheek wordt met de cloud gesynchroniseerd…';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -9,6 +9,17 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'Je herstelde bibliotheek wordt met de cloud gesynchroniseerd…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Herstelde bibliotheek gesynchroniseerd.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Controleren';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle => 'Sneltoetsen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -9,6 +9,17 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing =>
+      'A sincronizar a sua biblioteca restaurada com a nuvem…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced =>
+      'Biblioteca restaurada sincronizada.';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => 'Rever';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle =>
       'Atalhos de Teclado';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -9,6 +9,11 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return 'Sincronização em pausa — a biblioteca foi substituída a partir de uma cópia de segurança em \"$deviceName\".';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing =>
       'A sincronizar a sua biblioteca restaurada com a nuvem…';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -9,6 +9,11 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String settings_cloudSync_replace_globalBanner(String deviceName) {
+    return '同步已暂停 — 资料库已从 \"$deviceName\" 上的备份替换。';
+  }
+
+  @override
   String get settings_cloudSync_postRestore_syncing => '正在将恢复的资料库与云同步…';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -9,6 +9,15 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get settings_cloudSync_postRestore_syncing => '正在将恢复的资料库与云同步…';
+
+  @override
+  String get settings_cloudSync_postRestore_synced => '已同步恢复的资料库。';
+
+  @override
+  String get settings_cloudSync_replace_reviewAction => '查看';
+
+  @override
   String get accessibility_dialog_keyboardShortcutsTitle => '键盘快捷键';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "nl",
+  "settings_cloudSync_replace_globalBanner": "Synchronisatie onderbroken — de bibliotheek is vervangen vanaf een back-up op \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "Je herstelde bibliotheek wordt met de cloud gesynchroniseerd…",
   "settings_cloudSync_postRestore_synced": "Herstelde bibliotheek gesynchroniseerd.",
   "settings_cloudSync_replace_reviewAction": "Controleren",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "nl",
+  "settings_cloudSync_postRestore_syncing": "Je herstelde bibliotheek wordt met de cloud gesynchroniseerd…",
+  "settings_cloudSync_postRestore_synced": "Herstelde bibliotheek gesynchroniseerd.",
+  "settings_cloudSync_replace_reviewAction": "Controleren",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,6 +1,9 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "pt",
+  "settings_cloudSync_postRestore_syncing": "A sincronizar a sua biblioteca restaurada com a nuvem…",
+  "settings_cloudSync_postRestore_synced": "Biblioteca restaurada sincronizada.",
+  "settings_cloudSync_replace_reviewAction": "Rever",
   "@trips_itinerary_dayLabel": {
     "placeholders": {
       "dayNumber": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,6 +1,7 @@
 {
   "@@last_modified": "2026-06-15",
   "@@locale": "pt",
+  "settings_cloudSync_replace_globalBanner": "Sincronização em pausa — a biblioteca foi substituída a partir de uma cópia de segurança em \"{deviceName}\".",
   "settings_cloudSync_postRestore_syncing": "A sincronizar a sua biblioteca restaurada com a nuvem…",
   "settings_cloudSync_postRestore_synced": "Biblioteca restaurada sincronizada.",
   "settings_cloudSync_replace_reviewAction": "Rever",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "zh",
+  "settings_cloudSync_replace_globalBanner": "同步已暂停 — 资料库已从 \"{deviceName}\" 上的备份替换。",
   "settings_cloudSync_postRestore_syncing": "正在将恢复的资料库与云同步…",
   "settings_cloudSync_postRestore_synced": "已同步恢复的资料库。",
   "settings_cloudSync_replace_reviewAction": "查看",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,5 +1,8 @@
 {
   "@@locale": "zh",
+  "settings_cloudSync_postRestore_syncing": "正在将恢复的资料库与云同步…",
+  "settings_cloudSync_postRestore_synced": "已同步恢复的资料库。",
+  "settings_cloudSync_replace_reviewAction": "查看",
   "@@last_modified": "2026-06-15",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/app.dart';
+import 'package:submersion/core/router/app_router.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/services/sync/sync_initializer.dart'
+    show DeviceIdentityStatus;
+import 'package:submersion/core/services/sync/sync_service.dart'
+    show ConflictResolution;
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import 'helpers/mock_providers.dart';
+
+/// A [SyncNotifier] stand-in whose state can be driven directly from a test,
+/// so the app-root `ref.listen` callback can be exercised through real state
+/// transitions without instantiating the database-backed notifier.
+class _DrivableSyncNotifier extends StateNotifier<SyncState>
+    implements SyncNotifier {
+  _DrivableSyncNotifier(super.state);
+
+  /// Push a new state, firing listeners exactly as the real notifier would.
+  void emit(SyncState next) => state = next;
+
+  @override
+  Future<void> performSync({bool auto = false}) async {}
+
+  @override
+  Future<FirstSyncMergeInfo?> firstSyncMergeInfo() async => null;
+
+  @override
+  Future<LibraryEpochMarker?> libraryReplaceInfo() async => null;
+
+  @override
+  Future<void> adoptReplacedLibrary() async {}
+
+  @override
+  Future<void> acknowledgeMoved() async {}
+
+  @override
+  Future<void> checkLibraryMoved() async {}
+
+  @override
+  Future<void> cleanupOldBackendData() async {}
+
+  @override
+  Future<void> dismissOldBackendCleanup() async {}
+
+  @override
+  Future<void> recordBackendDeparture({
+    required CloudStorageProvider oldProvider,
+    required String toProviderId,
+    String? toProviderName,
+  }) async {}
+
+  @override
+  Future<void> refreshState() async {}
+
+  @override
+  Future<void> resetSyncState() async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> resolveConflict(
+    String entityType,
+    String recordId,
+    ConflictResolution resolution,
+  ) async {}
+}
+
+/// Minimal router wired to the real [rootNavigatorKey] so the app-root adopt
+/// dialog (which reads `rootNavigatorKey.currentContext`) can surface.
+GoRouter _testRouter() => GoRouter(
+  navigatorKey: rootNavigatorKey,
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const Scaffold(body: SizedBox.shrink()),
+    ),
+  ],
+);
+
+LibraryEpochMarker _marker() => const LibraryEpochMarker(
+  epochId: 'epoch-1',
+  replacedAt: 1700000000000,
+  deviceId: 'device-1',
+  deviceName: 'Eric Mac',
+);
+
+void main() {
+  /// Pumps [SubmersionApp] with the providers its build/launch path reads
+  /// stubbed out, leaving [sync] as the driver for the app-root listener.
+  Future<void> pumpApp(WidgetTester tester, _DrivableSyncNotifier sync) async {
+    final base = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          appRouterProvider.overrideWithValue(_testRouter()),
+          syncStateProvider.overrideWith((ref) => sync),
+          reconcileDeviceIdentityProvider.overrideWith(
+            (ref) async => DeviceIdentityStatus.unchanged,
+          ),
+          restoreLastProviderProvider.overrideWith((ref) async {}),
+        ],
+        child: const SubmersionApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows the post-restore syncing notice when sync begins', (
+    tester,
+  ) async {
+    final sync = _DrivableSyncNotifier(const SyncState());
+    await pumpApp(tester, sync);
+
+    sync.emit(const SyncState(postRestoreSyncing: true));
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.text('Syncing your restored library with the cloud…'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows the synced notice when the post-restore sync completes', (
+    tester,
+  ) async {
+    final sync = _DrivableSyncNotifier(
+      const SyncState(postRestoreSyncing: true),
+    );
+    await pumpApp(tester, sync);
+
+    sync.emit(const SyncState(status: SyncStatus.success));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Restored library synced.'), findsOneWidget);
+  });
+
+  testWidgets('also surfaces the synced notice on a conflict outcome', (
+    tester,
+  ) async {
+    final sync = _DrivableSyncNotifier(
+      const SyncState(postRestoreSyncing: true),
+    );
+    await pumpApp(tester, sync);
+
+    sync.emit(const SyncState(status: SyncStatus.hasConflicts));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Restored library synced.'), findsOneWidget);
+  });
+
+  testWidgets('surfaces the replaced-library banner and adopt dialog', (
+    tester,
+  ) async {
+    final sync = _DrivableSyncNotifier(const SyncState());
+    await pumpApp(tester, sync);
+
+    sync.emit(
+      SyncState(replaceAwaitingAdoption: true, replaceMarker: _marker()),
+    );
+    await tester.pumpAndSettle();
+
+    // Persistent banner rides across screens.
+    expect(find.textContaining('Sync is paused'), findsOneWidget);
+    // Once-per-session modal auto-opens.
+    expect(find.text('Adopt Restored Library?'), findsOneWidget);
+  });
+
+  testWidgets('does not surface a banner when the replace marker is missing', (
+    tester,
+  ) async {
+    final sync = _DrivableSyncNotifier(const SyncState());
+    await pumpApp(tester, sync);
+
+    // replaceAwaitingAdoption with no marker is a no-op (guard clause).
+    sync.emit(const SyncState(replaceAwaitingAdoption: true));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Sync is paused'), findsNothing);
+    expect(find.text('Adopt Restored Library?'), findsNothing);
+  });
+
+  testWidgets('clears the banner once adoption is resolved', (tester) async {
+    final sync = _DrivableSyncNotifier(const SyncState());
+    await pumpApp(tester, sync);
+
+    sync.emit(
+      SyncState(replaceAwaitingAdoption: true, replaceMarker: _marker()),
+    );
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Sync is paused'), findsOneWidget);
+
+    // Dismiss the auto-opened modal, leaving the banner behind.
+    await tester.tap(find.text('Not Now'));
+    await tester.pumpAndSettle();
+
+    sync.emit(const SyncState());
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Sync is paused'), findsNothing);
+  });
+
+  testWidgets('the banner Review action reopens the adopt dialog', (
+    tester,
+  ) async {
+    final sync = _DrivableSyncNotifier(const SyncState());
+    await pumpApp(tester, sync);
+
+    sync.emit(
+      SyncState(replaceAwaitingAdoption: true, replaceMarker: _marker()),
+    );
+    await tester.pumpAndSettle();
+
+    // Close the once-per-session auto modal; the banner persists.
+    await tester.tap(find.text('Not Now'));
+    await tester.pumpAndSettle();
+    expect(find.text('Adopt Restored Library?'), findsNothing);
+
+    // Tapping the banner's Review action reopens the dialog.
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+    expect(find.text('Adopt Restored Library?'), findsOneWidget);
+  });
+}

--- a/test/core/services/sync/established_provider_store_test.dart
+++ b/test/core/services/sync/established_provider_store_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late EstablishedProviderStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    store = EstablishedProviderStore(await SharedPreferences.getInstance());
+  });
+
+  test('unknown provider is not established', () {
+    expect(store.contains('s3'), isFalse);
+  });
+
+  test('add marks a provider established and is idempotent', () async {
+    await store.add('s3');
+    await store.add('s3');
+    expect(store.contains('s3'), isTrue);
+  });
+
+  test('is scoped per provider', () async {
+    await store.add('s3');
+    expect(store.contains('s3'), isTrue);
+    expect(store.contains('icloud'), isFalse);
+  });
+
+  test('survives a new store instance over the same prefs (restore)', () async {
+    await store.add('s3');
+    final reopened =
+        EstablishedProviderStore(await SharedPreferences.getInstance());
+    expect(reopened.contains('s3'), isTrue);
+  });
+
+  test('clear forgets all providers', () async {
+    await store.add('s3');
+    await store.clear();
+    expect(store.contains('s3'), isFalse);
+  });
+}

--- a/test/core/services/sync/established_provider_store_test.dart
+++ b/test/core/services/sync/established_provider_store_test.dart
@@ -30,8 +30,9 @@ void main() {
 
   test('survives a new store instance over the same prefs (restore)', () async {
     await store.add('s3');
-    final reopened =
-        EstablishedProviderStore(await SharedPreferences.getInstance());
+    final reopened = EstablishedProviderStore(
+      await SharedPreferences.getInstance(),
+    );
     expect(reopened.contains('s3'), isTrue);
   });
 

--- a/test/core/services/sync/post_restore_sync_store_test.dart
+++ b/test/core/services/sync/post_restore_sync_store_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PostRestoreSyncStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    store = PostRestoreSyncStore(await SharedPreferences.getInstance());
+  });
+
+  test('defaults to not pending', () {
+    expect(store.pending, isFalse);
+  });
+
+  test('setPending then clear round-trips', () async {
+    await store.setPending();
+    expect(store.pending, isTrue);
+    await store.clear();
+    expect(store.pending, isFalse);
+  });
+
+  test('survives a new store instance over the same prefs (restore)', () async {
+    await store.setPending();
+    final reopened = PostRestoreSyncStore(await SharedPreferences.getInstance());
+    expect(reopened.pending, isTrue);
+  });
+}

--- a/test/core/services/sync/post_restore_sync_store_test.dart
+++ b/test/core/services/sync/post_restore_sync_store_test.dart
@@ -25,7 +25,9 @@ void main() {
 
   test('survives a new store instance over the same prefs (restore)', () async {
     await store.setPending();
-    final reopened = PostRestoreSyncStore(await SharedPreferences.getInstance());
+    final reopened = PostRestoreSyncStore(
+      await SharedPreferences.getInstance(),
+    );
     expect(reopened.pending, isTrue);
   });
 }

--- a/test/core/services/sync/restore_resume_convergence_test.dart
+++ b/test/core/services/sync/restore_resume_convergence_test.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/settings/presentation/providers/sync_provide
 import '../../../helpers/fake_cloud_storage_provider.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../helpers/test_database.dart';
+import '../../../helpers/wait_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -53,7 +54,14 @@ void main() {
 
       // Constructing the notifier runs _initialize, which consumes the intent.
       container.read(syncStateProvider);
-      await Future<void>.delayed(const Duration(seconds: 4));
+      // Poll for the pulled row instead of a fixed sleep (CI-robust).
+      await waitUntil(
+        () async =>
+            (await DatabaseService.instance.database
+                .customSelect("SELECT id FROM dives WHERE id = 'a1'")
+                .getSingleOrNull()) !=
+            null,
+      );
 
       final row = await DatabaseService.instance.database
           .customSelect("SELECT id FROM dives WHERE id = 'a1'")

--- a/test/core/services/sync/restore_resume_convergence_test.dart
+++ b/test/core/services/sync/restore_resume_convergence_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'a pending post-restore intent converges with a peer on launch, no manual '
+    'Sync Now',
+    () async {
+      final cloud = FakeCloudStorageProvider();
+
+      // Device A: create a dive and publish it to the shared cloud.
+      await setUpTestDatabase();
+      final svcA = SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+      );
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'a1', diveNumber: 1),
+      );
+      expect((await svcA.performSync()).status, SyncResultStatus.success);
+      await tearDownTestDatabase();
+
+      // Device B: fresh DB with a pending post-restore intent (as if just
+      // restored). No auto-sync triggers are wired here; only _initialize's
+      // forced, gate-bypassing sync runs.
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      await PostRestoreSyncStore(prefs).setPending();
+      await setUpTestDatabase();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Constructing the notifier runs _initialize, which consumes the intent.
+      container.read(syncStateProvider);
+      await Future<void>.delayed(const Duration(seconds: 4));
+
+      final row = await DatabaseService.instance.database
+          .customSelect("SELECT id FROM dives WHERE id = 'a1'")
+          .getSingleOrNull();
+      expect(
+        row,
+        isNotNull,
+        reason:
+            'device B must converge with A via the forced post-restore sync, '
+            'without a manual Sync Now',
+      );
+      await tearDownTestDatabase();
+    },
+  );
+}

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -8,11 +8,14 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/sync/library_epoch_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 
 // =============================================================================
 // Test Doubles
@@ -217,6 +220,64 @@ void main() {
       preferences = BackupPreferences(prefs);
       fakeCloud = FakeCloudStorageProvider();
       fakeDb = FakeBackupDatabaseAdapter();
+    });
+
+    group('post-restore sync intent', () {
+      test('Merge restore sets the post-restore sync intent', () async {
+        final intentStore = PostRestoreSyncStore(
+          await SharedPreferences.getInstance(),
+        );
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: _SpySyncRepository(),
+          postRestoreSyncStore: intentStore,
+        );
+        final src = File(
+          '${Directory.systemTemp.path}/restore_merge_'
+          '${DateTime.now().microsecondsSinceEpoch}.db',
+        );
+        await src.writeAsString('db');
+        addTearDown(() async {
+          if (await src.exists()) await src.delete();
+        });
+
+        await service.restoreFromFile(src.path); // mode defaults to merge
+
+        expect(
+          intentStore.pending,
+          isTrue,
+          reason: 'a Merge restore must arm the post-restore sync intent',
+        );
+      });
+
+      test('Replace restore does NOT set the merge intent', () async {
+        final prefs = await SharedPreferences.getInstance();
+        final intentStore = PostRestoreSyncStore(prefs);
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: _SpySyncRepository(),
+          epochStore: LibraryEpochStore(prefs),
+          postRestoreSyncStore: intentStore,
+        );
+        final src = File(
+          '${Directory.systemTemp.path}/restore_replace_'
+          '${DateTime.now().microsecondsSinceEpoch}.db',
+        );
+        await src.writeAsString('db');
+        addTearDown(() async {
+          if (await src.exists()) await src.delete();
+        });
+
+        await service.restoreFromFile(src.path, mode: RestoreMode.replace);
+
+        expect(
+          intentStore.pending,
+          isFalse,
+          reason: 'Replace uses pendingReplace, not the merge intent',
+        );
+      });
     });
 
     group('restore re-baselines sync', () {

--- a/test/features/settings/presentation/providers/sync_providers_epoch_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_epoch_test.dart
@@ -254,6 +254,26 @@ void main() {
         reason: 'the replace wrote the marker',
       );
     });
+
+    test('stays dormant when no cloud provider is configured', () async {
+      // A persisted Replace intent must not fire performSync() without a
+      // provider, or launch would surface a "no provider configured" error
+      // even for users who never enabled cloud sync.
+      await LibraryEpochStore(prefs).setPendingReplace(marker);
+      await seedLocalDive('restored-dive');
+
+      final container = await makeContainer(cloudConfigured: false);
+
+      // Let _initialize run its async chain (restore + refresh + intent check).
+      for (var i = 0; i < 10; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+
+      // The intent survives for a later launch that has a provider...
+      expect(LibraryEpochStore(prefs).pendingReplace, isNotNull);
+      // ...and launch never drove the notifier into an error/syncing state.
+      expect(container.read(syncStateProvider).status, SyncStatus.idle);
+    });
   });
 
   group('resetSyncState escape hatch', () {

--- a/test/features/settings/presentation/providers/sync_providers_restore_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_restore_test.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/established_provider_store.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
@@ -16,6 +15,7 @@ import '../../../../helpers/changeset_test_helpers.dart';
 import '../../../../helpers/fake_cloud_storage_provider.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_database.dart';
+import '../../../../helpers/wait_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -30,8 +30,10 @@ void main() {
     cloud = FakeCloudStorageProvider();
   });
 
-  tearDown(() {
-    DatabaseService.instance.resetForTesting();
+  tearDown(() async {
+    // Close the Drift connection (not just null the reference) so open DBs
+    // don't leak across tests.
+    await tearDownTestDatabase();
   });
 
   Future<ProviderContainer> makeContainer() async {
@@ -125,12 +127,14 @@ void main() {
           createTestDiveWithBottomTime(id: 'd1'),
         );
 
-        // Construct the notifier (runs _initialize) and let it finish.
+        // Construct the notifier (runs _initialize, which forces the sync).
         container.read(syncStateProvider);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        // Allow the forced sync (and its internal post-success refresh delay) to
-        // complete.
-        await Future<void>.delayed(const Duration(seconds: 3));
+        // Wait on the concrete terminal condition (sync finished + intent
+        // consumed) instead of a fixed sleep, so the test isn't CI-flaky.
+        await waitUntil(() async {
+          final s = container.read(syncStateProvider);
+          return !s.postRestoreSyncing && !PostRestoreSyncStore(prefs).pending;
+        });
 
         final state = container.read(syncStateProvider);
         expect(
@@ -199,7 +203,9 @@ void main() {
       // Constructing the notifier runs _initialize, which proactively detects
       // the replaced library (no pending intent, provider configured).
       container.read(syncStateProvider);
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await waitUntil(
+        () async => container.read(syncStateProvider).replaceAwaitingAdoption,
+      );
 
       final state = container.read(syncStateProvider);
       expect(

--- a/test/features/settings/presentation/providers/sync_providers_restore_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_restore_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/established_provider_store.dart';
+import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -78,5 +79,25 @@ void main() {
             'after a restore wiped its in-DB cursor',
       );
     });
+  });
+
+  test('a successful sync anchors the provider and clears the intent',
+      () async {
+    await PostRestoreSyncStore(prefs).setPending();
+    final container = await makeContainer();
+    await seedLocalDive('d1');
+
+    await container.read(syncStateProvider.notifier).performSync();
+
+    expect(
+      EstablishedProviderStore(prefs).contains(cloud.providerId),
+      isTrue,
+      reason: 'a clean sync marks this provider established',
+    );
+    expect(
+      PostRestoreSyncStore(prefs).pending,
+      isFalse,
+      reason: 'the post-restore intent is consumed once a sync succeeds',
+    );
   });
 }

--- a/test/features/settings/presentation/providers/sync_providers_restore_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_restore_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/changeset_test_helpers.dart';
+import '../../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferences prefs;
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  Future<ProviderContainer> makeContainer() async {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(cloud),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(syncStateProvider);
+    await container.read(syncStateProvider.notifier).refreshState();
+    return container;
+  }
+
+  Future<void> seedLocalDive(String id) async {
+    await DiveRepository().createDive(createTestDiveWithBottomTime(id: id));
+  }
+
+  group('firstSyncMergeInfo established-provider short-circuit', () {
+    test('genuine new device with peers + local dives still gates', () async {
+      final container = await makeContainer();
+      await seedLocalDive('d1');
+      await seedPeerManifest(cloud, 'peer-device');
+
+      final info =
+          await container.read(syncStateProvider.notifier).firstSyncMergeInfo();
+      expect(
+        info,
+        isNotNull,
+        reason: 'a brand-new device must still confirm before merging',
+      );
+    });
+
+    test('established provider short-circuits the gate (restore case)',
+        () async {
+      await EstablishedProviderStore(prefs).add(cloud.providerId);
+      final container = await makeContainer();
+      await seedLocalDive('d1');
+      await seedPeerManifest(cloud, 'peer-device');
+
+      final info =
+          await container.read(syncStateProvider.notifier).firstSyncMergeInfo();
+      expect(
+        info,
+        isNull,
+        reason:
+            'a device that already synced here is not first-contact, even '
+            'after a restore wiped its in-DB cursor',
+      );
+    });
+  });
+}

--- a/test/features/settings/presentation/providers/sync_providers_restore_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_restore_test.dart
@@ -147,4 +147,25 @@ void main() {
       },
     );
   });
+
+  test(
+    'resetSyncState clears the anchor and the post-restore intent',
+    () async {
+      final container = await makeContainer();
+      // Let _initialize settle; it is inert with no pending intent at
+      // construction, so the stores are set here without racing a forced sync.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await EstablishedProviderStore(prefs).add(cloud.providerId);
+      await PostRestoreSyncStore(prefs).setPending();
+
+      await container.read(syncStateProvider.notifier).resetSyncState();
+
+      expect(
+        EstablishedProviderStore(prefs).contains(cloud.providerId),
+        isFalse,
+        reason: 'an explicit reset is a true fresh start, so re-arm the gate',
+      );
+      expect(PostRestoreSyncStore(prefs).pending, isFalse);
+    },
+  );
 }

--- a/test/features/settings/presentation/providers/sync_providers_restore_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_restore_test.dart
@@ -53,8 +53,9 @@ void main() {
       await seedLocalDive('d1');
       await seedPeerManifest(cloud, 'peer-device');
 
-      final info =
-          await container.read(syncStateProvider.notifier).firstSyncMergeInfo();
+      final info = await container
+          .read(syncStateProvider.notifier)
+          .firstSyncMergeInfo();
       expect(
         info,
         isNotNull,
@@ -62,28 +63,32 @@ void main() {
       );
     });
 
-    test('established provider short-circuits the gate (restore case)',
-        () async {
-      await EstablishedProviderStore(prefs).add(cloud.providerId);
-      final container = await makeContainer();
-      await seedLocalDive('d1');
-      await seedPeerManifest(cloud, 'peer-device');
+    test(
+      'established provider short-circuits the gate (restore case)',
+      () async {
+        await EstablishedProviderStore(prefs).add(cloud.providerId);
+        final container = await makeContainer();
+        await seedLocalDive('d1');
+        await seedPeerManifest(cloud, 'peer-device');
 
-      final info =
-          await container.read(syncStateProvider.notifier).firstSyncMergeInfo();
-      expect(
-        info,
-        isNull,
-        reason:
-            'a device that already synced here is not first-contact, even '
-            'after a restore wiped its in-DB cursor',
-      );
-    });
+        final info = await container
+            .read(syncStateProvider.notifier)
+            .firstSyncMergeInfo();
+        expect(
+          info,
+          isNull,
+          reason:
+              'a device that already synced here is not first-contact, even '
+              'after a restore wiped its in-DB cursor',
+        );
+      },
+    );
   });
 
-  test('a successful sync anchors the provider and clears the intent',
-      () async {
-    await PostRestoreSyncStore(prefs).setPending();
+  test('a successful sync anchors the provider', () async {
+    // No pending intent here, so _initialize stays inert and the explicit
+    // performSync is the only sync (deterministic). The intent-clear behavior
+    // is covered by the launch test below.
     final container = await makeContainer();
     await seedLocalDive('d1');
 
@@ -94,10 +99,52 @@ void main() {
       isTrue,
       reason: 'a clean sync marks this provider established',
     );
-    expect(
-      PostRestoreSyncStore(prefs).pending,
-      isFalse,
-      reason: 'the post-restore intent is consumed once a sync succeeds',
+  });
+
+  group('post-restore launch sync', () {
+    test(
+      'a pending intent forces a sync that bypasses the first-contact gate',
+      () async {
+        // Arrange the EXACT condition that used to defer: peers + local dives +
+        // null cursor + a pending post-restore intent.
+        await PostRestoreSyncStore(prefs).setPending();
+        await seedPeerManifest(cloud, 'peer-device');
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            cloudStorageProviderProvider.overrideWithValue(cloud),
+          ],
+        );
+        addTearDown(container.dispose);
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'd1'),
+        );
+
+        // Construct the notifier (runs _initialize) and let it finish.
+        container.read(syncStateProvider);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        // Allow the forced sync (and its internal post-success refresh delay) to
+        // complete.
+        await Future<void>.delayed(const Duration(seconds: 3));
+
+        final state = container.read(syncStateProvider);
+        expect(
+          state.firstSyncAwaitingConfirmation,
+          isFalse,
+          reason: 'THE BUG: the forced post-restore sync must not defer',
+        );
+        expect(
+          PostRestoreSyncStore(prefs).pending,
+          isFalse,
+          reason: 'a successful forced sync consumes the intent',
+        );
+        expect(
+          state.postRestoreSyncing,
+          isFalse,
+          reason: 'the syncing flag is lowered when the forced sync finishes',
+        );
+      },
     );
   });
 }

--- a/test/features/settings/presentation/providers/sync_providers_restore_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_restore_test.dart
@@ -1,8 +1,12 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/established_provider_store.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -166,6 +170,44 @@ void main() {
         reason: 'an explicit reset is a true fresh start, so re-arm the gate',
       );
       expect(PostRestoreSyncStore(prefs).pending, isFalse);
+    },
+  );
+
+  test(
+    'a foreign epoch with local dives arms replaceAwaitingAdoption on launch',
+    () async {
+      const foreign = LibraryEpochMarker(
+        epochId: 'foreign-epoch',
+        replacedAt: 1764000000000,
+        deviceId: 'mac-device',
+        deviceName: 'Eric Mac',
+      );
+      cloud.seedFile(
+        libraryEpochFileName,
+        Uint8List.fromList(utf8.encode(jsonEncode(foreign.toJson()))),
+      );
+      await seedLocalDive('d1');
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Constructing the notifier runs _initialize, which proactively detects
+      // the replaced library (no pending intent, provider configured).
+      container.read(syncStateProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      final state = container.read(syncStateProvider);
+      expect(
+        state.replaceAwaitingAdoption,
+        isTrue,
+        reason: 'a replaced library must surface even with auto-sync off',
+      );
+      expect(state.replaceMarker?.epochId, 'foreign-epoch');
     },
   );
 }

--- a/test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart
@@ -19,6 +19,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         child: MaterialApp(
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Builder(

--- a/test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/adopt_replaced_library_dialog_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  testWidgets('renders the replacing device name and the two actions', (
+    tester,
+  ) async {
+    const marker = LibraryEpochMarker(
+      epochId: 'e1',
+      replacedAt: 1764000000000,
+      deviceId: 'replacer',
+      deviceName: 'Eric Mac',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) => ElevatedButton(
+                  onPressed: () =>
+                      showAdoptReplacedLibraryDialog(context, ref, marker),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Adopt Restored Library?'), findsOneWidget);
+    expect(find.textContaining('Eric Mac'), findsOneWidget);
+    expect(find.text('Not Now'), findsOneWidget);
+
+    // Cancelling closes cleanly without touching backup/sync providers.
+    await tester.tap(find.text('Not Now'));
+    await tester.pumpAndSettle();
+    expect(find.text('Adopt Restored Library?'), findsNothing);
+  });
+}

--- a/test/helpers/wait_until.dart
+++ b/test/helpers/wait_until.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Polls [condition] until it returns true or [timeout] elapses (then fails).
+///
+/// Use instead of fixed `Future.delayed` sleeps when waiting for async work
+/// (a forced sync, a pulled row) so tests assert on the concrete outcome and
+/// are not timing-dependent on slow or loaded CI.
+Future<void> waitUntil(
+  Future<bool> Function() condition, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final sw = Stopwatch()..start();
+  while (!await condition()) {
+    if (sw.elapsed > timeout) {
+      fail('waitUntil: condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+  }
+}


### PR DESCRIPTION
## Summary
Restoring a database with cloud sync enabled silently stopped sync until the user manually opened Cloud Sync settings and tapped **Sync Now** — on both the restoring device and the other synced devices. This PR carries the restore dialog's consent forward so sync resumes on its own (Merge) or surfaces an unmissable prompt (Replace).

Two distinct gates were tripping:
- **Restoring device (Merge):** restore nulls `lastSyncTime`, so the first-contact gate re-armed and auto-sync silently deferred.
- **Other devices (Replace-everywhere):** the new library epoch paused them behind a settings-only banner.

## What changed
**Gate 1 — restoring device auto-resumes (non-destructive):**
- New `PostRestoreSyncStore` + `EstablishedProviderStore` (SharedPreferences, survive restore).
- `firstSyncMergeInfo` skips established providers (root-cause fix; a genuinely new device still gates — regression-guarded).
- `_initialize` forces a gate-bypassing `performSync(auto:false)` after a Merge restore; success anchors the provider and clears the intent. `BackupService` arms the intent on Merge restore; `resetSyncState` clears both.

**Gate 2 — other devices surface unmissably (destructive, still confirmed):**
- Proactive epoch detection on launch, independent of the auto-sync toggles.
- Reusable adopt dialog; an app-root listener drives a post-restore notice SnackBar, a persistent banner, and a once-per-session modal. Root navigator key added. The destructive adopt itself is unchanged (still confirmed + safety-backed-up).
- Three new localized strings across all 11 locales.

Spec: `docs/superpowers/specs/2026-06-15-smoother-restore-sync-design.md`
Plan: `docs/superpowers/plans/2026-06-15-smoother-restore-sync.md`

## Test Plan
- [x] 8,834 unit/widget tests pass; whole-project `flutter analyze` clean; formatted
- [x] Two-device restore-resume convergence test (forced sync, no manual Sync Now)
- [x] Regression guard: a genuinely new device still hits the first-contact gate
- [ ] Device verification (Mac + iPhone): Merge restore auto-resumes with the SnackBar notice; Replace-everywhere surfaces the global adopt dialog + persistent banner on the other device