### PR TITLE
fix(ble): identify Scubapro G2 HUD instead of Aladin Sport Matrix (#285)

### DIFF
--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -107,6 +107,39 @@ static int strcasecmp_nospace(const char *a, const char *b) {
     return 0;
 }
 
+// Some Scubapro/Uwatec dive computers advertise a short BLE name that differs
+// from the libdivecomputer product string. dc_filter_uwatec matches each such
+// alias against EVERY Uwatec/Scubapro descriptor, so the family-level fallback
+// in libdc_descriptor_match reports the first one ("Aladin Sport Matrix",
+// model 0x17) for all of them. strcasecmp_nospace can't bridge the gap because
+// the alias is not just a spacing variant of the product (e.g. "HUD" vs
+// "G2 HUD", "Galileo 3" vs "G3"). Map the known aliases to their specific
+// model code so the exact-model preference in the matcher picks the right
+// descriptor. The alias strings are exactly the BLE names from
+// dc_filter_uwatec's match list; the model codes are from descriptor.c.
+// Regression for issue #285 (G2 HUD advertised as "HUD"). Returns 0 (not a
+// valid model in the table) when the name is not a known alias.
+static unsigned int uwatec_ble_alias_model(const char *name) {
+    static const struct {
+        const char *alias;
+        unsigned int model;
+    } aliases[] = {
+        {"HUD", 0x42},       // G2 HUD
+        {"Galileo 3", 0x34}, // G3
+        {"A1", 0x25},        // Aladin A1
+        {"A2", 0x28},        // Aladin A2
+    };
+    if (name == NULL) {
+        return 0;
+    }
+    for (size_t i = 0; i < sizeof(aliases) / sizeof(aliases[0]); i++) {
+        if (strcasecmp_nospace(name, aliases[i].alias) == 0) {
+            return aliases[i].model;
+        }
+    }
+    return 0;
+}
+
 int libdc_descriptor_match(const char *name, unsigned int transport,
                            libdc_descriptor_info_t *info) {
     if (name == NULL || info == NULL) {
@@ -146,6 +179,18 @@ int libdc_descriptor_match(const char *name, unsigned int transport,
                 name_model = ((unsigned int)c0 << 8) | (unsigned int)c1;
                 has_name_model = 1;
             }
+        }
+    }
+
+    // Scubapro/Uwatec short BLE aliases (e.g. "HUD" for "G2 HUD") that differ
+    // from the libdivecomputer product name. Resolving them to a specific model
+    // lets the exact-model preference in the loop below pick the right
+    // descriptor instead of the first family-level fallback. See issue #285.
+    if (!has_name_model && (transport & LIBDC_TRANSPORT_BLE)) {
+        unsigned int alias_model = uwatec_ble_alias_model(name);
+        if (alias_model != 0) {
+            name_model = alias_model;
+            has_name_model = 1;
         }
     }
 

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -33,7 +33,27 @@ target_include_directories(test_descriptor_matcher PRIVATE
     ${CONFIG_DIR}
 )
 
+# Integration test: links the real libdivecomputer descriptor table so it
+# exercises libdc_descriptor_match end-to-end (BLE name -> descriptor). The
+# minimal source set below is everything the matcher transitively needs from
+# libdivecomputer.
+add_executable(test_descriptor_match_integration
+    test_descriptor_match_integration.c
+    ${WRAPPER_DIR}/libdc_wrapper.c
+    ${LIBDC_DIR}/src/descriptor.c
+    ${LIBDC_DIR}/src/iterator.c
+    ${LIBDC_DIR}/src/array.c
+    ${LIBDC_DIR}/src/platform.c
+    ${LIBDC_DIR}/src/version.c
+)
+target_include_directories(test_descriptor_match_integration PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${CONFIG_DIR}
+)
+
 enable_testing()
 add_test(NAME test_dive_converter COMMAND test_dive_converter)
 add_test(NAME test_serial_callbacks COMMAND test_serial_callbacks)
 add_test(NAME test_descriptor_matcher COMMAND test_descriptor_matcher)
+add_test(NAME test_descriptor_match_integration COMMAND test_descriptor_match_integration)

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -1,0 +1,90 @@
+// Integration test for libdc_descriptor_match against the REAL libdivecomputer
+// descriptor table. Unlike test_descriptor_matcher.c (which unit-tests the
+// strcasecmp_nospace helper in isolation), this test links the actual
+// descriptor.c so it exercises end-to-end BLE name -> descriptor resolution.
+//
+// Regression for issue #285: the Scubapro Galileo HUD advertises the short BLE
+// name "HUD", but dc_filter_uwatec matches that alias against EVERY Uwatec/
+// Scubapro descriptor. Without an alias->model mapping, the matcher falls back
+// to the first family-level descriptor ("Aladin Sport Matrix", model 0x17)
+// instead of the real model ("G2 HUD", model 0x42). The same alias-vs-product
+// gap affects "Galileo 3" (product "G3"), "A1" ("Aladin A1") and "A2"
+// ("Aladin A2"). Model codes below come from descriptor.c.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "libdc_wrapper.h"
+
+static void expect_ble_match(const char *name, const char *expected_product,
+                             unsigned int expected_model) {
+    libdc_descriptor_info_t info;
+    memset(&info, 0, sizeof(info));
+    int ok = libdc_descriptor_match(name, LIBDC_TRANSPORT_BLE, &info);
+    if (!ok) {
+        fprintf(stderr, "FAIL: \"%s\" did not match any descriptor\n", name);
+        assert(ok);
+    }
+    if (strcmp(info.product, expected_product) != 0 ||
+        info.model != expected_model) {
+        fprintf(stderr,
+                "FAIL: \"%s\" resolved to %s/0x%02x, expected %s/0x%02x\n",
+                name, info.product, info.model, expected_product,
+                expected_model);
+        assert(0);
+    }
+}
+
+// The reported device: BLE name "HUD" must resolve to the G2 HUD (0x42),
+// not the family-level "Aladin Sport Matrix" fallback (0x17).
+static void test_hud_resolves_to_g2_hud(void) {
+    expect_ble_match("HUD", "G2 HUD", 0x42);
+    printf("PASS: test_hud_resolves_to_g2_hud\n");
+}
+
+// Same alias-vs-product gap for the other short Scubapro/Uwatec BLE names.
+static void test_other_short_aliases_resolve(void) {
+    expect_ble_match("Galileo 3", "G3", 0x34);
+    expect_ble_match("A1", "Aladin A1", 0x25);
+    expect_ble_match("A2", "Aladin A2", 0x28);
+    printf("PASS: test_other_short_aliases_resolve\n");
+}
+
+// Aliases are case-insensitive (BLE advertised names vary by stack/firmware).
+static void test_alias_match_is_case_insensitive(void) {
+    expect_ble_match("hud", "G2 HUD", 0x42);
+    expect_ble_match("a1", "Aladin A1", 0x25);
+    printf("PASS: test_alias_match_is_case_insensitive\n");
+}
+
+// Regression guard: names whose product string already matches exactly must
+// keep resolving to themselves and must NOT be captured by the alias table.
+static void test_exact_product_names_unchanged(void) {
+    expect_ble_match("G2", "G2", 0x32);
+    expect_ble_match("G2 TEK", "G2 TEK", 0x31);
+    expect_ble_match("Luna 2.0", "Luna 2.0", 0x51);
+    expect_ble_match("Luna 2.0 AI", "Luna 2.0 AI", 0x50);
+    printf("PASS: test_exact_product_names_unchanged\n");
+}
+
+// Regression guard: a non-Uwatec device (different vendor/filter) is unaffected.
+static void test_non_uwatec_device_unaffected(void) {
+    libdc_descriptor_info_t info;
+    memset(&info, 0, sizeof(info));
+    int ok = libdc_descriptor_match("Teric", LIBDC_TRANSPORT_BLE, &info);
+    assert(ok);
+    assert(strcmp(info.vendor, "Shearwater") == 0);
+    assert(strcmp(info.product, "Teric") == 0);
+    printf("PASS: test_non_uwatec_device_unaffected\n");
+}
+
+int main(void) {
+    test_hud_resolves_to_g2_hud();
+    test_other_short_aliases_resolve();
+    test_alias_match_is_case_insensitive();
+    test_exact_product_names_unchanged();
+    test_non_uwatec_device_unaffected();
+    printf("\nAll descriptor match integration tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

The Scubapro Galileo HUD (G2 HUD) is identified over BLE as **"Aladin Sport Matrix"** (issue #285). Root cause: the HUD advertises the short BLE name `HUD`, but libdivecomputer's product string is `G2 HUD`. `dc_filter_uwatec` matches every Uwatec/Scubapro alias against *every* descriptor in the family, so `libdc_descriptor_match`'s exact-product tiebreaker missed (`"HUD" != "G2 HUD"`) and fell back to the first family entry — Aladin Sport Matrix (model `0x17` = 23, the "23" in the reporter's logs).

The same alias-vs-product gap affected other short names, corrected here too:

| BLE alias | before | after |
|---|---|---|
| `HUD` | Aladin Sport Matrix (0x17) | **G2 HUD (0x42)** |
| `Galileo 3` | Aladin Sport Matrix (0x17) | **G3 (0x34)** |
| `A1` / `A2` | Aladin Sport Matrix (0x17) | **Aladin A1 (0x25) / A2 (0x28)** |

Names that already match their product (`G2`, `G2 TEK`, `Luna 2.0`, `Luna 2.0 AI`) and non-Uwatec devices are unaffected.

## Implementation

`uwatec_ble_alias_model()` in the shared `libdc_wrapper.c` maps the known aliases to a specific model, feeding the matcher's existing exact-model preference (the mechanism already used for Pelagic devices). One shared C file covers macOS, iOS, Android, Linux, and Windows.

## Tests

New `test_descriptor_match_integration.c` links the **real** libdivecomputer descriptor table and asserts end-to-end BLE-name -> descriptor resolution. It fails before this change (`HUD -> Aladin Sport Matrix/0x17`) and passes after. Wired into the native ctest suite; all 4 native tests green.

## Scope - what this does NOT fix

- **Intermittent BLE download failures (`-7`/`-8`)** in #285 are a *separate*, hardware-dependent transport/device-state issue. This naming fix is cosmetic to the download: the `uwatec_smart` driver reads the model from the device, and the parser treats `0x17` and `0x42` identically (same `switch` case) — which is why Android test 1 in the issue fully succeeded. Suggested follow-ups (Android `requestConnectionPriority(HIGH)`, power-cycle-before-retry UX) need the reporter's hardware to verify.
- **USB "Invalid device address"** is covered by #364.

Partially addresses #285 (the misidentification only); leaving the issue open for the download failures.