### PR TITLE
fix(secure-storage): retry on legacy keychain for ad-hoc no-sandbox build

### DIFF
--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -23,5 +23,7 @@
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.application-groups</key>
 	<array/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/lib/core/services/cloud_storage/s3/s3_credentials_store.dart
+++ b/lib/core/services/cloud_storage/s3/s3_credentials_store.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
 
 /// Persists the S3 sync configuration -- secrets included -- as a single
 /// JSON blob in the platform keychain. One blob keeps load/save atomic;
@@ -11,16 +12,19 @@ import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 ///
 /// A corrupt blob is left in place rather than deleted, so a transient
 /// decode bug cannot destroy credentials; save() simply overwrites it.
+///
+/// Keychain access goes through [FallbackSecureStorage], which retries on the
+/// legacy keychain when the ad-hoc no-sandbox build has no access group.
 class S3CredentialsStore {
   S3CredentialsStore({FlutterSecureStorage? storage})
-    : _storage = storage ?? const FlutterSecureStorage();
+    : _storage = FallbackSecureStorage(storage ?? const FlutterSecureStorage());
 
-  final FlutterSecureStorage _storage;
+  final FallbackSecureStorage _storage;
 
   static const String storageKey = 'sync_s3_config';
 
-  /// The stored config, or null when unset or the stored blob is corrupt;
-  /// platform keychain errors propagate.
+  /// The stored config, or null when unset or the stored blob is corrupt.
+  /// Keychain errors other than a missing entitlement propagate.
   Future<S3Config?> load() async {
     final raw = await _storage.read(key: storageKey);
     if (raw == null) return null;

--- a/lib/core/services/secure_storage/fallback_secure_storage.dart
+++ b/lib/core/services/secure_storage/fallback_secure_storage.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// A thin wrapper over [FlutterSecureStorage] that transparently retries on
+/// the macOS legacy (file-based) keychain when the default data-protection
+/// keychain reports `errSecMissingEntitlement` (-34018).
+///
+/// That status occurs on the ad-hoc-signed no-sandbox (GitHub-distribution)
+/// build, whose signature carries no team `application-identifier` and hence
+/// no keychain access group. Sandboxed / team-signed / iOS builds never hit
+/// it, so the first attempt -- byte-identical to a plain [FlutterSecureStorage]
+/// call -- succeeds and no fallback runs. `mOptions` is ignored on non-macOS
+/// platforms, so wrapping is cross-platform-safe.
+///
+/// Only the missing-entitlement status triggers the retry; every other
+/// keychain error propagates, so a locked keychain is never misread.
+class FallbackSecureStorage {
+  FallbackSecureStorage(this._storage);
+
+  final FlutterSecureStorage _storage;
+
+  /// `errSecMissingEntitlement` -- "a required entitlement isn't present".
+  static const int _errSecMissingEntitlement = -34018;
+
+  /// Selects the legacy file-based keychain on the retry.
+  static const MacOsOptions _legacyKeychain = MacOsOptions(
+    usesDataProtectionKeychain: false,
+  );
+
+  Future<String?> read({required String key}) => _withFallback(
+    () => _storage.read(key: key),
+    () => _storage.read(key: key, mOptions: _legacyKeychain),
+  );
+
+  Future<void> write({required String key, required String value}) =>
+      _withFallback(
+        () => _storage.write(key: key, value: value),
+        () => _storage.write(key: key, value: value, mOptions: _legacyKeychain),
+      );
+
+  Future<void> delete({required String key}) => _withFallback(
+    () => _storage.delete(key: key),
+    () => _storage.delete(key: key, mOptions: _legacyKeychain),
+  );
+
+  /// Runs [primary] (the default data-protection keychain) and, only when it
+  /// throws `errSecMissingEntitlement`, runs [legacy] (the file-based
+  /// keychain) instead. The first attempt is awaited so its [PlatformException]
+  /// surfaces inside the try rather than escaping as a rejected future.
+  Future<T> _withFallback<T>(
+    Future<T> Function() primary,
+    Future<T> Function() legacy,
+  ) async {
+    try {
+      return await primary();
+    } on PlatformException catch (e) {
+      if (e.details == _errSecMissingEntitlement) {
+        return legacy();
+      }
+      rethrow;
+    }
+  }
+}

--- a/lib/features/media/data/services/local_bookmark_storage.dart
+++ b/lib/features/media/data/services/local_bookmark_storage.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
 
 /// Persists iOS / macOS security-scoped bookmark blobs in the platform
 /// keychain via flutter_secure_storage.
@@ -20,10 +21,10 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// use the current bookmark-bytes resolution flow rather than the older
 /// `resolveBookmark()` session-based API.
 class LocalBookmarkStorage {
-  final FlutterSecureStorage _storage;
+  final FallbackSecureStorage _storage;
 
   LocalBookmarkStorage({FlutterSecureStorage? storage})
-    : _storage = storage ?? const FlutterSecureStorage();
+    : _storage = FallbackSecureStorage(storage ?? const FlutterSecureStorage());
 
   static String _key(String bookmarkRef) => 'bookmark:$bookmarkRef';
 

--- a/lib/features/media/data/services/network_credentials_service.dart
+++ b/lib/features/media/data/services/network_credentials_service.dart
@@ -20,6 +20,7 @@ import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
 import 'package:submersion/features/media/data/repositories/network_credentials_repository.dart';
 
 class NetworkCredentialsService {
@@ -27,10 +28,10 @@ class NetworkCredentialsService {
     required NetworkCredentialsRepository repository,
     required FlutterSecureStorage storage,
   }) : _repo = repository,
-       _storage = storage;
+       _storage = FallbackSecureStorage(storage);
 
   final NetworkCredentialsRepository _repo;
-  final FlutterSecureStorage _storage;
+  final FallbackSecureStorage _storage;
 
   /// Per-process cache of resolved (hostname -> headers) so repeated
   /// `headersFor` calls during a single bulk-import or scan don't hit

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -37,5 +37,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -33,5 +33,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/macos/Runner/ReleaseNoSandbox.entitlements
+++ b/macos/Runner/ReleaseNoSandbox.entitlements
@@ -25,5 +25,13 @@
 	<!-- Photo library access for attaching dive photos -->
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
+
+	<!-- Keychain access for flutter_secure_storage (S3 sync credentials). -->
+	<!-- This ad-hoc signature has no team prefix, so the data-protection -->
+	<!-- keychain is unavailable here and S3CredentialsStore falls back to -->
+	<!-- the legacy file-based keychain at runtime. Declared for parity and -->
+	<!-- in case this build is ever re-signed with a Developer ID identity. -->
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/test/core/services/cloud_storage/s3/s3_credentials_store_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_credentials_store_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
@@ -62,6 +65,106 @@ class _ThrowingSecureStorage extends Fake implements FlutterSecureStorage {
   }) async => throw Exception('keychain locked');
 }
 
+/// Simulates an ad-hoc-signed, no-sandbox macOS build: the data-protection
+/// keychain returns `errSecMissingEntitlement` (-34018) because the binary
+/// carries no keychain access group, while the legacy file-based keychain
+/// works. Lets the tests prove [S3CredentialsStore] retries on the legacy
+/// keychain.
+class _NoEntitlementSecureStorage extends Fake implements FlutterSecureStorage {
+  /// Backing store standing in for the legacy (file-based) keychain.
+  final Map<String, String> legacy = {};
+
+  /// Set once the data-protection keychain has been attempted, proving the
+  /// store prefers the secure keychain before falling back.
+  bool dataProtectionAttempted = false;
+
+  static const int _errSecMissingEntitlement = -34018;
+
+  bool _usesDataProtection(AppleOptions? mOptions) =>
+      (mOptions as MacOsOptions?)?.usesDataProtectionKeychain ?? true;
+
+  PlatformException _missingEntitlement() => PlatformException(
+    code: 'Unexpected security result code',
+    message: "A required entitlement isn't present.",
+    details: _errSecMissingEntitlement,
+  );
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (_usesDataProtection(mOptions)) {
+      dataProtectionAttempted = true;
+      throw _missingEntitlement();
+    }
+    return legacy[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (_usesDataProtection(mOptions)) {
+      dataProtectionAttempted = true;
+      throw _missingEntitlement();
+    }
+    if (value == null) {
+      legacy.remove(key);
+    } else {
+      legacy[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (_usesDataProtection(mOptions)) {
+      dataProtectionAttempted = true;
+      throw _missingEntitlement();
+    }
+    legacy.remove(key);
+  }
+}
+
+/// Throws a keychain [PlatformException] whose status is NOT the
+/// missing-entitlement code, proving the fallback rethrows it untouched.
+class _OtherSecurityErrorStorage extends Fake implements FlutterSecureStorage {
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => throw PlatformException(
+    code: 'Unexpected security result code',
+    message: 'interaction not allowed',
+    details: -25308, // errSecInteractionNotAllowed
+  );
+}
+
 void main() {
   late _MemorySecureStorage storage;
   late S3CredentialsStore store;
@@ -117,5 +220,52 @@ void main() {
   test('storage errors propagate to the caller', () async {
     final throwingStore = S3CredentialsStore(storage: _ThrowingSecureStorage());
     expect(throwingStore.load(), throwsA(isA<Exception>()));
+  });
+
+  group('keychain entitlement fallback', () {
+    test('load falls back to the legacy keychain when the data-protection '
+        'keychain reports errSecMissingEntitlement', () async {
+      final storage = _NoEntitlementSecureStorage();
+      storage.legacy[S3CredentialsStore.storageKey] = jsonEncode(
+        config().toJson(),
+      );
+      final fallbackStore = S3CredentialsStore(storage: storage);
+
+      final loaded = await fallbackStore.load();
+
+      expect(
+        storage.dataProtectionAttempted,
+        isTrue,
+        reason: 'the secure keychain must be tried before the legacy one',
+      );
+      expect(loaded, isNotNull);
+      expect(loaded!.bucket, 'dive-sync');
+    });
+
+    test(
+      'save falls back to the legacy keychain on errSecMissingEntitlement',
+      () async {
+        final storage = _NoEntitlementSecureStorage();
+        final fallbackStore = S3CredentialsStore(storage: storage);
+
+        await fallbackStore.save(config());
+
+        expect(
+          storage.legacy.containsKey(S3CredentialsStore.storageKey),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'a non-entitlement PlatformException is not swallowed by the fallback',
+      () async {
+        final failingStore = S3CredentialsStore(
+          storage: _OtherSecurityErrorStorage(),
+        );
+
+        expect(failingStore.load(), throwsA(isA<PlatformException>()));
+      },
+    );
   });
 }

--- a/test/core/services/cloud_storage/s3/s3_credentials_store_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_credentials_store_test.dart
@@ -6,52 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 
-class _MemorySecureStorage extends Fake implements FlutterSecureStorage {
-  final Map<String, String> values = {};
+import '../../../../support/fake_keychain_storage.dart';
 
-  @override
-  Future<String?> read({
-    required String key,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => values[key];
-
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      values.remove(key);
-    } else {
-      values[key] = value;
-    }
-  }
-
-  @override
-  Future<void> delete({
-    required String key,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    values.remove(key);
-  }
-}
-
+/// Throws a generic (non-[PlatformException]) error, proving the fallback only
+/// intercepts keychain platform errors and lets everything else propagate.
 class _ThrowingSecureStorage extends Fake implements FlutterSecureStorage {
   @override
   Future<String?> read({
@@ -65,112 +23,12 @@ class _ThrowingSecureStorage extends Fake implements FlutterSecureStorage {
   }) async => throw Exception('keychain locked');
 }
 
-/// Simulates an ad-hoc-signed, no-sandbox macOS build: the data-protection
-/// keychain returns `errSecMissingEntitlement` (-34018) because the binary
-/// carries no keychain access group, while the legacy file-based keychain
-/// works. Lets the tests prove [S3CredentialsStore] retries on the legacy
-/// keychain.
-class _NoEntitlementSecureStorage extends Fake implements FlutterSecureStorage {
-  /// Backing store standing in for the legacy (file-based) keychain.
-  final Map<String, String> legacy = {};
-
-  /// Set once the data-protection keychain has been attempted, proving the
-  /// store prefers the secure keychain before falling back.
-  bool dataProtectionAttempted = false;
-
-  static const int _errSecMissingEntitlement = -34018;
-
-  bool _usesDataProtection(AppleOptions? mOptions) =>
-      (mOptions as MacOsOptions?)?.usesDataProtectionKeychain ?? true;
-
-  PlatformException _missingEntitlement() => PlatformException(
-    code: 'Unexpected security result code',
-    message: "A required entitlement isn't present.",
-    details: _errSecMissingEntitlement,
-  );
-
-  @override
-  Future<String?> read({
-    required String key,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (_usesDataProtection(mOptions)) {
-      dataProtectionAttempted = true;
-      throw _missingEntitlement();
-    }
-    return legacy[key];
-  }
-
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (_usesDataProtection(mOptions)) {
-      dataProtectionAttempted = true;
-      throw _missingEntitlement();
-    }
-    if (value == null) {
-      legacy.remove(key);
-    } else {
-      legacy[key] = value;
-    }
-  }
-
-  @override
-  Future<void> delete({
-    required String key,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (_usesDataProtection(mOptions)) {
-      dataProtectionAttempted = true;
-      throw _missingEntitlement();
-    }
-    legacy.remove(key);
-  }
-}
-
-/// Throws a keychain [PlatformException] whose status is NOT the
-/// missing-entitlement code, proving the fallback rethrows it untouched.
-class _OtherSecurityErrorStorage extends Fake implements FlutterSecureStorage {
-  @override
-  Future<String?> read({
-    required String key,
-    AppleOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    AppleOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => throw PlatformException(
-    code: 'Unexpected security result code',
-    message: 'interaction not allowed',
-    details: -25308, // errSecInteractionNotAllowed
-  );
-}
-
 void main() {
-  late _MemorySecureStorage storage;
+  late InMemoryKeychain storage;
   late S3CredentialsStore store;
 
   setUp(() {
-    storage = _MemorySecureStorage();
+    storage = InMemoryKeychain();
     store = S3CredentialsStore(storage: storage);
   });
 
@@ -225,7 +83,7 @@ void main() {
   group('keychain entitlement fallback', () {
     test('load falls back to the legacy keychain when the data-protection '
         'keychain reports errSecMissingEntitlement', () async {
-      final storage = _NoEntitlementSecureStorage();
+      final storage = NoEntitlementKeychain();
       storage.legacy[S3CredentialsStore.storageKey] = jsonEncode(
         config().toJson(),
       );
@@ -245,7 +103,7 @@ void main() {
     test(
       'save falls back to the legacy keychain on errSecMissingEntitlement',
       () async {
-        final storage = _NoEntitlementSecureStorage();
+        final storage = NoEntitlementKeychain();
         final fallbackStore = S3CredentialsStore(storage: storage);
 
         await fallbackStore.save(config());
@@ -261,7 +119,7 @@ void main() {
       'a non-entitlement PlatformException is not swallowed by the fallback',
       () async {
         final failingStore = S3CredentialsStore(
-          storage: _OtherSecurityErrorStorage(),
+          storage: FailingKeychain(-25308),
         );
 
         expect(failingStore.load(), throwsA(isA<PlatformException>()));

--- a/test/core/services/secure_storage/fallback_secure_storage_test.dart
+++ b/test/core/services/secure_storage/fallback_secure_storage_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
+
+import '../../../support/fake_keychain_storage.dart';
+
+void main() {
+  test(
+    'read returns the primary keychain value without falling back',
+    () async {
+      final inner = InMemoryKeychain()..values['k'] = 'v';
+      final storage = FallbackSecureStorage(inner);
+
+      expect(await storage.read(key: 'k'), 'v');
+    },
+  );
+
+  test(
+    'read falls back to the legacy keychain on errSecMissingEntitlement',
+    () async {
+      final inner = NoEntitlementKeychain()..legacy['k'] = 'v';
+      final storage = FallbackSecureStorage(inner);
+
+      expect(await storage.read(key: 'k'), 'v');
+      expect(inner.dataProtectionAttempted, isTrue);
+    },
+  );
+
+  test(
+    'write falls back to the legacy keychain on errSecMissingEntitlement',
+    () async {
+      final inner = NoEntitlementKeychain();
+      final storage = FallbackSecureStorage(inner);
+
+      await storage.write(key: 'k', value: 'v');
+
+      expect(inner.legacy['k'], 'v');
+    },
+  );
+
+  test(
+    'delete falls back to the legacy keychain on errSecMissingEntitlement',
+    () async {
+      final inner = NoEntitlementKeychain()..legacy['k'] = 'v';
+      final storage = FallbackSecureStorage(inner);
+
+      await storage.delete(key: 'k');
+
+      expect(inner.legacy.containsKey('k'), isFalse);
+    },
+  );
+
+  test('a non-entitlement PlatformException propagates unchanged', () async {
+    final storage = FallbackSecureStorage(FailingKeychain(-25308));
+
+    expect(storage.read(key: 'k'), throwsA(isA<PlatformException>()));
+  });
+}

--- a/test/features/media/data/services/local_bookmark_storage_test.dart
+++ b/test/features/media/data/services/local_bookmark_storage_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 
+import '../../../../support/fake_keychain_storage.dart';
 import 'local_bookmark_storage_test.mocks.dart';
 
 @GenerateMocks([FlutterSecureStorage])
@@ -52,4 +53,18 @@ void main() {
     await subject.delete('ref-1');
     verify(mockStorage.delete(key: 'bookmark:ref-1')).called(1);
   });
+
+  test(
+    'write/read fall back to the legacy keychain on errSecMissingEntitlement',
+    () async {
+      final inner = NoEntitlementKeychain();
+      final fallbackSubject = LocalBookmarkStorage(storage: inner);
+
+      await fallbackSubject.write('ref-1', Uint8List.fromList([1, 2, 3]));
+      final blob = await fallbackSubject.read('ref-1');
+
+      expect(inner.dataProtectionAttempted, isTrue);
+      expect(blob, [1, 2, 3]);
+    },
+  );
 }

--- a/test/features/media/data/services/network_credentials_service_test.dart
+++ b/test/features/media/data/services/network_credentials_service_test.dart
@@ -21,6 +21,7 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/media/data/repositories/network_credentials_repository.dart';
 import 'package:submersion/features/media/data/services/network_credentials_service.dart';
 
+import '../../../../support/fake_keychain_storage.dart';
 import 'network_credentials_service_test.mocks.dart';
 
 @GenerateMocks([FlutterSecureStorage, NetworkCredentialsRepository])
@@ -291,6 +292,39 @@ void main() {
       );
       expect(headers, isNull);
       verify(storage.delete(key: 'media_network_cred_example.com')).called(1);
+    },
+  );
+
+  test(
+    'save+headersFor fall back to the legacy keychain on errSecMissingEntitlement',
+    () async {
+      final inner = NoEntitlementKeychain();
+      final fallbackService = NetworkCredentialsService(
+        repository: repo,
+        storage: inner,
+      );
+      when(
+        repo.upsert(
+          hostname: anyNamed('hostname'),
+          authType: anyNamed('authType'),
+          displayName: anyNamed('displayName'),
+        ),
+      ).thenAnswer((_) async => 'host-id-1');
+      when(
+        repo.findByHostname('example.com'),
+      ).thenAnswer((_) async => host(authType: 'bearer'));
+
+      await fallbackService.save(
+        hostname: 'example.com',
+        authType: 'bearer',
+        token: 't',
+      );
+      final headers = await fallbackService.headersFor(
+        Uri.parse('https://example.com/x'),
+      );
+
+      expect(inner.dataProtectionAttempted, isTrue);
+      expect(headers?['Authorization'], 'Bearer t');
     },
   );
 }

--- a/test/support/fake_keychain_storage.dart
+++ b/test/support/fake_keychain_storage.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 const int kErrSecMissingEntitlement = -34018;
 
 bool _usesDataProtection(AppleOptions? mOptions) =>
-    (mOptions as MacOsOptions?)?.usesDataProtectionKeychain ?? true;
+    mOptions is MacOsOptions ? mOptions.usesDataProtectionKeychain : true;
 
 /// An in-memory keychain that ignores `mOptions` -- both keychains behave
 /// identically, modelling a normally-entitled build where no fallback runs.

--- a/test/support/fake_keychain_storage.dart
+++ b/test/support/fake_keychain_storage.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// `errSecMissingEntitlement` -- the macOS Security framework status the
+/// ad-hoc-signed no-sandbox build provokes from the data-protection keychain.
+const int kErrSecMissingEntitlement = -34018;
+
+bool _usesDataProtection(AppleOptions? mOptions) =>
+    (mOptions as MacOsOptions?)?.usesDataProtectionKeychain ?? true;
+
+/// An in-memory keychain that ignores `mOptions` -- both keychains behave
+/// identically, modelling a normally-entitled build where no fallback runs.
+class InMemoryKeychain extends Fake implements FlutterSecureStorage {
+  final Map<String, String> values = {};
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => values[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    values.remove(key);
+  }
+}
+
+/// Models the ad-hoc-signed no-sandbox macOS build: the data-protection
+/// keychain (default / `usesDataProtectionKeychain: true`) throws
+/// `errSecMissingEntitlement`, while the legacy keychain
+/// (`usesDataProtectionKeychain: false`) works against [legacy].
+class NoEntitlementKeychain extends Fake implements FlutterSecureStorage {
+  /// Backing store standing in for the legacy (file-based) keychain.
+  final Map<String, String> legacy = {};
+
+  /// Set once the data-protection keychain has been attempted, proving the
+  /// caller tries the secure keychain before falling back.
+  bool dataProtectionAttempted = false;
+
+  PlatformException _missing() => PlatformException(
+    code: 'Unexpected security result code',
+    message: "A required entitlement isn't present.",
+    details: kErrSecMissingEntitlement,
+  );
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (_usesDataProtection(mOptions)) {
+      dataProtectionAttempted = true;
+      throw _missing();
+    }
+    return legacy[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (_usesDataProtection(mOptions)) {
+      dataProtectionAttempted = true;
+      throw _missing();
+    }
+    if (value == null) {
+      legacy.remove(key);
+    } else {
+      legacy[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (_usesDataProtection(mOptions)) {
+      dataProtectionAttempted = true;
+      throw _missing();
+    }
+    legacy.remove(key);
+  }
+}
+
+/// A keychain that always throws a [PlatformException] carrying [status] on
+/// read -- used to verify that errors other than the missing entitlement
+/// propagate unchanged.
+class FailingKeychain extends Fake implements FlutterSecureStorage {
+  FailingKeychain(this.status);
+
+  final int status;
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => throw PlatformException(
+    code: 'Unexpected security result code',
+    message: 'interaction not allowed',
+    details: status,
+  );
+}


### PR DESCRIPTION
## Problem

Configuring S3 sync on the macOS **no-sandbox GitHub-distribution build** fails with:

> Could not access secure storage: PlatformException(Unexpected security result code, Code: -34018, Message: A required entitlement isn't present., -34018, null)

`-34018` is `errSecMissingEntitlement`. The no-sandbox build is **ad-hoc signed** (`scripts/release/build_nosandbox_macos.sh` -> `codesign --sign -`), so it has no team `application-identifier` and therefore no keychain access group. `flutter_secure_storage` v10 defaults macOS to the **data-protection keychain**, which refuses access without an access group, so every `read`/`write`/`delete` returns `-34018`.

This broke S3 credential storage (the designated sync path for that build) and would equally affect the media bookmark / network-credential stores, which use the same plugin.

## Fix

1. **`FallbackSecureStorage` decorator** (`lib/core/services/secure_storage/`): tries the default keychain, and **only** on `PlatformException.details == -34018` retries the same operation against the legacy file-based keychain (`MacOsOptions(usesDataProtectionKeychain: false)`), which ad-hoc non-sandboxed apps can use. Every other keychain error propagates unchanged, preserving the "locked keychain != not configured" invariant. The first attempt is a plain call (no `mOptions`), so the success path is byte-identical to before. Wired into `S3CredentialsStore`, `LocalBookmarkStorage`, and `NetworkCredentialsService`.
2. **`keychain-access-groups`** (empty `<array/>`) declared in all four entitlements files (macOS Debug/Release/ReleaseNoSandbox + iOS Runner) -- the plugin's required setup, so the data-protection keychain works on team-signed / App Store / iOS builds.

## Tests

- `FallbackSecureStorage`: 5 unit tests (primary success; -34018 fallback on read/write/delete; non-entitlement error propagates) -- TDD RED->GREEN.
- One fallback wiring test per store (S3, bookmark, network) proving each routes through the decorator.
- Reusable Fake keychain kit in `test/support/fake_keychain_storage.dart`.
- All 32 affected tests pass; `flutter analyze` clean; `dart format` clean.

## Verification

- Unit-tested + analyze clean.
- **Device verification pending**: build via `scripts/release/build_nosandbox_macos.sh`, confirm S3 save/load works with no `-34018`, and regression-check the sandboxed `flutter run -d macos` build + iPhone.

## Notes

Independent of the iCloud-tile-UX work (#337) -- based on `main`. That branch's design doc carries a note explaining this fix is a prerequisite for its "use S3 instead of iCloud" remediation.