### PR TITLE
Modify text color of Save button on dive detail page

### DIFF
--- a/lib/shared/widgets/forms/edit_form_scaffold.dart
+++ b/lib/shared/widgets/forms/edit_form_scaffold.dart
@@ -74,19 +74,30 @@ class EditFormScaffold extends StatelessWidget {
 
   Widget _saveButton(BuildContext context, {required bool filled}) {
     if (isSaving) {
-      return const Padding(
-        padding: EdgeInsets.all(12),
+      return Padding(
+        padding: const EdgeInsets.all(12),
         child: SizedBox(
           width: 22,
           height: 22,
-          child: CircularProgressIndicator(strokeWidth: 2),
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: filled ? null : AppBarTheme.of(context).foregroundColor,
+          ),
         ),
       );
     }
     final label = Text(context.l10n.forms_save);
-    return filled
-        ? FilledButton(onPressed: onSave, child: label)
-        : TextButton(onPressed: onSave, child: label);
+    if (filled) {
+      return FilledButton(onPressed: onSave, child: label);
+    }
+    final foreground = AppBarTheme.of(context).foregroundColor;
+    return TextButton(
+      style: foreground != null
+          ? TextButton.styleFrom(foregroundColor: foreground)
+          : null,
+      onPressed: onSave,
+      child: label,
+    );
   }
 
   @override

--- a/test/shared/widgets/forms/edit_form_scaffold_test.dart
+++ b/test/shared/widgets/forms/edit_form_scaffold_test.dart
@@ -124,42 +124,43 @@ void main() {
   });
 
   testWidgets(
-      'full-page save button uses AppBar foreground color, not primary',
-      (tester) async {
-    // Simulates themes like Tropical where AppBar bg == primary color,
-    // which would make a default TextButton invisible.
-    const appBarForeground = Color(0xFFFFFFFF);
-    const primary = Color(0xFF00B4A0);
+    'full-page save button uses AppBar foreground color, not primary',
+    (tester) async {
+      // Simulates themes like Tropical where AppBar bg == primary color,
+      // which would make a default TextButton invisible.
+      const appBarForeground = Color(0xFFFFFFFF);
+      const primary = Color(0xFF00B4A0);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: ThemeData(
-          colorScheme: const ColorScheme.light(primary: primary),
-          appBarTheme: const AppBarTheme(
-            backgroundColor: primary,
-            foregroundColor: appBarForeground,
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData(
+            colorScheme: const ColorScheme.light(primary: primary),
+            appBarTheme: const AppBarTheme(
+              backgroundColor: primary,
+              foregroundColor: appBarForeground,
+            ),
+          ),
+          home: EditFormScaffold(
+            title: 'Edit',
+            embedded: false,
+            isSaving: false,
+            hasUnsavedChanges: false,
+            onSave: () {},
+            child: const SizedBox(),
           ),
         ),
-        home: EditFormScaffold(
-          title: 'Edit',
-          embedded: false,
-          isSaving: false,
-          hasUnsavedChanges: false,
-          onSave: () {},
-          child: const SizedBox(),
-        ),
-      ),
-    );
+      );
 
-    final textWidget = tester.widget<Text>(find.text('Save'));
-    // The text style should resolve to the AppBar foreground, not primary.
-    final renderParagraph =
-        tester.renderObject<RenderParagraph>(find.text('Save'));
-    final paintedColor = renderParagraph.text.style?.color;
-    expect(paintedColor, appBarForeground);
-  });
+      // The text style should resolve to the AppBar foreground, not primary.
+      final renderParagraph = tester.renderObject<RenderParagraph>(
+        find.text('Save'),
+      );
+      final paintedColor = renderParagraph.text.style?.color;
+      expect(paintedColor, appBarForeground);
+    },
+  );
 
   testWidgets('does not impose a fixed content width', (tester) async {
     // Width handling moved to ResponsiveFormColumns; the scaffold passes the

--- a/test/shared/widgets/forms/edit_form_scaffold_test.dart
+++ b/test/shared/widgets/forms/edit_form_scaffold_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/shared/widgets/forms/edit_form_scaffold.dart';
@@ -120,6 +121,44 @@ void main() {
     await tester.tap(find.text('Discard'));
     await tester.pumpAndSettle();
     expect(find.text('BODY'), findsNothing);
+  });
+
+  testWidgets(
+      'full-page save button uses AppBar foreground color, not primary',
+      (tester) async {
+    // Simulates themes like Tropical where AppBar bg == primary color,
+    // which would make a default TextButton invisible.
+    const appBarForeground = Color(0xFFFFFFFF);
+    const primary = Color(0xFF00B4A0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: ThemeData(
+          colorScheme: const ColorScheme.light(primary: primary),
+          appBarTheme: const AppBarTheme(
+            backgroundColor: primary,
+            foregroundColor: appBarForeground,
+          ),
+        ),
+        home: EditFormScaffold(
+          title: 'Edit',
+          embedded: false,
+          isSaving: false,
+          hasUnsavedChanges: false,
+          onSave: () {},
+          child: const SizedBox(),
+        ),
+      ),
+    );
+
+    final textWidget = tester.widget<Text>(find.text('Save'));
+    // The text style should resolve to the AppBar foreground, not primary.
+    final renderParagraph =
+        tester.renderObject<RenderParagraph>(find.text('Save'));
+    final paintedColor = renderParagraph.text.style?.color;
+    expect(paintedColor, appBarForeground);
   });
 
   testWidgets('does not impose a fixed content width', (tester) async {


### PR DESCRIPTION
## Summary

On iPhone and iPad, when using the Tropical theme (and possibly others, did not test) the "Save" button is not visible. At first I thought somehow it was read-only due to sync or something... caused some confusion... but eventually realized that with the default "Submersion" theme it was visible, and if you tap where the button is even in Tropical theme it does work.

It appears to be purely a UX thing where the font color is the same as the app header. May apply to other edit pages as well, I only tested this one

## Changes

- text font color of Save chip on iOS mobile (iPhone and iPad) should now be the same as the default for the app header (white in the case of the Tropical theme)

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: Windows to ensure that isn't broken; I do not have the tools to build/test iOS

