### PR TITLE
Fix CCR/SCR CNS calculation to use measured loop ppO2

### DIFF
--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -513,9 +513,11 @@ class ProfileAnalysisService {
   /// [gasSegments] optionally provides a time-ordered gas schedule for
   /// decompression calculations across the profile.
   /// [rebreatherPpO2Curve] is the per-sample ppO2 (bar) resolved from O2 cells
-  /// or the setpoint for CCR/SCR dives. When provided it drives the ppO2, CNS,
-  /// and OTU calculations directly, so they match the measured loop ppO2 rather
-  /// than a setpoint or OC depth x FO2 fallback. Must align with [depths].
+  /// or the setpoint for CCR/SCR dives. When provided and aligned with [depths]
+  /// it drives the ppO2, CNS, and OTU calculations directly, so they match the
+  /// measured loop ppO2 rather than a setpoint or OC depth x FO2 fallback. A
+  /// curve whose length does not match [depths] is treated as absent and the
+  /// usual setpoint/SCR fallback applies.
   ProfileAnalysis analyze({
     required String diveId,
     required List<double> depths,
@@ -600,36 +602,43 @@ class ProfileAnalysisService {
     // A measured ppO2 curve (from O2 cells/setpoint) takes priority for
     // rebreather dives: it reflects the actual loop ppO2, unlike the setpoint
     // (which may be absent for imported dives) or the OC depth x FO2 fallback.
-    final hasMeasuredPpO2 =
+    // Resolve to a non-null local once so each dive-mode branch can rely on a
+    // plain != null check for promotion.
+    final measuredPpO2 =
         rebreatherPpO2Curve != null &&
-        rebreatherPpO2Curve.length == depths.length;
+            rebreatherPpO2Curve.length == depths.length
+        ? rebreatherPpO2Curve
+        : null;
 
     // Calculate ppO2 curve based on dive mode
     final List<double> ppO2Curve;
     switch (diveMode) {
       case DiveMode.ccr:
-        if (hasMeasuredPpO2) {
+        // CCR ppO2 must come from measured loop data or the setpoint, never the
+        // OC depth x FO2 fallback (that uses the diluent/first-tank O2 and
+        // grossly overstates CNS). With no ppO2 data at all, leave it unknown
+        // (zero) rather than fabricate a value.
+        final ccrSetpoint = setpointHigh ?? setpointLow;
+        if (measuredPpO2 != null) {
           // CCR: measured loop ppO2 from O2 cells / setpoint
-          ppO2Curve = rebreatherPpO2Curve;
-        } else if (setpointHigh != null) {
-          // CCR: ppO2 equals the setpoint (constant or variable by depth phase)
+          ppO2Curve = measuredPpO2;
+        } else if (ccrSetpoint != null) {
+          // CCR: ppO2 equals the setpoint (constant or variable by depth phase).
+          // Only apply the depth-phased low setpoint when a high setpoint is the
+          // working value; an only-low-setpoint dive uses it as a constant.
           ppO2Curve = _o2ToxicityCalculator.calculatePpO2CurveCCR(
             depths,
-            setpointHigh: setpointHigh,
-            setpointLow: setpointLow,
+            setpointHigh: ccrSetpoint,
+            setpointLow: setpointHigh != null ? setpointLow : null,
             lowSetpointMaxDepth: lowSetpointMaxDepth,
           );
         } else {
-          // Fallback to OC calculation if no setpoint provided
-          ppO2Curve = _o2ToxicityCalculator.calculatePpO2Curve(
-            depths,
-            o2Fraction,
-          );
+          ppO2Curve = List<double>.filled(depths.length, 0.0);
         }
       case DiveMode.scr:
-        if (hasMeasuredPpO2) {
+        if (measuredPpO2 != null) {
           // SCR: measured loop ppO2 from O2 cells / setpoint
-          ppO2Curve = rebreatherPpO2Curve;
+          ppO2Curve = measuredPpO2;
         } else if (scrInjectionRate != null && scrSupplyO2Percent != null) {
           // SCR: ppO2 varies with depth based on steady-state loop FO2
           ppO2Curve = _o2ToxicityCalculator.calculatePpO2CurveSCR(
@@ -639,11 +648,9 @@ class ProfileAnalysisService {
             vo2: scrVo2,
           );
         } else {
-          // Fallback to OC calculation if SCR params not provided
-          ppO2Curve = _o2ToxicityCalculator.calculatePpO2Curve(
-            depths,
-            o2Fraction,
-          );
+          // No loop ppO2 data and no SCR parameters: cannot know the loop ppO2.
+          // Leave it unknown (zero) rather than use the wrong OC depth x FO2.
+          ppO2Curve = List<double>.filled(depths.length, 0.0);
         }
       case DiveMode.oc:
         // OC: ppO2 = ambient pressure × FO2

--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -512,6 +512,10 @@ class ProfileAnalysisService {
   /// [startOtu] is cumulative OTU from earlier same-day dives (non-negative).
   /// [gasSegments] optionally provides a time-ordered gas schedule for
   /// decompression calculations across the profile.
+  /// [rebreatherPpO2Curve] is the per-sample ppO2 (bar) resolved from O2 cells
+  /// or the setpoint for CCR/SCR dives. When provided it drives the ppO2, CNS,
+  /// and OTU calculations directly, so they match the measured loop ppO2 rather
+  /// than a setpoint or OC depth x FO2 fallback. Must align with [depths].
   ProfileAnalysis analyze({
     required String diveId,
     required List<double> depths,
@@ -530,6 +534,7 @@ class ProfileAnalysisService {
     List<TissueCompartment>? startCompartments,
     double startOtu = 0.0,
     List<ProfileGasSegment>? gasSegments,
+    List<double>? rebreatherPpO2Curve,
   }) {
     if (depths.isEmpty || depths.length != timestamps.length) {
       return ProfileAnalysis.empty();
@@ -592,12 +597,22 @@ class ProfileAnalysisService {
     final pointN2Fractions = ocGasMetrics?.n2Fractions;
     final pointHeFractions = ocGasMetrics?.heFractions;
 
+    // A measured ppO2 curve (from O2 cells/setpoint) takes priority for
+    // rebreather dives: it reflects the actual loop ppO2, unlike the setpoint
+    // (which may be absent for imported dives) or the OC depth x FO2 fallback.
+    final hasMeasuredPpO2 =
+        rebreatherPpO2Curve != null &&
+        rebreatherPpO2Curve.length == depths.length;
+
     // Calculate ppO2 curve based on dive mode
     final List<double> ppO2Curve;
     switch (diveMode) {
       case DiveMode.ccr:
-        // CCR: ppO2 equals the setpoint (constant or variable by depth phase)
-        if (setpointHigh != null) {
+        if (hasMeasuredPpO2) {
+          // CCR: measured loop ppO2 from O2 cells / setpoint
+          ppO2Curve = rebreatherPpO2Curve;
+        } else if (setpointHigh != null) {
+          // CCR: ppO2 equals the setpoint (constant or variable by depth phase)
           ppO2Curve = _o2ToxicityCalculator.calculatePpO2CurveCCR(
             depths,
             setpointHigh: setpointHigh,
@@ -612,8 +627,11 @@ class ProfileAnalysisService {
           );
         }
       case DiveMode.scr:
-        // SCR: ppO2 varies with depth based on steady-state loop FO2
-        if (scrInjectionRate != null && scrSupplyO2Percent != null) {
+        if (hasMeasuredPpO2) {
+          // SCR: measured loop ppO2 from O2 cells / setpoint
+          ppO2Curve = rebreatherPpO2Curve;
+        } else if (scrInjectionRate != null && scrSupplyO2Percent != null) {
+          // SCR: ppO2 varies with depth based on steady-state loop FO2
           ppO2Curve = _o2ToxicityCalculator.calculatePpO2CurveSCR(
             depths,
             injectionRateLpm: scrInjectionRate,

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -240,6 +240,7 @@ ProfileAnalysisService _resolveAnalysisService(
   MetricDataSource ceilingSource = MetricDataSource.calculated,
   MetricDataSource ttsSource = MetricDataSource.calculated,
   MetricDataSource cnsSource = MetricDataSource.calculated,
+  RebreatherPpO2? rebreatherPpO2,
 }) {
   final hasComputerNdl = profile.any((p) => p.ndl != null);
   final hasComputerCeiling = profile.any((p) => p.ceiling != null);
@@ -256,78 +257,14 @@ ProfileAnalysisService _resolveAnalysisService(
 
   // ---- ppO2 / O2 cell overlay (CCR/SCR) ----
   // For rebreather dives the displayed ppO2 must come from sensor data or the
-  // setpoint, never the OC depth x FO2 fallback. Resolve per sample with the
-  // priority: computer ppO2 (dc_supplied) -> cell average -> setpoint. Cells
-  // are exposed individually for the tooltip. Averaging here is display-time
-  // only (the no-calculation rule applies to import, not display).
-  const cellAccessors = <double? Function(DiveProfilePoint)>[
-    _o2Sensor1,
-    _o2Sensor2,
-    _o2Sensor3,
-    _o2Sensor4,
-    _o2Sensor5,
-    _o2Sensor6,
-  ];
-  double? cellAverage(DiveProfilePoint p) {
-    var sum = 0.0;
-    var count = 0;
-    for (final accessor in cellAccessors) {
-      final value = accessor(p);
-      if (value != null) {
-        sum += value;
-        count++;
-      }
-    }
-    return count == 0 ? null : sum / count;
-  }
-
-  final hasComputerPpO2 = profile.any((p) => p.ppO2 != null);
-  final hasCells = profile.any((p) => cellAverage(p) != null);
-  final hasSetpoint = profile.any((p) => p.setpoint != null);
-  final hasSensorData = hasComputerPpO2 || hasCells;
-  final hasRebreatherPpO2 = hasSensorData || hasSetpoint;
-
-  List<double>? resolvedPpO2;
-  List<List<double?>>? o2SensorCurves;
-  var ppO2FromSensorAverage = false;
-  if (hasRebreatherPpO2) {
-    // Pick ONE source for the whole dive — sensor data when present, otherwise
-    // the setpoint — and never mix them. Mixing makes the curve jump between
-    // the measured value and the setpoint on samples where the cells are
-    // momentarily absent. Within the chosen source, hold the last known value
-    // across gaps (and back-fill leading gaps with the first reading) so the
-    // curve stays continuous instead of dropping out.
-    final raw = List<double?>.generate(profile.length, (i) {
-      final p = profile[i];
-      return hasSensorData ? (p.ppO2 ?? cellAverage(p)) : p.setpoint;
-    });
-    final firstKnown = raw.firstWhere((v) => v != null, orElse: () => null);
-    double? carry = firstKnown;
-    resolvedPpO2 = List<double>.generate(profile.length, (i) {
-      final value = raw[i];
-      if (value != null) carry = value;
-      return carry ?? 0.0;
-    });
-    // Tooltip labels the value as an average only when cells are the source
-    // (no computer-supplied ppO2 was available).
-    ppO2FromSensorAverage = hasSensorData && !hasComputerPpO2;
-    // Expose each cell as its own per-sample curve, indexed by physical cell
-    // position so the tooltip labels them correctly (curve index i == Sensor
-    // i+1). Build curves up to the highest-numbered cell that has any reading;
-    // any lower cell with no readings stays an all-null curve, which the chart
-    // skips per-sample. This keeps labels right even when cells are absent or
-    // non-contiguous (e.g. a failed/unreported cell).
-    var highestCell = -1;
-    for (var i = 0; i < cellAccessors.length; i++) {
-      if (profile.any((p) => cellAccessors[i](p) != null)) highestCell = i;
-    }
-    if (highestCell >= 0) {
-      o2SensorCurves = [
-        for (var i = 0; i <= highestCell; i++)
-          profile.map(cellAccessors[i]).toList(),
-      ];
-    }
-  }
+  // setpoint, never the OC depth x FO2 fallback. The same resolved curve is fed
+  // into the analysis (see [resolveRebreatherPpO2]) so the CNS/OTU numbers match
+  // the displayed ppO2. Callers that already resolved it pass it in to avoid a
+  // second pass over the profile; otherwise resolve it here.
+  final resolved = rebreatherPpO2 ?? resolveRebreatherPpO2(profile);
+  final resolvedPpO2 = resolved?.curve;
+  final o2SensorCurves = resolved?.sensorCurves;
+  final ppO2FromSensorAverage = resolved?.fromSensorAverage ?? false;
 
   // Report actual source used (fallback to calculated if no data)
   final sourceInfo = (
@@ -399,6 +336,102 @@ double? _o2Sensor4(DiveProfilePoint p) => p.o2Sensor4;
 double? _o2Sensor5(DiveProfilePoint p) => p.o2Sensor5;
 double? _o2Sensor6(DiveProfilePoint p) => p.o2Sensor6;
 
+const _cellAccessors = <double? Function(DiveProfilePoint)>[
+  _o2Sensor1,
+  _o2Sensor2,
+  _o2Sensor3,
+  _o2Sensor4,
+  _o2Sensor5,
+  _o2Sensor6,
+];
+
+double? _cellAverage(DiveProfilePoint p) {
+  var sum = 0.0;
+  var count = 0;
+  for (final accessor in _cellAccessors) {
+    final value = accessor(p);
+    if (value != null) {
+      sum += value;
+      count++;
+    }
+  }
+  return count == 0 ? null : sum / count;
+}
+
+/// Resolved per-sample ppO2 for a rebreather dive.
+typedef RebreatherPpO2 = ({
+  /// ppO2 (bar) at each sample, continuous (last-known carried across gaps).
+  List<double> curve,
+
+  /// True when [curve] comes from averaging O2 cells (no computer-supplied
+  /// ppO2 was available). Used to label the chart tooltip.
+  bool fromSensorAverage,
+
+  /// Each O2 cell exposed as its own per-sample curve for the tooltip, or null
+  /// when the dive has no cell data.
+  List<List<double?>>? sensorCurves,
+});
+
+/// Resolves the per-sample ppO2 curve for a rebreather dive from sensor/setpoint
+/// data, returning null for profiles with no cells/ppO2/setpoint (e.g. OC).
+///
+/// This is the single source of truth for rebreather ppO2: it is used both to
+/// display the ppO2 curve and to drive the CNS/OTU calculation, so the two never
+/// disagree. ppO2 priority is computer ppO2 (dc_supplied) -> cell average ->
+/// setpoint, never the OC depth x FO2 fallback (the CCR ppO2 source rule).
+RebreatherPpO2? resolveRebreatherPpO2(List<DiveProfilePoint> profile) {
+  final hasComputerPpO2 = profile.any((p) => p.ppO2 != null);
+  final hasCells = profile.any((p) => _cellAverage(p) != null);
+  final hasSetpoint = profile.any((p) => p.setpoint != null);
+  final hasSensorData = hasComputerPpO2 || hasCells;
+  final hasRebreatherPpO2 = hasSensorData || hasSetpoint;
+  if (!hasRebreatherPpO2) return null;
+
+  // Pick ONE source for the whole dive — sensor data when present, otherwise
+  // the setpoint — and never mix them. Mixing makes the curve jump between the
+  // measured value and the setpoint on samples where the cells are momentarily
+  // absent. Within the chosen source, hold the last known value across gaps
+  // (and back-fill leading gaps with the first reading) so the curve stays
+  // continuous instead of dropping out.
+  final raw = List<double?>.generate(profile.length, (i) {
+    final p = profile[i];
+    return hasSensorData ? (p.ppO2 ?? _cellAverage(p)) : p.setpoint;
+  });
+  final firstKnown = raw.firstWhere((v) => v != null, orElse: () => null);
+  double? carry = firstKnown;
+  final curve = List<double>.generate(profile.length, (i) {
+    final value = raw[i];
+    if (value != null) carry = value;
+    return carry ?? 0.0;
+  });
+
+  // Expose each cell as its own per-sample curve, indexed by physical cell
+  // position so the tooltip labels them correctly (curve index i == Sensor
+  // i+1). Build curves up to the highest-numbered cell that has any reading;
+  // any lower cell with no readings stays an all-null curve, which the chart
+  // skips per-sample. This keeps labels right even when cells are absent or
+  // non-contiguous (e.g. a failed/unreported cell).
+  List<List<double?>>? sensorCurves;
+  var highestCell = -1;
+  for (var i = 0; i < _cellAccessors.length; i++) {
+    if (profile.any((p) => _cellAccessors[i](p) != null)) highestCell = i;
+  }
+  if (highestCell >= 0) {
+    sensorCurves = [
+      for (var i = 0; i <= highestCell; i++)
+        profile.map(_cellAccessors[i]).toList(),
+    ];
+  }
+
+  return (
+    curve: curve,
+    // Tooltip labels the value as an average only when cells are the source
+    // (no computer-supplied ppO2 was available).
+    fromSensorAverage: hasSensorData && !hasComputerPpO2,
+    sensorCurves: sensorCurves,
+  );
+}
+
 /// Provider for the ProfileAnalysisService configured with user settings
 final profileAnalysisServiceProvider = Provider<ProfileAnalysisService>((ref) {
   // Get decompression settings
@@ -451,6 +484,7 @@ class _ProfileAnalysisInput {
   final List<TissueCompartment>? startCompartments;
   final double startOtu;
   final List<ProfileGasSegment>? gasSegments;
+  final List<double>? rebreatherPpO2Curve;
 
   const _ProfileAnalysisInput({
     required this.gfLow,
@@ -477,6 +511,7 @@ class _ProfileAnalysisInput {
     this.startCompartments,
     this.startOtu = 0.0,
     this.gasSegments,
+    this.rebreatherPpO2Curve,
   });
 }
 
@@ -510,6 +545,7 @@ ProfileAnalysis _runProfileAnalysis(_ProfileAnalysisInput input) {
     startCompartments: input.startCompartments,
     startOtu: input.startOtu,
     gasSegments: input.gasSegments,
+    rebreatherPpO2Curve: input.rebreatherPpO2Curve,
   );
 }
 
@@ -635,6 +671,11 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
             await repository.getGasSwitchesForDive(diveId),
           )
         : null;
+    // Resolve rebreather loop ppO2 once and reuse it for both the analysis
+    // (CNS/OTU) and the display overlay so the two always agree.
+    final rebreatherPpO2 = dive.diveMode == DiveMode.oc
+        ? null
+        : resolveRebreatherPpO2(dive.profile);
     // Run Buhlmann analysis on a background isolate to keep UI responsive
     _log.debug(
       'Analyzing profile for dive $diveId with ${depths.length} points, '
@@ -668,6 +709,7 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
         startCompartments: startCompartments,
         startOtu: startOtu,
         gasSegments: gasSegments,
+        rebreatherPpO2Curve: rebreatherPpO2?.curve,
       ),
     );
 
@@ -679,6 +721,7 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
       ceilingSource: ceilingSource,
       ttsSource: ttsSource,
       cnsSource: cnsSource,
+      rebreatherPpO2: rebreatherPpO2,
     );
 
     // Publish actual source info for legend badge display
@@ -1017,6 +1060,12 @@ final diveProfileAnalysisProvider = Provider.family<ProfileAnalysis?, Dive>((
     // Get cumulative OTU from earlier same-day dives (0.0 while loading)
     final startOtu = ref.watch(residualOtuProvider(dive.id)).valueOrNull ?? 0.0;
 
+    // Resolve rebreather loop ppO2 once and reuse it for both the analysis
+    // (CNS/OTU) and the display overlay so the two always agree.
+    final rebreatherPpO2 = dive.diveMode == DiveMode.oc
+        ? null
+        : resolveRebreatherPpO2(dive.profile);
+
     final analysis = service.analyze(
       diveId: dive.id,
       depths: depths,
@@ -1034,6 +1083,7 @@ final diveProfileAnalysisProvider = Provider.family<ProfileAnalysis?, Dive>((
       scrInjectionRate: dive.scrInjectionRate,
       scrSupplyO2Percent: dive.diluentGas?.o2,
       scrVo2: dive.assumedVo2 ?? 1.3,
+      rebreatherPpO2Curve: rebreatherPpO2?.curve,
     );
 
     // Overlay computer-reported deco data where available
@@ -1044,6 +1094,7 @@ final diveProfileAnalysisProvider = Provider.family<ProfileAnalysis?, Dive>((
       ceilingSource: MetricDataSource.computer,
       ttsSource: MetricDataSource.computer,
       cnsSource: MetricDataSource.computer,
+      rebreatherPpO2: rebreatherPpO2,
     );
     return overlaid;
   } catch (e, stackTrace) {

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -159,56 +159,81 @@ void main() {
       );
     });
 
-    test(
-      'CCR: rebreatherPpO2Curve drives CNS, not OC depth x FO2 fallback',
-      () {
-        // Deep CCR dive on a 50% diluent with no dive-level setpoint (as
-        // imported from Subsurface). Without the measured curve, the CCR branch
-        // falls back to OC depth x FO2 (0.5), inflating ppO2 to ~2.5 bar at 40m
-        // and producing a wildly overstated CNS. The measured loop ppO2 (~1.2
-        // bar from the O2 cells) must drive CNS instead.
-        final depths = <double>[];
-        final timestamps = <int>[];
-        for (int t = 0; t <= 40 * 60; t += 60) {
-          timestamps.add(t);
-          depths.add(40.0);
-        }
-        final measuredPpO2 = List<double>.filled(depths.length, 1.2);
+    test('CCR: measured loop ppO2 drives CNS', () {
+      // Deep CCR dive on a 50% diluent. The measured loop ppO2 (~1.2 bar from
+      // the O2 cells) must drive CNS, never the OC depth x FO2 of the diluent
+      // (which would inflate ppO2 to ~2.5 bar at 40m).
+      final depths = <double>[];
+      final timestamps = <int>[];
+      for (int t = 0; t <= 40 * 60; t += 60) {
+        timestamps.add(t);
+        depths.add(40.0);
+      }
+      final measuredPpO2 = List<double>.filled(depths.length, 1.2);
 
-        final withCells = service.analyze(
-          diveId: 'ccr-with-cells',
-          depths: depths,
-          timestamps: timestamps,
-          o2Fraction: 0.5,
-          diveMode: DiveMode.ccr,
-          rebreatherPpO2Curve: measuredPpO2,
-        );
+      final withCells = service.analyze(
+        diveId: 'ccr-with-cells',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: 0.5,
+        diveMode: DiveMode.ccr,
+        rebreatherPpO2Curve: measuredPpO2,
+      );
 
-        final ocFallback = service.analyze(
-          diveId: 'ccr-oc-fallback',
-          depths: depths,
-          timestamps: timestamps,
-          o2Fraction: 0.5,
-          diveMode: DiveMode.ccr,
-        );
+      // ppO2 comes from the measured curve, not depth x FO2 (which is 2.5).
+      expect(withCells.ppO2Curve.last, closeTo(1.2, 1e-9));
+      // 40 min at ppO2 1.2 bar -> ~210-min NOAA limit -> ~19% CNS.
+      expect(withCells.o2Exposure.cnsEnd, closeTo(40 / 210 * 100, 1.0));
+      expect(
+        withCells.cnsCurve!.last,
+        closeTo(withCells.o2Exposure.cnsEnd, 1e-6),
+      );
+    });
 
-        // ppO2 comes from the measured curve, not depth x FO2.
-        expect(withCells.ppO2Curve.last, closeTo(1.2, 1e-9));
-        expect(ocFallback.ppO2Curve.last, closeTo(2.5, 1e-9));
+    test('CCR: no loop ppO2 data never falls back to OC depth x FO2', () {
+      // No cells, no measured ppO2, no setpoint. The CCR ppO2 must not be
+      // computed as depth x diluent-FO2 (that would read 2.5 bar at 40m and
+      // fabricate a large CNS); it stays unknown (zero) instead.
+      final depths = <double>[];
+      final timestamps = <int>[];
+      for (int t = 0; t <= 40 * 60; t += 60) {
+        timestamps.add(t);
+        depths.add(40.0);
+      }
 
-        // 40 min at ppO2 1.2 bar -> ~210-min NOAA limit -> ~19% CNS.
-        expect(withCells.o2Exposure.cnsEnd, closeTo(40 / 210 * 100, 1.0));
-        // The OC fallback grossly overstates CNS (ppO2 2.5 -> 10%/min).
-        expect(
-          ocFallback.o2Exposure.cnsEnd,
-          greaterThan(withCells.o2Exposure.cnsEnd * 5),
-        );
-        expect(
-          withCells.cnsCurve!.last,
-          closeTo(withCells.o2Exposure.cnsEnd, 1e-6),
-        );
-      },
-    );
+      final result = service.analyze(
+        diveId: 'ccr-no-ppo2',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: 0.5,
+        diveMode: DiveMode.ccr,
+      );
+
+      expect(result.ppO2Curve.every((v) => v == 0.0), isTrue);
+      expect(result.o2Exposure.cnsEnd, 0.0);
+    });
+
+    test('CCR: only-low setpoint is used as a constant ppO2', () {
+      final depths = <double>[];
+      final timestamps = <int>[];
+      for (int t = 0; t <= 40 * 60; t += 60) {
+        timestamps.add(t);
+        depths.add(40.0);
+      }
+
+      final result = service.analyze(
+        diveId: 'ccr-low-sp-only',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: 0.5,
+        diveMode: DiveMode.ccr,
+        setpointLow: 0.7,
+      );
+
+      // Constant 0.7 bar everywhere (no depth-phased switch without a high sp),
+      // never the OC 2.5 bar.
+      expect(result.ppO2Curve.every((v) => v == 0.7), isTrue);
+    });
 
     test('single gas segment matches single-gas analysis', () {
       final depths = <double>[];

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -159,6 +159,57 @@ void main() {
       );
     });
 
+    test(
+      'CCR: rebreatherPpO2Curve drives CNS, not OC depth x FO2 fallback',
+      () {
+        // Deep CCR dive on a 50% diluent with no dive-level setpoint (as
+        // imported from Subsurface). Without the measured curve, the CCR branch
+        // falls back to OC depth x FO2 (0.5), inflating ppO2 to ~2.5 bar at 40m
+        // and producing a wildly overstated CNS. The measured loop ppO2 (~1.2
+        // bar from the O2 cells) must drive CNS instead.
+        final depths = <double>[];
+        final timestamps = <int>[];
+        for (int t = 0; t <= 40 * 60; t += 60) {
+          timestamps.add(t);
+          depths.add(40.0);
+        }
+        final measuredPpO2 = List<double>.filled(depths.length, 1.2);
+
+        final withCells = service.analyze(
+          diveId: 'ccr-with-cells',
+          depths: depths,
+          timestamps: timestamps,
+          o2Fraction: 0.5,
+          diveMode: DiveMode.ccr,
+          rebreatherPpO2Curve: measuredPpO2,
+        );
+
+        final ocFallback = service.analyze(
+          diveId: 'ccr-oc-fallback',
+          depths: depths,
+          timestamps: timestamps,
+          o2Fraction: 0.5,
+          diveMode: DiveMode.ccr,
+        );
+
+        // ppO2 comes from the measured curve, not depth x FO2.
+        expect(withCells.ppO2Curve.last, closeTo(1.2, 1e-9));
+        expect(ocFallback.ppO2Curve.last, closeTo(2.5, 1e-9));
+
+        // 40 min at ppO2 1.2 bar -> ~210-min NOAA limit -> ~19% CNS.
+        expect(withCells.o2Exposure.cnsEnd, closeTo(40 / 210 * 100, 1.0));
+        // The OC fallback grossly overstates CNS (ppO2 2.5 -> 10%/min).
+        expect(
+          ocFallback.o2Exposure.cnsEnd,
+          greaterThan(withCells.o2Exposure.cnsEnd * 5),
+        );
+        expect(
+          withCells.cnsCurve!.last,
+          closeTo(withCells.o2Exposure.cnsEnd, 1e-6),
+        );
+      },
+    );
+
     test('single gas segment matches single-gas analysis', () {
       final depths = <double>[];
       final timestamps = <int>[];


### PR DESCRIPTION
Fixes #266 

## Summary

For rebreather (CCR/SCR) dives, the calculated CNS% was computed from the wrong ppO2 source, producing grossly inflated values.

ProfileAnalysisService.analyze() built the CCR ppO2 curve from the dive-level setpointHigh/setpointLow fields. Subsurface imports never set those, so CCR fell through to the open-circuit formula — ambient pressure × first-tank FO2 — which is
 physically meaningless for a rebreather (loop ppO2 is regulated to the setpoint, decoupled from depth). On a 50% diluent that reads 2.5 bar at 40 m, so the CNS clock ran ~10×.

## Changes

  - Single source of truth for rebreather ppO2 (resolveRebreatherPpO2): resolves a continuous per-sample ppO2 curve with priority computer ppO2 (dc_supplied) → O2 cell average → setpoint, never OC. The same curve now drives both the displayed
  ppO2 chart and the CNS/OTU calculation, so they can't disagree. The display overlay reuses this instead of duplicating the resolution inline.
  - Feed the measured curve into analyze() so CNS, OTU, max ppO2, and ppO2 warning events all derive from real loop ppO2 (also clears the false ppO2High events the old fallback generated at depth).
  - Removed the OC depth × FO2 fallback for CCR/SCR. CCR resolves measured → setpoint (high, or low used as a constant when that's all there is) → otherwise unknown (zero); SCR resolves measured → loop-FO2 from injection params → otherwise
  zero. ppO2/CNS are safety numbers, so "unknown" is preferred over a confidently-wrong value.

  
## Notes / follow-ups

  - Out of scope (separate task): the native libdivecomputer download path still collapses per-cell DC_SAMPLE_PPO2 into a single value in our wrapper (libdc_download.c), so natively-downloaded CCR dives don't yet carry individual cell data.
  The vendored library already exposes it per sensor; only our bridge + pigeon schema need updating.
  - "Unknown" ppO2 currently renders as 0 (the curve type is non-nullable); making it explicitly "unavailable" in the UI would be a larger, follow-up change.

## Test Plan

- [X] `flutter test` passes
- [X] `flutter analyze` passes
- [X] Manual testing on: Windows

## Screenshots

Please check now

- CNS curve
- Tissue loading heatmap
- O2 toxicity box

## CCR dive CNS curve (calculated) before

This curve went up to 277%

<img width="1527" height="954" alt="before" src="https://github.com/user-attachments/assets/c5e1ca82-5417-491b-9d3b-11646117363e" />

## CCR dive CNS curve (calculated) after
<img width="1525" height="1032" alt="after" src="https://github.com/user-attachments/assets/39b89918-b687-4dcd-bd43-62ddeae7ff70" />


## CCR dive cns curve (computer data), before and after. 
This screenshot is for verification of the new values. 
<img width="1528" height="947" alt="image" src="https://github.com/user-attachments/assets/9b16ae6a-9ada-461e-8ab9-a8c8bbf5d23d" />


## Also see the same dive imported in subsurface
<img width="982" height="738" alt="image" src="https://github.com/user-attachments/assets/a0b73d03-bea3-4c97-a26f-a608d6f9bd4b" />

compare heatmap and cns values


