### PR TITLE
fix(macos): drop keychain-access-groups from no-sandbox DMG entitlements (fixes launch crash)

### DIFF
--- a/macos/Runner/ReleaseNoSandbox.entitlements
+++ b/macos/Runner/ReleaseNoSandbox.entitlements
@@ -26,12 +26,18 @@
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 
-	<!-- Keychain access for flutter_secure_storage (S3 sync credentials). -->
-	<!-- This ad-hoc signature has no team prefix, so the data-protection -->
-	<!-- keychain is unavailable here and S3CredentialsStore falls back to -->
-	<!-- the legacy file-based keychain at runtime. Declared for parity and -->
-	<!-- in case this build is ever re-signed with a Developer ID identity. -->
-	<key>keychain-access-groups</key>
-	<array/>
+	<!-- IMPORTANT: do NOT add `keychain-access-groups` to this file. -->
+	<!-- CI (.github/workflows/release.yml) signs this DMG with a Developer ID -->
+	<!-- identity + hardened runtime and NO provisioning profile. In that mode -->
+	<!-- keychain-access-groups is a restricted entitlement AMFI cannot -->
+	<!-- authorize, so launchd refuses to spawn the app ("Launchd job spawn -->
+	<!-- failed", POSIX 163). An empty <array/> here shipped in v1.5.2 (build -->
+	<!-- 99) and made the app fail to launch on macOS. -->
+	<!-- It also grants no usable keychain group: S3 sync credentials on this -->
+	<!-- build are stored via flutter_secure_storage's legacy file-based -->
+	<!-- keychain (FallbackSecureStorage), which needs no access group on a -->
+	<!-- non-sandboxed app. The sandboxed App Store (Release.entitlements) and -->
+	<!-- iOS builds DO declare keychain-access-groups, where their provisioning -->
+	<!-- profile authorizes it. -->
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

The macOS **GitHub-distribution DMG** of v1.5.2 (build 99) failed to launch on macOS — `open` reports `RBSRequestErrorDomain Code=5 "Launch failed"` → `NSPOSIXErrorDomain Code=163 "Launchd job spawn failed"`, with no crash report (the process is never spawned). This removes the entitlement that causes it.

## Root cause

#340 added an empty `keychain-access-groups` `<array/>` to all entitlements files. The GitHub DMG is signed in CI (`.github/workflows/release.yml`, Pass 2) with a **Developer ID Application** identity + **hardened runtime** and **no provisioning profile**. In that configuration `keychain-access-groups` is a *restricted* entitlement AMFI cannot authorize, so **launchd refuses to spawn the app**.

The entitlements comment assumed this build is *ad-hoc* signed ("…in case this build is ever re-signed with a Developer ID identity") — but CI already signs it with Developer ID + hardened runtime. That mismatch is how the regression shipped. App Store `Release`, `DebugProfile`, and iOS `Runner` carry a provisioning profile that authorizes the entitlement, so they were unaffected.

## Evidence

Forensics on the actual failing DMG (release run artifact):
- Embedded entitlements: `keychain-access-groups = ()` (empty), `flags=0x10000(runtime)`, `Authority=Developer ID Application`, **no embedded provisioning profile**. Signature valid + notarized + Gatekeeper-accepted — so not a Gatekeeper/notarization issue.
- Running the inner binary directly from a terminal works (bypasses launchd's standalone enforcement), which masked the bug.
- **Isolation test:** the same bundle signed two ways differing only in this key → **with** it `open` fails (spawn denied); **without** it the app launches. Single-variable confirmation.

## Fix

Remove `keychain-access-groups` from `macos/Runner/ReleaseNoSandbox.entitlements` only, and replace the stale comment with one explaining why it must not be re-added.

**Storage-neutral:** the empty array never provided a usable keychain group, so S3 credentials on this build were already stored via `flutter_secure_storage`'s legacy file-based keychain (`FallbackSecureStorage`, #340). `keychain-access-groups` is retained in `Release`/`DebugProfile`/iOS, where the provisioning profile authorizes it.

## Test plan

- [x] Isolation test: removal restores launch; presence reproduces the failure.
- [ ] New CI DMG (new build number — 99 is burned) launches on a clean Mac.
- [ ] Verify S3 save/load on the no-sandbox DMG (fallback path; #340's pending device verification, independent of this fix).