### PR TITLE
fix(importer): import all o2 sensors, not only the first one

### DIFF
--- a/lib/features/dive_computer/data/services/dive_parser.dart
+++ b/lib/features/dive_computer/data/services/dive_parser.dart
@@ -41,6 +41,12 @@ class DiveParser {
           decoTime: sample.decoTime,
           decoDepth: sample.decoDepth,
           tts: sample.tts,
+          o2Sensor1: sample.o2Sensor1,
+          o2Sensor2: sample.o2Sensor2,
+          o2Sensor3: sample.o2Sensor3,
+          o2Sensor4: sample.o2Sensor4,
+          o2Sensor5: sample.o2Sensor5,
+          o2Sensor6: sample.o2Sensor6,
         ),
       );
     }

--- a/lib/features/dive_computer/data/services/parsed_dive_mapper.dart
+++ b/lib/features/dive_computer/data/services/parsed_dive_mapper.dart
@@ -64,6 +64,12 @@ DownloadedDive parsedDiveToDownloaded(pigeon.ParsedDive parsed) {
             tts: s.tts,
             ndl: s.decoType == 0 ? s.decoTime : null,
             ceiling: s.decoType != null && s.decoType != 0 ? s.decoDepth : null,
+            o2Sensor1: s.o2Sensor1,
+            o2Sensor2: s.o2Sensor2,
+            o2Sensor3: s.o2Sensor3,
+            o2Sensor4: s.o2Sensor4,
+            o2Sensor5: s.o2Sensor5,
+            o2Sensor6: s.o2Sensor6,
           ),
         )
         .toList(),

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -418,6 +418,12 @@ class ReparseService {
             rbt: Value(s.rbt),
             decoType: Value(s.decoType),
             tts: Value(s.tts),
+            o2Sensor1: Value(s.o2Sensor1),
+            o2Sensor2: Value(s.o2Sensor2),
+            o2Sensor3: Value(s.o2Sensor3),
+            o2Sensor4: Value(s.o2Sensor4),
+            o2Sensor5: Value(s.o2Sensor5),
+            o2Sensor6: Value(s.o2Sensor6),
           ),
         );
       }

--- a/lib/features/dive_computer/domain/entities/downloaded_dive.dart
+++ b/lib/features/dive_computer/domain/entities/downloaded_dive.dart
@@ -231,6 +231,15 @@ class ProfileSample {
   /// Time to surface in seconds
   final int? tts;
 
+  /// Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+  /// cell has no reading. [ppo2] holds the aggregate/computed value.
+  final double? o2Sensor1;
+  final double? o2Sensor2;
+  final double? o2Sensor3;
+  final double? o2Sensor4;
+  final double? o2Sensor5;
+  final double? o2Sensor6;
+
   const ProfileSample({
     required this.timeSeconds,
     required this.depth,
@@ -249,6 +258,12 @@ class ProfileSample {
     this.decoTime,
     this.decoDepth,
     this.tts,
+    this.o2Sensor1,
+    this.o2Sensor2,
+    this.o2Sensor3,
+    this.o2Sensor4,
+    this.o2Sensor5,
+    this.o2Sensor6,
   });
 }
 

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -1016,6 +1016,12 @@ class DiveComputerRepository {
               rbt: Value(point.rbt),
               decoType: Value(point.decoType),
               tts: Value(point.tts),
+              o2Sensor1: Value(point.o2Sensor1),
+              o2Sensor2: Value(point.o2Sensor2),
+              o2Sensor3: Value(point.o2Sensor3),
+              o2Sensor4: Value(point.o2Sensor4),
+              o2Sensor5: Value(point.o2Sensor5),
+              o2Sensor6: Value(point.o2Sensor6),
             ),
           );
         }
@@ -1584,6 +1590,14 @@ class ProfilePointData {
   /// Time to surface in seconds
   final int? tts;
 
+  /// Individual CCR O2 cell ppO2 readings in bar (sensor 1..6)
+  final double? o2Sensor1;
+  final double? o2Sensor2;
+  final double? o2Sensor3;
+  final double? o2Sensor4;
+  final double? o2Sensor5;
+  final double? o2Sensor6;
+
   const ProfilePointData({
     required this.timestamp,
     required this.depth,
@@ -1602,6 +1616,12 @@ class ProfilePointData {
     this.decoTime,
     this.decoDepth,
     this.tts,
+    this.o2Sensor1,
+    this.o2Sensor2,
+    this.o2Sensor3,
+    this.o2Sensor4,
+    this.o2Sensor5,
+    this.o2Sensor6,
   });
 }
 

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -874,8 +874,9 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveSample(
     if (index < 0 || static_cast<unsigned int>(index) >= dive->sample_count) return nullptr;
 
     const libdc_sample_t *s = &dive->samples[index];
-    // All 14 fields. Integer sentinels (UINT32_MAX) are cast to double.
-    jdouble values[14] = {
+    // All 20 fields (14 base + 6 O2 cells). Integer sentinels (UINT32_MAX) are
+    // cast to double; NAN doubles pass through and become null on the Kotlin side.
+    jdouble values[20] = {
         static_cast<jdouble>(s->time_ms),
         s->depth,
         s->temperature,
@@ -889,10 +890,16 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveSample(
         static_cast<jdouble>(s->deco_type),
         static_cast<jdouble>(s->deco_time),
         s->deco_depth,
-        static_cast<jdouble>(s->deco_tts)
+        static_cast<jdouble>(s->deco_tts),
+        s->o2_sensor[0],
+        s->o2_sensor[1],
+        s->o2_sensor[2],
+        s->o2_sensor[3],
+        s->o2_sensor[4],
+        s->o2_sensor[5]
     };
-    jdoubleArray result = env->NewDoubleArray(14);
-    env->SetDoubleArrayRegion(result, 0, 14, values);
+    jdoubleArray result = env->NewDoubleArray(20);
+    env->SetDoubleArrayRegion(result, 0, 20, values);
     return result;
 }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
@@ -137,7 +137,18 @@ data class ProfileSample (
   val decoType: Long? = null,
   val decoTime: Long? = null,
   val decoDepth: Double? = null,
-  val tts: Long? = null
+  val tts: Long? = null,
+  /**
+   * Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+   * cell has no reading. libdivecomputer reports these per-sensor via
+   * DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+   */
+  val o2Sensor1: Double? = null,
+  val o2Sensor2: Double? = null,
+  val o2Sensor3: Double? = null,
+  val o2Sensor4: Double? = null,
+  val o2Sensor5: Double? = null,
+  val o2Sensor6: Double? = null
 )
  {
   companion object {
@@ -156,7 +167,13 @@ data class ProfileSample (
       val decoTime = pigeonVar_list[11] as Long?
       val decoDepth = pigeonVar_list[12] as Double?
       val tts = pigeonVar_list[13] as Long?
-      return ProfileSample(timeSeconds, depthMeters, temperatureCelsius, pressureBar, tankIndex, heartRate, setpoint, ppo2, cns, rbt, decoType, decoTime, decoDepth, tts)
+      val o2Sensor1 = pigeonVar_list[14] as Double?
+      val o2Sensor2 = pigeonVar_list[15] as Double?
+      val o2Sensor3 = pigeonVar_list[16] as Double?
+      val o2Sensor4 = pigeonVar_list[17] as Double?
+      val o2Sensor5 = pigeonVar_list[18] as Double?
+      val o2Sensor6 = pigeonVar_list[19] as Double?
+      return ProfileSample(timeSeconds, depthMeters, temperatureCelsius, pressureBar, tankIndex, heartRate, setpoint, ppo2, cns, rbt, decoType, decoTime, decoDepth, tts, o2Sensor1, o2Sensor2, o2Sensor3, o2Sensor4, o2Sensor5, o2Sensor6)
     }
   }
   fun toList(): List<Any?> {
@@ -175,6 +192,12 @@ data class ProfileSample (
       decoTime,
       decoDepth,
       tts,
+      o2Sensor1,
+      o2Sensor2,
+      o2Sensor3,
+      o2Sensor4,
+      o2Sensor5,
+      o2Sensor6,
     )
   }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -459,7 +459,13 @@ class DiveComputerHostApiImpl(
                 decoType = if (s[10].toLong() == UINT32_SENTINEL) null else s[10].toLong(),
                 decoTime = if (s[11].toLong() == UINT32_SENTINEL) null else s[11].toLong(),
                 decoDepth = if (s[12].isNaN()) null else s[12],
-                tts = if (s[13].toLong() == UINT32_SENTINEL || s[13].toLong() == 0L) null else s[13].toLong()
+                tts = if (s[13].toLong() == UINT32_SENTINEL || s[13].toLong() == 0L) null else s[13].toLong(),
+                o2Sensor1 = if (s[14].isNaN()) null else s[14],
+                o2Sensor2 = if (s[15].isNaN()) null else s[15],
+                o2Sensor3 = if (s[16].isNaN()) null else s[16],
+                o2Sensor4 = if (s[17].isNaN()) null else s[17],
+                o2Sensor5 = if (s[18].isNaN()) null else s[18],
+                o2Sensor6 = if (s[19].isNaN()) null else s[19]
             )
         }
 

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -596,7 +596,14 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
                     decoType: s.deco_type == UInt32.max ? nil : Int64(s.deco_type),
                     decoTime: s.deco_time == UInt32.max ? nil : Int64(s.deco_time),
                     decoDepth: s.deco_depth.isNaN ? nil : s.deco_depth,
-                    tts: s.deco_tts == UInt32.max || s.deco_tts == 0 ? nil : Int64(s.deco_tts)
+                    tts: s.deco_tts == UInt32.max || s.deco_tts == 0 ? nil : Int64(s.deco_tts),
+                    // C `double o2_sensor[6]` imports as a 6-tuple.
+                    o2Sensor1: s.o2_sensor.0.isNaN ? nil : s.o2_sensor.0,
+                    o2Sensor2: s.o2_sensor.1.isNaN ? nil : s.o2_sensor.1,
+                    o2Sensor3: s.o2_sensor.2.isNaN ? nil : s.o2_sensor.2,
+                    o2Sensor4: s.o2_sensor.3.isNaN ? nil : s.o2_sensor.3,
+                    o2Sensor5: s.o2_sensor.4.isNaN ? nil : s.o2_sensor.4,
+                    o2Sensor6: s.o2_sensor.5.isNaN ? nil : s.o2_sensor.5
                 ))
             }
         }

--- a/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
@@ -163,6 +163,15 @@ struct ProfileSample {
   var decoTime: Int64? = nil
   var decoDepth: Double? = nil
   var tts: Int64? = nil
+  /// Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+  /// cell has no reading. libdivecomputer reports these per-sensor via
+  /// DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+  var o2Sensor1: Double? = nil
+  var o2Sensor2: Double? = nil
+  var o2Sensor3: Double? = nil
+  var o2Sensor4: Double? = nil
+  var o2Sensor5: Double? = nil
+  var o2Sensor6: Double? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -181,6 +190,12 @@ struct ProfileSample {
     let decoTime: Int64? = nilOrValue(pigeonVar_list[11])
     let decoDepth: Double? = nilOrValue(pigeonVar_list[12])
     let tts: Int64? = nilOrValue(pigeonVar_list[13])
+    let o2Sensor1: Double? = nilOrValue(pigeonVar_list[14])
+    let o2Sensor2: Double? = nilOrValue(pigeonVar_list[15])
+    let o2Sensor3: Double? = nilOrValue(pigeonVar_list[16])
+    let o2Sensor4: Double? = nilOrValue(pigeonVar_list[17])
+    let o2Sensor5: Double? = nilOrValue(pigeonVar_list[18])
+    let o2Sensor6: Double? = nilOrValue(pigeonVar_list[19])
 
     return ProfileSample(
       timeSeconds: timeSeconds,
@@ -196,7 +211,13 @@ struct ProfileSample {
       decoType: decoType,
       decoTime: decoTime,
       decoDepth: decoDepth,
-      tts: tts
+      tts: tts,
+      o2Sensor1: o2Sensor1,
+      o2Sensor2: o2Sensor2,
+      o2Sensor3: o2Sensor3,
+      o2Sensor4: o2Sensor4,
+      o2Sensor5: o2Sensor5,
+      o2Sensor6: o2Sensor6
     )
   }
   func toList() -> [Any?] {
@@ -215,6 +236,12 @@ struct ProfileSample {
       decoTime,
       decoDepth,
       tts,
+      o2Sensor1,
+      o2Sensor2,
+      o2Sensor3,
+      o2Sensor4,
+      o2Sensor5,
+      o2Sensor6,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
+++ b/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
@@ -117,6 +117,12 @@ class ProfileSample {
     this.decoTime,
     this.decoDepth,
     this.tts,
+    this.o2Sensor1,
+    this.o2Sensor2,
+    this.o2Sensor3,
+    this.o2Sensor4,
+    this.o2Sensor5,
+    this.o2Sensor6,
   });
 
   int timeSeconds;
@@ -147,6 +153,21 @@ class ProfileSample {
 
   int? tts;
 
+  /// Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+  /// cell has no reading. libdivecomputer reports these per-sensor via
+  /// DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+  double? o2Sensor1;
+
+  double? o2Sensor2;
+
+  double? o2Sensor3;
+
+  double? o2Sensor4;
+
+  double? o2Sensor5;
+
+  double? o2Sensor6;
+
   Object encode() {
     return <Object?>[
       timeSeconds,
@@ -163,6 +184,12 @@ class ProfileSample {
       decoTime,
       decoDepth,
       tts,
+      o2Sensor1,
+      o2Sensor2,
+      o2Sensor3,
+      o2Sensor4,
+      o2Sensor5,
+      o2Sensor6,
     ];
   }
 
@@ -183,6 +210,12 @@ class ProfileSample {
       decoTime: result[11] as int?,
       decoDepth: result[12] as double?,
       tts: result[13] as int?,
+      o2Sensor1: result[14] as double?,
+      o2Sensor2: result[15] as double?,
+      o2Sensor3: result[16] as double?,
+      o2Sensor4: result[17] as double?,
+      o2Sensor5: result[18] as double?,
+      o2Sensor6: result[19] as double?,
     );
   }
 }

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
@@ -201,6 +201,12 @@ struct _LibdivecomputerPluginProfileSample {
   int64_t* deco_time;
   double* deco_depth;
   int64_t* tts;
+  double* o2_sensor1;
+  double* o2_sensor2;
+  double* o2_sensor3;
+  double* o2_sensor4;
+  double* o2_sensor5;
+  double* o2_sensor6;
 };
 
 G_DEFINE_TYPE(LibdivecomputerPluginProfileSample, libdivecomputer_plugin_profile_sample, G_TYPE_OBJECT)
@@ -219,6 +225,12 @@ static void libdivecomputer_plugin_profile_sample_dispose(GObject* object) {
   g_clear_pointer(&self->deco_time, g_free);
   g_clear_pointer(&self->deco_depth, g_free);
   g_clear_pointer(&self->tts, g_free);
+  g_clear_pointer(&self->o2_sensor1, g_free);
+  g_clear_pointer(&self->o2_sensor2, g_free);
+  g_clear_pointer(&self->o2_sensor3, g_free);
+  g_clear_pointer(&self->o2_sensor4, g_free);
+  g_clear_pointer(&self->o2_sensor5, g_free);
+  g_clear_pointer(&self->o2_sensor6, g_free);
   G_OBJECT_CLASS(libdivecomputer_plugin_profile_sample_parent_class)->dispose(object);
 }
 
@@ -229,7 +241,7 @@ static void libdivecomputer_plugin_profile_sample_class_init(LibdivecomputerPlug
   G_OBJECT_CLASS(klass)->dispose = libdivecomputer_plugin_profile_sample_dispose;
 }
 
-LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, int64_t* heart_rate, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts) {
+LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, int64_t* heart_rate, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts, double* o2_sensor1, double* o2_sensor2, double* o2_sensor3, double* o2_sensor4, double* o2_sensor5, double* o2_sensor6) {
   LibdivecomputerPluginProfileSample* self = LIBDIVECOMPUTER_PLUGIN_PROFILE_SAMPLE(g_object_new(libdivecomputer_plugin_profile_sample_get_type(), nullptr));
   self->time_seconds = time_seconds;
   self->depth_meters = depth_meters;
@@ -317,6 +329,48 @@ LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(in
   else {
     self->tts = nullptr;
   }
+  if (o2_sensor1 != nullptr) {
+    self->o2_sensor1 = static_cast<double*>(malloc(sizeof(double)));
+    *self->o2_sensor1 = *o2_sensor1;
+  }
+  else {
+    self->o2_sensor1 = nullptr;
+  }
+  if (o2_sensor2 != nullptr) {
+    self->o2_sensor2 = static_cast<double*>(malloc(sizeof(double)));
+    *self->o2_sensor2 = *o2_sensor2;
+  }
+  else {
+    self->o2_sensor2 = nullptr;
+  }
+  if (o2_sensor3 != nullptr) {
+    self->o2_sensor3 = static_cast<double*>(malloc(sizeof(double)));
+    *self->o2_sensor3 = *o2_sensor3;
+  }
+  else {
+    self->o2_sensor3 = nullptr;
+  }
+  if (o2_sensor4 != nullptr) {
+    self->o2_sensor4 = static_cast<double*>(malloc(sizeof(double)));
+    *self->o2_sensor4 = *o2_sensor4;
+  }
+  else {
+    self->o2_sensor4 = nullptr;
+  }
+  if (o2_sensor5 != nullptr) {
+    self->o2_sensor5 = static_cast<double*>(malloc(sizeof(double)));
+    *self->o2_sensor5 = *o2_sensor5;
+  }
+  else {
+    self->o2_sensor5 = nullptr;
+  }
+  if (o2_sensor6 != nullptr) {
+    self->o2_sensor6 = static_cast<double*>(malloc(sizeof(double)));
+    *self->o2_sensor6 = *o2_sensor6;
+  }
+  else {
+    self->o2_sensor6 = nullptr;
+  }
   return self;
 }
 
@@ -390,6 +444,36 @@ int64_t* libdivecomputer_plugin_profile_sample_get_tts(LibdivecomputerPluginProf
   return self->tts;
 }
 
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor1(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->o2_sensor1;
+}
+
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor2(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->o2_sensor2;
+}
+
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor3(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->o2_sensor3;
+}
+
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor4(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->o2_sensor4;
+}
+
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor5(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->o2_sensor5;
+}
+
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor6(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->o2_sensor6;
+}
+
 static FlValue* libdivecomputer_plugin_profile_sample_to_list(LibdivecomputerPluginProfileSample* self) {
   FlValue* values = fl_value_new_list();
   fl_value_append_take(values, fl_value_new_int(self->time_seconds));
@@ -406,6 +490,12 @@ static FlValue* libdivecomputer_plugin_profile_sample_to_list(LibdivecomputerPlu
   fl_value_append_take(values, self->deco_time != nullptr ? fl_value_new_int(*self->deco_time) : fl_value_new_null());
   fl_value_append_take(values, self->deco_depth != nullptr ? fl_value_new_float(*self->deco_depth) : fl_value_new_null());
   fl_value_append_take(values, self->tts != nullptr ? fl_value_new_int(*self->tts) : fl_value_new_null());
+  fl_value_append_take(values, self->o2_sensor1 != nullptr ? fl_value_new_float(*self->o2_sensor1) : fl_value_new_null());
+  fl_value_append_take(values, self->o2_sensor2 != nullptr ? fl_value_new_float(*self->o2_sensor2) : fl_value_new_null());
+  fl_value_append_take(values, self->o2_sensor3 != nullptr ? fl_value_new_float(*self->o2_sensor3) : fl_value_new_null());
+  fl_value_append_take(values, self->o2_sensor4 != nullptr ? fl_value_new_float(*self->o2_sensor4) : fl_value_new_null());
+  fl_value_append_take(values, self->o2_sensor5 != nullptr ? fl_value_new_float(*self->o2_sensor5) : fl_value_new_null());
+  fl_value_append_take(values, self->o2_sensor6 != nullptr ? fl_value_new_float(*self->o2_sensor6) : fl_value_new_null());
   return values;
 }
 
@@ -498,7 +588,49 @@ static LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample
     tts_value = fl_value_get_int(value13);
     tts = &tts_value;
   }
-  return libdivecomputer_plugin_profile_sample_new(time_seconds, depth_meters, temperature_celsius, pressure_bar, tank_index, heart_rate, setpoint, ppo2, cns, rbt, deco_type, deco_time, deco_depth, tts);
+  FlValue* value14 = fl_value_get_list_value(values, 14);
+  double* o2_sensor1 = nullptr;
+  double o2_sensor1_value;
+  if (fl_value_get_type(value14) != FL_VALUE_TYPE_NULL) {
+    o2_sensor1_value = fl_value_get_float(value14);
+    o2_sensor1 = &o2_sensor1_value;
+  }
+  FlValue* value15 = fl_value_get_list_value(values, 15);
+  double* o2_sensor2 = nullptr;
+  double o2_sensor2_value;
+  if (fl_value_get_type(value15) != FL_VALUE_TYPE_NULL) {
+    o2_sensor2_value = fl_value_get_float(value15);
+    o2_sensor2 = &o2_sensor2_value;
+  }
+  FlValue* value16 = fl_value_get_list_value(values, 16);
+  double* o2_sensor3 = nullptr;
+  double o2_sensor3_value;
+  if (fl_value_get_type(value16) != FL_VALUE_TYPE_NULL) {
+    o2_sensor3_value = fl_value_get_float(value16);
+    o2_sensor3 = &o2_sensor3_value;
+  }
+  FlValue* value17 = fl_value_get_list_value(values, 17);
+  double* o2_sensor4 = nullptr;
+  double o2_sensor4_value;
+  if (fl_value_get_type(value17) != FL_VALUE_TYPE_NULL) {
+    o2_sensor4_value = fl_value_get_float(value17);
+    o2_sensor4 = &o2_sensor4_value;
+  }
+  FlValue* value18 = fl_value_get_list_value(values, 18);
+  double* o2_sensor5 = nullptr;
+  double o2_sensor5_value;
+  if (fl_value_get_type(value18) != FL_VALUE_TYPE_NULL) {
+    o2_sensor5_value = fl_value_get_float(value18);
+    o2_sensor5 = &o2_sensor5_value;
+  }
+  FlValue* value19 = fl_value_get_list_value(values, 19);
+  double* o2_sensor6 = nullptr;
+  double o2_sensor6_value;
+  if (fl_value_get_type(value19) != FL_VALUE_TYPE_NULL) {
+    o2_sensor6_value = fl_value_get_float(value19);
+    o2_sensor6 = &o2_sensor6_value;
+  }
+  return libdivecomputer_plugin_profile_sample_new(time_seconds, depth_meters, temperature_celsius, pressure_bar, tank_index, heart_rate, setpoint, ppo2, cns, rbt, deco_type, deco_time, deco_depth, tts, o2_sensor1, o2_sensor2, o2_sensor3, o2_sensor4, o2_sensor5, o2_sensor6);
 }
 
 struct _LibdivecomputerPluginGasMix {

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
@@ -188,12 +188,18 @@ G_DECLARE_FINAL_TYPE(LibdivecomputerPluginProfileSample, libdivecomputer_plugin_
  * deco_time: field in this object.
  * deco_depth: field in this object.
  * tts: field in this object.
+ * o2_sensor1: field in this object.
+ * o2_sensor2: field in this object.
+ * o2_sensor3: field in this object.
+ * o2_sensor4: field in this object.
+ * o2_sensor5: field in this object.
+ * o2_sensor6: field in this object.
  *
  * Creates a new #ProfileSample object.
  *
  * Returns: a new #LibdivecomputerPluginProfileSample
  */
-LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, int64_t* heart_rate, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts);
+LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, int64_t* heart_rate, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts, double* o2_sensor1, double* o2_sensor2, double* o2_sensor3, double* o2_sensor4, double* o2_sensor5, double* o2_sensor6);
 
 /**
  * libdivecomputer_plugin_profile_sample_get_time_seconds
@@ -334,6 +340,68 @@ double* libdivecomputer_plugin_profile_sample_get_deco_depth(LibdivecomputerPlug
  * Returns: the field value.
  */
 int64_t* libdivecomputer_plugin_profile_sample_get_tts(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_o2_sensor1
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+ * cell has no reading. libdivecomputer reports these per-sensor via
+ * DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+ *
+ * Returns: the field value.
+ */
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor1(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_o2_sensor2
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Gets the value of the o2Sensor2 field of @object.
+ *
+ * Returns: the field value.
+ */
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor2(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_o2_sensor3
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Gets the value of the o2Sensor3 field of @object.
+ *
+ * Returns: the field value.
+ */
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor3(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_o2_sensor4
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Gets the value of the o2Sensor4 field of @object.
+ *
+ * Returns: the field value.
+ */
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor4(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_o2_sensor5
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Gets the value of the o2Sensor5 field of @object.
+ *
+ * Returns: the field value.
+ */
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor5(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_o2_sensor6
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Gets the value of the o2Sensor6 field of @object.
+ *
+ * Returns: the field value.
+ */
+double* libdivecomputer_plugin_profile_sample_get_o2_sensor6(LibdivecomputerPluginProfileSample* object);
 
 /**
  * LibdivecomputerPluginGasMix:

--- a/packages/libdivecomputer_plugin/linux/dive_converter.c
+++ b/packages/libdivecomputer_plugin/linux/dive_converter.c
@@ -114,11 +114,21 @@ LibdivecomputerPluginParsedDive* convert_parsed_dive(
                     ? NULL
                     : &tts_val;
 
+            // Per-cell O2 ppO2: NaN -> NULL. cell_vals must outlive the
+            // constructor call (it copies each value).
+            double cell_vals[6];
+            double* o2_sensor[6];
+            for (int c = 0; c < 6; c++) {
+                cell_vals[c] = s->o2_sensor[c];
+                o2_sensor[c] = isnan(cell_vals[c]) ? NULL : &cell_vals[c];
+            }
+
             LibdivecomputerPluginProfileSample* sample =
                 libdivecomputer_plugin_profile_sample_new(
                     time_seconds, s->depth, temp_c, pressure, tank_index,
                     heart_rate, setpoint, ppo2, cns, rbt, deco_type,
-                    deco_time, deco_depth, tts);
+                    deco_time, deco_depth, tts, o2_sensor[0], o2_sensor[1],
+                    o2_sensor[2], o2_sensor[3], o2_sensor[4], o2_sensor[5]);
 
             fl_value_append_take(
                 samples,

--- a/packages/libdivecomputer_plugin/macos/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/DiveComputerApi.g.swift
@@ -163,6 +163,15 @@ struct ProfileSample {
   var decoTime: Int64? = nil
   var decoDepth: Double? = nil
   var tts: Int64? = nil
+  /// Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+  /// cell has no reading. libdivecomputer reports these per-sensor via
+  /// DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+  var o2Sensor1: Double? = nil
+  var o2Sensor2: Double? = nil
+  var o2Sensor3: Double? = nil
+  var o2Sensor4: Double? = nil
+  var o2Sensor5: Double? = nil
+  var o2Sensor6: Double? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -181,6 +190,12 @@ struct ProfileSample {
     let decoTime: Int64? = nilOrValue(pigeonVar_list[11])
     let decoDepth: Double? = nilOrValue(pigeonVar_list[12])
     let tts: Int64? = nilOrValue(pigeonVar_list[13])
+    let o2Sensor1: Double? = nilOrValue(pigeonVar_list[14])
+    let o2Sensor2: Double? = nilOrValue(pigeonVar_list[15])
+    let o2Sensor3: Double? = nilOrValue(pigeonVar_list[16])
+    let o2Sensor4: Double? = nilOrValue(pigeonVar_list[17])
+    let o2Sensor5: Double? = nilOrValue(pigeonVar_list[18])
+    let o2Sensor6: Double? = nilOrValue(pigeonVar_list[19])
 
     return ProfileSample(
       timeSeconds: timeSeconds,
@@ -196,7 +211,13 @@ struct ProfileSample {
       decoType: decoType,
       decoTime: decoTime,
       decoDepth: decoDepth,
-      tts: tts
+      tts: tts,
+      o2Sensor1: o2Sensor1,
+      o2Sensor2: o2Sensor2,
+      o2Sensor3: o2Sensor3,
+      o2Sensor4: o2Sensor4,
+      o2Sensor5: o2Sensor5,
+      o2Sensor6: o2Sensor6
     )
   }
   func toList() -> [Any?] {
@@ -215,6 +236,12 @@ struct ProfileSample {
       decoTime,
       decoDepth,
       tts,
+      o2Sensor1,
+      o2Sensor2,
+      o2Sensor3,
+      o2Sensor4,
+      o2Sensor5,
+      o2Sensor6,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -181,6 +181,9 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.heartbeat = UINT32_MAX;
         state->current_sample.setpoint = NAN;
         state->current_sample.ppo2 = NAN;
+        for (int cell = 0; cell < 6; cell++) {
+            state->current_sample.o2_sensor[cell] = NAN;
+        }
         state->current_sample.cns = NAN;
         state->current_sample.rbt = UINT32_MAX;
         state->current_sample.deco_type = UINT32_MAX;
@@ -205,7 +208,17 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.setpoint = value->setpoint;
         break;
     case DC_SAMPLE_PPO2:
-        state->current_sample.ppo2 = value->ppo2.value;
+        // libdivecomputer fires this once per O2 cell (sensor = 0,1,2,...) and
+        // optionally once with DC_SENSOR_NONE for the aggregate/computed value.
+        // Keep the aggregate in `ppo2`; store each cell separately. Don't derive
+        // ppo2 from a cell -- the Dart layer averages the cells when no
+        // aggregate is present.
+        if (value->ppo2.sensor == DC_SENSOR_NONE) {
+            state->current_sample.ppo2 = value->ppo2.value;
+        } else if (value->ppo2.sensor < 6) {
+            state->current_sample.o2_sensor[value->ppo2.sensor] =
+                value->ppo2.value;
+        }
         break;
     case DC_SAMPLE_CNS:
         state->current_sample.cns = value->cns * 100.0;  // fraction to percentage

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -142,7 +142,8 @@ typedef struct {
     // New fields for full sample capture
     unsigned int heartbeat;    // bpm (UINT32_MAX if unavailable)
     double setpoint;           // bar (NAN if unavailable)
-    double ppo2;               // bar (NAN if unavailable, first sensor)
+    double ppo2;               // bar (NAN if unavailable; aggregate/computed)
+    double o2_sensor[6];       // per-cell ppO2 in bar (NAN if that cell absent)
     double cns;                // percentage 0-100 (NAN if unavailable)
     unsigned int rbt;          // remaining bottom time in seconds (UINT32_MAX if unavailable)
     // Decompression status at this sample

--- a/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
+++ b/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
@@ -66,6 +66,12 @@ class ProfileSample {
     this.decoTime,
     this.decoDepth,
     this.tts,
+    this.o2Sensor1,
+    this.o2Sensor2,
+    this.o2Sensor3,
+    this.o2Sensor4,
+    this.o2Sensor5,
+    this.o2Sensor6,
   });
   final int timeSeconds;
   final double depthMeters;
@@ -81,6 +87,16 @@ class ProfileSample {
   final int? decoTime;
   final double? decoDepth;
   final int? tts;
+
+  /// Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+  /// cell has no reading. libdivecomputer reports these per-sensor via
+  /// DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+  final double? o2Sensor1;
+  final double? o2Sensor2;
+  final double? o2Sensor3;
+  final double? o2Sensor4;
+  final double? o2Sensor5;
+  final double? o2Sensor6;
 }
 
 class GasMix {

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
@@ -229,7 +229,13 @@ ProfileSample::ProfileSample(
   const int64_t* deco_type,
   const int64_t* deco_time,
   const double* deco_depth,
-  const int64_t* tts)
+  const int64_t* tts,
+  const double* o2_sensor1,
+  const double* o2_sensor2,
+  const double* o2_sensor3,
+  const double* o2_sensor4,
+  const double* o2_sensor5,
+  const double* o2_sensor6)
  : time_seconds_(time_seconds),
     depth_meters_(depth_meters),
     temperature_celsius_(temperature_celsius ? std::optional<double>(*temperature_celsius) : std::nullopt),
@@ -243,7 +249,13 @@ ProfileSample::ProfileSample(
     deco_type_(deco_type ? std::optional<int64_t>(*deco_type) : std::nullopt),
     deco_time_(deco_time ? std::optional<int64_t>(*deco_time) : std::nullopt),
     deco_depth_(deco_depth ? std::optional<double>(*deco_depth) : std::nullopt),
-    tts_(tts ? std::optional<int64_t>(*tts) : std::nullopt) {}
+    tts_(tts ? std::optional<int64_t>(*tts) : std::nullopt),
+    o2_sensor1_(o2_sensor1 ? std::optional<double>(*o2_sensor1) : std::nullopt),
+    o2_sensor2_(o2_sensor2 ? std::optional<double>(*o2_sensor2) : std::nullopt),
+    o2_sensor3_(o2_sensor3 ? std::optional<double>(*o2_sensor3) : std::nullopt),
+    o2_sensor4_(o2_sensor4 ? std::optional<double>(*o2_sensor4) : std::nullopt),
+    o2_sensor5_(o2_sensor5 ? std::optional<double>(*o2_sensor5) : std::nullopt),
+    o2_sensor6_(o2_sensor6 ? std::optional<double>(*o2_sensor6) : std::nullopt) {}
 
 int64_t ProfileSample::time_seconds() const {
   return time_seconds_;
@@ -419,9 +431,87 @@ void ProfileSample::set_tts(int64_t value_arg) {
 }
 
 
+const double* ProfileSample::o2_sensor1() const {
+  return o2_sensor1_ ? &(*o2_sensor1_) : nullptr;
+}
+
+void ProfileSample::set_o2_sensor1(const double* value_arg) {
+  o2_sensor1_ = value_arg ? std::optional<double>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_o2_sensor1(double value_arg) {
+  o2_sensor1_ = value_arg;
+}
+
+
+const double* ProfileSample::o2_sensor2() const {
+  return o2_sensor2_ ? &(*o2_sensor2_) : nullptr;
+}
+
+void ProfileSample::set_o2_sensor2(const double* value_arg) {
+  o2_sensor2_ = value_arg ? std::optional<double>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_o2_sensor2(double value_arg) {
+  o2_sensor2_ = value_arg;
+}
+
+
+const double* ProfileSample::o2_sensor3() const {
+  return o2_sensor3_ ? &(*o2_sensor3_) : nullptr;
+}
+
+void ProfileSample::set_o2_sensor3(const double* value_arg) {
+  o2_sensor3_ = value_arg ? std::optional<double>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_o2_sensor3(double value_arg) {
+  o2_sensor3_ = value_arg;
+}
+
+
+const double* ProfileSample::o2_sensor4() const {
+  return o2_sensor4_ ? &(*o2_sensor4_) : nullptr;
+}
+
+void ProfileSample::set_o2_sensor4(const double* value_arg) {
+  o2_sensor4_ = value_arg ? std::optional<double>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_o2_sensor4(double value_arg) {
+  o2_sensor4_ = value_arg;
+}
+
+
+const double* ProfileSample::o2_sensor5() const {
+  return o2_sensor5_ ? &(*o2_sensor5_) : nullptr;
+}
+
+void ProfileSample::set_o2_sensor5(const double* value_arg) {
+  o2_sensor5_ = value_arg ? std::optional<double>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_o2_sensor5(double value_arg) {
+  o2_sensor5_ = value_arg;
+}
+
+
+const double* ProfileSample::o2_sensor6() const {
+  return o2_sensor6_ ? &(*o2_sensor6_) : nullptr;
+}
+
+void ProfileSample::set_o2_sensor6(const double* value_arg) {
+  o2_sensor6_ = value_arg ? std::optional<double>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_o2_sensor6(double value_arg) {
+  o2_sensor6_ = value_arg;
+}
+
+
 EncodableList ProfileSample::ToEncodableList() const {
   EncodableList list;
-  list.reserve(14);
+  list.reserve(20);
   list.push_back(EncodableValue(time_seconds_));
   list.push_back(EncodableValue(depth_meters_));
   list.push_back(temperature_celsius_ ? EncodableValue(*temperature_celsius_) : EncodableValue());
@@ -436,6 +526,12 @@ EncodableList ProfileSample::ToEncodableList() const {
   list.push_back(deco_time_ ? EncodableValue(*deco_time_) : EncodableValue());
   list.push_back(deco_depth_ ? EncodableValue(*deco_depth_) : EncodableValue());
   list.push_back(tts_ ? EncodableValue(*tts_) : EncodableValue());
+  list.push_back(o2_sensor1_ ? EncodableValue(*o2_sensor1_) : EncodableValue());
+  list.push_back(o2_sensor2_ ? EncodableValue(*o2_sensor2_) : EncodableValue());
+  list.push_back(o2_sensor3_ ? EncodableValue(*o2_sensor3_) : EncodableValue());
+  list.push_back(o2_sensor4_ ? EncodableValue(*o2_sensor4_) : EncodableValue());
+  list.push_back(o2_sensor5_ ? EncodableValue(*o2_sensor5_) : EncodableValue());
+  list.push_back(o2_sensor6_ ? EncodableValue(*o2_sensor6_) : EncodableValue());
   return list;
 }
 
@@ -490,6 +586,30 @@ ProfileSample ProfileSample::FromEncodableList(const EncodableList& list) {
   auto& encodable_tts = list[13];
   if (!encodable_tts.IsNull()) {
     decoded.set_tts(std::get<int64_t>(encodable_tts));
+  }
+  auto& encodable_o2_sensor1 = list[14];
+  if (!encodable_o2_sensor1.IsNull()) {
+    decoded.set_o2_sensor1(std::get<double>(encodable_o2_sensor1));
+  }
+  auto& encodable_o2_sensor2 = list[15];
+  if (!encodable_o2_sensor2.IsNull()) {
+    decoded.set_o2_sensor2(std::get<double>(encodable_o2_sensor2));
+  }
+  auto& encodable_o2_sensor3 = list[16];
+  if (!encodable_o2_sensor3.IsNull()) {
+    decoded.set_o2_sensor3(std::get<double>(encodable_o2_sensor3));
+  }
+  auto& encodable_o2_sensor4 = list[17];
+  if (!encodable_o2_sensor4.IsNull()) {
+    decoded.set_o2_sensor4(std::get<double>(encodable_o2_sensor4));
+  }
+  auto& encodable_o2_sensor5 = list[18];
+  if (!encodable_o2_sensor5.IsNull()) {
+    decoded.set_o2_sensor5(std::get<double>(encodable_o2_sensor5));
+  }
+  auto& encodable_o2_sensor6 = list[19];
+  if (!encodable_o2_sensor6.IsNull()) {
+    decoded.set_o2_sensor6(std::get<double>(encodable_o2_sensor6));
   }
   return decoded;
 }

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
@@ -181,7 +181,13 @@ class ProfileSample {
     const int64_t* deco_type,
     const int64_t* deco_time,
     const double* deco_depth,
-    const int64_t* tts);
+    const int64_t* tts,
+    const double* o2_sensor1,
+    const double* o2_sensor2,
+    const double* o2_sensor3,
+    const double* o2_sensor4,
+    const double* o2_sensor5,
+    const double* o2_sensor6);
 
   int64_t time_seconds() const;
   void set_time_seconds(int64_t value_arg);
@@ -237,6 +243,33 @@ class ProfileSample {
   void set_tts(const int64_t* value_arg);
   void set_tts(int64_t value_arg);
 
+  // Individual CCR O2 cell ppO2 readings in bar (sensor 1..6), null when that
+  // cell has no reading. libdivecomputer reports these per-sensor via
+  // DC_SAMPLE_PPO2; [ppo2] holds the aggregate/computed value.
+  const double* o2_sensor1() const;
+  void set_o2_sensor1(const double* value_arg);
+  void set_o2_sensor1(double value_arg);
+
+  const double* o2_sensor2() const;
+  void set_o2_sensor2(const double* value_arg);
+  void set_o2_sensor2(double value_arg);
+
+  const double* o2_sensor3() const;
+  void set_o2_sensor3(const double* value_arg);
+  void set_o2_sensor3(double value_arg);
+
+  const double* o2_sensor4() const;
+  void set_o2_sensor4(const double* value_arg);
+  void set_o2_sensor4(double value_arg);
+
+  const double* o2_sensor5() const;
+  void set_o2_sensor5(const double* value_arg);
+  void set_o2_sensor5(double value_arg);
+
+  const double* o2_sensor6() const;
+  void set_o2_sensor6(const double* value_arg);
+  void set_o2_sensor6(double value_arg);
+
 
  private:
   static ProfileSample FromEncodableList(const flutter::EncodableList& list);
@@ -258,6 +291,12 @@ class ProfileSample {
   std::optional<int64_t> deco_time_;
   std::optional<double> deco_depth_;
   std::optional<int64_t> tts_;
+  std::optional<double> o2_sensor1_;
+  std::optional<double> o2_sensor2_;
+  std::optional<double> o2_sensor3_;
+  std::optional<double> o2_sensor4_;
+  std::optional<double> o2_sensor5_;
+  std::optional<double> o2_sensor6_;
 
 };
 

--- a/packages/libdivecomputer_plugin/windows/dive_converter.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_converter.cc
@@ -92,6 +92,14 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
                 std::isnan(s.deco_depth) ? std::nullopt
                                          : std::optional<double>(s.deco_depth);
 
+            // Per-cell O2 ppO2: NaN -> nullopt.
+            std::optional<double> o2_sensor[6];
+            for (int c = 0; c < 6; c++) {
+                o2_sensor[c] = std::isnan(s.o2_sensor[c])
+                                   ? std::nullopt
+                                   : std::optional<double>(s.o2_sensor[c]);
+            }
+
             // Nullable ints: UINT32_MAX -> nullptr.
             std::optional<int64_t> tank_index =
                 (s.tank == UINT32_MAX)
@@ -137,7 +145,13 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
                     deco_type ? &*deco_type : nullptr,
                     deco_time ? &*deco_time : nullptr,
                     deco_depth ? &*deco_depth : nullptr,
-                    tts ? &*tts : nullptr)));
+                    tts ? &*tts : nullptr,
+                    o2_sensor[0] ? &*o2_sensor[0] : nullptr,
+                    o2_sensor[1] ? &*o2_sensor[1] : nullptr,
+                    o2_sensor[2] ? &*o2_sensor[2] : nullptr,
+                    o2_sensor[3] ? &*o2_sensor[3] : nullptr,
+                    o2_sensor[4] ? &*o2_sensor[4] : nullptr,
+                    o2_sensor[5] ? &*o2_sensor[5] : nullptr)));
         }
     }
 

--- a/test/features/dive_computer/data/services/dive_parser_test.dart
+++ b/test/features/dive_computer/data/services/dive_parser_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_computer/data/services/dive_parser.dart';
+import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
+
+void main() {
+  const parser = DiveParser();
+
+  ProfileSample sample({
+    required int time,
+    required double depth,
+    double? temperature,
+    double? pressure,
+    int? tankIndex,
+    int? heartRate,
+  }) => ProfileSample(
+    timeSeconds: time,
+    depth: depth,
+    temperature: temperature,
+    pressure: pressure,
+    tankIndex: tankIndex,
+    heartRate: heartRate,
+  );
+
+  DownloadedDive diveWith({
+    List<ProfileSample> profile = const [],
+    List<DownloadedTank> tanks = const [],
+  }) => DownloadedDive(
+    startTime: DateTime(2024, 6, 15, 8, 30),
+    durationSeconds: 3600,
+    maxDepth: 30.0,
+    profile: profile,
+    tanks: tanks,
+  );
+
+  group('parseProfile', () {
+    test('maps all sample fields including the six O2 sensors', () {
+      final dive = diveWith(
+        profile: [
+          const ProfileSample(
+            timeSeconds: 60,
+            depth: 12.5,
+            temperature: 18.0,
+            pressure: 180.0,
+            tankIndex: 1,
+            heartRate: 85,
+            setpoint: 1.3,
+            ppo2: 1.28,
+            cns: 5.0,
+            ndl: 600,
+            ceiling: 0.0,
+            ascentRate: 8.0,
+            rbt: 1200,
+            decoType: 0,
+            decoTime: 0,
+            decoDepth: 0.0,
+            tts: 300,
+            o2Sensor1: 1.21,
+            o2Sensor2: 1.25,
+            o2Sensor3: 1.29,
+            o2Sensor4: 1.30,
+            o2Sensor5: 1.31,
+            o2Sensor6: 1.32,
+          ),
+        ],
+      );
+
+      final points = parser.parseProfile(dive);
+
+      expect(points, hasLength(1));
+      final p = points.single;
+      expect(p.timestamp, 60);
+      expect(p.depth, 12.5);
+      expect(p.temperature, 18.0);
+      expect(p.pressure, 180.0);
+      expect(p.tankIndex, 1);
+      expect(p.heartRate, 85);
+      expect(p.setpoint, 1.3);
+      expect(p.ppO2, 1.28);
+      expect(p.cns, 5.0);
+      expect(p.ndl, 600);
+      expect(p.ceiling, 0.0);
+      expect(p.ascentRate, 8.0);
+      expect(p.rbt, 1200);
+      expect(p.decoType, 0);
+      expect(p.decoTime, 0);
+      expect(p.decoDepth, 0.0);
+      expect(p.tts, 300);
+      expect(p.o2Sensor1, 1.21);
+      expect(p.o2Sensor2, 1.25);
+      expect(p.o2Sensor3, 1.29);
+      expect(p.o2Sensor4, 1.30);
+      expect(p.o2Sensor5, 1.31);
+      expect(p.o2Sensor6, 1.32);
+    });
+
+    test('passes through null O2 sensors when not present', () {
+      final dive = diveWith(profile: [sample(time: 0, depth: 5.0)]);
+
+      final point = parser.parseProfile(dive).single;
+
+      expect(point.o2Sensor1, isNull);
+      expect(point.o2Sensor2, isNull);
+      expect(point.o2Sensor3, isNull);
+      expect(point.o2Sensor4, isNull);
+      expect(point.o2Sensor5, isNull);
+      expect(point.o2Sensor6, isNull);
+    });
+
+    test('preserves order and count of samples', () {
+      final dive = diveWith(
+        profile: [
+          sample(time: 0, depth: 0.0),
+          sample(time: 30, depth: 10.0),
+          sample(time: 60, depth: 20.0),
+        ],
+      );
+
+      final points = parser.parseProfile(dive);
+
+      expect(points.map((p) => p.timestamp), [0, 30, 60]);
+      expect(points.map((p) => p.depth), [0.0, 10.0, 20.0]);
+    });
+
+    test('returns an empty list for a dive without samples', () {
+      expect(parser.parseProfile(diveWith()), isEmpty);
+    });
+  });
+
+  group('parseTanks', () {
+    test('maps every tank field', () {
+      final dive = diveWith(
+        tanks: const [
+          DownloadedTank(
+            index: 0,
+            o2Percent: 32.0,
+            hePercent: 0.0,
+            startPressure: 200.0,
+            endPressure: 50.0,
+            volumeLiters: 12.0,
+          ),
+          DownloadedTank(
+            index: 1,
+            o2Percent: 21.0,
+            hePercent: 35.0,
+            startPressure: 230.0,
+            endPressure: 80.0,
+            volumeLiters: 11.1,
+          ),
+        ],
+      );
+
+      final tanks = parser.parseTanks(dive);
+
+      expect(tanks, hasLength(2));
+      expect(tanks[0].index, 0);
+      expect(tanks[0].o2Percent, 32.0);
+      expect(tanks[0].hePercent, 0.0);
+      expect(tanks[0].startPressure, 200.0);
+      expect(tanks[0].endPressure, 50.0);
+      expect(tanks[0].volumeLiters, 12.0);
+      expect(tanks[1].index, 1);
+      expect(tanks[1].hePercent, 35.0);
+    });
+
+    test('returns an empty list for a dive without tanks', () {
+      expect(parser.parseTanks(diveWith()), isEmpty);
+    });
+  });
+
+  group('calculateMaxDepth', () {
+    test('returns the deepest sample', () {
+      final profile = [
+        sample(time: 0, depth: 5.0),
+        sample(time: 30, depth: 22.5),
+        sample(time: 60, depth: 18.0),
+      ];
+      expect(parser.calculateMaxDepth(profile), 22.5);
+    });
+
+    test('returns 0 for an empty profile', () {
+      expect(parser.calculateMaxDepth(const []), 0.0);
+    });
+  });
+
+  group('calculateAvgDepth', () {
+    test('weights depth by time interval', () {
+      // 10m for 60s, then 20m for 60s, last sample assumed 1s at 20m.
+      final profile = [
+        sample(time: 0, depth: 10.0),
+        sample(time: 60, depth: 20.0),
+        sample(time: 120, depth: 20.0),
+      ];
+
+      // (10*60 + 20*60 + 20*1) / (60 + 60 + 1) = 1820 / 121
+      expect(parser.calculateAvgDepth(profile), closeTo(1820 / 121, 1e-9));
+    });
+
+    test('returns 0 for an empty profile', () {
+      expect(parser.calculateAvgDepth(const []), 0.0);
+    });
+
+    test('handles a single sample', () {
+      expect(parser.calculateAvgDepth([sample(time: 0, depth: 15.0)]), 15.0);
+    });
+  });
+
+  group('extractTemperatureRange', () {
+    test('returns min and max of available temperatures', () {
+      final profile = [
+        sample(time: 0, depth: 5.0, temperature: 20.0),
+        sample(time: 30, depth: 15.0, temperature: 14.0),
+        sample(time: 60, depth: 10.0, temperature: 17.0),
+      ];
+
+      final range = parser.extractTemperatureRange(profile);
+
+      expect(range.min, 14.0);
+      expect(range.max, 20.0);
+    });
+
+    test('ignores samples without temperature', () {
+      final profile = [
+        sample(time: 0, depth: 5.0),
+        sample(time: 30, depth: 15.0, temperature: 12.0),
+      ];
+
+      final range = parser.extractTemperatureRange(profile);
+
+      expect(range.min, 12.0);
+      expect(range.max, 12.0);
+    });
+
+    test('returns nulls when no temperatures are present', () {
+      final range = parser.extractTemperatureRange([
+        sample(time: 0, depth: 5.0),
+      ]);
+
+      expect(range.min, isNull);
+      expect(range.max, isNull);
+    });
+  });
+
+  group('detectSafetyStop', () {
+    test('detects a safety stop held at ~5m before surfacing', () {
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 0.0),
+        sample(time: 60, depth: 20.0),
+        // Safety stop window: 5m from 120s to 300s (180s > 120s minimum).
+        sample(time: 120, depth: 5.0),
+        sample(time: 180, depth: 5.0),
+        sample(time: 240, depth: 5.0),
+        sample(time: 300, depth: 5.0),
+        // Surface afterwards.
+        sample(time: 360, depth: 0.0),
+      ];
+
+      final stop = parser.detectSafetyStop(profile);
+
+      expect(stop, isNotNull);
+      expect(stop!.startTime, 120);
+      expect(stop.duration, greaterThanOrEqualTo(120));
+      expect(stop.depth, 5.0);
+    });
+
+    test('returns null when the stop is too short', () {
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 0.0),
+        sample(time: 60, depth: 20.0),
+        sample(time: 120, depth: 5.0),
+        sample(time: 160, depth: 5.0), // only 40s at 5m
+        sample(time: 220, depth: 0.0),
+      ];
+
+      expect(parser.detectSafetyStop(profile), isNull);
+    });
+
+    test('returns null when there is no shallow stop', () {
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 0.0),
+        sample(time: 60, depth: 25.0),
+        sample(time: 120, depth: 25.0),
+        sample(time: 180, depth: 0.0),
+      ];
+
+      expect(parser.detectSafetyStop(profile), isNull);
+    });
+  });
+
+  group('calculateAscentRates', () {
+    test('reports rate and severity for ascending segments only', () {
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 30.0),
+        // Descending segment is ignored.
+        sample(time: 30, depth: 32.0),
+        // Ascend 5m in 60s -> 5 m/min (safe).
+        sample(time: 90, depth: 27.0),
+        // Ascend 15m in 60s -> 15 m/min (critical).
+        sample(time: 150, depth: 12.0),
+      ];
+
+      final rates = parser.calculateAscentRates(profile);
+
+      expect(rates, hasLength(2));
+      expect(rates[0].rateMetersPerMin, closeTo(5.0, 1e-9));
+      expect(rates[0].severity, AscentRateSeverity.safe);
+      expect(rates[1].rateMetersPerMin, closeTo(15.0, 1e-9));
+      expect(rates[1].severity, AscentRateSeverity.critical);
+    });
+
+    test('classifies the warning band (9-12 m/min)', () {
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 20.0),
+        sample(time: 60, depth: 10.0), // 10 m/min
+      ];
+
+      final rates = parser.calculateAscentRates(profile);
+
+      expect(rates, hasLength(1));
+      expect(rates.single.severity, AscentRateSeverity.warning);
+    });
+
+    test('returns empty when there is no ascent', () {
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 5.0),
+        sample(time: 60, depth: 20.0),
+      ];
+
+      expect(parser.calculateAscentRates(profile), isEmpty);
+    });
+  });
+
+  group('analyzeDivePhases', () {
+    test('identifies descent end, ascent start and bottom time', () {
+      // Max depth (30m) is first reached at t=90. descentEnd is the first
+      // sample within 10% of max (>=27m) before that: t=60. ascentStart is the
+      // last sample within 10% of max: t=150.
+      final profile = <ProfileSample>[
+        sample(time: 0, depth: 0.0),
+        sample(time: 30, depth: 15.0),
+        sample(time: 60, depth: 28.0),
+        sample(time: 90, depth: 30.0),
+        sample(time: 120, depth: 30.0),
+        sample(time: 150, depth: 30.0),
+        sample(time: 180, depth: 10.0),
+        sample(time: 240, depth: 0.0),
+      ];
+
+      final phases = parser.analyzeDivePhases(profile);
+
+      expect(phases.descentEnd, 60);
+      expect(phases.ascentStart, 150);
+      expect(phases.bottomTime, 90);
+    });
+
+    test('returns zeroed phases for an empty profile', () {
+      final phases = parser.analyzeDivePhases(const []);
+
+      expect(phases.descentEnd, 0);
+      expect(phases.ascentStart, 0);
+      expect(phases.bottomTime, 0);
+    });
+  });
+}

--- a/test/features/dive_computer/data/services/parsed_dive_mapper_test.dart
+++ b/test/features/dive_computer/data/services/parsed_dive_mapper_test.dart
@@ -177,6 +177,33 @@ void main() {
       expect(downloaded.profile[2].heartRate, 85);
     });
 
+    test('maps per-cell O2 sensor ppO2 (absent cells stay null)', () {
+      final parsed = makeParsedDive(
+        fingerprint: 'cells1',
+        samples: [
+          pigeon.ProfileSample(
+            timeSeconds: 0,
+            depthMeters: 0.0,
+            ppo2: 0.7,
+            o2Sensor1: 0.68,
+            o2Sensor2: 0.70,
+            o2Sensor3: 0.72,
+          ),
+        ],
+      );
+
+      final downloaded = parsedDiveToDownloaded(parsed);
+      final p = downloaded.profile.single;
+
+      expect(p.ppo2, 0.7);
+      expect(p.o2Sensor1, 0.68);
+      expect(p.o2Sensor2, 0.70);
+      expect(p.o2Sensor3, 0.72);
+      expect(p.o2Sensor4, isNull);
+      expect(p.o2Sensor5, isNull);
+      expect(p.o2Sensor6, isNull);
+    });
+
     // --- Tanks and gas mixes ---
 
     test('maps tanks with gas mixes correctly', () {


### PR DESCRIPTION
## Summary

 CCR dives record one ppO2 reading per individual O2 cell (up to 6), but the  importer was only keeping the first sensor and discarding the rest. This PR plumbs all six O2 cell readings end-to-end so each cell's ppO2 is preserved on import and available for display and re-parse.

The aggregate/computed `ppo2` value is unchanged; the per-cell values are stored alongside it as `o2Sensor1..6`.

## Changes
 
   - **Native (all platforms):** extract per-cell O2 ppO2 (`o2_sensor1..6`) from libdivecomputer samples in the converters and surface them through the Pigeon `ProfileSample` API — Android (JNI/Kotlin), iOS/macOS (Swift/C), Linux (GObject), and Windows (C++).
   - **Pigeon contract:** added `o2Sensor1..6` to `ProfileSample` and regenerated the platform bindings.
   - **Dart import path:** carried the six fields through `ProfileSample` → DiveParser.parseProfile` → `ProfilePointData`, plus the `parsed_dive_mapper` and `reparse_service` flows.
   - **Linux memory leak fix:** restored the `raw_data` / `raw_fingerprint` frees in `libdivecomputer_plugin_parsed_dive_dispose` that were accidentally dropped while hand-editing the generated file (these buffers are still allocated in `_new`). Addresses the Copilot review finding.

## Test Plan

- [X] `flutter test` passes
- [X] `flutter analyze` passes
- [ ] Manual testing on: <!-- list platforms tested -->

**No manual testing from my side as in don't have my ccr unit here at home at the moment.** 

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->
