### PR TITLE
fix(android): SAF-backed backups + custom DB location under scoped storage (#300)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-android-saf-backup-and-db-location.md
+++ b/docs/superpowers/plans/2026-06-21-android-saf-backup-and-db-location.md
@@ -1,0 +1,1438 @@
+# Android SAF backups + DB-location fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make manual and automatic backups, and the custom database location, work on Android 11+ (scoped storage) — fixing issue #300.
+
+**Architecture:** Backups to a user-chosen folder go through the Storage Access Framework (a new in-repo `submersion_saf` Flutter plugin: persisted `content://` tree URI + `DocumentFile` streamed writes), routed via a `BackupTarget` abstraction so the existing filesystem path is untouched. The live database — which SQLite must open by real path — relocates to an app-specific external dir (internal or SD card) via `path_provider`, reusing the existing path-based migration machinery.
+
+**Tech Stack:** Flutter, Dart, Kotlin (`androidx.documentfile`), `path_provider`, MethodChannel, Workmanager.
+
+## Global Constraints
+
+- Android-only behavior. Every new code path is gated on `Platform.isAndroid`; `submersion_saf` declares only the `android` platform.
+- No third-party SAF library; no `MANAGE_EXTERNAL_STORAGE` permission.
+- Preserve existing branches verbatim for iOS / macOS / Windows / Linux (see spec §3.1 table). A non-`content://` backup ref must always take the pre-existing filesystem path.
+- SAF MethodChannel name: `app.submersion/saf`. Plugin Kotlin package: `app.submersion.saf`.
+- Plugin gradle: `minSdk = 21`, `compileSdk = 34` (match `packages/libdivecomputer_plugin`).
+- `dart format .` clean and `flutter analyze` (whole project) clean before each commit.
+- New user-facing strings added to `lib/l10n/arb/app_en.arb` AND all 10 non-en locale ARBs, then `flutter gen-l10n` run — never leave English fallbacks.
+- Do not auto-commit outside these tasks; each task ends with one commit on branch `worktree-worktree-issue-300-android-backup`.
+
+Spec: `docs/superpowers/specs/2026-06-20-android-saf-backup-and-db-location-design.md`
+
+---
+
+## File Structure
+
+New (plugin):
+- `packages/submersion_saf/pubspec.yaml` — Android-only plugin manifest
+- `packages/submersion_saf/android/build.gradle`
+- `packages/submersion_saf/android/src/main/AndroidManifest.xml`
+- `packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt`
+- `packages/submersion_saf/lib/submersion_saf.dart` — Dart facade
+
+New (app):
+- `lib/features/backup/data/services/backup_saf_port.dart` — `BackupSafPort` seam + channel impl
+- `lib/features/backup/data/services/backup_target.dart` — `BackupTarget`, `FilesystemBackupTarget`, `SafBackupTarget`, `isSafRef`, `BackupTargetLease`
+- `test/.../submersion_saf_facade_test.dart`, `backup_target_test.dart`, `backup_target_lease_test.dart`, `backup_service_saf_refs_test.dart`, `database_location_external_dirs_test.dart`
+
+Modified (app):
+- `pubspec.yaml` — add `submersion_saf` path dep
+- `lib/features/backup/data/services/backup_service.dart` — inject `BackupSafPort`; add `resolveBackupTargetLeased`; rewire `performBackup`; ref-aware size/restore/delete/history
+- `lib/features/backup/data/repositories/backup_preferences.dart` — `backup_location_label` get/set
+- `lib/features/backup/presentation/providers/backup_providers.dart` — Saf location setter
+- `lib/features/backup/presentation/pages/backup_settings_page.dart` — Android SAF picker branch + label subtitle
+- `lib/core/services/database_location_service.dart` — Android external-dir chooser; fix stale comment
+- `lib/l10n/arb/*.arb` — DB-location strings
+
+---
+
+# Part A — SAF backups
+
+## Task A1: Scaffold the `submersion_saf` plugin (Android-only)
+
+**Files:**
+- Create: `packages/submersion_saf/pubspec.yaml`
+- Create: `packages/submersion_saf/android/build.gradle`
+- Create: `packages/submersion_saf/android/src/main/AndroidManifest.xml`
+- Create: `packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt`
+- Create: `packages/submersion_saf/lib/submersion_saf.dart`
+- Modify: `pubspec.yaml` (app, dependencies)
+
+**Interfaces:**
+- Produces (Dart facade, used by A2 and the settings page):
+  - `class SafFolder { final String uri; final String displayName; }`
+  - `SubmersionSaf.pickFolder() -> Future<SafFolder?>`
+  - `SubmersionSaf.writeBackup({required String treeUri, required String fileName, required String sourcePath}) -> Future<String>` (document URI)
+  - `SubmersionSaf.readBackup({required String documentUri, required String destPath}) -> Future<void>`
+  - `SubmersionSaf.delete(String documentUri) -> Future<bool>`
+  - `SubmersionSaf.exists(String documentUri) -> Future<bool>`
+  - `SubmersionSaf.resolveTree(String treeUri) -> Future<String?>`
+
+- [ ] **Step 1: Create the plugin pubspec**
+
+`packages/submersion_saf/pubspec.yaml`:
+```yaml
+name: submersion_saf
+description: Android Storage Access Framework helpers (persisted tree URIs, DocumentFile writes) for Submersion backups.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.10.0
+  flutter: ">=3.10.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: app.submersion.saf
+        pluginClass: SubmersionSafPlugin
+```
+
+- [ ] **Step 2: Create the plugin gradle** (mirrors `packages/libdivecomputer_plugin/android/build.gradle`, minus NDK/CMake)
+
+`packages/submersion_saf/android/build.gradle`:
+```gradle
+group = "app.submersion.saf"
+version = "0.1.0"
+
+buildscript {
+    repositories { google(); mavenCentral() }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+    }
+}
+
+rootProject.allprojects {
+    repositories { google(); mavenCentral() }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    namespace = "app.submersion.saf"
+    compileSdk = 34
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions { jvmTarget = "1.8" }
+    defaultConfig { minSdk = 21 }
+    sourceSets { main.java.srcDirs += "src/main/kotlin" }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.22"
+    implementation "androidx.documentfile:documentfile:1.0.1"
+}
+```
+
+- [ ] **Step 3: Create the plugin manifest**
+
+`packages/submersion_saf/android/src/main/AndroidManifest.xml`:
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+- [ ] **Step 4: Create the native plugin** (FlutterPlugin + ActivityAware; write/read/delete/exists/resolveTree use applicationContext so they work in the Workmanager isolate; pickFolder needs the Activity)
+
+`packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt`:
+```kotlin
+package app.submersion.saf
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
+import java.io.File
+
+private const val CHANNEL = "app.submersion/saf"
+private const val OPEN_TREE_REQUEST = 0xC0DE
+
+class SubmersionSafPlugin :
+    FlutterPlugin,
+    ActivityAware,
+    MethodChannel.MethodCallHandler,
+    PluginRegistry.ActivityResultListener {
+
+    private lateinit var context: Context
+    private lateinit var channel: MethodChannel
+    private var activity: Activity? = null
+    private var activityBinding: ActivityPluginBinding? = null
+    private var pendingPick: MethodChannel.Result? = null
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        context = binding.applicationContext
+        channel = MethodChannel(binding.binaryMessenger, CHANNEL)
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+        activityBinding = binding
+        binding.addActivityResultListener(this)
+    }
+
+    override fun onDetachedFromActivity() {
+        activityBinding?.removeActivityResultListener(this)
+        activity = null
+        activityBinding = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(b: ActivityPluginBinding) = onAttachedToActivity(b)
+    override fun onDetachedFromActivityForConfigChanges() = onDetachedFromActivity()
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "pickFolder" -> pickFolder(result)
+            "writeBackup" -> writeBackup(call, result)
+            "readBackup" -> readBackup(call, result)
+            "delete" -> delete(call, result)
+            "exists" -> exists(call, result)
+            "resolveTree" -> resolveTree(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun pickFolder(result: MethodChannel.Result) {
+        val act = activity ?: return result.error("NO_ACTIVITY", "No foreground activity", null)
+        if (pendingPick != null) return result.error("BUSY", "A pick is already in progress", null)
+        pendingPick = result
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION,
+            )
+        }
+        act.startActivityForResult(intent, OPEN_TREE_REQUEST)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode != OPEN_TREE_REQUEST) return false
+        val result = pendingPick ?: return true
+        pendingPick = null
+        val uri = data?.data
+        if (resultCode != Activity.RESULT_OK || uri == null) {
+            result.success(null)
+            return true
+        }
+        return try {
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            context.contentResolver.takePersistableUriPermission(uri, flags)
+            val name = DocumentFile.fromTreeUri(context, uri)?.name ?: ""
+            result.success(mapOf("uri" to uri.toString(), "displayName" to name))
+            true
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.localizedMessage, null)
+            true
+        }
+    }
+
+    private fun writeBackup(call: MethodCall, result: MethodChannel.Result) {
+        val treeUri = call.argument<String>("treeUri")!!
+        val fileName = call.argument<String>("fileName")!!
+        val sourcePath = call.argument<String>("sourcePath")!!
+        try {
+            val tree = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+                ?: return result.error("NO_TREE", "Tree URI did not resolve", null)
+            // Replace an existing same-name file so retries don't accumulate "(1)" copies.
+            tree.findFile(fileName)?.delete()
+            val doc = tree.createFile("application/octet-stream", fileName)
+                ?: return result.error("CREATE_FAILED", "createFile returned null", null)
+            context.contentResolver.openOutputStream(doc.uri).use { out ->
+                if (out == null) return result.error("OPEN_FAILED", "openOutputStream null", null)
+                File(sourcePath).inputStream().use { it.copyTo(out) }
+            }
+            result.success(doc.uri.toString())
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.localizedMessage, null)
+        } catch (e: Exception) {
+            result.error("WRITE_FAILED", e.localizedMessage, null)
+        }
+    }
+
+    private fun readBackup(call: MethodCall, result: MethodChannel.Result) {
+        val documentUri = call.argument<String>("documentUri")!!
+        val destPath = call.argument<String>("destPath")!!
+        try {
+            context.contentResolver.openInputStream(Uri.parse(documentUri)).use { input ->
+                if (input == null) return result.error("OPEN_FAILED", "openInputStream null", null)
+                File(destPath).outputStream().use { input.copyTo(it) }
+            }
+            result.success(null)
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.localizedMessage, null)
+        } catch (e: Exception) {
+            result.error("READ_FAILED", e.localizedMessage, null)
+        }
+    }
+
+    private fun delete(call: MethodCall, result: MethodChannel.Result) {
+        val documentUri = call.argument<String>("documentUri")!!
+        val ok = try {
+            DocumentFile.fromSingleUri(context, Uri.parse(documentUri))?.delete() ?: false
+        } catch (_: Exception) { false }
+        result.success(ok)
+    }
+
+    private fun exists(call: MethodCall, result: MethodChannel.Result) {
+        val documentUri = call.argument<String>("documentUri")!!
+        val ok = try {
+            DocumentFile.fromSingleUri(context, Uri.parse(documentUri))?.exists() ?: false
+        } catch (_: Exception) { false }
+        result.success(ok)
+    }
+
+    private fun resolveTree(call: MethodCall, result: MethodChannel.Result) {
+        val treeUri = call.argument<String>("treeUri")!!
+        val name = try {
+            val df = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            if (df != null && df.exists() && df.canWrite()) (df.name ?: "") else null
+        } catch (_: Exception) { null }
+        result.success(name)
+    }
+}
+```
+
+- [ ] **Step 5: Create the Dart facade**
+
+`packages/submersion_saf/lib/submersion_saf.dart`:
+```dart
+import 'package:flutter/services.dart';
+
+/// A picked SAF directory: the persisted tree URI and its human display name.
+class SafFolder {
+  const SafFolder({required this.uri, required this.displayName});
+  final String uri;
+  final String displayName;
+}
+
+/// Thin Dart facade over the Android `app.submersion/saf` channel.
+///
+/// Android-only. Callers MUST guard with `Platform.isAndroid`; on other
+/// platforms the channel has no handler and calls throw MissingPluginException.
+class SubmersionSaf {
+  const SubmersionSaf._();
+  static const MethodChannel _channel = MethodChannel('app.submersion/saf');
+
+  static Future<SafFolder?> pickFolder() async {
+    final res = await _channel.invokeMapMethod<String, dynamic>('pickFolder');
+    if (res == null) return null;
+    return SafFolder(
+      uri: res['uri'] as String,
+      displayName: res['displayName'] as String,
+    );
+  }
+
+  static Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) async {
+    final uri = await _channel.invokeMethod<String>('writeBackup', {
+      'treeUri': treeUri,
+      'fileName': fileName,
+      'sourcePath': sourcePath,
+    });
+    return uri!;
+  }
+
+  static Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) =>
+      _channel.invokeMethod<void>('readBackup', {
+        'documentUri': documentUri,
+        'destPath': destPath,
+      });
+
+  static Future<bool> delete(String documentUri) async =>
+      await _channel.invokeMethod<bool>('delete', {'documentUri': documentUri}) ??
+      false;
+
+  static Future<bool> exists(String documentUri) async =>
+      await _channel.invokeMethod<bool>('exists', {'documentUri': documentUri}) ??
+      false;
+
+  static Future<String?> resolveTree(String treeUri) =>
+      _channel.invokeMethod<String?>('resolveTree', {'treeUri': treeUri});
+}
+```
+
+- [ ] **Step 6: Add the path dependency to the app** — in `pubspec.yaml`, under `dependencies:`, beside the existing `libdivecomputer_plugin`:
+```yaml
+  submersion_saf:
+    path: packages/submersion_saf
+```
+
+- [ ] **Step 7: Resolve, analyze, build**
+
+Run: `flutter pub get`
+Expected: resolves; `submersion_saf` linked.
+
+Run: `flutter analyze`
+Expected: No issues.
+
+Run: `flutter build apk --debug`
+Expected: BUILD SUCCESSFUL (proves the plugin + `GeneratedPluginRegistrant` compile on Android).
+
+- [ ] **Step 8: Commit**
+```bash
+git add packages/submersion_saf pubspec.yaml pubspec.lock docs/superpowers
+git commit -m "feat(android): scaffold submersion_saf plugin for SAF backups (#300)"
+```
+
+---
+
+## Task A2: `BackupSafPort` seam + facade-delegation test
+
+**Files:**
+- Create: `lib/features/backup/data/services/backup_saf_port.dart`
+- Test: `test/features/backup/data/services/submersion_saf_facade_test.dart`
+
+**Interfaces:**
+- Consumes: `SubmersionSaf` (A1).
+- Produces:
+  - `abstract class BackupSafPort { Future<String> writeBackup({required String treeUri, required String fileName, required String sourcePath}); Future<void> readBackup({required String documentUri, required String destPath}); Future<bool> delete(String documentUri); Future<bool> exists(String documentUri); Future<String?> resolveTree(String treeUri); }`
+  - `class MethodChannelBackupSafPort implements BackupSafPort` (delegates to `SubmersionSaf`).
+
+- [ ] **Step 1: Write the failing test** (mock the channel, prove the facade marshals args/results)
+
+`test/features/backup/data/services/submersion_saf_facade_test.dart`:
+```dart
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion_saf/submersion_saf.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('app.submersion/saf');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('writeBackup passes args and returns the document URI', () async {
+    MethodCall? seen;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      seen = call;
+      return 'content://doc/1';
+    });
+
+    final uri = await SubmersionSaf.writeBackup(
+      treeUri: 'content://tree/1',
+      fileName: 'b.db',
+      sourcePath: '/data/x.db',
+    );
+
+    expect(uri, 'content://doc/1');
+    expect(seen!.method, 'writeBackup');
+    expect((seen!.arguments as Map)['fileName'], 'b.db');
+  });
+
+  test('pickFolder maps a null channel result to null', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+    expect(await SubmersionSaf.pickFolder(), isNull);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/backup/data/services/submersion_saf_facade_test.dart`
+Expected: FAIL (until `submersion_saf` is importable — passes once A1's pub get is in effect; if it already passes, that is acceptable since it validates the A1 facade. Treat a compile error about the import as the expected initial failure.)
+
+- [ ] **Step 3: Create the port**
+
+`lib/features/backup/data/services/backup_saf_port.dart`:
+```dart
+import 'package:submersion_saf/submersion_saf.dart';
+
+/// Narrow seam over [SubmersionSaf] so backup logic is unit-testable with a
+/// fake (no native channel). Android-only in practice; callers gate on platform.
+abstract class BackupSafPort {
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  });
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  });
+  Future<bool> delete(String documentUri);
+  Future<bool> exists(String documentUri);
+  Future<String?> resolveTree(String treeUri);
+}
+
+class MethodChannelBackupSafPort implements BackupSafPort {
+  const MethodChannelBackupSafPort();
+
+  @override
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) =>
+      SubmersionSaf.writeBackup(
+        treeUri: treeUri,
+        fileName: fileName,
+        sourcePath: sourcePath,
+      );
+
+  @override
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) =>
+      SubmersionSaf.readBackup(documentUri: documentUri, destPath: destPath);
+
+  @override
+  Future<bool> delete(String documentUri) => SubmersionSaf.delete(documentUri);
+
+  @override
+  Future<bool> exists(String documentUri) => SubmersionSaf.exists(documentUri);
+
+  @override
+  Future<String?> resolveTree(String treeUri) =>
+      SubmersionSaf.resolveTree(treeUri);
+}
+```
+
+- [ ] **Step 4: Run test + analyze**
+
+Run: `flutter test test/features/backup/data/services/submersion_saf_facade_test.dart`
+Expected: PASS.
+Run: `flutter analyze` — Expected: No issues.
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/features/backup/data/services/backup_saf_port.dart test/features/backup/data/services/submersion_saf_facade_test.dart
+git commit -m "feat(backup): add BackupSafPort seam over the SAF facade (#300)"
+```
+
+---
+
+## Task A3: `BackupTarget` abstraction + `isSafRef`
+
+**Files:**
+- Create: `lib/features/backup/data/services/backup_target.dart`
+- Test: `test/features/backup/data/services/backup_target_test.dart`
+
+**Interfaces:**
+- Consumes: `BackupDatabaseAdapter` (existing, `backup_service.dart`), `BackupSafPort` (A2).
+- Produces:
+  - `bool isSafRef(String ref)` — true iff `ref.startsWith('content://')`.
+  - `abstract class BackupTarget { Future<String> write(BackupDatabaseAdapter adapter, String fileName); }`
+  - `class FilesystemBackupTarget implements BackupTarget` (ctor `FilesystemBackupTarget(String dir)`).
+  - `class SafBackupTarget implements BackupTarget` (ctor `SafBackupTarget(String treeUri, BackupSafPort port)`).
+  - `class BackupTargetLease { final BackupTarget target; Future<void> release(); }`
+
+- [ ] **Step 1: Write the failing test**
+
+`test/features/backup/data/services/backup_target_test.dart`:
+```dart
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
+
+class _FakeAdapter implements BackupDatabaseAdapter {
+  _FakeAdapter(this.dbPath);
+  final String dbPath;
+  String? copiedTo;
+  @override
+  Future<void> backup(String destinationPath) async {
+    copiedTo = destinationPath;
+    await File(dbPath).copy(destinationPath);
+  }
+  @override
+  Future<void> restore(String backupPath) async {}
+  @override
+  Future<String> get databasePath async => dbPath;
+  @override
+  AppDatabase get database => throw UnimplementedError();
+}
+
+class _FakeSafPort implements BackupSafPort {
+  String? wroteSource;
+  String? wroteName;
+  @override
+  Future<String> writeBackup({required String treeUri, required String fileName, required String sourcePath}) async {
+    wroteSource = sourcePath;
+    wroteName = fileName;
+    return 'content://tree/1/doc/$fileName';
+  }
+  @override
+  Future<void> readBackup({required String documentUri, required String destPath}) async {}
+  @override
+  Future<bool> delete(String documentUri) async => true;
+  @override
+  Future<bool> exists(String documentUri) async => true;
+  @override
+  Future<String?> resolveTree(String treeUri) async => 'Backups';
+}
+
+void main() {
+  test('isSafRef detects content URIs', () {
+    expect(isSafRef('content://x/y'), isTrue);
+    expect(isSafRef('/storage/emulated/0/x.db'), isFalse);
+  });
+
+  test('FilesystemBackupTarget delegates to adapter.backup and returns the path', () async {
+    final tmp = await Directory.systemTemp.createTemp('fbt_');
+    addTearDown(() => tmp.delete(recursive: true));
+    final src = File(p.join(tmp.path, 'src.db'));
+    await src.writeAsString('db');
+    final adapter = _FakeAdapter(src.path);
+
+    final ref = await FilesystemBackupTarget(tmp.path).write(adapter, 'out.db');
+
+    expect(ref, p.join(tmp.path, 'out.db'));
+    expect(adapter.copiedTo, ref);
+    expect(File(ref).existsSync(), isTrue);
+  });
+
+  test('SafBackupTarget writes the source DB via the port, returns the doc URI', () async {
+    final port = _FakeSafPort();
+    final adapter = _FakeAdapter('/data/live.db');
+
+    final ref = await SafBackupTarget('content://tree/1', port).write(adapter, 'out.db');
+
+    expect(ref, 'content://tree/1/doc/out.db');
+    expect(port.wroteSource, '/data/live.db');
+    expect(port.wroteName, 'out.db');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/backup/data/services/backup_target_test.dart`
+Expected: FAIL — `backup_target.dart` not found / symbols undefined.
+
+- [ ] **Step 3: Implement `backup_target.dart`**
+```dart
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+
+/// True iff [ref] is a SAF document/tree URI rather than a filesystem path.
+/// Only Android's picker produces these, so it doubles as the platform branch.
+bool isSafRef(String ref) => ref.startsWith('content://');
+
+/// Where a backup is written. Two implementations: a filesystem directory
+/// (default sandbox, desktop, Apple bookmarked dirs) and an Android SAF tree.
+abstract class BackupTarget {
+  /// Writes a backup named [fileName] using [adapter] to produce the bytes.
+  /// Returns the stored ref: a filesystem path or a `content://` document URI.
+  Future<String> write(BackupDatabaseAdapter adapter, String fileName);
+}
+
+/// Filesystem target. Delegates to [BackupDatabaseAdapter.backup] verbatim so
+/// existing behavior (and its tests) are unchanged.
+class FilesystemBackupTarget implements BackupTarget {
+  const FilesystemBackupTarget(this.dir);
+  final String dir;
+
+  @override
+  Future<String> write(BackupDatabaseAdapter adapter, String fileName) async {
+    final dest = p.join(dir, fileName);
+    await adapter.backup(dest);
+    return dest;
+  }
+}
+
+/// Android SAF target. Streams the live DB into the persisted tree via the port.
+class SafBackupTarget implements BackupTarget {
+  const SafBackupTarget(this.treeUri, this.port);
+  final String treeUri;
+  final BackupSafPort port;
+
+  @override
+  Future<String> write(BackupDatabaseAdapter adapter, String fileName) async {
+    final source = await adapter.databasePath;
+    return port.writeBackup(
+      treeUri: treeUri,
+      fileName: fileName,
+      sourcePath: source,
+    );
+  }
+}
+
+/// A resolved target plus a release callback (arms/releases Apple security-scoped
+/// access for filesystem targets; a no-op for SAF and the default location).
+class BackupTargetLease {
+  const BackupTargetLease(this.target, this._release);
+  final BackupTarget target;
+  final Future<void> Function() _release;
+  Future<void> release() => _release();
+}
+```
+
+- [ ] **Step 4: Run test + analyze**
+
+Run: `flutter test test/features/backup/data/services/backup_target_test.dart`
+Expected: PASS.
+Run: `flutter analyze` — Expected: No issues.
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/features/backup/data/services/backup_target.dart test/features/backup/data/services/backup_target_test.dart
+git commit -m "feat(backup): add BackupTarget abstraction (filesystem + SAF) (#300)"
+```
+
+---
+
+## Task A4: `resolveBackupTargetLeased` + rewire `performBackup`
+
+**Files:**
+- Modify: `lib/features/backup/data/services/backup_service.dart`
+- Test: `test/features/backup/data/services/backup_target_lease_test.dart`
+
+**Interfaces:**
+- Consumes: `BackupTarget`/`SafBackupTarget`/`FilesystemBackupTarget`/`BackupTargetLease`/`isSafRef` (A3), `BackupSafPort` (A2), existing `resolveBackupsDirectoryLeased`.
+- Produces:
+  - `BackupService` gains constructor param `BackupSafPort? safPort` (defaults to `const MethodChannelBackupSafPort()`).
+  - `static Future<BackupTargetLease> BackupService.resolveBackupTargetLeased(BackupPreferences preferences, {BackupBookmarkPort? bookmarks, BackupSafPort? saf})`.
+
+- [ ] **Step 1: Write the failing test** (SAF branch + self-heal; filesystem delegation)
+
+`test/features/backup/data/services/backup_target_lease_test.dart`:
+```dart
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/backup_bookmark_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
+
+class _FakeSafPort implements BackupSafPort {
+  _FakeSafPort({this.tree});
+  final String? tree; // resolveTree result
+  @override
+  Future<String> writeBackup({required String treeUri, required String fileName, required String sourcePath}) async => 'content://doc';
+  @override
+  Future<void> readBackup({required String documentUri, required String destPath}) async {}
+  @override
+  Future<bool> delete(String documentUri) async => true;
+  @override
+  Future<bool> exists(String documentUri) async => true;
+  @override
+  Future<String?> resolveTree(String treeUri) async => tree;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BackupPreferences preferences;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async => Directory.systemTemp.path,
+    );
+  });
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = BackupPreferences(await SharedPreferences.getInstance());
+  });
+  tearDown(() => BackupBookmarkService.debugSupportedOverride = null);
+
+  test('content:// location + live grant -> SafBackupTarget', () async {
+    await preferences.setBackupLocation('content://tree/1');
+    final lease = await BackupService.resolveBackupTargetLeased(
+      preferences,
+      saf: _FakeSafPort(tree: 'Backups'),
+    );
+    expect(lease.target, isA<SafBackupTarget>());
+    await lease.release();
+  });
+
+  test('content:// location + dead grant -> self-heal to filesystem default', () async {
+    await preferences.setBackupLocation('content://tree/gone');
+    final lease = await BackupService.resolveBackupTargetLeased(
+      preferences,
+      saf: _FakeSafPort(tree: null),
+    );
+    expect(lease.target, isA<FilesystemBackupTarget>());
+    expect(preferences.getSettings().backupLocation, isNull);
+  });
+
+  test('filesystem location -> FilesystemBackupTarget (delegates to existing resolver)', () async {
+    final tmp = await Directory.systemTemp.createTemp('btl_');
+    addTearDown(() => tmp.delete(recursive: true));
+    await preferences.setBackupLocation(tmp.path);
+    BackupBookmarkService.debugSupportedOverride = false;
+    final lease = await BackupService.resolveBackupTargetLeased(preferences);
+    expect(lease.target, isA<FilesystemBackupTarget>());
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/backup/data/services/backup_target_lease_test.dart`
+Expected: FAIL — `resolveBackupTargetLeased` undefined.
+
+- [ ] **Step 3: Add the import + field + method, and rewire `performBackup`**
+
+In `backup_service.dart` add imports:
+```dart
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
+```
+Add field + constructor param (place beside `_cloudProvider`):
+```dart
+  final BackupSafPort _safPort;
+```
+```dart
+    BackupSafPort? safPort,
+```
+```dart
+       _safPort = safPort ?? const MethodChannelBackupSafPort(),
+```
+Add the wrapper resolver (immediately after `resolveBackupsDirectoryLeased`):
+```dart
+  /// Resolves where the next backup goes as a [BackupTarget]. A `content://`
+  /// custom location (Android SAF) yields a [SafBackupTarget] after confirming
+  /// the persisted tree grant still resolves; a dead grant self-heals to the
+  /// sandbox default. Everything else delegates to the existing filesystem
+  /// resolver, leaving iOS/macOS/Windows/Linux behavior untouched.
+  static Future<BackupTargetLease> resolveBackupTargetLeased(
+    BackupPreferences preferences, {
+    BackupBookmarkPort? bookmarks,
+    BackupSafPort? saf,
+  }) async {
+    final custom = preferences.getSettings().backupLocation;
+    if (custom != null && isSafRef(custom)) {
+      final port = saf ?? const MethodChannelBackupSafPort();
+      final label = await port.resolveTree(custom);
+      if (label == null) {
+        // Grant revoked or folder deleted: reset to default so backups keep
+        // working (mirrors the Apple dead-bookmark self-heal). The settings
+        // subtitle reverts to the default, signaling a re-pick is needed.
+        await preferences.setBackupLocation(null);
+        final dir = await resolveDefaultBackupsDirectory();
+        return BackupTargetLease(FilesystemBackupTarget(dir), _noRelease);
+      }
+      return BackupTargetLease(SafBackupTarget(custom, port), _noRelease);
+    }
+    final lease = await resolveBackupsDirectoryLeased(
+      preferences,
+      bookmarks: bookmarks,
+    );
+    return BackupTargetLease(FilesystemBackupTarget(lease.path), lease.release);
+  }
+```
+Rewrite `performBackup` to use the target, and change `_performBackupInto` to accept a `BackupTarget`:
+```dart
+  Future<BackupRecord> performBackup({bool isAutomatic = false}) async {
+    _log.info('Starting backup (automatic: $isAutomatic)');
+    final lease = await BackupService.resolveBackupTargetLeased(
+      _preferences,
+      saf: _safPort,
+    );
+    try {
+      return await _performBackupInto(lease.target, isAutomatic: isAutomatic);
+    } finally {
+      await lease.release();
+    }
+  }
+
+  Future<BackupRecord> _performBackupInto(
+    BackupTarget target, {
+    required bool isAutomatic,
+  }) async {
+    final filename = _generateFilename();
+    final ref = await target.write(_dbAdapter, filename);
+
+    // SAF refs are content URIs (no File length); the backup is a byte copy of
+    // the live DB, so its size equals the source's. Filesystem refs keep the
+    // existing File(ref).length() behavior.
+    final sizeBytes = isSafRef(ref)
+        ? await File(await _dbAdapter.databasePath).length()
+        : await File(ref).length();
+
+    final counts = await _getDiveSiteCounts();
+
+    String? cloudFileId;
+    var location = BackupLocation.local;
+    final settings = _preferences.getSettings();
+    if (settings.cloudBackupEnabled && _cloudProvider != null) {
+      try {
+        cloudFileId = await _uploadToCloud(ref, filename);
+        location = BackupLocation.both;
+        _log.info('Backup uploaded to cloud: $cloudFileId');
+      } catch (e, stack) {
+        _log.error('Cloud upload failed, backup is local-only',
+            error: e, stackTrace: stack);
+      }
+    }
+
+    final record = BackupRecord(
+      id: _uuid.v4(),
+      filename: filename,
+      timestamp: DateTime.now(),
+      sizeBytes: sizeBytes,
+      location: location,
+      diveCount: counts.diveCount,
+      siteCount: counts.siteCount,
+      cloudFileId: cloudFileId,
+      localPath: ref,
+      isAutomatic: isAutomatic,
+    );
+
+    await _preferences.addRecord(record);
+    await _preferences.setLastBackupTime(record.timestamp);
+    await pruneOldBackups(settings.retentionCount);
+    _log.info('Backup completed: ${record.filename} (${record.formattedSize})');
+    return record;
+  }
+```
+(Note: cloud + custom location are mutually exclusive, so `_uploadToCloud(ref, …)` only ever receives a filesystem ref — no SAF read needed.)
+
+- [ ] **Step 4: Run new + existing backup tests + analyze**
+
+Run: `flutter test test/features/backup/data/services/backup_target_lease_test.dart test/features/backup/data/services/backup_service_leased_test.dart test/features/backup/data/services/backup_service_test.dart`
+Expected: PASS (new SAF cases pass; the 9 leased cases and the service cases stay green — the old resolver is untouched).
+Run: `flutter analyze` — Expected: No issues.
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/features/backup/data/services/backup_service.dart test/features/backup/data/services/backup_target_lease_test.dart
+git commit -m "feat(backup): route performBackup through BackupTarget with SAF self-heal (#300)"
+```
+
+---
+
+## Task A5: Ref-aware restore / delete / history
+
+**Files:**
+- Modify: `lib/features/backup/data/services/backup_service.dart`
+- Test: `test/features/backup/data/services/backup_service_saf_refs_test.dart`
+
+**Interfaces:**
+- Consumes: `_safPort` (A4), `isSafRef` (A3).
+- Produces: behavior changes only (no new public symbols).
+
+- [ ] **Step 1: Write the failing test** (delete + history route SAF refs to the port; restore reads SAF to a temp file)
+
+`test/features/backup/data/services/backup_service_saf_refs_test.dart`:
+```dart
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+
+class _NoopAdapter implements BackupDatabaseAdapter {
+  @override
+  Future<void> backup(String destinationPath) async {}
+  @override
+  Future<void> restore(String backupPath) async {}
+  @override
+  Future<String> get databasePath async => '/data/live.db';
+  @override
+  AppDatabase get database => throw UnimplementedError();
+}
+
+class _RecordingSafPort implements BackupSafPort {
+  final List<String> deleted = [];
+  final Set<String> existing = {};
+  @override
+  Future<String> writeBackup({required String treeUri, required String fileName, required String sourcePath}) async => 'content://doc';
+  @override
+  Future<void> readBackup({required String documentUri, required String destPath}) async {}
+  @override
+  Future<bool> delete(String documentUri) async { deleted.add(documentUri); return true; }
+  @override
+  Future<bool> exists(String documentUri) async => existing.contains(documentUri);
+  @override
+  Future<String?> resolveTree(String treeUri) async => 'Backups';
+}
+
+BackupRecord _saf(String id, String uri) => BackupRecord(
+      id: id, filename: 'f.db', timestamp: DateTime(2026), sizeBytes: 1,
+      location: BackupLocation.local, diveCount: 0, siteCount: 0, localPath: uri);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BackupPreferences prefs;
+  late _RecordingSafPort port;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async => Directory.systemTemp.path,
+    );
+  });
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = BackupPreferences(await SharedPreferences.getInstance());
+    port = _RecordingSafPort();
+  });
+
+  BackupService service() =>
+      BackupService(dbAdapter: _NoopAdapter(), preferences: prefs, safPort: port);
+
+  test('deleteBackup routes a SAF ref to the port', () async {
+    final r = _saf('1', 'content://doc/1');
+    await prefs.addRecord(r);
+    await service().deleteBackup(r);
+    expect(port.deleted, ['content://doc/1']);
+  });
+
+  test('getValidatedBackupHistory keeps a SAF record whose doc still exists', () async {
+    port.existing.add('content://doc/keep');
+    await prefs.addRecord(_saf('keep', 'content://doc/keep'));
+    await prefs.addRecord(_saf('gone', 'content://doc/gone'));
+    final valid = await service().getValidatedBackupHistory();
+    expect(valid.map((r) => r.id), ['keep']);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/backup/data/services/backup_service_saf_refs_test.dart`
+Expected: FAIL — `deleteBackup` calls `File('content://…').delete()` (no-op, record not pruned by the port) and history uses `File.exists`.
+
+- [ ] **Step 3: Make `deleteBackup`, `getValidatedBackupHistory`, and restore ref-aware**
+
+In `deleteBackup`, replace the local-file block:
+```dart
+    if (record.localPath != null) {
+      final ref = record.localPath!;
+      if (isSafRef(ref)) {
+        await _safPort.delete(ref);
+        _log.info('Deleted SAF backup: $ref');
+      } else {
+        final file = File(ref);
+        if (await file.exists()) {
+          await file.delete();
+          _log.info('Deleted local file: $ref');
+        }
+      }
+    }
+```
+In `getValidatedBackupHistory`, replace the existence check:
+```dart
+      if (record.localPath != null && record.cloudFileId == null) {
+        final ref = record.localPath!;
+        final stillThere =
+            isSafRef(ref) ? await _safPort.exists(ref) : await File(ref).exists();
+        if (!stillThere) {
+          _log.info('Pruning stale backup record: ${record.filename}');
+          pruned = true;
+          continue;
+        }
+      }
+```
+In `restoreFromBackup`, make the local source SAF-aware (read to a temp file before validating/restoring). Replace the source-path resolution block:
+```dart
+    String sourcePath;
+    final localRef = record.localPath;
+    if (localRef != null && isSafRef(localRef)) {
+      if (!await _safPort.exists(localRef)) {
+        throw const BackupException('Backup file not found locally or in cloud');
+      }
+      final tempDir = await getTemporaryDirectory();
+      sourcePath = p.join(tempDir.path, record.filename);
+      await _safPort.readBackup(documentUri: localRef, destPath: sourcePath);
+    } else if (localRef != null && await File(localRef).exists()) {
+      sourcePath = localRef;
+    } else if (record.cloudFileId != null && _cloudProvider != null) {
+      _log.info('Downloading backup from cloud');
+      sourcePath = await _downloadFromCloud(record.cloudFileId!, record.filename);
+    } else {
+      throw const BackupException('Backup file not found locally or in cloud');
+    }
+```
+
+- [ ] **Step 4: Run new + existing restore tests + analyze**
+
+Run: `flutter test test/features/backup/data/services/backup_service_saf_refs_test.dart test/features/backup/data/services/backup_service_test.dart test/features/backup/presentation/providers/backup_providers_restore_test.dart`
+Expected: PASS.
+Run: `flutter analyze` — Expected: No issues.
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/features/backup/data/services/backup_service.dart test/features/backup/data/services/backup_service_saf_refs_test.dart
+git commit -m "feat(backup): ref-aware restore/delete/history for SAF backups (#300)"
+```
+
+---
+
+## Task A6: Backup-settings picker (Android SAF branch) + label
+
+**Files:**
+- Modify: `lib/features/backup/data/repositories/backup_preferences.dart`
+- Modify: `lib/features/backup/presentation/providers/backup_providers.dart`
+- Modify: `lib/features/backup/presentation/pages/backup_settings_page.dart`
+- Test: `test/features/backup/data/repositories/backup_preferences_test.dart` (extend)
+
+**Interfaces:**
+- Produces:
+  - `BackupPreferences.setBackupLocationLabel(String?)` and `String? get backupLocationLabel` (key `backup_location_label`).
+  - `BackupSettingsNotifier.setSafBackupLocation(String uri, String label)`.
+
+- [ ] **Step 1: Write the failing test** (label round-trips and is cleared with the location)
+
+Append to `backup_preferences_test.dart`:
+```dart
+  test('backup location label round-trips and clears with the location', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+    await prefs.setBackupLocation('content://tree/1');
+    await prefs.setBackupLocationLabel('Backups');
+    expect(prefs.backupLocationLabel, 'Backups');
+    await prefs.setBackupLocation(null);
+    expect(prefs.backupLocationLabel, isNull);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/backup/data/repositories/backup_preferences_test.dart`
+Expected: FAIL — `setBackupLocationLabel` undefined.
+
+- [ ] **Step 3: Implement label storage** in `backup_preferences.dart`
+
+Add key constant:
+```dart
+  static const String _backupLocationLabelKey = 'backup_location_label';
+```
+In `setBackupLocation`, when clearing (`path == null`) also remove the label:
+```dart
+      await _prefs.remove(_backupLocationLabelKey);
+```
+Add accessors:
+```dart
+  Future<void> setBackupLocationLabel(String? label) async {
+    if (label == null) {
+      await _prefs.remove(_backupLocationLabelKey);
+    } else {
+      await _prefs.setString(_backupLocationLabelKey, label);
+    }
+  }
+
+  String? get backupLocationLabel => _prefs.getString(_backupLocationLabelKey);
+```
+
+- [ ] **Step 4: Add the notifier setter** in `backup_providers.dart` (beside `setBackupLocationWithBookmark`)
+```dart
+  /// Android SAF: persist a content:// tree URI as the location plus its human
+  /// label for display. Turns cloud backup off, like any custom location.
+  Future<void> setSafBackupLocation(String uri, String label) async {
+    await _prefs.setCloudBackupEnabled(false);
+    await _prefs.setBackupLocation(uri);
+    await _prefs.setBackupLocationLabel(label);
+    state = _prefs.getSettings();
+  }
+```
+
+- [ ] **Step 5: Wire the picker + subtitle** in `backup_settings_page.dart`
+
+Add import:
+```dart
+import 'package:submersion_saf/submersion_saf.dart';
+```
+Replace the picker `onPressed` body's platform branch so Android uses SAF (keep iOS and desktop intact):
+```dart
+              final BackupFolderPick? picked;
+              if (Platform.isIOS) {
+                picked = await BackupBookmarkService.pickFolder();
+              } else if (Platform.isAndroid) {
+                final folder = await SubmersionSaf.pickFolder();
+                if (folder != null) {
+                  await ref
+                      .read(backupSettingsProvider.notifier)
+                      .setSafBackupLocation(folder.uri, folder.displayName);
+                }
+                return; // SAF path persists directly; skip the bookmark flow.
+              } else {
+                final path = await FilePicker.getDirectoryPath(
+                  dialogTitle: context.l10n.backup_location_title,
+                );
+                picked = path == null
+                    ? null
+                    : BackupFolderPick(
+                        path: path,
+                        bookmark: BackupBookmarkService.isSupported
+                            ? await BackupBookmarkService.createBookmark(path)
+                            : null,
+                      );
+              }
+              if (picked != null) {
+                await ref
+                    .read(backupSettingsProvider.notifier)
+                    .setBackupLocationWithBookmark(picked.path, picked.bookmark);
+              }
+```
+Update the subtitle so a SAF location shows its label, not the raw URI:
+```dart
+          subtitle: Text(
+            cloudDestination ??
+                ref.read(backupSettingsProvider.notifier).locationLabel ??
+                settings.backupLocation ??
+                context.l10n.backup_location_default,
+```
+Add a `locationLabel` getter to the notifier:
+```dart
+  String? get locationLabel => _prefs.backupLocationLabel;
+```
+
+- [ ] **Step 6: Run tests + analyze + format**
+
+Run: `flutter test test/features/backup/data/repositories/backup_preferences_test.dart test/features/backup/presentation/pages/backup_settings_page_test.dart test/features/backup/presentation/providers/backup_settings_notifier_test.dart`
+Expected: PASS (update notifier mock test expectations if the new method trips a mock).
+Run: `dart format .` then `flutter analyze` — Expected: formatted, No issues.
+
+- [ ] **Step 7: Commit**
+```bash
+git add lib/features/backup test/features/backup
+git commit -m "feat(backup): Android SAF folder picker + label display (#300)"
+```
+
+---
+
+# Part B — Custom DB location (Internal / SD card)
+
+## Task B1: Android external-dir chooser for the DB location
+
+**Files:**
+- Modify: `lib/core/services/database_location_service.dart`
+- Test: `test/core/services/database_location_external_dirs_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `class ExternalVolumeOption { final String path; final String label; }`
+  - `List<ExternalVolumeOption> labelExternalDirs(List<String> dirPaths)` — pure, testable: index 0 / `emulated` segment → "Internal storage"; others → "SD card".
+
+- [ ] **Step 1: Write the failing test**
+
+`test/core/services/database_location_external_dirs_test.dart`:
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_location_service.dart';
+
+void main() {
+  test('labels the emulated volume Internal and others SD card', () {
+    final opts = labelExternalDirs([
+      '/storage/emulated/0/Android/data/app.submersion/files',
+      '/storage/1A2B-3C4D/Android/data/app.submersion/files',
+    ]);
+    expect(opts[0].label, 'Internal storage');
+    expect(opts[1].label, 'SD card');
+    expect(opts[1].path, contains('1A2B-3C4D'));
+  });
+
+  test('single volume is Internal', () {
+    final opts = labelExternalDirs(['/storage/emulated/0/Android/data/x/files']);
+    expect(opts.single.label, 'Internal storage');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/database_location_external_dirs_test.dart`
+Expected: FAIL — `labelExternalDirs`/`ExternalVolumeOption` undefined.
+
+- [ ] **Step 3: Implement the labeler + Android picker branch**
+
+Add to `database_location_service.dart` (top-level, below the class or above it):
+```dart
+/// A selectable external volume for the database location (Android).
+class ExternalVolumeOption {
+  const ExternalVolumeOption({required this.path, required this.label});
+  final String path;
+  final String label;
+}
+
+/// Labels app-specific external dirs without native code: the primary emulated
+/// volume is "Internal storage"; any other volume is "SD card".
+List<ExternalVolumeOption> labelExternalDirs(List<String> dirPaths) {
+  final out = <ExternalVolumeOption>[];
+  for (var i = 0; i < dirPaths.length; i++) {
+    final path = dirPaths[i];
+    final isInternal = i == 0 || path.contains('/storage/emulated/');
+    out.add(ExternalVolumeOption(
+      path: path,
+      label: isInternal ? 'Internal storage' : 'SD card',
+    ));
+  }
+  return out;
+}
+```
+Add `import 'package:flutter/material.dart';` if not present (for the chooser dialog) and a parameterized chooser hook. In `pickCustomFolder`, insert an Android branch before the existing `else` (file_picker), keeping iOS and desktop intact:
+```dart
+    if (Platform.isAndroid) {
+      final dirs = await getExternalStorageDirectories();
+      if (dirs == null || dirs.isEmpty) return null;
+      final options = labelExternalDirs(dirs.map((d) => d.path).toList());
+      final chosen = await _chooseExternalVolume?.call(options) ??
+          options.first; // _chooseExternalVolume injected by the UI; default first
+      final dbDir = p.join(chosen.path, 'Submersion');
+      await Directory(dbDir).create(recursive: true);
+      return FolderPickResultWithBookmark(path: dbDir);
+    }
+```
+Add an injectable chooser callback field (set by the settings UI; nullable so headless/default callers fall back to the first volume):
+```dart
+  /// UI hook to let the user choose among external volumes (Android). Injected
+  /// by the storage settings page; when null the first (internal) volume is used.
+  Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)?
+      _chooseExternalVolume;
+  set externalVolumeChooser(
+          Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)? f) =>
+      _chooseExternalVolume = f;
+```
+Fix the stale comment on `isCustomFolderSupported`:
+```dart
+  /// - Android: app-specific external storage (internal or SD card). The live
+  ///   DB needs a real path; arbitrary SAF folders cannot back a SQLite file.
+```
+Add import:
+```dart
+import 'package:path_provider/path_provider.dart';
+```
+(`getExternalStorageDirectories` — already transitively available; ensure the symbol resolves.)
+
+- [ ] **Step 4: Run test + analyze**
+
+Run: `flutter test test/core/services/database_location_external_dirs_test.dart`
+Expected: PASS.
+Run: `flutter analyze` — Expected: No issues.
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/core/services/database_location_service.dart test/core/services/database_location_external_dirs_test.dart
+git commit -m "feat(db-location): Android internal/SD-card chooser via external dirs (#300)"
+```
+
+---
+
+## Task B2: Localize the DB-location strings + wire the chooser UI
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` + all non-en locale ARBs in `lib/l10n/arb/`
+- Modify: the storage settings page that calls `pickCustomFolder` (set `externalVolumeChooser` to a real dialog using the localized strings)
+- Modify: `lib/core/services/database_location_service.dart` (replace the hardcoded English labels with keys passed in from the UI, OR keep labels in UI layer)
+
+**Interfaces:**
+- Consumes: `labelExternalDirs`, `ExternalVolumeOption` (B1).
+
+- [ ] **Step 1: Add English ARB keys** in `app_en.arb`:
+```json
+  "db_location_internal": "Internal storage",
+  "db_location_sd_card": "SD card",
+  "db_location_choose_volume": "Choose storage volume",
+  "db_location_external_note": "Files here are removed if you uninstall the app."
+```
+
+- [ ] **Step 2: Add translations** for all 10 non-en locales (`app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`) — real translations, following the locale's existing entries. (Move the "Internal storage"/"SD card" literals out of `labelExternalDirs` into the UI chooser so they use these keys; `labelExternalDirs` returns a stable enum/flag the UI maps to a localized string. Adjust B1's labeler to return `isInternal` and let the UI pick the string, to avoid English in the service layer.)
+
+- [ ] **Step 3: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: `app_localizations*.dart` regenerated with the new getters.
+
+- [ ] **Step 4: Wire the chooser** in the storage settings page: set `service.externalVolumeChooser` to show a dialog listing the localized volume labels + the uninstall note, returning the chosen `ExternalVolumeOption`.
+
+- [ ] **Step 5: Run tests + analyze + format**
+
+Run: `flutter test test/core/services/ test/features/settings/`
+Expected: PASS.
+Run: `dart format .` && `flutter analyze` — Expected: clean.
+
+- [ ] **Step 6: Commit**
+```bash
+git add lib/l10n lib/core/services/database_location_service.dart lib/features/settings
+git commit -m "feat(db-location): localized internal/SD-card chooser UI (#300)"
+```
+
+---
+
+## Task C1: Full verification pass
+
+**Files:** none (verification + spec/plan already committed)
+
+- [ ] **Step 1: Format + analyze whole project**
+
+Run: `dart format --set-exit-if-changed .`
+Run: `flutter analyze`
+Expected: both clean.
+
+- [ ] **Step 2: Run the backup + DB-location + l10n test suites**
+
+Run: `flutter test test/features/backup test/core/services test/core/database`
+Expected: all PASS.
+
+- [ ] **Step 3: Android build smoke**
+
+Run: `flutter build apk --debug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Record device-verification checklist** (cannot be automated; the reporter offered to test):
+  - Manual "Backup Now" to an internal folder and an SD-card folder → success, file visible in a file manager.
+  - Automatic backup (toggle on, force the Workmanager task) lands in the chosen folder with the app backgrounded.
+  - Restore from a SAF backup.
+  - Relocate the DB to the SD card and back; data intact.
+  - Revoke the folder permission → next backup self-heals to default.
+
+- [ ] **Step 5: Final commit (if any formatting changes)**
+```bash
+git add -A
+git commit -m "chore: format + verification pass for Android SAF backups (#300)"
+```
+
+---
+
+## Self-review notes
+
+- Spec §4 (SAF backups) → Tasks A1–A6. Spec §5 (DB location) → Tasks B1–B2. Spec §3.1 platform gating → enforced by `isSafRef` discrimination (A3/A4) and the Android-only picker branches (A6/B1).
+- Background isolate (spec §4.6): satisfied by A1 making SAF a registered plugin (auto-registered in the Workmanager engine); no code beyond A1.
+- Self-heal (spec §4.5): A4 `resolveBackupTargetLeased`.
+- Open follow-ups (spec §8) intentionally not tasked: nicer SD labels via `StorageManager`; migrating media SAF to the new plugin.
+- Note: B2 refines B1 by moving the English volume labels into the UI layer for localization; implement B1's labeler returning an `isInternal` flag if you prefer to avoid the small churn (either is acceptable; B2 step 2 calls this out).

--- a/docs/superpowers/specs/2026-06-20-android-saf-backup-and-db-location-design.md
+++ b/docs/superpowers/specs/2026-06-20-android-saf-backup-and-db-location-design.md
@@ -1,0 +1,300 @@
+# Android backup & custom DB-location under scoped storage (issue #300)
+
+Status: approved 2026-06-21
+Date: 2026-06-20
+Issue: https://github.com/submersion-app/submersion/issues/300
+
+## 1. Problem & root cause
+
+A user on Android 16 (Samsung A52s, LineageOS, no Play Services) sets a custom
+backup folder, grants access, and every backup — manual and automatic — fails:
+
+```
+Backup failed: PathAccessException: Cannot copy file to <folder>
+path = '/data/user/0/app.submersion/app_flutter/Submersion/submersion.db'
+(OS Error: Operation not permitted, errno = 1)
+```
+
+Root cause (verified end-to-end in the code and plugin sources):
+
+1. The folder is picked with `FilePicker.getDirectoryPath()`. In `file_picker`
+   11.0.2 that resolves the SAF tree URI down to a raw `/storage/...` path
+   (`FileUtils.getFullPathFromTreeUri`, FileUtils.kt:612) and **discards the
+   `content://` URI** — it never calls `takePersistableUriPermission`.
+2. The raw path is stored in `SharedPreferences` as `backup_location`.
+3. At backup time `BackupService.resolveBackupsDirectoryLeased` treats the
+   stored value as a bare writable directory (the comment literally says
+   *"Desktop/Android: bare custom paths persist and work without scoping"*).
+4. `DatabaseService.backup` does `File(sourceDb).copy(dest)` into it.
+
+On Android 11+ an app cannot write to arbitrary shared-storage paths with
+`dart:io`. The manifest has only `READ_EXTERNAL_STORAGE` (maxSdkVersion 32) and
+no `MANAGE_EXTERNAL_STORAGE`, so the copy is `EPERM`. The grant the user gave is
+a SAF `content://` tree-URI permission, which `File` cannot use.
+
+The identical bug exists for the **custom database location**
+(`DatabaseLocationService.pickCustomFolder` → `getDirectoryPath` →
+`getDatabasePath` opens the live DB at `customFolderPath/submersion.db`). Its
+comment even claims "Android: Uses Storage Access Framework (SAF)" — it does not.
+
+## 2. Goals / non-goals
+
+Goals:
+- Manual **and automatic** backups to a user-chosen folder succeed on Android 11+.
+- Restore, delete, prune, and history validation work for those backups.
+- Custom DB location works on Android (the reporter specifically wants the SD card).
+- No broad permissions (`MANAGE_EXTERNAL_STORAGE`); no third-party SAF library.
+- Existing iOS / macOS / Windows / Linux behavior unchanged.
+- Existing already-broken Android configs self-heal (no bricking, no lost backups).
+
+Non-goals:
+- Arbitrary-folder placement of the *live database* (SQLite needs a real lockable
+  path; SAF streams cannot back a live DB). DB location is a curated choice.
+- Cloud backup changes (a custom location and cloud backup remain mutually
+  exclusive, as today).
+
+## 3. Why two different mechanisms
+
+A **backup** is a one-shot file write — SAF (`content://` + `DocumentFile` +
+`ContentResolver` streams) is the correct Android tool. The **live database** is
+opened by SQLite via a POSIX path and relies on byte-range locks, `mmap`, and
+`-wal`/`-shm` sidecars, none of which work over a SAF stream. So:
+
+| Feature        | Android mechanism                                        |
+| -------------- | -------------------------------------------------------- |
+| Backups        | SAF: persisted tree URI + DocumentFile writes (new plugin) |
+| DB location    | App-specific external dirs (`getExternalStorageDirectories`) — real writable paths |
+
+## 3.1 Platform impact
+
+This change is **Android-only in behavior**. iOS, macOS, Windows, and Linux are
+unchanged by design. Desktop does not need the fix: a user-picked folder there is
+a normal writable POSIX path, so `File.copy` already works.
+
+Gating contract the implementation and review MUST honor: every new behavior is
+guarded by `Platform.isAndroid`, and `submersion_saf` is declared Android-only
+(not registered, no native code, never called elsewhere; all call sites are
+`Platform.isAndroid`-gated).
+
+The risk is not new behavior on other platforms but the fact that Android is
+currently **lumped into the same branch** as desktop in three shared code points.
+Each must be split so only Android changes:
+
+| Shared code point | Today Android shares with | Change | Must stay identical |
+| ----------------- | ------------------------- | ------ | ------------------- |
+| Backup picker (`backup_settings_page.dart`) | `else` = Android + macOS + Win + Linux | add `else if (isAndroid)` → SAF | macOS file_picker+bookmark; Win/Linux file_picker |
+| `resolveBackupsDirectoryLeased` `!isSupported` branch | Android + Win + Linux (bare path) | gate SAF + self-heal on `isAndroid` | Win/Linux bare-path behavior |
+| DB picker (`database_location_service.dart`) | `else` = Android + macOS + Win + Linux | add `else if (isAndroid)` → external-dir chooser | macOS/Win/Linux file_picker |
+
+Two guardrails contain the refactor risk: (1) `BackupTarget` / `BackupRecord`
+ref-routing keeps the filesystem path behavior-identical — a non-`content://` ref
+always takes the old path; (2) the existing backup test suite runs on **Linux
+CI**, so any regression to the shared filesystem path is caught automatically.
+iOS/macOS security-scoped paths are not modified.
+
+## 4. Part A — SAF backups
+
+### 4.1 In-repo plugin `submersion_saf` (the linchpin)
+
+Automatic backups run in Workmanager's background isolate. That isolate's
+`FlutterEngine(applicationContext)` (workmanager_android `BackgroundWorker.kt:68`)
+auto-registers **pub plugins** via `GeneratedPluginRegistrant`, but app-local
+channels declared in `MainActivity.configureFlutterEngine` are not in
+`GeneratedPluginRegistrant` and are therefore **absent** in the background engine.
+
+To make SAF reachable from both the UI engine and the background isolate, the
+native SAF code lives in a small **in-repo Flutter plugin** (path dependency,
+our own Kotlin — not a third-party SAF package). Being a "plugin", `flutter pub
+get` adds it to `GeneratedPluginRegistrant`, so it auto-registers in every
+engine, including Workmanager's.
+
+Layout:
+```
+packages/submersion_saf/
+  pubspec.yaml                       # flutter.plugin.platforms.android only
+  lib/submersion_saf.dart            # Dart facade (MethodChannel)
+  android/build.gradle
+  android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt
+```
+App `pubspec.yaml` gains `submersion_saf: { path: packages/submersion_saf }`.
+
+The plugin is `FlutterPlugin` + `ActivityAware`:
+- `onAttachedToEngine` registers the channel using `binding.applicationContext`.
+  All non-UI methods use `applicationContext` + `contentResolver`, so they work
+  in the background isolate with no Activity.
+- `onAttachedToActivity` stores the Activity only for `pickFolder` (UI-only).
+
+Channel `app.submersion/saf`, methods:
+- `pickFolder() -> {uri: String, displayName: String}?` — launches
+  `ACTION_OPEN_DOCUMENT_TREE`, `takePersistableUriPermission(READ|WRITE)`,
+  returns the tree URI + the folder's display name. Uses an
+  `ActivityResultListener` (the pattern `file_picker`'s `FilePickerDelegate`
+  uses). Returns null on user-cancel. This is the only method needing an Activity.
+- `writeBackup(treeUri, fileName, sourcePath) -> String` (the created document
+  URI) — `DocumentFile.fromTreeUri(...).createFile("application/octet-stream",
+  fileName)`, then stream-copy `File(sourcePath)` (app-private, natively readable)
+  into `contentResolver.openOutputStream(doc.uri)`. **Streamed, not bytes over the
+  channel** (the DB can be many MB). `application/octet-stream` is used so the
+  provider keeps the supplied `*.db` display name (verify on device — some
+  providers rewrite extensions by MIME; fall back to a `.db`-mapped MIME if so).
+- `readBackup(documentUri, destPath) -> String` — `openInputStream(uri)` copied
+  to `File(destPath)` (a temp file), for restore/validation.
+- `delete(documentUri) -> bool` — `DocumentFile.fromSingleUri(uri).delete()`.
+- `exists(documentUri) -> bool` — `DocumentFile.fromSingleUri(uri).exists()`.
+- `resolveTree(treeUri) -> String?` (display name, or null if the grant is gone)
+  — used for the settings label and self-heal.
+
+`SecurityException`/`IllegalArgumentException` map to typed channel errors that
+the Dart side treats as "location unusable" (triggers self-heal), never a raw
+`PathAccessException`.
+
+The child document URI is reachable under the persisted **tree** grant across
+restarts, so only the tree URI is persisted as the location; per-backup child
+URIs live in the backup history records.
+
+### 4.2 Dart seam — `BackupTarget`
+
+Replace the leaky "return a directory path, caller does `File.copy`" seam with a
+polymorphic target. `resolveBackupsDirectoryLeased` (which returns a path today)
+becomes `resolveBackupTargetLeased` returning a `BackupTarget`:
+
+- `FilesystemBackupTarget(dir)` — current behavior verbatim: default sandbox dir,
+  desktop bare paths, Apple security-scoped bookmarked dirs. `write` = `File.copy`.
+- `SafBackupTarget(treeUri, port)` — `write` calls `port.writeBackup(...)`.
+
+```dart
+abstract class BackupTarget {
+  /// Writes the source DB as [fileName]; returns a ref (path or content URI).
+  Future<String> write(String sourceDbPath, String fileName);
+  Future<void> release();
+}
+```
+
+`_performBackupInto` is rewritten to ask the target to `write` and to store the
+returned ref as `BackupRecord.localPath` (a path for filesystem, a `content://`
+document URI for SAF). The recorded `sizeBytes` is taken from
+`File(sourceDbPath).length()` — the backup is a byte copy of the source DB, so
+its size equals the source's. This removes today's `File(localPath).length()`,
+which would fail on a `content://` ref, and needs no SAF stat call.
+
+The SAF channel is wrapped behind a `BackupSafPort` interface (mirroring the
+existing `BackupBookmarkPort`) so `SafBackupTarget` and the record helpers are
+unit-tested against a fake with no native channel.
+
+### 4.3 Ref-aware record handling
+
+`BackupRecord.localPath` is already nullable `String`; it now may hold a
+`content://` URI. Add a small helper:
+
+```dart
+bool isSafRef(String ref) => ref.startsWith('content://');
+```
+
+Touch points that currently assume a filesystem path, each routed through the
+port when `isSafRef`:
+- `restoreFromBackup` / `restoreFromFile`: if the source ref is a SAF URI,
+  `port.readBackup(uri, tempPath)` first, then validate + restore from the temp
+  file (existing path-based `validateBackupFile` is reused on the temp copy).
+- `deleteBackup`: `port.delete(uri)` instead of `File(...).delete()`.
+- `getValidatedBackupHistory`: `port.exists(uri)` instead of `File(...).exists()`
+  (otherwise SAF backups would be wrongly pruned from history).
+
+Size is recorded at write time from the source DB length (see 4.2), so no
+read-back of a `content://` ref is needed for sizing.
+
+### 4.4 Picker wiring & storage
+
+`backup_settings_page.dart`: on Android call `SubmersionSaf.pickFolder()` instead
+of `FilePicker.getDirectoryPath()`. iOS keeps `BackupBookmarkService.pickFolder`;
+desktop keeps `file_picker`. Store the tree URI in the existing `backup_location`
+key and add `backup_location_label` (the display name) so the settings subtitle
+shows e.g. "Backups" rather than a raw `content://…` string.
+
+### 4.5 Migration / self-heal
+
+Existing Android users have a dead `/storage/...` string in `backup_location`.
+In `resolveBackupTargetLeased`, on Android:
+- If the stored location is not a `content://` URI, or `resolveTree` returns null
+  (grant gone / folder deleted), reset to the sandbox default
+  (`setBackupLocation(null)`) so backups keep working, and flag the settings row
+  to prompt a re-pick. This mirrors the Apple dead-bookmark reset already present.
+
+### 4.6 Background isolate
+
+No code change beyond 4.1: because `submersion_saf` is a registered plugin, the
+Workmanager engine has the `app.submersion/saf` channel, and `writeBackup` uses
+`applicationContext`. Automatic backups write straight to the chosen folder with
+the app closed. The persisted URI permission is app-global, so it is valid in the
+worker process.
+
+### 4.7 Pre-migration backups (unchanged)
+
+`PreMigrationBackupService` writes to the sandbox default (never the custom
+location) and is unaffected.
+
+## 5. Part B — DB location (Internal / SD card)
+
+Single surgical change in `DatabaseLocationService.pickCustomFolder()` on Android:
+replace `FilePicker.getDirectoryPath()` with a curated chooser over
+`getExternalStorageDirectories()` (path_provider), which returns app-specific
+dirs on each volume — internal emulated storage and the removable SD card — as
+real, writable paths with no permissions. The chosen path is
+`<extDir>/Submersion` (created if needed), consistent with the default layout.
+
+Labeling without native code: index/volume heuristic — a path segment of
+`emulated` → "Internal storage"; otherwise "SD card". Presented via a simple
+selection dialog/sheet.
+
+Everything downstream is unchanged and path-based:
+`verifyFolderAccessible` (writes a `.submersion_test` file — succeeds on these
+dirs), `migrateToCustomFolder` → `_copyDatabaseFiles` (`File.copy` of
+`.db`/`-wal`/`-shm`), `getDatabasePath` (`join(path, 'submersion.db')`). Fix the
+stale `isCustomFolderSupported` comment.
+
+Caveat surfaced in UI copy: app-specific external dirs are cleared on uninstall
+(appropriate for a live DB; backups handle portability).
+
+## 6. Error handling & edge cases
+
+- Pick cancelled → no-op, location unchanged.
+- Grant revoked / folder deleted between backups → typed error → self-heal to
+  default + re-pick prompt; the in-app backup history `exists` check prunes the
+  now-unreadable record only if it has no other copy.
+- Large DB → streamed natively, never marshalled through Dart.
+- SAF MIME/extension quirk → validated on device (4.1).
+- Custom location + cloud backup remain mutually exclusive (no SAF read needed
+  for cloud upload).
+- DB-location SD card removed → `verifyFolderAccessible` fails on next switch;
+  existing migration error handling applies (no silent data loss; the live DB is
+  only ever *moved* after a verified copy).
+
+## 7. Testing
+
+Dart unit tests (no native channel — use fakes):
+- `SafBackupTarget.write` calls the port and returns the document URI.
+- Ref routing: restore/delete/history-validation pick SAF vs filesystem paths
+  from a fake `BackupSafPort` and a fake filesystem.
+- Self-heal: a non-`content://` Android location resets to default.
+- `FilesystemBackupTarget` keeps all existing backup tests green (old path
+  unchanged).
+- DB-location: Android picker returns an external-dir path; migration reuses
+  existing covered logic.
+
+Native (device-verified, not in the Dart suite): `DocumentFile` create/write/
+read/delete, `takePersistableUriPermission` persistence across restart, and an
+**automatic** (Workmanager) backup landing in the chosen folder with the app
+closed — on the reporter's Android 16 device class.
+
+## 8. Out of scope / follow-ups
+
+- Nicer SD-card labels via `StorageManager.getStorageVolumes()` (would add native
+  code; heuristic labels ship first).
+- Migrating existing media-source SAF handling to the new plugin (LocalMediaHandler
+  stays as-is; no behavior change intended).
+
+## 9. Rollout
+
+Code + Dart tests land in this PR. Hardware verification (manual + automatic
+backup to internal and SD card, restore, and DB relocation) is pending on a real
+Android 11+ device, consistent with how other native Android work in this repo is
+validated. The reporter offered to test.

--- a/lib/core/services/database_location_service.dart
+++ b/lib/core/services/database_location_service.dart
@@ -152,27 +152,18 @@ class DatabaseLocationService {
     // so SAF content URIs cannot back it. Offer the app-specific external
     // volumes (internal storage + SD card) from path_provider -- real writable
     // paths that need no permissions.
+    // The native volume query + platform gate are untestable in the host VM;
+    // the selection/cancel logic lives in the unit-tested [resolveAndroidDbDir].
+    // coverage:ignore-start
     if (Platform.isAndroid) {
       final dirs = await getExternalStorageDirectories();
       if (dirs == null || dirs.isEmpty) return null;
       final options = classifyExternalDirs(dirs.map((d) => d.path).toList());
-      final chooser = _chooseExternalVolume;
-      final ExternalVolumeOption chosen;
-      if (chooser != null) {
-        final picked = await chooser(options);
-        // A null result means the user dismissed the chooser -> cancel the
-        // whole pick rather than silently relocating to the first volume.
-        if (picked == null) return null;
-        chosen = picked;
-      } else {
-        // No chooser injected (e.g. background/headless flows): default to the
-        // primary internal volume.
-        chosen = options.first;
-      }
-      final dbDir = p.join(chosen.path, 'Submersion');
-      await Directory(dbDir).create(recursive: true);
+      final dbDir = await resolveAndroidDbDir(options, _chooseExternalVolume);
+      if (dbDir == null) return null;
       return FolderPickResultWithBookmark(path: dbDir);
     }
+    // coverage:ignore-end
 
     // On other platforms (desktop), use file_picker
     try {
@@ -369,4 +360,32 @@ List<ExternalVolumeOption> classifyExternalDirs(List<String> dirPaths) {
     out.add(ExternalVolumeOption(path: path, isInternal: isInternal));
   }
   return out;
+}
+
+/// Resolves and creates the database directory among [options] using [chooser]
+/// (or the primary internal volume when no chooser is provided). Returns null
+/// if the user dismissed the chooser.
+///
+/// Extracted from the Android branch of
+/// [DatabaseLocationService.pickCustomFolder] so the selection + cancel logic
+/// is unit-testable without a platform channel.
+Future<String?> resolveAndroidDbDir(
+  List<ExternalVolumeOption> options,
+  Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)? chooser,
+) async {
+  final ExternalVolumeOption chosen;
+  if (chooser != null) {
+    final picked = await chooser(options);
+    // A null result means the user dismissed the chooser -> cancel rather than
+    // silently relocating to the first volume.
+    if (picked == null) return null;
+    chosen = picked;
+  } else {
+    // No chooser injected (e.g. background/headless flows): default to the
+    // primary internal volume.
+    chosen = options.first;
+  }
+  final dbDir = p.join(chosen.path, 'Submersion');
+  await Directory(dbDir).create(recursive: true);
+  return dbDir;
 }

--- a/lib/core/services/database_location_service.dart
+++ b/lib/core/services/database_location_service.dart
@@ -156,8 +156,19 @@ class DatabaseLocationService {
       final dirs = await getExternalStorageDirectories();
       if (dirs == null || dirs.isEmpty) return null;
       final options = classifyExternalDirs(dirs.map((d) => d.path).toList());
-      final chosen =
-          await _chooseExternalVolume?.call(options) ?? options.first;
+      final chooser = _chooseExternalVolume;
+      final ExternalVolumeOption chosen;
+      if (chooser != null) {
+        final picked = await chooser(options);
+        // A null result means the user dismissed the chooser -> cancel the
+        // whole pick rather than silently relocating to the first volume.
+        if (picked == null) return null;
+        chosen = picked;
+      } else {
+        // No chooser injected (e.g. background/headless flows): default to the
+        // primary internal volume.
+        chosen = options.first;
+      }
       final dbDir = p.join(chosen.path, 'Submersion');
       await Directory(dbDir).create(recursive: true);
       return FolderPickResultWithBookmark(path: dbDir);

--- a/lib/core/services/database_location_service.dart
+++ b/lib/core/services/database_location_service.dart
@@ -31,6 +31,15 @@ class DatabaseLocationService {
 
   DatabaseLocationService(this._prefs);
 
+  /// UI hook to let the user choose among external volumes (Android). Set by the
+  /// storage settings page; when null the first (internal) volume is used.
+  Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)?
+  _chooseExternalVolume;
+
+  set externalVolumeChooser(
+    Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)? chooser,
+  ) => _chooseExternalVolume = chooser;
+
   /// Get the current storage configuration
   Future<StorageConfig> getStorageConfig() async {
     final modeString = _prefs.getString(_modeKey);
@@ -105,7 +114,9 @@ class DatabaseLocationService {
   /// - macOS: Full support with security-scoped bookmarks
   /// - iOS: Full support with security-scoped bookmarks for iCloud Drive
   /// - Windows/Linux: Full support with standard file system access
-  /// - Android: Uses Storage Access Framework (SAF)
+  /// - Android: app-specific external storage (internal or SD card). The live
+  ///   DB needs a real lockable path; arbitrary SAF folders cannot back a
+  ///   SQLite file, so the choice is curated to writable app-specific volumes.
   bool get isCustomFolderSupported => true;
 
   /// Check if we're running on a desktop platform
@@ -137,7 +148,22 @@ class DatabaseLocationService {
       }
     }
 
-    // On other platforms, use file_picker
+    // Android: the live DB needs a real lockable path (SQLite locking + WAL),
+    // so SAF content URIs cannot back it. Offer the app-specific external
+    // volumes (internal storage + SD card) from path_provider -- real writable
+    // paths that need no permissions.
+    if (Platform.isAndroid) {
+      final dirs = await getExternalStorageDirectories();
+      if (dirs == null || dirs.isEmpty) return null;
+      final options = classifyExternalDirs(dirs.map((d) => d.path).toList());
+      final chosen =
+          await _chooseExternalVolume?.call(options) ?? options.first;
+      final dbDir = p.join(chosen.path, 'Submersion');
+      await Directory(dbDir).create(recursive: true);
+      return FolderPickResultWithBookmark(path: dbDir);
+    }
+
+    // On other platforms (desktop), use file_picker
     try {
       final result = await FilePicker.getDirectoryPath(
         dialogTitle: 'Choose Database Storage Location',
@@ -309,4 +335,27 @@ class FolderPickResultWithBookmark {
   final Uint8List? bookmarkData;
 
   const FolderPickResultWithBookmark({required this.path, this.bookmarkData});
+}
+
+/// A selectable external volume for the database location (Android).
+class ExternalVolumeOption {
+  const ExternalVolumeOption({required this.path, required this.isInternal});
+
+  final String path;
+
+  /// True for the primary emulated/internal volume; false for removable (SD).
+  final bool isInternal;
+}
+
+/// Classifies app-specific external dirs without native code: the primary
+/// emulated volume is internal; any other volume is removable (SD card). The UI
+/// maps [ExternalVolumeOption.isInternal] to a localized label.
+List<ExternalVolumeOption> classifyExternalDirs(List<String> dirPaths) {
+  final out = <ExternalVolumeOption>[];
+  for (var i = 0; i < dirPaths.length; i++) {
+    final path = dirPaths[i];
+    final isInternal = i == 0 || path.contains('/storage/emulated/');
+    out.add(ExternalVolumeOption(path: path, isInternal: isInternal));
+  }
+  return out;
 }

--- a/lib/features/backup/data/repositories/backup_preferences.dart
+++ b/lib/features/backup/data/repositories/backup_preferences.dart
@@ -19,6 +19,7 @@ class BackupPreferences {
   static const String _cloudBackupEnabledKey = 'backup_cloud_enabled';
   static const String _backupLocationKey = 'backup_location';
   static const String _backupLocationBookmarkKey = 'backup_location_bookmark';
+  static const String _backupLocationLabelKey = 'backup_location_label';
   static const String _historyKey = 'backup_history';
 
   final SharedPreferences _prefs;
@@ -70,6 +71,8 @@ class BackupPreferences {
       // location (reset to default) must drop the bookmark too -- otherwise a
       // dangling security-scoped bookmark would linger.
       await _prefs.remove(_backupLocationBookmarkKey);
+      // The label is likewise meaningless without a location.
+      await _prefs.remove(_backupLocationLabelKey);
     } else {
       await _prefs.setString(_backupLocationKey, path);
     }
@@ -91,6 +94,18 @@ class BackupPreferences {
     if (encoded == null) return null;
     return base64Decode(encoded);
   }
+
+  /// Human label for the custom backup location (e.g. the SAF folder's display
+  /// name on Android), shown in settings instead of a raw `content://` URI.
+  Future<void> setBackupLocationLabel(String? label) async {
+    if (label == null) {
+      await _prefs.remove(_backupLocationLabelKey);
+    } else {
+      await _prefs.setString(_backupLocationLabelKey, label);
+    }
+  }
+
+  String? get backupLocationLabel => _prefs.getString(_backupLocationLabelKey);
 
   // ===========================================================================
   // History

--- a/lib/features/backup/data/services/backup_database_adapter.dart
+++ b/lib/features/backup/data/services/backup_database_adapter.dart
@@ -1,0 +1,35 @@
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+/// Thin interface for the database operations BackupService needs.
+///
+/// Allows injecting a fake in tests without depending on the
+/// [DatabaseService] singleton directly. Lives in its own file so both
+/// `backup_service.dart` and `backup_target.dart` can depend on it without a
+/// circular import.
+abstract class BackupDatabaseAdapter {
+  Future<void> backup(String destinationPath);
+  Future<void> restore(String backupPath);
+  Future<String> get databasePath;
+  AppDatabase get database;
+}
+
+/// Default adapter that delegates to [DatabaseService.instance].
+class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
+  final DatabaseService _dbAdapter;
+
+  const DefaultBackupDatabaseAdapter(this._dbAdapter);
+
+  @override
+  Future<void> backup(String destinationPath) =>
+      _dbAdapter.backup(destinationPath);
+
+  @override
+  Future<void> restore(String backupPath) => _dbAdapter.restore(backupPath);
+
+  @override
+  Future<String> get databasePath => _dbAdapter.databasePath;
+
+  @override
+  AppDatabase get database => _dbAdapter.database;
+}

--- a/lib/features/backup/data/services/backup_database_adapter.dart
+++ b/lib/features/backup/data/services/backup_database_adapter.dart
@@ -15,6 +15,11 @@ abstract class BackupDatabaseAdapter {
 }
 
 /// Default adapter that delegates to [DatabaseService.instance].
+///
+/// Pure production glue around the private-constructor singleton (which cannot
+/// be faked), so tests exercise the [BackupDatabaseAdapter] interface via fakes
+/// and this delegation is excluded from coverage.
+// coverage:ignore-start
 class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
   final DatabaseService _dbAdapter;
 
@@ -33,3 +38,5 @@ class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database => _dbAdapter.database;
 }
+
+// coverage:ignore-end

--- a/lib/features/backup/data/services/backup_saf_port.dart
+++ b/lib/features/backup/data/services/backup_saf_port.dart
@@ -1,0 +1,53 @@
+import 'package:submersion_saf/submersion_saf.dart';
+
+/// Narrow seam over [SubmersionSaf] so backup logic is unit-testable with a
+/// fake (no native channel). Android-only in practice; callers gate on platform
+/// by checking whether the stored location is a `content://` ref.
+abstract class BackupSafPort {
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  });
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  });
+  Future<bool> delete(String documentUri);
+  Future<bool> exists(String documentUri);
+  Future<String?> resolveTree(String treeUri);
+}
+
+/// Default [BackupSafPort] that delegates to the [SubmersionSaf] platform channel.
+class MethodChannelBackupSafPort implements BackupSafPort {
+  const MethodChannelBackupSafPort();
+
+  @override
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) =>
+      SubmersionSaf.writeBackup(
+        treeUri: treeUri,
+        fileName: fileName,
+        sourcePath: sourcePath,
+      );
+
+  @override
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) =>
+      SubmersionSaf.readBackup(documentUri: documentUri, destPath: destPath);
+
+  @override
+  Future<bool> delete(String documentUri) => SubmersionSaf.delete(documentUri);
+
+  @override
+  Future<bool> exists(String documentUri) => SubmersionSaf.exists(documentUri);
+
+  @override
+  Future<String?> resolveTree(String treeUri) =>
+      SubmersionSaf.resolveTree(treeUri);
+}

--- a/lib/features/backup/data/services/backup_saf_port.dart
+++ b/lib/features/backup/data/services/backup_saf_port.dart
@@ -27,19 +27,17 @@ class MethodChannelBackupSafPort implements BackupSafPort {
     required String treeUri,
     required String fileName,
     required String sourcePath,
-  }) =>
-      SubmersionSaf.writeBackup(
-        treeUri: treeUri,
-        fileName: fileName,
-        sourcePath: sourcePath,
-      );
+  }) => SubmersionSaf.writeBackup(
+    treeUri: treeUri,
+    fileName: fileName,
+    sourcePath: sourcePath,
+  );
 
   @override
   Future<void> readBackup({
     required String documentUri,
     required String destPath,
-  }) =>
-      SubmersionSaf.readBackup(documentUri: documentUri, destPath: destPath);
+  }) => SubmersionSaf.readBackup(documentUri: documentUri, destPath: destPath);
 
   @override
   Future<bool> delete(String documentUri) => SubmersionSaf.delete(documentUri);

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -356,7 +356,9 @@ class BackupService {
     final localRef = record.localPath;
     if (localRef != null && isSafRef(localRef)) {
       if (!await _safPort.exists(localRef)) {
-        throw const BackupException('Backup file not found locally or in cloud');
+        throw const BackupException(
+          'Backup file not found locally or in cloud',
+        );
       }
       final tempDir = await getTemporaryDirectory();
       sourcePath = p.join(tempDir.path, record.filename);

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -350,10 +350,19 @@ class BackupService {
     // in their configured backup location and in the history list.
     await performBackup();
 
-    // Determine backup source path
+    // Determine backup source path. A SAF (content://) ref is streamed to a
+    // temp file first; SQLite open + validation need a real filesystem path.
     String sourcePath;
-    if (record.localPath != null && await File(record.localPath!).exists()) {
-      sourcePath = record.localPath!;
+    final localRef = record.localPath;
+    if (localRef != null && isSafRef(localRef)) {
+      if (!await _safPort.exists(localRef)) {
+        throw const BackupException('Backup file not found locally or in cloud');
+      }
+      final tempDir = await getTemporaryDirectory();
+      sourcePath = p.join(tempDir.path, record.filename);
+      await _safPort.readBackup(documentUri: localRef, destPath: sourcePath);
+    } else if (localRef != null && await File(localRef).exists()) {
+      sourcePath = localRef;
     } else if (record.cloudFileId != null && _cloudProvider != null) {
       // Download from cloud to a temp location
       _log.info('Downloading backup from cloud');
@@ -548,8 +557,11 @@ class BackupService {
 
     for (final record in history) {
       if (record.localPath != null && record.cloudFileId == null) {
-        final file = File(record.localPath!);
-        if (!await file.exists()) {
+        final ref = record.localPath!;
+        final stillThere = isSafRef(ref)
+            ? await _safPort.exists(ref)
+            : await File(ref).exists();
+        if (!stillThere) {
           _log.info('Pruning stale backup record: ${record.filename}');
           pruned = true;
           continue;
@@ -570,12 +582,18 @@ class BackupService {
   Future<void> deleteBackup(BackupRecord record) async {
     _log.info('Deleting backup: ${record.filename}');
 
-    // Delete local file
+    // Delete local file (filesystem path or SAF document URI)
     if (record.localPath != null) {
-      final file = File(record.localPath!);
-      if (await file.exists()) {
-        await file.delete();
-        _log.info('Deleted local file: ${record.localPath}');
+      final ref = record.localPath!;
+      if (isSafRef(ref)) {
+        await _safPort.delete(ref);
+        _log.info('Deleted SAF backup: $ref');
+      } else {
+        final file = File(ref);
+        if (await file.exists()) {
+          await file.delete();
+          _log.info('Deleted local file: $ref');
+        }
       }
     }
 

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -9,51 +9,25 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
-import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
-import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_database_adapter.dart';
 import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
 import 'package:submersion/features/backup/data/services/backup_target.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 
-/// Thin interface for the database operations BackupService needs.
-///
-/// Allows injecting a fake in tests without depending on the
-/// [DatabaseService] singleton directly.
-abstract class BackupDatabaseAdapter {
-  Future<void> backup(String destinationPath);
-  Future<void> restore(String backupPath);
-  Future<String> get databasePath;
-  AppDatabase get database;
-}
-
-/// Default adapter that delegates to [DatabaseService.instance].
-class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
-  final DatabaseService _dbAdapter;
-
-  const DefaultBackupDatabaseAdapter(this._dbAdapter);
-
-  @override
-  Future<void> backup(String destinationPath) =>
-      _dbAdapter.backup(destinationPath);
-
-  @override
-  Future<void> restore(String backupPath) => _dbAdapter.restore(backupPath);
-
-  @override
-  Future<String> get databasePath => _dbAdapter.databasePath;
-
-  @override
-  AppDatabase get database => _dbAdapter.database;
-}
+// BackupDatabaseAdapter + DefaultBackupDatabaseAdapter live in
+// backup_database_adapter.dart; re-exported so existing importers
+// (background_service, providers, tests) keep resolving these types from
+// backup_service.dart after the extraction that broke the backup_target cycle.
+export 'package:submersion/features/backup/data/services/backup_database_adapter.dart';
 
 /// A backups directory ready to write into, plus [release] to call when the
 /// caller is done -- which stops any security-scoped access that was armed to

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -18,6 +18,8 @@ import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
@@ -105,6 +107,10 @@ class BackupService {
   /// Set on a Merge restore so the next launch forces one reconciling sync.
   /// Nullable so existing constructions keep working.
   final PostRestoreSyncStore? _postRestoreSyncStore;
+
+  /// SAF write/read/delete seam for Android custom (`content://`) backup
+  /// locations. Defaults to the real platform channel; injectable for tests.
+  final BackupSafPort _safPort;
   final _log = LoggerService.forClass(BackupService);
   final _uuid = const Uuid();
 
@@ -118,12 +124,14 @@ class BackupService {
     SyncRepository? syncRepository,
     LibraryEpochStore? epochStore,
     PostRestoreSyncStore? postRestoreSyncStore,
+    BackupSafPort? safPort,
   }) : _dbAdapter = dbAdapter,
        _preferences = preferences,
        _cloudProvider = cloudProvider,
        _syncRepository = syncRepository ?? SyncRepository(),
        _epochStore = epochStore,
-       _postRestoreSyncStore = postRestoreSyncStore;
+       _postRestoreSyncStore = postRestoreSyncStore,
+       _safPort = safPort ?? const MethodChannelBackupSafPort();
 
   // ===========================================================================
   // Backup
@@ -136,43 +144,47 @@ class BackupService {
   /// the backup is also uploaded to cloud storage.
   Future<BackupRecord> performBackup({bool isAutomatic = false}) async {
     _log.info('Starting backup (automatic: $isAutomatic)');
-    // Arm any security-scoped access needed to reach a custom Apple location,
-    // and release it once the write (and prune) are done.
-    final lease = await BackupService.resolveBackupsDirectoryLeased(
+    // Resolve where the backup goes (filesystem dir or Android SAF tree) and
+    // arm any security-scoped access; release it once the write+prune are done.
+    final lease = await BackupService.resolveBackupTargetLeased(
       _preferences,
+      saf: _safPort,
     );
     try {
-      return await _performBackupInto(lease.path, isAutomatic: isAutomatic);
+      return await _performBackupInto(lease.target, isAutomatic: isAutomatic);
     } finally {
       await lease.release();
     }
   }
 
   Future<BackupRecord> _performBackupInto(
-    String localDir, {
+    BackupTarget target, {
     required bool isAutomatic,
   }) async {
     final filename = _generateFilename();
-    final localPath = p.join(localDir, filename);
 
-    // Copy the database file
-    await _dbAdapter.backup(localPath);
+    // Write the backup; ref is a filesystem path or a content:// document URI.
+    final ref = await target.write(_dbAdapter, filename);
 
-    // Get file size
-    final backupFile = File(localPath);
-    final sizeBytes = await backupFile.length();
+    // SAF refs are content URIs (no File length). The backup is a byte copy of
+    // the live DB, so its size equals the source's. Filesystem refs keep the
+    // existing File(ref).length() behavior.
+    final sizeBytes = isSafRef(ref)
+        ? await File(await _dbAdapter.databasePath).length()
+        : await File(ref).length();
 
     // Get dive and site counts
     final counts = await _getDiveSiteCounts();
 
-    // Attempt cloud upload
+    // Attempt cloud upload (cloud + a custom location are mutually exclusive,
+    // so ref is always a filesystem path here).
     String? cloudFileId;
     var location = BackupLocation.local;
 
     final settings = _preferences.getSettings();
     if (settings.cloudBackupEnabled && _cloudProvider != null) {
       try {
-        cloudFileId = await _uploadToCloud(localPath, filename);
+        cloudFileId = await _uploadToCloud(ref, filename);
         location = BackupLocation.both;
         _log.info('Backup uploaded to cloud: $cloudFileId');
       } catch (e, stack) {
@@ -194,7 +206,7 @@ class BackupService {
       diveCount: counts.diveCount,
       siteCount: counts.siteCount,
       cloudFileId: cloudFileId,
-      localPath: localPath,
+      localPath: ref,
       isAutomatic: isAutomatic,
     );
 
@@ -738,6 +750,37 @@ class BackupService {
     // on this platform. Reset to the sandbox default so backups keep working.
     await preferences.setBackupLocation(null); // clears location + bookmark
     return BackupDirLease(await resolveDefaultBackupsDirectory(), _noRelease);
+  }
+
+  /// Resolves where the next backup goes as a [BackupTarget]. A `content://`
+  /// custom location (Android SAF) yields a [SafBackupTarget] after confirming
+  /// the persisted tree grant still resolves; a dead grant self-heals to the
+  /// sandbox default. Everything else delegates to
+  /// [resolveBackupsDirectoryLeased], leaving iOS/macOS/Windows/Linux untouched.
+  static Future<BackupTargetLease> resolveBackupTargetLeased(
+    BackupPreferences preferences, {
+    BackupBookmarkPort? bookmarks,
+    BackupSafPort? saf,
+  }) async {
+    final custom = preferences.getSettings().backupLocation;
+    if (custom != null && isSafRef(custom)) {
+      final port = saf ?? const MethodChannelBackupSafPort();
+      final label = await port.resolveTree(custom);
+      if (label == null) {
+        // Grant revoked or folder deleted: reset to default so backups keep
+        // working (mirrors the Apple dead-bookmark self-heal). The settings
+        // subtitle reverts to the default, signaling a re-pick is needed.
+        await preferences.setBackupLocation(null);
+        final dir = await resolveDefaultBackupsDirectory();
+        return BackupTargetLease(FilesystemBackupTarget(dir), _noRelease);
+      }
+      return BackupTargetLease(SafBackupTarget(custom, port), _noRelease);
+    }
+    final lease = await resolveBackupsDirectoryLeased(
+      preferences,
+      bookmarks: bookmarks,
+    );
+    return BackupTargetLease(FilesystemBackupTarget(lease.path), lease.release);
   }
 
   static Future<void> _noRelease() async {}

--- a/lib/features/backup/data/services/backup_target.dart
+++ b/lib/features/backup/data/services/backup_target.dart
@@ -1,0 +1,62 @@
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+
+/// True iff [ref] is a SAF document/tree URI rather than a filesystem path.
+/// Only Android's picker produces these, so it doubles as the platform branch:
+/// non-`content://` refs always take the pre-existing filesystem path.
+bool isSafRef(String ref) => ref.startsWith('content://');
+
+/// Where a backup is written. Two implementations: a filesystem directory
+/// (default sandbox, desktop, Apple bookmarked dirs) and an Android SAF tree.
+abstract class BackupTarget {
+  /// Writes a backup named [fileName] using [adapter] to produce the bytes.
+  /// Returns the stored ref: a filesystem path or a `content://` document URI.
+  Future<String> write(BackupDatabaseAdapter adapter, String fileName);
+}
+
+/// Filesystem target. Delegates to [BackupDatabaseAdapter.backup] verbatim so
+/// existing behavior (and its tests) are unchanged.
+class FilesystemBackupTarget implements BackupTarget {
+  const FilesystemBackupTarget(this.dir);
+
+  final String dir;
+
+  @override
+  Future<String> write(BackupDatabaseAdapter adapter, String fileName) async {
+    final dest = p.join(dir, fileName);
+    await adapter.backup(dest);
+    return dest;
+  }
+}
+
+/// Android SAF target. Streams the live DB into the persisted tree via the port.
+class SafBackupTarget implements BackupTarget {
+  const SafBackupTarget(this.treeUri, this.port);
+
+  final String treeUri;
+  final BackupSafPort port;
+
+  @override
+  Future<String> write(BackupDatabaseAdapter adapter, String fileName) async {
+    final source = await adapter.databasePath;
+    return port.writeBackup(
+      treeUri: treeUri,
+      fileName: fileName,
+      sourcePath: source,
+    );
+  }
+}
+
+/// A resolved target plus a release callback. The callback arms/releases Apple
+/// security-scoped access for filesystem targets; it is a no-op for SAF and the
+/// default location.
+class BackupTargetLease {
+  const BackupTargetLease(this.target, this._release);
+
+  final BackupTarget target;
+  final Future<void> Function() _release;
+
+  Future<void> release() => _release();
+}

--- a/lib/features/backup/data/services/backup_target.dart
+++ b/lib/features/backup/data/services/backup_target.dart
@@ -1,7 +1,7 @@
 import 'package:path/path.dart' as p;
 
+import 'package:submersion/features/backup/data/services/backup_database_adapter.dart';
 import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
-import 'package:submersion/features/backup/data/services/backup_service.dart';
 
 /// True iff [ref] is a SAF document/tree URI rather than a filesystem path.
 /// Only Android's picker produces these, so it doubles as the platform branch:

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:submersion_saf/submersion_saf.dart';
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -482,6 +483,7 @@ class BackupSettingsPage extends ConsumerWidget {
           title: Text(context.l10n.backup_location_title),
           subtitle: Text(
             cloudDestination ??
+                ref.read(backupSettingsProvider.notifier).locationLabel ??
                 settings.backupLocation ??
                 context.l10n.backup_location_default,
             maxLines: 1,
@@ -494,6 +496,17 @@ class BackupSettingsPage extends ConsumerWidget {
                 // iOS: capture a security-scoped bookmark directly -- a bare
                 // file_picker path would lose its scope on the next launch.
                 picked = await BackupBookmarkService.pickFolder();
+              } else if (Platform.isAndroid) {
+                // Android: pick a SAF tree (content:// URI). A file_picker path
+                // is unwritable under scoped storage, so persist the URI + its
+                // display name and skip the bookmark flow entirely.
+                final folder = await SubmersionSaf.pickFolder();
+                if (folder != null) {
+                  await ref
+                      .read(backupSettingsProvider.notifier)
+                      .setSafBackupLocation(folder.uri, folder.displayName);
+                }
+                return;
               } else {
                 final path = await FilePicker.getDirectoryPath(
                   dialogTitle: context.l10n.backup_location_title,

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -499,7 +499,10 @@ class BackupSettingsPage extends ConsumerWidget {
               } else if (Platform.isAndroid) {
                 // Android: pick a SAF tree (content:// URI). A file_picker path
                 // is unwritable under scoped storage, so persist the URI + its
-                // display name and skip the bookmark flow entirely.
+                // display name and skip the bookmark flow entirely. Native +
+                // platform-gated, so the branch body is excluded from coverage;
+                // setSafBackupLocation itself is unit-tested separately.
+                // coverage:ignore-start
                 final folder = await SubmersionSaf.pickFolder();
                 if (folder != null) {
                   await ref
@@ -507,6 +510,7 @@ class BackupSettingsPage extends ConsumerWidget {
                       .setSafBackupLocation(folder.uri, folder.displayName);
                 }
                 return;
+                // coverage:ignore-end
               } else {
                 final path = await FilePicker.getDirectoryPath(
                   dialogTitle: context.l10n.backup_location_title,

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -97,6 +97,18 @@ class BackupSettingsNotifier extends StateNotifier<BackupSettings> {
     state = _prefs.getSettings();
   }
 
+  /// Android SAF: persist a `content://` tree URI as the location plus its human
+  /// label for display. Turns cloud backup off, like any custom location.
+  Future<void> setSafBackupLocation(String uri, String label) async {
+    await _prefs.setCloudBackupEnabled(false);
+    await _prefs.setBackupLocation(uri);
+    await _prefs.setBackupLocationLabel(label);
+    state = _prefs.getSettings();
+  }
+
+  /// Display label for a custom location (e.g. the SAF folder name), or null.
+  String? get locationLabel => _prefs.backupLocationLabel;
+
   /// Sign-out hook: cloud sync is being disabled, so cloud backup loses its
   /// destination. Resets the location to default only when cloud backup was
   /// actually on -- an unrelated custom location is none of sync's business.

--- a/lib/features/settings/presentation/pages/storage_settings_page.dart
+++ b/lib/features/settings/presentation/pages/storage_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/domain/entities/storage_config.dart';
+import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/database_migration_service.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/settings/presentation/pages/reset_complete_page.dart';
@@ -487,10 +488,45 @@ class _StorageSettingsPageState extends ConsumerState<StorageSettingsPage> {
     await _selectAndMigrateToCustomFolder();
   }
 
+  /// Android-only: lets the user pick which app-specific external volume
+  /// (internal storage or SD card) holds the database. The chooser is only
+  /// invoked from the Android pick branch; other platforms never call it.
+  Future<ExternalVolumeOption?> _chooseStorageVolume(
+    List<ExternalVolumeOption> options,
+  ) async {
+    if (!mounted) return null;
+    return showDialog<ExternalVolumeOption>(
+      context: context,
+      builder: (context) => SimpleDialog(
+        title: Text(context.l10n.db_location_choose_volume),
+        children: [
+          for (final option in options)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, option),
+              child: Text(
+                option.isInternal
+                    ? context.l10n.db_location_internal
+                    : context.l10n.db_location_sd_card,
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 8, 24, 8),
+            child: Text(
+              context.l10n.db_location_external_note,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _selectAndMigrateToCustomFolder() async {
     // Pick a folder
     final notifier = ref.read(storageConfigNotifierProvider.notifier);
-    final pickResult = await notifier.pickCustomFolder();
+    final pickResult = await notifier.pickCustomFolder(
+      chooser: _chooseStorageVolume,
+    );
 
     if (pickResult == null || !mounted) return;
 

--- a/lib/features/settings/presentation/pages/storage_settings_page.dart
+++ b/lib/features/settings/presentation/pages/storage_settings_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/settings/presentation/widgets/existing_datab
 import 'package:submersion/features/settings/presentation/widgets/migration_confirmation_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/migration_progress_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/reset_database_dialog.dart';
+import 'package:submersion/features/settings/presentation/widgets/storage_volume_chooser_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 class StorageSettingsPage extends ConsumerStatefulWidget {
@@ -491,35 +492,19 @@ class _StorageSettingsPageState extends ConsumerState<StorageSettingsPage> {
   /// Android-only: lets the user pick which app-specific external volume
   /// (internal storage or SD card) holds the database. The chooser is only
   /// invoked from the Android pick branch; other platforms never call it.
+  // Thin showDialog glue; the dialog content lives in the widget-tested
+  // StorageVolumeChooserDialog.
+  // coverage:ignore-start
   Future<ExternalVolumeOption?> _chooseStorageVolume(
     List<ExternalVolumeOption> options,
   ) async {
     if (!mounted) return null;
     return showDialog<ExternalVolumeOption>(
       context: context,
-      builder: (context) => SimpleDialog(
-        title: Text(context.l10n.db_location_choose_volume),
-        children: [
-          for (final option in options)
-            SimpleDialogOption(
-              onPressed: () => Navigator.pop(context, option),
-              child: Text(
-                option.isInternal
-                    ? context.l10n.db_location_internal
-                    : context.l10n.db_location_sd_card,
-              ),
-            ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(24, 8, 24, 8),
-            child: Text(
-              context.l10n.db_location_external_note,
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-          ),
-        ],
-      ),
+      builder: (_) => StorageVolumeChooserDialog(options: options),
     );
   }
+  // coverage:ignore-end
 
   Future<void> _selectAndMigrateToCustomFolder() async {
     // Pick a folder

--- a/lib/features/settings/presentation/providers/storage_providers.dart
+++ b/lib/features/settings/presentation/providers/storage_providers.dart
@@ -143,7 +143,13 @@ class StorageConfigNotifier extends StateNotifier<StorageConfigState> {
     Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)? chooser,
   }) async {
     _locationService.externalVolumeChooser = chooser;
-    return _locationService.pickCustomFolder();
+    try {
+      return await _locationService.pickCustomFolder();
+    } finally {
+      // Don't let the service retain a UI closure (which captures the page)
+      // beyond this call.
+      _locationService.externalVolumeChooser = null;
+    }
   }
 
   /// Check for existing database at a folder

--- a/lib/features/settings/presentation/providers/storage_providers.dart
+++ b/lib/features/settings/presentation/providers/storage_providers.dart
@@ -139,7 +139,10 @@ class StorageConfigNotifier extends StateNotifier<StorageConfigState> {
   ///
   /// Returns a [FolderPickResultWithBookmark] containing the path and optional
   /// bookmark data (for iOS), or null if cancelled.
-  Future<FolderPickResultWithBookmark?> pickCustomFolder() async {
+  Future<FolderPickResultWithBookmark?> pickCustomFolder({
+    Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)? chooser,
+  }) async {
+    _locationService.externalVolumeChooser = chooser;
     return _locationService.pickCustomFolder();
   }
 

--- a/lib/features/settings/presentation/widgets/storage_volume_chooser_dialog.dart
+++ b/lib/features/settings/presentation/widgets/storage_volume_chooser_dialog.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/services/database_location_service.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Lets the user pick which app-specific external volume (internal storage or
+/// SD card) holds the database. Pops with the chosen [ExternalVolumeOption], or
+/// null if dismissed.
+class StorageVolumeChooserDialog extends StatelessWidget {
+  const StorageVolumeChooserDialog({super.key, required this.options});
+
+  final List<ExternalVolumeOption> options;
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      title: Text(context.l10n.db_location_choose_volume),
+      children: [
+        for (final option in options)
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(context, option),
+            child: Text(
+              option.isInternal
+                  ? context.l10n.db_location_internal
+                  : context.l10n.db_location_sd_card,
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 8, 24, 8),
+          child: Text(
+            context.l10n.db_location_external_note,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "الموقع",
   "diveLog_detail_locationsMap_title": "مواقع الغوص",
   "diveLog_detail_coordinatesCopied": "تم نسخ الإحداثيات إلى الحافظة",
-  "diveLog_detail_openInMaps": "فتح في الخرائط"
+  "diveLog_detail_openInMaps": "فتح في الخرائط",
+  "db_location_choose_volume": "اختيار موقع التخزين",
+  "db_location_internal": "التخزين الداخلي",
+  "db_location_sd_card": "بطاقة SD",
+  "db_location_external_note": "تُحذف الملفات هنا عند إلغاء تثبيت التطبيق."
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Tauchplatz",
   "diveLog_detail_locationsMap_title": "Tauchorte",
   "diveLog_detail_coordinatesCopied": "Koordinaten in die Zwischenablage kopiert",
-  "diveLog_detail_openInMaps": "In Karten öffnen"
+  "diveLog_detail_openInMaps": "In Karten öffnen",
+  "db_location_choose_volume": "Speicherort wählen",
+  "db_location_internal": "Interner Speicher",
+  "db_location_sd_card": "SD-Karte",
+  "db_location_external_note": "Dateien hier werden entfernt, wenn Sie die App deinstallieren."
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10635,5 +10635,9 @@
   "statistics_priorBreakdown": "{logged} logged + {prior} prior",
   "@statistics_priorBreakdown": {"placeholders": {"logged": {"type": "String"}, "prior": {"type": "String"}}},
   "statistics_divingSince": "Diving since {year}",
-  "@statistics_divingSince": {"placeholders": {"year": {"type": "int"}}}
+  "@statistics_divingSince": {"placeholders": {"year": {"type": "int"}}},
+  "db_location_choose_volume": "Choose storage location",
+  "db_location_internal": "Internal storage",
+  "db_location_sd_card": "SD card",
+  "db_location_external_note": "Files here are removed if you uninstall the app."
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Punto de buceo",
   "diveLog_detail_locationsMap_title": "Ubicaciones de buceo",
   "diveLog_detail_coordinatesCopied": "Coordenadas copiadas al portapapeles",
-  "diveLog_detail_openInMaps": "Abrir en Mapas"
+  "diveLog_detail_openInMaps": "Abrir en Mapas",
+  "db_location_choose_volume": "Elegir ubicación de almacenamiento",
+  "db_location_internal": "Almacenamiento interno",
+  "db_location_sd_card": "Tarjeta SD",
+  "db_location_external_note": "Los archivos aquí se eliminan si desinstalas la aplicación."
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Site",
   "diveLog_detail_locationsMap_title": "Lieux de plongée",
   "diveLog_detail_coordinatesCopied": "Coordonnées copiées dans le presse-papiers",
-  "diveLog_detail_openInMaps": "Ouvrir dans Plans"
+  "diveLog_detail_openInMaps": "Ouvrir dans Plans",
+  "db_location_choose_volume": "Choisir l'emplacement de stockage",
+  "db_location_internal": "Stockage interne",
+  "db_location_sd_card": "Carte SD",
+  "db_location_external_note": "Les fichiers ici sont supprimés si vous désinstallez l'application."
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "אתר",
   "diveLog_detail_locationsMap_title": "מיקומי צלילה",
   "diveLog_detail_coordinatesCopied": "הקואורדינטות הועתקו ללוח",
-  "diveLog_detail_openInMaps": "פתח במפות"
+  "diveLog_detail_openInMaps": "פתח במפות",
+  "db_location_choose_volume": "בחירת מיקום אחסון",
+  "db_location_internal": "אחסון פנימי",
+  "db_location_sd_card": "כרטיס SD",
+  "db_location_external_note": "הקבצים כאן נמחקים אם מסירים את האפליקציה."
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Merülőhely",
   "diveLog_detail_locationsMap_title": "Merülési helyszínek",
   "diveLog_detail_coordinatesCopied": "Koordináták a vágólapra másolva",
-  "diveLog_detail_openInMaps": "Megnyitás a Térképekben"
+  "diveLog_detail_openInMaps": "Megnyitás a Térképekben",
+  "db_location_choose_volume": "Tárhely kiválasztása",
+  "db_location_internal": "Belső tárhely",
+  "db_location_sd_card": "SD-kártya",
+  "db_location_external_note": "Az itt tárolt fájlok törlődnek, ha eltávolítja az alkalmazást."
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Sito",
   "diveLog_detail_locationsMap_title": "Posizioni dell'immersione",
   "diveLog_detail_coordinatesCopied": "Coordinate copiate negli appunti",
-  "diveLog_detail_openInMaps": "Apri in Mappe"
+  "diveLog_detail_openInMaps": "Apri in Mappe",
+  "db_location_choose_volume": "Scegli posizione di archiviazione",
+  "db_location_internal": "Memoria interna",
+  "db_location_sd_card": "Scheda SD",
+  "db_location_external_note": "I file qui vengono rimossi se disinstalli l'app."
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -28959,6 +28959,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Diving since {year}'**
   String statistics_divingSince(int year);
+
+  /// No description provided for @db_location_choose_volume.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose storage location'**
+  String get db_location_choose_volume;
+
+  /// No description provided for @db_location_internal.
+  ///
+  /// In en, this message translates to:
+  /// **'Internal storage'**
+  String get db_location_internal;
+
+  /// No description provided for @db_location_sd_card.
+  ///
+  /// In en, this message translates to:
+  /// **'SD card'**
+  String get db_location_sd_card;
+
+  /// No description provided for @db_location_external_note.
+  ///
+  /// In en, this message translates to:
+  /// **'Files here are removed if you uninstall the app.'**
+  String get db_location_external_note;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16910,4 +16910,17 @@ class AppLocalizationsAr extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'يغوص منذ $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'اختيار موقع التخزين';
+
+  @override
+  String get db_location_internal => 'التخزين الداخلي';
+
+  @override
+  String get db_location_sd_card => 'بطاقة SD';
+
+  @override
+  String get db_location_external_note =>
+      'تُحذف الملفات هنا عند إلغاء تثبيت التطبيق.';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -17201,4 +17201,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Taucht seit $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Speicherort wählen';
+
+  @override
+  String get db_location_internal => 'Interner Speicher';
+
+  @override
+  String get db_location_sd_card => 'SD-Karte';
+
+  @override
+  String get db_location_external_note =>
+      'Dateien hier werden entfernt, wenn Sie die App deinstallieren.';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16946,4 +16946,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Diving since $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Choose storage location';
+
+  @override
+  String get db_location_internal => 'Internal storage';
+
+  @override
+  String get db_location_sd_card => 'SD card';
+
+  @override
+  String get db_location_external_note =>
+      'Files here are removed if you uninstall the app.';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -17245,4 +17245,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Buceando desde $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Elegir ubicación de almacenamiento';
+
+  @override
+  String get db_location_internal => 'Almacenamiento interno';
+
+  @override
+  String get db_location_sd_card => 'Tarjeta SD';
+
+  @override
+  String get db_location_external_note =>
+      'Los archivos aquí se eliminan si desinstalas la aplicación.';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -17300,4 +17300,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Plonge depuis $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Choisir l\'emplacement de stockage';
+
+  @override
+  String get db_location_internal => 'Stockage interne';
+
+  @override
+  String get db_location_sd_card => 'Carte SD';
+
+  @override
+  String get db_location_external_note =>
+      'Les fichiers ici sont supprimés si vous désinstallez l\'application.';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16789,4 +16789,17 @@ class AppLocalizationsHe extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'צולל מאז $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'בחירת מיקום אחסון';
+
+  @override
+  String get db_location_internal => 'אחסון פנימי';
+
+  @override
+  String get db_location_sd_card => 'כרטיס SD';
+
+  @override
+  String get db_location_external_note =>
+      'הקבצים כאן נמחקים אם מסירים את האפליקציה.';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -17187,4 +17187,17 @@ class AppLocalizationsHu extends AppLocalizations {
   String statistics_divingSince(int year) {
     return '$year óta merül';
   }
+
+  @override
+  String get db_location_choose_volume => 'Tárhely kiválasztása';
+
+  @override
+  String get db_location_internal => 'Belső tárhely';
+
+  @override
+  String get db_location_sd_card => 'SD-kártya';
+
+  @override
+  String get db_location_external_note =>
+      'Az itt tárolt fájlok törlődnek, ha eltávolítja az alkalmazást.';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -17236,4 +17236,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Immersioni dal $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Scegli posizione di archiviazione';
+
+  @override
+  String get db_location_internal => 'Memoria interna';
+
+  @override
+  String get db_location_sd_card => 'Scheda SD';
+
+  @override
+  String get db_location_external_note =>
+      'I file qui vengono rimossi se disinstalli l\'app.';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -17099,4 +17099,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Duikt sinds $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Opslaglocatie kiezen';
+
+  @override
+  String get db_location_internal => 'Interne opslag';
+
+  @override
+  String get db_location_sd_card => 'SD-kaart';
+
+  @override
+  String get db_location_external_note =>
+      'Bestanden hier worden verwijderd als je de app verwijdert.';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -17241,4 +17241,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String statistics_divingSince(int year) {
     return 'Mergulha desde $year';
   }
+
+  @override
+  String get db_location_choose_volume => 'Escolher local de armazenamento';
+
+  @override
+  String get db_location_internal => 'Armazenamento interno';
+
+  @override
+  String get db_location_sd_card => 'Cartão SD';
+
+  @override
+  String get db_location_external_note =>
+      'Os arquivos aqui são removidos se você desinstalar o aplicativo.';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -16399,4 +16399,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String statistics_divingSince(int year) {
     return '自 $year 年起潜水';
   }
+
+  @override
+  String get db_location_choose_volume => '选择存储位置';
+
+  @override
+  String get db_location_internal => '内部存储';
+
+  @override
+  String get db_location_sd_card => 'SD卡';
+
+  @override
+  String get db_location_external_note => '卸载应用后，此处的文件将被删除。';
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Duikstek",
   "diveLog_detail_locationsMap_title": "Duiklocaties",
   "diveLog_detail_coordinatesCopied": "Coördinaten gekopieerd naar klembord",
-  "diveLog_detail_openInMaps": "Openen in Kaarten"
+  "diveLog_detail_openInMaps": "Openen in Kaarten",
+  "db_location_choose_volume": "Opslaglocatie kiezen",
+  "db_location_internal": "Interne opslag",
+  "db_location_sd_card": "SD-kaart",
+  "db_location_external_note": "Bestanden hier worden verwijderd als je de app verwijdert."
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "Ponto de mergulho",
   "diveLog_detail_locationsMap_title": "Locais de mergulho",
   "diveLog_detail_coordinatesCopied": "Coordenadas copiadas para a área de transferência",
-  "diveLog_detail_openInMaps": "Abrir no Mapas"
+  "diveLog_detail_openInMaps": "Abrir no Mapas",
+  "db_location_choose_volume": "Escolher local de armazenamento",
+  "db_location_internal": "Armazenamento interno",
+  "db_location_sd_card": "Cartão SD",
+  "db_location_external_note": "Os arquivos aqui são removidos se você desinstalar o aplicativo."
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4883,5 +4883,9 @@
   "diveLog_detail_surfaceGps_site": "潜点",
   "diveLog_detail_locationsMap_title": "潜水位置",
   "diveLog_detail_coordinatesCopied": "坐标已复制到剪贴板",
-  "diveLog_detail_openInMaps": "在地图中打开"
+  "diveLog_detail_openInMaps": "在地图中打开",
+  "db_location_choose_volume": "选择存储位置",
+  "db_location_internal": "内部存储",
+  "db_location_sd_card": "SD卡",
+  "db_location_external_note": "卸载应用后，此处的文件将被删除。"
 }

--- a/packages/submersion_saf/android/build.gradle
+++ b/packages/submersion_saf/android/build.gradle
@@ -1,0 +1,50 @@
+group = "app.submersion.saf"
+version = "0.1.0"
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    namespace = "app.submersion.saf"
+    compileSdk = 34
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    sourceSets {
+        main.java.srcDirs += "src/main/kotlin"
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.22"
+    implementation "androidx.documentfile:documentfile:1.0.1"
+}

--- a/packages/submersion_saf/android/src/main/AndroidManifest.xml
+++ b/packages/submersion_saf/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt
+++ b/packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt
@@ -48,21 +48,38 @@ class SubmersionSafPlugin :
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        attach(binding)
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        attach(binding)
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        // Transient detach (e.g. rotation): keep any in-flight pick alive so it
+        // can complete once the activity reattaches.
+        detach()
+    }
+
+    override fun onDetachedFromActivity() {
+        // Real teardown: complete any in-flight pick as cancelled so the Dart
+        // Future resolves and a later pick isn't blocked with "BUSY".
+        pendingPick?.success(null)
+        pendingPick = null
+        detach()
+    }
+
+    private fun attach(binding: ActivityPluginBinding) {
         activity = binding.activity
         activityBinding = binding
         binding.addActivityResultListener(this)
     }
 
-    override fun onDetachedFromActivity() {
+    private fun detach() {
         activityBinding?.removeActivityResultListener(this)
         activity = null
         activityBinding = null
     }
-
-    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) =
-        onAttachedToActivity(binding)
-
-    override fun onDetachedFromActivityForConfigChanges() = onDetachedFromActivity()
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {

--- a/packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt
+++ b/packages/submersion_saf/android/src/main/kotlin/app/submersion/saf/SubmersionSafPlugin.kt
@@ -1,0 +1,191 @@
+package app.submersion.saf
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
+import java.io.File
+
+private const val CHANNEL = "app.submersion/saf"
+private const val OPEN_TREE_REQUEST = 0xC0DE
+
+/**
+ * Storage Access Framework helpers for backups.
+ *
+ * Registered as a plugin (not a manual MainActivity channel) so that
+ * GeneratedPluginRegistrant also installs it in the Workmanager background
+ * isolate's engine -- letting automatic backups write to the chosen folder
+ * with the app closed. All methods except [pickFolder] use applicationContext
+ * and need no Activity; [pickFolder] launches ACTION_OPEN_DOCUMENT_TREE.
+ */
+class SubmersionSafPlugin :
+    FlutterPlugin,
+    ActivityAware,
+    MethodChannel.MethodCallHandler,
+    PluginRegistry.ActivityResultListener {
+
+    private lateinit var context: Context
+    private lateinit var channel: MethodChannel
+    private var activity: Activity? = null
+    private var activityBinding: ActivityPluginBinding? = null
+    private var pendingPick: MethodChannel.Result? = null
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        context = binding.applicationContext
+        channel = MethodChannel(binding.binaryMessenger, CHANNEL)
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+        activityBinding = binding
+        binding.addActivityResultListener(this)
+    }
+
+    override fun onDetachedFromActivity() {
+        activityBinding?.removeActivityResultListener(this)
+        activity = null
+        activityBinding = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) =
+        onAttachedToActivity(binding)
+
+    override fun onDetachedFromActivityForConfigChanges() = onDetachedFromActivity()
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "pickFolder" -> pickFolder(result)
+            "writeBackup" -> writeBackup(call, result)
+            "readBackup" -> readBackup(call, result)
+            "delete" -> delete(call, result)
+            "exists" -> exists(call, result)
+            "resolveTree" -> resolveTree(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun pickFolder(result: MethodChannel.Result) {
+        val act = activity
+            ?: return result.error("NO_ACTIVITY", "No foreground activity", null)
+        if (pendingPick != null) {
+            return result.error("BUSY", "A pick is already in progress", null)
+        }
+        pendingPick = result
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION,
+            )
+        }
+        act.startActivityForResult(intent, OPEN_TREE_REQUEST)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode != OPEN_TREE_REQUEST) return false
+        val result = pendingPick ?: return true
+        pendingPick = null
+        val uri = data?.data
+        if (resultCode != Activity.RESULT_OK || uri == null) {
+            result.success(null)
+            return true
+        }
+        return try {
+            val flags =
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            context.contentResolver.takePersistableUriPermission(uri, flags)
+            val name = DocumentFile.fromTreeUri(context, uri)?.name ?: ""
+            result.success(mapOf("uri" to uri.toString(), "displayName" to name))
+            true
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.localizedMessage, null)
+            true
+        }
+    }
+
+    private fun writeBackup(call: MethodCall, result: MethodChannel.Result) {
+        val treeUri = call.argument<String>("treeUri")!!
+        val fileName = call.argument<String>("fileName")!!
+        val sourcePath = call.argument<String>("sourcePath")!!
+        try {
+            val tree = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+                ?: return result.error("NO_TREE", "Tree URI did not resolve", null)
+            // Replace an existing same-name file so retries don't accumulate "(1)" copies.
+            tree.findFile(fileName)?.delete()
+            val doc = tree.createFile("application/octet-stream", fileName)
+                ?: return result.error("CREATE_FAILED", "createFile returned null", null)
+            context.contentResolver.openOutputStream(doc.uri).use { out ->
+                if (out == null) {
+                    return result.error("OPEN_FAILED", "openOutputStream returned null", null)
+                }
+                File(sourcePath).inputStream().use { it.copyTo(out) }
+            }
+            result.success(doc.uri.toString())
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.localizedMessage, null)
+        } catch (e: Exception) {
+            result.error("WRITE_FAILED", e.localizedMessage, null)
+        }
+    }
+
+    private fun readBackup(call: MethodCall, result: MethodChannel.Result) {
+        val documentUri = call.argument<String>("documentUri")!!
+        val destPath = call.argument<String>("destPath")!!
+        try {
+            context.contentResolver.openInputStream(Uri.parse(documentUri)).use { input ->
+                if (input == null) {
+                    return result.error("OPEN_FAILED", "openInputStream returned null", null)
+                }
+                File(destPath).outputStream().use { input.copyTo(it) }
+            }
+            result.success(null)
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.localizedMessage, null)
+        } catch (e: Exception) {
+            result.error("READ_FAILED", e.localizedMessage, null)
+        }
+    }
+
+    private fun delete(call: MethodCall, result: MethodChannel.Result) {
+        val documentUri = call.argument<String>("documentUri")!!
+        val ok = try {
+            DocumentFile.fromSingleUri(context, Uri.parse(documentUri))?.delete() ?: false
+        } catch (_: Exception) {
+            false
+        }
+        result.success(ok)
+    }
+
+    private fun exists(call: MethodCall, result: MethodChannel.Result) {
+        val documentUri = call.argument<String>("documentUri")!!
+        val ok = try {
+            DocumentFile.fromSingleUri(context, Uri.parse(documentUri))?.exists() ?: false
+        } catch (_: Exception) {
+            false
+        }
+        result.success(ok)
+    }
+
+    private fun resolveTree(call: MethodCall, result: MethodChannel.Result) {
+        val treeUri = call.argument<String>("treeUri")!!
+        val name = try {
+            val df = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            if (df != null && df.exists() && df.canWrite()) (df.name ?: "") else null
+        } catch (_: Exception) {
+            null
+        }
+        result.success(name)
+    }
+}

--- a/packages/submersion_saf/lib/submersion_saf.dart
+++ b/packages/submersion_saf/lib/submersion_saf.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/services.dart';
+
+/// A picked SAF directory: the persisted tree URI and its human display name.
+class SafFolder {
+  const SafFolder({required this.uri, required this.displayName});
+
+  final String uri;
+  final String displayName;
+}
+
+/// Thin Dart facade over the Android `app.submersion/saf` channel.
+///
+/// Android-only. Callers MUST guard with `Platform.isAndroid`; on other
+/// platforms the channel has no handler and calls throw [MissingPluginException].
+class SubmersionSaf {
+  const SubmersionSaf._();
+
+  static const MethodChannel _channel = MethodChannel('app.submersion/saf');
+
+  /// Launches the system folder picker, persists read/write permission on the
+  /// chosen tree, and returns it. Null if the user cancelled.
+  static Future<SafFolder?> pickFolder() async {
+    final res = await _channel.invokeMapMethod<String, dynamic>('pickFolder');
+    if (res == null) return null;
+    return SafFolder(
+      uri: res['uri'] as String,
+      displayName: res['displayName'] as String,
+    );
+  }
+
+  /// Streams the file at [sourcePath] into [treeUri] as [fileName]. Returns the
+  /// created document's URI (stored as the backup record's ref).
+  static Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) async {
+    final uri = await _channel.invokeMethod<String>('writeBackup', {
+      'treeUri': treeUri,
+      'fileName': fileName,
+      'sourcePath': sourcePath,
+    });
+    return uri!;
+  }
+
+  /// Streams the document at [documentUri] out to [destPath] (a temp file used
+  /// for restore/validation).
+  static Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) =>
+      _channel.invokeMethod<void>('readBackup', {
+        'documentUri': documentUri,
+        'destPath': destPath,
+      });
+
+  /// Deletes the document at [documentUri]. Returns whether it was deleted.
+  static Future<bool> delete(String documentUri) async =>
+      await _channel
+          .invokeMethod<bool>('delete', {'documentUri': documentUri}) ??
+      false;
+
+  /// Whether the document at [documentUri] still exists.
+  static Future<bool> exists(String documentUri) async =>
+      await _channel
+          .invokeMethod<bool>('exists', {'documentUri': documentUri}) ??
+      false;
+
+  /// Returns the writable tree's display name, or null if the persisted grant
+  /// is gone (revoked / folder deleted) -- the signal to self-heal.
+  static Future<String?> resolveTree(String treeUri) =>
+      _channel.invokeMethod<String?>('resolveTree', {'treeUri': treeUri});
+}

--- a/packages/submersion_saf/lib/submersion_saf.dart
+++ b/packages/submersion_saf/lib/submersion_saf.dart
@@ -48,22 +48,23 @@ class SubmersionSaf {
   static Future<void> readBackup({
     required String documentUri,
     required String destPath,
-  }) =>
-      _channel.invokeMethod<void>('readBackup', {
-        'documentUri': documentUri,
-        'destPath': destPath,
-      });
+  }) => _channel.invokeMethod<void>('readBackup', {
+    'documentUri': documentUri,
+    'destPath': destPath,
+  });
 
   /// Deletes the document at [documentUri]. Returns whether it was deleted.
   static Future<bool> delete(String documentUri) async =>
-      await _channel
-          .invokeMethod<bool>('delete', {'documentUri': documentUri}) ??
+      await _channel.invokeMethod<bool>('delete', {
+        'documentUri': documentUri,
+      }) ??
       false;
 
   /// Whether the document at [documentUri] still exists.
   static Future<bool> exists(String documentUri) async =>
-      await _channel
-          .invokeMethod<bool>('exists', {'documentUri': documentUri}) ??
+      await _channel.invokeMethod<bool>('exists', {
+        'documentUri': documentUri,
+      }) ??
       false;
 
   /// Returns the writable tree's display name, or null if the persisted grant

--- a/packages/submersion_saf/pubspec.yaml
+++ b/packages/submersion_saf/pubspec.yaml
@@ -1,0 +1,24 @@
+name: submersion_saf
+description: Android Storage Access Framework helpers (persisted tree URIs, DocumentFile writes) for Submersion backups.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.10.0
+  flutter: ">=3.10.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: app.submersion.saf
+        pluginClass: SubmersionSafPlugin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1879,6 +1879,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  submersion_saf:
+    dependency: "direct main"
+    description:
+      path: "packages/submersion_saf"
+      relative: true
+    source: path
+    version: "0.1.0"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,8 @@ dependencies:
   # Platform Integration
   libdivecomputer_plugin:
     path: packages/libdivecomputer_plugin
+  submersion_saf:
+    path: packages/submersion_saf
   permission_handler: ^12.0.1
   file_picker: ^11.0.2
   image_picker: ^1.1.2

--- a/test/core/services/database_location_external_dirs_test.dart
+++ b/test/core/services/database_location_external_dirs_test.dart
@@ -1,24 +1,82 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test(
-    'classifies the emulated volume as internal and others as removable',
-    () {
-      final opts = classifyExternalDirs([
-        '/storage/emulated/0/Android/data/app.submersion/files',
-        '/storage/1A2B-3C4D/Android/data/app.submersion/files',
-      ]);
-      expect(opts[0].isInternal, isTrue);
-      expect(opts[1].isInternal, isFalse);
-      expect(opts[1].path, contains('1A2B-3C4D'));
+    'externalVolumeChooser setter stores the chooser without error',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final service = DatabaseLocationService(
+        await SharedPreferences.getInstance(),
+      );
+      service.externalVolumeChooser = (options) async => options.first;
+      // Setter is write-only; exercising it is the assertion (no throw).
     },
   );
 
-  test('a single volume is classified as internal', () {
-    final opts = classifyExternalDirs([
-      '/storage/emulated/0/Android/data/app.submersion/files',
-    ]);
-    expect(opts.single.isInternal, isTrue);
+  group('classifyExternalDirs', () {
+    test(
+      'classifies the emulated volume as internal and others as removable',
+      () {
+        final opts = classifyExternalDirs([
+          '/storage/emulated/0/Android/data/app.submersion/files',
+          '/storage/1A2B-3C4D/Android/data/app.submersion/files',
+        ]);
+        expect(opts[0].isInternal, isTrue);
+        expect(opts[1].isInternal, isFalse);
+        expect(opts[1].path, contains('1A2B-3C4D'));
+      },
+    );
+
+    test('a single volume is classified as internal', () {
+      final opts = classifyExternalDirs([
+        '/storage/emulated/0/Android/data/app.submersion/files',
+      ]);
+      expect(opts.single.isInternal, isTrue);
+    });
+  });
+
+  group('resolveAndroidDbDir', () {
+    test('chooser pick creates and returns <chosen>/Submersion', () async {
+      final tmp = await Directory.systemTemp.createTemp('radd_pick_');
+      addTearDown(() => tmp.delete(recursive: true));
+      final opts = classifyExternalDirs([
+        p.join(tmp.path, 'internal'),
+        p.join(tmp.path, 'sd'),
+      ]);
+
+      final dir = await resolveAndroidDbDir(opts, (o) async => o[1]);
+
+      expect(dir, p.join(tmp.path, 'sd', 'Submersion'));
+      expect(Directory(dir!).existsSync(), isTrue);
+    });
+
+    test('dismissed chooser returns null and creates nothing', () async {
+      final opts = classifyExternalDirs([
+        '/storage/emulated/0/x',
+        '/storage/SD/x',
+      ]);
+      expect(await resolveAndroidDbDir(opts, (o) async => null), isNull);
+    });
+
+    test('no chooser defaults to the internal (first) volume', () async {
+      final tmp = await Directory.systemTemp.createTemp('radd_default_');
+      addTearDown(() => tmp.delete(recursive: true));
+      final opts = classifyExternalDirs([
+        p.join(tmp.path, 'internal'),
+        p.join(tmp.path, 'sd'),
+      ]);
+
+      final dir = await resolveAndroidDbDir(opts, null);
+
+      expect(dir, p.join(tmp.path, 'internal', 'Submersion'));
+      expect(Directory(dir!).existsSync(), isTrue);
+    });
   });
 }

--- a/test/core/services/database_location_external_dirs_test.dart
+++ b/test/core/services/database_location_external_dirs_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_location_service.dart';
+
+void main() {
+  test(
+    'classifies the emulated volume as internal and others as removable',
+    () {
+      final opts = classifyExternalDirs([
+        '/storage/emulated/0/Android/data/app.submersion/files',
+        '/storage/1A2B-3C4D/Android/data/app.submersion/files',
+      ]);
+      expect(opts[0].isInternal, isTrue);
+      expect(opts[1].isInternal, isFalse);
+      expect(opts[1].path, contains('1A2B-3C4D'));
+    },
+  );
+
+  test('a single volume is classified as internal', () {
+    final opts = classifyExternalDirs([
+      '/storage/emulated/0/Android/data/app.submersion/files',
+    ]);
+    expect(opts.single.isInternal, isTrue);
+  });
+}

--- a/test/features/backup/data/repositories/backup_preferences_test.dart
+++ b/test/features/backup/data/repositories/backup_preferences_test.dart
@@ -211,4 +211,18 @@ void main() {
       expect(history.first.id, 'r3');
     });
   });
+
+  group('BackupPreferences location label', () {
+    test(
+      'backup location label round-trips and clears with the location',
+      () async {
+        await backupPreferences.setBackupLocation('content://tree/1');
+        await backupPreferences.setBackupLocationLabel('Backups');
+        expect(backupPreferences.backupLocationLabel, 'Backups');
+
+        await backupPreferences.setBackupLocation(null);
+        expect(backupPreferences.backupLocationLabel, isNull);
+      },
+    );
+  });
 }

--- a/test/features/backup/data/repositories/backup_preferences_test.dart
+++ b/test/features/backup/data/repositories/backup_preferences_test.dart
@@ -224,5 +224,13 @@ void main() {
         expect(backupPreferences.backupLocationLabel, isNull);
       },
     );
+
+    test('setBackupLocationLabel(null) clears the label directly', () async {
+      await backupPreferences.setBackupLocationLabel('Backups');
+      expect(backupPreferences.backupLocationLabel, 'Backups');
+
+      await backupPreferences.setBackupLocationLabel(null);
+      expect(backupPreferences.backupLocationLabel, isNull);
+    });
   });
 }

--- a/test/features/backup/data/services/backup_saf_port_test.dart
+++ b/test/features/backup/data/services/backup_saf_port_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+
+/// Exercises [MethodChannelBackupSafPort] (and, through it, the SubmersionSaf
+/// facade) against a mocked `app.submersion/saf` channel.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('app.submersion/saf');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  const port = MethodChannelBackupSafPort();
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      switch (call.method) {
+        case 'writeBackup':
+          return 'content://doc/new';
+        case 'delete':
+          return true;
+        case 'exists':
+          return false;
+        case 'resolveTree':
+          return 'Backups';
+        default:
+          return null;
+      }
+    });
+  });
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  Map args() => calls.single.arguments as Map;
+
+  test('writeBackup forwards args and returns the document URI', () async {
+    final uri = await port.writeBackup(
+      treeUri: 'content://tree',
+      fileName: 'b.db',
+      sourcePath: '/data/x.db',
+    );
+    expect(uri, 'content://doc/new');
+    expect(calls.single.method, 'writeBackup');
+    expect(args()['treeUri'], 'content://tree');
+    expect(args()['fileName'], 'b.db');
+    expect(args()['sourcePath'], '/data/x.db');
+  });
+
+  test('readBackup forwards documentUri + destPath', () async {
+    await port.readBackup(documentUri: 'content://doc', destPath: '/tmp/x.db');
+    expect(calls.single.method, 'readBackup');
+    expect(args()['documentUri'], 'content://doc');
+    expect(args()['destPath'], '/tmp/x.db');
+  });
+
+  test('delete forwards documentUri and returns the result', () async {
+    expect(await port.delete('content://doc'), isTrue);
+    expect(calls.single.method, 'delete');
+    expect(args()['documentUri'], 'content://doc');
+  });
+
+  test('exists forwards documentUri and returns the result', () async {
+    expect(await port.exists('content://doc'), isFalse);
+    expect(calls.single.method, 'exists');
+    expect(args()['documentUri'], 'content://doc');
+  });
+
+  test('resolveTree forwards treeUri and returns the display name', () async {
+    expect(await port.resolveTree('content://tree'), 'Backups');
+    expect(calls.single.method, 'resolveTree');
+    expect(args()['treeUri'], 'content://tree');
+  });
+
+  test('delete/exists coerce a null channel result to false', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+    expect(await port.delete('content://doc'), isFalse);
+    expect(await port.exists('content://doc'), isFalse);
+  });
+}

--- a/test/features/backup/data/services/backup_service_saf_io_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_io_test.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+
+/// Adapter whose [databasePath] points at a real file (so size reads work) and
+/// whose [backup] copies it, mirroring the production filesystem copy.
+class _FileWritingAdapter implements BackupDatabaseAdapter {
+  _FileWritingAdapter(this.dbPath);
+  final String dbPath;
+  int restoreCalls = 0;
+
+  @override
+  Future<void> backup(String destinationPath) async {
+    final f = File(destinationPath);
+    await f.parent.create(recursive: true);
+    await File(dbPath).copy(destinationPath);
+  }
+
+  @override
+  Future<void> restore(String backupPath) async => restoreCalls++;
+
+  @override
+  Future<String> get databasePath async => dbPath;
+
+  @override
+  AppDatabase get database => throw UnimplementedError();
+}
+
+class _FakeSafPort implements BackupSafPort {
+  _FakeSafPort({this.validSourcePath});
+
+  /// If set, [readBackup] copies this (valid) DB to the requested temp path.
+  final String? validSourcePath;
+  String? wroteFrom;
+
+  @override
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) async {
+    wroteFrom = sourcePath;
+    return 'content://tree/doc/$fileName';
+  }
+
+  @override
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) async {
+    final src = validSourcePath;
+    if (src != null) await File(src).copy(destPath);
+  }
+
+  @override
+  Future<bool> delete(String documentUri) async => true;
+
+  @override
+  Future<bool> exists(String documentUri) async => true;
+
+  @override
+  Future<String?> resolveTree(String treeUri) async => 'Backups';
+}
+
+class _SpySync extends SyncRepository {
+  int rebaselineCalls = 0;
+
+  @override
+  Future<String> getDeviceId() async => 'live';
+
+  @override
+  Future<String?> getLastAcceptedEpochId() async => null;
+
+  @override
+  Future<void> rebaselineAfterRestore({
+    String? preserveDeviceId,
+    String? preserveEpochId,
+  }) async => rebaselineCalls++;
+}
+
+String _validDb(String dir, String name) {
+  final path = '$dir/$name';
+  final db = sqlite3.sqlite3.open(path);
+  db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
+  db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
+  db.dispose();
+  return path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BackupPreferences prefs;
+  late Directory tmp;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => Directory.systemTemp.path,
+        );
+  });
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = BackupPreferences(await SharedPreferences.getInstance());
+    tmp = await Directory.systemTemp.createTemp('saf_io_');
+  });
+  tearDown(() => tmp.delete(recursive: true));
+
+  test(
+    'performBackup to a SAF location writes via the port + records the URI',
+    () async {
+      final live = _validDb(tmp.path, 'live.db');
+      await prefs.setBackupLocation('content://tree/1');
+      final port = _FakeSafPort();
+      final service = BackupService(
+        dbAdapter: _FileWritingAdapter(live),
+        preferences: prefs,
+        safPort: port,
+      );
+
+      final record = await service.performBackup();
+
+      expect(record.localPath, startsWith('content://tree/doc/'));
+      expect(record.sizeBytes, greaterThan(0));
+      expect(port.wroteFrom, live);
+    },
+  );
+
+  test(
+    'restoreFromBackup streams a SAF backup to a temp file and restores it',
+    () async {
+      final source = _validDb(tmp.path, 'backup.db');
+      final adapter = _FileWritingAdapter(_validDb(tmp.path, 'live.db'));
+      final spy = _SpySync();
+      final service = BackupService(
+        dbAdapter: adapter,
+        preferences: prefs,
+        safPort: _FakeSafPort(validSourcePath: source),
+        syncRepository: spy,
+      );
+
+      final record = BackupRecord(
+        id: 'r',
+        filename: 'restore_me.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+        localPath: 'content://tree/doc/x',
+      );
+
+      await service.restoreFromBackup(record);
+
+      expect(adapter.restoreCalls, 1);
+      expect(spy.rebaselineCalls, 1);
+    },
+  );
+
+  test('restoreFromBackup throws when the SAF document is gone', () async {
+    final port = _FakeSafPort()..wroteFrom = null;
+    // exists() returns true in the fake; override via a record whose doc is
+    // absent by using a port that reports missing.
+    final service = BackupService(
+      dbAdapter: _FileWritingAdapter(_validDb(tmp.path, 'live.db')),
+      preferences: prefs,
+      safPort: _MissingSafPort(),
+      syncRepository: _SpySync(),
+    );
+    final record = BackupRecord(
+      id: 'r',
+      filename: 'gone.db',
+      timestamp: DateTime(2026),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+      localPath: 'content://tree/doc/gone',
+    );
+
+    expect(() => service.restoreFromBackup(record), throwsA(isA<Exception>()));
+    expect(port.wroteFrom, isNull);
+  });
+}
+
+class _MissingSafPort extends _FakeSafPort {
+  @override
+  Future<bool> exists(String documentUri) async => false;
+}

--- a/test/features/backup/data/services/backup_service_saf_refs_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_refs_test.dart
@@ -33,8 +33,7 @@ class _RecordingSafPort implements BackupSafPort {
     required String treeUri,
     required String fileName,
     required String sourcePath,
-  }) async =>
-      'content://doc';
+  }) async => 'content://doc';
 
   @override
   Future<void> readBackup({
@@ -49,22 +48,23 @@ class _RecordingSafPort implements BackupSafPort {
   }
 
   @override
-  Future<bool> exists(String documentUri) async => existing.contains(documentUri);
+  Future<bool> exists(String documentUri) async =>
+      existing.contains(documentUri);
 
   @override
   Future<String?> resolveTree(String treeUri) async => 'Backups';
 }
 
 BackupRecord _saf(String id, String uri) => BackupRecord(
-      id: id,
-      filename: 'f.db',
-      timestamp: DateTime(2026),
-      sizeBytes: 1,
-      location: BackupLocation.local,
-      diveCount: 0,
-      siteCount: 0,
-      localPath: uri,
-    );
+  id: id,
+  filename: 'f.db',
+  timestamp: DateTime(2026),
+  sizeBytes: 1,
+  location: BackupLocation.local,
+  diveCount: 0,
+  siteCount: 0,
+  localPath: uri,
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -74,9 +74,9 @@ void main() {
   setUpAll(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
-      const MethodChannel('plugins.flutter.io/path_provider'),
-      (call) async => Directory.systemTemp.path,
-    );
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => Directory.systemTemp.path,
+        );
   });
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -85,10 +85,10 @@ void main() {
   });
 
   BackupService service() => BackupService(
-        dbAdapter: _NoopAdapter(),
-        preferences: prefs,
-        safPort: port,
-      );
+    dbAdapter: _NoopAdapter(),
+    preferences: prefs,
+    safPort: port,
+  );
 
   test('deleteBackup routes a SAF ref to the port', () async {
     final r = _saf('1', 'content://doc/1');
@@ -97,12 +97,14 @@ void main() {
     expect(port.deleted, ['content://doc/1']);
   });
 
-  test('getValidatedBackupHistory keeps a SAF record whose doc still exists',
-      () async {
-    port.existing.add('content://doc/keep');
-    await prefs.addRecord(_saf('keep', 'content://doc/keep'));
-    await prefs.addRecord(_saf('gone', 'content://doc/gone'));
-    final valid = await service().getValidatedBackupHistory();
-    expect(valid.map((r) => r.id), ['keep']);
-  });
+  test(
+    'getValidatedBackupHistory keeps a SAF record whose doc still exists',
+    () async {
+      port.existing.add('content://doc/keep');
+      await prefs.addRecord(_saf('keep', 'content://doc/keep'));
+      await prefs.addRecord(_saf('gone', 'content://doc/gone'));
+      final valid = await service().getValidatedBackupHistory();
+      expect(valid.map((r) => r.id), ['keep']);
+    },
+  );
 }

--- a/test/features/backup/data/services/backup_service_saf_refs_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_refs_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+
+class _NoopAdapter implements BackupDatabaseAdapter {
+  @override
+  Future<void> backup(String destinationPath) async {}
+
+  @override
+  Future<void> restore(String backupPath) async {}
+
+  @override
+  Future<String> get databasePath async => '/data/live.db';
+
+  @override
+  AppDatabase get database => throw UnimplementedError();
+}
+
+class _RecordingSafPort implements BackupSafPort {
+  final List<String> deleted = [];
+  final Set<String> existing = {};
+
+  @override
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) async =>
+      'content://doc';
+
+  @override
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) async {}
+
+  @override
+  Future<bool> delete(String documentUri) async {
+    deleted.add(documentUri);
+    return true;
+  }
+
+  @override
+  Future<bool> exists(String documentUri) async => existing.contains(documentUri);
+
+  @override
+  Future<String?> resolveTree(String treeUri) async => 'Backups';
+}
+
+BackupRecord _saf(String id, String uri) => BackupRecord(
+      id: id,
+      filename: 'f.db',
+      timestamp: DateTime(2026),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+      diveCount: 0,
+      siteCount: 0,
+      localPath: uri,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BackupPreferences prefs;
+  late _RecordingSafPort port;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async => Directory.systemTemp.path,
+    );
+  });
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = BackupPreferences(await SharedPreferences.getInstance());
+    port = _RecordingSafPort();
+  });
+
+  BackupService service() => BackupService(
+        dbAdapter: _NoopAdapter(),
+        preferences: prefs,
+        safPort: port,
+      );
+
+  test('deleteBackup routes a SAF ref to the port', () async {
+    final r = _saf('1', 'content://doc/1');
+    await prefs.addRecord(r);
+    await service().deleteBackup(r);
+    expect(port.deleted, ['content://doc/1']);
+  });
+
+  test('getValidatedBackupHistory keeps a SAF record whose doc still exists',
+      () async {
+    port.existing.add('content://doc/keep');
+    await prefs.addRecord(_saf('keep', 'content://doc/keep'));
+    await prefs.addRecord(_saf('gone', 'content://doc/gone'));
+    final valid = await service().getValidatedBackupHistory();
+    expect(valid.map((r) => r.id), ['keep']);
+  });
+}

--- a/test/features/backup/data/services/backup_service_saf_refs_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_refs_test.dart
@@ -107,4 +107,18 @@ void main() {
       expect(valid.map((r) => r.id), ['keep']);
     },
   );
+
+  test('deleteBackup removes a filesystem-path backup file', () async {
+    final tmp = await Directory.systemTemp.createTemp('del_fs_');
+    addTearDown(() => tmp.delete(recursive: true));
+    final file = File('${tmp.path}/b.db');
+    await file.writeAsString('x');
+    final r = _saf('fs', file.path);
+    await prefs.addRecord(r);
+
+    await service().deleteBackup(r);
+
+    expect(file.existsSync(), isFalse);
+    expect(port.deleted, isEmpty); // filesystem path must not route to SAF
+  });
 }

--- a/test/features/backup/data/services/backup_target_lease_test.dart
+++ b/test/features/backup/data/services/backup_target_lease_test.dart
@@ -19,8 +19,7 @@ class _FakeSafPort implements BackupSafPort {
     required String treeUri,
     required String fileName,
     required String sourcePath,
-  }) async =>
-      'content://doc';
+  }) async => 'content://doc';
 
   @override
   Future<void> readBackup({
@@ -45,9 +44,9 @@ void main() {
   setUpAll(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
-      const MethodChannel('plugins.flutter.io/path_provider'),
-      (call) async => Directory.systemTemp.path,
-    );
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => Directory.systemTemp.path,
+        );
   });
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -65,25 +64,28 @@ void main() {
     await lease.release();
   });
 
-  test('content:// location + dead grant -> self-heal to filesystem default',
-      () async {
-    await preferences.setBackupLocation('content://tree/gone');
-    final lease = await BackupService.resolveBackupTargetLeased(
-      preferences,
-      saf: _FakeSafPort(tree: null),
-    );
-    expect(lease.target, isA<FilesystemBackupTarget>());
-    expect(preferences.getSettings().backupLocation, isNull);
-  });
+  test(
+    'content:// location + dead grant -> self-heal to filesystem default',
+    () async {
+      await preferences.setBackupLocation('content://tree/gone');
+      final lease = await BackupService.resolveBackupTargetLeased(
+        preferences,
+        saf: _FakeSafPort(tree: null),
+      );
+      expect(lease.target, isA<FilesystemBackupTarget>());
+      expect(preferences.getSettings().backupLocation, isNull);
+    },
+  );
 
   test(
-      'filesystem location -> FilesystemBackupTarget (delegates to existing resolver)',
-      () async {
-    final tmp = await Directory.systemTemp.createTemp('btl_');
-    addTearDown(() => tmp.delete(recursive: true));
-    await preferences.setBackupLocation(tmp.path);
-    BackupBookmarkService.debugSupportedOverride = false;
-    final lease = await BackupService.resolveBackupTargetLeased(preferences);
-    expect(lease.target, isA<FilesystemBackupTarget>());
-  });
+    'filesystem location -> FilesystemBackupTarget (delegates to existing resolver)',
+    () async {
+      final tmp = await Directory.systemTemp.createTemp('btl_');
+      addTearDown(() => tmp.delete(recursive: true));
+      await preferences.setBackupLocation(tmp.path);
+      BackupBookmarkService.debugSupportedOverride = false;
+      final lease = await BackupService.resolveBackupTargetLeased(preferences);
+      expect(lease.target, isA<FilesystemBackupTarget>());
+    },
+  );
 }

--- a/test/features/backup/data/services/backup_target_lease_test.dart
+++ b/test/features/backup/data/services/backup_target_lease_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/backup_bookmark_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
+
+class _FakeSafPort implements BackupSafPort {
+  _FakeSafPort({this.tree});
+  final String? tree; // resolveTree result
+
+  @override
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) async =>
+      'content://doc';
+
+  @override
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) async {}
+
+  @override
+  Future<bool> delete(String documentUri) async => true;
+
+  @override
+  Future<bool> exists(String documentUri) async => true;
+
+  @override
+  Future<String?> resolveTree(String treeUri) async => tree;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BackupPreferences preferences;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async => Directory.systemTemp.path,
+    );
+  });
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = BackupPreferences(await SharedPreferences.getInstance());
+  });
+  tearDown(() => BackupBookmarkService.debugSupportedOverride = null);
+
+  test('content:// location + live grant -> SafBackupTarget', () async {
+    await preferences.setBackupLocation('content://tree/1');
+    final lease = await BackupService.resolveBackupTargetLeased(
+      preferences,
+      saf: _FakeSafPort(tree: 'Backups'),
+    );
+    expect(lease.target, isA<SafBackupTarget>());
+    await lease.release();
+  });
+
+  test('content:// location + dead grant -> self-heal to filesystem default',
+      () async {
+    await preferences.setBackupLocation('content://tree/gone');
+    final lease = await BackupService.resolveBackupTargetLeased(
+      preferences,
+      saf: _FakeSafPort(tree: null),
+    );
+    expect(lease.target, isA<FilesystemBackupTarget>());
+    expect(preferences.getSettings().backupLocation, isNull);
+  });
+
+  test(
+      'filesystem location -> FilesystemBackupTarget (delegates to existing resolver)',
+      () async {
+    final tmp = await Directory.systemTemp.createTemp('btl_');
+    addTearDown(() => tmp.delete(recursive: true));
+    await preferences.setBackupLocation(tmp.path);
+    BackupBookmarkService.debugSupportedOverride = false;
+    final lease = await BackupService.resolveBackupTargetLeased(preferences);
+    expect(lease.target, isA<FilesystemBackupTarget>());
+  });
+}

--- a/test/features/backup/data/services/backup_target_test.dart
+++ b/test/features/backup/data/services/backup_target_test.dart
@@ -66,31 +66,39 @@ void main() {
     expect(isSafRef('/storage/emulated/0/x.db'), isFalse);
   });
 
-  test('FilesystemBackupTarget delegates to adapter.backup and returns the path',
-      () async {
-    final tmp = await Directory.systemTemp.createTemp('fbt_');
-    addTearDown(() => tmp.delete(recursive: true));
-    final src = File(p.join(tmp.path, 'src.db'));
-    await src.writeAsString('db');
-    final adapter = _FakeAdapter(src.path);
+  test(
+    'FilesystemBackupTarget delegates to adapter.backup and returns the path',
+    () async {
+      final tmp = await Directory.systemTemp.createTemp('fbt_');
+      addTearDown(() => tmp.delete(recursive: true));
+      final src = File(p.join(tmp.path, 'src.db'));
+      await src.writeAsString('db');
+      final adapter = _FakeAdapter(src.path);
 
-    final ref = await FilesystemBackupTarget(tmp.path).write(adapter, 'out.db');
+      final ref = await FilesystemBackupTarget(
+        tmp.path,
+      ).write(adapter, 'out.db');
 
-    expect(ref, p.join(tmp.path, 'out.db'));
-    expect(adapter.copiedTo, ref);
-    expect(File(ref).existsSync(), isTrue);
-  });
+      expect(ref, p.join(tmp.path, 'out.db'));
+      expect(adapter.copiedTo, ref);
+      expect(File(ref).existsSync(), isTrue);
+    },
+  );
 
-  test('SafBackupTarget writes the source DB via the port, returns the doc URI',
-      () async {
-    final port = _FakeSafPort();
-    final adapter = _FakeAdapter('/data/live.db');
+  test(
+    'SafBackupTarget writes the source DB via the port, returns the doc URI',
+    () async {
+      final port = _FakeSafPort();
+      final adapter = _FakeAdapter('/data/live.db');
 
-    final ref =
-        await SafBackupTarget('content://tree/1', port).write(adapter, 'out.db');
+      final ref = await SafBackupTarget(
+        'content://tree/1',
+        port,
+      ).write(adapter, 'out.db');
 
-    expect(ref, 'content://tree/1/doc/out.db');
-    expect(port.wroteSource, '/data/live.db');
-    expect(port.wroteName, 'out.db');
-  });
+      expect(ref, 'content://tree/1/doc/out.db');
+      expect(port.wroteSource, '/data/live.db');
+      expect(port.wroteName, 'out.db');
+    },
+  );
 }

--- a/test/features/backup/data/services/backup_target_test.dart
+++ b/test/features/backup/data/services/backup_target_test.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/backup/data/services/backup_saf_port.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
+
+class _FakeAdapter implements BackupDatabaseAdapter {
+  _FakeAdapter(this.dbPath);
+  final String dbPath;
+  String? copiedTo;
+
+  @override
+  Future<void> backup(String destinationPath) async {
+    copiedTo = destinationPath;
+    await File(dbPath).copy(destinationPath);
+  }
+
+  @override
+  Future<void> restore(String backupPath) async {}
+
+  @override
+  Future<String> get databasePath async => dbPath;
+
+  @override
+  AppDatabase get database => throw UnimplementedError();
+}
+
+class _FakeSafPort implements BackupSafPort {
+  String? wroteSource;
+  String? wroteName;
+
+  @override
+  Future<String> writeBackup({
+    required String treeUri,
+    required String fileName,
+    required String sourcePath,
+  }) async {
+    wroteSource = sourcePath;
+    wroteName = fileName;
+    return 'content://tree/1/doc/$fileName';
+  }
+
+  @override
+  Future<void> readBackup({
+    required String documentUri,
+    required String destPath,
+  }) async {}
+
+  @override
+  Future<bool> delete(String documentUri) async => true;
+
+  @override
+  Future<bool> exists(String documentUri) async => true;
+
+  @override
+  Future<String?> resolveTree(String treeUri) async => 'Backups';
+}
+
+void main() {
+  test('isSafRef detects content URIs', () {
+    expect(isSafRef('content://x/y'), isTrue);
+    expect(isSafRef('/storage/emulated/0/x.db'), isFalse);
+  });
+
+  test('FilesystemBackupTarget delegates to adapter.backup and returns the path',
+      () async {
+    final tmp = await Directory.systemTemp.createTemp('fbt_');
+    addTearDown(() => tmp.delete(recursive: true));
+    final src = File(p.join(tmp.path, 'src.db'));
+    await src.writeAsString('db');
+    final adapter = _FakeAdapter(src.path);
+
+    final ref = await FilesystemBackupTarget(tmp.path).write(adapter, 'out.db');
+
+    expect(ref, p.join(tmp.path, 'out.db'));
+    expect(adapter.copiedTo, ref);
+    expect(File(ref).existsSync(), isTrue);
+  });
+
+  test('SafBackupTarget writes the source DB via the port, returns the doc URI',
+      () async {
+    final port = _FakeSafPort();
+    final adapter = _FakeAdapter('/data/live.db');
+
+    final ref =
+        await SafBackupTarget('content://tree/1', port).write(adapter, 'out.db');
+
+    expect(ref, 'content://tree/1/doc/out.db');
+    expect(port.wroteSource, '/data/live.db');
+    expect(port.wroteName, 'out.db');
+  });
+}

--- a/test/features/backup/data/services/submersion_saf_facade_test.dart
+++ b/test/features/backup/data/services/submersion_saf_facade_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion_saf/submersion_saf.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('app.submersion/saf');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('writeBackup passes args and returns the document URI', () async {
+    MethodCall? seen;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      seen = call;
+      return 'content://doc/1';
+    });
+
+    final uri = await SubmersionSaf.writeBackup(
+      treeUri: 'content://tree/1',
+      fileName: 'b.db',
+      sourcePath: '/data/x.db',
+    );
+
+    expect(uri, 'content://doc/1');
+    expect(seen!.method, 'writeBackup');
+    expect((seen!.arguments as Map)['fileName'], 'b.db');
+  });
+
+  test('pickFolder maps a null channel result to null', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+    expect(await SubmersionSaf.pickFolder(), isNull);
+  });
+
+  test('resolveTree returns the display name', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => 'Backups');
+    expect(await SubmersionSaf.resolveTree('content://tree/1'), 'Backups');
+  });
+}

--- a/test/features/backup/presentation/providers/backup_saf_location_test.dart
+++ b/test/features/backup/presentation/providers/backup_saf_location_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+
+void main() {
+  late BackupSettingsNotifier notifier;
+  late BackupPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = BackupPreferences(await SharedPreferences.getInstance());
+    notifier = BackupSettingsNotifier(prefs);
+  });
+
+  test(
+    'setSafBackupLocation persists uri + label and disables cloud backup',
+    () async {
+      await notifier.setCloudBackupEnabled(true);
+      await notifier.setSafBackupLocation('content://tree/1', 'Backups');
+
+      expect(notifier.state.backupLocation, 'content://tree/1');
+      expect(notifier.locationLabel, 'Backups');
+      expect(notifier.state.cloudBackupEnabled, isFalse);
+      expect(prefs.backupLocationLabel, 'Backups');
+    },
+  );
+
+  test('locationLabel is null when no custom location is set', () {
+    expect(notifier.locationLabel, isNull);
+  });
+
+  test('resetting the location to default clears the label', () async {
+    await notifier.setSafBackupLocation('content://tree/1', 'Backups');
+    await notifier.setBackupLocation(null);
+
+    expect(notifier.locationLabel, isNull);
+    expect(notifier.state.backupLocation, isNull);
+  });
+}

--- a/test/features/settings/presentation/providers/storage_providers_pick_test.dart
+++ b/test/features/settings/presentation/providers/storage_providers_pick_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/database_location_service.dart';
+import 'package:submersion/core/services/database_migration_service.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/settings/presentation/providers/storage_providers.dart';
+
+/// Records every assignment to [externalVolumeChooser] so the wrapper's
+/// set-then-clear-in-finally contract can be asserted, and short-circuits the
+/// underlying pick.
+class _SpyLocationService extends DatabaseLocationService {
+  _SpyLocationService(super.prefs);
+
+  final chooserAssignments = <Object?>[];
+
+  @override
+  set externalVolumeChooser(
+    Future<ExternalVolumeOption?> Function(List<ExternalVolumeOption>)? chooser,
+  ) => chooserAssignments.add(chooser);
+
+  @override
+  Future<FolderPickResultWithBookmark?> pickCustomFolder() async => null;
+}
+
+Future<ExternalVolumeOption?> _chooser(List<ExternalVolumeOption> o) async =>
+    o.first;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('pickCustomFolder sets the chooser then clears it in finally', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final spy = _SpyLocationService(prefs);
+    final notifier = StorageConfigNotifier(
+      spy,
+      DatabaseMigrationService(DatabaseService.instance, spy),
+    );
+
+    final result = await notifier.pickCustomFolder(chooser: _chooser);
+
+    expect(result, isNull);
+    // First the chooser is installed, then cleared to null in the finally.
+    expect(spy.chooserAssignments, hasLength(2));
+    expect(spy.chooserAssignments.first, isNotNull);
+    expect(spy.chooserAssignments.last, isNull);
+  });
+}

--- a/test/features/settings/presentation/widgets/storage_volume_chooser_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/storage_volume_chooser_dialog_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/services/database_location_service.dart';
+import 'package:submersion/features/settings/presentation/widgets/storage_volume_chooser_dialog.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  final options = classifyExternalDirs([
+    '/storage/emulated/0/Android/data/app.submersion/files',
+    '/storage/1A2B-3C4D/Android/data/app.submersion/files',
+  ]);
+
+  Future<ExternalVolumeOption?> pumpAndOpen(WidgetTester tester) async {
+    ExternalVolumeOption? picked;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                picked = await showDialog<ExternalVolumeOption>(
+                  context: context,
+                  builder: (_) => StorageVolumeChooserDialog(options: options),
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return picked;
+  }
+
+  testWidgets('shows internal + SD options and the uninstall note', (
+    tester,
+  ) async {
+    await pumpAndOpen(tester);
+
+    expect(find.text('Internal storage'), findsOneWidget);
+    expect(find.text('SD card'), findsOneWidget);
+    expect(
+      find.text('Files here are removed if you uninstall the app.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping SD card pops with the removable option', (tester) async {
+    await pumpAndOpen(tester);
+    await tester.tap(find.text('SD card'));
+    await tester.pumpAndSettle();
+
+    // Re-open to read the captured value via a second pump is unnecessary:
+    // the dialog already popped, so assert on the rebuilt tree state instead.
+    expect(find.byType(StorageVolumeChooserDialog), findsNothing);
+  });
+
+  testWidgets('tapping Internal storage selects the internal volume', (
+    tester,
+  ) async {
+    ExternalVolumeOption? picked;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                picked = await showDialog<ExternalVolumeOption>(
+                  context: context,
+                  builder: (_) => StorageVolumeChooserDialog(options: options),
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Internal storage'));
+    await tester.pumpAndSettle();
+
+    expect(picked, isNotNull);
+    expect(picked!.isInternal, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes **#300** — on Android 11+ (reporter: Android 16 / LineageOS, Samsung A52s) every backup to a user-chosen folder failed with:

```
Backup failed: PathAccessException: Cannot copy file to <folder>
... submersion.db (OS Error: Operation not permitted, errno = 1)
```

The same scoped-storage bug also affected the **custom database location** feature. This PR fixes both, Android-only.

## Root cause

A folder picked via the system picker is granted as a SAF `content://` tree-URI permission, **not** filesystem write access. But the code used `file_picker.getDirectoryPath()` — which in v11 resolves the tree URI down to a raw `/storage/...` path and discards the `content://` grant — then wrote with `dart:io` `File.copy()`. With only `READ_EXTERNAL_STORAGE` (maxSdk 32) in the manifest, that copy is `EPERM` under scoped storage. (The custom-DB path had an identical bug, plus a stale comment claiming it already used SAF.)

A backup is a one-shot file write, so SAF is the right tool. The live database is **not** — SQLite needs a real lockable path (`-wal`/`-shm`, byte-range locks), so it can't live on a SAF stream. Hence two different mechanisms.

## What changed

### Part A — SAF backups
- **New in-repo `submersion_saf` plugin** (`packages/submersion_saf`, our own Kotlin — no third-party SAF lib): persists the tree URI with read/write permission and writes/reads/deletes backups via `DocumentFile` + `ContentResolver` streams. It's a *plugin* (not a manual `MainActivity` channel) specifically so `GeneratedPluginRegistrant` installs it in the **Workmanager background isolate** too — letting **automatic** backups write to the chosen folder with the app closed.
- **`BackupTarget` abstraction** (`FilesystemBackupTarget` unchanged, `SafBackupTarget` new). `performBackup` now resolves a target via `resolveBackupTargetLeased`, which branches on the ref format: a `content://` location → SAF; anything else delegates to the existing filesystem resolver. A dead/revoked grant **self-heals** to the sandbox default so backups keep working (mirrors the existing Apple dead-bookmark reset).
- **`BackupRecord.localPath`** is now a path-or-`content://` ref; restore / delete / history-validation route SAF refs through the plugin (restore streams the doc to a temp file first, since SQLite + validation need a real path).
- Backup-settings picker uses the SAF picker on Android and shows the folder's display name (not a raw URI).

### Part B — custom DB location
- On Android, `pickCustomFolder()` now offers a curated choice among app-specific external volumes from `path_provider` (Internal storage / SD card) — real writable paths SQLite can open, no permissions. Localized chooser dialog added (4 strings × 11 locales). All existing path-based migration logic is reused unchanged.

## Platform impact

**Android-only in behavior.** iOS / macOS / Windows / Linux are unchanged — every new path is gated on `Platform.isAndroid` or the `content://` ref discriminator, and `submersion_saf` declares only the `android` platform. The edits split Android out of branches it previously shared with desktop; the shared filesystem path stays byte-for-byte identical and is covered by the existing suite on Linux CI.

## Testing

- New unit tests: SAF facade (mock channel), `BackupTarget`, `resolveBackupTargetLeased` + self-heal, ref-aware restore/delete/history, location-label round-trip, external-dir classifier.
- Existing `backup_service_leased_test` (9 cases) and all backup tests stay green — the old resolver is untouched.
- **Full suite: 9070 passed / 9 skipped.** `flutter analyze` clean. `dart format` clean (whole project). Debug **APK builds** with the native plugin.

## Device verification (pending — reporter offered to test)

Native SAF can't be exercised in the Dart suite. To confirm on a real Android 11+ device:
- [ ] Manual "Backup Now" to an internal folder **and** an SD-card folder → success, file visible in a file manager
- [ ] **Automatic** (Workmanager) backup lands in the chosen folder with the app backgrounded *(the key architectural risk — background-isolate plugin registration)*
- [ ] Restore from a SAF backup
- [ ] Relocate the DB to the SD card and back; data intact
- [ ] Revoke the folder permission → next backup self-heals to the default location

## Docs

Design + plan committed under `docs/superpowers/` (spec: root cause, the SAF-vs-SQLite asymmetry, platform-impact contract; plan: task-by-task TDD breakdown).

Closes #300