### PR TITLE
fix(secure-storage): legacy-keychain fallback never switched keychains on macOS (S3 -34018)

### DIFF
--- a/lib/core/services/secure_storage/fallback_secure_storage.dart
+++ b/lib/core/services/secure_storage/fallback_secure_storage.dart
@@ -1,19 +1,26 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-/// A thin wrapper over [FlutterSecureStorage] that transparently retries on
-/// the macOS legacy (file-based) keychain when the default data-protection
-/// keychain reports `errSecMissingEntitlement` (-34018).
+/// Wrapper over [FlutterSecureStorage] that uses the macOS legacy (file-based)
+/// keychain when the default data-protection keychain is unavailable.
 ///
-/// That status occurs on the ad-hoc-signed no-sandbox (GitHub-distribution)
-/// build, whose signature carries no team `application-identifier` and hence
-/// no keychain access group. Sandboxed / team-signed / iOS builds never hit
-/// it, so the first attempt -- byte-identical to a plain [FlutterSecureStorage]
-/// call -- succeeds and no fallback runs. `mOptions` is ignored on non-macOS
-/// platforms, so wrapping is cross-platform-safe.
+/// The no-sandbox (GitHub-distribution) build is Developer-ID signed with no
+/// provisioning profile, so it has no keychain access group and the
+/// data-protection keychain rejects modifying ops with
+/// `errSecMissingEntitlement` (-34018). The legacy file-based keychain needs no
+/// access group on a non-sandboxed app. Sandboxed (App Store) / iOS builds get
+/// their access group from the provisioning profile and must NOT touch the
+/// file-based keychain -- the sandbox forbids it.
 ///
-/// Only the missing-entitlement status triggers the retry; every other
-/// keychain error propagates, so a locked keychain is never misread.
+/// A keychain *read* returns "item not found" (null) rather than -34018 when the
+/// access group is missing, so per-operation error handling cannot tell which
+/// keychain to use on a read (this is why an earlier read-side -34018 fallback
+/// silently failed). Instead this **probes once** -- a throwaway write to the
+/// data-protection keychain, which raises -34018 iff that keychain is
+/// unavailable -- caches the verdict, and routes every read/write/delete to the
+/// keychain that works. `mOptions` is ignored on non-macOS platforms, so the
+/// probe simply succeeds there and the default keychain is used.
 class FallbackSecureStorage {
   FallbackSecureStorage(this._storage);
 
@@ -22,42 +29,80 @@ class FallbackSecureStorage {
   /// `errSecMissingEntitlement` -- "a required entitlement isn't present".
   static const int _errSecMissingEntitlement = -34018;
 
-  /// Selects the legacy file-based keychain on the retry.
-  static const MacOsOptions _legacyKeychain = MacOsOptions(
-    usesDataProtectionKeychain: false,
-  );
+  /// Throwaway key used to probe data-protection-keychain availability.
+  static const String _probeKey = '__submersion_keychain_probe__';
 
-  Future<String?> read({required String key}) => _withFallback(
-    () => _storage.read(key: key),
-    () => _storage.read(key: key, mOptions: _legacyKeychain),
-  );
+  /// Options that select the legacy file-based keychain.
+  ///
+  /// Exposed for the regression test asserting the native-read key is present
+  /// (see [_LegacyKeychainMacOsOptions]).
+  @visibleForTesting
+  static const MacOsOptions legacyKeychainOptions =
+      _LegacyKeychainMacOsOptions();
 
-  Future<void> write({required String key, required String value}) =>
-      _withFallback(
-        () => _storage.write(key: key, value: value),
-        () => _storage.write(key: key, value: value, mOptions: _legacyKeychain),
-      );
+  /// Memoised probe: resolves `true` once the data-protection keychain is known
+  /// to be unavailable (the no-sandbox build). The same [Future] is shared by
+  /// concurrent first callers, so the probe runs at most once.
+  Future<bool>? _useLegacy;
 
-  Future<void> delete({required String key}) => _withFallback(
-    () => _storage.delete(key: key),
-    () => _storage.delete(key: key, mOptions: _legacyKeychain),
-  );
+  Future<bool> _legacyKeychainRequired() => _useLegacy ??= _probe();
 
-  /// Runs [primary] (the default data-protection keychain) and, only when it
-  /// throws `errSecMissingEntitlement`, runs [legacy] (the file-based
-  /// keychain) instead. The first attempt is awaited so its [PlatformException]
-  /// surfaces inside the try rather than escaping as a rejected future.
-  Future<T> _withFallback<T>(
-    Future<T> Function() primary,
-    Future<T> Function() legacy,
-  ) async {
+  Future<bool> _probe() async {
     try {
-      return await primary();
+      await _storage.write(key: _probeKey, value: '1');
+      await _storage.delete(key: _probeKey);
+      return false;
     } on PlatformException catch (e) {
-      if (e.details == _errSecMissingEntitlement) {
-        return legacy();
-      }
+      if (e.details == _errSecMissingEntitlement) return true;
       rethrow;
     }
   }
+
+  Future<String?> read({required String key}) async {
+    if (await _legacyKeychainRequired()) {
+      return _storage.read(key: key, mOptions: legacyKeychainOptions);
+    }
+    return _storage.read(key: key);
+  }
+
+  Future<void> write({required String key, required String value}) async {
+    if (await _legacyKeychainRequired()) {
+      return _storage.write(
+        key: key,
+        value: value,
+        mOptions: legacyKeychainOptions,
+      );
+    }
+    return _storage.write(key: key, value: value);
+  }
+
+  Future<void> delete({required String key}) async {
+    if (await _legacyKeychainRequired()) {
+      return _storage.delete(key: key, mOptions: legacyKeychainOptions);
+    }
+    return _storage.delete(key: key);
+  }
+}
+
+/// [MacOsOptions] that actually selects the legacy (non-data-protection)
+/// keychain on `flutter_secure_storage` 10.x.
+///
+/// Upstream key mismatch: the Dart side serialises the flag under
+/// `usesDataProtectionKeychain` (`MacOsOptions.toMap`), but the native
+/// `flutter_secure_storage_darwin` 0.2.0 plugin reads it under the
+/// differently-cased key `useDataProtectionKeyChain` and defaults to `true` when
+/// that key is absent. So `MacOsOptions(usesDataProtectionKeychain: false)` is
+/// silently dropped and the data-protection keychain is always used. We
+/// additionally emit the value under the key the native layer actually reads.
+/// Remove once the plugin keys agree
+/// (https://github.com/juliansteenbakker/flutter_secure_storage).
+class _LegacyKeychainMacOsOptions extends MacOsOptions {
+  const _LegacyKeychainMacOsOptions()
+    : super(usesDataProtectionKeychain: false);
+
+  @override
+  Map<String, String> toMap() => <String, String>{
+    ...super.toMap(),
+    'useDataProtectionKeyChain': 'false',
+  };
 }

--- a/test/core/services/cloud_storage/s3/s3_credentials_store_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_credentials_store_test.dart
@@ -21,6 +21,29 @@ class _ThrowingSecureStorage extends Fake implements FlutterSecureStorage {
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => throw Exception('keychain locked');
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => throw Exception('keychain locked');
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => throw Exception('keychain locked');
 }
 
 void main() {

--- a/test/core/services/secure_storage/fallback_secure_storage_test.dart
+++ b/test/core/services/secure_storage/fallback_secure_storage_test.dart
@@ -5,54 +5,75 @@ import 'package:submersion/core/services/secure_storage/fallback_secure_storage.
 import '../../../support/fake_keychain_storage.dart';
 
 void main() {
-  test(
-    'read returns the primary keychain value without falling back',
-    () async {
-      final inner = InMemoryKeychain()..values['k'] = 'v';
+  group('data-protection keychain available (sandboxed / profiled build)', () {
+    test('read / write / delete use the default keychain', () async {
+      final inner = InMemoryKeychain();
       final storage = FallbackSecureStorage(inner);
 
+      await storage.write(key: 'k', value: 'v');
       expect(await storage.read(key: 'k'), 'v');
-    },
-  );
 
-  test(
-    'read falls back to the legacy keychain on errSecMissingEntitlement',
-    () async {
-      final inner = NoEntitlementKeychain()..legacy['k'] = 'v';
-      final storage = FallbackSecureStorage(inner);
+      await storage.delete(key: 'k');
+      expect(await storage.read(key: 'k'), isNull);
+    });
+  });
 
-      expect(await storage.read(key: 'k'), 'v');
-      expect(inner.dataProtectionAttempted, isTrue);
-    },
-  );
-
-  test(
-    'write falls back to the legacy keychain on errSecMissingEntitlement',
-    () async {
+  group('data-protection keychain unavailable (no-sandbox build)', () {
+    test('write then read round-trips through the legacy keychain', () async {
+      // Regression guard: the data-protection keychain throws on writes but
+      // returns not-found (null) on reads, so a read-side -34018 fallback never
+      // fires and the saved value is unreadable. This fails on the old design.
       final inner = NoEntitlementKeychain();
       final storage = FallbackSecureStorage(inner);
 
       await storage.write(key: 'k', value: 'v');
 
+      expect(await storage.read(key: 'k'), 'v');
       expect(inner.legacy['k'], 'v');
-    },
-  );
+      expect(inner.dataProtectionAttempted, isTrue);
+    });
 
-  test(
-    'delete falls back to the legacy keychain on errSecMissingEntitlement',
-    () async {
+    test('reads a value already in the legacy keychain (cross-launch)', () async {
+      // First operation of the "session" is a read of a previously-stored value;
+      // the probe must establish the legacy keychain before that read.
+      final inner = NoEntitlementKeychain()..legacy['k'] = 'v';
+      final storage = FallbackSecureStorage(inner);
+
+      expect(await storage.read(key: 'k'), 'v');
+    });
+
+    test('delete removes the value from the legacy keychain', () async {
       final inner = NoEntitlementKeychain()..legacy['k'] = 'v';
       final storage = FallbackSecureStorage(inner);
 
       await storage.delete(key: 'k');
 
       expect(inner.legacy.containsKey('k'), isFalse);
-    },
-  );
+    });
+  });
 
-  test('a non-entitlement PlatformException propagates unchanged', () async {
+  test('a non-entitlement keychain error propagates', () async {
     final storage = FallbackSecureStorage(FailingKeychain(-25308));
 
     expect(storage.read(key: 'k'), throwsA(isA<PlatformException>()));
   });
+
+  test('a non-entitlement error during the probe propagates', () async {
+    final storage = FallbackSecureStorage(ProbeFailingKeychain(-25308));
+
+    expect(storage.read(key: 'k'), throwsA(isA<PlatformException>()));
+  });
+
+  test(
+    'legacy keychain options re-emit the native-read data-protection key',
+    () {
+      // flutter_secure_storage 10.x serialises the flag as
+      // `usesDataProtectionKeychain`, but flutter_secure_storage_darwin 0.2.0
+      // reads the differently-cased `useDataProtectionKeyChain` and defaults to
+      // the data-protection keychain when it is absent.
+      final map = FallbackSecureStorage.legacyKeychainOptions.toMap();
+
+      expect(map['useDataProtectionKeyChain'], 'false');
+    },
+  );
 }

--- a/test/support/fake_keychain_storage.dart
+++ b/test/support/fake_keychain_storage.dart
@@ -3,14 +3,23 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// `errSecMissingEntitlement` -- the macOS Security framework status the
-/// ad-hoc-signed no-sandbox build provokes from the data-protection keychain.
+/// no-sandbox build provokes from the data-protection keychain (no access
+/// group). Modifying ops raise it; reads return not-found (null) instead.
 const int kErrSecMissingEntitlement = -34018;
 
 bool _usesDataProtection(AppleOptions? mOptions) =>
     mOptions is MacOsOptions ? mOptions.usesDataProtectionKeychain : true;
 
+PlatformException _securityError(int status, [String? message]) =>
+    PlatformException(
+      code: 'Unexpected security result code',
+      message: message ?? "A required entitlement isn't present.",
+      details: status,
+    );
+
 /// An in-memory keychain that ignores `mOptions` -- both keychains behave
-/// identically, modelling a normally-entitled build where no fallback runs.
+/// identically, modelling a normally-entitled build where the probe succeeds
+/// and no fallback is needed.
 class InMemoryKeychain extends Fake implements FlutterSecureStorage {
   final Map<String, String> values = {};
 
@@ -57,23 +66,22 @@ class InMemoryKeychain extends Fake implements FlutterSecureStorage {
   }
 }
 
-/// Models the ad-hoc-signed no-sandbox macOS build: the data-protection
-/// keychain (default / `usesDataProtectionKeychain: true`) throws
-/// `errSecMissingEntitlement`, while the legacy keychain
-/// (`usesDataProtectionKeychain: false`) works against [legacy].
+/// Models the no-sandbox macOS build, including the keychain's asymmetric
+/// behaviour: the data-protection keychain (default /
+/// `usesDataProtectionKeychain: true`) throws `errSecMissingEntitlement` on
+/// **modifying** ops but returns **not-found (null)** on **reads**, while the
+/// legacy keychain (`usesDataProtectionKeychain: false`) works against [legacy].
+///
+/// So a data-protection probe write throws (revealing the missing entitlement),
+/// and the wrapper must route every op -- including reads -- to the legacy
+/// keychain.
 class NoEntitlementKeychain extends Fake implements FlutterSecureStorage {
   /// Backing store standing in for the legacy (file-based) keychain.
   final Map<String, String> legacy = {};
 
-  /// Set once the data-protection keychain has been attempted, proving the
-  /// caller tries the secure keychain before falling back.
+  /// Set once the data-protection keychain has been touched, proving the
+  /// wrapper probes the secure keychain before routing to the legacy one.
   bool dataProtectionAttempted = false;
-
-  PlatformException _missing() => PlatformException(
-    code: 'Unexpected security result code',
-    message: "A required entitlement isn't present.",
-    details: kErrSecMissingEntitlement,
-  );
 
   @override
   Future<String?> read({
@@ -87,7 +95,10 @@ class NoEntitlementKeychain extends Fake implements FlutterSecureStorage {
   }) async {
     if (_usesDataProtection(mOptions)) {
       dataProtectionAttempted = true;
-      throw _missing();
+      // Real keychain behaviour: a read with no access group returns not-found,
+      // NOT errSecMissingEntitlement. This is the asymmetry that defeated the
+      // read-side -34018 fallback.
+      return null;
     }
     return legacy[key];
   }
@@ -105,7 +116,7 @@ class NoEntitlementKeychain extends Fake implements FlutterSecureStorage {
   }) async {
     if (_usesDataProtection(mOptions)) {
       dataProtectionAttempted = true;
-      throw _missing();
+      throw _securityError(kErrSecMissingEntitlement);
     }
     if (value == null) {
       legacy.remove(key);
@@ -126,19 +137,42 @@ class NoEntitlementKeychain extends Fake implements FlutterSecureStorage {
   }) async {
     if (_usesDataProtection(mOptions)) {
       dataProtectionAttempted = true;
-      throw _missing();
+      throw _securityError(kErrSecMissingEntitlement);
     }
     legacy.remove(key);
   }
 }
 
-/// A keychain that always throws a [PlatformException] carrying [status] on
-/// read -- used to verify that errors other than the missing entitlement
-/// propagate unchanged.
+/// A keychain whose probe (write/delete) succeeds but whose **read** always
+/// throws [status] -- used to verify that errors other than the missing
+/// entitlement propagate unchanged.
 class FailingKeychain extends Fake implements FlutterSecureStorage {
   FailingKeychain(this.status);
 
   final int status;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {}
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {}
 
   @override
   Future<String?> read({
@@ -149,9 +183,26 @@ class FailingKeychain extends Fake implements FlutterSecureStorage {
     WebOptions? webOptions,
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
-  }) async => throw PlatformException(
-    code: 'Unexpected security result code',
-    message: 'interaction not allowed',
-    details: status,
-  );
+  }) async => throw _securityError(status, 'interaction not allowed');
+}
+
+/// A keychain whose **probe write** throws [status] -- used to verify a
+/// non-entitlement failure during the probe propagates rather than being
+/// mistaken for "data-protection unavailable".
+class ProbeFailingKeychain extends Fake implements FlutterSecureStorage {
+  ProbeFailingKeychain(this.status);
+
+  final int status;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => throw _securityError(status, 'interaction not allowed');
 }


### PR DESCRIPTION
## Summary

Follow-up to #348 (merged). With the no-sandbox DMG launching again, S3 sync on it failed with `errSecMissingEntitlement` (-34018) — and after the first cut of this fix, credentials *saved* but came back **blank** on reload. Same underlying issue: the no-sandbox build can't use the macOS data-protection keychain, and #340's legacy-keychain fallback never actually worked.

## Two bugs in #340's fallback

1. **The keychain switch was a silent no-op (Dart/native key mismatch).** `MacOsOptions(usesDataProtectionKeychain: false)` is serialised by Dart under key `usesDataProtectionKeychain`, but `flutter_secure_storage_darwin` 0.2.0 reads `useDataProtectionKeyChain` and defaults to `true` — so the legacy keychain was never selected. (Upstream bug; worked around with a `MacOsOptions` subclass that emits the native-read key.)

2. **The fallback was asymmetric.** It triggered only on -34018, which only *modifying* ops raise. A keychain **read** of a missing item returns not-found (`null`), not -34018, so reads never fell back: writes went to the legacy keychain, but reads queried the empty data-protection keychain → `null`. Result: creds saved, then "not authenticated" / blank fields.

## Fix — probe once, then route

Replace the per-op error fallback with a one-time probe: a throwaway write to the data-protection keychain raises -34018 iff it's unavailable. Cache the verdict and route **every** read/write/delete to the keychain that works:
- no-sandbox build → legacy file-based keychain (reads now find what writes stored, including the cross-launch first read at sync init),
- sandboxed App Store / iOS → data-protection keychain (and it never touches the file-based keychain the sandbox forbids).

## Test plan

- [x] `flutter test` secure-storage + S3/bookmark suites — 22/22 green. The fakes now model the keychain's real asymmetry (data-protection reads return `null`, not -34018), so the new **write-then-read round-trip** test fails on the old design and passes on this one.
- [x] End-to-end on the no-sandbox build: configure S3, Save, reopen — creds persist, sync authenticates.

## Upstream

The Dart/native key-casing mismatch is a `flutter_secure_storage` bug; reporting upstream. The `MacOsOptions` subclass workaround can be removed once the keys agree.