### PR TITLE
fix(sync): keep equipment-set & dive gear membership across devices (#347)

### DIFF
--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -692,11 +692,38 @@ class SyncService {
     var recordsFailed = 0;
     final pendingByEntity = await _pendingRecordMap();
 
+    // A payload can present a record as LIVE and ALSO carry a tombstone for the
+    // same key -- the on-the-wire signature of a composite-natural-key junction
+    // (equipment_set_items, dive_equipment) rebuilt by its repository via
+    // delete-all-then-reinsert. A row cannot be both present and deleted in one
+    // source snapshot, so the live table is authoritative and the tombstone is
+    // a stale artifact. Collect these self-contradicted keys: the deletion is
+    // skipped below and the live row wins (clearing any local tombstone in the
+    // merge heals a peer that already dropped the row on the buggy build).
+    final contradictedByEntity = <String, Set<String>>{};
+    final liveByType = remotePayload.data.toJson();
+    for (final delEntry in remotePayload.deletions.entries) {
+      final deletedIds = {for (final d in delEntry.value) d.id};
+      if (deletedIds.isEmpty) continue;
+      final live = liveByType[delEntry.key];
+      if (live is! List) continue;
+      final contradicted = <String>{};
+      for (final rec in live) {
+        if (rec is! Map<String, dynamic>) continue;
+        final id = _recordIdForEntity(delEntry.key, rec);
+        if (id != null && deletedIds.contains(id)) contradicted.add(id);
+      }
+      if (contradicted.isNotEmpty) {
+        contradictedByEntity[delEntry.key] = contradicted;
+      }
+    }
+
     final deletionResult = await _applyRemoteDeletions(
       remotePayload.deletions,
       lastSyncMs,
       remotePayload.exportedAt,
       pendingByEntity,
+      contradictedByEntity,
     );
     recordsApplied += deletionResult.recordsApplied;
     conflictsFound += deletionResult.conflictsFound;
@@ -868,6 +895,7 @@ class SyncService {
         pendingRecordIds: pendingByEntity[entry.type] ?? const <String>{},
         allTombstones: tombstonesByEntity,
         revivedParents: revivedParents,
+        contradicted: contradictedByEntity[entry.type] ?? const <String>{},
       );
       recordsApplied += result.recordsApplied;
       conflictsFound += result.conflictsFound;
@@ -893,6 +921,7 @@ class SyncService {
     int? lastSyncMs,
     int remoteExportedAt,
     Map<String, Set<String>> pendingByEntity,
+    Map<String, Set<String>> contradictedByEntity,
   ) async {
     var applied = 0;
     var conflicts = 0;
@@ -906,15 +935,23 @@ class SyncService {
           if (pendingByEntity[entityType]?.contains(recordId) == true) {
             continue;
           }
+          if (contradictedByEntity[entityType]?.contains(recordId) == true) {
+            // The same payload re-inserts this row as live; the tombstone is a
+            // stale delete-all+reinsert artifact. Skip it so the live row
+            // survives (the merge upserts it and clears any local tombstone).
+            continue;
+          }
           final local = await _serializer.fetchRecord(entityType, recordId);
-          // _extractUpdatedAtMillis falls back to createdAt, so a row that was
-          // created locally after our last sync is protected from a stale
-          // remote tombstone even on append-only child tables that have a
-          // createdAt. The handful of child tables with neither updatedAt nor
-          // createdAt (dive_profiles, dive_tanks, dive_equipment,
-          // tank_pressure_profiles, sightings) have no age signal; they are
-          // regenerated wholesale with fresh ids on re-import, so a stale
-          // tombstone won't match a current row.
+          // _extractUpdatedAtMillis falls back to createdAt, so a row created
+          // locally after our last sync is protected from a stale remote
+          // tombstone even on append-only child tables that have a createdAt.
+          // Clockless child tables with neither updatedAt nor createdAt
+          // (dive_profiles, dive_tanks, tank_pressure_profiles, sightings) have
+          // no age signal: the uuid-keyed ones regenerate with fresh ids on
+          // re-import, so a stale tombstone won't match a current row. The
+          // composite-natural-key junctions (dive_equipment, equipment_set_items)
+          // WOULD match a re-inserted row, but the contradicted-key skip above
+          // already drops a tombstone whose key the same payload re-inserts.
           final localUpdatedAt = _extractUpdatedAtMillis(local);
           final deletionTimestamp = deletion.deletedAt > 0
               ? deletion.deletedAt
@@ -1055,6 +1092,7 @@ class SyncService {
     required Set<String> pendingRecordIds,
     required Map<String, Map<String, int>> allTombstones,
     required Map<String, Set<String>> revivedParents,
+    required Set<String> contradicted,
   }) async {
     if (records.isEmpty) {
       return const _MergeResult(recordsApplied: 0, conflictsFound: 0);
@@ -1114,19 +1152,31 @@ class SyncService {
         // seen our delete re-introduces the record on every sync.
         final deletedAt = selfTombstones[recordId];
         if (deletedAt != null) {
-          final remoteUpdatedAt = hasUpdatedAt
-              ? _extractUpdatedAtMillis(record)
-              : null;
-          if (remoteUpdatedAt == null || remoteUpdatedAt <= deletedAt) {
-            // No newer remote edit -- the deletion wins; stay deleted.
-            continue;
+          if (contradicted.contains(recordId)) {
+            // This same payload presents the record as live AND tombstones it
+            // (a delete-all+reinsert artifact). The live row is the source's
+            // current truth, so drop the stale tombstone -- including a local
+            // one a prior buggy sync left behind -- and apply the record. This
+            // is what self-heals a peer that already dropped the membership.
+            await _syncRepository.removeDeletion(
+              entityType: entityType,
+              recordId: recordId,
+            );
+          } else {
+            final remoteUpdatedAt = hasUpdatedAt
+                ? _extractUpdatedAtMillis(record)
+                : null;
+            if (remoteUpdatedAt == null || remoteUpdatedAt <= deletedAt) {
+              // No newer remote edit -- the deletion wins; stay deleted.
+              continue;
+            }
+            // Remote edit is newer than the deletion: revive the record and
+            // drop the now-obsolete tombstone so it stops re-deleting it.
+            await _syncRepository.removeDeletion(
+              entityType: entityType,
+              recordId: recordId,
+            );
           }
-          // Remote edit is newer than the deletion: revive the record and drop
-          // the now-obsolete tombstone so it stops re-deleting it.
-          await _syncRepository.removeDeletion(
-            entityType: entityType,
-            recordId: recordId,
-          );
         }
 
         if (!hasUpdatedAt) {

--- a/test/core/services/sync/sync_junction_reinsert_test.dart
+++ b/test/core/services/sync/sync_junction_reinsert_test.dart
@@ -1,0 +1,271 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/changeset_test_helpers.dart';
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for issue #347 ("iCloud Syncing Equipment Sets").
+///
+/// Composite-natural-key junction tables (equipment_set_items keyed by
+/// `setId|equipmentId`, dive_equipment keyed by `diveId|equipmentId`) are
+/// rebuilt by their repositories with a "delete all rows for the parent,
+/// log a tombstone for each, then re-insert" idiom. A single sync payload
+/// therefore carries the membership row as LIVE *and* a tombstone for the
+/// exact same key.
+///
+/// These rows carry no per-row clock (no updatedAt / hlc), so the merge's
+/// local-deletion guard compares a null remote timestamp against the
+/// tombstone's deletedAt and the deletion always wins -- silently dropping
+/// the membership on every other device. The set's name/description survive
+/// because the parent row is only ever updated, never delete-logged.
+///
+/// The fix: a tombstone whose key is also present as a LIVE row in the same
+/// payload is a stale artifact; the live row is the source's current truth.
+void main() {
+  group('Same-payload junction reinsert (issue #347)', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    // A complete equipment row: Drift's fromJson casts every non-nullable
+    // column, so DB defaults (status, currency, notes, isActive) must be
+    // present in the JSON even though the table declares defaults for them.
+    Map<String, dynamic> equipmentRow(String id, String name, String type) => {
+      'id': id,
+      'name': name,
+      'type': type,
+      'status': 'active',
+      'purchaseCurrency': 'USD',
+      'notes': '',
+      'isActive': true,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    };
+
+    SyncPayload payloadOf(SyncData data, Map<String, List<SyncDeletion>> dels) {
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      return SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 9000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: data,
+        deletions: dels,
+      );
+    }
+
+    test(
+      'equipment-set membership survives a same-payload tombstone',
+      () async {
+        final serializer = SyncDataSerializer();
+        final db = DatabaseService.instance.database;
+
+        // Parents already exist on this device (synced earlier).
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('gear-1', 'Wetsuit', 'wetsuit'),
+        );
+        await serializer.upsertRecord('equipmentSets', {
+          'id': 'set-1',
+          'name': 'Warm Weather',
+          'description': 'six items',
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+
+        // Peer's changeset: the membership row is live AND tombstoned (the
+        // delete-all+reinsert signature of EquipmentSetRepository.updateSet).
+        final payload = payloadOf(
+          const SyncData(
+            equipmentSetItems: [
+              {'setId': 'set-1', 'equipmentId': 'gear-1'},
+            ],
+          ),
+          {
+            'equipmentSetItems': [
+              const SyncDeletion(id: 'set-1|gear-1', deletedAt: 5000),
+            ],
+          },
+        );
+        await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+        final result = await buildService().performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+
+        final items = await (db.select(
+          db.equipmentSetItems,
+        )..where((t) => t.setId.equals('set-1'))).get();
+        expect(
+          items.map((i) => i.equipmentId),
+          contains('gear-1'),
+          reason:
+              'the set must keep its gear: the live row in the same payload is '
+              'authoritative over a stale reinsert tombstone',
+        );
+      },
+    );
+
+    test(
+      'dive-equipment membership survives a same-payload tombstone',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+        final db = DatabaseService.instance.database;
+
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('gear-2', 'Regulator', 'regulator'),
+        );
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-1', diveNumber: 1),
+        );
+
+        final payload = payloadOf(
+          const SyncData(
+            diveEquipment: [
+              {'diveId': 'dive-1', 'equipmentId': 'gear-2'},
+            ],
+          ),
+          {
+            'diveEquipment': [
+              const SyncDeletion(id: 'dive-1|gear-2', deletedAt: 5000),
+            ],
+          },
+        );
+        await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+        final result = await buildService().performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+
+        final links = await (db.select(
+          db.diveEquipment,
+        )..where((t) => t.diveId.equals('dive-1'))).get();
+        expect(
+          links.map((l) => l.equipmentId),
+          contains('gear-2'),
+          reason: 'editing a dive must not drop its gear on the peer',
+        );
+      },
+    );
+
+    test('a genuine deletion (no live row in payload) still applies', () async {
+      final serializer = SyncDataSerializer();
+      final db = DatabaseService.instance.database;
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-3', 'Fins', 'fins'),
+      );
+      await serializer.upsertRecord('equipmentSets', {
+        'id': 'set-2',
+        'name': 'Cold Weather',
+        'description': '',
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      // The membership currently exists locally.
+      await serializer.upsertRecord('equipmentSetItems', {
+        'setId': 'set-2',
+        'equipmentId': 'gear-3',
+      });
+
+      // Peer removed the item: a tombstone with NO matching live row.
+      final payload = payloadOf(const SyncData(), {
+        'equipmentSetItems': [
+          const SyncDeletion(id: 'set-2|gear-3', deletedAt: 5000),
+        ],
+      });
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final items = await (db.select(
+        db.equipmentSetItems,
+      )..where((t) => t.setId.equals('set-2'))).get();
+      expect(
+        items,
+        isEmpty,
+        reason:
+            'a real removal (tombstone without a live row) must still apply',
+      );
+    });
+
+    test('an already-dropped item is healed when re-published live', () async {
+      final serializer = SyncDataSerializer();
+      final db = DatabaseService.instance.database;
+
+      // This device previously applied the buggy delete and dropped the item,
+      // leaving behind a local tombstone for it.
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-4', 'Mask', 'mask'),
+      );
+      await serializer.upsertRecord('equipmentSets', {
+        'id': 'set-3',
+        'name': 'Travel',
+        'description': '',
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await SyncRepository().logDeletion(
+        entityType: 'equipmentSetItems',
+        recordId: 'set-3|gear-4',
+        deletedAt: 4000,
+      );
+
+      // The good device re-publishes the set (live row + reinsert tombstone).
+      final payload = payloadOf(
+        const SyncData(
+          equipmentSetItems: [
+            {'setId': 'set-3', 'equipmentId': 'gear-4'},
+          ],
+        ),
+        {
+          'equipmentSetItems': [
+            const SyncDeletion(id: 'set-3|gear-4', deletedAt: 5000),
+          ],
+        },
+      );
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final items = await (db.select(
+        db.equipmentSetItems,
+      )..where((t) => t.setId.equals('set-3'))).get();
+      expect(
+        items.map((i) => i.equipmentId),
+        contains('gear-4'),
+        reason:
+            'a stale local tombstone must not block a live row the same payload '
+            're-inserts: the corrupted device self-heals',
+      );
+    });
+  });
+}

--- a/test/core/services/sync/sync_junction_reinsert_test.dart
+++ b/test/core/services/sync/sync_junction_reinsert_test.dart
@@ -267,5 +267,75 @@ void main() {
             're-inserts: the corrupted device self-heals',
       );
     });
+
+    test(
+      'a set edit keeps survivors and removes one in the same payload',
+      () async {
+        final serializer = SyncDataSerializer();
+        final db = DatabaseService.instance.database;
+
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('g-a', 'A', 'mask'),
+        );
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('g-b', 'B', 'fins'),
+        );
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('g-c', 'C', 'bcd'),
+        );
+        await serializer.upsertRecord('equipmentSets', {
+          'id': 'set-4',
+          'name': 'Mixed',
+          'description': '',
+          'createdAt': 1000,
+          'updatedAt': 1000,
+        });
+        // C is currently a member locally and is being removed by the edit.
+        await serializer.upsertRecord('equipmentSetItems', {
+          'setId': 'set-4',
+          'equipmentId': 'g-c',
+        });
+
+        // updateSet on the peer keeps A and B (live + reinsert tombstone) and
+        // drops C (tombstone only, no live row) -- one payload that is
+        // contradicted for some keys and a genuine delete for another.
+        final payload = payloadOf(
+          const SyncData(
+            equipmentSetItems: [
+              {'setId': 'set-4', 'equipmentId': 'g-a'},
+              {'setId': 'set-4', 'equipmentId': 'g-b'},
+            ],
+          ),
+          {
+            'equipmentSetItems': [
+              const SyncDeletion(id: 'set-4|g-a', deletedAt: 5000),
+              const SyncDeletion(id: 'set-4|g-b', deletedAt: 5000),
+              const SyncDeletion(id: 'set-4|g-c', deletedAt: 5000),
+            ],
+          },
+        );
+        await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+        final result = await buildService().performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+
+        final ids =
+            (await (db.select(
+                  db.equipmentSetItems,
+                )..where((t) => t.setId.equals('set-4'))).get())
+                .map((i) => i.equipmentId)
+                .toSet();
+        expect(
+          ids,
+          {'g-a', 'g-b'},
+          reason:
+              'survivors (live + same-payload tombstone) are kept; the genuinely '
+              'removed item (tombstone with no live row) is deleted',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Problem

Fixes #347. iCloud sync kept an equipment set's name/description but dropped **all** its gear to 0 on the other device. The same silent data loss affected **dive gear** (`dive_equipment`) on every dive edit.

## Root cause

Composite-natural-key **junction tables** are rebuilt by their repositories with a *delete-all -> tombstone-each -> reinsert* idiom (`EquipmentSetRepository.updateSet`, `DiveRepository.updateDive`). So a single sync changeset carries the membership row as **live** *and* a **tombstone for the exact same key** (`setId|equipmentId`, `diveId|equipmentId`).

These junction rows have no per-row clock (no `updatedAt`/`hlc`). In the merge's local-deletion guard `remoteUpdatedAt` is therefore `null`, and the rule `remoteUpdatedAt == null || remoteUpdatedAt <= deletedAt` made **the tombstone always win** -- deleting the membership on the peer. The parent set/dive survived because its row is only ever updated, never delete-logged.

(The old comment in `_applyRemoteDeletions` rationalized this as "clockless children regenerate with fresh ids so a stale tombstone won't match" -- true for uuid-keyed tables, but false for composite natural keys. Corrected here.)

## Fix

One change, in the merge engine (`sync_service.dart._applyRemotePayloadInner`): compute the **self-contradicted keys** -- those present as a live row *and* tombstoned in the same payload. A row cannot be both present and deleted in one source snapshot, so the live row is authoritative:

- `_applyRemoteDeletions` **skips** those tombstones, and
- `_mergeEntity` **clears any pre-existing local tombstone** for them and upserts -- so a device already corrupted by the old build **self-heals** the next time the membership is re-published.

Safe because base and changesets apply as *separate* payloads, so a genuine later delete is never bundled with an older live copy of the same key.

## Scope

- **Fixed (data loss):** `equipment_set_items` (#347) and `dive_equipment`. The guard is generic, so any future clockless composite-key junction is covered automatically.
- **Not affected:** `dive_tags` (re-inserts with fresh uuids -> tombstone key != live key, so it churns but never loses data); the Replace/adoption path (reconstructs from the live-data union, never applies tombstones).
- Repositories are **intentionally untouched** -- their delete-all+reinsert is now harmless and powers the self-heal.

## Testing

- New `test/core/services/sync/sync_junction_reinsert_test.dart` (4 cases: equipment-set survives, dive-gear survives, genuine deletion still applies, already-dropped item self-heals). Verified red -> green.
- Full sync suite green (296 tests); `flutter analyze` clean.
- 2-device iCloud hardware verification still recommended. Already-affected devices can also recover via Settings -> "Reset Sync State".