### PR TITLE
fix(ble): correct Halcyon Symbios Tx/Rx direction (#288)

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -28,15 +28,20 @@ private val PREFERRED_SERVICE_UUIDS = setOf(
 )
 private val PREFERRED_WRITE_UUIDS = setOf(
     UUID.fromString("6606ab42-89d5-4a00-a8ce-4eb5e1414ee0"),
-    // Halcyon Symbios Tx: the app sends commands here. Its Rx counterpart
-    // (00000101) also advertises write and ties on raw score, so without this
-    // bias the scorer writes to Rx and the device never answers (issue #288).
-    UUID.fromString("00000201-8c3b-4f2c-a59e-8c08224f3253")
+    // Halcyon Symbios: the app writes commands to the device's Rx endpoint
+    // (00000101). Both Symbios characteristics advertise read+write+indicate and
+    // tie on raw score, so a preferred UUID is required to tell them apart. The
+    // Tx/Rx names are device-centric: Subsurface's qt-ble.cpp writes commands to
+    // 00000101 ("Rx") and reads replies from 00000201 ("Tx"). PR #356 mapped
+    // these backwards and the device never answered (issue #288).
+    UUID.fromString("00000101-8c3b-4f2c-a59e-8c08224f3253")
 )
 private val PREFERRED_NOTIFY_UUIDS = setOf(
     UUID.fromString("a60b8e5c-b267-44d7-9764-837caf96489e"),
-    // Halcyon Symbios Rx: the device sends replies here via indications.
-    UUID.fromString("00000101-8c3b-4f2c-a59e-8c08224f3253")
+    // Halcyon Symbios: the device transmits replies on its Tx endpoint
+    // (00000201) via indications; the app writes commands on 00000101 (see
+    // PREFERRED_WRITE_UUIDS and issue #288).
+    UUID.fromString("00000201-8c3b-4f2c-a59e-8c08224f3253")
 )
 
 // Bridges Android BLE GATT communication to libdivecomputer's synchronous

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleCharacteristicSelector.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleCharacteristicSelector.swift
@@ -50,17 +50,23 @@ enum BleCharacteristicSelector {
     static let preferredWriteUUIDs: Set<CBUUID> = [
         // Pelagic gen1 (Aqualung i330R / Apeks DSX) command characteristic.
         CBUUID(string: "6606AB42-89D5-4A00-A8CE-4EB5E1414EE0"),
-        // Halcyon Symbios Tx: the app sends commands here. Its Rx counterpart
-        // (00000101) also advertises write and ties on raw score, so without
-        // this bias the scorer writes to Rx and the device never answers
-        // (issue #288).
-        CBUUID(string: "00000201-8C3B-4F2C-A59E-8C08224F3253"),
+        // Halcyon Symbios: the app writes commands to the device's Rx endpoint
+        // (00000101). Both Symbios characteristics advertise read+write+indicate
+        // and tie on raw score, so a preferred UUID is required to tell them
+        // apart. The Tx/Rx names are device-centric: Subsurface's qt-ble.cpp
+        // writes commands to 00000101 ("Rx") and reads replies from 00000201
+        // ("Tx"). PR #356 mapped these backwards -- it wrote to 00000201, which
+        // the device accepts at the ATT layer but never answers -- so downloads
+        // timed out with result=-7 (issue #288).
+        CBUUID(string: "00000101-8C3B-4F2C-A59E-8C08224F3253"),
     ]
 
     static let preferredNotifyUUIDs: Set<CBUUID> = [
         CBUUID(string: "A60B8E5C-B267-44D7-9764-837CAF96489E"),
-        // Halcyon Symbios Rx: the device sends replies here via indications.
-        CBUUID(string: "00000101-8C3B-4F2C-A59E-8C08224F3253"),
+        // Halcyon Symbios: the device transmits replies on its Tx endpoint
+        // (00000201) via indications; the app writes commands on 00000101 (see
+        // preferredWriteUUIDs and issue #288).
+        CBUUID(string: "00000201-8C3B-4F2C-A59E-8C08224F3253"),
     ]
 
     /// Score a write candidate, or nil if the characteristic cannot be written.

--- a/packages/libdivecomputer_plugin/darwin/Tests/BleCharacteristicSelectorTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/BleCharacteristicSelectorTests/main.swift
@@ -41,27 +41,32 @@ let halcyonTx = "00000201-8C3B-4F2C-A59E-8C08224F3253"
 let pelagicWrite = "6606AB42-89D5-4A00-A8CE-4EB5E1414EE0"
 let preferredService = "CB3C4555-D670-4670-BC20-B61DBC851E9A"
 
-// 1. Halcyon Symbios (issue #288): Rx (00000101: read+write+indicate, app
-// receives replies) and Tx (00000201: write, app sends commands). Both
-// advertise plain write and tie on raw score, with Rx at the lower handle, so
-// the generic scorer would pick Rx for writing and the device never answers.
-// Commands must go to Tx; replies must be read from Rx.
+// 1. Halcyon Symbios (issue #288). On a real device BOTH characteristics
+// advertise read+write+indicate (confirmed by the GATT discovery log on the
+// issue), so the raw write/notify scores tie and a preferred UUID must decide
+// the pair. The Tx/Rx names are device-centric -- Subsurface's qt-ble.cpp
+// labels 00000101 "Rx" and 00000201 "Tx" and writes commands to the device's
+// Rx while reading replies from the device's Tx. So the app must WRITE to
+// 00000101 (halcyonRx) and SUBSCRIBE on 00000201 (halcyonTx). PR #356 mapped
+// these backwards (wrote to Tx, listened on Rx); the device received the write
+// at the ATT layer but never answered (result=-7). This asserts the corrected
+// mapping that matches the known-working Subsurface implementation.
 do {
     let services = [
         BleCharacteristicSelector.Service(
             uuid: CBUUID(string: halcyonService),
             characteristics: [
                 char(halcyonRx, [.read, .write, .indicate]),
-                char(halcyonTx, [.write]),
+                char(halcyonTx, [.read, .write, .indicate]),
             ]
         )
     ]
     let result = resolve(services, BleCharacteristicSelector.select(services: services))
-    expect(result?.write == CBUUID(string: halcyonTx),
-           "halcyon: command write characteristic is Tx (00000201), "
+    expect(result?.write == CBUUID(string: halcyonRx),
+           "halcyon: app writes commands to the device Rx (00000101), "
                + "got \(result?.write.uuidString ?? "nil")")
-    expect(result?.notify == CBUUID(string: halcyonRx),
-           "halcyon: notify characteristic is Rx (00000101), "
+    expect(result?.notify == CBUUID(string: halcyonTx),
+           "halcyon: app reads replies from the device Tx (00000201), "
                + "got \(result?.notify.uuidString ?? "nil")")
 }
 

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -11,9 +11,12 @@ static const char* PREFERRED_WRITE_UUID =
     "6606ab42-89d5-4a00-a8ce-4eb5e1414ee0";
 static const char* PREFERRED_NOTIFY_UUID =
     "a60b8e5c-b267-44d7-9764-837caf96489e";
-// Halcyon Symbios Tx (commands) and Rx (replies via indications). Rx also
-// advertises write and ties with Tx on raw score, so without this bias the
-// scorer may write to Rx and the device never answers (issue #288).
+// Halcyon Symbios device-centric Tx/Rx endpoints. The app WRITES commands to
+// the device's Rx (00000101) and READS replies (indications) from its Tx
+// (00000201) -- matching Subsurface's qt-ble.cpp. Both chars advertise
+// read+write+indicate and tie on raw score, so these biases pick the pair.
+// PR #356 biased them backwards (wrote to Tx) and the device never answered
+// (issue #288).
 static const char* HALCYON_SYMBIOS_TX_UUID =
     "00000201-8c3b-4f2c-a59e-8c08224f3253";
 static const char* HALCYON_SYMBIOS_RX_UUID =
@@ -237,7 +240,7 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
             if (can_write_no_rsp) ws += 4;
             if (can_write) ws += 2;
             if (g_ascii_strcasecmp(uuid, PREFERRED_WRITE_UUID) == 0 ||
-                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_TX_UUID) == 0) {
+                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_RX_UUID) == 0) {
                 ws += 1000;
             }
             if (ws > best_write_score) {
@@ -256,7 +259,7 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
             if (can_notify) ns += 4;
             if (can_indicate) ns += 2;
             if (g_ascii_strcasecmp(uuid, PREFERRED_NOTIFY_UUID) == 0 ||
-                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_RX_UUID) == 0) {
+                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_TX_UUID) == 0) {
                 ns += 1000;
             }
             if (ns > best_notify_score) {

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -20,9 +20,12 @@ const winrt::guid BleIoStream::kPreferredWriteUuid{
 const winrt::guid BleIoStream::kPreferredNotifyUuid{
     0xA60B8E5C, 0xB267, 0x44D7,
     {0x97, 0x64, 0x83, 0x7C, 0xAF, 0x96, 0x48, 0x9E}};
-// Halcyon Symbios Tx (commands) and Rx (replies via indications). Rx also
-// advertises write and ties with Tx on raw score, so without this bias the
-// scorer may write to Rx and the device never answers (issue #288).
+// Halcyon Symbios device-centric Tx/Rx endpoints. The app WRITES commands to
+// the device's Rx (00000101) and READS replies (indications) from its Tx
+// (00000201) -- matching Subsurface's qt-ble.cpp. Both chars advertise
+// read+write+indicate and tie on raw score, so these biases pick the pair.
+// PR #356 biased them backwards (wrote to Tx) and the device never answered
+// (issue #288).
 const winrt::guid BleIoStream::kHalcyonSymbiosTxUuid{
     0x00000201, 0x8C3B, 0x4F2C,
     {0xA5, 0x9E, 0x8C, 0x08, 0x22, 0x4F, 0x32, 0x53}};
@@ -101,7 +104,7 @@ bool BleIoStream::DiscoverCharacteristics() {
                     ws += 2;
                 }
                 if (ch.Uuid() == kPreferredWriteUuid ||
-                    ch.Uuid() == kHalcyonSymbiosTxUuid) {
+                    ch.Uuid() == kHalcyonSymbiosRxUuid) {
                     ws += 1000;
                 }
                 if (ws > best_write_score) {
@@ -125,7 +128,7 @@ bool BleIoStream::DiscoverCharacteristics() {
                     ns += 2;
                 }
                 if (ch.Uuid() == kPreferredNotifyUuid ||
-                    ch.Uuid() == kHalcyonSymbiosRxUuid) {
+                    ch.Uuid() == kHalcyonSymbiosTxUuid) {
                     ns += 1000;
                 }
                 if (ns > best_notify_score) {


### PR DESCRIPTION
## Summary

Follow-up to #356, which addressed the Halcyon Symbios download timeout (#288) but **mapped the Tx/Rx characteristics backwards**. Fresh logs on the issue show the previous build still failing with `result=-7`.

The Tx/Rx names on the Symbios are **device-centric**:
- `00000201` ("Tx") is the channel the **device transmits** on -> the app must **subscribe** here.
- `00000101` ("Rx") is where the **device receives** -> the app must **write commands** here.

PR #356 read "Tx = where the app sends" and biased `write -> 00000201`, `notify -> 00000101`. Because both characteristics advertise `read,write,indicate`, the ATT write to `00000201` is ACK'd at the link layer, but the device never acts on a command sent to its own transmit channel and sends no reply — hence the 3000 ms read timeout and `result=-7`.

The correct mapping (confirmed against Subsurface's `core/qt-ble.cpp` `skip_characteristics`, the known-working implementation for this device) is **write -> `00000101`, read/notify -> `00000201`**.

## Evidence (from the two logs on #288)

| Build | Write char | Notify char | Result |
|-------|-----------|-------------|--------|
| Pre-#356 | `00000101` ✓ | `00000101` ✗ (collapsed onto one char) | -7 |
| #356 (current) | `00000201` ✗ | `00000101` ✗ | -7 |
| **This PR** | **`00000101`** | **`00000201`** | matches Subsurface |

#356's insight — that write and notify must be *different* characteristics — was correct; only the assignment was inverted.

## Changes

Swapped the preferred-UUID bias on all four native characteristic scorers:

- `darwin/.../BleCharacteristicSelector.swift` (macOS + iOS)
- `android/.../BleIoStream.kt`
- `windows/ble_io_stream.cc`
- `linux/ble_io_stream.c`

Plus the Darwin standalone selector test (`Tests/BleCharacteristicSelectorTests/main.swift`): rewritten to model the **real** device — both characteristics advertise `read,write,indicate`, so raw scores tie and the preferred UUID is what decides — and to assert `write == 00000101` / `notify == 00000201`. The old test cheated by modeling `00000201` as write-only, which hid the ambiguity.

## Testing

- Darwin native suite (`darwin/run_native_tests.sh`): rewrote the assertion (RED), applied the swap (GREEN), **17/17 native tests pass**.
- No Dart changed; the Dart analyze/test suites are unaffected.
- Windows/Linux/Android edits are pure identifier swaps mirroring the proven Darwin logic (not buildable on the dev host; CI covers them).

## Note

Not using a `Closes #288` keyword on purpose: this is the second attempt at the Tx/Rx direction, so the issue should stay open until the reporter confirms an end-to-end download on real hardware.

A possible future hardening (intentionally **not** in this PR, to keep it minimal): mirror Subsurface and accept notification data from any characteristic in the service, making the transport robust to this class of Tx/Rx confusion.