### PR TITLE
fix(backup): never brick startup on an unusable backup location; full iOS/macOS bookmark support

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B6F7A1C22F0A1234001C2D3E /* ICloudContainerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F7A1C12F0A1234001C2D3E /* ICloudContainerHandler.swift */; };
 		C7F8A2D42F0B2345001D3E4F /* MetadataWriteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F8A2D32F0B2345001D3E4F /* MetadataWriteHandler.swift */; };
 		D8E9F0A22F0C3456001E4F50 /* LocalMediaHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E9F0A12F0C3456001E4F50 /* LocalMediaHandler.swift */; };
+		BB05C0DEBB05C0DE00000002 /* BackupBookmarkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB05C0DEBB05C0DE00000001 /* BackupBookmarkHandler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		C7F8A2D32F0B2345001D3E4F /* MetadataWriteHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataWriteHandler.swift; sourceTree = "<group>"; };
 		D48C3D26F3310C3983763F37 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8E9F0A12F0C3456001E4F50 /* LocalMediaHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalMediaHandler.swift; sourceTree = "<group>"; };
+		BB05C0DEBB05C0DE00000001 /* BackupBookmarkHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackupBookmarkHandler.swift; sourceTree = "<group>"; };
 		DBBF9F6530874A986D338166 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		F22E11F21EB668A4099D29B8 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -154,6 +156,7 @@
 				B6F7A1C12F0A1234001C2D3E /* ICloudContainerHandler.swift */,
 				C7F8A2D32F0B2345001D3E4F /* MetadataWriteHandler.swift */,
 				D8E9F0A12F0C3456001E4F50 /* LocalMediaHandler.swift */,
+				BB05C0DEBB05C0DE00000001 /* BackupBookmarkHandler.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -417,6 +420,7 @@
 				B6F7A1C22F0A1234001C2D3E /* ICloudContainerHandler.swift in Sources */,
 				C7F8A2D42F0B2345001D3E4F /* MetadataWriteHandler.swift in Sources */,
 				D8E9F0A22F0C3456001E4F50 /* LocalMediaHandler.swift in Sources */,
+				BB05C0DEBB05C0DE00000002 /* BackupBookmarkHandler.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,6 +8,7 @@ import workmanager_apple
   private var icloudHandler: ICloudContainerHandler?
   private var metadataHandler: MetadataWriteHandler?
   private var localMediaHandler: LocalMediaHandler?
+  private var backupBookmarkHandler: BackupBookmarkHandler?
 
   override func application(
     _ application: UIApplication,
@@ -34,6 +35,9 @@ import workmanager_apple
     if let localMediaRegistrar = self.registrar(forPlugin: "LocalMediaHandler") {
       localMediaHandler = LocalMediaHandler(messenger: localMediaRegistrar.messenger())
     }
+    if let backupRegistrar = self.registrar(forPlugin: "BackupBookmarkHandler") {
+      backupBookmarkHandler = BackupBookmarkHandler(messenger: backupRegistrar.messenger())
+    }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
@@ -41,6 +45,7 @@ import workmanager_apple
   override func applicationWillTerminate(_ application: UIApplication) {
     // Clean up security-scoped resource access
     bookmarkHandler?.cleanup()
+    backupBookmarkHandler?.releaseAll()
   }
 
   /// iOS caches launch screen snapshots in Library/SplashBoard.

--- a/ios/Runner/BackupBookmarkHandler.swift
+++ b/ios/Runner/BackupBookmarkHandler.swift
@@ -1,0 +1,269 @@
+import Flutter
+import UIKit
+import UniformTypeIdentifiers
+
+/// Dedicated security-scoped bookmark handler for the custom BACKUP folder.
+///
+/// Deliberately separate from `SecurityScopedBookmarkHandler` (which serves the
+/// custom database location). Like `LocalMediaHandler`, it keeps MULTIPLE
+/// concurrently active scoped URLs keyed by a session-local ref, rather than a
+/// single `activeSecurityScopedURL`. iOS permits many concurrent
+/// security-scoped resources, so the database scope and a backup-folder scope
+/// coexist -- arming one never displaces the other.
+///
+/// Channel: `app.submersion/backup_bookmark`
+///   - pickFolderWithSecurityScope() -> { path, bookmarkData }
+///   - createBookmark(path) -> bookmarkData
+///   - resolveBookmark(bookmarkData) -> { ref, path, isStale }   (scope armed)
+///   - releaseBookmark(ref) -> nil
+///   - releaseAllBookmarks() -> nil
+///   - verifyWriteAccess(path) -> Bool
+class BackupBookmarkHandler: NSObject, UIDocumentPickerDelegate {
+
+    private let channel: FlutterMethodChannel
+
+    /// Active security-scoped URLs keyed by the ref handed back to Dart.
+    private var active: [String: URL] = [:]
+
+    /// Pending result callback while the folder picker is on screen.
+    private var pendingPickerResult: FlutterResult?
+
+    init(messenger: FlutterBinaryMessenger) {
+        channel = FlutterMethodChannel(
+            name: "app.submersion/backup_bookmark",
+            binaryMessenger: messenger
+        )
+        super.init()
+        channel.setMethodCallHandler { [weak self] call, result in
+            self?.handle(call, result: result)
+        }
+    }
+
+    deinit {
+        releaseAll()
+    }
+
+    /// Stops accessing every backup URL we hold. Called on app teardown.
+    func releaseAll() {
+        for (_, url) in active {
+            url.stopAccessingSecurityScopedResource()
+        }
+        active.removeAll()
+    }
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "pickFolderWithSecurityScope":
+            pickFolder(result: result)
+
+        case "createBookmark":
+            guard let path = stringArg(call, "path") else {
+                result(invalidArgs("path"))
+                return
+            }
+            createBookmark(for: path, result: result)
+
+        case "resolveBookmark":
+            guard let args = call.arguments as? [String: Any],
+                let data = args["bookmarkData"] as? FlutterStandardTypedData
+            else {
+                result(invalidArgs("bookmarkData"))
+                return
+            }
+            resolveBookmark(data: data.data, result: result)
+
+        case "releaseBookmark":
+            guard let ref = stringArg(call, "ref") else {
+                result(invalidArgs("ref"))
+                return
+            }
+            if let url = active.removeValue(forKey: ref) {
+                url.stopAccessingSecurityScopedResource()
+            }
+            result(nil)
+
+        case "releaseAllBookmarks":
+            releaseAll()
+            result(nil)
+
+        case "verifyWriteAccess":
+            guard let path = stringArg(call, "path") else {
+                result(invalidArgs("path"))
+                return
+            }
+            verifyWriteAccess(path: path, result: result)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func stringArg(_ call: FlutterMethodCall, _ name: String) -> String? {
+        (call.arguments as? [String: Any])?[name] as? String
+    }
+
+    private func invalidArgs(_ name: String) -> FlutterError {
+        FlutterError(
+            code: "INVALID_ARGS", message: "Missing \(name) argument", details: nil)
+    }
+
+    // MARK: - Folder picker
+
+    private func pickFolder(result: @escaping FlutterResult) {
+        guard let viewController = UIApplication.shared.windows.first?.rootViewController
+        else {
+            result(
+                FlutterError(
+                    code: "NO_VIEW_CONTROLLER",
+                    message: "Could not find root view controller", details: nil))
+            return
+        }
+        pendingPickerResult = result
+
+        let picker: UIDocumentPickerViewController
+        if #available(iOS 14.0, *) {
+            picker = UIDocumentPickerViewController(forOpeningContentTypes: [.folder])
+        } else {
+            picker = UIDocumentPickerViewController(
+                documentTypes: ["public.folder"], in: .open)
+        }
+        picker.delegate = self
+        picker.allowsMultipleSelection = false
+        picker.modalPresentationStyle = .formSheet
+        viewController.present(picker, animated: true)
+    }
+
+    func documentPicker(
+        _ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]
+    ) {
+        guard let result = pendingPickerResult else { return }
+        pendingPickerResult = nil
+        guard let url = urls.first else {
+            result(nil)
+            return
+        }
+
+        guard url.startAccessingSecurityScopedResource() else {
+            result(
+                FlutterError(
+                    code: "ACCESS_ERROR",
+                    message: "Failed to start accessing security-scoped resource",
+                    details: nil))
+            return
+        }
+        // The pick's scope is only needed to mint the bookmark and verify write
+        // access. We do NOT keep it active -- runtime access is re-armed later
+        // via resolveBookmark (which returns a ref the caller releases).
+        defer { url.stopAccessingSecurityScopedResource() }
+
+        do {
+            let bookmarkData = try url.bookmarkData(
+                options: .minimalBookmark,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+
+            let testFileURL = url.appendingPathComponent(".submersion_test")
+            do {
+                try "test".data(using: .utf8)!.write(to: testFileURL)
+                try FileManager.default.removeItem(at: testFileURL)
+            } catch {
+                result(
+                    FlutterError(
+                        code: "WRITE_ERROR",
+                        message: "Cannot write to selected folder. Please check permissions.",
+                        details: error.localizedDescription))
+                return
+            }
+
+            result([
+                "path": url.path,
+                "bookmarkData": FlutterStandardTypedData(bytes: bookmarkData),
+            ])
+        } catch {
+            result(
+                FlutterError(
+                    code: "BOOKMARK_ERROR",
+                    message: "Failed to create bookmark: \(error.localizedDescription)",
+                    details: nil))
+        }
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        guard let result = pendingPickerResult else { return }
+        pendingPickerResult = nil
+        result(nil)
+    }
+
+    // MARK: - Bookmarks
+
+    private func createBookmark(for path: String, result: @escaping FlutterResult) {
+        let url = URL(fileURLWithPath: path)
+        do {
+            let data = try url.bookmarkData(
+                options: .minimalBookmark,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+            result(FlutterStandardTypedData(bytes: data))
+        } catch {
+            result(
+                FlutterError(
+                    code: "BOOKMARK_ERROR",
+                    message: "Failed to create bookmark: \(error.localizedDescription)",
+                    details: nil))
+        }
+    }
+
+    private func resolveBookmark(data: Data, result: @escaping FlutterResult) {
+        do {
+            var isStale = false
+            let url = try URL(
+                resolvingBookmarkData: data,
+                options: [],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+            guard url.startAccessingSecurityScopedResource() else {
+                result(
+                    FlutterError(
+                        code: "ACCESS_ERROR",
+                        message: "Failed to start accessing security-scoped resource",
+                        details: nil))
+                return
+            }
+            let ref = UUID().uuidString
+            active[ref] = url
+            result(["ref": ref, "path": url.path, "isStale": isStale])
+        } catch {
+            result(
+                FlutterError(
+                    code: "RESOLVE_ERROR",
+                    message: "Failed to resolve bookmark: \(error.localizedDescription)",
+                    details: nil))
+        }
+    }
+
+    private func verifyWriteAccess(path: String, result: @escaping FlutterResult) {
+        let url: URL
+        var startedHere = false
+        if let activeURL = active.values.first(where: { $0.path == path }) {
+            url = activeURL
+        } else {
+            url = URL(fileURLWithPath: path)
+            startedHere = url.startAccessingSecurityScopedResource()
+        }
+        defer {
+            if startedHere { url.stopAccessingSecurityScopedResource() }
+        }
+
+        let testFileURL = url.appendingPathComponent(".submersion_test")
+        do {
+            try "test".data(using: .utf8)!.write(to: testFileURL)
+            try FileManager.default.removeItem(at: testFileURL)
+            result(true)
+        } catch {
+            result(false)
+        }
+    }
+}

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -337,6 +337,11 @@ class _StartupWrapperState extends State<StartupWrapper>
       service = PreMigrationBackupService(
         livePathProvider: () async => dbPath,
         backupsDirProvider: () => BackupService.resolveBackupsDirectory(prefs),
+        // If the user's custom backup location is unreachable (e.g. an iOS
+        // iCloud path whose security scope was lost), degrade to the app
+        // sandbox so a pre-migration safety copy can never brick startup.
+        fallbackBackupsDirProvider:
+            BackupService.resolveDefaultBackupsDirectory,
         preferences: prefs,
       );
     }

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -325,6 +325,7 @@ class _StartupWrapperState extends State<StartupWrapper>
 
     final PreMigrationBackupService service;
     final String appVersion;
+    BackupDirLease? lease;
     if (widget.preMigrationBackupFactory != null) {
       service = widget.preMigrationBackupFactory!(
         livePath: dbPath,
@@ -334,23 +335,29 @@ class _StartupWrapperState extends State<StartupWrapper>
     } else {
       final info = await PackageInfo.fromPlatform();
       appVersion = '${info.version}.${info.buildNumber}';
+      // Arm any security-scoped bookmark for the custom location (and
+      // self-heal a stale one to the sandbox default) before the safety copy.
+      // Layer 1's fallback below still applies if writing to the armed path
+      // fails, so a pre-migration backup can never brick startup.
+      lease = await BackupService.resolveBackupsDirectoryLeased(prefs);
       service = PreMigrationBackupService(
         livePathProvider: () async => dbPath,
-        backupsDirProvider: () => BackupService.resolveBackupsDirectory(prefs),
-        // If the user's custom backup location is unreachable (e.g. an iOS
-        // iCloud path whose security scope was lost), degrade to the app
-        // sandbox so a pre-migration safety copy can never brick startup.
+        backupsDirProvider: () async => lease!.path,
         fallbackBackupsDirProvider:
             BackupService.resolveDefaultBackupsDirectory,
         preferences: prefs,
       );
     }
 
-    await service.backupIfMigrationPending(
-      stored: stored,
-      target: AppDatabase.currentSchemaVersion,
-      appVersion: appVersion,
-    );
+    try {
+      await service.backupIfMigrationPending(
+        stored: stored,
+        target: AppDatabase.currentSchemaVersion,
+        appVersion: appVersion,
+      );
+    } finally {
+      await lease?.release();
+    }
   }
 
   /// Re-runs backup → services → ready without the 1-second splash delay used

--- a/lib/core/services/backup_bookmark_service.dart
+++ b/lib/core/services/backup_bookmark_service.dart
@@ -67,6 +67,8 @@ class BackupBookmarkService {
         path: path,
         bookmark: result['bookmarkData'] as Uint8List?,
       );
+    } on MissingPluginException {
+      return null;
     } on PlatformException catch (e) {
       debugPrint('Backup folder pick failed: ${e.message}');
       rethrow;
@@ -82,6 +84,8 @@ class BackupBookmarkService {
       return await _channel.invokeMethod<Uint8List>('createBookmark', {
         'path': path,
       });
+    } on MissingPluginException {
+      return null;
     } on PlatformException catch (e) {
       debugPrint('Backup bookmark create failed: ${e.message}');
       return null;
@@ -108,6 +112,8 @@ class BackupBookmarkService {
         path: path,
         isStale: result['isStale'] as bool? ?? false,
       );
+    } on MissingPluginException {
+      return null;
     } on PlatformException catch (e) {
       debugPrint('Backup bookmark resolve failed: ${e.message}');
       return null;
@@ -119,6 +125,8 @@ class BackupBookmarkService {
     if (!isSupported) return;
     try {
       await _channel.invokeMethod<void>('releaseBookmark', {'ref': ref});
+    } on MissingPluginException {
+      // No native handler available; nothing to release.
     } on PlatformException catch (e) {
       debugPrint('Backup bookmark release failed: ${e.message}');
     }
@@ -129,6 +137,8 @@ class BackupBookmarkService {
     if (!isSupported) return;
     try {
       await _channel.invokeMethod<void>('releaseAllBookmarks');
+    } on MissingPluginException {
+      // No native handler available; nothing to release.
     } on PlatformException catch (e) {
       debugPrint('Backup bookmark releaseAll failed: ${e.message}');
     }
@@ -143,6 +153,8 @@ class BackupBookmarkService {
         'path': path,
       });
       return ok ?? false;
+    } on MissingPluginException {
+      return false;
     } on PlatformException catch (e) {
       debugPrint('Backup bookmark verifyWriteAccess failed: ${e.message}');
       return false;

--- a/lib/core/services/backup_bookmark_service.dart
+++ b/lib/core/services/backup_bookmark_service.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Result of picking a backup folder on iOS: the chosen path plus a
+/// persistable security-scoped bookmark for regaining access after restart.
+@immutable
+class BackupFolderPick {
+  final String path;
+  final Uint8List? bookmark;
+  const BackupFolderPick({required this.path, this.bookmark});
+}
+
+/// A resolved, currently-armed security-scoped bookmark.
+///
+/// [ref] is a session-local handle that MUST be passed to
+/// [BackupBookmarkService.release] when access is no longer needed, so the
+/// native side can balance its `startAccessingSecurityScopedResource` call.
+@immutable
+class BackupBookmarkLease {
+  final String ref;
+  final String path;
+  final bool isStale;
+  const BackupBookmarkLease({
+    required this.ref,
+    required this.path,
+    required this.isStale,
+  });
+}
+
+/// Dart wrapper over the `app.submersion/backup_bookmark` channel.
+///
+/// Backups use a DEDICATED native handler, separate from the database-location
+/// [SecurityScopedBookmarkHandler], so arming a backup-folder scope never
+/// displaces the database scope. The native side keeps multiple concurrently
+/// active scoped URLs keyed by [BackupBookmarkLease.ref].
+///
+/// Every method is a no-op on non-Apple platforms (callers keep using bare
+/// paths there, which work without security scoping).
+class BackupBookmarkService {
+  static const _channel = MethodChannel('app.submersion/backup_bookmark');
+
+  /// Test seam overriding the platform-support check. Production leaves null so
+  /// the real `Platform` check is used. Mirrors
+  /// `BackupFailedException.debugIsWindows`.
+  @visibleForTesting
+  static bool? debugSupportedOverride;
+
+  /// Whether security-scoped bookmarks are supported on this platform.
+  static bool get isSupported =>
+      debugSupportedOverride ?? (Platform.isIOS || Platform.isMacOS);
+
+  /// Presents the native folder picker (iOS) and returns the picked path plus
+  /// a security-scoped bookmark captured while access is still live. Returns
+  /// null if the user cancelled or the platform is unsupported.
+  static Future<BackupFolderPick?> pickFolder() async {
+    if (!isSupported) return null;
+    try {
+      final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+        'pickFolderWithSecurityScope',
+      );
+      if (result == null) return null;
+      final path = result['path'] as String?;
+      if (path == null) return null;
+      return BackupFolderPick(
+        path: path,
+        bookmark: result['bookmarkData'] as Uint8List?,
+      );
+    } on PlatformException catch (e) {
+      debugPrint('Backup folder pick failed: ${e.message}');
+      rethrow;
+    }
+  }
+
+  /// Creates a security-scoped bookmark for [path]. Used on macOS where the
+  /// folder is chosen via file_picker rather than the native picker. Returns
+  /// null on failure or unsupported platforms.
+  static Future<Uint8List?> createBookmark(String path) async {
+    if (!isSupported) return null;
+    try {
+      return await _channel.invokeMethod<Uint8List>('createBookmark', {
+        'path': path,
+      });
+    } on PlatformException catch (e) {
+      debugPrint('Backup bookmark create failed: ${e.message}');
+      return null;
+    }
+  }
+
+  /// Resolves a stored bookmark, starts security-scoped access, and returns a
+  /// [BackupBookmarkLease]. The caller must [release] the lease's ref when
+  /// done. Returns null if the bookmark cannot be resolved or the platform is
+  /// unsupported.
+  static Future<BackupBookmarkLease?> resolveBookmark(Uint8List data) async {
+    if (!isSupported) return null;
+    try {
+      final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+        'resolveBookmark',
+        {'bookmarkData': data},
+      );
+      if (result == null) return null;
+      final ref = result['ref'] as String?;
+      final path = result['path'] as String?;
+      if (ref == null || path == null) return null;
+      return BackupBookmarkLease(
+        ref: ref,
+        path: path,
+        isStale: result['isStale'] as bool? ?? false,
+      );
+    } on PlatformException catch (e) {
+      debugPrint('Backup bookmark resolve failed: ${e.message}');
+      return null;
+    }
+  }
+
+  /// Stops security-scoped access for the resource held under [ref].
+  static Future<void> release(String ref) async {
+    if (!isSupported) return;
+    try {
+      await _channel.invokeMethod<void>('releaseBookmark', {'ref': ref});
+    } on PlatformException catch (e) {
+      debugPrint('Backup bookmark release failed: ${e.message}');
+    }
+  }
+
+  /// Stops security-scoped access for every backup URL the native side holds.
+  static Future<void> releaseAll() async {
+    if (!isSupported) return;
+    try {
+      await _channel.invokeMethod<void>('releaseAllBookmarks');
+    } on PlatformException catch (e) {
+      debugPrint('Backup bookmark releaseAll failed: ${e.message}');
+    }
+  }
+
+  /// Verifies write access to [path] using security-scoped access. Returns
+  /// false on failure or unsupported platforms.
+  static Future<bool> verifyWriteAccess(String path) async {
+    if (!isSupported) return false;
+    try {
+      final ok = await _channel.invokeMethod<bool>('verifyWriteAccess', {
+        'path': path,
+      });
+      return ok ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('Backup bookmark verifyWriteAccess failed: ${e.message}');
+      return false;
+    }
+  }
+}

--- a/lib/features/backup/data/repositories/backup_preferences.dart
+++ b/lib/features/backup/data/repositories/backup_preferences.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -17,6 +18,7 @@ class BackupPreferences {
   static const String _lastBackupTimeKey = 'backup_last_time';
   static const String _cloudBackupEnabledKey = 'backup_cloud_enabled';
   static const String _backupLocationKey = 'backup_location';
+  static const String _backupLocationBookmarkKey = 'backup_location_bookmark';
   static const String _historyKey = 'backup_history';
 
   final SharedPreferences _prefs;
@@ -64,9 +66,30 @@ class BackupPreferences {
   Future<void> setBackupLocation(String? path) async {
     if (path == null) {
       await _prefs.remove(_backupLocationKey);
+      // The bookmark only has meaning paired with a location, so clearing the
+      // location (reset to default) must drop the bookmark too -- otherwise a
+      // dangling security-scoped bookmark would linger.
+      await _prefs.remove(_backupLocationBookmarkKey);
     } else {
       await _prefs.setString(_backupLocationKey, path);
     }
+  }
+
+  /// Persists the security-scoped bookmark bytes for the custom backup
+  /// location (Apple platforms), stored as base64. Null removes it.
+  Future<void> setBackupLocationBookmark(List<int>? bytes) async {
+    if (bytes == null) {
+      await _prefs.remove(_backupLocationBookmarkKey);
+    } else {
+      await _prefs.setString(_backupLocationBookmarkKey, base64Encode(bytes));
+    }
+  }
+
+  /// Reads the stored backup-location bookmark bytes, or null if none is set.
+  Uint8List? getBackupLocationBookmark() {
+    final encoded = _prefs.getString(_backupLocationBookmarkKey);
+    if (encoded == null) return null;
+    return base64Decode(encoded);
   }
 
   // ===========================================================================

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -622,6 +622,16 @@ class BackupService {
       }
       return customDir.path;
     }
+    return resolveDefaultBackupsDirectory();
+  }
+
+  /// The default backups directory inside the app's sandbox documents dir.
+  ///
+  /// Always writable (it lives inside the app container), so it doubles as the
+  /// safe fallback when a user-chosen custom location is unreachable -- see
+  /// PreMigrationBackupService. Unlike [resolveBackupsDirectory] this ignores
+  /// any configured custom location by design.
+  static Future<String> resolveDefaultBackupsDirectory() async {
     final appDir = await getApplicationDocumentsDirectory();
     final backupDir = Directory(p.join(appDir.path, _localBackupFolder));
     if (!await backupDir.exists()) {
@@ -635,16 +645,11 @@ class BackupService {
       BackupService.resolveBackupsDirectory(_preferences);
 
   /// Get the local backups directory, creating it if needed.
-  Future<String> getLocalBackupsDirectory() async {
-    // Direct-path version bypassing custom-location check; preserved for
-    // existing callers that want the default location specifically.
-    final appDir = await getApplicationDocumentsDirectory();
-    final backupDir = Directory(p.join(appDir.path, _localBackupFolder));
-    if (!await backupDir.exists()) {
-      await backupDir.create(recursive: true);
-    }
-    return backupDir.path;
-  }
+  ///
+  /// Direct-path version bypassing the custom-location check; preserved for
+  /// existing callers that want the default location specifically.
+  Future<String> getLocalBackupsDirectory() =>
+      BackupService.resolveDefaultBackupsDirectory();
 
   // ===========================================================================
   // Private Helpers

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -70,6 +70,7 @@ class BackupDirLease {
 abstract class BackupBookmarkPort {
   Future<BackupBookmarkLease?> resolve(Uint8List data);
   Future<void> release(String ref);
+  Future<Uint8List?> createBookmark(String path);
 }
 
 class _DefaultBackupBookmarkPort implements BackupBookmarkPort {
@@ -81,6 +82,10 @@ class _DefaultBackupBookmarkPort implements BackupBookmarkPort {
 
   @override
   Future<void> release(String ref) => BackupBookmarkService.release(ref);
+
+  @override
+  Future<Uint8List?> createBookmark(String path) =>
+      BackupBookmarkService.createBookmark(path);
 }
 
 /// Core backup service handling backup creation, restore, pruning, and cloud upload.
@@ -712,6 +717,17 @@ class BackupService {
     if (bytes != null) {
       final lease = await port.resolve(bytes);
       if (lease != null) {
+        if (lease.isStale) {
+          // Resolved but stale (the folder moved, or an OS upgrade aged the
+          // bookmark). Re-mint it from the now-armed path so it stops resolving
+          // stale -- best-effort: if re-minting fails we keep the resolved
+          // location rather than discard a working choice. A genuinely broken
+          // bookmark resolves to null below and is reset to the default.
+          final fresh = await port.createBookmark(lease.path);
+          if (fresh != null) {
+            await preferences.setBackupLocationBookmark(fresh);
+          }
+        }
         return BackupDirLease(
           await _ensureDir(lease.path),
           () => port.release(lease.ref),

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -131,9 +131,23 @@ class BackupService {
   /// the backup is also uploaded to cloud storage.
   Future<BackupRecord> performBackup({bool isAutomatic = false}) async {
     _log.info('Starting backup (automatic: $isAutomatic)');
+    // Arm any security-scoped access needed to reach a custom Apple location,
+    // and release it once the write (and prune) are done.
+    final lease = await BackupService.resolveBackupsDirectoryLeased(
+      _preferences,
+    );
+    try {
+      return await _performBackupInto(lease.path, isAutomatic: isAutomatic);
+    } finally {
+      await lease.release();
+    }
+  }
 
+  Future<BackupRecord> _performBackupInto(
+    String localDir, {
+    required bool isAutomatic,
+  }) async {
     final filename = _generateFilename();
-    final localDir = await getBackupsDirectory();
     final localPath = p.join(localDir, filename);
 
     // Copy the database file

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -10,6 +10,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -50,6 +51,36 @@ class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => _dbAdapter.database;
+}
+
+/// A backups directory ready to write into, plus [release] to call when the
+/// caller is done -- which stops any security-scoped access that was armed to
+/// reach a custom Apple location. For the default/sandbox location the release
+/// is a no-op.
+class BackupDirLease {
+  final String path;
+  final Future<void> Function() _release;
+  const BackupDirLease(this.path, this._release);
+
+  Future<void> release() => _release();
+}
+
+/// Narrow seam over [BackupBookmarkService] so the leased resolver can be
+/// tested without a native channel.
+abstract class BackupBookmarkPort {
+  Future<BackupBookmarkLease?> resolve(Uint8List data);
+  Future<void> release(String ref);
+}
+
+class _DefaultBackupBookmarkPort implements BackupBookmarkPort {
+  const _DefaultBackupBookmarkPort();
+
+  @override
+  Future<BackupBookmarkLease?> resolve(Uint8List data) =>
+      BackupBookmarkService.resolveBookmark(data);
+
+  @override
+  Future<void> release(String ref) => BackupBookmarkService.release(ref);
 }
 
 /// Core backup service handling backup creation, restore, pruning, and cloud upload.
@@ -638,6 +669,53 @@ class BackupService {
       await backupDir.create(recursive: true);
     }
     return backupDir.path;
+  }
+
+  /// Resolves the backups directory and arms any security-scoped access needed
+  /// to write into it, returning a [BackupDirLease]. Callers MUST call
+  /// [BackupDirLease.release] when finished writing.
+  ///
+  /// On Apple platforms a custom location is only reachable through its
+  /// security-scoped bookmark. If the bookmark is missing or cannot be
+  /// resolved (e.g. an iCloud folder whose access was revoked), the location is
+  /// reset to the sandbox default rather than left broken -- this is what
+  /// self-heals an already-stored dead path. On other platforms, and for the
+  /// default location, the path is returned directly with a no-op release.
+  static Future<BackupDirLease> resolveBackupsDirectoryLeased(
+    BackupPreferences preferences, {
+    BackupBookmarkPort? bookmarks,
+  }) async {
+    final custom = preferences.getSettings().backupLocation;
+    if (custom == null) {
+      return BackupDirLease(await resolveDefaultBackupsDirectory(), _noRelease);
+    }
+    if (!BackupBookmarkService.isSupported) {
+      // Desktop/Android: bare custom paths persist and work without scoping.
+      return BackupDirLease(await _ensureDir(custom), _noRelease);
+    }
+    final port = bookmarks ?? const _DefaultBackupBookmarkPort();
+    final bytes = preferences.getBackupLocationBookmark();
+    if (bytes != null) {
+      final lease = await port.resolve(bytes);
+      if (lease != null) {
+        return BackupDirLease(
+          await _ensureDir(lease.path),
+          () => port.release(lease.ref),
+        );
+      }
+    }
+    // No bookmark, or it could not be resolved: the custom location is unusable
+    // on this platform. Reset to the sandbox default so backups keep working.
+    await preferences.setBackupLocation(null); // clears location + bookmark
+    return BackupDirLease(await resolveDefaultBackupsDirectory(), _noRelease);
+  }
+
+  static Future<void> _noRelease() async {}
+
+  static Future<String> _ensureDir(String dir) async {
+    final directory = Directory(dir);
+    if (!await directory.exists()) await directory.create(recursive: true);
+    return dir;
   }
 
   /// Get the active backups directory (custom or default), creating it if needed.

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -20,6 +20,7 @@ class PreMigrationBackupService {
   static const int _retainN = 3;
   final AsyncPathResolver _livePathProvider;
   final AsyncPathResolver _backupsDirProvider;
+  final AsyncPathResolver? _fallbackBackupsDirProvider;
   final BackupPreferences _preferences;
   final DateTime Function() _clock;
   final String Function() _idGenerator;
@@ -28,11 +29,13 @@ class PreMigrationBackupService {
   PreMigrationBackupService({
     required AsyncPathResolver livePathProvider,
     required AsyncPathResolver backupsDirProvider,
+    AsyncPathResolver? fallbackBackupsDirProvider,
     required BackupPreferences preferences,
     DateTime Function()? clock,
     String Function()? idGenerator,
   }) : _livePathProvider = livePathProvider,
        _backupsDirProvider = backupsDirProvider,
+       _fallbackBackupsDirProvider = fallbackBackupsDirProvider,
        _preferences = preferences,
        _clock = clock ?? DateTime.now,
        _idGenerator = idGenerator ?? (() => const Uuid().v4());
@@ -45,33 +48,37 @@ class PreMigrationBackupService {
     if (stored >= target) return;
 
     late final String livePath;
-    late final String backupsDir;
     try {
       livePath = await _livePathProvider();
       if (!await File(livePath).exists()) return;
-
-      backupsDir = await _backupsDirProvider();
-      await Directory(backupsDir).create(recursive: true);
-    } on BackupFailedException {
-      rethrow;
     } catch (e, stack) {
       throw BackupFailedException.fromError(e, stack);
     }
 
-    await _sweepTempFiles(backupsDir);
-
     final now = _clock().toUtc();
-    final ts = _formatTimestamp(now);
-    final filename = '$ts-v$stored-v$target.db';
-    final tempPath = p.join(backupsDir, '.$filename.tmp');
-    final finalPath = p.join(backupsDir, filename);
+    final filename = '${_formatTimestamp(now)}-v$stored-v$target.db';
 
+    late final String finalPath;
     try {
-      await File(livePath).copy(tempPath);
-      await File(tempPath).rename(finalPath);
-    } catch (e, stack) {
-      await _safeDelete(tempPath);
-      throw BackupFailedException.fromError(e, stack);
+      finalPath = await _backupInto(_backupsDirProvider, livePath, filename);
+    } catch (preferredError, preferredStack) {
+      final fallbackProvider = _fallbackBackupsDirProvider;
+      if (fallbackProvider == null) {
+        if (preferredError is BackupFailedException) rethrow;
+        throw BackupFailedException.fromError(preferredError, preferredStack);
+      }
+      _log.warning(
+        'Preferred backups location is unusable; falling back to the default '
+        'app location for the pre-migration backup.',
+        error: preferredError,
+        stackTrace: preferredStack,
+      );
+      try {
+        finalPath = await _backupInto(fallbackProvider, livePath, filename);
+      } catch (e, stack) {
+        if (e is BackupFailedException) rethrow;
+        throw BackupFailedException.fromError(e, stack);
+      }
     }
 
     late final int sizeBytes;
@@ -115,6 +122,34 @@ class PreMigrationBackupService {
         stackTrace: stack,
       );
     }
+  }
+
+  /// Resolves + creates [provider]'s directory, sweeps stale temp files, and
+  /// atomically copies the live DB into it. Returns the final path.
+  ///
+  /// Wrapping the WHOLE attempt -- not just directory creation -- means an
+  /// existing but unwritable preferred location (e.g. an iOS iCloud folder
+  /// whose write scope was lost, where create() is a no-op but the copy is
+  /// denied) still degrades to the caller's fallback instead of bricking
+  /// startup. Throws if any step fails; the caller decides whether to retry.
+  Future<String> _backupInto(
+    AsyncPathResolver provider,
+    String livePath,
+    String filename,
+  ) async {
+    final dir = await provider();
+    await Directory(dir).create(recursive: true);
+    await _sweepTempFiles(dir);
+    final tempPath = p.join(dir, '.$filename.tmp');
+    final finalPath = p.join(dir, filename);
+    try {
+      await File(livePath).copy(tempPath);
+      await File(tempPath).rename(finalPath);
+    } catch (e) {
+      await _safeDelete(tempPath);
+      rethrow;
+    }
+    return finalPath;
   }
 
   String _formatTimestamp(DateTime utc) {

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -6,6 +6,7 @@ import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
@@ -488,13 +489,31 @@ class BackupSettingsPage extends ConsumerWidget {
           ),
           trailing: TextButton(
             onPressed: () async {
-              final path = await FilePicker.getDirectoryPath(
-                dialogTitle: context.l10n.backup_location_title,
-              );
-              if (path != null) {
-                ref
+              final BackupFolderPick? picked;
+              if (Platform.isIOS) {
+                // iOS: capture a security-scoped bookmark directly -- a bare
+                // file_picker path would lose its scope on the next launch.
+                picked = await BackupBookmarkService.pickFolder();
+              } else {
+                final path = await FilePicker.getDirectoryPath(
+                  dialogTitle: context.l10n.backup_location_title,
+                );
+                picked = path == null
+                    ? null
+                    : BackupFolderPick(
+                        path: path,
+                        bookmark: BackupBookmarkService.isSupported
+                            ? await BackupBookmarkService.createBookmark(path)
+                            : null,
+                      );
+              }
+              if (picked != null) {
+                await ref
                     .read(backupSettingsProvider.notifier)
-                    .setBackupLocation(path);
+                    .setBackupLocationWithBookmark(
+                      picked.path,
+                      picked.bookmark,
+                    );
               }
             },
             child: Text(context.l10n.backup_location_change),

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -81,6 +81,22 @@ class BackupSettingsNotifier extends StateNotifier<BackupSettings> {
     state = _prefs.getSettings();
   }
 
+  /// Sets a custom backup location together with its security-scoped bookmark
+  /// (Apple platforms). The bookmark is what lets the location survive an app
+  /// restart; a null bookmark is fine on desktop, where bare paths persist.
+  ///
+  /// Like [setBackupLocation], choosing a custom location turns cloud backup
+  /// off -- the conflicting cloud key is cleared before the location is set.
+  Future<void> setBackupLocationWithBookmark(
+    String path,
+    List<int>? bookmark,
+  ) async {
+    await _prefs.setCloudBackupEnabled(false);
+    await _prefs.setBackupLocation(path);
+    await _prefs.setBackupLocationBookmark(bookmark);
+    state = _prefs.getSettings();
+  }
+
   /// Sign-out hook: cloud sync is being disabled, so cloud backup loses its
   /// destination. Resets the location to default only when cloud backup was
   /// actually on -- an unrelated custom location is none of sync's business.

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		C507DEAA18B2C2BBCAA8F79D /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 777A6CC8C816F9057D0180DB /* Pods_Runner.framework */; };
 		DEAD1234BEEF56780011AABC /* MetadataWriteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAD1234BEEF56780011AABB /* MetadataWriteHandler.swift */; };
 		E9F0A1B42F0D4567001F5061 /* LocalMediaHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F0A1B32F0D4567001F5061 /* LocalMediaHandler.swift */; };
+		BB05C0DEBB05C0DE00000012 /* BackupBookmarkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB05C0DEBB05C0DE00000011 /* BackupBookmarkHandler.swift */; };
 		F00D1234ABCDEF0011223345 /* ICloudContainerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D1234ABCDEF0011223344 /* ICloudContainerHandler.swift */; };
 /* End PBXBuildFile section */
 
@@ -97,6 +98,7 @@
 		AABBCC001122334455667789 /* SecurityScopedBookmarkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScopedBookmarkHandler.swift; sourceTree = "<group>"; };
 		DEAD1234BEEF56780011AABB /* MetadataWriteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataWriteHandler.swift; sourceTree = "<group>"; };
 		E9F0A1B32F0D4567001F5061 /* LocalMediaHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMediaHandler.swift; sourceTree = "<group>"; };
+		BB05C0DEBB05C0DE00000011 /* BackupBookmarkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBookmarkHandler.swift; sourceTree = "<group>"; };
 		F00D1234ABCDEF0011223344 /* ICloudContainerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudContainerHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -204,6 +206,7 @@
 				F00D1234ABCDEF0011223344 /* ICloudContainerHandler.swift */,
 				DEAD1234BEEF56780011AABB /* MetadataWriteHandler.swift */,
 				E9F0A1B32F0D4567001F5061 /* LocalMediaHandler.swift */,
+				BB05C0DEBB05C0DE00000011 /* BackupBookmarkHandler.swift */,
 				A1B2C3D4E5F6A7B80011AABB /* PrivacyInfo.xcprivacy */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
@@ -475,6 +478,7 @@
 				F00D1234ABCDEF0011223345 /* ICloudContainerHandler.swift in Sources */,
 				DEAD1234BEEF56780011AABC /* MetadataWriteHandler.swift in Sources */,
 				E9F0A1B42F0D4567001F5061 /* LocalMediaHandler.swift in Sources */,
+				BB05C0DEBB05C0DE00000012 /* BackupBookmarkHandler.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -9,6 +9,7 @@ class AppDelegate: FlutterAppDelegate {
   private var icloudHandler: ICloudContainerHandler?
   private var metadataHandler: MetadataWriteHandler?
   private var localMediaHandler: LocalMediaHandler?
+  private var backupBookmarkHandler: BackupBookmarkHandler?
   private var updateChannel: FlutterMethodChannel?
 
   /// Mac App Store and TestFlight builds contain a receipt file;
@@ -37,6 +38,7 @@ class AppDelegate: FlutterAppDelegate {
       icloudHandler = ICloudContainerHandler(messenger: messenger)
       metadataHandler = MetadataWriteHandler(messenger: messenger)
       localMediaHandler = LocalMediaHandler(messenger: messenger)
+      backupBookmarkHandler = BackupBookmarkHandler(messenger: messenger)
       updateChannel = FlutterMethodChannel(
         name: "app.submersion/updates",
         binaryMessenger: messenger
@@ -57,6 +59,7 @@ class AppDelegate: FlutterAppDelegate {
 
   override func applicationWillTerminate(_ notification: Notification) {
     bookmarkHandler?.cleanup()
+    backupBookmarkHandler?.releaseAll()
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/macos/Runner/BackupBookmarkHandler.swift
+++ b/macos/Runner/BackupBookmarkHandler.swift
@@ -1,0 +1,171 @@
+import Cocoa
+import FlutterMacOS
+
+/// Dedicated security-scoped bookmark handler for the custom BACKUP folder
+/// (macOS). See `ios/Runner/BackupBookmarkHandler.swift` for the rationale: a
+/// separate, multi-slot handler so a backup-folder scope never displaces the
+/// database-location scope held by `SecurityScopedBookmarkHandler`.
+///
+/// macOS requires `.withSecurityScope` at BOTH bookmark creation and
+/// resolution (unlike iOS's `.minimalBookmark` + `[]`). The folder itself is
+/// chosen via file_picker on the Dart side, so there is no native picker here.
+///
+/// Channel: `app.submersion/backup_bookmark`
+///   - createBookmark(path) -> bookmarkData
+///   - resolveBookmark(bookmarkData) -> { ref, path, isStale }   (scope armed)
+///   - releaseBookmark(ref) -> nil
+///   - releaseAllBookmarks() -> nil
+///   - verifyWriteAccess(path) -> Bool
+class BackupBookmarkHandler: NSObject {
+
+    private let channel: FlutterMethodChannel
+
+    /// Active security-scoped URLs keyed by the ref handed back to Dart.
+    private var active: [String: URL] = [:]
+
+    init(messenger: FlutterBinaryMessenger) {
+        channel = FlutterMethodChannel(
+            name: "app.submersion/backup_bookmark",
+            binaryMessenger: messenger
+        )
+        super.init()
+        channel.setMethodCallHandler { [weak self] call, result in
+            self?.handle(call, result: result)
+        }
+    }
+
+    deinit {
+        releaseAll()
+    }
+
+    /// Stops accessing every backup URL we hold. Called on app teardown.
+    func releaseAll() {
+        for (_, url) in active {
+            url.stopAccessingSecurityScopedResource()
+        }
+        active.removeAll()
+    }
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "createBookmark":
+            guard let path = stringArg(call, "path") else {
+                result(invalidArgs("path"))
+                return
+            }
+            createBookmark(for: path, result: result)
+
+        case "resolveBookmark":
+            guard let args = call.arguments as? [String: Any],
+                let data = args["bookmarkData"] as? FlutterStandardTypedData
+            else {
+                result(invalidArgs("bookmarkData"))
+                return
+            }
+            resolveBookmark(data: data.data, result: result)
+
+        case "releaseBookmark":
+            guard let ref = stringArg(call, "ref") else {
+                result(invalidArgs("ref"))
+                return
+            }
+            if let url = active.removeValue(forKey: ref) {
+                url.stopAccessingSecurityScopedResource()
+            }
+            result(nil)
+
+        case "releaseAllBookmarks":
+            releaseAll()
+            result(nil)
+
+        case "verifyWriteAccess":
+            guard let path = stringArg(call, "path") else {
+                result(invalidArgs("path"))
+                return
+            }
+            verifyWriteAccess(path: path, result: result)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func stringArg(_ call: FlutterMethodCall, _ name: String) -> String? {
+        (call.arguments as? [String: Any])?[name] as? String
+    }
+
+    private func invalidArgs(_ name: String) -> FlutterError {
+        FlutterError(
+            code: "INVALID_ARGS", message: "Missing \(name) argument", details: nil)
+    }
+
+    private func createBookmark(for path: String, result: @escaping FlutterResult) {
+        let url = URL(fileURLWithPath: path)
+        do {
+            let data = try url.bookmarkData(
+                options: .withSecurityScope,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+            result(FlutterStandardTypedData(bytes: data))
+        } catch {
+            result(
+                FlutterError(
+                    code: "BOOKMARK_ERROR",
+                    message: "Failed to create bookmark: \(error.localizedDescription)",
+                    details: nil))
+        }
+    }
+
+    private func resolveBookmark(data: Data, result: @escaping FlutterResult) {
+        do {
+            var isStale = false
+            let url = try URL(
+                resolvingBookmarkData: data,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+            guard url.startAccessingSecurityScopedResource() else {
+                result(
+                    FlutterError(
+                        code: "ACCESS_ERROR",
+                        message: "Failed to start accessing security-scoped resource",
+                        details: nil))
+                return
+            }
+            let ref = UUID().uuidString
+            active[ref] = url
+            result(["ref": ref, "path": url.path, "isStale": isStale])
+        } catch {
+            result(
+                FlutterError(
+                    code: "RESOLVE_ERROR",
+                    message: "Failed to resolve bookmark: \(error.localizedDescription)",
+                    details: nil))
+        }
+    }
+
+    private func verifyWriteAccess(path: String, result: @escaping FlutterResult) {
+        let url: URL
+        var startedHere = false
+        if let activeURL = active.values.first(where: { $0.path == path }) {
+            url = activeURL
+        } else {
+            url = URL(fileURLWithPath: path)
+            startedHere = url.startAccessingSecurityScopedResource()
+        }
+        defer {
+            if startedHere { url.stopAccessingSecurityScopedResource() }
+        }
+
+        let testFileURL = url.appendingPathComponent(".submersion_test")
+        do {
+            try "test".data(using: .utf8)!.write(to: testFileURL)
+            try FileManager.default.removeItem(at: testFileURL)
+            result(true)
+        } catch {
+            result(false)
+        }
+    }
+}

--- a/test/core/services/backup_bookmark_service_test.dart
+++ b/test/core/services/backup_bookmark_service_test.dart
@@ -114,4 +114,36 @@ void main() {
     expect(await BackupBookmarkService.resolveBookmark(Uint8List(1)), isNull);
     expect(await BackupBookmarkService.verifyWriteAccess('/x'), isFalse);
   });
+
+  group('error and unsupported handling', () {
+    test('create/resolve/verify swallow a PlatformException', () async {
+      mock((_) async => throw PlatformException(code: 'BOOM'));
+      expect(await BackupBookmarkService.createBookmark('/x'), isNull);
+      expect(await BackupBookmarkService.resolveBookmark(Uint8List(1)), isNull);
+      expect(await BackupBookmarkService.verifyWriteAccess('/x'), isFalse);
+    });
+
+    test('release and releaseAll swallow a PlatformException', () async {
+      mock((_) async => throw PlatformException(code: 'BOOM'));
+      await BackupBookmarkService.release('r'); // must not throw
+      await BackupBookmarkService.releaseAll(); // must not throw
+    });
+
+    test('pickFolder rethrows a PlatformException', () async {
+      mock((_) async => throw PlatformException(code: 'BOOM'));
+      await expectLater(
+        BackupBookmarkService.pickFolder(),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+
+    test('release/releaseAll/pickFolder are no-ops when unsupported', () async {
+      BackupBookmarkService.debugSupportedOverride = false;
+      mock((_) async => null);
+      await BackupBookmarkService.release('r');
+      await BackupBookmarkService.releaseAll();
+      expect(await BackupBookmarkService.pickFolder(), isNull);
+      expect(calls, isEmpty);
+    });
+  });
 }

--- a/test/core/services/backup_bookmark_service_test.dart
+++ b/test/core/services/backup_bookmark_service_test.dart
@@ -106,4 +106,12 @@ void main() {
     expect(await BackupBookmarkService.verifyWriteAccess('/x'), isFalse);
     expect(calls, isEmpty);
   });
+
+  test('degrades to null/false when no native handler is registered', () async {
+    // No mock() handler in this test -> the channel has no handler, so
+    // invokeMethod throws MissingPluginException, which must be swallowed.
+    expect(await BackupBookmarkService.createBookmark('/x'), isNull);
+    expect(await BackupBookmarkService.resolveBookmark(Uint8List(1)), isNull);
+    expect(await BackupBookmarkService.verifyWriteAccess('/x'), isFalse);
+  });
 }

--- a/test/core/services/backup_bookmark_service_test.dart
+++ b/test/core/services/backup_bookmark_service_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/backup_bookmark_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('app.submersion/backup_bookmark');
+  final calls = <MethodCall>[];
+
+  void mock(Future<Object?> Function(MethodCall call) handler) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return handler(call);
+        });
+  }
+
+  setUp(() {
+    calls.clear();
+    BackupBookmarkService.debugSupportedOverride = true;
+  });
+
+  tearDown(() {
+    BackupBookmarkService.debugSupportedOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('resolveBookmark returns a lease with ref, path, and isStale', () async {
+    mock((call) async {
+      if (call.method == 'resolveBookmark') {
+        return {'ref': 'r1', 'path': '/x/Backups', 'isStale': true};
+      }
+      return null;
+    });
+
+    final lease = await BackupBookmarkService.resolveBookmark(Uint8List(4));
+
+    expect(lease, isNotNull);
+    expect(lease!.ref, 'r1');
+    expect(lease.path, '/x/Backups');
+    expect(lease.isStale, isTrue);
+    expect(calls.single.method, 'resolveBookmark');
+  });
+
+  test('release invokes releaseBookmark with the ref', () async {
+    mock((_) async => null);
+
+    await BackupBookmarkService.release('r9');
+
+    expect(calls.single.method, 'releaseBookmark');
+    expect((calls.single.arguments as Map)['ref'], 'r9');
+  });
+
+  test('releaseAll invokes releaseAllBookmarks', () async {
+    mock((_) async => null);
+
+    await BackupBookmarkService.releaseAll();
+
+    expect(calls.single.method, 'releaseAllBookmarks');
+  });
+
+  test('verifyWriteAccess returns the channel bool', () async {
+    mock((call) async => call.method == 'verifyWriteAccess' ? true : null);
+
+    expect(await BackupBookmarkService.verifyWriteAccess('/x'), isTrue);
+  });
+
+  test('createBookmark returns the bookmark bytes', () async {
+    mock(
+      (call) async => call.method == 'createBookmark'
+          ? Uint8List.fromList([1, 2, 3])
+          : null,
+    );
+
+    final bytes = await BackupBookmarkService.createBookmark('/x/Backups');
+
+    expect(bytes, [1, 2, 3]);
+    expect((calls.single.arguments as Map)['path'], '/x/Backups');
+  });
+
+  test('pickFolder returns path and bookmark', () async {
+    mock(
+      (call) async => call.method == 'pickFolderWithSecurityScope'
+          ? {
+              'path': '/x/Backups',
+              'bookmarkData': Uint8List.fromList([9]),
+            }
+          : null,
+    );
+
+    final pick = await BackupBookmarkService.pickFolder();
+
+    expect(pick, isNotNull);
+    expect(pick!.path, '/x/Backups');
+    expect(pick.bookmark, [9]);
+  });
+
+  test('makes no channel call and returns null when unsupported', () async {
+    BackupBookmarkService.debugSupportedOverride = false;
+    mock((_) async => null);
+
+    expect(await BackupBookmarkService.resolveBookmark(Uint8List(1)), isNull);
+    expect(await BackupBookmarkService.createBookmark('/x'), isNull);
+    expect(await BackupBookmarkService.verifyWriteAccess('/x'), isFalse);
+    expect(calls, isEmpty);
+  });
+}

--- a/test/features/backup/data/repositories/backup_preferences_test.dart
+++ b/test/features/backup/data/repositories/backup_preferences_test.dart
@@ -102,6 +102,34 @@ void main() {
     });
   });
 
+  group('BackupPreferences backup-location bookmark', () {
+    test('getBackupLocationBookmark returns null by default', () {
+      expect(backupPreferences.getBackupLocationBookmark(), isNull);
+    });
+
+    test(
+      'setBackupLocationBookmark persists and round-trips the bytes',
+      () async {
+        await backupPreferences.setBackupLocationBookmark([1, 2, 3, 250]);
+        expect(backupPreferences.getBackupLocationBookmark(), [1, 2, 3, 250]);
+      },
+    );
+
+    test('setBackupLocationBookmark(null) clears the bookmark', () async {
+      await backupPreferences.setBackupLocationBookmark([1, 2, 3]);
+      await backupPreferences.setBackupLocationBookmark(null);
+      expect(backupPreferences.getBackupLocationBookmark(), isNull);
+    });
+
+    test('setBackupLocation(null) also clears the bookmark', () async {
+      await backupPreferences.setBackupLocation('/custom/icloud/dir');
+      await backupPreferences.setBackupLocationBookmark([9, 8, 7]);
+      await backupPreferences.setBackupLocation(null);
+      expect(backupPreferences.getSettings().backupLocation, isNull);
+      expect(backupPreferences.getBackupLocationBookmark(), isNull);
+    });
+  });
+
   group('BackupPreferences history', () {
     BackupRecord createRecord(String id, {int diveCount = 10}) {
       return BackupRecord(

--- a/test/features/backup/data/services/backup_service_leased_test.dart
+++ b/test/features/backup/data/services/backup_service_leased_test.dart
@@ -11,10 +11,12 @@ import 'package:submersion/features/backup/data/services/backup_service.dart';
 /// Fake of the narrow bookmark seam so the leased resolver can be tested
 /// without a native channel.
 class _FakeBookmarkPort implements BackupBookmarkPort {
-  _FakeBookmarkPort({this.resolveResult});
+  _FakeBookmarkPort({this.resolveResult, this.createResult});
   final BackupBookmarkLease? resolveResult;
+  final List<int>? createResult;
   final List<String> released = [];
   int resolveCalls = 0;
+  int createCalls = 0;
 
   @override
   Future<BackupBookmarkLease?> resolve(Uint8List data) async {
@@ -24,6 +26,13 @@ class _FakeBookmarkPort implements BackupBookmarkPort {
 
   @override
   Future<void> release(String ref) async => released.add(ref);
+
+  @override
+  Future<Uint8List?> createBookmark(String path) async {
+    createCalls++;
+    final r = createResult;
+    return r == null ? null : Uint8List.fromList(r);
+  }
 }
 
 void main() {
@@ -90,6 +99,63 @@ void main() {
       },
     );
 
+    test('Apple + stale bookmark -> kept and re-minted (not reset)', () async {
+      final tmp = await Directory.systemTemp.createTemp('lease_stale_');
+      addTearDown(() => tmp.delete(recursive: true));
+      await preferences.setBackupLocation('/icloud/dir');
+      await preferences.setBackupLocationBookmark([1, 2, 3]);
+      BackupBookmarkService.debugSupportedOverride = true;
+      final port = _FakeBookmarkPort(
+        resolveResult: BackupBookmarkLease(
+          ref: 'R',
+          path: tmp.path,
+          isStale: true,
+        ),
+        createResult: [9, 9, 9],
+      );
+
+      final lease = await BackupService.resolveBackupsDirectoryLeased(
+        preferences,
+        bookmarks: port,
+      );
+
+      expect(lease.path, tmp.path);
+      expect(preferences.getSettings().backupLocation, '/icloud/dir');
+      expect(preferences.getBackupLocationBookmark(), [9, 9, 9]);
+      expect(port.createCalls, 1);
+      await lease.release();
+      expect(port.released, ['R']);
+    });
+
+    test(
+      'Apple + stale bookmark, re-mint fails -> location still kept',
+      () async {
+        final tmp = await Directory.systemTemp.createTemp('lease_stale2_');
+        addTearDown(() => tmp.delete(recursive: true));
+        await preferences.setBackupLocation('/icloud/dir');
+        await preferences.setBackupLocationBookmark([1, 2, 3]);
+        BackupBookmarkService.debugSupportedOverride = true;
+        final port = _FakeBookmarkPort(
+          resolveResult: BackupBookmarkLease(
+            ref: 'R',
+            path: tmp.path,
+            isStale: true,
+          ),
+          createResult: null, // re-minting fails
+        );
+
+        final lease = await BackupService.resolveBackupsDirectoryLeased(
+          preferences,
+          bookmarks: port,
+        );
+
+        expect(lease.path, tmp.path);
+        expect(preferences.getSettings().backupLocation, '/icloud/dir');
+        expect(preferences.getBackupLocationBookmark(), [1, 2, 3]);
+        expect(port.createCalls, 1);
+      },
+    );
+
     test('Apple + unresolvable bookmark -> resets to default', () async {
       await preferences.setBackupLocation('/icloud/dir');
       await preferences.setBackupLocationBookmark([1, 2, 3]);
@@ -124,6 +190,43 @@ void main() {
         expect(lease.path, contains('Submersion'));
       },
     );
+
+    test('uses the default bookmark port when none is injected', () async {
+      final tmp = await Directory.systemTemp.createTemp('lease_defport_');
+      addTearDown(() => tmp.delete(recursive: true));
+      await preferences.setBackupLocation('/icloud/dir');
+      await preferences.setBackupLocationBookmark([1, 2, 3]);
+      BackupBookmarkService.debugSupportedOverride = true;
+      final released = <String>[];
+      const channel = MethodChannel('app.submersion/backup_bookmark');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'resolveBookmark') {
+              return {'ref': 'DR', 'path': tmp.path, 'isStale': true};
+            }
+            if (call.method == 'createBookmark') {
+              return Uint8List.fromList([7, 7]);
+            }
+            if (call.method == 'releaseBookmark') {
+              released.add((call.arguments as Map)['ref'] as String);
+            }
+            return null;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+
+      // No `bookmarks:` arg -> the real _DefaultBackupBookmarkPort is exercised.
+      final lease = await BackupService.resolveBackupsDirectoryLeased(
+        preferences,
+      );
+
+      expect(lease.path, tmp.path);
+      expect(preferences.getBackupLocationBookmark(), [7, 7]); // re-minted
+      await lease.release();
+      expect(released, ['DR']);
+    });
 
     test(
       'non-Apple + custom location -> bare path, no bookmark calls',

--- a/test/features/backup/data/services/backup_service_leased_test.dart
+++ b/test/features/backup/data/services/backup_service_leased_test.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/backup_bookmark_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+
+/// Fake of the narrow bookmark seam so the leased resolver can be tested
+/// without a native channel.
+class _FakeBookmarkPort implements BackupBookmarkPort {
+  _FakeBookmarkPort({this.resolveResult});
+  final BackupBookmarkLease? resolveResult;
+  final List<String> released = [];
+  int resolveCalls = 0;
+
+  @override
+  Future<BackupBookmarkLease?> resolve(Uint8List data) async {
+    resolveCalls++;
+    return resolveResult;
+  }
+
+  @override
+  Future<void> release(String ref) async => released.add(ref);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BackupPreferences preferences;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => Directory.systemTemp.path,
+        );
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = BackupPreferences(await SharedPreferences.getInstance());
+  });
+
+  tearDown(() {
+    BackupBookmarkService.debugSupportedOverride = null;
+  });
+
+  group('resolveBackupsDirectoryLeased', () {
+    test('no custom location -> sandbox default, no bookmark calls', () async {
+      final port = _FakeBookmarkPort();
+
+      final lease = await BackupService.resolveBackupsDirectoryLeased(
+        preferences,
+        bookmarks: port,
+      );
+
+      expect(lease.path, contains('Submersion'));
+      expect(lease.path, contains('Backups'));
+      expect(port.resolveCalls, 0);
+      await lease.release(); // no-op; must not throw
+    });
+
+    test(
+      'Apple + resolvable bookmark -> armed path, releases the ref',
+      () async {
+        final tmp = await Directory.systemTemp.createTemp('lease_ok_');
+        addTearDown(() => tmp.delete(recursive: true));
+        await preferences.setBackupLocation('/icloud/dir');
+        await preferences.setBackupLocationBookmark([1, 2, 3]);
+        BackupBookmarkService.debugSupportedOverride = true;
+        final port = _FakeBookmarkPort(
+          resolveResult: BackupBookmarkLease(
+            ref: 'R',
+            path: tmp.path,
+            isStale: false,
+          ),
+        );
+
+        final lease = await BackupService.resolveBackupsDirectoryLeased(
+          preferences,
+          bookmarks: port,
+        );
+
+        expect(lease.path, tmp.path);
+        expect(port.resolveCalls, 1);
+        await lease.release();
+        expect(port.released, ['R']);
+      },
+    );
+
+    test('Apple + unresolvable bookmark -> resets to default', () async {
+      await preferences.setBackupLocation('/icloud/dir');
+      await preferences.setBackupLocationBookmark([1, 2, 3]);
+      BackupBookmarkService.debugSupportedOverride = true;
+      final port = _FakeBookmarkPort(resolveResult: null);
+
+      final lease = await BackupService.resolveBackupsDirectoryLeased(
+        preferences,
+        bookmarks: port,
+      );
+
+      expect(preferences.getSettings().backupLocation, isNull);
+      expect(preferences.getBackupLocationBookmark(), isNull);
+      expect(lease.path, contains('Submersion'));
+      expect(port.resolveCalls, 1);
+    });
+
+    test(
+      'Apple + custom location but no bookmark -> resets to default',
+      () async {
+        await preferences.setBackupLocation('/icloud/dir');
+        BackupBookmarkService.debugSupportedOverride = true;
+        final port = _FakeBookmarkPort();
+
+        final lease = await BackupService.resolveBackupsDirectoryLeased(
+          preferences,
+          bookmarks: port,
+        );
+
+        expect(port.resolveCalls, 0);
+        expect(preferences.getSettings().backupLocation, isNull);
+        expect(lease.path, contains('Submersion'));
+      },
+    );
+
+    test(
+      'non-Apple + custom location -> bare path, no bookmark calls',
+      () async {
+        final tmp = await Directory.systemTemp.createTemp('lease_bare_');
+        addTearDown(() => tmp.delete(recursive: true));
+        await preferences.setBackupLocation(tmp.path);
+        BackupBookmarkService.debugSupportedOverride = false;
+        final port = _FakeBookmarkPort();
+
+        final lease = await BackupService.resolveBackupsDirectoryLeased(
+          preferences,
+          bookmarks: port,
+        );
+
+        expect(lease.path, tmp.path);
+        expect(port.resolveCalls, 0);
+      },
+    );
+  });
+}

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -975,6 +975,23 @@ void main() {
       });
     });
 
+    group('resolveBackupsDirectory', () {
+      test('creates and returns the custom location; else default', () async {
+        final base = await Directory.systemTemp.createTemp('rbd_');
+        addTearDown(() => base.delete(recursive: true));
+        final sub = '${base.path}/backups_sub'; // does not exist yet
+
+        await preferences.setBackupLocation(sub);
+        expect(await BackupService.resolveBackupsDirectory(preferences), sub);
+        expect(await Directory(sub).exists(), isTrue); // created
+
+        await preferences.setBackupLocation(null);
+        final def = await BackupService.resolveBackupsDirectory(preferences);
+        expect(def, contains('Submersion'));
+        expect(def, contains('Backups'));
+      });
+    });
+
     group('resolveDefaultBackupsDirectory', () {
       test('returns the sandbox Submersion/Backups path even when a custom '
           'location is configured', () async {

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -7,6 +7,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
@@ -904,6 +905,9 @@ void main() {
       });
 
       test('pre-restore backup uses configured backup location', () async {
+        // Desktop bare-path semantics (on Apple a bookmark would be required).
+        BackupBookmarkService.debugSupportedOverride = false;
+        addTearDown(() => BackupBookmarkService.debugSupportedOverride = null);
         final tempDir = await Directory.systemTemp.createTemp('backup_test_');
         final customDir = await Directory.systemTemp.createTemp('custom_');
         final backupFile = File('${tempDir.path}/test.db');
@@ -935,6 +939,10 @@ void main() {
 
     group('performBackup with custom location', () {
       test('uses custom backup location from settings', () async {
+        // On Apple a custom location is reached via a security-scoped bookmark;
+        // this bare-path test models the desktop case where paths persist.
+        BackupBookmarkService.debugSupportedOverride = false;
+        addTearDown(() => BackupBookmarkService.debugSupportedOverride = null);
         final tempDir = await Directory.systemTemp.createTemp('backup_test_');
 
         await preferences.setBackupLocation(tempDir.path);

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -967,6 +967,22 @@ void main() {
       });
     });
 
+    group('resolveDefaultBackupsDirectory', () {
+      test('returns the sandbox Submersion/Backups path even when a custom '
+          'location is configured', () async {
+        // The default resolver is the safe fallback the pre-migration backup
+        // uses when the custom location is unreachable, so it must ignore
+        // backupLocation entirely and always target the app sandbox.
+        await preferences.setBackupLocation('/some/custom/icloud/path');
+
+        final path = await BackupService.resolveDefaultBackupsDirectory();
+
+        expect(path, contains('Submersion'));
+        expect(path, contains('Backups'));
+        expect(path, isNot(contains('icloud')));
+      });
+    });
+
     group('getValidatedBackupHistory', () {
       test(
         'removes records where local file is gone and no cloud backup',

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -448,6 +448,171 @@ void main() {
     });
   });
 
+  group('fallback to default location', () {
+    test('falls back to the default backups dir when the preferred location '
+        'cannot be created', () async {
+      // Reproduces the iOS report: the stored custom backup_location is an
+      // iCloud-Drive path whose security scope is gone, so resolving/creating
+      // it throws EPERM. With a fallback provider the pre-migration backup
+      // must still succeed by writing into the app sandbox instead of
+      // bricking startup.
+      final tmp = await Directory.systemTemp.createTemp('pmbs_fallback_');
+      addTearDown(() => tmp.delete(recursive: true));
+      final live = File(p.join(tmp.path, 'submersion.db'));
+      await live.writeAsBytes(List<int>.generate(512, (i) => i % 256));
+      final fallbackDir = Directory(p.join(tmp.path, 'default_backups'));
+      SharedPreferences.setMockInitialValues({});
+      final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => live.path,
+        backupsDirProvider: () async => throw const FileSystemException(
+          'Creation failed',
+          '/private/var/mobile/Library/Mobile Documents/com~apple~CloudDocs',
+          OSError('Operation not permitted', 1),
+        ),
+        fallbackBackupsDirProvider: () async => fallbackDir.path,
+        preferences: prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'fallback-id',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      const expectedName = '20260412-081201000-v63-v64.db';
+      final backupFile = File(p.join(fallbackDir.path, expectedName));
+      expect(
+        await backupFile.exists(),
+        isTrue,
+        reason: 'backup should land in the fallback directory',
+      );
+      expect(await backupFile.readAsBytes(), await live.readAsBytes());
+      final history = prefs.getHistory();
+      expect(history, hasLength(1));
+      expect(history.single.localPath, backupFile.path);
+    });
+
+    test(
+      'rethrows when both preferred and fallback locations are unusable',
+      () async {
+        final tmp = await Directory.systemTemp.createTemp('pmbs_fb_fail_');
+        addTearDown(() => tmp.delete(recursive: true));
+        final live = File(p.join(tmp.path, 'submersion.db'));
+        await live.writeAsBytes([1, 2, 3]);
+        // Fallback path is a regular file, so creating it as a dir fails too.
+        final conflicting = File(p.join(tmp.path, 'not-a-dir'));
+        await conflicting.writeAsBytes([0]);
+        SharedPreferences.setMockInitialValues({});
+        final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+        final service = PreMigrationBackupService(
+          livePathProvider: () async => live.path,
+          backupsDirProvider: () async =>
+              throw const FileSystemException('primary unavailable'),
+          fallbackBackupsDirProvider: () async => conflicting.path,
+          preferences: prefs,
+          clock: () => DateTime.utc(2026, 4, 12),
+          idGenerator: () => 'id',
+        );
+
+        await expectLater(
+          service.backupIfMigrationPending(
+            stored: 63,
+            target: 64,
+            appVersion: '1.6.0.1241',
+          ),
+          throwsA(isA<BackupFailedException>()),
+        );
+      },
+    );
+
+    test(
+      'without a fallback provider, a preferred-location failure still throws',
+      () async {
+        // Preserves the original (no-fallback) contract used by callers that
+        // want strict behavior.
+        final tmp = await Directory.systemTemp.createTemp('pmbs_no_fb_');
+        addTearDown(() => tmp.delete(recursive: true));
+        final live = File(p.join(tmp.path, 'submersion.db'));
+        await live.writeAsBytes([1, 2, 3]);
+        SharedPreferences.setMockInitialValues({});
+        final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+        final service = PreMigrationBackupService(
+          livePathProvider: () async => live.path,
+          backupsDirProvider: () async =>
+              throw const FileSystemException('primary unavailable'),
+          preferences: prefs,
+          clock: () => DateTime.utc(2026, 4, 12),
+          idGenerator: () => 'id',
+        );
+
+        await expectLater(
+          service.backupIfMigrationPending(
+            stored: 63,
+            target: 64,
+            appVersion: '1.6.0.1241',
+          ),
+          throwsA(isA<BackupFailedException>()),
+        );
+      },
+    );
+
+    test(
+      'falls back when the preferred dir exists but the copy into it fails',
+      () async {
+        // The variant the reporter could also hit: an iCloud dir that EXISTS
+        // but whose write scope is gone. create() is a no-op (it exists) and
+        // the copy into it throws -- the fallback must still rescue startup.
+        final tmp = await Directory.systemTemp.createTemp('pmbs_copyfail_');
+        addTearDown(() => tmp.delete(recursive: true));
+        final live = File(p.join(tmp.path, 'submersion.db'));
+        await live.writeAsBytes(List<int>.generate(256, (i) => i % 256));
+        final preferred = Directory(p.join(tmp.path, 'preferred'));
+        await preferred.create();
+        await Process.run('chmod', ['000', preferred.path]);
+        addTearDown(() => Process.run('chmod', ['755', preferred.path]));
+        final fallback = Directory(p.join(tmp.path, 'fallback'));
+        SharedPreferences.setMockInitialValues({});
+        final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+        final service = PreMigrationBackupService(
+          livePathProvider: () async => live.path,
+          backupsDirProvider: () async => preferred.path,
+          fallbackBackupsDirProvider: () async => fallback.path,
+          preferences: prefs,
+          clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+          idGenerator: () => 'copyfail-id',
+        );
+
+        await service.backupIfMigrationPending(
+          stored: 63,
+          target: 64,
+          appVersion: '1.6.0.1241',
+        );
+
+        final landed = File(
+          p.join(fallback.path, '20260412-081201000-v63-v64.db'),
+        );
+        expect(
+          await landed.exists(),
+          isTrue,
+          reason: 'backup should land in the fallback when the copy fails',
+        );
+        final history = prefs.getHistory();
+        expect(history, hasLength(1));
+        expect(history.single.localPath, landed.path);
+      },
+      skip: Platform.isWindows
+          ? 'chmod-based permission denial is not portable to Windows'
+          : null,
+    );
+  });
+
   group('construction', () {
     test('default idGenerator produces a UUID-shaped id', () async {
       final f = await _makeFixture();

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -442,10 +443,24 @@ void main() {
       originalPicker = FilePickerPlatform.instance;
       mockPicker = MockFilePickerPlatform();
       FilePickerPlatform.instance = mockPicker;
+      // On Apple hosts the picker flow mints a security-scoped bookmark via
+      // this channel; mock it so the call resolves under controlled async.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('app.submersion/backup_bookmark'),
+            (call) async => call.method == 'createBookmark'
+                ? Uint8List.fromList([1, 2, 3])
+                : null,
+          );
     });
 
     tearDown(() {
       FilePickerPlatform.instance = originalPicker;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('app.submersion/backup_bookmark'),
+            null,
+          );
     });
 
     Future<void> pumpApp(

--- a/test/features/backup/presentation/providers/backup_settings_notifier_test.dart
+++ b/test/features/backup/presentation/providers/backup_settings_notifier_test.dart
@@ -48,6 +48,32 @@ void main() {
     );
   });
 
+  group('setBackupLocationWithBookmark', () {
+    test('persists both the path and the security-scoped bookmark', () async {
+      await notifier.setBackupLocationWithBookmark('/icloud/dir', [1, 2, 3]);
+
+      expect(notifier.state.backupLocation, '/icloud/dir');
+      expect(prefs.getSettings().backupLocation, '/icloud/dir');
+      expect(prefs.getBackupLocationBookmark(), [1, 2, 3]);
+    });
+
+    test('turns cloud backup off (mutually exclusive destinations)', () async {
+      await notifier.setCloudBackupEnabled(true);
+
+      await notifier.setBackupLocationWithBookmark('/icloud/dir', [9]);
+
+      expect(notifier.state.cloudBackupEnabled, isFalse);
+      expect(notifier.state.backupLocation, '/icloud/dir');
+    });
+
+    test('accepts a null bookmark (desktop bare-path case)', () async {
+      await notifier.setBackupLocationWithBookmark('/desktop/dir', null);
+
+      expect(prefs.getSettings().backupLocation, '/desktop/dir');
+      expect(prefs.getBackupLocationBookmark(), isNull);
+    });
+  });
+
   group('disableCloudBackup (cloud sync sign-out hook)', () {
     test('turns cloud backup off and resets the location', () async {
       await notifier.setCloudBackupEnabled(true);


### PR DESCRIPTION
## Problem

A community user (followup on #305) hit a fatal **"Couldn't back up your data"** screen on startup. A custom `backup_location` pointing at an iCloud Drive folder had become inaccessible — the raw path lost its iOS security scope across launches — so the **pre-migration backup** (a hard startup gate) threw `PathAccessException`/EPERM with only **Retry/Quit**. Retry re-ran the identical failing path, so the user was locked out, unable to reach Settings to fix it.

Two layers:
- **Trigger:** the backup-location picker stored a bare path from `FilePicker.getDirectoryPath()`; on iOS that loses its security scope. (The custom **database** location feature already does this correctly with security-scoped bookmarks — backups never got parity.)
- **Amplifier:** the pre-migration backup is a fatal startup precondition with no escape hatch.

## Fix

**Layer 1 — un-brick:** the pre-migration backup degrades to the app-sandbox default when the preferred location can't be written. The fallback wraps the *whole* attempt — directory resolve + create **and** the file copy — so an existing-but-unwritable folder degrades too, not just a create failure. This self-heals anyone who already stored a dead path, with no Settings interaction.

**Layer 2 — full iOS/macOS bookmark support:**
- A **dedicated** `BackupBookmarkHandler` (iOS + macOS, channel `app.submersion/backup_bookmark`), modeled on the multi-slot `LocalMediaHandler` (`[ref: URL]`), so a backup-folder security scope **never displaces the custom-database-location scope** — the two coexist. The existing single-slot `SecurityScopedBookmarkHandler` is untouched (zero regression risk to the DB-location feature).
- `BackupBookmarkService` (Dart wrapper) + bookmark bytes persisted in `BackupPreferences` (cleared with the location).
- The picker captures a bookmark: iOS native folder picker; macOS `file_picker` + `createBookmark`.
- `BackupService.resolveBackupsDirectoryLeased` arms the bookmark and returns a `BackupDirLease` the caller releases after writing; a stale/unresolvable bookmark **resets to the sandbox default** (self-heal). `performBackup` and the startup pre-migration backup route through the lease.

## Testing

- Full suite: **8932 passed, 12 skipped, 0 failed**; `flutter analyze` clean.
- Both native targets build: `flutter build ios --simulator` and `flutter build macos`.
- New/changed unit tests cover the fallback (create + copy steps), the channel wrapper (incl. `MissingPluginException` degrade), bookmark persistence, the leased resolver (arm / reset-stale / non-Apple), and the picker wiring.
- Reproduced the original crash live on the simulator first to confirm the diagnosis.

## Device verification (pending — needs real hardware)

The simulator can't exercise real iCloud security-scoping, so this needs a device pass:

- [ ] iPhone/iPad: pick an iCloud backup folder → **Backup Now** writes there; force a migration → the pre-migration backup also writes there and the app opens
- [ ] Relaunch → bookmark re-arms (no re-pick needed)
- [ ] Delete/move the folder → silently resets to the default location (no brick)
- [ ] Custom **database** location *and* custom **backup** folder both in iCloud → both scopes coexist (no conflict)
- [ ] macOS: same as above