### PR TITLE
fix(sac): honor SAC unit preference in dives table column

### DIFF
--- a/lib/core/constants/dive_field_extractor.dart
+++ b/lib/core/constants/dive_field_extractor.dart
@@ -11,8 +11,13 @@ extension DiveFieldExtractor on DiveField {
   /// [sacUnit] selects which base value [DiveField.sacRate] yields: volume-based
   /// L/min ([Dive.sac]) or pressure-based bar/min ([Dive.sacPressure]). It must
   /// match the [UnitFormatter] later used to format the value so the unit suffix
-  /// is correct. Other fields ignore it.
-  dynamic extractFromDive(Dive dive, {SacUnit sacUnit = SacUnit.litersPerMin}) {
+  /// is correct. Defaults to [SacUnit.pressurePerMin] to match the AppSettings
+  /// default, so an omitted argument stays consistent with default settings.
+  /// Other fields ignore it.
+  dynamic extractFromDive(
+    Dive dive, {
+    SacUnit sacUnit = SacUnit.pressurePerMin,
+  }) {
     switch (this) {
       case DiveField.diveNumber:
         return dive.diveNumber;

--- a/lib/core/constants/dive_field_extractor.dart
+++ b/lib/core/constants/dive_field_extractor.dart
@@ -1,4 +1,5 @@
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 
@@ -6,7 +7,12 @@ import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 /// entities for each [DiveField].
 extension DiveFieldExtractor on DiveField {
   /// Extract the raw value for this field from a full [Dive] entity.
-  dynamic extractFromDive(Dive dive) {
+  ///
+  /// [sacUnit] selects which base value [DiveField.sacRate] yields: volume-based
+  /// L/min ([Dive.sac]) or pressure-based bar/min ([Dive.sacPressure]). It must
+  /// match the [UnitFormatter] later used to format the value so the unit suffix
+  /// is correct. Other fields ignore it.
+  dynamic extractFromDive(Dive dive, {SacUnit sacUnit = SacUnit.litersPerMin}) {
     switch (this) {
       case DiveField.diveNumber:
         return dive.diveNumber;
@@ -65,7 +71,7 @@ extension DiveFieldExtractor on DiveField {
       case DiveField.endPressure:
         return dive.tanks.isNotEmpty ? dive.tanks.first.endPressure : null;
       case DiveField.sacRate:
-        return _computeSacRate(dive);
+        return _computeSacRate(dive, sacUnit);
       case DiveField.gasConsumed:
         return _computeGasConsumed(dive);
       case DiveField.totalWeight:
@@ -168,11 +174,15 @@ extension DiveFieldExtractor on DiveField {
   }
 }
 
-/// Compute the SAC rate (Surface Air Consumption) in L/min from a [Dive].
+/// Compute the SAC rate (Surface Air Consumption) for a [Dive].
 ///
-/// Delegates to [Dive.sac], which sums gas consumed across all tanks with
-/// valid data and divides by runtime and average pressure.
-double? _computeSacRate(Dive dive) => dive.sac;
+/// Returns the base value matching [sacUnit]:
+/// - [SacUnit.litersPerMin]: volume-based L/min from [Dive.sac] (sums gas across
+///   all tanks with volume data).
+/// - [SacUnit.pressurePerMin]: pressure-based bar/min from [Dive.sacPressure]
+///   (back gas tank pressure drop; no tank volume required).
+double? _computeSacRate(Dive dive, SacUnit sacUnit) =>
+    sacUnit == SacUnit.litersPerMin ? dive.sac : dive.sacPressure;
 
 /// Compute the total gas consumed in liters across all tanks of a [Dive].
 double? _computeGasConsumed(Dive dive) {

--- a/lib/core/constants/dive_field_formatter.dart
+++ b/lib/core/constants/dive_field_formatter.dart
@@ -30,7 +30,10 @@ extension DiveFieldFormatter on DiveField {
 
       case DiveField.sacRate:
         if (value is double) {
-          return '${value.toStringAsFixed(1)} ${units.volumeSymbol}/min';
+          // The base unit of [value] depends on the SAC mode: L/min in volume
+          // mode, bar/min in pressure mode. [convertSac] and [sacSymbol] honor
+          // the diver's SAC unit and volume/pressure unit preferences.
+          return '${units.convertSac(value).toStringAsFixed(1)} ${units.sacSymbol}';
         }
         return '--';
 

--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -168,6 +168,30 @@ class UnitFormatter {
   }
 
   // ============================================================================
+  // SAC (Surface Air Consumption)
+  // ============================================================================
+
+  /// The diver's SAC unit mode: volume-based (L/min) or pressure-based
+  /// (bar/min or psi/min).
+  SacUnit get sacUnit => settings.sacUnit;
+
+  /// SAC display suffix: "L/min", "cuft/min", "bar/min", or "psi/min".
+  ///
+  /// Volume mode uses the volume unit; pressure mode uses the pressure unit.
+  String get sacSymbol => settings.sacUnit == SacUnit.litersPerMin
+      ? '$volumeSymbol/min'
+      : '$pressureSymbol/min';
+
+  /// Convert a base SAC value into the diver's preferred unit.
+  ///
+  /// In volume mode the input is L/min (from `Dive.sac`) and is converted to
+  /// the volume unit. In pressure mode the input is bar/min (from
+  /// `Dive.sacPressure`) and is converted to the pressure unit.
+  double convertSac(double value) => settings.sacUnit == SacUnit.litersPerMin
+      ? convertVolume(value)
+      : convertPressure(value);
+
+  // ============================================================================
   // Weight
   // ============================================================================
 

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -857,7 +857,10 @@ class DiveListTile extends ConsumerWidget {
                           runSpacing: 4,
                           children: extraFields.map((field) {
                             final value = fullDive != null
-                                ? field.extractFromDive(fullDive!)
+                                ? field.extractFromDive(
+                                    fullDive!,
+                                    sacUnit: units.sacUnit,
+                                  )
                                 : (field.extractFromSummary(summary!) ??
                                       _fallbackValue(field));
                             final formatted = field.formatValue(value, units);
@@ -1004,7 +1007,7 @@ class DiveListTile extends ConsumerWidget {
   ) {
     // Use full Dive when available (has all fields), otherwise try summary
     dynamic value = fullDive != null
-        ? field.extractFromDive(fullDive!)
+        ? field.extractFromDive(fullDive!, sacUnit: units.sacUnit)
         : summary != null
         ? field.extractFromSummary(summary)
         : null;

--- a/lib/features/dive_log/presentation/widgets/dive_table_view.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_table_view.dart
@@ -138,8 +138,8 @@ class _DiveTableViewState extends ConsumerState<DiveTableView> {
 
     final sorted = List<Dive>.from(widget.dives);
     sorted.sort((a, b) {
-      final va = field.extractFromDive(a);
-      final vb = field.extractFromDive(b);
+      final va = field.extractFromDive(a, sacUnit: units.sacUnit);
+      final vb = field.extractFromDive(b, sacUnit: units.sacUnit);
 
       // Nulls always sort to the end
       if (va == null && vb == null) return 0;
@@ -238,7 +238,7 @@ class _DiveTableViewState extends ConsumerState<DiveTableView> {
     required bool isSelected,
     bool isLastPinned = false,
   }) {
-    final value = column.field.extractFromDive(dive);
+    final value = column.field.extractFromDive(dive, sacUnit: units.sacUnit);
     final text = column.field.formatValue(value, units);
     final rightAligned = _isRightAligned(column.field);
 

--- a/test/core/constants/dive_field_extractor_test.dart
+++ b/test/core/constants/dive_field_extractor_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
@@ -464,6 +465,54 @@ void main() {
       // Tank 2: 7.0  * (200 - 150) = 350L
       // Total: 1550L / 52 / 2.82 ≈ 10.57
       expect(result as double, closeTo(10.57, 0.1));
+    });
+
+    test('sacRate volume mode returns L/min from dive.sac', () {
+      final result = DiveField.sacRate.extractFromDive(
+        testDive,
+        sacUnit: SacUnit.litersPerMin,
+      );
+      // 1800L / 52 / 2.82 ≈ 12.28
+      expect(result as double, closeTo(12.28, 0.1));
+    });
+
+    test('sacRate pressure mode returns bar/min from dive.sacPressure', () {
+      final result = DiveField.sacRate.extractFromDive(
+        testDive,
+        sacUnit: SacUnit.pressurePerMin,
+      );
+      // 150 bar / 52 / 2.82 ≈ 1.02 bar/min
+      expect(result as double, closeTo(1.02, 0.05));
+    });
+
+    test('sacRate pressure mode works without tank volume', () {
+      // A tank with pressures but no volume: volume-based SAC is impossible,
+      // but pressure-based SAC only needs the pressure drop.
+      const noVolumeTank = DiveTank(
+        id: 'tank-nv',
+        startPressure: 200.0,
+        endPressure: 50.0,
+        role: TankRole.backGas,
+      );
+      final dive = Dive(
+        id: 'dive-nv-prs',
+        dateTime: now,
+        runtime: const Duration(minutes: 45),
+        avgDepth: 18.0,
+        tanks: [noVolumeTank],
+      );
+
+      expect(
+        DiveField.sacRate.extractFromDive(dive, sacUnit: SacUnit.litersPerMin),
+        isNull,
+      );
+      expect(
+        DiveField.sacRate.extractFromDive(
+          dive,
+          sacUnit: SacUnit.pressurePerMin,
+        ),
+        isA<double>(),
+      );
     });
 
     test('gasConsumed sums all tanks on multi-tank dive', () {

--- a/test/core/constants/dive_field_extractor_test.dart
+++ b/test/core/constants/dive_field_extractor_test.dart
@@ -365,14 +365,15 @@ void main() {
   });
 
   group('DiveFieldExtractor - SAC rate and gas consumed', () {
-    test('sacRate computes correctly with valid tank data', () {
+    test('sacRate defaults to pressurePerMin to match AppSettings default', () {
+      // No sacUnit passed -> uses the default. The default matches the
+      // AppSettings default (pressurePerMin), so an omitted argument stays
+      // consistent with default settings instead of silently producing an
+      // L/min value that a default UnitFormatter would mislabel as bar/min.
       final result = DiveField.sacRate.extractFromDive(testDive);
       expect(result, isA<double>());
-      // Calculation: gasLiters = 12.0 * (200.0 - 50.0) = 1800
-      // minutes = 52 * 60 / 60 = 52.0
-      // avgPressureAtm = (18.2 / 10.0) + 1.0 = 2.82
-      // sacRate = 1800 / 52.0 / 2.82 = ~12.28
-      expect((result as double), closeTo(12.28, 0.1));
+      // Pressure-based: 150 bar / 52 / 2.82 ≈ 1.02 bar/min
+      expect((result as double), closeTo(1.02, 0.05));
     });
 
     test('gasConsumed computes correctly with valid tank data', () {
@@ -405,7 +406,12 @@ void main() {
         avgDepth: 18.0,
         tanks: [noVolumeTank],
       );
-      expect(DiveField.sacRate.extractFromDive(dive), isNull);
+      // Volume mode requires tank volume; pressure mode would still produce a
+      // value here, so this null check is specific to litersPerMin.
+      expect(
+        DiveField.sacRate.extractFromDive(dive, sacUnit: SacUnit.litersPerMin),
+        isNull,
+      );
     });
 
     test('sacRate returns null when no avgDepth', () {
@@ -459,7 +465,10 @@ void main() {
         avgDepth: 18.2,
         tanks: [tank1, tank2],
       );
-      final result = DiveField.sacRate.extractFromDive(dive);
+      final result = DiveField.sacRate.extractFromDive(
+        dive,
+        sacUnit: SacUnit.litersPerMin,
+      );
       expect(result, isA<double>());
       // Tank 1: 12.0 * (200 - 100) = 1200L
       // Tank 2: 7.0  * (200 - 150) = 350L

--- a/test/core/constants/dive_field_formatter_test.dart
+++ b/test/core/constants/dive_field_formatter_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
@@ -124,9 +125,50 @@ void main() {
   });
 
   group('DiveFieldFormatter - gas fields', () {
-    test('sacRate formats with volume symbol and per-minute', () {
-      final result = DiveField.sacRate.formatValue(12.3, units);
-      expect(result, '12.3 ${units.volumeSymbol}/min');
+    test('sacRate volume mode (litersPerMin) formats as L/min', () {
+      const litersUnits = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.litersPerMin,
+          volumeUnit: VolumeUnit.liters,
+        ),
+      );
+      final result = DiveField.sacRate.formatValue(12.3, litersUnits);
+      expect(result, '12.3 L/min');
+    });
+
+    test('sacRate volume mode converts L/min to cuft/min in imperial', () {
+      const cuftUnits = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.litersPerMin,
+          volumeUnit: VolumeUnit.cubicFeet,
+        ),
+      );
+      // 12.3 L/min * 0.0353147 = 0.434 cuft/min
+      final result = DiveField.sacRate.formatValue(12.3, cuftUnits);
+      expect(result, '0.4 cuft/min');
+    });
+
+    test('sacRate pressure mode (pressurePerMin) formats as bar/min', () {
+      const barUnits = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.pressurePerMin,
+          pressureUnit: PressureUnit.bar,
+        ),
+      );
+      final result = DiveField.sacRate.formatValue(12.3, barUnits);
+      expect(result, '12.3 bar/min');
+    });
+
+    test('sacRate pressure mode converts bar/min to psi/min in imperial', () {
+      const psiUnits = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.pressurePerMin,
+          pressureUnit: PressureUnit.psi,
+        ),
+      );
+      // 12.3 bar/min * 14.5038 = 178.4 psi/min
+      final result = DiveField.sacRate.formatValue(12.3, psiUnits);
+      expect(result, '178.4 psi/min');
     });
 
     test('sacRate returns "--" for non-double', () {

--- a/test/core/utils/unit_formatter_sac_test.dart
+++ b/test/core/utils/unit_formatter_sac_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  group('UnitFormatter SAC rate', () {
+    group('volume-based (litersPerMin)', () {
+      const liters = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.litersPerMin,
+          volumeUnit: VolumeUnit.liters,
+        ),
+      );
+      const cuft = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.litersPerMin,
+          volumeUnit: VolumeUnit.cubicFeet,
+        ),
+      );
+
+      test('sacUnit reflects the setting', () {
+        expect(liters.sacUnit, SacUnit.litersPerMin);
+      });
+
+      test('sacSymbol is volume per minute', () {
+        expect(liters.sacSymbol, 'L/min');
+        expect(cuft.sacSymbol, 'cuft/min');
+      });
+
+      test('convertSac leaves liters unchanged in metric', () {
+        expect(liters.convertSac(15.0), closeTo(15.0, 0.0001));
+      });
+
+      test('convertSac converts liters to cubic feet in imperial', () {
+        expect(cuft.convertSac(15.0), closeTo(0.5297, 0.001));
+      });
+    });
+
+    group('pressure-based (pressurePerMin)', () {
+      const bar = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.pressurePerMin,
+          pressureUnit: PressureUnit.bar,
+        ),
+      );
+      const psi = UnitFormatter(
+        AppSettings(
+          sacUnit: SacUnit.pressurePerMin,
+          pressureUnit: PressureUnit.psi,
+        ),
+      );
+
+      test('sacUnit reflects the setting', () {
+        expect(bar.sacUnit, SacUnit.pressurePerMin);
+      });
+
+      test('sacSymbol is pressure per minute', () {
+        expect(bar.sacSymbol, 'bar/min');
+        expect(psi.sacSymbol, 'psi/min');
+      });
+
+      test('convertSac leaves bar unchanged in metric', () {
+        expect(bar.convertSac(1.5), closeTo(1.5, 0.0001));
+      });
+
+      test('convertSac converts bar to psi in imperial', () {
+        expect(psi.convertSac(1.5), closeTo(21.7557, 0.001));
+      });
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_list_tile_sac_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_list_tile_sac_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(super.initial);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestCardConfigNotifier extends CardViewConfigNotifier {
+  _TestCardConfigNotifier(CardViewConfig config)
+    : super.withMode(ListViewMode.detailed) {
+    state = config;
+  }
+}
+
+void main() {
+  // One back-gas tank chosen for clean SAC values:
+  // minutes = 50, avgPressureAtm = 10/10 + 1 = 2.0
+  // sac         = (10L * 100bar) / 50 / 2.0 = 10.0 L/min
+  // sacPressure = 100bar / 50 / 2.0         = 1.0 bar/min
+  Dive sacDive() => Dive(
+    id: 'lt-sac',
+    diveNumber: 7,
+    dateTime: DateTime(2024, 6, 1),
+    runtime: const Duration(minutes: 50),
+    avgDepth: 10.0,
+    tanks: const [
+      DiveTank(
+        id: 't',
+        volume: 10.0,
+        startPressure: 200.0,
+        endPressure: 100.0,
+        role: TankRole.backGas,
+      ),
+    ],
+  );
+
+  Widget buildTile(AppSettings settings) {
+    final config = CardViewConfig.defaultDetailed().copyWith(
+      extraFields: [DiveField.sacRate],
+    );
+    return testApp(
+      overrides: [
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
+        detailedCardConfigProvider.overrideWith(
+          (ref) => _TestCardConfigNotifier(config),
+        ),
+      ],
+      child: DiveListTile(
+        diveId: 'lt-sac',
+        diveNumber: 7,
+        dateTime: DateTime(2024, 6, 1),
+        fullDive: sacDive(),
+      ),
+    );
+  }
+
+  group('DiveListTile SAC extra field', () {
+    testWidgets('honors pressure preference (bar/min)', (tester) async {
+      await tester.pumpWidget(
+        buildTile(
+          const AppSettings(
+            sacUnit: SacUnit.pressurePerMin,
+            pressureUnit: PressureUnit.bar,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('1.0 bar/min'), findsOneWidget);
+    });
+
+    testWidgets('honors volume preference (L/min)', (tester) async {
+      await tester.pumpWidget(
+        buildTile(
+          const AppSettings(
+            sacUnit: SacUnit.litersPerMin,
+            volumeUnit: VolumeUnit.liters,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('10.0 L/min'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -16,7 +18,8 @@ import '../../../../helpers/test_app.dart';
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
-  _TestSettingsNotifier() : super(const AppSettings());
+  _TestSettingsNotifier([AppSettings? initial])
+    : super(initial ?? const AppSettings());
 
   @override
   Future<void> setMapStyle(MapStyle style) async =>
@@ -57,6 +60,39 @@ Dive _makeDive({
   );
 }
 
+/// A dive with one back-gas tank chosen to yield clean SAC values:
+/// volume-based 10.0 L/min ([Dive.sac]) and pressure-based 1.0 bar/min
+/// ([Dive.sacPressure]).
+///
+/// minutes = 50, avgPressureAtm = 10/10 + 1 = 2.0
+/// sac        = (10L * 100bar) / 50 / 2.0 = 10.0 L/min
+/// sacPressure = 100bar / 50 / 2.0        = 1.0 bar/min
+Dive _makeSacDive() {
+  return Dive(
+    id: 'sac-1',
+    dateTime: DateTime(2024, 6, 1),
+    diveNumber: 1,
+    runtime: const Duration(minutes: 50),
+    avgDepth: 10.0,
+    tanks: const [
+      DiveTank(
+        id: 'sac-tank',
+        volume: 10.0,
+        startPressure: 200.0,
+        endPressure: 100.0,
+        role: TankRole.backGas,
+      ),
+    ],
+  );
+}
+
+final _sacConfig = TableViewConfig(
+  columns: [
+    TableColumnConfig(field: DiveField.diveNumber, isPinned: true),
+    TableColumnConfig(field: DiveField.sacRate),
+  ],
+);
+
 Widget _buildTable({
   required List<Dive> dives,
   void Function(String)? onDiveTap,
@@ -65,10 +101,11 @@ Widget _buildTable({
   Set<String>? selectedIds,
   bool isSelectionMode = false,
   TableViewConfig? config,
+  AppSettings? settings,
 }) {
   return testApp(
     overrides: [
-      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
       tableViewConfigProvider.overrideWith(
         (ref) => _TestTableConfigNotifier(config ?? _testConfig),
       ),
@@ -767,6 +804,77 @@ void main() {
 
       expect(find.text('#1'), findsOneWidget);
       expect(find.text('10.0m'), findsOneWidget);
+    });
+
+    // -----------------------------------------------------------------------
+    // SAC rate column honors the diver's SAC unit and volume/pressure prefs
+    // (regression for issue #277: the column always showed raw L/min).
+    // -----------------------------------------------------------------------
+
+    testWidgets('sacRate pressure mode (default) shows bar/min', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTable(dives: [_makeSacDive()], config: _sacConfig),
+      );
+      await tester.pumpAndSettle();
+
+      // Default sacUnit is pressurePerMin -> back-gas pressure SAC in bar/min.
+      expect(find.text('1.0 bar/min'), findsOneWidget);
+    });
+
+    testWidgets('sacRate pressure mode converts to psi/min in imperial', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTable(
+          dives: [_makeSacDive()],
+          config: _sacConfig,
+          settings: const AppSettings(
+            sacUnit: SacUnit.pressurePerMin,
+            pressureUnit: PressureUnit.psi,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 1.0 bar/min * 14.5038 = 14.5 psi/min
+      expect(find.text('14.5 psi/min'), findsOneWidget);
+    });
+
+    testWidgets('sacRate volume mode shows L/min', (tester) async {
+      await tester.pumpWidget(
+        _buildTable(
+          dives: [_makeSacDive()],
+          config: _sacConfig,
+          settings: const AppSettings(
+            sacUnit: SacUnit.litersPerMin,
+            volumeUnit: VolumeUnit.liters,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('10.0 L/min'), findsOneWidget);
+    });
+
+    testWidgets('sacRate volume mode converts to cuft/min in imperial', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTable(
+          dives: [_makeSacDive()],
+          config: _sacConfig,
+          settings: const AppSettings(
+            sacUnit: SacUnit.litersPerMin,
+            volumeUnit: VolumeUnit.cubicFeet,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 10.0 L/min * 0.0353147 = 0.4 cuft/min
+      expect(find.text('0.4 cuft/min'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Problem

Issue #277 had two halves. PR #305 fixed the multi-tank SAC *calculation*. This fixes the remaining *unit* half: the Dives table `SAC Rate` column always rendered the raw volume-based **L/min** value, ignoring:

- unit conversion (never converted L/min → cuft/min or bar/min → psi/min), and
- the diver's **SAC Rate Unit** preference (`litersPerMin` vs `pressurePerMin`).

With the default `pressurePerMin` preference, divers saw a volume number mislabeled as `L/min`; imperial divers never saw `cuft/min` or `psi/min`.

## Root cause

The column flows through the generic extract → format pipeline:

- `_computeSacRate` always returned `dive.sac` (L/min), never `dive.sacPressure` (bar/min).
- The formatter hardcoded `'${value} ${units.volumeSymbol}/min'` — no conversion, no `sacUnit` branch.

`Dive.sac` / `Dive.sacPressure` and the detail page's `_buildSacRow` already had the correct semantics; the table column just wasn't using them.

## Changes

- **`unit_formatter.dart`** — `sacUnit`, `sacSymbol`, `convertSac()`: one home for "L/min → volume unit" vs "bar/min → pressure unit".
- **`dive_field_formatter.dart`** — `sacRate` case now `convertSac(value)` + `sacSymbol`.
- **`dive_field_extractor.dart`** — `extractFromDive(dive, {sacUnit})` yields `dive.sac` (volume) or `dive.sacPressure` (pressure) so the value matches the formatter.
- **`dive_table_view.dart`** — passes `units.sacUnit` into extraction for both the cell and the sort comparison (sorting matches what's shown).
- **`dive_list_page.dart`** — same wiring for the two stat-slot SAC displays.

Mirrors `dive_detail_page._buildSacRow`, which already honored the preference.

## Design note

SAC is the one field whose *base quantity* depends on a preference (L/min vs bar/min), so the extractor and formatter must agree. Both derive from a single source of truth, `units.sacUnit` — the extractor is handed it explicitly, the formatter reads it from the same `UnitFormatter`.

## Tests (red → green)

- `unit_formatter_sac_test.dart` (new) — `convertSac` / `sacSymbol` for all four mode/unit combos.
- `dive_field_formatter_test.dart` — SAC formatting for L/min, cuft/min, bar/min, psi/min.
- `dive_field_extractor_test.dart` — volume vs pressure base value; pressure mode works without tank volume.
- `dive_table_view_test.dart` — end-to-end: the rendered column shows `1.0 bar/min` (default), `14.5 psi/min`, `10.0 L/min`, `0.4 cuft/min`. Confirmed to fail without the widget wiring.

`flutter analyze` clean; `dart format` clean.

Closes #277