### PR TITLE
fix(s3): support periods in S3 bucket names (path-style addressing)

### DIFF
--- a/lib/core/services/cloud_storage/s3/s3_api_client.dart
+++ b/lib/core/services/cloud_storage/s3/s3_api_client.dart
@@ -169,25 +169,26 @@ class S3ApiClient {
   /// addressing. The path comes back already SigV4-encoded so the signed
   /// bytes and the wire bytes cannot diverge.
   ({String scheme, String host, int? port, String path}) _target(String key) {
+    // effectivePathStyle, not the raw flag: a dotted bucket over HTTPS is
+    // forced path-style to dodge the wildcard-cert TLS failure (issue #335).
+    final pathStyle = _config.effectivePathStyle;
     final String scheme;
     final String host;
     int? port;
     if (_config.isAws) {
       scheme = 'https';
-      host = _config.pathStyle
+      host = pathStyle
           ? 's3.$_region.amazonaws.com'
           : '${_config.bucket}.s3.$_region.amazonaws.com';
     } else {
       final endpointUri = Uri.parse(_config.endpoint);
       final endpointHost = _effectiveCustomHost(endpointUri.host);
       scheme = endpointUri.scheme;
-      host = _config.pathStyle
-          ? endpointHost
-          : '${_config.bucket}.$endpointHost';
+      host = pathStyle ? endpointHost : '${_config.bucket}.$endpointHost';
       if (endpointUri.hasPort) port = endpointUri.port;
     }
     final encodedKey = SigV4Signer.uriEncode(key, encodeSlash: false);
-    final path = _config.pathStyle
+    final path = pathStyle
         ? '/${_config.bucket}${encodedKey.isEmpty ? '/' : '/$encodedKey'}'
         : '/$encodedKey';
     return (scheme: scheme, host: host, port: port, path: path);

--- a/lib/core/services/cloud_storage/s3/s3_config.dart
+++ b/lib/core/services/cloud_storage/s3/s3_config.dart
@@ -79,6 +79,23 @@ class S3Config {
   bool get isInsecureEndpoint =>
       !isAws && Uri.tryParse(endpoint)?.scheme == 'http';
 
+  /// Whether requests travel over TLS. AWS S3 proper is always HTTPS; a
+  /// custom endpoint follows its own scheme.
+  bool get _usesTls => isAws || Uri.tryParse(endpoint)?.scheme == 'https';
+
+  /// Path-style addressing actually used on the wire, which may diverge from
+  /// the stored [pathStyle] flag.
+  ///
+  /// A bucket whose name contains a dot cannot be reached virtual-hosted-style
+  /// over HTTPS: the wildcard certificate (`*.s3.<region>.amazonaws.com`, or
+  /// the custom endpoint's equivalent) matches only a single DNS label, so
+  /// `my.bucket.s3...` fails the TLS handshake. AWS recommends path-style for
+  /// such buckets. Forcing it here repairs already-saved configs without a
+  /// migration, and only when TLS is in play (plain HTTP has no cert to break,
+  /// so the stored choice is honored). See issue #335.
+  bool get effectivePathStyle =>
+      pathStyle || (bucket.contains('.') && _usesTls);
+
   /// First validation problem, or null when the config is usable.
   /// UI-facing field errors live in the form; this is the entity-level guard.
   String? validate() {

--- a/test/core/services/cloud_storage/s3/s3_api_client_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_api_client_test.dart
@@ -99,6 +99,28 @@ void main() {
       },
     );
 
+    test(
+      'dotted AWS bucket routes path-style to dodge the wildcard cert (#335)',
+      () async {
+        late http.Request seen;
+        final mock = MockClient((request) async {
+          seen = request;
+          return http.Response.bytes([9], 200);
+        });
+        // pathStyle defaults to false for AWS; the dot must force it anyway,
+        // otherwise the host would be my.dive.bucket.s3...amazonaws.com and
+        // fail the *.s3.<region>.amazonaws.com TLS handshake.
+        final config = awsConfig().copyWith(bucket: 'my.dive.bucket');
+        await clientWith(config, mock).getObject('k.json');
+
+        expect(seen.url.host, 's3.eu-west-1.amazonaws.com');
+        expect(
+          seen.url.toString(),
+          'https://s3.eu-west-1.amazonaws.com/my.dive.bucket/k.json',
+        );
+      },
+    );
+
     test('keys needing encoding sign and ship the same bytes', () async {
       late http.Request seen;
       final mock = MockClient((request) async {

--- a/test/core/services/cloud_storage/s3/s3_config_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_config_test.dart
@@ -112,6 +112,56 @@ void main() {
     });
   });
 
+  group('S3Config.effectivePathStyle (dotted-bucket TLS guard, #335)', () {
+    S3Config aws({required String bucket, bool? pathStyle}) => S3Config(
+      endpoint: '',
+      region: 'ap-southeast-2',
+      bucket: bucket,
+      accessKeyId: 'a',
+      secretAccessKey: 's',
+      pathStyle: pathStyle,
+    );
+
+    test('plain AWS bucket without a dot mirrors the stored flag', () {
+      final config = aws(bucket: 'dive-sync');
+      expect(config.pathStyle, isFalse);
+      expect(config.effectivePathStyle, isFalse);
+    });
+
+    test('dotted AWS bucket forces path-style despite a false flag', () {
+      final config = aws(bucket: 'my.dive.bucket');
+      expect(config.pathStyle, isFalse);
+      expect(config.effectivePathStyle, isTrue);
+    });
+
+    test('dotted bucket on an HTTPS custom endpoint forces path-style', () {
+      final config = S3Config(
+        endpoint: 'https://minio.example.com',
+        bucket: 'my.bucket',
+        accessKeyId: 'a',
+        secretAccessKey: 's',
+        pathStyle: false,
+      );
+      expect(config.effectivePathStyle, isTrue);
+    });
+
+    test('dotted bucket on a plain-HTTP endpoint defers to the flag', () {
+      // No TLS handshake to break, so the stored choice is honored as-is.
+      final config = S3Config(
+        endpoint: 'http://nas.local:9000',
+        bucket: 'my.bucket',
+        accessKeyId: 'a',
+        secretAccessKey: 's',
+        pathStyle: false,
+      );
+      expect(config.effectivePathStyle, isFalse);
+    });
+
+    test('explicit path-style stays true regardless of the bucket', () {
+      expect(aws(bucket: 'plain', pathStyle: true).effectivePathStyle, isTrue);
+    });
+  });
+
   group('S3Config.validate', () {
     test('valid config returns null', () {
       expect(minio().validate(), isNull);


### PR DESCRIPTION
## Problem

Fixes #335. Configuring an S3 bucket sync connection with a **period in the bucket name** (e.g. `my.dive.bucket`) fails:

- **Test Connection** → "Cannot reach S3 endpoint"
- **Sync** → "Could not read the library epoch marker"

Removing the period makes it work. Reported on AWS (`ap-southeast-2`), Windows & Android.

## Root cause

A dotted AWS bucket was addressed **virtual-hosted-style**:

```
my.dive.bucket.s3.ap-southeast-2.amazonaws.com
```

AWS's wildcard TLS certificate `*.s3.<region>.amazonaws.com` matches only the single leftmost DNS label, so that 6-label host fails the TLS handshake. That one failure produces both reported symptoms (handshake during `listObjects` for Test Connection, and during `getObject` for the epoch marker, which fails closed).

Path-style addressing (`s3.<region>.amazonaws.com/my.dive.bucket`) was already supported in the client but was never auto-enabled for AWS buckets — only for custom endpoints.

## Fix

- `S3Config.effectivePathStyle` — `pathStyle || (bucket.contains('.') && _usesTls)`. Layers the TLS-safety rule on top of the user's stored flag.
- `S3ApiClient._target()` builds URLs from `effectivePathStyle` instead of the raw flag.

Fixing at the getter layer means:
- The region-correction replay path inherits it for free (single source of truth).
- **Already-saved broken configs are repaired the moment they load** — no DB migration, no "delete and re-add your connection."
- Scoped to HTTPS: plain-HTTP custom endpoints have no cert to break, so the user's explicit choice is honored there.

## Tests

TDD: new tests first reproduced the broken host `my.dive.bucket.s3.eu-west-1.amazonaws.com` (RED), then pass (GREEN).

- 5 new `S3Config.effectivePathStyle` unit tests (AWS dotted/plain, custom HTTPS, plain-HTTP defer, explicit override).
- 1 new wire-level `S3ApiClient` test asserting a dotted AWS bucket routes path-style.
- All existing S3 / cloud-storage / config-page suites green; whole-project `flutter analyze` clean.

## Verification still pending

Hardware verification on Windows/Android against a real dotted AWS bucket (this class of bug is TLS-stack-sensitive).
