### PR TITLE
fix(ble): OSTC nano (hw_ostc3) downloads over BLE (#280)

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -87,6 +87,17 @@ class BleIoStream(
         ) {
             if (newState == BluetoothProfile.STATE_CONNECTED) {
                 connected = true
+                // Request a high-priority (low-interval) connection so the dive
+                // computer's serial->BLE bridge can drain its buffer fast enough
+                // during bulk logbook/profile dumps. Some devices (e.g. the
+                // Heinrichs Weikamp OSTC nano, #280) stream the whole logbook
+                // back-to-back with no flow control and overflow -> drop
+                // notifications when the connection interval is too slow.
+                // Best-effort: the peripheral or controller may ignore it.
+                val priorityRequested =
+                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
+                NativeLogger.d(TAG, "BLE",
+                    "requestConnectionPriority(HIGH) -> $priorityRequested")
                 // Request a larger MTU before discovering services.
                 // Android defaults to 23 bytes (20 payload); CoreBluetooth
                 // negotiates automatically but Android requires an explicit call.

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -162,6 +162,12 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             }
         }
 
+        // CoreBluetooth exposes no connection-interval/priority API (unlike
+        // Android's requestConnectionPriority or Windows' preferred connection
+        // parameters): iOS negotiates the interval from the peripheral's
+        // preferred values. High-rate dumps (e.g. the OSTC nano logbook, #280)
+        // therefore rely on the device pacing itself; the hw_ostc3 read fix
+        // handles correctly-delivered data and a retry covers transient loss.
         NativeLogger.d("BleIoStream", category: "BLE", "Connected; discovering services")
         peripheral.discoverServices(nil)
         let discoverResult = discoverSemaphore.wait(timeout: .now() + .seconds(10))

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -174,6 +174,12 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
         return FALSE;
     }
 
+    // Note: BlueZ exposes no simple per-connection priority/interval API on
+    // org.bluez.Device1 (unlike Android's requestConnectionPriority or
+    // Windows' preferred connection parameters), so high-rate dumps (e.g. the
+    // OSTC nano logbook, #280) rely on the device pacing itself plus the
+    // hw_ostc3 read fix; transient notification loss is covered by a retry.
+
     // Get the device name.
     stream->device_name = get_string_property(
         stream->connection, device_path, "org.bluez.Device1", "Name");

--- a/packages/libdivecomputer_plugin/patches/0002-hw-ostc3-ble-partial-read.patch
+++ b/packages/libdivecomputer_plugin/patches/0002-hw-ostc3-ble-partial-read.patch
@@ -1,0 +1,39 @@
+diff --git a/src/hw_ostc3.c b/src/hw_ostc3.c
+index 6bd8560..9eb3c1d 100644
+--- a/src/hw_ostc3.c
++++ b/src/hw_ostc3.c
+@@ -215,18 +215,30 @@ hw_ostc3_read (hw_ostc3_device_t *device, dc_event_progress_t *progress, unsigne
+ 		if (nbytes + length > size)
+ 			length = size - nbytes;
+ 
+-		// Read the packet.
+-		rc = dc_iostream_read (device->iostream, data + nbytes, length, NULL);
++		// Read the packet, and advance by the number of bytes actually
++		// read rather than the requested length. Some transports return
++		// fewer bytes than requested per call: a BLE transport may deliver a
++		// single GATT notification per read (to preserve packet boundaries
++		// for the SLIP/packet based parsers), whereas a serial transport
++		// fills the request via its inter-byte timeout. Assuming a full read
++		// would skip over data that has not arrived yet and corrupt the
++		// downloaded logbook and dive profiles.
++		size_t actual = 0;
++		rc = dc_iostream_read (device->iostream, data + nbytes, length, &actual);
+ 		if (rc != DC_STATUS_SUCCESS)
+ 			return rc;
++		if (actual == 0) {
++			ERROR (((dc_device_t *) device)->context, "Failed to receive the packet.");
++			return DC_STATUS_TIMEOUT;
++		}
+ 
+ 		// Update and emit a progress event.
+ 		if (progress) {
+-			progress->current += length;
++			progress->current += actual;
+ 			device_event_emit ((dc_device_t *) device, DC_EVENT_PROGRESS, progress);
+ 		}
+ 
+-		nbytes += length;
++		nbytes += actual;
+ 	}
+ 
+ 	return rc;

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -52,8 +52,37 @@ target_include_directories(test_descriptor_match_integration PRIVATE
     ${CONFIG_DIR}
 )
 
+# Regression test for issue #280: hw_ostc3_read must accumulate the bytes each
+# read actually returns, not assume every dc_iostream_read filled the full
+# request (false for the one-notification-per-read BLE transport). The test
+# #includes hw_ostc3.c to reach the static read helper, so it links that
+# driver's transitive leaf dependencies + the private headers under src/.
+# device.c is deliberately NOT linked: its dc_device_open switch-dispatches to
+# ~40 driver *_device_open functions and would pull in the whole library; the
+# few device-private symbols hw_ostc3.c references from functions this test
+# never calls are stubbed in test_hw_ostc3_read.c instead.
+add_executable(test_hw_ostc3_read
+    test_hw_ostc3_read.c
+    ${LIBDC_DIR}/src/iostream.c
+    ${LIBDC_DIR}/src/custom.c
+    ${LIBDC_DIR}/src/array.c
+    ${LIBDC_DIR}/src/context.c
+    ${LIBDC_DIR}/src/buffer.c
+    ${LIBDC_DIR}/src/aes.c
+    ${LIBDC_DIR}/src/packet.c
+    ${LIBDC_DIR}/src/common.c
+    ${LIBDC_DIR}/src/platform.c
+)
+target_include_directories(test_hw_ostc3_read PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${CONFIG_DIR}
+)
+
 enable_testing()
 add_test(NAME test_dive_converter COMMAND test_dive_converter)
 add_test(NAME test_serial_callbacks COMMAND test_serial_callbacks)
 add_test(NAME test_descriptor_matcher COMMAND test_descriptor_matcher)
 add_test(NAME test_descriptor_match_integration COMMAND test_descriptor_match_integration)
+add_test(NAME test_hw_ostc3_read COMMAND test_hw_ostc3_read)

--- a/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
+++ b/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
@@ -1,0 +1,155 @@
+// Regression test for issue #280: the Heinrichs Weikamp OSTC nano (and the
+// whole hw_ostc3 family) connected over BLE but failed to download dives with
+// result=-7.
+//
+// Root cause: hw_ostc3_read() reads fixed blocks (e.g. the 4096-byte COMPACT
+// logbook) in 1024-byte chunks and assumed each dc_iostream_read() returned the
+// full requested size. That holds for serial (its inter-byte timeout stops a
+// read at the gap between packets), but the BLE transport returns at most one
+// GATT notification per read -- the packet-boundary behavior added in
+// "fix(ble): preserve GATT notification boundaries" for the i330R/Shearwater
+// parsers. The driver advanced its write offset by the requested length instead
+// of the bytes actually read, so it consumed only one notification per 1024
+// bytes, left the rest of the block uninitialized, and then mismatched the
+// trailing ready byte -- failing the download.
+//
+// hw_ostc3_read is static, so this test #includes the translation unit to reach
+// it. A mock custom iostream serves a scripted payload one 16-byte
+// "notification" per read, reproducing the BLE transport. The fix makes
+// hw_ostc3_read accumulate the bytes actually returned, filling the whole block
+// across however many reads it takes.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libdivecomputer/common.h>
+#include <libdivecomputer/context.h>
+#include <libdivecomputer/custom.h>
+
+#include "hw_ostc3.c"  // for the static hw_ostc3_read + hw_ostc3_device_t
+
+// Stubs for the device-private symbols that the #included hw_ostc3.c
+// references only from functions this test never calls (device open/close/
+// foreach/firmware). Their real definitions live in device.c, which cannot be
+// linked here: its dc_device_open switch-dispatches to ~40 driver
+// *_device_open functions and would drag in the whole library. hw_ostc3_read
+// (the function under test, called with progress == NULL) invokes none of
+// these, so trivial stubs satisfy the linker without affecting the test.
+int dc_device_isinstance(dc_device_t *device, const dc_device_vtable_t *vtable) {
+  (void)device;
+  (void)vtable;
+  return 0;
+}
+dc_device_t *dc_device_allocate(dc_context_t *context,
+                                const dc_device_vtable_t *vtable) {
+  (void)context;
+  (void)vtable;
+  return NULL;
+}
+void dc_device_deallocate(dc_device_t *device) { (void)device; }
+void device_event_emit(dc_device_t *device, dc_event_type_t event,
+                       const void *data) {
+  (void)device;
+  (void)event;
+  (void)data;
+}
+int device_is_cancelled(dc_device_t *device) {
+  (void)device;
+  return 0;
+}
+
+// One GATT notification carries up to 16 bytes in this mock, matching the
+// OSTC nano debug logs from the issue (mostly 16-byte notifications).
+#define MOCK_CHUNK 16
+
+typedef struct {
+  const unsigned char *data;
+  size_t size;
+  size_t offset;
+  int read_calls;
+} mock_stream_t;
+
+// Serves at most one notification (MOCK_CHUNK bytes) per read, regardless of
+// how many bytes the caller requested -- exactly what the BLE transport does.
+static dc_status_t mock_read(void *userdata, void *data, size_t size,
+                             size_t *actual) {
+  mock_stream_t *m = (mock_stream_t *)userdata;
+  size_t remaining = m->size - m->offset;
+  size_t n = size < MOCK_CHUNK ? size : MOCK_CHUNK;
+  if (n > remaining) n = remaining;
+  memcpy(data, m->data + m->offset, n);
+  m->offset += n;
+  m->read_calls++;
+  if (actual) *actual = n;
+  return DC_STATUS_SUCCESS;
+}
+
+static dc_status_t mock_close(void *userdata) {
+  (void)userdata;
+  return DC_STATUS_SUCCESS;
+}
+
+static int failures = 0;
+
+// Reads `total` bytes through hw_ostc3_read against the chunked mock transport
+// and verifies every byte was filled with the scripted payload.
+static void check_fill(size_t total) {
+  unsigned char *payload = (unsigned char *)malloc(total);
+  for (size_t i = 0; i < total; i++) payload[i] = (unsigned char)(i & 0xFF);
+
+  dc_context_t *ctx = NULL;
+  assert(dc_context_new(&ctx) == DC_STATUS_SUCCESS);
+
+  mock_stream_t mock = {payload, total, 0, 0};
+  dc_custom_cbs_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.read = mock_read;
+  cbs.close = mock_close;
+
+  dc_iostream_t *iostream = NULL;
+  assert(dc_custom_open(&iostream, ctx, DC_TRANSPORT_BLE, &cbs, &mock) ==
+         DC_STATUS_SUCCESS);
+
+  hw_ostc3_device_t dev;
+  memset(&dev, 0, sizeof(dev));
+  dev.base.context = ctx;
+  dev.iostream = iostream;
+
+  unsigned char *out = (unsigned char *)malloc(total);
+  memset(out, 0xEE, total);  // sentinel: unfilled bytes stay 0xEE
+
+  dc_status_t rc = hw_ostc3_read(&dev, NULL, out, total);
+
+  if (rc == DC_STATUS_SUCCESS && memcmp(out, payload, total) == 0) {
+    printf("PASS: hw_ostc3_read fills %zu bytes across %d one-notification reads\n",
+           total, mock.read_calls);
+  } else {
+    size_t bad = 0;
+    while (bad < total && out[bad] == payload[bad]) bad++;
+    printf("FAIL: hw_ostc3_read(%zu) rc=%d, first mismatch at byte %zu "
+           "(got 0x%02x want 0x%02x) after %d reads\n",
+           total, (int)rc, bad, bad < total ? out[bad] : 0,
+           bad < total ? payload[bad] : 0, mock.read_calls);
+    failures++;
+  }
+
+  dc_iostream_close(iostream);
+  dc_context_free(ctx);
+  free(payload);
+  free(out);
+}
+
+int main(void) {
+  check_fill(64);    // exact multiple of the 16-byte notification size
+  check_fill(40);    // non-multiple: the final read is a partial (8 bytes)
+  check_fill(4096);  // the real COMPACT logbook size from issue #280
+
+  if (failures == 0) {
+    printf("All hw_ostc3_read tests passed.\n");
+    return 0;
+  }
+  printf("%d hw_ostc3_read test(s) FAILED.\n", failures);
+  return 1;
+}

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -51,6 +51,21 @@ bool BleIoStream::ConnectAndDiscover(uint64_t bluetooth_address) {
         if (!device_) return false;
 
         device_name_ = winrt::to_string(device_.Name());
+
+        // Request a throughput-optimized (low-interval) connection so a dive
+        // computer's serial->BLE bridge can drain its buffer during bulk
+        // logbook/profile dumps without overflowing and dropping
+        // notifications (issue #280, OSTC nano). Best-effort: hold the request
+        // for the connection's lifetime; ignore failures on Windows < 2004 or
+        // unsupported controllers.
+        try {
+            preferred_connection_request_ =
+                device_.RequestPreferredConnectionParameters(
+                    BluetoothLEPreferredConnectionParameters::
+                        ThroughputOptimized());
+        } catch (...) {
+        }
+
         return DiscoverCharacteristics();
     } catch (...) {
         return false;
@@ -224,6 +239,9 @@ void BleIoStream::Close() {
         notify_characteristic_ = nullptr;
     }
     write_characteristic_ = nullptr;
+    // Release the throughput-optimized connection request (reverts to the
+    // controller's default interval) before tearing down the device.
+    preferred_connection_request_ = nullptr;
     if (device_) {
         device_.Close();
         device_ = nullptr;

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -91,6 +91,13 @@ class BleIoStream {
   static const winrt::guid kHalcyonSymbiosRxUuid;
 
   winrt::Windows::Devices::Bluetooth::BluetoothLEDevice device_{nullptr};
+  // Held for the connection's lifetime to keep a throughput-optimized
+  // (low-interval) connection request active; released in Close(). A faster
+  // connection interval lets a dive computer's serial->BLE bridge drain its
+  // buffer during bulk logbook dumps without dropping notifications (#280).
+  winrt::Windows::Devices::Bluetooth::
+      BluetoothLEPreferredConnectionParametersRequest
+          preferred_connection_request_{nullptr};
   winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
       GattCharacteristic write_characteristic_{nullptr};
   winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::


### PR DESCRIPTION
## Summary

Fixes #280 — the Heinrichs Weikamp OSTC nano connects over BLE but fails to download dives (`result=-7`). Investigation found **two** layers; this PR addresses the deterministic one and adds a best-effort mitigation for the other.

### 1. Correctness — the deterministic break (the actual fix)

`hw_ostc3_read` downloads fixed blocks (the 4096-byte `COMPACT` logbook, dive headers, profiles) in 1024-byte chunks and assumed **every** `dc_iostream_read` returned the full requested size:

```c
rc = dc_iostream_read(device->iostream, data + nbytes, length, NULL);
...
nbytes += length;   // assumes the whole 1024 arrived
```

That holds for serial (its inter-byte timeout stops a read at the gap between packets), but **not** for the BLE transport, which returns **one GATT notification per read** — the packet-boundary behavior introduced for the i330R/Shearwater parsers in *"fix(ble): preserve GATT notification boundaries"*. So the driver advanced 1024 bytes while only ~16 arrived, read mostly-uninitialized memory, and mismatched the trailing ready byte → download fails. This breaks the **entire `hw_ostc3` family** over BLE on every platform.

The transport can't distinguish "full read" from "one packet": upstream `dc_iostream_read` always hands the transport a non-NULL `actual` (libdivecomputer commit `945898f`, by design). The i330R/Shearwater parsers read with `actual != NULL` (one-notification is correct for them); `hw_ostc3` + ~20 other drivers read with `actual == NULL` (they need the full fill). So the fix belongs in the **driver**.

**Fix** (vendored fork `submersion-app/libdivecomputer@44515a4`, submodule bumped here): `hw_ostc3_read` now advances by the bytes **actually** returned, filling the block across as many notifications as it takes. No-op for serial (`actual == size`). Covers COMPACT/HEADER/DIVE reads, all platforms.

### 2. Robustness — reduce notification loss

The reporter's build *predated* the regression above; their download still failed because CoreBluetooth delivered only **4090 of 4096** bytes — ~6 GATT notifications lost during the ~300/sec `COMPACT` fire-hose (the OSTC's serial→BLE bridge overflows when the connection interval is too slow; notifications are unacknowledged, so they're dropped). To reduce that, we now request a faster connection where the platform allows it:

- **Android** — `requestConnectionPriority(CONNECTION_PRIORITY_HIGH)`
- **Windows** — `BluetoothLEPreferredConnectionParameters.ThroughputOptimized` (held for the connection lifetime)
- **iOS/macOS (CoreBluetooth)** and **Linux (BlueZ)** — no app-facing connection-interval API; documented inline.

This is a best-effort hint (like the existing `requestMtu`); it complements, not replaces, the correctness fix.

## Tests

- New `test/native/test_hw_ostc3_read.c` (`#include`s `hw_ostc3.c` to reach the static helper; mock one-notification iostream). **RED** before the fix: a 4096-byte read did **4** reads → garbage at byte 16. **GREEN** after: **256** reads → full block. Also covers exact-multiple and partial-final-chunk cases.
- Full native C suite (5 tests) and Swift suite pass; `hw_ostc3.c` compiles clean under `-Wall -Wextra`.

## Verification status

- ✅ Unit/regression tests, native suites, clean compile.
- ⏳ **OSTC nano hardware verification pending** (cannot test BLE here).
- ⏳ **Windows WinRT** connection-parameters code validated by CI (no Windows toolchain locally).