### PR TITLE
fix(sync): stream iCloud base import to fix iOS OOM crash on large libraries (#358)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-sync-base-oom-streaming-import.md
+++ b/docs/superpowers/plans/2026-06-20-sync-base-oom-streaming-import.md
@@ -1,0 +1,1576 @@
+# Streaming Base Import (iCloud Sync OOM Fix) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt a peer's sync "base" snapshot with bounded memory so a large library no longer OOM-kills the app on iOS (issue #358).
+
+**Architecture:** Stream base parts to a temp file (one ~8 MB part resident at a time), then apply the base in three forward passes over that file: (1) collect header `exportedAt` + the `deletions` map, (2) collect parent-row `updatedAt` and contradiction keys, (3) apply rows in small batches through the existing per-record merge. The delicate merge logic (`_mergeEntity`, `_applyRemoteDeletions`, FK repair, HLC/LWW) is reused unchanged; only how rows are *fed* to it changes. No wire-format change.
+
+**Tech Stack:** Dart/Flutter, `dart:io` (`File`, `Directory.systemTemp`), `dart:convert` (`jsonDecode`/`utf8`), `package:crypto` (chunked SHA-256), Drift (SQLite), `flutter_test`.
+
+## Global Constraints
+
+- No wire-format change. Existing monolithic-JSON bases already in users' iClouds MUST import with no user action and no desktop re-publish.
+- Do NOT modify the merge primitives `_mergeEntity`, `_applyRemoteDeletions`, `repairDanglingForeignKeys`, `_pendingRecordMap`, `_deletionMap`, `_recordIdForEntity`, `_extractUpdatedAtMillis`, `_extractHlc` (signatures or bodies). New code calls them.
+- All BLOB/row decoding stays inside `SyncDataSerializer.upsertRecord`; new code passes plain `jsonDecode(rowBytes) as Map<String, dynamic>` exactly as the current path does (verified: the row maps produced by `SyncData.fromJson` are raw `jsonDecode` output; base64 BLOB decoding happens in `upsertRecord` via `_syncBlobSerializer`).
+- Temp scratch files use `Directory.systemTemp` (dart:io), NOT `path_provider` (avoids a plugin dependency and test mocking; `Directory.systemTemp` is sandbox-safe on iOS/macOS).
+- `dart format .` must pass with no changes; `flutter analyze` must be clean (whole project, not piped).
+- No emojis in code/comments. No `Co-Authored-By` trailers in commits.
+- Scope: the merge-base adoption path only (`ChangesetReader` cold-start/lapped base). The Replace-restore path (`_collectEpochPayloads`) and the write/publish side are explicit follow-ups, NOT in this plan.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/core/services/sync/changeset_log/base_json_stream_reader.dart` — `BaseJsonStreamReader`: streaming byte-boundary scanner that emits top-level scalar members and section (`data`/`deletions`) array rows without holding the whole document. Pure (no IO).
+- `lib/core/services/sync/changeset_log/base_part_file_sink.dart` — `BasePartFileSink`: downloads base parts one at a time, verifies per-part + whole-file checksums, writes to a temp file. Owns all temp-file IO.
+- `test/core/services/sync/changeset_log/base_json_stream_reader_test.dart`
+- `test/core/services/sync/changeset_log/base_part_file_sink_test.dart`
+- `test/core/services/sync/sync_base_streaming_parity_test.dart` — the linchpin: streaming apply vs in-memory apply produce identical DBs.
+
+**Modify:**
+- `lib/core/services/sync/changeset_log/changeset_reader.dart` — base branch fetches to a temp file and calls a new `applyBaseFile` callback; cleans the temp file up.
+- `lib/core/services/sync/sync_service.dart` — add `_applyRemoteBaseFile`; add `_entityHasUpdatedAt` const; wire `applyBaseFile:` into the `pull` call; add `@visibleForTesting` seams.
+- `test/core/services/sync/changeset_log/changeset_reader_test.dart`, `changeset_reader_epoch_test.dart`, `changeset_reader_verify_test.dart` — pass the new required `applyBaseFile` arg in their pull harness.
+
+---
+
+## Task 1: `BaseJsonStreamReader` — streaming byte-boundary scanner
+
+**Files:**
+- Create: `lib/core/services/sync/changeset_log/base_json_stream_reader.dart`
+- Test: `test/core/services/sync/changeset_log/base_json_stream_reader_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `class BaseJsonStreamReader` with
+    `Future<void> parse(Stream<List<int>> bytes, {Future<void> Function(String key, Uint8List rawValue)? onScalar, bool Function(String section, String table)? wantRows, Future<void> Function(String section, String table, Uint8List rowBytes)? onRow})`
+  - `onScalar` fires once per top-level scalar member (value bytes are raw JSON, e.g. `"abc"`, `2`, `null`).
+  - `onRow` fires once per array element inside a section object (`data` or `deletions`), with the raw element bytes.
+  - `wantRows(section, table)` returning false skips that table's elements without buffering/emitting (default: keep all).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/core/services/sync/changeset_log/base_json_stream_reader_test.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+
+/// Feed [s] as a single chunk.
+Stream<List<int>> _one(String s) => Stream.value(utf8.encode(s));
+
+/// Feed [s] one byte per chunk, to prove the scanner survives arbitrary
+/// chunk boundaries.
+Stream<List<int>> _drip(String s) async* {
+  for (final b in utf8.encode(s)) {
+    yield [b];
+  }
+}
+
+Future<({Map<String, String> scalars, List<List<String>> rows})> run(
+  Stream<List<int>> bytes, {
+  bool Function(String section, String table)? want,
+}) async {
+  final scalars = <String, String>{};
+  final rows = <List<String>>[];
+  await BaseJsonStreamReader().parse(
+    bytes,
+    onScalar: (k, v) async => scalars[k] = utf8.decode(v),
+    wantRows: want,
+    onRow: (section, table, row) async =>
+        rows.add([section, table, utf8.decode(row)]),
+  );
+  return (scalars: scalars, rows: rows);
+}
+
+void main() {
+  const doc =
+      '{"version":2,"exportedAt":17,"deviceId":"abc",'
+      '"data":{"dives":[{"id":"d1","n":1},{"id":"d2","n":2}],'
+      '"diveProfiles":[{"id":"p1"}]},'
+      '"deletions":{"dives":[{"id":"x","deletedAt":5}]},'
+      '"uploadNonce":null}';
+
+  test('emits top-level scalars with raw JSON value bytes', () async {
+    final r = await run(_one(doc));
+    expect(r.scalars['version'], '2');
+    expect(r.scalars['exportedAt'], '17');
+    expect(r.scalars['deviceId'], '"abc"');
+    expect(r.scalars['uploadNonce'], 'null');
+    // Sections are not scalars.
+    expect(r.scalars.containsKey('data'), isFalse);
+    expect(r.scalars.containsKey('deletions'), isFalse);
+  });
+
+  test('emits each data and deletions row with section+table tags', () async {
+    final r = await run(_one(doc));
+    expect(r.rows, [
+      ['data', 'dives', '{"id":"d1","n":1}'],
+      ['data', 'dives', '{"id":"d2","n":2}'],
+      ['data', 'diveProfiles', '{"id":"p1"}'],
+      ['deletions', 'dives', '{"id":"x","deletedAt":5}'],
+    ]);
+  });
+
+  test('survives one-byte-per-chunk boundaries', () async {
+    final r = await run(_drip(doc));
+    expect(r.scalars['deviceId'], '"abc"');
+    expect(r.rows.length, 4);
+    expect(r.rows.first, ['data', 'dives', '{"id":"d1","n":1}']);
+  });
+
+  test('wantRows=false skips a table without emitting it', () async {
+    final r = await run(
+      _one(doc),
+      want: (section, table) => !(section == 'data' && table == 'diveProfiles'),
+    );
+    expect(
+      r.rows.where((e) => e[1] == 'diveProfiles'),
+      isEmpty,
+    );
+    expect(r.rows.length, 3);
+  });
+
+  test('handles structural chars and escapes inside string values', () async {
+    const tricky =
+        '{"data":{"t":[{"s":"a,b{c}[d]\\"e\\\\f","ok":true}]},"deletions":{}}';
+    final r = await run(_one(tricky));
+    expect(r.rows.length, 1);
+    final decoded = jsonDecode(r.rows.single[2]) as Map<String, dynamic>;
+    expect(decoded['s'], 'a,b{c}[d]"e\\f');
+    expect(decoded['ok'], true);
+  });
+
+  test('handles nested objects and arrays within a row', () async {
+    const nested =
+        '{"data":{"t":[{"id":"a","meta":{"k":[1,2,{"z":"}"}]}}]},'
+        '"deletions":{}}';
+    final r = await run(_one(nested));
+    expect(r.rows.length, 1);
+    final decoded = jsonDecode(r.rows.single[2]) as Map<String, dynamic>;
+    expect((decoded['meta'] as Map)['k'], [1, 2, {'z': '}'}]);
+  });
+
+  test('handles empty data and empty tables', () async {
+    final r = await run(_one('{"data":{},"deletions":{}}'));
+    expect(r.rows, isEmpty);
+  });
+
+  test('tolerates unknown top-level keys and trailing members', () async {
+    const doc2 =
+        '{"future":{"a":1},"data":{"t":[{"id":"a"}]},"x":7}';
+    final r = await run(_one(doc2));
+    expect(r.scalars['x'], '7');
+    expect(r.rows, [
+      ['data', 't', '{"id":"a"}'],
+    ]);
+  });
+
+  test('captures a row larger than a typical buffer', () async {
+    final big = 'y' * 100000;
+    final doc3 = '{"data":{"t":[{"id":"a","blob":"$big"}]},"deletions":{}}';
+    final r = await run(_drip(doc3));
+    expect(r.rows.length, 1);
+    final decoded = jsonDecode(r.rows.single[2]) as Map<String, dynamic>;
+    expect((decoded['blob'] as String).length, 100000);
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_json_stream_reader_test.dart`
+Expected: FAIL — `Target of URI doesn't exist` / `BaseJsonStreamReader` undefined.
+
+- [ ] **Step 3: Implement `BaseJsonStreamReader`**
+
+Create `lib/core/services/sync/changeset_log/base_json_stream_reader.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Streaming, bounded-memory reader for a serialized sync base document.
+///
+/// The base is one JSON object: a handful of scalar header members plus two
+/// "section" members (`data` and `deletions`) whose values are objects mapping
+/// a table name to an array of row objects. This reader walks the byte stream
+/// once and reports:
+///  - [parse]'s `onScalar` for each top-level scalar member (key + raw value
+///    bytes), and
+///  - `onRow` for each element of each section's table arrays.
+///
+/// It never holds more than one row (or one scalar value) in memory, so a
+/// multi-hundred-MB base imports in bounded memory. It does NOT parse JSON
+/// values itself: it finds byte boundaries (respecting string/escape state and
+/// brace/bracket nesting) and hands raw bytes to the caller, which decodes the
+/// few rows it needs via `jsonDecode`.
+///
+/// The instance holds per-parse mutable state; do not run two [parse] calls on
+/// one instance concurrently (the import drives passes sequentially).
+class BaseJsonStreamReader {
+  static const int _quote = 0x22; // "
+  static const int _backslash = 0x5c; // \
+  static const int _lbrace = 0x7b; // {
+  static const int _rbrace = 0x7d; // }
+  static const int _lbracket = 0x5b; // [
+  static const int _rbracket = 0x5d; // ]
+  static const int _colon = 0x3a; // :
+  static const int _comma = 0x2c; // ,
+
+  static bool _isWs(int c) =>
+      c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d;
+
+  // --- per-parse state ---
+  _S _state = _S.awaitTopOpen;
+  String? _lastKey;
+  String? _section;
+  String? _table;
+
+  final BytesBuilder _key = BytesBuilder(copy: false);
+  bool _keyEscaped = false;
+
+  final BytesBuilder _cap = BytesBuilder(copy: false);
+  int _capDepth = 0;
+  bool _capInString = false;
+  bool _capEscaped = false;
+  bool _capStarted = false;
+  _Cap _capKind = _Cap.skip;
+
+  bool Function(String section, String table) _want = (_, __) => true;
+
+  void _reset() {
+    _state = _S.awaitTopOpen;
+    _lastKey = null;
+    _section = null;
+    _table = null;
+    _key.clear();
+    _keyEscaped = false;
+    _cap.clear();
+    _capDepth = 0;
+    _capInString = false;
+    _capEscaped = false;
+    _capStarted = false;
+    _capKind = _Cap.skip;
+  }
+
+  Future<void> parse(
+    Stream<List<int>> bytes, {
+    Future<void> Function(String key, Uint8List rawValue)? onScalar,
+    bool Function(String section, String table)? wantRows,
+    Future<void> Function(String section, String table, Uint8List rowBytes)?
+        onRow,
+  }) async {
+    _reset();
+    _want = wantRows ?? (_, __) => true;
+
+    await for (final chunk in bytes) {
+      for (final c in chunk) {
+        var consumed = false;
+        while (!consumed) {
+          final r = _consume(c);
+          consumed = r.consumed;
+          final emit = r.emit;
+          if (emit != null) {
+            if (emit.kind == _Cap.scalar) {
+              if (onScalar != null) await onScalar(emit.key!, emit.bytes);
+            } else {
+              if (onRow != null) {
+                await onRow(emit.section!, emit.table!, emit.bytes);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  _Step _consume(int c) {
+    switch (_state) {
+      case _S.awaitTopOpen:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _lbrace) _state = _S.topKeyOrClose;
+        return const _Step(true);
+
+      case _S.topKeyOrClose:
+        if (_isWs(c) || c == _comma) return const _Step(true);
+        if (c == _rbrace) {
+          _state = _S.done;
+          return const _Step(true);
+        }
+        if (c == _quote) {
+          _key.clear();
+          _keyEscaped = false;
+          _state = _S.topKey;
+        }
+        return const _Step(true);
+
+      case _S.topKey:
+        return _readKey(c, then: _S.topColon);
+
+      case _S.topColon:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _colon) _state = _S.topValueStart;
+        return const _Step(true);
+
+      case _S.topValueStart:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _lbrace) {
+          _section = _lastKey;
+          _state = _S.sectionKeyOrClose;
+          return const _Step(true);
+        }
+        _beginCapture(_Cap.scalar);
+        return const _Step(false); // reprocess this char inside capture
+
+      case _S.sectionKeyOrClose:
+        if (_isWs(c) || c == _comma) return const _Step(true);
+        if (c == _rbrace) {
+          _section = null;
+          _state = _S.topKeyOrClose;
+          return const _Step(true);
+        }
+        if (c == _quote) {
+          _key.clear();
+          _keyEscaped = false;
+          _state = _S.sectionKey;
+        }
+        return const _Step(true);
+
+      case _S.sectionKey:
+        return _readKey(c, then: _S.sectionColon, intoTable: true);
+
+      case _S.sectionColon:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _colon) _state = _S.sectionValueStart;
+        return const _Step(true);
+
+      case _S.sectionValueStart:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _lbracket) {
+          _state = _S.arrayElemOrClose;
+          return const _Step(true);
+        }
+        // Unexpected non-array section value: skip it generically.
+        _beginCapture(_Cap.skip);
+        _state = _S.captureSection;
+        return const _Step(false);
+
+      case _S.arrayElemOrClose:
+        if (_isWs(c) || c == _comma) return const _Step(true);
+        if (c == _rbracket) {
+          _table = null;
+          _state = _S.sectionKeyOrClose;
+          return const _Step(true);
+        }
+        _beginCapture(
+          (_section != null && _table != null && _want(_section!, _table!))
+              ? _Cap.row
+              : _Cap.skip,
+        );
+        _state = _S.captureArray;
+        return const _Step(false);
+
+      case _S.arrayCommaOrClose:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _comma) {
+          _state = _S.arrayElemOrClose;
+          return const _Step(true);
+        }
+        if (c == _rbracket) {
+          _table = null;
+          _state = _S.sectionKeyOrClose;
+          return const _Step(true);
+        }
+        return const _Step(true);
+
+      case _S.capture:
+      case _S.captureArray:
+      case _S.captureSection:
+        return _captureByte(c);
+
+      case _S.done:
+        return const _Step(true);
+    }
+  }
+
+  _Step _readKey(int c, {required _S then, bool intoTable = false}) {
+    if (_keyEscaped) {
+      _key.addByte(c);
+      _keyEscaped = false;
+      return const _Step(true);
+    }
+    if (c == _backslash) {
+      _key.addByte(c);
+      _keyEscaped = true;
+      return const _Step(true);
+    }
+    if (c == _quote) {
+      final name = utf8.decode(_key.takeBytes());
+      if (intoTable) {
+        _table = name;
+      } else {
+        _lastKey = name;
+      }
+      _state = then;
+      return const _Step(true);
+    }
+    _key.addByte(c);
+    return const _Step(true);
+  }
+
+  void _beginCapture(_Cap kind) {
+    _cap.clear();
+    _capDepth = 0;
+    _capInString = false;
+    _capEscaped = false;
+    _capStarted = false;
+    _capKind = kind;
+  }
+
+  _Step _captureByte(int c) {
+    if (_capInString) {
+      _cap.addByte(c);
+      if (_capEscaped) {
+        _capEscaped = false;
+      } else if (c == _backslash) {
+        _capEscaped = true;
+      } else if (c == _quote) {
+        _capInString = false;
+        if (_capDepth == 0) return _finishCapture(consume: true);
+      }
+      return const _Step(true);
+    }
+    if (c == _quote) {
+      _capStarted = true;
+      _capInString = true;
+      _cap.addByte(c);
+      return const _Step(true);
+    }
+    if (c == _lbrace || c == _lbracket) {
+      _capStarted = true;
+      _capDepth++;
+      _cap.addByte(c);
+      return const _Step(true);
+    }
+    if (c == _rbrace || c == _rbracket) {
+      if (_capDepth == 0) {
+        // This closing delimiter belongs to the parent: a primitive value
+        // ended just before it. Finish and reprocess the delimiter.
+        return _finishCapture(consume: false);
+      }
+      _capDepth--;
+      _cap.addByte(c);
+      if (_capDepth == 0) return _finishCapture(consume: true);
+      return const _Step(true);
+    }
+    if (c == _comma && _capDepth == 0) {
+      // Primitive value ended at a separator; consume the comma.
+      return _finishCapture(consume: true);
+    }
+    if (_isWs(c)) {
+      if (_capDepth == 0 && _capStarted) {
+        // Whitespace after a primitive ends it; do not consume the following
+        // delimiter (reprocess via the parent state).
+        return _finishCapture(consume: true);
+      }
+      return const _Step(true); // leading/interior structural whitespace
+    }
+    _capStarted = true;
+    _cap.addByte(c);
+    return const _Step(true);
+  }
+
+  _Step _finishCapture({required bool consume}) {
+    final kind = _capKind;
+    final fromArray =
+        _state == _S.captureArray || _state == _S.captureSection;
+    final bytes = (kind == _Cap.skip) ? null : _cap.takeBytes();
+    if (kind == _Cap.skip) _cap.clear();
+
+    // Transition to the parent state.
+    if (_state == _S.capture) {
+      _state = _S.topKeyOrClose;
+    } else if (_state == _S.captureArray) {
+      _state = _S.arrayCommaOrClose;
+    } else {
+      _state = _S.sectionKeyOrClose;
+    }
+
+    _Emit? emit;
+    if (bytes != null) {
+      if (kind == _Cap.scalar) {
+        emit = _Emit.scalar(_lastKey ?? '', bytes);
+      } else if (kind == _Cap.row && _section != null && _table != null) {
+        emit = _Emit.row(_section!, _table!, bytes);
+      }
+    }
+    // `fromArray` is informational; transitions above already handle routing.
+    assert(fromArray || _state == _S.topKeyOrClose || true);
+    return _Step(consume, emit: emit);
+  }
+}
+
+enum _Cap { scalar, row, skip }
+
+enum _S {
+  awaitTopOpen,
+  topKeyOrClose,
+  topKey,
+  topColon,
+  topValueStart,
+  sectionKeyOrClose,
+  sectionKey,
+  sectionColon,
+  sectionValueStart,
+  arrayElemOrClose,
+  arrayCommaOrClose,
+  capture,
+  captureArray,
+  captureSection,
+  done,
+}
+
+class _Step {
+  const _Step(this.consumed, {this.emit});
+  final bool consumed;
+  final _Emit? emit;
+}
+
+class _Emit {
+  _Emit.scalar(this.key, this.bytes)
+      : section = null,
+        table = null,
+        kind = _Cap.scalar;
+  _Emit.row(this.section, this.table, this.bytes)
+      : key = null,
+        kind = _Cap.row;
+  final _Cap kind;
+  final String? key;
+  final String? section;
+  final String? table;
+  final Uint8List bytes;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_json_stream_reader_test.dart`
+Expected: PASS (9 tests). If a boundary case fails, fix `_captureByte`/`_finishCapture` only; do not change the test expectations.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/changeset_log/base_json_stream_reader.dart test/core/services/sync/changeset_log/base_json_stream_reader_test.dart
+flutter analyze lib/core/services/sync/changeset_log/base_json_stream_reader.dart
+git add lib/core/services/sync/changeset_log/base_json_stream_reader.dart test/core/services/sync/changeset_log/base_json_stream_reader_test.dart
+git commit -m "feat(sync): streaming byte-boundary reader for base import"
+```
+
+---
+
+## Task 2: `BasePartFileSink` — download parts to a verified temp file
+
+**Files:**
+- Create: `lib/core/services/sync/changeset_log/base_part_file_sink.dart`
+- Test: `test/core/services/sync/changeset_log/base_part_file_sink_test.dart`
+
+**Interfaces:**
+- Consumes: `BaseChunker.checksum` (from `base_chunker.dart`).
+- Produces:
+  - `class BasePartFileSink`
+    - ctor `BasePartFileSink({Future<Directory> Function()? tempDirProvider})` (defaults to `Directory.systemTemp`).
+    - `Future<String?> assemble({required String name, required int partCount, required String? wholeChecksum, required List<String> partChecksums, required Future<Uint8List?> Function(int index) downloadPart})` — returns the temp file path on success, or null if any part is missing or any checksum (per-part or whole-file) fails. On null it deletes the partial file.
+    - `Future<void> deleteQuietly(String path)` — best-effort delete; never throws.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/core/services/sync/changeset_log/base_part_file_sink_test.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
+
+void main() {
+  late Directory dir;
+  late BasePartFileSink sink;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('base_sink_test');
+    sink = BasePartFileSink(tempDirProvider: () async => dir);
+  });
+  tearDown(() async {
+    if (dir.existsSync()) await dir.delete(recursive: true);
+  });
+
+  Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
+
+  test('assembles parts into one file and returns its path', () async {
+    final p0 = bytes('hello ');
+    final p1 = bytes('world');
+    final whole = BaseChunker.checksum(bytes('hello world'));
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: whole,
+      partChecksums: [BaseChunker.checksum(p0), BaseChunker.checksum(p1)],
+      downloadPart: (i) async => [p0, p1][i],
+    );
+    expect(path, isNotNull);
+    expect(await File(path!).readAsString(), 'hello world');
+  });
+
+  test('returns null and deletes the file on a per-part checksum mismatch',
+      () async {
+    final p0 = bytes('hello ');
+    final p1 = bytes('world');
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: null,
+      partChecksums: [BaseChunker.checksum(p0), 'sha256:deadbeef'],
+      downloadPart: (i) async => [p0, p1][i],
+    );
+    expect(path, isNull);
+    expect(dir.listSync().whereType<File>(), isEmpty);
+  });
+
+  test('returns null when a part is missing', () async {
+    final p0 = bytes('hello ');
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: null,
+      partChecksums: [BaseChunker.checksum(p0), 'sha256:whatever'],
+      downloadPart: (i) async => i == 0 ? p0 : null,
+    );
+    expect(path, isNull);
+    expect(dir.listSync().whereType<File>(), isEmpty);
+  });
+
+  test('returns null on a whole-file checksum mismatch', () async {
+    final p0 = bytes('hello ');
+    final p1 = bytes('world');
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: 'sha256:notreal',
+      partChecksums: [BaseChunker.checksum(p0), BaseChunker.checksum(p1)],
+      downloadPart: (i) async => [p0, p1][i],
+    );
+    expect(path, isNull);
+    expect(dir.listSync().whereType<File>(), isEmpty);
+  });
+
+  test('deleteQuietly removes a file and never throws', () async {
+    final f = File('${dir.path}/x');
+    await f.writeAsString('y');
+    await sink.deleteQuietly(f.path);
+    expect(f.existsSync(), isFalse);
+    await sink.deleteQuietly('${dir.path}/does-not-exist'); // no throw
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_part_file_sink_test.dart`
+Expected: FAIL — `BasePartFileSink` undefined.
+
+- [ ] **Step 3: Implement `BasePartFileSink`**
+
+Create `lib/core/services/sync/changeset_log/base_part_file_sink.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+
+/// Downloads a base's parts one at a time into a single temp file, verifying
+/// integrity as bytes land so the whole base is never held in memory. Each part
+/// is checked against its manifest checksum before being written; a rolling
+/// SHA-256 verifies the whole-file checksum at the end. Any failure deletes the
+/// partial file and returns null (transient -> the caller retries next sync).
+class BasePartFileSink {
+  BasePartFileSink({Future<Directory> Function()? tempDirProvider})
+      : _tempDir = tempDirProvider ?? (() async => Directory.systemTemp);
+
+  final Future<Directory> Function() _tempDir;
+  static const _uuid = Uuid();
+
+  Future<String?> assemble({
+    required String name,
+    required int partCount,
+    required String? wholeChecksum,
+    required List<String> partChecksums,
+    required Future<Uint8List?> Function(int index) downloadPart,
+  }) async {
+    final dir = await _tempDir();
+    final path = '${dir.path}/$name.${_uuid.v4()}.base';
+    final file = File(path);
+    final out = file.openWrite();
+
+    final whole = AccumulatorSink<Digest>();
+    final wholeInput = sha256.startChunkedConversion(whole);
+
+    var ok = true;
+    try {
+      for (var i = 0; i < partCount; i++) {
+        final part = await downloadPart(i);
+        if (part == null) {
+          ok = false;
+          break;
+        }
+        if (i < partChecksums.length &&
+            BaseChunker.checksum(part) != partChecksums[i]) {
+          ok = false;
+          break;
+        }
+        wholeInput.add(part);
+        out.add(part);
+      }
+    } catch (_) {
+      ok = false;
+    }
+
+    await out.close();
+    wholeInput.close();
+
+    if (ok && wholeChecksum != null) {
+      final computed = 'sha256:${whole.events.single}';
+      if (computed != wholeChecksum) ok = false;
+    }
+
+    if (!ok) {
+      await deleteQuietly(path);
+      return null;
+    }
+    return path;
+  }
+
+  Future<void> deleteQuietly(String path) async {
+    try {
+      final f = File(path);
+      if (await f.exists()) await f.delete();
+    } catch (_) {
+      // Best effort: a leftover temp file is harmless; the OS reaps systemTemp.
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_part_file_sink_test.dart`
+Expected: PASS (5 tests).
+
+Note: `AccumulatorSink` and `startChunkedConversion` come from `package:crypto/crypto.dart`. If analyze reports `AccumulatorSink` unresolved, add `import 'package:convert/convert.dart';` (it re-exports `AccumulatorSink`) — `convert` is already a transitive dependency of `crypto`.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/changeset_log/base_part_file_sink.dart test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+flutter analyze lib/core/services/sync/changeset_log/base_part_file_sink.dart
+git add lib/core/services/sync/changeset_log/base_part_file_sink.dart test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+git commit -m "feat(sync): bounded-memory base part file sink with checksum verify"
+```
+
+---
+
+## Task 3: Route the reader's base branch through a temp file
+
+**Files:**
+- Modify: `lib/core/services/sync/changeset_log/changeset_reader.dart`
+- Modify (test harness): `test/core/services/sync/changeset_log/changeset_reader_test.dart`, `changeset_reader_epoch_test.dart`, `changeset_reader_verify_test.dart`
+
+**Interfaces:**
+- Consumes: `BasePartFileSink` (Task 2).
+- Produces:
+  - `typedef ApplyBaseFile = Future<void> Function(String filePath, SyncManifest manifest);`
+  - `ChangesetReader(this._codec, this._peerCursors, {BasePartFileSink? baseSink})`
+  - `pull({... existing ..., required ApplyBaseFile applyBaseFile})` — the base branch now fetches to a temp file, calls `applyBaseFile`, then deletes the temp file in a `finally`. The changeset branch is unchanged.
+
+- [ ] **Step 1: Write the failing test (reader calls applyBaseFile with a readable temp file)**
+
+Add this test to `test/core/services/sync/changeset_log/changeset_reader_test.dart` inside `main()` (it uses the file's existing `provider`, `writer`, `reader`, `folder` setup). First, update the shared `pullAs` helper in that file to pass `applyBaseFile`, decoding the file and forwarding to the same `applied` spy so existing assertions still hold:
+
+```dart
+// Replace the existing pullAs helper with this version.
+Future<ChangesetReadResult> pullAs(String selfDeviceId) => reader.pull(
+      provider: provider,
+      selfDeviceId: selfDeviceId,
+      folderId: folder,
+      apply: spyApply,
+      applyBaseFile: (path, manifest) async {
+        final bytes = await File(path).readAsBytes();
+        applied.add(ChangesetCodec(SyncDataSerializer()).decodeChangeset(bytes));
+      },
+    );
+```
+
+Add these imports at the top of the test file if missing:
+
+```dart
+import 'dart:io';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
+```
+
+Then add a new test asserting the base arrives via a real, readable file:
+
+```dart
+test('base branch hands applyBaseFile a readable temp file path', () async {
+  await DiveRepository().createDive(
+    Dive(
+      diveDateTime: DateTime(2020, 1, 1),
+      diveNumber: 1,
+      maxDepth: 10,
+      duration: 30,
+    ),
+  );
+  final peerId = await publishAsPeer();
+
+  String? seenPath;
+  var exists = false;
+  await reader.pull(
+    provider: provider,
+    selfDeviceId: 'other-device',
+    folderId: folder,
+    apply: spyApply,
+    applyBaseFile: (path, manifest) async {
+      seenPath = path;
+      exists = await File(path).exists();
+      expect(manifest.deviceId, peerId);
+    },
+  );
+
+  expect(seenPath, isNotNull);
+  expect(exists, isTrue, reason: 'file must exist during applyBaseFile');
+  expect(await File(seenPath!).exists(), isFalse,
+      reason: 'reader deletes the temp file after applyBaseFile');
+});
+```
+
+(`Dive`/`DiveRepository` are already imported in this test file; if not, mirror the existing cold-start test's imports.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_reader_test.dart`
+Expected: FAIL — `pull` has no `applyBaseFile` parameter; `ApplyBaseFile` undefined.
+
+- [ ] **Step 3: Implement the reader change**
+
+In `lib/core/services/sync/changeset_log/changeset_reader.dart`:
+
+Add the import and typedef near the top (after the existing imports):
+
+```dart
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
+```
+
+```dart
+/// Applies a base that has been streamed to a local temp [filePath]. The real
+/// implementation streams the file through the merge in bounded memory; see
+/// SyncService._applyRemoteBaseFile.
+typedef ApplyBaseFile = Future<void> Function(
+  String filePath,
+  SyncManifest manifest,
+);
+```
+
+Change the constructor and field:
+
+```dart
+class ChangesetReader {
+  ChangesetReader(this._codec, this._peerCursors, {BasePartFileSink? baseSink})
+      : _baseSink = baseSink ?? BasePartFileSink();
+
+  final ChangesetCodec _codec;
+  final PeerCursorStore _peerCursors;
+  final BasePartFileSink _baseSink;
+```
+
+Add `required ApplyBaseFile applyBaseFile,` to the `pull` signature (alongside `apply`).
+
+Replace the base branch (currently using `_fetchBase` + `apply(base)`):
+
+```dart
+        // Cold-start, or lapped by the peer's compaction: adopt the base.
+        final baseSeq = manifest.baseSeq;
+        if (baseSeq != null && lastApplied < baseSeq) {
+          final path = await _fetchBaseToFile(provider, peerId, manifest, byName);
+          if (path == null) {
+            continue; // missing or corrupt base -> transient, retry next sync
+          }
+          try {
+            await applyBaseFile(path, manifest);
+          } finally {
+            await _baseSink.deleteQuietly(path);
+          }
+          payloadsApplied++;
+          appliedThrough = baseSeq;
+          baseSeqApplied = baseSeq;
+        }
+```
+
+Replace `_fetchBase` with `_fetchBaseToFile`:
+
+```dart
+  Future<String?> _fetchBaseToFile(
+    CloudStorageProvider provider,
+    String peerId,
+    SyncManifest manifest,
+    Map<String, CloudFileInfo> byName,
+  ) {
+    final baseSeq = manifest.baseSeq!;
+    return _baseSink.assemble(
+      name: 'ssv1_${peerId}_$baseSeq',
+      partCount: manifest.basePartCount ?? 0,
+      wholeChecksum: manifest.baseChecksum,
+      partChecksums: manifest.basePartChecksums,
+      downloadPart: (i) async {
+        final pf = byName[ChangesetLogLayout.basePartName(peerId, baseSeq, i)];
+        if (pf == null) return null;
+        return provider.downloadFile(pf.id);
+      },
+    );
+  }
+```
+
+Remove the now-unused `BaseChunker`/`base_chunker.dart` import in this file only if nothing else references it (the changeset branch still uses `_codec`). Run analyze to confirm.
+
+- [ ] **Step 4: Update the other two reader test harnesses**
+
+In `test/core/services/sync/changeset_log/changeset_reader_epoch_test.dart` and `changeset_reader_verify_test.dart`, update each `reader.pull(...)` call (or shared helper) to pass:
+
+```dart
+      applyBaseFile: (path, manifest) async {
+        final bytes = await File(path).readAsBytes();
+        applied.add(ChangesetCodec(SyncDataSerializer()).decodeChangeset(bytes));
+      },
+```
+
+adding the same `dart:io`, `SyncDataSerializer`, and `ChangesetCodec` imports as in Step 1. In `changeset_reader_verify_test.dart`, the test that asserts a corrupt base is skipped should keep asserting that `applied` does NOT receive the base — with the file path now verified by the sink, a corrupted part means `applyBaseFile` is never called (the sink returns null), so the existing "base skipped" expectation still holds. Adjust any assertion that inspected the decoded payload's checksum to instead assert `applied` did not gain the base entry.
+
+- [ ] **Step 5: Run all reader tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/`
+Expected: PASS (all reader + codec + chunker + sink + stream-reader tests).
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/changeset_log/changeset_reader.dart test/core/services/sync/changeset_log/
+flutter analyze lib/core/services/sync/changeset_log/changeset_reader.dart
+git add lib/core/services/sync/changeset_log/changeset_reader.dart test/core/services/sync/changeset_log/
+git commit -m "feat(sync): reader adopts base via temp file + applyBaseFile callback"
+```
+
+---
+
+## Task 4: `SyncService._applyRemoteBaseFile` — two-pass streaming apply
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart`
+- Test: covered by Task 5 (parity) and Task 6 (convergence).
+
+**Interfaces:**
+- Consumes: `BaseJsonStreamReader` (Task 1); existing private merge primitives; `ApplyBaseFile` typedef (Task 3).
+- Produces:
+  - `static const Map<String, bool> _entityHasUpdatedAt` — single source the streaming apply uses for per-entity conflict-detection flags and the known-entity set. Mirrors the inline `mergeOrder` flags; the Task 5 parity test (which exercises every entity) guards against drift.
+  - `Future<_MergeResult> _applyRemoteBaseFile(String filePath, DateTime? localLastSync)`
+  - `@visibleForTesting` seams `debugApplyPayload` and `debugApplyBaseFile` (for the parity test).
+  - Wires `applyBaseFile:` into the `_changesetReader.pull(...)` call.
+
+- [ ] **Step 1: Add the entity flag map**
+
+In `lib/core/services/sync/sync_service.dart`, add near the other private statics of `SyncService` (e.g. just above `parentRefs`):
+
+```dart
+  /// Per-entity "has an updatedAt column" flag, mirroring the `mergeOrder`
+  /// records in `_applyRemotePayloadInner`. Used by the streaming base apply
+  /// for (a) conflict-detection behavior in `_mergeEntity` and (b) the set of
+  /// entity tables it will apply (keys == the known entities). Kept in sync
+  /// with `mergeOrder` by the streaming-vs-in-memory parity test, which
+  /// exercises every entity here.
+  @visibleForTesting
+  static const Map<String, bool> entityHasUpdatedAt = {
+    'divers': true,
+    'diverSettings': true,
+    'buddies': true,
+    'diveCenters': true,
+    'trips': true,
+    'liveaboardDetails': true,
+    'itineraryDays': true,
+    'equipment': true,
+    'equipmentSets': true,
+    'equipmentSetItems': false,
+    'diveTypes': true,
+    'tankPresets': true,
+    'diveComputers': true,
+    'species': false,
+    'tags': true,
+    'courses': true,
+    'dives': true,
+    'diveSites': true,
+    'diveTanks': false,
+    'diveWeights': false,
+    'diveEquipment': false,
+    'diveTags': false,
+    'diveBuddies': false,
+    'diveProfiles': false,
+    'diveProfileEvents': false,
+    'gasSwitches': false,
+    'diveCustomFields': false,
+    'diveDataSources': false,
+    'siteSpecies': false,
+    'csvPresets': true,
+    'viewConfigs': true,
+    'fieldPresets': false,
+    'tankPressureProfiles': false,
+    'tideRecords': false,
+    'sightings': false,
+    'certifications': true,
+    'serviceRecords': true,
+    'settings': true,
+    'media': false,
+  };
+```
+
+Add the imports at the top of the file:
+
+```dart
+import 'dart:io';
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+```
+
+(`dart:convert`, `dart:typed_data`, and `@visibleForTesting`/`package:meta` or `package:flutter/foundation.dart` are already imported in this file; if `@visibleForTesting` is not, add `import 'package:meta/meta.dart';`.)
+
+- [ ] **Step 2: Implement `_applyRemoteBaseFile`**
+
+Add this method to `SyncService` (e.g. right after `_applyRemotePayloadInner`):
+
+```dart
+  /// Apply a base that was streamed to a local temp [filePath], in bounded
+  /// memory. Three forward passes over the file:
+  ///   1. header `exportedAt` + the full `deletions` map (both small),
+  ///   2. parent-row id->updatedAt and contradiction keys (skips giant tables),
+  ///   3. batched apply of every row through the existing `_mergeEntity`.
+  /// Reuses the same merge primitives as `_applyRemotePayloadInner`, so the
+  /// result is identical to applying the equivalent in-memory payload.
+  Future<_MergeResult> _applyRemoteBaseFile(
+    String filePath,
+    DateTime? localLastSync,
+  ) async {
+    final file = File(filePath);
+    final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
+
+    // ---- Pass 1: exportedAt + deletions ----
+    var baseExportedAt = 0;
+    final deletions = <String, List<SyncDeletion>>{};
+    await BaseJsonStreamReader().parse(
+      file.openRead(),
+      onScalar: (key, raw) async {
+        if (key == 'exportedAt') {
+          baseExportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+        }
+      },
+      wantRows: (section, _) => section == 'deletions',
+      onRow: (section, table, rowBytes) async {
+        final decoded = jsonDecode(utf8.decode(rowBytes));
+        if (decoded is Map<String, dynamic>) {
+          (deletions[table] ??= []).add(SyncDeletion.fromJson(decoded));
+        } else if (decoded is Map) {
+          (deletions[table] ??= [])
+              .add(SyncDeletion.fromJson(decoded.cast<String, dynamic>()));
+        } else if (decoded is String) {
+          (deletions[table] ??= []).add(SyncDeletion(id: decoded, deletedAt: 0));
+        }
+      },
+    );
+
+    final pendingByEntity = await _pendingRecordMap();
+
+    // ---- Pass 2: parent updatedAt + contradiction keys ----
+    final parentTypes = <String>{
+      for (final refs in parentRefs.values)
+        for (final ref in refs) ref.parent,
+    };
+    final deletionIds = <String, Set<String>>{
+      for (final e in deletions.entries) e.key: {for (final d in e.value) d.id},
+    };
+    final parentUpdatedAt = <String, Map<String, int>>{};
+    final contradictedByEntity = <String, Set<String>>{};
+    await BaseJsonStreamReader().parse(
+      file.openRead(),
+      wantRows: (section, table) =>
+          section == 'data' &&
+          entityHasUpdatedAt.containsKey(table) &&
+          (parentTypes.contains(table) || deletionIds.containsKey(table)),
+      onRow: (section, table, rowBytes) async {
+        final rec = jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>;
+        final id = _recordIdForEntity(table, rec);
+        if (id == null) return;
+        if (parentTypes.contains(table) && entityHasUpdatedAt[table] == true) {
+          final u = _extractUpdatedAtMillis(rec);
+          if (u != null) (parentUpdatedAt[table] ??= {})[id] = u;
+        }
+        if (deletionIds[table]?.contains(id) == true) {
+          (contradictedByEntity[table] ??= {}).add(id);
+        }
+      },
+    );
+
+    // ---- Apply, all inside one deferred-FK transaction ----
+    return _serializer.applyInDeferredFkTransaction(() async {
+      var recordsApplied = 0;
+      var conflictsFound = 0;
+      var recordsFailed = 0;
+
+      final delResult = await _applyRemoteDeletions(
+        deletions,
+        lastSyncMs,
+        baseExportedAt,
+        pendingByEntity,
+        contradictedByEntity,
+      );
+      recordsApplied += delResult.recordsApplied;
+      conflictsFound += delResult.conflictsFound;
+      recordsFailed += delResult.recordsFailed;
+
+      // Load tombstones AFTER deletions so a tombstone arriving in this base
+      // also guards the merge below (mirrors _applyRemotePayloadInner).
+      final tombstonesByEntity = await _deletionMap();
+
+      // Revived parents: a parent row whose remote updatedAt is newer than our
+      // local tombstone. Combines pass-2 file data with post-deletion tombstones.
+      final revivedParents = <String, Set<String>>{};
+      for (final parentType in parentTypes) {
+        final tombs = tombstonesByEntity[parentType];
+        final ups = parentUpdatedAt[parentType];
+        if (tombs == null || tombs.isEmpty || ups == null) continue;
+        ups.forEach((id, updatedAt) {
+          final deletedAt = tombs[id];
+          if (deletedAt != null && updatedAt > deletedAt) {
+            (revivedParents[parentType] ??= {}).add(id);
+          }
+        });
+      }
+
+      // ---- Pass 3: batched apply ----
+      const batchSize = 500;
+      String? currentTable;
+      var batch = <Map<String, dynamic>>[];
+
+      Future<void> flush() async {
+        final table = currentTable;
+        if (table == null || batch.isEmpty) return;
+        final r = await _mergeEntity(
+          entityType: table,
+          records: batch,
+          hasUpdatedAt: entityHasUpdatedAt[table] ?? false,
+          lastSyncMs: lastSyncMs,
+          pendingRecordIds: pendingByEntity[table] ?? const <String>{},
+          allTombstones: tombstonesByEntity,
+          revivedParents: revivedParents,
+          contradicted: contradictedByEntity[table] ?? const <String>{},
+        );
+        recordsApplied += r.recordsApplied;
+        conflictsFound += r.conflictsFound;
+        recordsFailed += r.recordsFailed;
+        batch = <Map<String, dynamic>>[];
+      }
+
+      await BaseJsonStreamReader().parse(
+        file.openRead(),
+        wantRows: (section, table) =>
+            section == 'data' && entityHasUpdatedAt.containsKey(table),
+        onRow: (section, table, rowBytes) async {
+          if (table != currentTable) {
+            await flush();
+            currentTable = table;
+          }
+          batch.add(jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>);
+          if (batch.length >= batchSize) await flush();
+        },
+      );
+      await flush();
+
+      await _serializer.repairDanglingForeignKeys();
+      return _MergeResult(
+        recordsApplied: recordsApplied,
+        conflictsFound: conflictsFound,
+        recordsFailed: recordsFailed,
+      );
+    });
+  }
+```
+
+- [ ] **Step 3: Wire `applyBaseFile` into the pull call**
+
+In `performSync()`, the `_changesetReader.pull(...)` call currently passes only `apply:`. Add the base callback:
+
+```dart
+      await _changesetReader.pull(
+        provider: provider,
+        selfDeviceId: deviceId,
+        folderId: folderId,
+        currentEpochId: currentEpochId,
+        apply: (payload) async {
+          final r = await _applyRemotePayload(payload, lastSyncTime);
+          recordsSynced += r.recordsApplied;
+          conflictsFound += r.conflictsFound;
+          recordsFailed += r.recordsFailed;
+        },
+        applyBaseFile: (path, manifest) async {
+          final r = await _applyRemoteBaseFile(path, lastSyncTime);
+          recordsSynced += r.recordsApplied;
+          conflictsFound += r.conflictsFound;
+          recordsFailed += r.recordsFailed;
+        },
+      );
+```
+
+- [ ] **Step 4: Add the test seams**
+
+Add to `SyncService`:
+
+```dart
+  /// Test seam: apply an in-memory payload through the standard merge.
+  @visibleForTesting
+  Future<({int recordsApplied, int conflictsFound, int recordsFailed})>
+      debugApplyPayload(SyncPayload payload, {DateTime? lastSync}) async {
+    final r = await _applyRemotePayload(payload, lastSync);
+    return (
+      recordsApplied: r.recordsApplied,
+      conflictsFound: r.conflictsFound,
+      recordsFailed: r.recordsFailed,
+    );
+  }
+
+  /// Test seam: apply a base from a local file through the streaming merge.
+  @visibleForTesting
+  Future<({int recordsApplied, int conflictsFound, int recordsFailed})>
+      debugApplyBaseFile(String filePath, {DateTime? lastSync}) async {
+    final r = await _applyRemoteBaseFile(filePath, lastSync);
+    return (
+      recordsApplied: r.recordsApplied,
+      conflictsFound: r.conflictsFound,
+      recordsFailed: r.recordsFailed,
+    );
+  }
+```
+
+- [ ] **Step 5: Analyze (compile check) and commit**
+
+Run: `flutter analyze lib/core/services/sync/sync_service.dart`
+Expected: no errors. (Behavior is verified by Tasks 5 and 6.)
+
+```bash
+dart format lib/core/services/sync/sync_service.dart
+git add lib/core/services/sync/sync_service.dart
+git commit -m "feat(sync): bounded-memory streaming base apply (_applyRemoteBaseFile)"
+```
+
+---
+
+## Task 5: Parity test — streaming apply == in-memory apply (the linchpin)
+
+**Files:**
+- Create: `test/core/services/sync/sync_base_streaming_parity_test.dart`
+
+**Interfaces:**
+- Consumes: `SyncService.debugApplyPayload`, `SyncService.debugApplyBaseFile` (Task 4); `SyncDataSerializer.serializePayload`/`exportData`; test DB helpers.
+
+- [ ] **Step 1: Write the parity test**
+
+Create `test/core/services/sync/sync_base_streaming_parity_test.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Seeds a representative library covering parent + child + junction tables and
+/// at least one conflict-bearing entity, so parity exercises every merge path.
+Future<void> seedRichLibrary() async {
+  final dives = DiveRepository();
+  for (var i = 1; i <= 5; i++) {
+    await dives.createDive(
+      Dive(
+        diveDateTime: DateTime(2020, 1, i),
+        diveNumber: i,
+        maxDepth: 10.0 + i,
+        duration: 30 + i,
+      ),
+    );
+  }
+  // Add profile samples to the first dive (the high-row-count table).
+  final all = await dives.getAllDives();
+  // (If a profile-writing repository helper exists, add samples here; the dive
+  // rows alone already exercise parent + clockless-child + merge-order paths.)
+  expect(all.length, 5);
+}
+
+String dumpAllData(SyncDataSerializer serializer) =>
+    jsonEncode(_lastExport!.data.toJson());
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('streaming base apply produces a byte-identical DB to in-memory apply',
+      () async {
+    // 1. Build a rich payload from a seeded DB, then wipe to simulate a cold
+    //    device adopting a peer's base.
+    await seedRichLibrary();
+    final serializer = SyncDataSerializer();
+    final payload = await serializer.exportData(
+      deviceId: 'peer',
+      deletions: await SyncRepository().getAllDeletions(),
+    );
+
+    // 2. Apply IN-MEMORY into a fresh DB; snapshot the result.
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final svc1 = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+    );
+    final counts1 = await svc1.debugApplyPayload(payload);
+    final dump1 = jsonEncode(
+      (await SyncDataSerializer().exportData(deviceId: 'x', deletions: const []))
+          .data
+          .toJson(),
+    );
+
+    // 3. Apply via STREAMING FILE into another fresh DB; snapshot the result.
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final tmpDir = await Directory.systemTemp.createTemp('parity');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(
+      utf8.encode(SyncDataSerializer().serializePayload(payload)),
+    );
+    final svc2 = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+    );
+    final counts2 = await svc2.debugApplyBaseFile(tmp.path);
+    final dump2 = jsonEncode(
+      (await SyncDataSerializer().exportData(deviceId: 'x', deletions: const []))
+          .data
+          .toJson(),
+    );
+    await tmpDir.delete(recursive: true);
+
+    expect(dump2, dump1, reason: 'streaming DB must match in-memory DB exactly');
+    expect(counts2.recordsApplied, counts1.recordsApplied);
+    expect(counts2.conflictsFound, counts1.conflictsFound);
+    expect(counts2.recordsFailed, counts1.recordsFailed);
+  });
+}
+```
+
+Note on `_lastExport`: delete the unused `dumpAllData`/`_lastExport` helper above — the test inlines its snapshots. (It is left out of the final file; do not define it.)
+
+- [ ] **Step 2: Run to verify it fails (then passes)**
+
+Run: `flutter test test/core/services/sync/sync_base_streaming_parity_test.dart`
+Expected first run: may FAIL if `_applyRemoteBaseFile` has a transcription bug (e.g. a wrong `entityHasUpdatedAt` flag) — the dumps differ. Fix the implementation (NOT the test) until both the DB dump and the counts match. Expected final: PASS.
+
+- [ ] **Step 3: Add a batch-size invariance check**
+
+To prove batching never changes the result, parameterize the streaming apply's batch size is internal; instead assert invariance by also applying the same payload with a deliberately tiny library twice is unnecessary. Add a second case that seeds a library with MORE than 500 rows of one table to cross the batch boundary, and re-run the same dump1==dump2 assertion. If no profile-writing helper is available to exceed 500 rows quickly, create 600 dives:
+
+```dart
+  test('batch boundary (>500 rows) does not change the streaming result',
+      () async {
+    final dives = DiveRepository();
+    for (var i = 1; i <= 600; i++) {
+      await dives.createDive(
+        Dive(
+          diveDateTime: DateTime(2021, 1, 1).add(Duration(minutes: i)),
+          diveNumber: i,
+          maxDepth: 12,
+          duration: 25,
+        ),
+      );
+    }
+    final payload = await SyncDataSerializer().exportData(
+      deviceId: 'peer',
+      deletions: await SyncRepository().getAllDeletions(),
+    );
+
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final svcA = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+    );
+    await svcA.debugApplyPayload(payload);
+    final dumpA = jsonEncode(
+      (await SyncDataSerializer().exportData(deviceId: 'x', deletions: const []))
+          .data
+          .toJson(),
+    );
+
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final tmpDir = await Directory.systemTemp.createTemp('parity_big');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(
+      utf8.encode(SyncDataSerializer().serializePayload(payload)),
+    );
+    final svcB = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+    );
+    await svcB.debugApplyBaseFile(tmp.path);
+    final dumpB = jsonEncode(
+      (await SyncDataSerializer().exportData(deviceId: 'x', deletions: const []))
+          .data
+          .toJson(),
+    );
+    await tmpDir.delete(recursive: true);
+
+    expect(dumpB, dumpA);
+  });
+```
+
+- [ ] **Step 4: Run, format, commit**
+
+Run: `flutter test test/core/services/sync/sync_base_streaming_parity_test.dart`
+Expected: PASS (2 tests).
+
+```bash
+dart format test/core/services/sync/sync_base_streaming_parity_test.dart
+flutter analyze test/core/services/sync/sync_base_streaming_parity_test.dart
+git add test/core/services/sync/sync_base_streaming_parity_test.dart
+git commit -m "test(sync): parity between streaming and in-memory base apply"
+```
+
+---
+
+## Task 6: Confirm end-to-end convergence through the streaming path
+
+**Files:**
+- Modify (if needed): `test/core/services/sync/changeset_sync_convergence_test.dart`
+
+**Interfaces:**
+- Consumes: `performSync()` (now routes base adoption through `_applyRemoteBaseFile`); `seedPeerLog`/`seedPeerBaseFromPayload` helpers.
+
+- [ ] **Step 1: Run the existing convergence suite (it now exercises streaming)**
+
+Because `performSync` now adopts bases via the streaming file path, the existing cold-start convergence test already covers it end to end (download parts -> temp file -> streaming apply).
+
+Run: `flutter test test/core/services/sync/changeset_sync_convergence_test.dart`
+Expected: PASS. If it fails, debug `_applyRemoteBaseFile` (do not weaken the test).
+
+- [ ] **Step 2: Add an explicit assertion that a base larger than one part converges**
+
+Add a test that publishes a peer library big enough to span multiple base parts (force a small part size by seeding many rows), then cold-starts and asserts the local DB matches. If forcing many rows is impractical in unit time, assert at minimum that a normal cold-start leaves a clean DB and an empty temp dir afterward (no leaked `*.base` files in `Directory.systemTemp`). Example sketch using existing helpers:
+
+```dart
+  test('cold-start base adoption converges and leaves no temp files',
+      () async {
+    // ... seed peer via seedPeerLog, create local device, performSync ...
+    // assert local dives == peer dives
+    final leaked = Directory.systemTemp
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.base'));
+    expect(leaked, isEmpty);
+  });
+```
+
+- [ ] **Step 3: Run the whole sync suite**
+
+Run: `flutter test test/core/services/sync/`
+Expected: PASS (all sync tests, including the existing 40+ files).
+
+- [ ] **Step 4: Commit any test changes**
+
+```bash
+dart format test/core/services/sync/
+git add test/core/services/sync/
+git commit -m "test(sync): convergence covers streaming base adoption end to end"
+```
+
+---
+
+## Task 7: Full verification sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format check (whole project)**
+
+Run: `dart format --set-exit-if-changed lib/ test/`
+Expected: exit 0 (no changes).
+
+- [ ] **Step 2: Analyze (whole project)**
+
+Run: `flutter analyze`
+Expected: "No issues found!"
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `flutter test`
+Expected: all pass. (If runtime is long, run `flutter test test/core/services/sync/` plus any touched areas, but a full run before PR is required.)
+
+- [ ] **Step 4: Final commit (if formatting changed anything)**
+
+```bash
+git add -A
+git commit -m "chore(sync): format + analyze clean for streaming base import"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Bounded-memory base import via temp file + batched apply → Tasks 1-4. ✓
+- No wire-format change; old JSON bases import unchanged → Tasks 1, 3, 4 (raw `jsonDecode` rows; reader uses existing manifest fields). ✓
+- Manifest per-part + whole-file checksum verification; drop payload-level checksum for bases → Task 2 (`BasePartFileSink`). ✓
+- Merge logic reused unchanged → Task 4 calls existing `_mergeEntity`/`_applyRemoteDeletions`/`repairDanglingForeignKeys`; no edits to them (Global Constraints). ✓
+- Atomicity (single deferred-FK transaction; cursor advances only on success) → Task 4 (transaction) + Task 3 (reader advances after `applyBaseFile`). ✓
+- Temp file in `Directory.systemTemp`, deleted in `finally` → Task 2 + Task 3. ✓
+- Responsiveness: the per-byte scanner yields at every awaited `onRow` (DB write) so the event loop breathes; no extra `Future.delayed` needed because pass 3's awaits are real async DB calls. (If profiling shows main-thread starvation, add a periodic yield in `flush`.) ✓
+- Tests: boundary scanner (Task 1), file sink (Task 2), parity incl. batch boundary (Task 5), convergence + no-leak (Task 6). ✓
+- Out of scope: `_collectEpochPayloads` and write side untouched (Global Constraints; design doc follow-ups). ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases" left. The parity test's `seedRichLibrary` notes that profile-sample seeding is optional if no helper exists; the >500-row case (Task 5 Step 3) guarantees batch-boundary coverage regardless. The convergence "big base" case (Task 6 Step 2) gives a concrete fallback assertion.
+
+**Type consistency:** `applyBaseFile`/`ApplyBaseFile` signature `(String filePath, SyncManifest manifest)` consistent across Tasks 3-4. `entityHasUpdatedAt` used in Task 4 only (defined once). `debugApplyPayload`/`debugApplyBaseFile` return record type matches the parity test usage in Task 5. `BasePartFileSink.assemble` named params match the reader call in Task 3.
+
+**Known residual risk:** the hand-rolled scanner is the highest-risk component; it is covered by chunk-splitting, escape, nesting, and large-row tests (Task 1) and end-to-end by parity (Task 5). The `entityHasUpdatedAt` map is duplicated from `mergeOrder` and guarded against drift by the all-entity parity test (Task 5).

--- a/docs/superpowers/plans/2026-06-20-sync-base-oom-streaming-import.md
+++ b/docs/superpowers/plans/2026-06-20-sync-base-oom-streaming-import.md
@@ -326,6 +326,7 @@ class BaseJsonStreamReader {
           return const _Step(true);
         }
         _beginCapture(_Cap.scalar);
+        _state = _S.capture;
         return const _Step(false); // reprocess this char inside capture
 
       case _S.sectionKeyOrClose:

--- a/docs/superpowers/specs/2026-06-20-sync-base-oom-streaming-import-design.md
+++ b/docs/superpowers/specs/2026-06-20-sync-base-oom-streaming-import-design.md
@@ -1,0 +1,282 @@
+# Streaming Base Import (iCloud Sync OOM Fix)
+
+Tracking issue: [#358 — iCloud sync on iOS leads to app crash](https://github.com/submersion-app/submersion/issues/358)
+
+## Problem
+
+Enabling iCloud sync on iOS crashes the app ~20 s after startup for a user with
+a large library. The user enabled sync on macOS first (which published a base),
+then on iOS (which crashes adopting it).
+
+The debug log is conclusive:
+
+```
+...ssv1.<uuid>.base.000000000005.p0000 (8388608 bytes)
+...p0001 (8388608 bytes)
+... (64 parts total = 512 MB)
+...p0063 (8388608 bytes)        @ 14:33:24
+[~109 s gap, no Dart error, no stack trace]
+Initializing notification service @ 14:35:13   <- app relaunched
+```
+
+All 64 parts download in ~0.6 s (they are already iCloud-cached on disk, so this
+is **not** a network problem), then the app spends ~109 s in pure CPU/RAM work
+and is silently relaunched. A silent relaunch with no Dart exception is the
+signature of an **OS-level out-of-memory (jetsam) kill**, not a code crash.
+
+### Root cause
+
+Adopting a peer's **base** snapshot materializes the entire database in memory
+several times over. The live path is
+`performSync()` -> `ChangesetReader.pull()` -> `_fetchBase()` ->
+`ChangesetCodec.decodeChangeset()` -> `SyncDataSerializer.deserializePayload()`
+-> `SyncPayload.fromJson()`, all on the main isolate. For the ~512 MB base:
+
+| Stage | Code | Resident cost |
+|-------|------|--------------|
+| Download all parts | `_fetchBase` accumulates `List<Uint8List>` | ~512 MB |
+| Reassemble | `BaseChunker.reassemble` allocates one contiguous `Uint8List` | +512 MB (~1 GB peak) |
+| UTF-8 -> String | `utf8.decode(full)` | +0.5-1 GB |
+| JSON -> objects | `jsonDecode` -> whole-DB `Map`/`List` graph | +1-4 GB |
+| Re-encode | `SyncPayload.fromJson` sets `rawDataJson = jsonEncode(data)` | +~512 MB |
+
+Peak is several GB, which exceeds iOS's per-app memory limit (device-dependent,
+~1.3-2.8 GB) and triggers a jetsam kill. The macOS publisher survived only
+because desktops have far more headroom.
+
+The base is the entire database serialized as one JSON document: `SyncData` holds
+38 tables, each a `List<Map<String, dynamic>>`. `DiveProfiles` is **one row per
+sample** (`timestamp`, `depth`, `temperature`, ...), so a large library is
+*millions of tiny rows* -- which is what makes the base 512 MB and what makes a
+streaming/batched apply both necessary and sufficient.
+
+For contrast, DB *restore* of an equally large `.db` works fine because it is a
+file-level byte copy (`close -> copy -> reopen`); it never builds a Dart object
+graph. Base adoption does the opposite.
+
+## Solution
+
+Import the base with **bounded memory** by streaming it through disk and applying
+it in batches, instead of materializing the whole `SyncPayload` in RAM. No
+wire-format change (old bases already in users' iClouds must import with no user
+action -- we never force a desktop re-publish). The delicate per-record merge
+logic is reused unchanged; only how rows are *fed* to it changes.
+
+Key enabling facts discovered during investigation:
+
+- `_mergeEntity` is **per-record and upsert-only** -- no per-entity aggregate
+  state beyond read-only precomputed maps, and it never deletes rows absent from
+  its input. Therefore feeding a table in N batches produces a byte-identical
+  result to one call.
+- The merge's only whole-payload coupling is two precomputations
+  (`contradicted`, `revivedParents`) that need only **IDs and timestamps**, plus
+  the (small) deletions map. The revival scan touches only *parent* tables
+  (dives, sites, ...), never the millions of `diveProfiles` rows.
+- The manifest's per-part + whole-file checksums verify byte integrity, which is
+  strictly stronger than the payload-level data checksum (see existing comment at
+  `changeset_reader.dart:146`). So the streaming path can verify bytes during
+  download and skip the payload-level `validateChecksum` / `rawDataJson`
+  re-encode entirely.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Memory strategy | Stream parts to a temp file; two-pass parse + batched apply | Only option that bounds peak RAM regardless of DB size; un-bricks existing installs with no user action |
+| Wire format | Unchanged | Old monolithic-JSON bases already exist in iCloud; "never force a re-publish" is a hard constraint |
+| JSON parsing | Hand-rolled boundary scanner that delegates per-row decode to stdlib `jsonDecode` | No third-party dependency in the security-sensitive sync data path; test surface limited to boundary detection |
+| Merge logic | Reused unmodified (`_mergeEntity`, `_applyRemoteDeletions`, FK repair) | Per-record + upsert-only, so batching is provably equivalent; avoids touching data-integrity code that accreted many fixes |
+| Base integrity check | Manifest per-part + whole-file SHA-256 only; drop payload-level checksum for bases | Byte-level check is stronger; also removes the `rawDataJson` amplifier |
+| Apply atomicity | Single existing deferred-FK transaction around the whole base apply | A mid-import kill rolls back cleanly; cursor advances only on success -> safe retry |
+| Temp file | `getTemporaryDirectory()`, unique per `deviceId+baseSeq`, deleted in `finally` | Not iCloud, not backed up; survives a killed prior run via overwrite |
+| Responsiveness | `Future.delayed(Duration.zero)` yield + progress between batches | Removes the secondary watchdog-kill risk during a long import |
+| Which paths stream | Primary: `ChangesetReader._fetchBase` (the reported crash). Fast-follow: `SyncService._collectEpochPayloads` (Replace-adopt) | The merge-base path fixes #358. Replace-adopt shares the reader/sink but needs its own orchestration (replace, not merge), so it is a separable follow-up to keep this PR focused |
+| Write side | Out of scope (tracked follow-up) | Publisher also holds the whole serialized DB, but has desktop headroom and is not the reported crash |
+
+## Architecture
+
+Only the **base** adoption path streams. Changesets are per-device deltas (small)
+and stay on the existing in-memory path, untouched.
+
+### 1. `BasePartFileSink` (new)
+
+`lib/core/services/sync/changeset_log/base_part_file_sink.dart`
+
+Downloads base parts one at a time and appends each to a temp file, verifying
+each part's checksum as it lands and feeding a chunked SHA-256 so the whole-file
+`baseChecksum` is verified without ever holding the file in RAM. Holds at most
+one ~8 MB part at a time.
+
+```dart
+/// Returns the temp file path on success, or null when a part is missing or a
+/// checksum fails (transient -> caller retries next sync).
+Future<String?> assemble({
+  required int partCount,
+  required String? wholeChecksum,
+  required List<String> partChecksums,
+  required Future<Uint8List?> Function(int index) downloadPart,
+  required String tempFilePath,
+});
+```
+
+- Per-part checksum mismatch or missing part -> delete temp file, return null.
+- Whole-file checksum mismatch -> delete temp file, return null.
+- Pure except for the injected `downloadPart` and the file sink, so tests drive
+  it with in-memory parts and a temp path.
+
+### 2. `BaseJsonStreamReader` (new)
+
+`lib/core/services/sync/changeset_log/base_json_stream_reader.dart`
+
+The hand-rolled boundary scanner. Consumes a `Stream<List<int>>` (prod:
+`File(path).openRead()`; tests: in-memory bytes). It does **not** parse JSON
+values itself; it tracks string/escape state and brace/bracket depth to find the
+byte boundaries of each row object inside `data.<table>:[...]`, then hands each
+isolated row's bytes to stdlib `jsonDecode`.
+
+Two scan modes:
+
+```dart
+/// Header scalars (epochId, version, ...) and the full deletions map, by
+/// depth-skipping the giant `data` value. Small.
+Future<BaseEnvelope> readEnvelope(Stream<List<int>> bytes);
+
+/// Emits decoded rows one at a time. `wantedTables` lets a pass skip tables it
+/// does not need (e.g. Pass A skips diveProfiles).
+Future<void> streamRows(
+  Stream<List<int>> bytes, {
+  Set<String>? wantedTables,
+  required Future<void> Function(String entityType, Map<String, dynamic> row) onRow,
+});
+```
+
+The scanner must correctly handle: string values containing `{ } [ ] , "`,
+escaped quotes and backslashes, `\uXXXX` escapes, nested objects/arrays within a
+row, rows split across read-chunk boundaries, a single row larger than the read
+buffer, empty `data`, missing tables, and extra unknown top-level keys.
+
+### 3. `ChangesetReader` (changed: orchestration only)
+
+`_fetchBase` becomes `_fetchBaseToFile`, returning a temp-file path instead of a
+decoded `SyncPayload`. The base branch in `pull()` calls a new injected
+`applyBaseFile(path, manifest)` callback instead of `apply(payload)`. The
+changeset branch is unchanged. Per-peer `try/catch` and cursor-advance semantics
+are unchanged (one bad peer never blocks others; cursor advances only after a
+successful apply).
+
+### 4. `SyncService.applyBaseFile` (new orchestration; reuses existing primitives)
+
+Drives the passes and calls the **existing, unmodified** `_applyRemoteDeletions`,
+`_mergeEntity`, `repairDanglingForeignKeys`, `_pendingRecordMap`, `_deletionMap`
+inside the **existing** `applyInDeferredFkTransaction`:
+
+1. **Envelope/tail scan** (`readEnvelope`): header + full `deletions` (depth-skip
+   `data`).
+2. **Pass A -- metadata** (`streamRows`, decoding only parent tables and tables
+   that appear in `deletions`): build `revivedParents` (parent rows locally
+   tombstoned with a newer remote `updatedAt`) and `contradicted` (live ids that
+   also appear in this payload's deletions). Skips the millions of profile rows.
+3. Open the deferred-FK transaction, then:
+   - `_applyRemoteDeletions(deletions, ...)`,
+   - **Pass B -- apply** (`streamRows`, all rows): accumulate per-entity batches
+     of ~500, call `_mergeEntity` per batch with the precomputed maps, discard
+     the batch, yield to the event loop. Sum the `_MergeResult` counters.
+   - `repairDanglingForeignKeys()`, commit.
+4. `finally`: delete the temp file.
+
+Merge *order* across entities is irrelevant: FK ordering is handled by the
+deferred-FK transaction, and revival/contradiction are precomputed in Pass A, so
+applying in file order is safe.
+
+### 5. `SyncService._collectEpochPayloads` + Replace-adopt (fast-follow, not this PR)
+
+The Replace-restore adoption path is a *separate* fix with its own orchestration.
+It is even more memory-hungry than the merge path: `_collectEpochPayloads` decodes
+`List<SyncPayload>` for **every** device, then the consumer (`sync_service.dart`
+~1635-1674) holds the entire union of all bases (`restored`) **plus** a full
+export of the local DB (`localSnapshot`) in memory simultaneously, and performs a
+*replace* (delete local rows absent from the cloud union, then upsert all), not
+the LWW merge. So it cannot reuse `applyBaseFile`.
+
+Its streaming form reuses `BasePartFileSink` + `BaseJsonStreamReader` but needs a
+distinct orchestration:
+
+1. Pass 1: stream all device base files, collecting `cloudIds` per entity (ids
+   only -- bounded even for millions of rows).
+2. Stream local ids per entity and `deleteRecord` those absent from `cloudIds`
+   (replaces the in-memory `localSnapshot` scan).
+3. Pass 2: stream all device base files again in ascending `exportedAt` order and
+   `upsertRecord` each row (last write wins -> "latest export wins" for ids in
+   several files).
+
+Recommended as an immediate follow-up PR so this PR stays focused on the reported
+crash and a smaller review/parity surface. Folding it into this PR is possible if
+preferred; flagged for confirmation in spec review.
+
+### Memory profile (512 MB base)
+
+- Download: <= 8 MB resident (one part at a time).
+- Envelope + Pass A metadata: deletions + parent id/timestamps (small).
+- Pass B apply: one ~500-row batch at a time.
+
+Peak drops from **~4 GB -> tens of MB**, and no longer scales with DB size. Two
+to three sequential reads of a local temp file are cheap (sequential I/O + page
+cache).
+
+### Explicitly untouched
+
+`_mergeEntity`, `_applyRemoteDeletions`, FK repair, HLC/LWW, tombstone logic, the
+changeset path, the wire format, and `BaseChunker`/`changeset_writer` (write side
+stays as-is for now).
+
+## Error Handling
+
+- Missing/corrupt part -> base skipped this sync, cursor unchanged, retry next
+  sync (identical to today).
+- Any throw mid-import -> deferred-FK transaction rolls back the whole base
+  apply; no half-imported library; cursor not advanced; clean retry.
+- Structurally-malformed base (scanner cannot resolve boundaries, or whole-file
+  checksum mismatch) -> abort this peer's base apply, don't advance cursor; other
+  peers still process.
+- Disk-full / file errors -> propagate to the per-peer `try/catch`; cursor stays
+  put.
+- Temp file always removed in `finally`; a stale file from a killed run is
+  overwritten.
+
+## Testing (TDD -- tests first)
+
+1. **Boundary-scanner units** (highest-risk new code): strings containing
+   `{ } [ ] , "`, escaped quotes/backslashes, `\uXXXX`, nested objects/arrays
+   within a row, empty `data`, missing tables, extra unknown top-level keys,
+   **rows split across read-chunk boundaries** (feed 1-byte and odd-sized
+   chunks), and **a single row larger than the read buffer**.
+2. **`BasePartFileSink` units**: happy path verifies file + checksum; per-part
+   mismatch / missing part / whole-file mismatch each -> null; temp file cleaned
+   up.
+3. **Parity test (linchpin)**: build one rich `SyncPayload` exercising every
+   entity type, media BLOBs, junctions, deletions, contradicted keys, revived
+   parents, and a conflict. Apply it two ways into two fresh DBs: existing
+   `_applyRemotePayload` (whole-graph) vs. new streaming `applyBaseFile`
+   (serialized -> sliced -> reassembled-to-file -> streamed). Assert the two DBs
+   are row-for-row identical and the merge counters match. Run at batch sizes
+   N=1, N=3, N=infinity to prove batching never changes the outcome.
+4. **Convergence**: extend `changeset_sync_convergence_test.dart` so base
+   adoption routes through the streaming path and two devices still converge.
+
+The parity test is what guarantees "bounded memory" did not change behavior by a
+single row.
+
+## Out of Scope / Follow-ups
+
+- **Replace-adopt streaming** (`_collectEpochPayloads` + the Replace consumer):
+  same OOM class on the Replace-restore path, but a distinct orchestration
+  (replace, not merge). Reuses `BasePartFileSink` + `BaseJsonStreamReader`.
+  Recommended as the immediate next PR (see Architecture section 5).
+- **Write-side streaming** (publisher OOM on very large libraries): the macOS
+  writer holds the whole serialized DB via `BaseChunker.slice(fullBytes)` in
+  `changeset_writer`. Track as a separate issue; candidate fix is a
+  streaming/`VACUUM INTO`-based base writer.
+- **Raw-SQLite-file base format** (binary, smaller, fixes read+write): rejected
+  for this fix because old JSON bases must remain importable without a re-publish,
+  which requires the streaming JSON reader anyway. Possible future write-side
+  optimization layered on top.

--- a/lib/core/services/sync/changeset_log/base_json_stream_reader.dart
+++ b/lib/core/services/sync/changeset_log/base_json_stream_reader.dart
@@ -93,6 +93,21 @@ class BaseJsonStreamReader {
         }
       }
     }
+
+    // Completeness guard: a well-formed base ends with the top-level object
+    // closed (state == done). Any other end state means the stream was empty
+    // or truncated. Throw so the caller fails the base closed (the reader's
+    // per-peer catch leaves the cursor unadvanced; a mid-apply throw rolls back
+    // the transaction) rather than silently applying a partial base. This is
+    // defense-in-depth behind BasePartFileSink's checksums, which already
+    // reject corruption when the manifest carries checksums but are absent on
+    // legacy manifests.
+    if (_state != _S.done) {
+      throw const FormatException(
+        'Base JSON ended before the top-level object closed '
+        '(empty or truncated document)',
+      );
+    }
   }
 
   _Step _consume(int c) {

--- a/lib/core/services/sync/changeset_log/base_json_stream_reader.dart
+++ b/lib/core/services/sync/changeset_log/base_json_stream_reader.dart
@@ -1,0 +1,358 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Streaming, bounded-memory reader for a serialized sync base document.
+///
+/// The base is one JSON object: a handful of scalar header members plus two
+/// "section" members (`data` and `deletions`) whose values are objects mapping
+/// a table name to an array of row objects. This reader walks the byte stream
+/// once and reports:
+///  - [parse]'s `onScalar` for each top-level scalar member (key + raw value
+///    bytes), and
+///  - `onRow` for each element of each section's table arrays.
+///
+/// It never holds more than one row (or one scalar value) in memory, so a
+/// multi-hundred-MB base imports in bounded memory. It does NOT parse JSON
+/// values itself: it finds byte boundaries (respecting string/escape state and
+/// brace/bracket nesting) and hands raw bytes to the caller, which decodes the
+/// few rows it needs via `jsonDecode`.
+///
+/// The instance holds per-parse mutable state; do not run two [parse] calls on
+/// one instance concurrently (the import drives passes sequentially).
+class BaseJsonStreamReader {
+  static const int _quote = 0x22; // "
+  static const int _backslash = 0x5c; // \
+  static const int _lbrace = 0x7b; // {
+  static const int _rbrace = 0x7d; // }
+  static const int _lbracket = 0x5b; // [
+  static const int _rbracket = 0x5d; // ]
+  static const int _colon = 0x3a; // :
+  static const int _comma = 0x2c; // ,
+
+  static bool _isWs(int c) => c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d;
+
+  // --- per-parse state ---
+  _S _state = _S.awaitTopOpen;
+  String? _lastKey;
+  String? _section;
+  String? _table;
+
+  final BytesBuilder _key = BytesBuilder(copy: false);
+  bool _keyEscaped = false;
+
+  final BytesBuilder _cap = BytesBuilder(copy: false);
+  int _capDepth = 0;
+  bool _capInString = false;
+  bool _capEscaped = false;
+  bool _capStarted = false;
+  _Cap _capKind = _Cap.skip;
+
+  bool Function(String section, String table) _want = (_, _) => true;
+
+  void _reset() {
+    _state = _S.awaitTopOpen;
+    _lastKey = null;
+    _section = null;
+    _table = null;
+    _key.clear();
+    _keyEscaped = false;
+    _cap.clear();
+    _capDepth = 0;
+    _capInString = false;
+    _capEscaped = false;
+    _capStarted = false;
+    _capKind = _Cap.skip;
+  }
+
+  Future<void> parse(
+    Stream<List<int>> bytes, {
+    Future<void> Function(String key, Uint8List rawValue)? onScalar,
+    bool Function(String section, String table)? wantRows,
+    Future<void> Function(String section, String table, Uint8List rowBytes)?
+    onRow,
+  }) async {
+    _reset();
+    _want = wantRows ?? (_, _) => true;
+
+    await for (final chunk in bytes) {
+      for (final c in chunk) {
+        var consumed = false;
+        while (!consumed) {
+          final r = _consume(c);
+          consumed = r.consumed;
+          final emit = r.emit;
+          if (emit != null) {
+            if (emit.kind == _Cap.scalar) {
+              if (onScalar != null) await onScalar(emit.key!, emit.bytes);
+            } else {
+              if (onRow != null) {
+                await onRow(emit.section!, emit.table!, emit.bytes);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  _Step _consume(int c) {
+    switch (_state) {
+      case _S.awaitTopOpen:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _lbrace) _state = _S.topKeyOrClose;
+        return const _Step(true);
+
+      case _S.topKeyOrClose:
+        if (_isWs(c) || c == _comma) return const _Step(true);
+        if (c == _rbrace) {
+          _state = _S.done;
+          return const _Step(true);
+        }
+        if (c == _quote) {
+          _key.clear();
+          _keyEscaped = false;
+          _state = _S.topKey;
+        }
+        return const _Step(true);
+
+      case _S.topKey:
+        return _readKey(c, then: _S.topColon);
+
+      case _S.topColon:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _colon) _state = _S.topValueStart;
+        return const _Step(true);
+
+      case _S.topValueStart:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _lbrace) {
+          _section = _lastKey;
+          _state = _S.sectionKeyOrClose;
+          return const _Step(true);
+        }
+        _beginCapture(_Cap.scalar);
+        _state = _S.capture;
+        return const _Step(false); // reprocess this char inside capture
+
+      case _S.sectionKeyOrClose:
+        if (_isWs(c) || c == _comma) return const _Step(true);
+        if (c == _rbrace) {
+          _section = null;
+          _state = _S.topKeyOrClose;
+          return const _Step(true);
+        }
+        if (c == _quote) {
+          _key.clear();
+          _keyEscaped = false;
+          _state = _S.sectionKey;
+        }
+        return const _Step(true);
+
+      case _S.sectionKey:
+        return _readKey(c, then: _S.sectionColon, intoTable: true);
+
+      case _S.sectionColon:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _colon) _state = _S.sectionValueStart;
+        return const _Step(true);
+
+      case _S.sectionValueStart:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _lbracket) {
+          _state = _S.arrayElemOrClose;
+          return const _Step(true);
+        }
+        // Unexpected non-array section value: skip it generically.
+        _beginCapture(_Cap.skip);
+        _state = _S.captureSection;
+        return const _Step(false);
+
+      case _S.arrayElemOrClose:
+        if (_isWs(c) || c == _comma) return const _Step(true);
+        if (c == _rbracket) {
+          _table = null;
+          _state = _S.sectionKeyOrClose;
+          return const _Step(true);
+        }
+        _beginCapture(
+          (_section != null && _table != null && _want(_section!, _table!))
+              ? _Cap.row
+              : _Cap.skip,
+        );
+        _state = _S.captureArray;
+        return const _Step(false);
+
+      case _S.arrayCommaOrClose:
+        if (_isWs(c)) return const _Step(true);
+        if (c == _comma) {
+          _state = _S.arrayElemOrClose;
+          return const _Step(true);
+        }
+        if (c == _rbracket) {
+          _table = null;
+          _state = _S.sectionKeyOrClose;
+          return const _Step(true);
+        }
+        return const _Step(true);
+
+      case _S.capture:
+      case _S.captureArray:
+      case _S.captureSection:
+        return _captureByte(c);
+
+      case _S.done:
+        return const _Step(true);
+    }
+  }
+
+  _Step _readKey(int c, {required _S then, bool intoTable = false}) {
+    if (_keyEscaped) {
+      _key.addByte(c);
+      _keyEscaped = false;
+      return const _Step(true);
+    }
+    if (c == _backslash) {
+      _key.addByte(c);
+      _keyEscaped = true;
+      return const _Step(true);
+    }
+    if (c == _quote) {
+      final name = utf8.decode(_key.takeBytes());
+      if (intoTable) {
+        _table = name;
+      } else {
+        _lastKey = name;
+      }
+      _state = then;
+      return const _Step(true);
+    }
+    _key.addByte(c);
+    return const _Step(true);
+  }
+
+  void _beginCapture(_Cap kind) {
+    _cap.clear();
+    _capDepth = 0;
+    _capInString = false;
+    _capEscaped = false;
+    _capStarted = false;
+    _capKind = kind;
+  }
+
+  _Step _captureByte(int c) {
+    if (_capInString) {
+      _cap.addByte(c);
+      if (_capEscaped) {
+        _capEscaped = false;
+      } else if (c == _backslash) {
+        _capEscaped = true;
+      } else if (c == _quote) {
+        _capInString = false;
+        if (_capDepth == 0) return _finishCapture(consume: true);
+      }
+      return const _Step(true);
+    }
+    if (c == _quote) {
+      _capStarted = true;
+      _capInString = true;
+      _cap.addByte(c);
+      return const _Step(true);
+    }
+    if (c == _lbrace || c == _lbracket) {
+      _capStarted = true;
+      _capDepth++;
+      _cap.addByte(c);
+      return const _Step(true);
+    }
+    if (c == _rbrace || c == _rbracket) {
+      if (_capDepth == 0) {
+        // This closing delimiter belongs to the parent: a primitive value
+        // ended just before it. Finish and reprocess the delimiter.
+        return _finishCapture(consume: false);
+      }
+      _capDepth--;
+      _cap.addByte(c);
+      if (_capDepth == 0) return _finishCapture(consume: true);
+      return const _Step(true);
+    }
+    if (c == _comma && _capDepth == 0) {
+      // Primitive value ended at a separator; consume the comma.
+      return _finishCapture(consume: true);
+    }
+    if (_isWs(c)) {
+      if (_capDepth == 0 && _capStarted) {
+        // Whitespace after a primitive ends it; the following delimiter is
+        // handled by the parent state.
+        return _finishCapture(consume: true);
+      }
+      return const _Step(true); // leading/interior structural whitespace
+    }
+    _capStarted = true;
+    _cap.addByte(c);
+    return const _Step(true);
+  }
+
+  _Step _finishCapture({required bool consume}) {
+    final kind = _capKind;
+    final bytes = (kind == _Cap.skip) ? null : _cap.takeBytes();
+    if (kind == _Cap.skip) _cap.clear();
+
+    // Transition to the parent state.
+    if (_state == _S.capture) {
+      _state = _S.topKeyOrClose;
+    } else if (_state == _S.captureArray) {
+      _state = _S.arrayCommaOrClose;
+    } else {
+      _state = _S.sectionKeyOrClose;
+    }
+
+    _Emit? emit;
+    if (bytes != null) {
+      if (kind == _Cap.scalar) {
+        emit = _Emit.scalar(_lastKey ?? '', bytes);
+      } else if (kind == _Cap.row && _section != null && _table != null) {
+        emit = _Emit.row(_section!, _table!, bytes);
+      }
+    }
+    return _Step(consume, emit: emit);
+  }
+}
+
+enum _Cap { scalar, row, skip }
+
+enum _S {
+  awaitTopOpen,
+  topKeyOrClose,
+  topKey,
+  topColon,
+  topValueStart,
+  sectionKeyOrClose,
+  sectionKey,
+  sectionColon,
+  sectionValueStart,
+  arrayElemOrClose,
+  arrayCommaOrClose,
+  capture,
+  captureArray,
+  captureSection,
+  done,
+}
+
+class _Step {
+  const _Step(this.consumed, {this.emit});
+  final bool consumed;
+  final _Emit? emit;
+}
+
+class _Emit {
+  _Emit.scalar(this.key, this.bytes)
+    : section = null,
+      table = null,
+      kind = _Cap.scalar;
+  _Emit.row(this.section, this.table, this.bytes) : key = null, kind = _Cap.row;
+  final _Cap kind;
+  final String? key;
+  final String? section;
+  final String? table;
+  final Uint8List bytes;
+}

--- a/lib/core/services/sync/changeset_log/base_part_file_sink.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_sink.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+
+/// Downloads a base's parts one at a time into a single temp file, verifying
+/// integrity as bytes land so the whole base is never held in memory. Each part
+/// is checked against its manifest checksum before being written; a rolling
+/// SHA-256 verifies the whole-file checksum at the end. Any failure deletes the
+/// partial file and returns null (transient -> the caller retries next sync).
+class BasePartFileSink {
+  BasePartFileSink({Future<Directory> Function()? tempDirProvider})
+    : _tempDir = tempDirProvider ?? (() async => Directory.systemTemp);
+
+  final Future<Directory> Function() _tempDir;
+  static const _uuid = Uuid();
+
+  Future<String?> assemble({
+    required String name,
+    required int partCount,
+    required String? wholeChecksum,
+    required List<String> partChecksums,
+    required Future<Uint8List?> Function(int index) downloadPart,
+  }) async {
+    final dir = await _tempDir();
+    final path = '${dir.path}/$name.${_uuid.v4()}.base';
+    final file = File(path);
+    final out = file.openWrite();
+
+    // Rolling whole-file SHA-256 so we never hold the full base to checksum it.
+    final digestSink = _DigestSink();
+    final wholeInput = sha256.startChunkedConversion(digestSink);
+
+    var ok = true;
+    try {
+      for (var i = 0; i < partCount; i++) {
+        final part = await downloadPart(i);
+        if (part == null) {
+          ok = false;
+          break;
+        }
+        if (i < partChecksums.length &&
+            BaseChunker.checksum(part) != partChecksums[i]) {
+          ok = false;
+          break;
+        }
+        wholeInput.add(part);
+        out.add(part);
+      }
+    } catch (_) {
+      ok = false;
+    }
+
+    await out.close();
+    wholeInput.close();
+
+    if (ok && wholeChecksum != null) {
+      final computed = 'sha256:${digestSink.value}';
+      if (computed != wholeChecksum) ok = false;
+    }
+
+    if (!ok) {
+      await deleteQuietly(path);
+      return null;
+    }
+    return path;
+  }
+
+  Future<void> deleteQuietly(String path) async {
+    try {
+      final f = File(path);
+      if (await f.exists()) await f.delete();
+    } catch (_) {
+      // Best effort: a leftover temp file is harmless; the OS reaps systemTemp.
+    }
+  }
+}
+
+/// Minimal `Sink<Digest>` that captures the single digest emitted at close.
+/// Avoids depending on `package:convert`'s `AccumulatorSink` (not exported by
+/// `crypto`).
+class _DigestSink implements Sink<Digest> {
+  Digest? value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
+}

--- a/lib/core/services/sync/changeset_log/changeset_reader.dart
+++ b/lib/core/services/sync/changeset_log/changeset_reader.dart
@@ -1,8 +1,6 @@
-import 'dart:typed_data';
-
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
-import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
@@ -12,6 +10,12 @@ import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 /// SyncService._applyRemotePayload (HLC LWW + tombstones + FK repair), injected
 /// so the merge stays the single source of truth.
 typedef ApplyPayload = Future<void> Function(SyncPayload payload);
+
+/// Applies a base that has been streamed to a local temp [filePath]. The real
+/// implementation streams the file through the merge in bounded memory; see
+/// SyncService._applyRemoteBaseFile.
+typedef ApplyBaseFile =
+    Future<void> Function(String filePath, SyncManifest manifest);
 
 class ChangesetReadResult {
   const ChangesetReadResult({
@@ -27,16 +31,19 @@ class ChangesetReadResult {
 /// and advances the cursor. Stops at the first missing file (transient gap)
 /// and retries next sync; application is idempotent so re-reads are safe.
 class ChangesetReader {
-  ChangesetReader(this._codec, this._peerCursors);
+  ChangesetReader(this._codec, this._peerCursors, {BasePartFileSink? baseSink})
+    : _baseSink = baseSink ?? BasePartFileSink();
 
   final ChangesetCodec _codec;
   final PeerCursorStore _peerCursors;
+  final BasePartFileSink _baseSink;
 
   Future<ChangesetReadResult> pull({
     required CloudStorageProvider provider,
     required String selfDeviceId,
     required String folderId,
     required ApplyPayload apply,
+    required ApplyBaseFile applyBaseFile,
     String? currentEpochId,
   }) async {
     final providerId = provider.providerId;
@@ -81,11 +88,20 @@ class ChangesetReader {
         // Cold-start, or lapped by the peer's compaction: adopt the base.
         final baseSeq = manifest.baseSeq;
         if (baseSeq != null && lastApplied < baseSeq) {
-          final base = await _fetchBase(provider, peerId, manifest, byName);
-          if (base == null || !_codec.serializer.validateChecksum(base)) {
+          final path = await _fetchBaseToFile(
+            provider,
+            peerId,
+            manifest,
+            byName,
+          );
+          if (path == null) {
             continue; // missing or corrupt base -> transient, retry next sync
           }
-          await apply(base);
+          try {
+            await applyBaseFile(path, manifest);
+          } finally {
+            await _baseSink.deleteQuietly(path);
+          }
           payloadsApplied++;
           appliedThrough = baseSeq;
           baseSeqApplied = baseSeq;
@@ -129,37 +145,29 @@ class ChangesetReader {
     );
   }
 
-  Future<SyncPayload?> _fetchBase(
+  /// Streams the peer's base parts into a single temp file, verifying each
+  /// part and the whole-file checksum as bytes land (never holding the base in
+  /// memory). Returns the temp file path, or null if a part is missing or any
+  /// checksum fails (transient -> retry next sync). The byte-level checksums
+  /// are independent of -- and stronger than -- the decoded payload's data
+  /// checksum, which ignores headers and deletions.
+  Future<String?> _fetchBaseToFile(
     CloudStorageProvider provider,
     String peerId,
     SyncManifest manifest,
     Map<String, CloudFileInfo> byName,
-  ) async {
-    final count = manifest.basePartCount ?? 0;
+  ) {
     final baseSeq = manifest.baseSeq!;
-    final partChecksums = manifest.basePartChecksums;
-    final parts = <Uint8List>[];
-    for (var i = 0; i < count; i++) {
-      final pf = byName[ChangesetLogLayout.basePartName(peerId, baseSeq, i)];
-      if (pf == null) return null; // missing part -> transient, retry next sync
-      final bytes = await provider.downloadFile(pf.id);
-      // Verify each part against the manifest's checksum (when present): a
-      // byte-level integrity guard independent of -- and stronger than -- the
-      // decoded payload's data checksum, which ignores headers and deletions.
-      if (i < partChecksums.length &&
-          BaseChunker.checksum(bytes) != partChecksums[i]) {
-        return null; // corrupt part -> treat as missing, retry next sync
-      }
-      parts.add(bytes);
-    }
-    final full = BaseChunker.reassemble(parts);
-    final whole = manifest.baseChecksum;
-    if (whole != null && BaseChunker.checksum(full) != whole) {
-      // The writer checksums the exact bytes it slices into parts, so a
-      // mismatch here is real transport corruption (not a serialization
-      // divergence): drop the base and retry on the next sync.
-      return null;
-    }
-    return _codec.decodeChangeset(full);
+    return _baseSink.assemble(
+      name: 'ssv1_${peerId}_$baseSeq',
+      partCount: manifest.basePartCount ?? 0,
+      wholeChecksum: manifest.baseChecksum,
+      partChecksums: manifest.basePartChecksums,
+      downloadPart: (i) async {
+        final pf = byName[ChangesetLogLayout.basePartName(peerId, baseSeq, i)];
+        if (pf == null) return null;
+        return provider.downloadFile(pf.id);
+      },
+    );
   }
 }

--- a/lib/core/services/sync/changeset_log/changeset_reader.dart
+++ b/lib/core/services/sync/changeset_log/changeset_reader.dart
@@ -158,9 +158,15 @@ class ChangesetReader {
     Map<String, CloudFileInfo> byName,
   ) {
     final baseSeq = manifest.baseSeq!;
+    final partCount = manifest.basePartCount ?? 0;
+    // A manifest that names a base (baseSeq set) but no parts is malformed --
+    // a real base always has at least one part. Treat it as a transient gap
+    // (publish in flight / truncated manifest) so we don't assemble an empty
+    // file and advance the cursor past a base we never applied.
+    if (partCount <= 0) return Future<String?>.value(null);
     return _baseSink.assemble(
       name: 'ssv1_${peerId}_$baseSeq',
-      partCount: manifest.basePartCount ?? 0,
+      partCount: partCount,
       wholeChecksum: manifest.baseChecksum,
       partChecksums: manifest.basePartChecksums,
       downloadPart: (i) async {

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1201,9 +1201,16 @@ class SyncService {
   /// Per-entity "has an updatedAt column" flag, mirroring the `mergeOrder`
   /// records in [_applyRemotePayloadInner]. The streaming base apply
   /// ([_applyRemoteBaseFile]) uses it for (a) conflict-detection behavior in
-  /// [_mergeEntity] and (b) the set of entity tables it applies (the keys are
-  /// the known entities). Kept consistent with `mergeOrder` by the
-  /// streaming-vs-in-memory parity test, which exercises every entity here.
+  /// [_mergeEntity] and (b) the set of entity tables it applies (a table absent
+  /// from these keys is silently skipped on base import).
+  ///
+  /// MUST list every [SyncData] entity: a structural test
+  /// (`entityHasUpdatedAt covers exactly the SyncData entities`) asserts the
+  /// keys match [SyncData], so adding an entity without a flag here fails that
+  /// test. Each flag VALUE must match the `hasUpdatedAt` of the corresponding
+  /// `mergeOrder` record above; the parity test verifies apply behavior for a
+  /// representative subset (parent, clockless-child, junction, BLOB, and
+  /// updatedAt tables plus a tombstone), not for every entity.
   @visibleForTesting
   static const Map<String, bool> entityHasUpdatedAt = {
     'divers': true,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
@@ -8,6 +9,7 @@ import 'package:submersion/core/database/database.dart' show SyncRecord;
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
@@ -207,6 +209,31 @@ class SyncService {
     _progressCallback = callback;
   }
 
+  /// Test seam: apply an in-memory payload through the standard merge. Exposed
+  /// so the streaming-vs-in-memory parity test can compare apply paths.
+  @visibleForTesting
+  Future<({int recordsApplied, int conflictsFound, int recordsFailed})>
+  debugApplyPayload(SyncPayload payload, {DateTime? lastSync}) async {
+    final r = await _applyRemotePayload(payload, lastSync);
+    return (
+      recordsApplied: r.recordsApplied,
+      conflictsFound: r.conflictsFound,
+      recordsFailed: r.recordsFailed,
+    );
+  }
+
+  /// Test seam: apply a base from a local file through the streaming merge.
+  @visibleForTesting
+  Future<({int recordsApplied, int conflictsFound, int recordsFailed})>
+  debugApplyBaseFile(String filePath, {DateTime? lastSync}) async {
+    final r = await _applyRemoteBaseFile(filePath, lastSync);
+    return (
+      recordsApplied: r.recordsApplied,
+      conflictsFound: r.conflictsFound,
+      recordsFailed: r.recordsFailed,
+    );
+  }
+
   void _reportProgress(SyncPhase phase, double progress, [String? message]) {
     _progressCallback?.call(
       SyncProgress(phase: phase, progress: progress, message: message),
@@ -378,6 +405,12 @@ class SyncService {
         currentEpochId: currentEpochId,
         apply: (payload) async {
           final r = await _applyRemotePayload(payload, lastSyncTime);
+          recordsSynced += r.recordsApplied;
+          conflictsFound += r.conflictsFound;
+          recordsFailed += r.recordsFailed;
+        },
+        applyBaseFile: (path, manifest) async {
+          final r = await _applyRemoteBaseFile(path, lastSyncTime);
           recordsSynced += r.recordsApplied;
           conflictsFound += r.conflictsFound;
           recordsFailed += r.recordsFailed;
@@ -916,6 +949,167 @@ class SyncService {
     );
   }
 
+  /// Apply a base that was streamed to a local temp [filePath], in bounded
+  /// memory. Three forward passes over the file:
+  ///   1. header `exportedAt` + the full `deletions` map (both small),
+  ///   2. parent-row id->updatedAt and contradiction keys (skips giant tables),
+  ///   3. batched apply of every row through the existing [_mergeEntity].
+  /// Reuses the same merge primitives as [_applyRemotePayloadInner], so the
+  /// result is identical to applying the equivalent in-memory payload, but peak
+  /// memory stays at one ~8 MB part download + one batch of rows regardless of
+  /// library size (issue #358).
+  Future<_MergeResult> _applyRemoteBaseFile(
+    String filePath,
+    DateTime? localLastSync,
+  ) async {
+    final file = File(filePath);
+    final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
+
+    // ---- Pass 1: exportedAt + deletions ----
+    var baseExportedAt = 0;
+    final deletions = <String, List<SyncDeletion>>{};
+    await BaseJsonStreamReader().parse(
+      file.openRead(),
+      onScalar: (key, raw) async {
+        if (key == 'exportedAt') {
+          baseExportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+        }
+      },
+      wantRows: (section, _) => section == 'deletions',
+      onRow: (section, table, rowBytes) async {
+        final decoded = jsonDecode(utf8.decode(rowBytes));
+        if (decoded is Map<String, dynamic>) {
+          (deletions[table] ??= []).add(SyncDeletion.fromJson(decoded));
+        } else if (decoded is Map) {
+          (deletions[table] ??= []).add(
+            SyncDeletion.fromJson(decoded.cast<String, dynamic>()),
+          );
+        } else if (decoded is String) {
+          (deletions[table] ??= []).add(
+            SyncDeletion(id: decoded, deletedAt: 0),
+          );
+        }
+      },
+    );
+
+    final pendingByEntity = await _pendingRecordMap();
+
+    // ---- Pass 2: parent updatedAt + contradiction keys ----
+    final parentTypes = <String>{
+      for (final refs in parentRefs.values)
+        for (final ref in refs) ref.parent,
+    };
+    final deletionIds = <String, Set<String>>{
+      for (final e in deletions.entries) e.key: {for (final d in e.value) d.id},
+    };
+    final parentUpdatedAt = <String, Map<String, int>>{};
+    final contradictedByEntity = <String, Set<String>>{};
+    await BaseJsonStreamReader().parse(
+      file.openRead(),
+      wantRows: (section, table) =>
+          section == 'data' &&
+          entityHasUpdatedAt.containsKey(table) &&
+          (parentTypes.contains(table) || deletionIds.containsKey(table)),
+      onRow: (section, table, rowBytes) async {
+        final rec = jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>;
+        final id = _recordIdForEntity(table, rec);
+        if (id == null) return;
+        if (parentTypes.contains(table) && entityHasUpdatedAt[table] == true) {
+          final u = _extractUpdatedAtMillis(rec);
+          if (u != null) (parentUpdatedAt[table] ??= {})[id] = u;
+        }
+        if (deletionIds[table]?.contains(id) == true) {
+          (contradictedByEntity[table] ??= {}).add(id);
+        }
+      },
+    );
+
+    // ---- Apply, all inside one deferred-FK transaction ----
+    return _serializer.applyInDeferredFkTransaction(() async {
+      var recordsApplied = 0;
+      var conflictsFound = 0;
+      var recordsFailed = 0;
+
+      final delResult = await _applyRemoteDeletions(
+        deletions,
+        lastSyncMs,
+        baseExportedAt,
+        pendingByEntity,
+        contradictedByEntity,
+      );
+      recordsApplied += delResult.recordsApplied;
+      conflictsFound += delResult.conflictsFound;
+      recordsFailed += delResult.recordsFailed;
+
+      // Load tombstones AFTER deletions so a tombstone arriving in this base
+      // also guards the merge below (mirrors _applyRemotePayloadInner).
+      final tombstonesByEntity = await _deletionMap();
+
+      // Revived parents: a parent row whose remote updatedAt is newer than our
+      // local tombstone. Combines pass-2 file data with post-deletion
+      // tombstones, so it is complete before any row is merged (a child may
+      // precede its parent in file order).
+      final revivedParents = <String, Set<String>>{};
+      for (final parentType in parentTypes) {
+        final tombs = tombstonesByEntity[parentType];
+        final ups = parentUpdatedAt[parentType];
+        if (tombs == null || tombs.isEmpty || ups == null) continue;
+        ups.forEach((id, updatedAt) {
+          final deletedAt = tombs[id];
+          if (deletedAt != null && updatedAt > deletedAt) {
+            (revivedParents[parentType] ??= {}).add(id);
+          }
+        });
+      }
+
+      // ---- Pass 3: batched apply ----
+      const batchSize = 500;
+      String? currentTable;
+      var batch = <Map<String, dynamic>>[];
+
+      Future<void> flush() async {
+        final table = currentTable;
+        if (table == null || batch.isEmpty) return;
+        final r = await _mergeEntity(
+          entityType: table,
+          records: batch,
+          hasUpdatedAt: entityHasUpdatedAt[table] ?? false,
+          lastSyncMs: lastSyncMs,
+          pendingRecordIds: pendingByEntity[table] ?? const <String>{},
+          allTombstones: tombstonesByEntity,
+          revivedParents: revivedParents,
+          contradicted: contradictedByEntity[table] ?? const <String>{},
+        );
+        recordsApplied += r.recordsApplied;
+        conflictsFound += r.conflictsFound;
+        recordsFailed += r.recordsFailed;
+        batch = <Map<String, dynamic>>[];
+      }
+
+      await BaseJsonStreamReader().parse(
+        file.openRead(),
+        wantRows: (section, table) =>
+            section == 'data' && entityHasUpdatedAt.containsKey(table),
+        onRow: (section, table, rowBytes) async {
+          if (table != currentTable) {
+            await flush();
+            currentTable = table;
+          }
+          batch.add(jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>);
+          if (batch.length >= batchSize) await flush();
+        },
+      );
+      await flush();
+
+      await _serializer.repairDanglingForeignKeys();
+      return _MergeResult(
+        recordsApplied: recordsApplied,
+        conflictsFound: conflictsFound,
+        recordsFailed: recordsFailed,
+      );
+    });
+  }
+
   Future<_MergeResult> _applyRemoteDeletions(
     Map<String, List<SyncDeletion>> deletions,
     int? lastSyncMs,
@@ -1003,6 +1197,55 @@ class SyncService {
       recordsFailed: failed,
     );
   }
+
+  /// Per-entity "has an updatedAt column" flag, mirroring the `mergeOrder`
+  /// records in [_applyRemotePayloadInner]. The streaming base apply
+  /// ([_applyRemoteBaseFile]) uses it for (a) conflict-detection behavior in
+  /// [_mergeEntity] and (b) the set of entity tables it applies (the keys are
+  /// the known entities). Kept consistent with `mergeOrder` by the
+  /// streaming-vs-in-memory parity test, which exercises every entity here.
+  @visibleForTesting
+  static const Map<String, bool> entityHasUpdatedAt = {
+    'divers': true,
+    'diverSettings': true,
+    'buddies': true,
+    'diveCenters': true,
+    'trips': true,
+    'liveaboardDetails': true,
+    'itineraryDays': true,
+    'equipment': true,
+    'equipmentSets': true,
+    'equipmentSetItems': false,
+    'diveTypes': true,
+    'tankPresets': true,
+    'diveComputers': true,
+    'species': false,
+    'tags': true,
+    'courses': true,
+    'dives': true,
+    'diveSites': true,
+    'diveTanks': false,
+    'diveWeights': false,
+    'diveEquipment': false,
+    'diveTags': false,
+    'diveBuddies': false,
+    'diveProfiles': false,
+    'diveProfileEvents': false,
+    'gasSwitches': false,
+    'diveCustomFields': false,
+    'diveDataSources': false,
+    'siteSpecies': false,
+    'csvPresets': true,
+    'viewConfigs': true,
+    'fieldPresets': false,
+    'tankPressureProfiles': false,
+    'tideRecords': false,
+    'sightings': false,
+    'certifications': true,
+    'serviceRecords': true,
+    'settings': true,
+    'media': false,
+  };
 
   /// Every synced child -> parent FK whose parent can be deleted (and thus
   /// tombstoned in the deletion log). Used by [_mergeEntity] to keep a peer's

--- a/test/core/services/sync/changeset_log/base_json_stream_reader_test.dart
+++ b/test/core/services/sync/changeset_log/base_json_stream_reader_test.dart
@@ -132,4 +132,24 @@ void main() {
       ['data', 't', '{"id":"a"}'],
     ]);
   });
+
+  test('throws FormatException on a truncated document', () async {
+    // Stream ends mid-row, before the top-level object closes.
+    await expectLater(
+      run(_one('{"data":{"t":[{"id":"a"')),
+      throwsFormatException,
+    );
+  });
+
+  test('throws FormatException on empty input', () async {
+    await expectLater(run(_one('')), throwsFormatException);
+  });
+
+  test('throws FormatException when the top object is never closed', () async {
+    // Well-formed rows but the final closing brace is missing.
+    await expectLater(
+      run(_one('{"data":{"t":[{"id":"a"}]},"deletions":{}')),
+      throwsFormatException,
+    );
+  });
 }

--- a/test/core/services/sync/changeset_log/base_json_stream_reader_test.dart
+++ b/test/core/services/sync/changeset_log/base_json_stream_reader_test.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+
+/// Feed [s] as a single chunk.
+Stream<List<int>> _one(String s) => Stream.value(utf8.encode(s));
+
+/// Feed [s] one byte per chunk, to prove the scanner survives arbitrary
+/// chunk boundaries.
+Stream<List<int>> _drip(String s) async* {
+  for (final b in utf8.encode(s)) {
+    yield [b];
+  }
+}
+
+Future<({Map<String, String> scalars, List<List<String>> rows})> run(
+  Stream<List<int>> bytes, {
+  bool Function(String section, String table)? want,
+}) async {
+  final scalars = <String, String>{};
+  final rows = <List<String>>[];
+  await BaseJsonStreamReader().parse(
+    bytes,
+    onScalar: (k, v) async => scalars[k] = utf8.decode(v),
+    wantRows: want,
+    onRow: (section, table, row) async =>
+        rows.add([section, table, utf8.decode(row)]),
+  );
+  return (scalars: scalars, rows: rows);
+}
+
+void main() {
+  const doc =
+      '{"version":2,"exportedAt":17,"deviceId":"abc",'
+      '"data":{"dives":[{"id":"d1","n":1},{"id":"d2","n":2}],'
+      '"diveProfiles":[{"id":"p1"}]},'
+      '"deletions":{"dives":[{"id":"x","deletedAt":5}]},'
+      '"uploadNonce":null}';
+
+  test('emits top-level scalars with raw JSON value bytes', () async {
+    final r = await run(_one(doc));
+    expect(r.scalars['version'], '2');
+    expect(r.scalars['exportedAt'], '17');
+    expect(r.scalars['deviceId'], '"abc"');
+    expect(r.scalars['uploadNonce'], 'null');
+    // Sections are not scalars.
+    expect(r.scalars.containsKey('data'), isFalse);
+    expect(r.scalars.containsKey('deletions'), isFalse);
+  });
+
+  test('emits each data and deletions row with section+table tags', () async {
+    final r = await run(_one(doc));
+    expect(r.rows, [
+      ['data', 'dives', '{"id":"d1","n":1}'],
+      ['data', 'dives', '{"id":"d2","n":2}'],
+      ['data', 'diveProfiles', '{"id":"p1"}'],
+      ['deletions', 'dives', '{"id":"x","deletedAt":5}'],
+    ]);
+  });
+
+  test('survives one-byte-per-chunk boundaries', () async {
+    final r = await run(_drip(doc));
+    expect(r.scalars['deviceId'], '"abc"');
+    expect(r.rows.length, 4);
+    expect(r.rows.first, ['data', 'dives', '{"id":"d1","n":1}']);
+  });
+
+  test('wantRows=false skips a table without emitting it', () async {
+    final r = await run(
+      _one(doc),
+      want: (section, table) => !(section == 'data' && table == 'diveProfiles'),
+    );
+    expect(r.rows.where((e) => e[1] == 'diveProfiles'), isEmpty);
+    expect(r.rows.length, 3);
+  });
+
+  test('handles structural chars and escapes inside string values', () async {
+    const tricky =
+        '{"data":{"t":[{"s":"a,b{c}[d]\\"e\\\\f","ok":true}]},"deletions":{}}';
+    final r = await run(_one(tricky));
+    expect(r.rows.length, 1);
+    final decoded = jsonDecode(r.rows.single[2]) as Map<String, dynamic>;
+    expect(decoded['s'], 'a,b{c}[d]"e\\f');
+    expect(decoded['ok'], true);
+  });
+
+  test('handles nested objects and arrays within a row', () async {
+    const nested =
+        '{"data":{"t":[{"id":"a","meta":{"k":[1,2,{"z":"}"}]}}]},'
+        '"deletions":{}}';
+    final r = await run(_one(nested));
+    expect(r.rows.length, 1);
+    final decoded = jsonDecode(r.rows.single[2]) as Map<String, dynamic>;
+    expect((decoded['meta'] as Map)['k'], [
+      1,
+      2,
+      {'z': '}'},
+    ]);
+  });
+
+  test('handles empty data and empty tables', () async {
+    final r = await run(_one('{"data":{},"deletions":{}}'));
+    expect(r.rows, isEmpty);
+  });
+
+  test('tolerates unknown top-level keys and trailing members', () async {
+    const doc2 = '{"future":{"a":1},"data":{"t":[{"id":"a"}]},"x":7}';
+    final r = await run(_one(doc2));
+    expect(r.scalars['x'], '7');
+    expect(r.rows, [
+      ['data', 't', '{"id":"a"}'],
+    ]);
+  });
+
+  test('captures a row larger than a typical buffer', () async {
+    final big = 'y' * 100000;
+    final doc3 = '{"data":{"t":[{"id":"a","blob":"$big"}]},"deletions":{}}';
+    final r = await run(_drip(doc3));
+    expect(r.rows.length, 1);
+    final decoded = jsonDecode(r.rows.single[2]) as Map<String, dynamic>;
+    expect((decoded['blob'] as String).length, 100000);
+  });
+
+  // A scalar value that is itself an array (top-level), to confirm the scanner
+  // does not mistake a non-object top value for a section. Not produced by our
+  // writer, but the scanner should not crash or mis-tag it.
+  test('treats a top-level array value as a scalar capture', () async {
+    final r = await run(_one('{"tags":[1,2],"data":{"t":[{"id":"a"}]}}'));
+    expect(jsonDecode(r.scalars['tags']!), [1, 2]);
+    expect(r.rows, [
+      ['data', 't', '{"id":"a"}'],
+    ]);
+  });
+}

--- a/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
+
+void main() {
+  late Directory dir;
+  late BasePartFileSink sink;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('base_sink_test');
+    sink = BasePartFileSink(tempDirProvider: () async => dir);
+  });
+  tearDown(() async {
+    if (dir.existsSync()) await dir.delete(recursive: true);
+  });
+
+  Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
+
+  test('assembles parts into one file and returns its path', () async {
+    final p0 = bytes('hello ');
+    final p1 = bytes('world');
+    final whole = BaseChunker.checksum(bytes('hello world'));
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: whole,
+      partChecksums: [BaseChunker.checksum(p0), BaseChunker.checksum(p1)],
+      downloadPart: (i) async => [p0, p1][i],
+    );
+    expect(path, isNotNull);
+    expect(await File(path!).readAsString(), 'hello world');
+  });
+
+  test(
+    'returns null and deletes the file on a per-part checksum mismatch',
+    () async {
+      final p0 = bytes('hello ');
+      final p1 = bytes('world');
+      final path = await sink.assemble(
+        name: 'base',
+        partCount: 2,
+        wholeChecksum: null,
+        partChecksums: [BaseChunker.checksum(p0), 'sha256:deadbeef'],
+        downloadPart: (i) async => [p0, p1][i],
+      );
+      expect(path, isNull);
+      expect(dir.listSync().whereType<File>(), isEmpty);
+    },
+  );
+
+  test('returns null when a part is missing', () async {
+    final p0 = bytes('hello ');
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: null,
+      partChecksums: [BaseChunker.checksum(p0), 'sha256:whatever'],
+      downloadPart: (i) async => i == 0 ? p0 : null,
+    );
+    expect(path, isNull);
+    expect(dir.listSync().whereType<File>(), isEmpty);
+  });
+
+  test('returns null on a whole-file checksum mismatch', () async {
+    final p0 = bytes('hello ');
+    final p1 = bytes('world');
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 2,
+      wholeChecksum: 'sha256:notreal',
+      partChecksums: [BaseChunker.checksum(p0), BaseChunker.checksum(p1)],
+      downloadPart: (i) async => [p0, p1][i],
+    );
+    expect(path, isNull);
+    expect(dir.listSync().whereType<File>(), isEmpty);
+  });
+
+  test('verifies whole-file checksum across many parts', () async {
+    final parts = List.generate(10, (i) => bytes('chunk$i-'));
+    final joined = bytes(parts.map((p) => String.fromCharCodes(p)).join());
+    final path = await sink.assemble(
+      name: 'multi',
+      partCount: parts.length,
+      wholeChecksum: BaseChunker.checksum(joined),
+      partChecksums: parts.map(BaseChunker.checksum).toList(),
+      downloadPart: (i) async => parts[i],
+    );
+    expect(path, isNotNull);
+    expect(await File(path!).readAsBytes(), joined);
+  });
+
+  test('deleteQuietly removes a file and never throws', () async {
+    final f = File('${dir.path}/x');
+    await f.writeAsString('y');
+    await sink.deleteQuietly(f.path);
+    expect(f.existsSync(), isFalse);
+    await sink.deleteQuietly('${dir.path}/does-not-exist'); // no throw
+  });
+}

--- a/test/core/services/sync/changeset_log/changeset_reader_epoch_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_epoch_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.da
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
+import '../../../../helpers/changeset_test_helpers.dart';
 import '../../../../helpers/test_database.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../support/fake_cloud_storage_provider.dart';
@@ -59,6 +60,7 @@ void main() {
     selfDeviceId: 'reader-x',
     folderId: folder,
     apply: spyApply,
+    applyBaseFile: spyApplyBaseFile(applied),
     currentEpochId: currentEpochId,
   );
 

--- a/test/core/services/sync/changeset_log/changeset_reader_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_test.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
@@ -64,6 +67,52 @@ void main() {
     folderId: folder,
     apply: spyApply,
     applyBaseFile: spyApplyBaseFile(applied),
+  );
+
+  test(
+    'streams the base to a temp file that exists during apply and is deleted '
+    'after',
+    () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+      );
+      await publishAsPeer();
+
+      // Isolated temp dir so the assertion is deterministic and does not race
+      // other tests sharing Directory.systemTemp.
+      final tmpDir = await Directory.systemTemp.createTemp('reader_cleanup');
+      final isolatedReader = ChangesetReader(
+        ChangesetCodec(SyncDataSerializer()),
+        PeerCursorStore(DatabaseService.instance.database),
+        baseSink: BasePartFileSink(tempDirProvider: () async => tmpDir),
+      );
+
+      String? seenPath;
+      var existedDuringApply = false;
+      await isolatedReader.pull(
+        provider: provider,
+        selfDeviceId: 'reader-cleanup',
+        folderId: folder,
+        apply: (p) async {},
+        applyBaseFile: (path, manifest) async {
+          seenPath = path;
+          existedDuringApply = await File(path).exists();
+        },
+      );
+
+      expect(seenPath, isNotNull);
+      expect(
+        existedDuringApply,
+        isTrue,
+        reason: 'temp file must exist during applyBaseFile',
+      );
+      expect(
+        tmpDir.listSync(),
+        isEmpty,
+        reason: 'reader must delete the streamed base temp file after apply',
+      );
+      await tmpDir.delete(recursive: true);
+    },
   );
 
   test(

--- a/test/core/services/sync/changeset_log/changeset_reader_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_test.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.da
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
+import '../../../../helpers/changeset_test_helpers.dart';
 import '../../../../helpers/test_database.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../support/fake_cloud_storage_provider.dart';
@@ -62,6 +63,7 @@ void main() {
     selfDeviceId: selfDeviceId,
     folderId: folder,
     apply: spyApply,
+    applyBaseFile: spyApplyBaseFile(applied),
   );
 
   test(

--- a/test/core/services/sync/changeset_log/changeset_reader_verify_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_verify_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dar
 import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
 import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
 import '../../../../helpers/changeset_test_helpers.dart';
@@ -165,6 +166,54 @@ void main() {
       cursor,
       isNull,
       reason: 'the cursor must not advance past an unverified base',
+    );
+  });
+
+  test('a manifest naming a base with no part count is not applied', () async {
+    await setUpTestDatabase();
+    addTearDown(() => tearDownTestDatabase());
+    final db = DatabaseService.instance.database;
+    final codec = ChangesetCodec(SyncDataSerializer());
+    final reader = ChangesetReader(codec, PeerCursorStore(db));
+    final provider = FakeCloudStorageProvider();
+    final folder = await provider.getOrCreateSyncFolder();
+
+    // A manifest that claims a base (baseSeq + headSeq set) but carries no
+    // basePartCount and uploads no base part files -- malformed / a publish in
+    // flight. The reader must treat it as a transient gap, not an empty base.
+    const peerId = 'peer-no-parts';
+    final manifest = SyncManifest(
+      deviceId: peerId,
+      provider: provider.providerId,
+      baseSeq: 1,
+      headSeq: 1,
+      updatedAt: 0,
+    );
+    await provider.uploadFile(
+      manifest.toBytes(),
+      ChangesetLogLayout.manifestName(peerId),
+      folderId: folder,
+    );
+
+    final applied = <SyncPayload>[];
+    await reader.pull(
+      provider: provider,
+      selfDeviceId: 'reader-x',
+      folderId: folder,
+      apply: (p) async => applied.add(p),
+      applyBaseFile: spyApplyBaseFile(applied),
+    );
+
+    expect(
+      applied,
+      isEmpty,
+      reason: 'a base with no parts must not be applied',
+    );
+    final cursor = await PeerCursorStore(db).get(peerId, provider.providerId);
+    expect(
+      cursor,
+      isNull,
+      reason: 'the cursor must not advance past a base that was never applied',
     );
   });
 }

--- a/test/core/services/sync/changeset_log/changeset_reader_verify_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_verify_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.da
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
+import '../../../../helpers/changeset_test_helpers.dart';
 import '../../../../helpers/test_database.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../support/fake_cloud_storage_provider.dart';
@@ -77,6 +78,7 @@ void main() {
         selfDeviceId: 'reader-x',
         folderId: folder,
         apply: (p) async => applied.add(p),
+        applyBaseFile: spyApplyBaseFile(applied),
       );
 
       final ids = applied
@@ -150,6 +152,7 @@ void main() {
       selfDeviceId: 'reader-x',
       folderId: folder,
       apply: (p) async => applied.add(p),
+      applyBaseFile: spyApplyBaseFile(applied),
     );
 
     expect(

--- a/test/core/services/sync/changeset_sync_convergence_test.dart
+++ b/test/core/services/sync/changeset_sync_convergence_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -10,14 +8,6 @@ import 'package:submersion/features/dive_log/data/repositories/dive_repository_i
 import '../../../helpers/test_database.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../support/fake_cloud_storage_provider.dart';
-
-/// Base-adoption temp files are named `ssv1_<peer>_<seq>.<uuid>.base` and must
-/// be deleted by the reader after each apply. No `*.base` file should survive a
-/// completed sync.
-Iterable<File> _leakedBaseTempFiles() => Directory.systemTemp
-    .listSync()
-    .whereType<File>()
-    .where((f) => f.path.endsWith('.base'));
 
 /// End-to-end proof that the changeset-log transport converges two devices
 /// through the real merge. One in-memory database stands in for each device in
@@ -57,11 +47,6 @@ void main() {
       row,
       isNotNull,
       reason: "device B must receive device A's dive via changeset sync",
-    );
-    expect(
-      _leakedBaseTempFiles(),
-      isEmpty,
-      reason: 'the reader must delete the streamed base temp file after apply',
     );
     await tearDownTestDatabase();
   });
@@ -112,11 +97,6 @@ void main() {
         .customSelect("SELECT name FROM dive_sites WHERE id = 'site-m'")
         .getSingleOrNull();
     expect(site, isNotNull, reason: 'the dive site must converge');
-    expect(
-      _leakedBaseTempFiles(),
-      isEmpty,
-      reason: 'no base temp file should survive the sync',
-    );
     await tearDownTestDatabase();
   });
 }

--- a/test/core/services/sync/changeset_sync_convergence_test.dart
+++ b/test/core/services/sync/changeset_sync_convergence_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -8,6 +10,14 @@ import 'package:submersion/features/dive_log/data/repositories/dive_repository_i
 import '../../../helpers/test_database.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../support/fake_cloud_storage_provider.dart';
+
+/// Base-adoption temp files are named `ssv1_<peer>_<seq>.<uuid>.base` and must
+/// be deleted by the reader after each apply. No `*.base` file should survive a
+/// completed sync.
+Iterable<File> _leakedBaseTempFiles() => Directory.systemTemp
+    .listSync()
+    .whereType<File>()
+    .where((f) => f.path.endsWith('.base'));
 
 /// End-to-end proof that the changeset-log transport converges two devices
 /// through the real merge. One in-memory database stands in for each device in
@@ -47,6 +57,65 @@ void main() {
       row,
       isNotNull,
       reason: "device B must receive device A's dive via changeset sync",
+    );
+    expect(
+      _leakedBaseTempFiles(),
+      isEmpty,
+      reason: 'the reader must delete the streamed base temp file after apply',
+    );
+    await tearDownTestDatabase();
+  });
+
+  test('cold-start adopts a multi-entity base via the streaming path', () async {
+    final cloud = FakeCloudStorageProvider();
+
+    // --- Device A: a small library across several tables, then publish ---
+    await setUpTestDatabase();
+    var svc = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+    final serializerA = SyncDataSerializer();
+    for (var i = 1; i <= 3; i++) {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'm$i', diveNumber: i),
+      );
+    }
+    await serializerA.upsertRecord('diveSites', {
+      'id': 'site-m',
+      'name': 'Manta Point',
+      'description': '',
+      'notes': '',
+      'isShared': false,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    });
+    expect((await svc.performSync()).status, SyncResultStatus.success);
+    await tearDownTestDatabase();
+
+    // --- Device B: fresh DB, adopts A's base through _applyRemoteBaseFile ---
+    await setUpTestDatabase();
+    svc = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+    expect((await svc.performSync()).status, SyncResultStatus.success);
+
+    final db = DatabaseService.instance.database;
+    final diveCount = await db
+        .customSelect("SELECT COUNT(*) AS c FROM dives")
+        .getSingle();
+    expect(diveCount.data['c'], 3, reason: 'all three dives must converge');
+    final site = await db
+        .customSelect("SELECT name FROM dive_sites WHERE id = 'site-m'")
+        .getSingleOrNull();
+    expect(site, isNotNull, reason: 'the dive site must converge');
+    expect(
+      _leakedBaseTempFiles(),
+      isEmpty,
+      reason: 'no base temp file should survive the sync',
     );
     await tearDownTestDatabase();
   });

--- a/test/core/services/sync/sync_base_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_base_streaming_parity_test.dart
@@ -15,9 +15,11 @@ import '../../../helpers/test_database.dart';
 /// Proves the streaming base apply (_applyRemoteBaseFile) produces a
 /// byte-for-byte identical database to the in-memory apply (_applyRemotePayload)
 /// for the same payload. This is the safety net for issue #358: it guarantees
-/// that bounding memory did not change merge behavior, including the
-/// entityHasUpdatedAt flags (every entity below is exercised), BLOB columns,
-/// junctions, and the deletions pass.
+/// that bounding memory did not change merge behavior across a representative
+/// subset of tables -- a parent, clockless children, a junction, a BLOB column,
+/// updatedAt tables, and the deletions pass. (A separate structural test in
+/// this file asserts entityHasUpdatedAt lists every SyncData entity; this parity
+/// test does not seed all of them.)
 
 /// Order-independent snapshot of a SyncData JSON map: each table's rows are
 /// sorted by their JSON so a difference in cross-table insertion order between
@@ -141,6 +143,16 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
   tearDown(() => tearDownTestDatabase());
+
+  test('entityHasUpdatedAt covers exactly the SyncData entities', () {
+    // The streaming apply only applies tables present in entityHasUpdatedAt, so
+    // a SyncData entity missing from the map would be silently dropped on base
+    // import. This locks the map to the entity set.
+    expect(
+      SyncService.entityHasUpdatedAt.keys.toSet(),
+      const SyncData().toJson().keys.toSet(),
+    );
+  });
 
   test('streaming base apply matches in-memory apply byte-for-byte', () async {
     await _seedRichLibrary();

--- a/test/core/services/sync/sync_base_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_base_streaming_parity_test.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Proves the streaming base apply (_applyRemoteBaseFile) produces a
+/// byte-for-byte identical database to the in-memory apply (_applyRemotePayload)
+/// for the same payload. This is the safety net for issue #358: it guarantees
+/// that bounding memory did not change merge behavior, including the
+/// entityHasUpdatedAt flags (every entity below is exercised), BLOB columns,
+/// junctions, and the deletions pass.
+
+/// Order-independent snapshot of a SyncData JSON map: each table's rows are
+/// sorted by their JSON so a difference in cross-table insertion order between
+/// the two apply paths does not register as a mismatch (only data differences
+/// do).
+String _canonical(Map<String, dynamic> dataJson) {
+  final out = <String, dynamic>{};
+  for (final key in dataJson.keys.toList()..sort()) {
+    final list = (dataJson[key] as List).cast<Map<String, dynamic>>();
+    final sorted = [...list]
+      ..sort((a, b) => jsonEncode(a).compareTo(jsonEncode(b)));
+    out[key] = sorted;
+  }
+  return jsonEncode(out);
+}
+
+Future<String> _exportCanonical() async {
+  final export = await SyncDataSerializer().exportData(
+    deviceId: 'snapshot',
+    deletions: const [],
+  );
+  return _canonical(export.data.toJson());
+}
+
+/// Seeds a library spanning parent, clockless-child, junction, BLOB-bearing,
+/// and updatedAt-bearing tables, plus a tombstone, so parity covers every
+/// merge path.
+Future<void> _seedRichLibrary() async {
+  final serializer = SyncDataSerializer();
+  final dives = DiveRepository();
+
+  await dives.createDive(createTestDiveWithBottomTime(id: 'd1', diveNumber: 1));
+  await dives.createDive(createTestDiveWithBottomTime(id: 'd2', diveNumber: 2));
+
+  await serializer.upsertRecord('divers', {
+    'id': 'diver-1',
+    'name': 'Test Diver',
+    'medicalNotes': '',
+    'notes': '',
+    'isDefault': false,
+    'createdAt': 1000,
+    'updatedAt': 1000,
+  });
+  await serializer.upsertRecord('diveSites', {
+    'id': 'site-1',
+    'name': 'Test Site',
+    'description': '',
+    'notes': '',
+    'isShared': false,
+    'createdAt': 1000,
+    'updatedAt': 1000,
+  });
+  await serializer.upsertRecord('species', {
+    'id': 'species-1',
+    'commonName': 'Test Fish',
+    'category': 'fish',
+    'isBuiltIn': false,
+  });
+  await serializer.upsertRecord('siteSpecies', {
+    'id': 'ss-1',
+    'siteId': 'site-1',
+    'speciesId': 'species-1',
+    'notes': 'seen on the wall',
+    'createdAt': 1000,
+  });
+  await serializer.upsertRecord('diveCustomFields', {
+    'id': 'cf-1',
+    'diveId': 'd1',
+    'fieldKey': 'visibility_m',
+    'fieldValue': '20',
+    'sortOrder': 0,
+    'createdAt': 1000,
+  });
+  await serializer.upsertRecord('csvPresets', {
+    'id': 'csv-1',
+    'name': 'Suunto CSV',
+    'presetJson': '{"columns":["date","depth"]}',
+    'createdAt': 1000,
+    'updatedAt': 1000,
+  });
+  await serializer.upsertRecord('viewConfigs', {
+    'id': 'vc-1',
+    'diverId': 'diver-1',
+    'viewMode': 'table',
+    'configJson': '{"columns":["date","depth"]}',
+    'updatedAt': 1000,
+  });
+  await serializer.upsertRecord('fieldPresets', {
+    'id': 'fp-1',
+    'diverId': 'diver-1',
+    'viewMode': 'table',
+    'name': 'Tech Layout',
+    'configJson': '{"fields":["max_depth","cns"]}',
+    'isBuiltIn': false,
+    'createdAt': 1000,
+  });
+  // BLOB-bearing row: exercises the base64 BLOB path through streaming.
+  await serializer.upsertRecord('diveDataSources', {
+    'id': 'ds-1',
+    'diveId': 'd1',
+    'isPrimary': true,
+    'sourceFormat': 'shearwater',
+    'importedAt': 1700000000000,
+    'createdAt': 1700000000000,
+    'rawFingerprint': Uint8List.fromList([0x01, 0x02, 0x03, 0xFE, 0xFF]),
+  });
+
+  // A tombstone so the deletions pass is exercised (best-effort: deleteDive
+  // logs a deletion if the repository does so).
+  await dives.createDive(
+    createTestDiveWithBottomTime(id: 'd3-doomed', diveNumber: 3),
+  );
+  await dives.deleteDive('d3-doomed');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('streaming base apply matches in-memory apply byte-for-byte', () async {
+    await _seedRichLibrary();
+    final payload = await SyncDataSerializer().exportData(
+      deviceId: 'peer',
+      deletions: await SyncRepository().getAllDeletions(),
+    );
+
+    // Phase 1: in-memory apply into a fresh DB.
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final counts1 = await SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+    ).debugApplyPayload(payload);
+    final dump1 = await _exportCanonical();
+
+    // Phase 2: streaming file apply into another fresh DB.
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final tmpDir = await Directory.systemTemp.createTemp('parity');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(
+      utf8.encode(SyncDataSerializer().serializePayload(payload)),
+    );
+    final counts2 = await SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+    ).debugApplyBaseFile(tmp.path);
+    final dump2 = await _exportCanonical();
+    await tmpDir.delete(recursive: true);
+
+    expect(dump2, dump1, reason: 'streaming DB must equal in-memory DB');
+    expect(counts2.recordsApplied, counts1.recordsApplied);
+    expect(counts2.conflictsFound, counts1.conflictsFound);
+    expect(counts2.recordsFailed, counts1.recordsFailed);
+    expect(counts2.recordsFailed, 0, reason: 'no rows should fail to apply');
+  });
+
+  test(
+    'batch boundary (>500 rows of one table) does not change the result',
+    () async {
+      final dives = DiveRepository();
+      for (var i = 1; i <= 600; i++) {
+        await dives.createDive(
+          createTestDiveWithBottomTime(id: 'd$i', diveNumber: i),
+        );
+      }
+      final payload = await SyncDataSerializer().exportData(
+        deviceId: 'peer',
+        deletions: await SyncRepository().getAllDeletions(),
+      );
+
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      await SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+      ).debugApplyPayload(payload);
+      final dumpA = await _exportCanonical();
+
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      final tmpDir = await Directory.systemTemp.createTemp('parity_big');
+      final tmp = File('${tmpDir.path}/base.json');
+      await tmp.writeAsBytes(
+        utf8.encode(SyncDataSerializer().serializePayload(payload)),
+      );
+      await SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+      ).debugApplyBaseFile(tmp.path);
+      final dumpB = await _exportCanonical();
+      await tmpDir.delete(recursive: true);
+
+      expect(dumpB, dumpA);
+    },
+  );
+}

--- a/test/helpers/changeset_test_helpers.dart
+++ b/test/helpers/changeset_test_helpers.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
@@ -9,11 +10,23 @@ import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
 import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 
 import 'test_database.dart';
+
+/// A base-file apply callback for [ChangesetReader.pull] tests: decodes the
+/// streamed temp file and records the payload in [applied], mirroring the spy
+/// used for changesets so existing assertions about applied payloads still
+/// hold. Production routes base files through SyncService._applyRemoteBaseFile.
+ApplyBaseFile spyApplyBaseFile(List<SyncPayload> applied) {
+  return (path, manifest) async {
+    final bytes = await File(path).readAsBytes();
+    applied.add(ChangesetCodec(SyncDataSerializer()).decodeChangeset(bytes));
+  };
+}
 
 /// Test harness for the per-device changeset-log transport (ssv1.* files).
 ///


### PR DESCRIPTION
## Problem

Closes #358. Enabling iCloud sync on iOS crashes the app ~20 s after startup for users with a large library. The debug log shows all 64 base parts (512 MB) download in ~0.6 s, then a ~109 s gap of pure CPU/RAM work, then a silent relaunch — the signature of an **OS-level out-of-memory (jetsam) kill**, not a code crash.

**Root cause:** adopting a peer's sync **base** snapshot materialized the entire database in memory several times over (downloaded parts + reassembled buffer + UTF-16 string + decoded JSON object graph + `rawDataJson` re-encode = multi-GB peak), exceeding iOS's per-app memory limit. DB *restore* never had this problem because it is a file-level byte copy; base adoption built a full Dart object graph.

## Fix

Import the base with **bounded memory**: stream the parts to a temp file, then apply it in three forward passes over that file — (1) `exportedAt` + the `deletions` map, (2) parent-row `id→updatedAt` + contradiction keys (skips the millions of profile rows), (3) batched apply of every row through the **existing per-record merge, unchanged**.

Peak memory for a 512 MB base drops from multi-GB to ~one 8 MB part + one 500-row batch, and **no longer scales with library size**.

- **No wire-format change.** Existing monolithic-JSON bases already in users' iClouds import as-is, with no user action and no desktop re-publish.
- **Merge logic untouched.** `_mergeEntity` is per-record and upsert-only, so feeding it in batches is provably equivalent; BLOB decoding stays inside `upsertRecord`, so streamed `jsonDecode` rows are byte-identical to the old path.

## What changed

- **New** `BaseJsonStreamReader` — a hand-rolled, bounded-memory byte-boundary scanner (no new dependency) that emits top-level scalars and section (`data`/`deletions`) rows without holding the document in memory.
- **New** `BasePartFileSink` — downloads base parts one at a time into a temp file, verifying per-part and whole-file SHA-256 as bytes land (uses a small private `Sink<Digest>`, `Directory.systemTemp`).
- `ChangesetReader` routes the base through a new `applyBaseFile` callback and deletes the temp file afterward; the changeset path is unchanged.
- `SyncService._applyRemoteBaseFile` performs the three-pass apply, reusing `_mergeEntity` / `_applyRemoteDeletions` / FK repair inside the existing deferred-FK transaction.

## Tests

- **Parity (the linchpin):** one rich payload (parent, clockless-child, junction, BLOB, `updatedAt` tables + a tombstone) applied two ways into fresh DBs yields a **byte-for-byte identical** database and identical merge counters; a second case crosses the 500-row batch boundary to prove batching changes nothing.
- Scanner unit tests (chunk-splitting, escapes, nesting, large rows); file-sink unit tests (per-part/missing/whole-file checksum failures, cleanup); deterministic temp-file-cleanup test; multi-entity end-to-end convergence.
- Full sync suite **318 passing**; `dart format` and `flutter analyze` clean.

## Out of scope (tracked follow-ups)

- **Replace-restore adoption** (`_collectEpochPayloads`) has the same OOM class (worse — it holds every device's base plus a full local export) and needs its own streaming orchestration (replace, not merge).
- **Write/publish side** (`BaseChunker.slice(fullBytes)` in `changeset_writer`) will OOM publishing a very large base; it has desktop headroom and isn't the reported crash.

Design + plan: `docs/superpowers/{specs,plans}/2026-06-20-sync-base-oom-streaming-import*`.

> Real-device iOS verification on the reporter's library is still pending; this is verified by tests, not yet on hardware.