### PR TITLE
feat(sync): iCloud availability in unsupported macOS builds

### DIFF
--- a/ios/Runner/ICloudContainerHandler.swift
+++ b/ios/Runner/ICloudContainerHandler.swift
@@ -1,6 +1,5 @@
 import Flutter
 import UIKit
-import Security
 
 /// Thread-safe atomic flag for one-shot operations.
 private class AtomicFlag {
@@ -115,31 +114,17 @@ class ICloudContainerHandler: NSObject {
     }
 
     /// Reports iCloud availability without resolving the container URL (which
-    /// can block). Distinguishes a build lacking the iCloud entitlement
-    /// ("unsupported") from a signed-out iCloud account ("signedOut").
+    /// can block). On iOS the app is always provisioned with its iCloud
+    /// entitlement — there is no Developer ID / no-sandbox distribution as on
+    /// macOS — so availability reduces to whether an iCloud account is signed
+    /// in. (`SecTask` entitlement inspection is macOS-only and unavailable on
+    /// iOS, so there is no "unsupported" state here.)
     private func getICloudAvailability(result: @escaping FlutterResult) {
         DispatchQueue.global(qos: .userInitiated).async {
-            let status: String
-            if !self.hasUbiquityEntitlement() {
-                status = "unsupported"
-            } else if FileManager.default.ubiquityIdentityToken == nil {
-                status = "signedOut"
-            } else {
-                status = "available"
-            }
+            let status = FileManager.default.ubiquityIdentityToken == nil
+                ? "signedOut" : "available"
             DispatchQueue.main.async { result(status) }
         }
-    }
-
-    /// Whether this process carries the iCloud ubiquity-container entitlement.
-    private func hasUbiquityEntitlement() -> Bool {
-        guard let task = SecTaskCreateFromSelf(nil) else { return false }
-        let key = "com.apple.developer.ubiquity-container-identifiers" as CFString
-        let value = SecTaskCopyValueForEntitlement(task, key, nil)
-        if let identifiers = value as? [String] {
-            return !identifiers.isEmpty
-        }
-        return value != nil
     }
 
     private func downloadIfNeeded(path: String, result: @escaping FlutterResult) {

--- a/ios/Runner/ICloudContainerHandler.swift
+++ b/ios/Runner/ICloudContainerHandler.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import Security
 
 /// Thread-safe atomic flag for one-shot operations.
 private class AtomicFlag {
@@ -77,6 +78,9 @@ class ICloudContainerHandler: NSObject {
             }
             refreshFolder(path: path, result: result)
 
+        case "getICloudAvailability":
+            getICloudAvailability(result: result)
+
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -108,6 +112,34 @@ class ICloudContainerHandler: NSObject {
                 result(FlutterError(code: "TIMEOUT", message: "iCloud container lookup timed out", details: nil))
             }
         }
+    }
+
+    /// Reports iCloud availability without resolving the container URL (which
+    /// can block). Distinguishes a build lacking the iCloud entitlement
+    /// ("unsupported") from a signed-out iCloud account ("signedOut").
+    private func getICloudAvailability(result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let status: String
+            if !self.hasUbiquityEntitlement() {
+                status = "unsupported"
+            } else if FileManager.default.ubiquityIdentityToken == nil {
+                status = "signedOut"
+            } else {
+                status = "available"
+            }
+            DispatchQueue.main.async { result(status) }
+        }
+    }
+
+    /// Whether this process carries the iCloud ubiquity-container entitlement.
+    private func hasUbiquityEntitlement() -> Bool {
+        guard let task = SecTaskCreateFromSelf(nil) else { return false }
+        let key = "com.apple.developer.ubiquity-container-identifiers" as CFString
+        let value = SecTaskCopyValueForEntitlement(task, key, nil)
+        if let identifiers = value as? [String] {
+            return !identifiers.isEmpty
+        }
+        return value != nil
     }
 
     private func downloadIfNeeded(path: String, result: @escaping FlutterResult) {

--- a/lib/core/services/cloud_storage/icloud_native_service.dart
+++ b/lib/core/services/cloud_storage/icloud_native_service.dart
@@ -4,6 +4,13 @@ import 'package:flutter/services.dart';
 
 import 'package:submersion/core/services/logger_service.dart';
 
+/// Runtime iCloud availability for the current build/device.
+///
+/// `unsupported` means this build lacks the iCloud (ubiquity-container)
+/// entitlement — e.g. a Developer ID / no-sandbox distribution build — so
+/// iCloud can never work here regardless of the user's iCloud account.
+enum ICloudAvailability { available, signedOut, unsupported, unknown }
+
 /// Platform channel helpers for iCloud container access and file download.
 class ICloudNativeService {
   static const MethodChannel _channel = MethodChannel(
@@ -28,6 +35,40 @@ class ICloudNativeService {
         stackTrace: stackTrace,
       );
       return null;
+    }
+  }
+
+  /// Pure mapping from the native status string to [ICloudAvailability].
+  /// Extracted so it can be unit-tested independently of `dart:io` Platform.
+  static ICloudAvailability availabilityFromStatus(String? status) {
+    return switch (status) {
+      'available' => ICloudAvailability.available,
+      'signedOut' => ICloudAvailability.signedOut,
+      'unsupported' => ICloudAvailability.unsupported,
+      _ => ICloudAvailability.unknown,
+    };
+  }
+
+  /// Reports iCloud availability for the current build/device.
+  ///
+  /// Non-blocking on the native side (it does not resolve the container URL),
+  /// so it cannot hang. Returns [ICloudAvailability.unknown] on any channel
+  /// error or unmirrored platform, which the UI treats optimistically.
+  static Future<ICloudAvailability> getAvailability() async {
+    if (!Platform.isIOS && !Platform.isMacOS) {
+      return ICloudAvailability.unsupported;
+    }
+    try {
+      final status = await _channel.invokeMethod<String>(
+        'getICloudAvailability',
+      );
+      return availabilityFromStatus(status);
+    } catch (e, stackTrace) {
+      _log.warning(
+        'Failed to get iCloud availability: $e',
+        stackTrace: stackTrace,
+      );
+      return ICloudAvailability.unknown;
     }
   }
 

--- a/lib/core/services/cloud_storage/icloud_native_service.dart
+++ b/lib/core/services/cloud_storage/icloud_native_service.dart
@@ -6,9 +6,15 @@ import 'package:submersion/core/services/logger_service.dart';
 
 /// Runtime iCloud availability for the current build/device.
 ///
-/// `unsupported` means this build lacks the iCloud (ubiquity-container)
-/// entitlement — e.g. a Developer ID / no-sandbox distribution build — so
-/// iCloud can never work here regardless of the user's iCloud account.
+/// - `available`: an iCloud account is signed in and this build can reach its
+///   ubiquity container.
+/// - `signedOut`: the build is entitled, but no iCloud account is signed in.
+/// - `unsupported`: iCloud can never work here, for either of two reasons — the
+///   running build lacks the ubiquity-container entitlement (e.g. a Developer ID
+///   / no-sandbox distribution build), or the platform is not iOS/macOS at all.
+///   The user's iCloud account is irrelevant in this state.
+/// - `unknown`: the status could not be determined (a channel error on an Apple
+///   platform); the UI treats it optimistically.
 enum ICloudAvailability { available, signedOut, unsupported, unknown }
 
 /// Platform channel helpers for iCloud container access and file download.
@@ -52,8 +58,10 @@ class ICloudNativeService {
   /// Reports iCloud availability for the current build/device.
   ///
   /// Non-blocking on the native side (it does not resolve the container URL),
-  /// so it cannot hang. Returns [ICloudAvailability.unknown] on any channel
-  /// error or unmirrored platform, which the UI treats optimistically.
+  /// so it cannot hang. Returns [ICloudAvailability.unsupported] on
+  /// non-iOS/macOS platforms, and [ICloudAvailability.unknown] on a channel
+  /// error (e.g. [MissingPluginException]) — `unknown` is treated optimistically
+  /// by the UI.
   static Future<ICloudAvailability> getAvailability() async {
     if (!Platform.isIOS && !Platform.isMacOS) {
       return ICloudAvailability.unsupported;

--- a/lib/core/services/cloud_storage/icloud_native_service.dart
+++ b/lib/core/services/cloud_storage/icloud_native_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'package:submersion/core/services/logger_service.dart';
@@ -59,13 +60,20 @@ class ICloudNativeService {
   ///
   /// Non-blocking on the native side (it does not resolve the container URL),
   /// so it cannot hang. Returns [ICloudAvailability.unsupported] on
-  /// non-iOS/macOS platforms, and [ICloudAvailability.unknown] on a channel
-  /// error (e.g. [MissingPluginException]) — `unknown` is treated optimistically
-  /// by the UI.
+  /// non-iOS/macOS platforms; otherwise delegates to [queryNativeAvailability].
   static Future<ICloudAvailability> getAvailability() async {
     if (!Platform.isIOS && !Platform.isMacOS) {
       return ICloudAvailability.unsupported;
     }
+    return queryNativeAvailability();
+  }
+
+  /// Invokes the native availability channel and maps the result. Unlike
+  /// [getAvailability] it has no platform guard, so it is unit-testable on any
+  /// host via a mocked method channel. Returns [ICloudAvailability.unknown] on a
+  /// channel error (e.g. [MissingPluginException]).
+  @visibleForTesting
+  static Future<ICloudAvailability> queryNativeAvailability() async {
     try {
       final status = await _channel.invokeMethod<String>(
         'getICloudAvailability',

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
+import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/sync/library_moved.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
@@ -401,6 +402,15 @@ class CloudSyncPage extends ConsumerWidget {
     WidgetRef ref,
     CloudProviderType? selectedProvider,
   ) {
+    final l10n = context.l10n;
+    final iCloudAvailability = ref
+        .watch(iCloudAvailabilityProvider)
+        .valueOrNull;
+    final iCloudUnsupported =
+        iCloudAvailability == ICloudAvailability.unsupported;
+    final iCloudDisabledSubtitle = (Platform.isIOS || Platform.isMacOS)
+        ? l10n.settings_cloudSync_provider_icloud_unsupportedSubtitle
+        : l10n.settings_cloudSync_provider_notAvailable;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -421,7 +431,8 @@ class CloudSyncPage extends ConsumerWidget {
           subtitle: 'Sync via Apple iCloud',
           icon: Icons.cloud,
           isSelected: selectedProvider == CloudProviderType.icloud,
-          isAvailable: Platform.isIOS || Platform.isMacOS,
+          isAvailable: !iCloudUnsupported,
+          disabledSubtitle: iCloudDisabledSubtitle,
         ),
         // Google Drive is hidden until its integration is fully
         // implemented; the CloudProviderType and provider plumbing remain
@@ -440,14 +451,19 @@ class CloudSyncPage extends ConsumerWidget {
     required IconData icon,
     required bool isSelected,
     required bool isAvailable,
+    String? disabledSubtitle,
   }) {
+    final l10n = context.l10n;
     return Semantics(
       selected: isSelected,
       child: ListTile(
         leading: Icon(icon),
         title: Text(title),
         subtitle: Text(
-          isAvailable ? subtitle : 'Not available on this platform',
+          isAvailable
+              ? subtitle
+              : (disabledSubtitle ??
+                    l10n.settings_cloudSync_provider_notAvailable),
         ),
         trailing: isSelected
             ? const Icon(
@@ -589,13 +605,49 @@ class CloudSyncPage extends ConsumerWidget {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              '${cloudProvider.providerName} connection failed: $e',
+              _connectionErrorMessage(
+                context,
+                ref,
+                provider,
+                cloudProvider.providerName,
+                e,
+              ),
             ),
             backgroundColor: Colors.red,
           ),
         );
       }
     }
+  }
+
+  /// Localized connection-failure message. For iCloud, picks wording that
+  /// matches the real availability state instead of leaking the raw exception.
+  String _connectionErrorMessage(
+    BuildContext context,
+    WidgetRef ref,
+    CloudProviderType provider,
+    String providerName,
+    Object error,
+  ) {
+    final l10n = context.l10n;
+    if (provider == CloudProviderType.icloud) {
+      final availability = ref.read(iCloudAvailabilityProvider).valueOrNull;
+      switch (availability) {
+        case ICloudAvailability.unsupported:
+          return l10n.settings_cloudSync_error_icloudUnsupported;
+        case ICloudAvailability.signedOut:
+          return l10n.settings_cloudSync_error_icloudSignedOut;
+        case ICloudAvailability.unknown:
+        case null:
+          return l10n.settings_cloudSync_error_icloudUnknown;
+        case ICloudAvailability.available:
+          break; // genuine failure despite availability — fall through
+      }
+    }
+    return l10n.settings_cloudSync_provider_connectionFailed(
+      providerName,
+      error.toString(),
+    );
   }
 
   /// Display name for a provider type, for dialogs and banners.

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
@@ -16,7 +14,37 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/conflict_resolution_dialog.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Localized connection-failure message for a cloud provider. For iCloud the
+/// wording reflects the real [iCloudAvailability] state; other providers (and a
+/// genuinely-available iCloud that still failed) get the generic message.
+///
+/// Pure (no `BuildContext`/`ref`) so it is unit-testable on any host.
+@visibleForTesting
+String connectionErrorMessage(
+  AppLocalizations l10n,
+  CloudProviderType provider,
+  ICloudAvailability? iCloudAvailability,
+  String providerName,
+  String error,
+) {
+  if (provider == CloudProviderType.icloud) {
+    switch (iCloudAvailability) {
+      case ICloudAvailability.unsupported:
+        return l10n.settings_cloudSync_error_icloudUnsupported;
+      case ICloudAvailability.signedOut:
+        return l10n.settings_cloudSync_error_icloudSignedOut;
+      case ICloudAvailability.unknown:
+      case null:
+        return l10n.settings_cloudSync_error_icloudUnknown;
+      case ICloudAvailability.available:
+        break; // genuine failure despite availability — use the generic message
+    }
+  }
+  return l10n.settings_cloudSync_provider_connectionFailed(providerName, error);
+}
 
 class CloudSyncPage extends ConsumerWidget {
   const CloudSyncPage({super.key});
@@ -403,12 +431,13 @@ class CloudSyncPage extends ConsumerWidget {
     CloudProviderType? selectedProvider,
   ) {
     final l10n = context.l10n;
+    final isApple = ref.watch(isApplePlatformProvider);
     final iCloudAvailability = ref
         .watch(iCloudAvailabilityProvider)
         .valueOrNull;
     final iCloudUnsupported =
         iCloudAvailability == ICloudAvailability.unsupported;
-    final iCloudDisabledSubtitle = (Platform.isIOS || Platform.isMacOS)
+    final iCloudDisabledSubtitle = isApple
         ? l10n.settings_cloudSync_provider_icloud_unsupportedSubtitle
         : l10n.settings_cloudSync_provider_notAvailable;
     return Column(
@@ -431,7 +460,7 @@ class CloudSyncPage extends ConsumerWidget {
           subtitle: 'Sync via Apple iCloud',
           icon: Icons.cloud,
           isSelected: selectedProvider == CloudProviderType.icloud,
-          isAvailable: !iCloudUnsupported,
+          isAvailable: isApple && !iCloudUnsupported,
           disabledSubtitle: iCloudDisabledSubtitle,
         ),
         // Google Drive is hidden until its integration is fully
@@ -620,8 +649,8 @@ class CloudSyncPage extends ConsumerWidget {
     }
   }
 
-  /// Localized connection-failure message. For iCloud, picks wording that
-  /// matches the real availability state instead of leaking the raw exception.
+  /// Localized connection-failure message. For iCloud, the wording reflects
+  /// the real availability state instead of leaking the raw exception.
   String _connectionErrorMessage(
     BuildContext context,
     WidgetRef ref,
@@ -629,22 +658,13 @@ class CloudSyncPage extends ConsumerWidget {
     String providerName,
     Object error,
   ) {
-    final l10n = context.l10n;
-    if (provider == CloudProviderType.icloud) {
-      final availability = ref.read(iCloudAvailabilityProvider).valueOrNull;
-      switch (availability) {
-        case ICloudAvailability.unsupported:
-          return l10n.settings_cloudSync_error_icloudUnsupported;
-        case ICloudAvailability.signedOut:
-          return l10n.settings_cloudSync_error_icloudSignedOut;
-        case ICloudAvailability.unknown:
-        case null:
-          return l10n.settings_cloudSync_error_icloudUnknown;
-        case ICloudAvailability.available:
-          break; // genuine failure despite availability — fall through
-      }
-    }
-    return l10n.settings_cloudSync_provider_connectionFailed(
+    final iCloudAvailability = provider == CloudProviderType.icloud
+        ? ref.read(iCloudAvailabilityProvider).valueOrNull
+        : null;
+    return connectionErrorMessage(
+      context.l10n,
+      provider,
+      iCloudAvailability,
       providerName,
       error.toString(),
     );

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -48,6 +48,14 @@ final iCloudAvailabilityProvider = FutureProvider<ICloudAvailability>((
   return ICloudNativeService.getAvailability();
 });
 
+/// Whether the host is an Apple platform (iOS/macOS), where iCloud can exist at
+/// all. Exposed as a provider so the iCloud tile is never enabled on non-Apple
+/// platforms (even transiently while [iCloudAvailabilityProvider] loads), and so
+/// widget tests can simulate an Apple platform on a non-Apple CI host.
+final isApplePlatformProvider = Provider<bool>(
+  (ref) => Platform.isIOS || Platform.isMacOS,
+);
+
 /// Sync preferences provider
 final syncPreferencesProvider = Provider<SyncPreferences>((ref) {
   final prefs = ref.watch(sharedPreferencesProvider);

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -11,6 +11,7 @@ import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
 import 'package:submersion/core/services/sync/established_provider_store.dart';
@@ -37,6 +38,14 @@ final syncRepositoryProvider = Provider<SyncRepository>((ref) {
 /// Sync data serializer provider
 final syncDataSerializerProvider = Provider<SyncDataSerializer>((ref) {
   return SyncDataSerializer();
+});
+
+/// Runtime iCloud availability for the current build/device. Drives the iCloud
+/// provider tile's enabled state and its connection-failure messaging.
+final iCloudAvailabilityProvider = FutureProvider<ICloudAvailability>((
+  ref,
+) async {
+  return ICloudNativeService.getAvailability();
 });
 
 /// Sync preferences provider

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات النظام.",
+  "settings_cloudSync_error_icloudUnknown": "تعذّر الوصول إلى iCloud. حاول مرة أخرى.",
+  "settings_cloudSync_error_icloudUnsupported": "مزامنة iCloud غير متوفرة في هذا الإصدار من Submersion. استخدم مزامنة S3 أو نسخة App Store.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "غير متوفر في هذا الإصدار — استخدم S3 أو نسخة App Store",
   "@@last_modified": "2026-06-15",
   "@@locale": "ar",
   "settings_cloudSync_replace_globalBanner": "المزامنة متوقفة مؤقتًا — تم استبدال المكتبة من نسخة احتياطية على \"{deviceName}\".",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات النظام.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات جهازك.",
   "settings_cloudSync_error_icloudUnknown": "تعذّر الوصول إلى iCloud. حاول مرة أخرى.",
   "settings_cloudSync_error_icloudUnsupported": "مزامنة iCloud غير متوفرة في هذا الإصدار من Submersion. استخدم مزامنة S3 أو نسخة App Store.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "غير متوفر في هذا الإصدار — استخدم S3 أو نسخة App Store",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud ist nicht verfügbar. Bitte melde dich in den Systemeinstellungen bei iCloud an.",
+  "settings_cloudSync_error_icloudUnknown": "iCloud konnte nicht erreicht werden. Bitte versuche es erneut.",
+  "settings_cloudSync_error_icloudUnsupported": "iCloud-Synchronisierung ist in diesem Build von Submersion nicht verfügbar. Verwende die S3-Synchronisierung oder die App-Store-Version.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "In diesem Build nicht verfügbar – verwende S3 oder die App-Store-Version",
   "@@last_modified": "2026-06-15",
   "@@locale": "de",
   "settings_cloudSync_replace_globalBanner": "Synchronisierung pausiert — die Bibliothek wurde aus einem Backup auf \"{deviceName}\" ersetzt.",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud ist nicht verfügbar. Bitte melde dich in den Systemeinstellungen bei iCloud an.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud ist nicht verfügbar. Bitte melde dich in den Geräteeinstellungen bei iCloud an.",
   "settings_cloudSync_error_icloudUnknown": "iCloud konnte nicht erreicht werden. Bitte versuche es erneut.",
   "settings_cloudSync_error_icloudUnsupported": "iCloud-Synchronisierung ist in diesem Build von Submersion nicht verfügbar. Verwende die S3-Synchronisierung oder die App-Store-Version.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "In diesem Build nicht verfügbar – verwende S3 oder die App-Store-Version",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud is not available. Please sign in to iCloud in System Settings.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud is not available. Please sign in to iCloud in your device settings.",
   "settings_cloudSync_error_icloudUnknown": "Couldn't reach iCloud. Please try again.",
   "settings_cloudSync_error_icloudUnsupported": "iCloud sync isn't available in this build of Submersion. Use S3 sync, or the App Store version.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Not available in this build — use S3 or the App Store version",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud is not available. Please sign in to iCloud in System Settings.",
+  "settings_cloudSync_error_icloudUnknown": "Couldn't reach iCloud. Please try again.",
+  "settings_cloudSync_error_icloudUnsupported": "iCloud sync isn't available in this build of Submersion. Use S3 sync, or the App Store version.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Not available in this build — use S3 or the App Store version",
   "@@locale": "en",
   "settings_cloudSync_replace_globalBanner": "Sync is paused — the library was replaced from a backup on \"{deviceName}\".",
   "@settings_cloudSync_replace_globalBanner": {"placeholders": {"deviceName": {"type": "String"}}},

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud no está disponible. Inicia sesión en iCloud en Ajustes del Sistema.",
+  "settings_cloudSync_error_icloudUnknown": "No se pudo conectar con iCloud. Inténtalo de nuevo.",
+  "settings_cloudSync_error_icloudUnsupported": "La sincronización con iCloud no está disponible en esta versión de Submersion. Usa la sincronización S3 o la versión de la App Store.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "No disponible en esta versión: usa S3 o la versión de la App Store",
   "@@last_modified": "2026-06-15",
   "@@locale": "es",
   "settings_cloudSync_replace_globalBanner": "Sincronización en pausa: la biblioteca se reemplazó desde una copia de seguridad en \"{deviceName}\".",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud no está disponible. Inicia sesión en iCloud en Ajustes del Sistema.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud no está disponible. Inicia sesión en iCloud en los ajustes de tu dispositivo.",
   "settings_cloudSync_error_icloudUnknown": "No se pudo conectar con iCloud. Inténtalo de nuevo.",
   "settings_cloudSync_error_icloudUnsupported": "La sincronización con iCloud no está disponible en esta versión de Submersion. Usa la sincronización S3 o la versión de la App Store.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "No disponible en esta versión: usa S3 o la versión de la App Store",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud n'est pas disponible. Connectez-vous à iCloud dans les Réglages Système.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud n'est pas disponible. Connectez-vous à iCloud dans les réglages de votre appareil.",
   "settings_cloudSync_error_icloudUnknown": "Impossible de joindre iCloud. Veuillez réessayer.",
   "settings_cloudSync_error_icloudUnsupported": "La synchronisation iCloud n'est pas disponible dans cette version de Submersion. Utilisez la synchronisation S3 ou la version de l'App Store.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Indisponible dans cette version — utilisez S3 ou la version de l'App Store",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud n'est pas disponible. Connectez-vous à iCloud dans les Réglages Système.",
+  "settings_cloudSync_error_icloudUnknown": "Impossible de joindre iCloud. Veuillez réessayer.",
+  "settings_cloudSync_error_icloudUnsupported": "La synchronisation iCloud n'est pas disponible dans cette version de Submersion. Utilisez la synchronisation S3 ou la version de l'App Store.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Indisponible dans cette version — utilisez S3 ou la version de l'App Store",
   "@@last_modified": "2026-06-15",
   "@@locale": "fr",
   "settings_cloudSync_replace_globalBanner": "Synchronisation en pause — la bibliothèque a été remplacée depuis une sauvegarde sur \"{deviceName}\".",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המערכת.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המכשיר.",
   "settings_cloudSync_error_icloudUnknown": "לא ניתן היה להגיע ל-iCloud. נסה שוב.",
   "settings_cloudSync_error_icloudUnsupported": "סנכרון iCloud אינו זמין בגרסה זו של Submersion. השתמש בסנכרון S3 או בגרסת App Store.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "לא זמין בגרסה זו — השתמש ב-S3 או בגרסת App Store",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המערכת.",
+  "settings_cloudSync_error_icloudUnknown": "לא ניתן היה להגיע ל-iCloud. נסה שוב.",
+  "settings_cloudSync_error_icloudUnsupported": "סנכרון iCloud אינו זמין בגרסה זו של Submersion. השתמש בסנכרון S3 או בגרסת App Store.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "לא זמין בגרסה זו — השתמש ב-S3 או בגרסת App Store",
   "@@last_modified": "2026-06-15",
   "@@locale": "he",
   "settings_cloudSync_replace_globalBanner": "הסנכרון מושהה — הספרייה הוחלפה מגיבוי במכשיר \"{deviceName}\".",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "Az iCloud nem érhető el. Jelentkezz be az iCloudba a Rendszerbeállításokban.",
+  "settings_cloudSync_error_icloudUnknown": "Nem sikerült elérni az iCloudot. Próbáld újra.",
+  "settings_cloudSync_error_icloudUnsupported": "Az iCloud-szinkronizálás nem érhető el a Submersion ezen buildjében. Használd az S3-szinkronizálást vagy az App Store-verziót.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Ebben a buildben nem érhető el – használj S3-at vagy az App Store-verziót",
   "@@last_modified": "2026-06-15",
   "@@locale": "hu",
   "settings_cloudSync_replace_globalBanner": "A szinkronizálás szünetel — a könyvtárat egy biztonsági másolatból cserélték itt: \"{deviceName}\".",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "Az iCloud nem érhető el. Jelentkezz be az iCloudba a Rendszerbeállításokban.",
+  "settings_cloudSync_error_icloudSignedOut": "Az iCloud nem érhető el. Jelentkezz be az iCloudba a készülék beállításaiban.",
   "settings_cloudSync_error_icloudUnknown": "Nem sikerült elérni az iCloudot. Próbáld újra.",
   "settings_cloudSync_error_icloudUnsupported": "Az iCloud-szinkronizálás nem érhető el a Submersion ezen buildjében. Használd az S3-szinkronizálást vagy az App Store-verziót.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Ebben a buildben nem érhető el – használj S3-at vagy az App Store-verziót",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud non è disponibile. Accedi a iCloud nelle Impostazioni di Sistema.",
+  "settings_cloudSync_error_icloudUnknown": "Impossibile raggiungere iCloud. Riprova.",
+  "settings_cloudSync_error_icloudUnsupported": "La sincronizzazione iCloud non è disponibile in questa build di Submersion. Usa la sincronizzazione S3 o la versione dell'App Store.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Non disponibile in questa build: usa S3 o la versione dell'App Store",
   "@@last_modified": "2026-06-15",
   "@@locale": "it",
   "settings_cloudSync_replace_globalBanner": "Sincronizzazione in pausa: la libreria è stata sostituita da un backup su \"{deviceName}\".",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud non è disponibile. Accedi a iCloud nelle Impostazioni di Sistema.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud non è disponibile. Accedi a iCloud nelle impostazioni del dispositivo.",
   "settings_cloudSync_error_icloudUnknown": "Impossibile raggiungere iCloud. Riprova.",
   "settings_cloudSync_error_icloudUnsupported": "La sincronizzazione iCloud non è disponibile in questa build di Submersion. Usa la sincronizzazione S3 o la versione dell'App Store.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Non disponibile in questa build: usa S3 o la versione dell'App Store",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -119,7 +119,7 @@ abstract class AppLocalizations {
   /// No description provided for @settings_cloudSync_error_icloudSignedOut.
   ///
   /// In en, this message translates to:
-  /// **'iCloud is not available. Please sign in to iCloud in System Settings.'**
+  /// **'iCloud is not available. Please sign in to iCloud in your device settings.'**
   String get settings_cloudSync_error_icloudSignedOut;
 
   /// No description provided for @settings_cloudSync_error_icloudUnknown.

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -116,6 +116,30 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @settings_cloudSync_error_icloudSignedOut.
+  ///
+  /// In en, this message translates to:
+  /// **'iCloud is not available. Please sign in to iCloud in System Settings.'**
+  String get settings_cloudSync_error_icloudSignedOut;
+
+  /// No description provided for @settings_cloudSync_error_icloudUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t reach iCloud. Please try again.'**
+  String get settings_cloudSync_error_icloudUnknown;
+
+  /// No description provided for @settings_cloudSync_error_icloudUnsupported.
+  ///
+  /// In en, this message translates to:
+  /// **'iCloud sync isn\'t available in this build of Submersion. Use S3 sync, or the App Store version.'**
+  String get settings_cloudSync_error_icloudUnsupported;
+
+  /// No description provided for @settings_cloudSync_provider_icloud_unsupportedSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Not available in this build — use S3 or the App Store version'**
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle;
+
   /// No description provided for @settings_cloudSync_replace_globalBanner.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -9,6 +9,22 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات النظام.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'تعذّر الوصول إلى iCloud. حاول مرة أخرى.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'مزامنة iCloud غير متوفرة في هذا الإصدار من Submersion. استخدم مزامنة S3 أو نسخة App Store.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'غير متوفر في هذا الإصدار — استخدم S3 أو نسخة App Store';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'المزامنة متوقفة مؤقتًا — تم استبدال المكتبة من نسخة احتياطية على \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -10,7 +10,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات النظام.';
+      'iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات جهازك.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -10,7 +10,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud ist nicht verfügbar. Bitte melde dich in den Systemeinstellungen bei iCloud an.';
+      'iCloud ist nicht verfügbar. Bitte melde dich in den Geräteeinstellungen bei iCloud an.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -9,6 +9,22 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud ist nicht verfügbar. Bitte melde dich in den Systemeinstellungen bei iCloud an.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'iCloud konnte nicht erreicht werden. Bitte versuche es erneut.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'iCloud-Synchronisierung ist in diesem Build von Submersion nicht verfügbar. Verwende die S3-Synchronisierung oder die App-Store-Version.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'In diesem Build nicht verfügbar – verwende S3 oder die App-Store-Version';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Synchronisierung pausiert — die Bibliothek wurde aus einem Backup auf \"$deviceName\" ersetzt.';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -10,7 +10,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud is not available. Please sign in to iCloud in System Settings.';
+      'iCloud is not available. Please sign in to iCloud in your device settings.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -9,6 +9,22 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud is not available. Please sign in to iCloud in System Settings.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'Couldn\'t reach iCloud. Please try again.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'iCloud sync isn\'t available in this build of Submersion. Use S3 sync, or the App Store version.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'Not available in this build — use S3 or the App Store version';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Sync is paused — the library was replaced from a backup on \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -9,6 +9,22 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud no está disponible. Inicia sesión en iCloud en Ajustes del Sistema.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'No se pudo conectar con iCloud. Inténtalo de nuevo.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'La sincronización con iCloud no está disponible en esta versión de Submersion. Usa la sincronización S3 o la versión de la App Store.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'No disponible en esta versión: usa S3 o la versión de la App Store';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Sincronización en pausa: la biblioteca se reemplazó desde una copia de seguridad en \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -10,7 +10,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud no está disponible. Inicia sesión en iCloud en Ajustes del Sistema.';
+      'iCloud no está disponible. Inicia sesión en iCloud en los ajustes de tu dispositivo.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -10,7 +10,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud n\'est pas disponible. Connectez-vous à iCloud dans les Réglages Système.';
+      'iCloud n\'est pas disponible. Connectez-vous à iCloud dans les réglages de votre appareil.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -9,6 +9,22 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud n\'est pas disponible. Connectez-vous à iCloud dans les Réglages Système.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'Impossible de joindre iCloud. Veuillez réessayer.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'La synchronisation iCloud n\'est pas disponible dans cette version de Submersion. Utilisez la synchronisation S3 ou la version de l\'App Store.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'Indisponible dans cette version — utilisez S3 ou la version de l\'App Store';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Synchronisation en pause — la bibliothèque a été remplacée depuis une sauvegarde sur \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -9,6 +9,22 @@ class AppLocalizationsHe extends AppLocalizations {
   AppLocalizationsHe([String locale = 'he']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המערכת.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'לא ניתן היה להגיע ל-iCloud. נסה שוב.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'סנכרון iCloud אינו זמין בגרסה זו של Submersion. השתמש בסנכרון S3 או בגרסת App Store.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'לא זמין בגרסה זו — השתמש ב-S3 או בגרסת App Store';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'הסנכרון מושהה — הספרייה הוחלפה מגיבוי במכשיר \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -10,7 +10,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המערכת.';
+      'iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המכשיר.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -9,6 +9,22 @@ class AppLocalizationsHu extends AppLocalizations {
   AppLocalizationsHu([String locale = 'hu']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'Az iCloud nem érhető el. Jelentkezz be az iCloudba a Rendszerbeállításokban.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'Nem sikerült elérni az iCloudot. Próbáld újra.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'Az iCloud-szinkronizálás nem érhető el a Submersion ezen buildjében. Használd az S3-szinkronizálást vagy az App Store-verziót.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'Ebben a buildben nem érhető el – használj S3-at vagy az App Store-verziót';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'A szinkronizálás szünetel — a könyvtárat egy biztonsági másolatból cserélték itt: \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -10,7 +10,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'Az iCloud nem érhető el. Jelentkezz be az iCloudba a Rendszerbeállításokban.';
+      'Az iCloud nem érhető el. Jelentkezz be az iCloudba a készülék beállításaiban.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -10,7 +10,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud non è disponibile. Accedi a iCloud nelle Impostazioni di Sistema.';
+      'iCloud non è disponibile. Accedi a iCloud nelle impostazioni del dispositivo.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -9,6 +9,22 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud non è disponibile. Accedi a iCloud nelle Impostazioni di Sistema.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'Impossibile raggiungere iCloud. Riprova.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'La sincronizzazione iCloud non è disponibile in questa build di Submersion. Usa la sincronizzazione S3 o la versione dell\'App Store.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'Non disponibile in questa build: usa S3 o la versione dell\'App Store';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Sincronizzazione in pausa: la libreria è stata sostituita da un backup su \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -10,7 +10,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud is niet beschikbaar. Log in bij iCloud in Systeeminstellingen.';
+      'iCloud is niet beschikbaar. Log in bij iCloud in de instellingen van je apparaat.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -9,6 +9,22 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud is niet beschikbaar. Log in bij iCloud in Systeeminstellingen.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'Kan iCloud niet bereiken. Probeer het opnieuw.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'iCloud-synchronisatie is niet beschikbaar in deze build van Submersion. Gebruik S3-synchronisatie of de App Store-versie.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'Niet beschikbaar in deze build — gebruik S3 of de App Store-versie';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Synchronisatie onderbroken — de bibliotheek is vervangen vanaf een back-up op \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -10,7 +10,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'O iCloud não está disponível. Inicie sessão no iCloud nas Definições do Sistema.';
+      'O iCloud não está disponível. Inicie sessão no iCloud nas definições do seu dispositivo.';
 
   @override
   String get settings_cloudSync_error_icloudUnknown =>

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -9,6 +9,22 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'O iCloud não está disponível. Inicie sessão no iCloud nas Definições do Sistema.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown =>
+      'Não foi possível aceder ao iCloud. Tente novamente.';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      'A sincronização do iCloud não está disponível nesta versão do Submersion. Use a sincronização S3 ou a versão da App Store.';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      'Indisponível nesta versão — use o S3 ou a versão da App Store';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return 'Sincronização em pausa — a biblioteca foi substituída a partir de uma cópia de segurança em \"$deviceName\".';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -9,6 +9,21 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get settings_cloudSync_error_icloudSignedOut =>
+      'iCloud 不可用。请在“系统设置”中登录 iCloud。';
+
+  @override
+  String get settings_cloudSync_error_icloudUnknown => '无法连接 iCloud。请重试。';
+
+  @override
+  String get settings_cloudSync_error_icloudUnsupported =>
+      '此 Submersion 版本不支持 iCloud 同步。请使用 S3 同步或 App Store 版本。';
+
+  @override
+  String get settings_cloudSync_provider_icloud_unsupportedSubtitle =>
+      '此版本不可用 — 请使用 S3 或 App Store 版本';
+
+  @override
   String settings_cloudSync_replace_globalBanner(String deviceName) {
     return '同步已暂停 — 资料库已从 \"$deviceName\" 上的备份替换。';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -10,7 +10,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_cloudSync_error_icloudSignedOut =>
-      'iCloud 不可用。请在“系统设置”中登录 iCloud。';
+      'iCloud 不可用。请在设备设置中登录 iCloud。';
 
   @override
   String get settings_cloudSync_error_icloudUnknown => '无法连接 iCloud。请重试。';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud is niet beschikbaar. Log in bij iCloud in Systeeminstellingen.",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud is niet beschikbaar. Log in bij iCloud in de instellingen van je apparaat.",
   "settings_cloudSync_error_icloudUnknown": "Kan iCloud niet bereiken. Probeer het opnieuw.",
   "settings_cloudSync_error_icloudUnsupported": "iCloud-synchronisatie is niet beschikbaar in deze build van Submersion. Gebruik S3-synchronisatie of de App Store-versie.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Niet beschikbaar in deze build — gebruik S3 of de App Store-versie",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud is niet beschikbaar. Log in bij iCloud in Systeeminstellingen.",
+  "settings_cloudSync_error_icloudUnknown": "Kan iCloud niet bereiken. Probeer het opnieuw.",
+  "settings_cloudSync_error_icloudUnsupported": "iCloud-synchronisatie is niet beschikbaar in deze build van Submersion. Gebruik S3-synchronisatie of de App Store-versie.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Niet beschikbaar in deze build — gebruik S3 of de App Store-versie",
   "@@last_modified": "2026-06-15",
   "@@locale": "nl",
   "settings_cloudSync_replace_globalBanner": "Synchronisatie onderbroken — de bibliotheek is vervangen vanaf een back-up op \"{deviceName}\".",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "O iCloud não está disponível. Inicie sessão no iCloud nas Definições do Sistema.",
+  "settings_cloudSync_error_icloudUnknown": "Não foi possível aceder ao iCloud. Tente novamente.",
+  "settings_cloudSync_error_icloudUnsupported": "A sincronização do iCloud não está disponível nesta versão do Submersion. Use a sincronização S3 ou a versão da App Store.",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Indisponível nesta versão — use o S3 ou a versão da App Store",
   "@@last_modified": "2026-06-15",
   "@@locale": "pt",
   "settings_cloudSync_replace_globalBanner": "Sincronização em pausa — a biblioteca foi substituída a partir de uma cópia de segurança em \"{deviceName}\".",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "O iCloud não está disponível. Inicie sessão no iCloud nas Definições do Sistema.",
+  "settings_cloudSync_error_icloudSignedOut": "O iCloud não está disponível. Inicie sessão no iCloud nas definições do seu dispositivo.",
   "settings_cloudSync_error_icloudUnknown": "Não foi possível aceder ao iCloud. Tente novamente.",
   "settings_cloudSync_error_icloudUnsupported": "A sincronização do iCloud não está disponível nesta versão do Submersion. Use a sincronização S3 ou a versão da App Store.",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "Indisponível nesta versão — use o S3 ou a versão da App Store",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,4 +1,8 @@
 {
+  "settings_cloudSync_error_icloudSignedOut": "iCloud 不可用。请在“系统设置”中登录 iCloud。",
+  "settings_cloudSync_error_icloudUnknown": "无法连接 iCloud。请重试。",
+  "settings_cloudSync_error_icloudUnsupported": "此 Submersion 版本不支持 iCloud 同步。请使用 S3 同步或 App Store 版本。",
+  "settings_cloudSync_provider_icloud_unsupportedSubtitle": "此版本不可用 — 请使用 S3 或 App Store 版本",
   "@@locale": "zh",
   "settings_cloudSync_replace_globalBanner": "同步已暂停 — 资料库已从 \"{deviceName}\" 上的备份替换。",
   "settings_cloudSync_postRestore_syncing": "正在将恢复的资料库与云同步…",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,5 +1,5 @@
 {
-  "settings_cloudSync_error_icloudSignedOut": "iCloud 不可用。请在“系统设置”中登录 iCloud。",
+  "settings_cloudSync_error_icloudSignedOut": "iCloud 不可用。请在设备设置中登录 iCloud。",
   "settings_cloudSync_error_icloudUnknown": "无法连接 iCloud。请重试。",
   "settings_cloudSync_error_icloudUnsupported": "此 Submersion 版本不支持 iCloud 同步。请使用 S3 同步或 App Store 版本。",
   "settings_cloudSync_provider_icloud_unsupportedSubtitle": "此版本不可用 — 请使用 S3 或 App Store 版本",

--- a/macos/Runner/ICloudContainerHandler.swift
+++ b/macos/Runner/ICloudContainerHandler.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import Security
 
 /// Thread-safe atomic flag for one-shot operations.
 private class AtomicFlag {
@@ -77,6 +78,9 @@ class ICloudContainerHandler: NSObject {
             }
             refreshFolder(path: path, result: result)
 
+        case "getICloudAvailability":
+            getICloudAvailability(result: result)
+
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -108,6 +112,35 @@ class ICloudContainerHandler: NSObject {
                 result(FlutterError(code: "TIMEOUT", message: "iCloud container lookup timed out", details: nil))
             }
         }
+    }
+
+    /// Reports iCloud availability without resolving the container URL (which
+    /// can block). Distinguishes a build lacking the iCloud entitlement
+    /// ("unsupported") from a signed-out iCloud account ("signedOut").
+    private func getICloudAvailability(result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let status: String
+            if !self.hasUbiquityEntitlement() {
+                status = "unsupported"
+            } else if FileManager.default.ubiquityIdentityToken == nil {
+                status = "signedOut"
+            } else {
+                status = "available"
+            }
+            DispatchQueue.main.async { result(status) }
+        }
+    }
+
+    /// Whether this process carries the iCloud ubiquity-container entitlement.
+    /// Developer ID / no-sandbox builds do not, so iCloud can never work there.
+    private func hasUbiquityEntitlement() -> Bool {
+        guard let task = SecTaskCreateFromSelf(nil) else { return false }
+        let key = "com.apple.developer.ubiquity-container-identifiers" as CFString
+        let value = SecTaskCopyValueForEntitlement(task, key, nil)
+        if let identifiers = value as? [String] {
+            return !identifiers.isEmpty
+        }
+        return value != nil
     }
 
     private func downloadIfNeeded(path: String, result: @escaping FlutterResult) {

--- a/test/core/services/cloud_storage/icloud_native_service_test.dart
+++ b/test/core/services/cloud_storage/icloud_native_service_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
+
+void main() {
+  group('ICloudNativeService.availabilityFromStatus', () {
+    test('maps "available"', () {
+      expect(
+        ICloudNativeService.availabilityFromStatus('available'),
+        ICloudAvailability.available,
+      );
+    });
+
+    test('maps "signedOut"', () {
+      expect(
+        ICloudNativeService.availabilityFromStatus('signedOut'),
+        ICloudAvailability.signedOut,
+      );
+    });
+
+    test('maps "unsupported"', () {
+      expect(
+        ICloudNativeService.availabilityFromStatus('unsupported'),
+        ICloudAvailability.unsupported,
+      );
+    });
+
+    test('maps an unrecognized string to unknown', () {
+      expect(
+        ICloudNativeService.availabilityFromStatus('wat'),
+        ICloudAvailability.unknown,
+      );
+    });
+
+    test('maps null to unknown', () {
+      expect(
+        ICloudNativeService.availabilityFromStatus(null),
+        ICloudAvailability.unknown,
+      );
+    });
+  });
+}

--- a/test/core/services/cloud_storage/icloud_native_service_test.dart
+++ b/test/core/services/cloud_storage/icloud_native_service_test.dart
@@ -1,7 +1,59 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ICloudNativeService.queryNativeAvailability', () {
+    const channel = MethodChannel('app.submersion/icloud_container');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+    tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    test('invokes getICloudAvailability and maps the native status', () async {
+      String? requested;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        requested = call.method;
+        return 'signedOut';
+      });
+
+      final result = await ICloudNativeService.queryNativeAvailability();
+
+      expect(requested, 'getICloudAvailability');
+      expect(result, ICloudAvailability.signedOut);
+    });
+
+    test('returns unknown when the channel throws', () async {
+      messenger.setMockMethodCallHandler(
+        channel,
+        (call) async => throw PlatformException(code: 'BOOM'),
+      );
+
+      expect(
+        await ICloudNativeService.queryNativeAvailability(),
+        ICloudAvailability.unknown,
+      );
+    });
+
+    test(
+      'getAvailability resolves to a value on the current platform',
+      () async {
+        messenger.setMockMethodCallHandler(
+          channel,
+          (call) async => 'available',
+        );
+        // Non-Apple hosts return unsupported via the platform guard; Apple hosts
+        // delegate to the channel. Either path resolves without throwing.
+        expect(
+          await ICloudNativeService.getAvailability(),
+          isA<ICloudAvailability>(),
+        );
+      },
+    );
+  });
+
   group('ICloudNativeService.availabilityFromStatus', () {
     test('maps "available"', () {
       expect(

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -30,6 +30,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
     show sharedPreferencesProvider;
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/l10n/arb/app_localizations_en.dart';
 
 import '../../../../helpers/fake_cloud_storage_provider.dart';
 import '../../../../helpers/mock_providers.dart';
@@ -324,6 +325,7 @@ void main() {
       syncOnResume: false,
     ),
     ICloudAvailability iCloudAvailability = ICloudAvailability.available,
+    bool applePlatform = true,
   }) async {
     final base = await getBaseOverrides();
     final fakeSync = _FakeSyncNotifier(syncState);
@@ -349,6 +351,7 @@ void main() {
           iCloudAvailabilityProvider.overrideWith(
             (ref) async => iCloudAvailability,
           ),
+          isApplePlatformProvider.overrideWithValue(applePlatform),
           isCloudSyncDisabledByCustomFolderProvider.overrideWithValue(
             customFolderMode,
           ),
@@ -389,6 +392,10 @@ void main() {
   }
 
   group('CloudSyncPage - iCloud availability', () {
+    ListTile iCloudTile(WidgetTester tester) => tester.widget<ListTile>(
+      find.ancestor(of: find.text('iCloud'), matching: find.byType(ListTile)),
+    );
+
     testWidgets('disables the iCloud tile when the build is unsupported', (
       tester,
     ) async {
@@ -397,40 +404,140 @@ void main() {
         iCloudAvailability: ICloudAvailability.unsupported,
       );
 
-      final tile = tester.widget<ListTile>(
-        find.ancestor(of: find.text('iCloud'), matching: find.byType(ListTile)),
-      );
-      expect(tile.enabled, isFalse);
+      expect(iCloudTile(tester).enabled, isFalse);
     });
 
     testWidgets('enables the iCloud tile when available', (tester) async {
       await pumpPage(tester, iCloudAvailability: ICloudAvailability.available);
 
-      final tile = tester.widget<ListTile>(
-        find.ancestor(of: find.text('iCloud'), matching: find.byType(ListTile)),
-      );
-      expect(tile.enabled, isTrue);
+      expect(iCloudTile(tester).enabled, isTrue);
     });
 
-    testWidgets(
-      'shows the build-specific subtitle when unsupported',
-      (tester) async {
-        await pumpPage(
-          tester,
-          iCloudAvailability: ICloudAvailability.unsupported,
-        );
+    testWidgets('shows the build-specific subtitle when unsupported', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        iCloudAvailability: ICloudAvailability.unsupported,
+      );
 
-        expect(
-          find.text(
-            'Not available in this build — use S3 or the App Store version',
-          ),
-          findsOneWidget,
-        );
-      },
-      // The build-vs-platform subtitle wording depends on dart:io Platform,
-      // so the exact text is only asserted on Apple hosts.
-      skip: !(Platform.isIOS || Platform.isMacOS),
-    );
+      expect(
+        find.text(
+          'Not available in this build — use S3 or the App Store version',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('disables with the platform subtitle on non-Apple platforms', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        applePlatform: false,
+        iCloudAvailability: ICloudAvailability.unsupported,
+      );
+
+      expect(iCloudTile(tester).enabled, isFalse);
+      expect(find.text('Not available on this platform'), findsOneWidget);
+    });
+
+    testWidgets('iCloud connection failure shows the signed-out message', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        iCloudAvailability: ICloudAvailability.signedOut,
+        cloudProvider: _ThrowingCloudStorageProvider(),
+      );
+
+      await tester.tap(find.text('iCloud'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'iCloud is not available. Please sign in to iCloud in your '
+          'device settings.',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('connectionErrorMessage', () {
+    final l10n = AppLocalizationsEn();
+
+    test('iCloud unsupported maps to the unsupported message', () {
+      expect(
+        connectionErrorMessage(
+          l10n,
+          CloudProviderType.icloud,
+          ICloudAvailability.unsupported,
+          'iCloud',
+          'err',
+        ),
+        l10n.settings_cloudSync_error_icloudUnsupported,
+      );
+    });
+
+    test('iCloud signedOut maps to the signed-out message', () {
+      expect(
+        connectionErrorMessage(
+          l10n,
+          CloudProviderType.icloud,
+          ICloudAvailability.signedOut,
+          'iCloud',
+          'err',
+        ),
+        l10n.settings_cloudSync_error_icloudSignedOut,
+      );
+    });
+
+    test('iCloud unknown maps to the unknown message', () {
+      expect(
+        connectionErrorMessage(
+          l10n,
+          CloudProviderType.icloud,
+          ICloudAvailability.unknown,
+          'iCloud',
+          'err',
+        ),
+        l10n.settings_cloudSync_error_icloudUnknown,
+      );
+    });
+
+    test('iCloud null availability maps to the unknown message', () {
+      expect(
+        connectionErrorMessage(
+          l10n,
+          CloudProviderType.icloud,
+          null,
+          'iCloud',
+          'err',
+        ),
+        l10n.settings_cloudSync_error_icloudUnknown,
+      );
+    });
+
+    test('available iCloud falls back to the generic message', () {
+      expect(
+        connectionErrorMessage(
+          l10n,
+          CloudProviderType.icloud,
+          ICloudAvailability.available,
+          'iCloud',
+          'boom',
+        ),
+        l10n.settings_cloudSync_provider_connectionFailed('iCloud', 'boom'),
+      );
+    });
+
+    test('non-iCloud provider uses the generic message', () {
+      expect(
+        connectionErrorMessage(l10n, CloudProviderType.s3, null, 'S3', 'boom'),
+        l10n.settings_cloudSync_provider_connectionFailed('S3', 'boom'),
+      );
+    });
   });
 
   group('CloudSyncPage - base render', () {

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType, SyncRepository;
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
@@ -322,6 +323,7 @@ void main() {
       syncOnLaunch: false,
       syncOnResume: false,
     ),
+    ICloudAvailability iCloudAvailability = ICloudAvailability.available,
   }) async {
     final base = await getBaseOverrides();
     final fakeSync = _FakeSyncNotifier(syncState);
@@ -343,6 +345,9 @@ void main() {
           ),
           selectedCloudProviderTypeProvider.overrideWith(
             (ref) => selectedProvider,
+          ),
+          iCloudAvailabilityProvider.overrideWith(
+            (ref) async => iCloudAvailability,
           ),
           isCloudSyncDisabledByCustomFolderProvider.overrideWithValue(
             customFolderMode,
@@ -382,6 +387,51 @@ void main() {
     }
     return (sync: fakeSync, merge: fakeMerge, backup: fakeBackup);
   }
+
+  group('CloudSyncPage - iCloud availability', () {
+    testWidgets('disables the iCloud tile when the build is unsupported', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        iCloudAvailability: ICloudAvailability.unsupported,
+      );
+
+      final tile = tester.widget<ListTile>(
+        find.ancestor(of: find.text('iCloud'), matching: find.byType(ListTile)),
+      );
+      expect(tile.enabled, isFalse);
+    });
+
+    testWidgets('enables the iCloud tile when available', (tester) async {
+      await pumpPage(tester, iCloudAvailability: ICloudAvailability.available);
+
+      final tile = tester.widget<ListTile>(
+        find.ancestor(of: find.text('iCloud'), matching: find.byType(ListTile)),
+      );
+      expect(tile.enabled, isTrue);
+    });
+
+    testWidgets(
+      'shows the build-specific subtitle when unsupported',
+      (tester) async {
+        await pumpPage(
+          tester,
+          iCloudAvailability: ICloudAvailability.unsupported,
+        );
+
+        expect(
+          find.text(
+            'Not available in this build — use S3 or the App Store version',
+          ),
+          findsOneWidget,
+        );
+      },
+      // The build-vs-platform subtitle wording depends on dart:io Platform,
+      // so the exact text is only asserted on Apple hosts.
+      skip: !(Platform.isIOS || Platform.isMacOS),
+    );
+  });
 
   group('CloudSyncPage - base render', () {
     testWidgets('renders app bar, provider tiles, and sections', (


### PR DESCRIPTION
## Summary
- macOS **Developer ID / no-sandbox** (GitHub-distribution) builds cannot use iCloud — Apple restricts iCloud entitlements to App Store + development signing — yet the iCloud sync tile was gated only by platform, so it offered an option it could never fulfill and then showed a misleading "Please sign in to iCloud" error even when the user *was* signed in.
- Adds a non-blocking native `getICloudAvailability`. On **macOS** it reports `available | signedOut | unsupported` from the running binary's real iCloud entitlement (`SecTaskCopyValueForEntitlement` on `ubiquity-container-identifiers`) plus `ubiquityIdentityToken`. On **iOS** it reports `available | signedOut` from `ubiquityIdentityToken` only — iOS is always provisioned with its entitlement and the `SecTask*` entitlement APIs are macOS-only, so there is no `unsupported` state on iOS. Surfaced through `iCloudAvailabilityProvider`.
- The Cloud Sync page gates the iCloud tile by real capability (`isApplePlatformProvider` + the availability state) — disabled with an honest subtitle in unsupported builds — and shows status-accurate, **localized** connection-failure messages. New strings translated across all 11 locales.

## Test Plan
- [x] Unit: status→enum mapping, `queryNativeAvailability` (channel mock), and the pure `connectionErrorMessage` (all branches) — host-independent
- [x] Widget: iCloud tile enabled/disabled + subtitle (Apple vs non-Apple) and the connection-failure message path
- [x] `flutter analyze` clean, `dart format` clean, macOS + iOS apps build, ~96% patch coverage on the changed files
- [x] Device: no-sandbox build shows disabled iCloud tile (+ S3 works); sandboxed dev build connects when signed in and shows the correct sign-in message when signed out; iPhone connects (regression)