### PR TITLE
Cursor/pinch-anchored zoom & pointer-aware navigation for the dive profile chart

### DIFF
--- a/docs/superpowers/plans/2026-06-21-dive-profile-chart-zoom-navigation.md
+++ b/docs/superpowers/plans/2026-06-21-dive-profile-chart-zoom-navigation.md
@@ -1,0 +1,1233 @@
+# Dive Profile Chart Zoom & Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the dive profile chart zoom anchor under the cursor/pinch (not the upper-left corner) and give it intuitive pan navigation, branched on the active pointer kind.
+
+**Architecture:** Lift all zoom/pan/anchor math out of `_DiveProfileChartState` into a pure, immutable `ProfileChartViewport` value object plus two pure helpers (`chartFocalFraction`, `chartDragIntent`). The widget keeps one `_viewport` field, re-sources its visible-window computation from it, and routes each input (mouse wheel, trackpad pinch, touch pinch, mouse drag, touch scrub, double-tap, double-tap-hold) to a one-line viewport transform. Uniform 2-D zoom is kept; only the anchoring and navigation change.
+
+**Tech Stack:** Flutter 3.x / Dart 3, `fl_chart ^1.1.1` (zoom/pan stays hand-rolled on top of it), Riverpod, `flutter_test`.
+
+## Global Constraints
+
+- **Library floor:** `fl_chart ^1.1.1` — do not change the dependency or adopt fl_chart's built-in transform.
+- **Zoom model:** uniform 2-D (one scalar scales time and depth together); zoom limits `[1.0, 10.0]`.
+- **Anchoring:** zoom anchors under the cursor (mouse/trackpad/wheel) or pinch focal point (touch), never the corner.
+- **Pointer routing:** branch on the active `PointerDeviceKind`, not `defaultTargetPlatform`. One-finger touch drag stays a tooltip scrub; mouse drag pans.
+- **Immutability always** (CLAUDE.md): `ProfileChartViewport` is `@immutable`; every gesture returns a new instance, never mutates.
+- **State scope:** zoom/pan stays local widget state in `_DiveProfileChartState`; no new Riverpod provider; per-instance and ephemeral, as today.
+- **No new user-facing strings:** reuse the existing `diveLog_profile_zoomHint` l10n key. (If any new string were added it would require translation into all 10 non-en locales — this plan adds none.)
+- **No emojis, no `print`/console output, no hardcoded secrets.** Proper null handling.
+- **Formatting/analysis:** `dart format .` must produce no changes; `flutter analyze` (whole project, not piped) must be clean — run both before every commit.
+- **Tests:** run the specific test file(s) for the task, not broad directories (avoids Bash timeouts).
+- **Branch:** all work and commits on `worktree-profile-chart-zoom-nav`. Per-task commits are pre-authorized by plan approval + subagent-driven execution. No `Co-Authored-By` trailer.
+
+---
+
+### Task 1: `ProfileChartViewport` value object
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart`
+- Test: `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `class ProfileChartViewport` with `const ProfileChartViewport({double zoom = 1, double offsetX = 0, double offsetY = 0})`
+  - `static const double minZoom = 1.0, maxZoom = 10.0;`
+  - `static const ProfileChartViewport reset = ProfileChartViewport();`
+  - `bool get isZoomed;` `double get visibleWidth;` `double get visibleHeight;`
+  - `ProfileChartViewport zoomedAt(double focalX, double focalY, double factor)`
+  - `ProfileChartViewport pannedBy(double dx, double dy)`
+  - fields `double zoom, offsetX, offsetY`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
+
+// Data fraction (0..1 of total range) currently under a focal point that sits
+// at `focal` (0..1) of the visible window.
+double _dataUnderFocal(double offset, double zoom, double focal) =>
+    offset + focal / zoom;
+
+void main() {
+  group('ProfileChartViewport', () {
+    test('reset is unzoomed at the origin', () {
+      const vp = ProfileChartViewport.reset;
+      expect(vp.zoom, 1.0);
+      expect(vp.offsetX, 0.0);
+      expect(vp.offsetY, 0.0);
+      expect(vp.isZoomed, isFalse);
+      expect(vp.visibleWidth, 1.0);
+      expect(vp.visibleHeight, 1.0);
+    });
+
+    test('zoomedAt center keeps the center centered', () {
+      final vp = ProfileChartViewport.reset.zoomedAt(0.5, 0.5, 2);
+      expect(vp.zoom, 2.0);
+      expect(vp.offsetX, closeTo(0.25, 1e-9));
+      expect(vp.offsetY, closeTo(0.25, 1e-9));
+      expect(vp.isZoomed, isTrue);
+    });
+
+    test('zoomedAt top-left pins the top-left corner', () {
+      final vp = ProfileChartViewport.reset.zoomedAt(0, 0, 2);
+      expect(vp.offsetX, closeTo(0.0, 1e-9));
+      expect(vp.offsetY, closeTo(0.0, 1e-9));
+    });
+
+    test('zoomedAt bottom-right pins the bottom-right corner', () {
+      final vp = ProfileChartViewport.reset.zoomedAt(1, 1, 2);
+      expect(vp.offsetX, closeTo(0.5, 1e-9));
+      expect(vp.offsetY, closeTo(0.5, 1e-9));
+    });
+
+    test('anchor invariant: the data point under the focal stays fixed', () {
+      const cases = [
+        [0.3, 0.7, 2.0],
+        [0.2, 0.5, 3.0],
+        [0.6, 0.4, 1.5],
+      ];
+      for (final c in cases) {
+        const start = ProfileChartViewport(zoom: 2, offsetX: 0.25, offsetY: 0.25);
+        final before = _dataUnderFocal(start.offsetX, start.zoom, c[0]);
+        final after = start.zoomedAt(c[0], c[1], c[2]);
+        final now = _dataUnderFocal(after.offsetX, after.zoom, c[0]);
+        expect(now, closeTo(before, 1e-9), reason: 'case $c');
+      }
+    });
+
+    test('pannedBy clamps to [0, 1 - 1/zoom]', () {
+      const vp = ProfileChartViewport(zoom: 2, offsetX: 0.25, offsetY: 0.25);
+      final left = vp.pannedBy(-1, -1);
+      expect(left.offsetX, 0.0);
+      expect(left.offsetY, 0.0);
+      final right = vp.pannedBy(1, 1);
+      expect(right.offsetX, closeTo(0.5, 1e-9)); // maxOff = 1 - 1/2
+      expect(right.offsetY, closeTo(0.5, 1e-9));
+    });
+
+    test('zoom clamps to [minZoom, maxZoom] and is a no-op at the rail', () {
+      // Zooming out from reset cannot go below 1.0 -> unchanged instance.
+      final out = ProfileChartViewport.reset.zoomedAt(0.5, 0.5, 0.5);
+      expect(out.zoom, 1.0);
+      expect(out.offsetX, 0.0);
+      // At max zoom, zooming further in is a no-op.
+      const atMax = ProfileChartViewport(zoom: 10, offsetX: 0.4, offsetY: 0.4);
+      final stillMax = atMax.zoomedAt(0.5, 0.5, 2);
+      expect(stillMax.zoom, 10.0);
+      expect(stillMax.offsetX, 0.4);
+    });
+
+    test('zoom in then out at the same focal round-trips to the origin', () {
+      final there = ProfileChartViewport.reset.zoomedAt(0.3, 0.7, 2);
+      final back = there.zoomedAt(0.3, 0.7, 0.5);
+      expect(back.zoom, closeTo(1.0, 1e-9));
+      expect(back.offsetX, closeTo(0.0, 1e-9));
+      expect(back.offsetY, closeTo(0.0, 1e-9));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: FAIL — `Error: Couldn't resolve the package 'profile_chart_viewport.dart'` / `ProfileChartViewport` is not defined.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart`:
+
+```dart
+import 'package:flutter/widgets.dart';
+
+/// Immutable description of the dive profile chart's visible window, expressed
+/// as normalized fractions [0,1] of the total data range. Resolution- and
+/// data-independent, so the anchor math is unit-testable with plain numbers.
+///
+/// `offsetX`/`offsetY` are the normalized left/top edges of the visible window
+/// (`offsetY == 0` is the surface). The window spans `1/zoom` of each axis, so
+/// both offsets are valid in `[0, 1 - 1/zoom]`.
+@immutable
+class ProfileChartViewport {
+  final double zoom; // >= 1.0
+  final double offsetX;
+  final double offsetY;
+
+  const ProfileChartViewport({
+    this.zoom = 1,
+    this.offsetX = 0,
+    this.offsetY = 0,
+  });
+
+  static const double minZoom = 1.0;
+  static const double maxZoom = 10.0;
+  static const ProfileChartViewport reset = ProfileChartViewport();
+
+  bool get isZoomed => zoom > 1.0;
+  double get visibleWidth => 1.0 / zoom;
+  double get visibleHeight => 1.0 / zoom;
+
+  /// Zoom by [factor] (>1 = in, <1 = out) keeping the data point under the
+  /// focal point fixed. [focalX]/[focalY] are fractions (0..1) of the visible
+  /// plot area under the cursor/pinch (0 = left/top edge).
+  ProfileChartViewport zoomedAt(double focalX, double focalY, double factor) {
+    final newZoom = (zoom * factor).clamp(minZoom, maxZoom);
+    if (newZoom == zoom) return this;
+    final anchorX = offsetX + focalX / zoom; // data fraction under focus, before
+    final anchorY = offsetY + focalY / zoom;
+    return ProfileChartViewport(
+      zoom: newZoom,
+      offsetX: anchorX - focalX / newZoom, // keep it under focus, after
+      offsetY: anchorY - focalY / newZoom,
+    )._clamped();
+  }
+
+  /// Pan by a normalized delta (fractions of the total range).
+  ProfileChartViewport pannedBy(double dx, double dy) => ProfileChartViewport(
+    zoom: zoom,
+    offsetX: offsetX + dx,
+    offsetY: offsetY + dy,
+  )._clamped();
+
+  ProfileChartViewport _clamped() {
+    final maxOff = 1.0 - 1.0 / zoom;
+    return ProfileChartViewport(
+      zoom: zoom,
+      offsetX: offsetX.clamp(0.0, maxOff),
+      offsetY: offsetY.clamp(0.0, maxOff),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: PASS (all 8 tests).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+git commit -m "feat: add ProfileChartViewport for cursor-anchored profile zoom"
+```
+Expected: format makes no further changes; analyze reports no issues.
+
+---
+
+### Task 2: `chartFocalFraction` plot-rect helper
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart`
+- Test: `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+
+**Interfaces:**
+- Consumes: `Offset`, `Size` (from `package:flutter/widgets.dart`).
+- Produces: `({double fx, double fy}) chartFocalFraction(Offset localPos, Size box, {required double left, required double right, required double top, required double bottom})` — maps a gesture's `localPosition` (in the full widget box) to a fraction (0..1, clamped) of the inner plot rect.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `profile_chart_viewport_test.dart`:
+
+```dart
+  group('chartFocalFraction', () {
+    const box = Size(200, 100);
+    const insets = (left: 40.0, right: 10.0, top: 0.0, bottom: 24.0);
+    // plotW = 200-40-10 = 150 ; plotH = 100-0-24 = 76
+
+    test('left/top gutter maps to 0', () {
+      final f = chartFocalFraction(const Offset(40, 0), box,
+          left: insets.left, right: insets.right, top: insets.top, bottom: insets.bottom);
+      expect(f.fx, closeTo(0.0, 1e-9));
+      expect(f.fy, closeTo(0.0, 1e-9));
+    });
+
+    test('right/bottom plot edge maps to 1', () {
+      final f = chartFocalFraction(const Offset(190, 76), box,
+          left: insets.left, right: insets.right, top: insets.top, bottom: insets.bottom);
+      expect(f.fx, closeTo(1.0, 1e-9));
+      expect(f.fy, closeTo(1.0, 1e-9));
+    });
+
+    test('mid plot maps to the expected fraction', () {
+      final f = chartFocalFraction(const Offset(115, 38), box,
+          left: insets.left, right: insets.right, top: insets.top, bottom: insets.bottom);
+      expect(f.fx, closeTo(0.5, 1e-9)); // (115-40)/150
+      expect(f.fy, closeTo(0.5, 1e-9)); // (38-0)/76
+    });
+
+    test('positions outside the plot clamp to [0,1]', () {
+      final lo = chartFocalFraction(const Offset(0, -50), box,
+          left: insets.left, right: insets.right, top: insets.top, bottom: insets.bottom);
+      expect(lo.fx, 0.0);
+      expect(lo.fy, 0.0);
+      final hi = chartFocalFraction(const Offset(500, 500), box,
+          left: insets.left, right: insets.right, top: insets.top, bottom: insets.bottom);
+      expect(hi.fx, 1.0);
+      expect(hi.fy, 1.0);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: FAIL — `The function 'chartFocalFraction' isn't defined`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `profile_chart_viewport.dart`:
+
+```dart
+/// Maps a gesture's [localPos] (in the full widget [box]) to a fraction
+/// (0..1, clamped) of the inner plot rect, given the reserved axis gutters.
+/// fl_chart reserves [left]/[right]/[top]/[bottom] for axis names + tick
+/// labels (+ the gas strip), so the data window only fills the inner rect.
+({double fx, double fy}) chartFocalFraction(
+  Offset localPos,
+  Size box, {
+  required double left,
+  required double right,
+  required double top,
+  required double bottom,
+}) {
+  final plotW = (box.width - left - right).clamp(1.0, double.infinity);
+  final plotH = (box.height - top - bottom).clamp(1.0, double.infinity);
+  return (
+    fx: ((localPos.dx - left) / plotW).clamp(0.0, 1.0),
+    fy: ((localPos.dy - top) / plotH).clamp(0.0, 1.0),
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: PASS (all groups).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+git commit -m "feat: add chartFocalFraction plot-rect focal mapping"
+```
+
+---
+
+### Task 3: `chartDragIntent` pointer-kind router
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart`
+- Test: `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+
+**Interfaces:**
+- Consumes: `PointerDeviceKind` (from `package:flutter/gestures.dart`).
+- Produces:
+  - `enum ChartDragIntent { pan, scrub, zoomPan, none }`
+  - `ChartDragIntent chartDragIntent({required PointerDeviceKind kind, required int pointerCount, required bool doubleTapHold})`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()`:
+
+```dart
+  group('chartDragIntent', () {
+    test('two or more pointers always zoom+pan', () {
+      for (final k in [PointerDeviceKind.touch, PointerDeviceKind.mouse]) {
+        expect(
+          chartDragIntent(kind: k, pointerCount: 2, doubleTapHold: false),
+          ChartDragIntent.zoomPan,
+        );
+      }
+    });
+
+    test('single mouse/trackpad pointer pans', () {
+      expect(
+        chartDragIntent(kind: PointerDeviceKind.mouse, pointerCount: 1, doubleTapHold: false),
+        ChartDragIntent.pan,
+      );
+      expect(
+        chartDragIntent(kind: PointerDeviceKind.trackpad, pointerCount: 1, doubleTapHold: false),
+        ChartDragIntent.pan,
+      );
+    });
+
+    test('single touch pointer scrubs', () {
+      expect(
+        chartDragIntent(kind: PointerDeviceKind.touch, pointerCount: 1, doubleTapHold: false),
+        ChartDragIntent.scrub,
+      );
+    });
+
+    test('single touch pointer pans during double-tap-hold', () {
+      expect(
+        chartDragIntent(kind: PointerDeviceKind.touch, pointerCount: 1, doubleTapHold: true),
+        ChartDragIntent.pan,
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: FAIL — `chartDragIntent` / `ChartDragIntent` not defined.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add the import at the top of `profile_chart_viewport.dart` (below the existing `widgets.dart` import):
+
+```dart
+import 'package:flutter/gestures.dart';
+```
+
+Append:
+
+```dart
+/// What a drag/scale event should do on the profile chart.
+enum ChartDragIntent { pan, scrub, zoomPan, none }
+
+/// Decides the meaning of an in-progress gesture from the active pointer kind,
+/// the pointer count, and whether a double-tap-hold is active. Keying off the
+/// pointer kind (not the platform) is what lets one-finger touch keep scrubbing
+/// while a mouse drag pans.
+ChartDragIntent chartDragIntent({
+  required PointerDeviceKind kind,
+  required int pointerCount,
+  required bool doubleTapHold,
+}) {
+  if (pointerCount >= 2) return ChartDragIntent.zoomPan;
+  if (doubleTapHold) return ChartDragIntent.pan;
+  return kind == PointerDeviceKind.touch
+      ? ChartDragIntent.scrub
+      : ChartDragIntent.pan;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+git commit -m "feat: add chartDragIntent pointer-kind drag routing"
+```
+
+---
+
+### Task 4: Wire the viewport into the chart; anchor all existing zoom channels
+
+This is an atomic refactor — it replaces the three zoom/pan doubles with one `_viewport` everywhere they are referenced, so the file only compiles once every reference is updated. In the process, the wheel anchors to the cursor, touch pinch anchors to the focal point, buttons zoom about center, and double-tap zooms about the tap point.
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`
+  (state `:457-469`, `_resetZoom` `:507-513`, `_zoomIn/_zoomOut/_clampPanOffsets` `:893-912`, legend args `:1027-1029`, hint `:1052-1063`, gestures `:1082-1153`, window `:1239-1246`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+
+**Interfaces:**
+- Consumes: `ProfileChartViewport`, `chartFocalFraction` (Tasks 1-2).
+- Produces (private to the state, relied on by Tasks 5-7):
+  - field `ProfileChartViewport _viewport`
+  - field `ProfileChartViewport _gestureStartViewport`
+  - field `Offset _startFocalPoint`
+  - field `Offset _lastTapDownLocal`
+  - method `({double left, double top, double right, double bottom}) _plotInsets(double availableWidth, UnitFormatter units)`
+
+- [ ] **Step 1: Write the failing widget tests**
+
+Append to `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart` (reuses the existing `_buildChart` and `_makeProfile` helpers in that file). Add these imports at the top if missing: `import 'package:flutter/gestures.dart';`.
+
+```dart
+  // Reads the primary fl_chart LineChartData (the depth/time plot is first).
+  LineChartData _primaryChartData(WidgetTester tester) =>
+      tester.widget<LineChart>(find.byType(LineChart).first).data;
+
+  group('zoom anchoring', () {
+    testWidgets('mouse wheel up zooms in WITHOUT pinning the left edge to 0',
+        (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final before = _primaryChartData(tester);
+      expect(before.minX, 0.0); // at zoom 1 the window starts at t=0
+
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+      // Cursor in the right third of the plot.
+      final cursor = topLeft + Offset(size.width * 0.75, size.height * 0.5);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: cursor, scrollDelta: const Offset(0, -100)),
+      );
+      await tester.pump();
+
+      final after = _primaryChartData(tester);
+      // Zoomed in: visible time range shrank.
+      expect(after.maxX - after.minX, lessThan(before.maxX - before.minX));
+      // Anchored toward the cursor, not the corner: left edge moved off 0.
+      expect(after.minX, greaterThan(0.0));
+    });
+
+    testWidgets('mouse wheel down at max-out keeps the full window',
+        (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, 100)),
+      );
+      await tester.pump();
+
+      final after = _primaryChartData(tester);
+      expect(after.minX, 0.0); // cannot zoom out past 1.0
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "zoom anchoring"`
+Expected: FAIL — the first test fails on `expect(after.minX, greaterThan(0.0))` because today's wheel zoom keeps `minX == 0` (upper-left anchoring).
+
+- [ ] **Step 3: Add the import and replace the zoom/pan state fields**
+
+At the top of `dive_profile_chart.dart`, add (with the other local widget imports):
+
+```dart
+import 'profile_chart_viewport.dart';
+```
+
+Replace `dive_profile_chart.dart:457-469` (the `// Zoom/pan state` … `_maxZoom` block) with:
+
+```dart
+  // Zoom/pan state — see profile_chart_viewport.dart.
+  ProfileChartViewport _viewport = ProfileChartViewport.reset;
+
+  // Snapshot of the viewport at the start of a continuous gesture; continuous
+  // gestures report cumulative scale/pan, so we apply them against this.
+  ProfileChartViewport _gestureStartViewport = ProfileChartViewport.reset;
+  Offset _startFocalPoint = Offset.zero;
+
+  // Local position of the most recent (double-)tap, for tap-anchored zoom.
+  Offset _lastTapDownLocal = Offset.zero;
+```
+
+- [ ] **Step 4: Add the `_plotInsets` helper**
+
+Insert this method just above `_zoomIn()` (i.e. just before `dive_profile_chart.dart:893`). It mirrors the existing plot-bounds math at `:2265-2270` and the bottom reservation at `:1379-1382`:
+
+```dart
+  /// The plot-rect insets (reserved axis gutters) for the current build, so a
+  /// gesture's local position can be mapped to a plot-area fraction. Mirrors
+  /// the axis reservations used for the gas-strip overlay (left/right at
+  /// :2265-2270, bottom at :1379-1382). Top has no titles, so its inset is 0.
+  ({double left, double top, double right, double bottom}) _plotInsets(
+    double availableWidth,
+    UnitFormatter units,
+  ) {
+    final legendNotifier = ref.read(profileLegendProvider.notifier);
+    final preferredMetric = legendNotifier.getEffectiveRightAxisMetric();
+    final effectiveRightAxisMetric = preferredMetric != null
+        ? _getEffectiveRightAxisMetric(preferredMetric)
+        : null;
+    final rightAxisRange = effectiveRightAxisMetric != null
+        ? _getMetricRange(effectiveRightAxisMetric, units)
+        : null;
+    final hasRightAxisName =
+        effectiveRightAxisMetric != null && rightAxisRange != null;
+
+    return (
+      left: DiveProfileChart._leftRightAxisNameSize +
+          DiveProfileChart.leftAxisSize(availableWidth),
+      top: 0,
+      right: (hasRightAxisName ? DiveProfileChart._leftRightAxisNameSize : 0) +
+          DiveProfileChart.rightAxisSize(availableWidth),
+      bottom: DiveProfileChart._bottomAxisNameSize +
+          (_hasGasStrip
+              ? DiveProfileChart._bottomTickReservedSize +
+                  DiveProfileChart.gasTimelineHeight
+              : DiveProfileChart._bottomTickReservedSize),
+    );
+  }
+```
+
+- [ ] **Step 5: Replace `_resetZoom`, `_zoomIn`, `_zoomOut`; delete `_clampPanOffsets`**
+
+Replace `dive_profile_chart.dart:507-513` (`_resetZoom`) with:
+
+```dart
+  void _resetZoom() {
+    setState(() => _viewport = ProfileChartViewport.reset);
+  }
+```
+
+Replace `dive_profile_chart.dart:893-912` (`_zoomIn`, `_zoomOut`, and the whole `_clampPanOffsets` method) with:
+
+```dart
+  // Buttons have no cursor, so they zoom about the visible center.
+  void _zoomIn() {
+    setState(() => _viewport = _viewport.zoomedAt(0.5, 0.5, 1.5));
+  }
+
+  void _zoomOut() {
+    setState(() => _viewport = _viewport.zoomedAt(0.5, 0.5, 1 / 1.5));
+  }
+```
+
+- [ ] **Step 6: Re-source the legend zoom-control args**
+
+Replace `dive_profile_chart.dart:1027-1029` (the `zoomLevel`/`minZoom`/`maxZoom` args) with:
+
+```dart
+              zoomLevel: _viewport.zoom,
+              minZoom: ProfileChartViewport.minZoom,
+              maxZoom: ProfileChartViewport.maxZoom,
+```
+
+- [ ] **Step 7: Re-source the zoom hint**
+
+Replace `dive_profile_chart.dart:1052` (`if (_zoomLevel > 1.0)`) with `if (_viewport.isZoomed)` and `dive_profile_chart.dart:1057` (`_zoomLevel.toStringAsFixed(1)`) with `_viewport.zoom.toStringAsFixed(1)`.
+
+- [ ] **Step 8: Rework the gesture handlers**
+
+Replace `dive_profile_chart.dart:1082-1136` (the `onScaleStart`, `onScaleUpdate`, and `onDoubleTap` handlers) with:
+
+```dart
+            onScaleStart: (details) {
+              _gestureStartViewport = _viewport;
+              _startFocalPoint = details.localFocalPoint;
+            },
+            onScaleUpdate: (details) {
+              // Single-pointer drags (mouse pan / touch scrub) are wired in a
+              // later task; for now only multi-touch pinch+pan acts here.
+              if (details.pointerCount < 2) return;
+
+              setState(() {
+                final box = constraints.biggest;
+                final insets = _plotInsets(constraints.maxWidth, units);
+                final plotW = (box.width - insets.left - insets.right)
+                    .clamp(1.0, double.infinity);
+                final plotH = (box.height - insets.top - insets.bottom)
+                    .clamp(1.0, double.infinity);
+                final focal = chartFocalFraction(
+                  _startFocalPoint,
+                  box,
+                  left: insets.left,
+                  right: insets.right,
+                  top: insets.top,
+                  bottom: insets.bottom,
+                );
+                // scale is cumulative from gesture start -> apply to snapshot.
+                var vp = _gestureStartViewport.zoomedAt(
+                  focal.fx,
+                  focal.fy,
+                  details.scale,
+                );
+                final panPx = details.localFocalPoint - _startFocalPoint;
+                vp = vp.pannedBy(
+                  -panPx.dx / plotW / vp.zoom,
+                  -panPx.dy / plotH / vp.zoom,
+                );
+                _viewport = vp;
+              });
+            },
+            onDoubleTapDown: (details) {
+              _lastTapDownLocal = details.localPosition;
+            },
+            onDoubleTap: () {
+              setState(() {
+                if (_viewport.isZoomed) {
+                  _viewport = ProfileChartViewport.reset;
+                } else {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final focal = chartFocalFraction(
+                    _lastTapDownLocal,
+                    box,
+                    left: insets.left,
+                    right: insets.right,
+                    top: insets.top,
+                    bottom: insets.bottom,
+                  );
+                  _viewport = _viewport.zoomedAt(focal.fx, focal.fy, 2.0);
+                }
+              });
+            },
+```
+
+- [ ] **Step 9: Rework the mouse-wheel handler**
+
+Replace `dive_profile_chart.dart:1138-1153` (the `onPointerSignal` body) with:
+
+```dart
+              onPointerSignal: (event) {
+                if (event is PointerScrollEvent) {
+                  setState(() {
+                    final box = constraints.biggest;
+                    final insets = _plotInsets(constraints.maxWidth, units);
+                    final focal = chartFocalFraction(
+                      event.localPosition,
+                      box,
+                      left: insets.left,
+                      right: insets.right,
+                      top: insets.top,
+                      bottom: insets.bottom,
+                    );
+                    final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
+                    _viewport = _viewport.zoomedAt(focal.fx, focal.fy, factor);
+                  });
+                }
+              },
+```
+
+- [ ] **Step 10: Re-source the visible-window computation**
+
+Replace `dive_profile_chart.dart:1239-1246` (the `visibleRangeX` … `visibleMaxDepth` block) with:
+
+```dart
+    // Apply zoom and pan to calculate visible bounds (see ProfileChartViewport).
+    final visibleRangeX = totalMaxTime * _viewport.visibleWidth;
+    final visibleRangeY = totalMaxDepth * _viewport.visibleHeight;
+
+    final visibleMinX = _viewport.offsetX * totalMaxTime;
+    final visibleMaxX = visibleMinX + visibleRangeX;
+
+    final visibleMinDepth = _viewport.offsetY * totalMaxDepth;
+    final visibleMaxDepth = visibleMinDepth + visibleRangeY;
+```
+
+- [ ] **Step 11: Run the tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+Expected: PASS — the new `zoom anchoring` group passes and all pre-existing chart tests stay green.
+
+- [ ] **Step 12: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "feat: anchor dive profile zoom to cursor/pinch via ProfileChartViewport"
+```
+
+---
+
+### Task 5: Trackpad pinch zoom-to-cursor + two-finger-scroll pan; pointer-kind tracking
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (state fields near `:457`; `initState` `:476`; the `Listener` at `:1137`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+
+**Interfaces:**
+- Consumes: `_viewport`, `_gestureStartViewport`, `_plotInsets`, `chartFocalFraction`, `ProfileChartViewport`.
+- Produces (relied on by Task 6): field `PointerDeviceKind _activePointerKind`; field `Offset _trackpadAnchor`.
+
+- [ ] **Step 1: Write the failing widget test**
+
+Append to `dive_profile_chart_test.dart`:
+
+```dart
+  group('trackpad interaction', () {
+    testWidgets('trackpad pinch zooms in anchored off-center (not at 0)',
+        (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+      final anchor = topLeft + Offset(size.width * 0.7, size.height * 0.5);
+
+      final before = tester.widget<LineChart>(chart).data;
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      await tester.sendEventToBinding(pointer.panZoomStart(anchor));
+      await tester.sendEventToBinding(
+        pointer.panZoomUpdate(anchor, scale: 2.0),
+      );
+      await tester.sendEventToBinding(pointer.panZoomEnd());
+      await tester.pump();
+
+      final after = tester.widget<LineChart>(chart).data;
+      expect(after.maxX - after.minX, lessThan(before.maxX - before.minX));
+      expect(after.minX, greaterThan(0.0)); // anchored toward the cursor
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "trackpad interaction"`
+Expected: FAIL — `after.minX` stays `0.0` (no trackpad pan-zoom handler yet), so `greaterThan(0.0)` fails.
+
+- [ ] **Step 3: Add pointer-kind + trackpad-anchor state fields**
+
+Immediately below the `_lastTapDownLocal` field added in Task 4, add:
+
+```dart
+  // Active pointer kind, corrected on the first real pointer event. Chooses
+  // pan-vs-scrub for single-pointer drags and is set by trackpad gestures.
+  PointerDeviceKind _activePointerKind =
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android)
+      ? PointerDeviceKind.touch
+      : PointerDeviceKind.mouse;
+
+  // Cursor position at the start of a trackpad pan/zoom gesture.
+  Offset _trackpadAnchor = Offset.zero;
+```
+
+If `defaultTargetPlatform` is not resolved, ensure `import 'package:flutter/foundation.dart';` is present at the top of the file (it usually already is for `kDebugMode`/`Equatable`-adjacent code; add it if `flutter analyze` reports it undefined).
+
+- [ ] **Step 4: Add the trackpad handlers + kind tracking to the `Listener`**
+
+In the `Listener` at `dive_profile_chart.dart:1137`, add these handlers alongside the existing `onPointerSignal` (keep `onPointerSignal` as reworked in Task 4):
+
+```dart
+              onPointerDown: (event) => _activePointerKind = event.kind,
+              onPointerPanZoomStart: (event) {
+                _activePointerKind = PointerDeviceKind.trackpad;
+                _gestureStartViewport = _viewport;
+                _trackpadAnchor = event.localPosition;
+              },
+              onPointerPanZoomUpdate: (event) {
+                setState(() {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final plotW = (box.width - insets.left - insets.right)
+                      .clamp(1.0, double.infinity);
+                  final plotH = (box.height - insets.top - insets.bottom)
+                      .clamp(1.0, double.infinity);
+                  final focal = chartFocalFraction(
+                    _trackpadAnchor,
+                    box,
+                    left: insets.left,
+                    right: insets.right,
+                    top: insets.top,
+                    bottom: insets.bottom,
+                  );
+                  // scale and localPan are cumulative from the gesture start.
+                  var vp = _gestureStartViewport.zoomedAt(
+                    focal.fx,
+                    focal.fy,
+                    event.scale,
+                  );
+                  vp = vp.pannedBy(
+                    -event.localPan.dx / plotW / vp.zoom,
+                    -event.localPan.dy / plotH / vp.zoom,
+                  );
+                  _viewport = vp;
+                });
+              },
+```
+
+Note: the two-finger-scroll pan sign (`-event.localPan`) is the natural-scroll convention; if hardware testing shows it inverted, flip the sign — this is the spec's "pan sign finalized under TDD".
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "trackpad interaction"`
+Expected: PASS. Then run the full file to confirm no regressions: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`.
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "feat: trackpad pinch zoom-to-cursor and two-finger pan on profile chart"
+```
+
+---
+
+### Task 6: Desktop hover-select + mouse click-drag pan (touch one-finger still scrubs)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (state field near `:457`; `onScaleUpdate` single-pointer branch; the `Listener`/its child at `:1137-1162`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+
+**Interfaces:**
+- Consumes: `chartDragIntent`, `ChartDragIntent`, `_activePointerKind`, `_viewport`, `_plotInsets`, `chartFocalFraction`, `widget.onPointSelected`, `widget.profile`.
+- Produces (relied on by Task 7): field `bool _doubleTapHold`; method `int? _hoverIndex(Offset, Size, insets)`.
+
+- [ ] **Step 1: Write the failing widget tests**
+
+Append to `dive_profile_chart_test.dart`:
+
+```dart
+  group('desktop pan and hover', () {
+    testWidgets('mouse click-drag pans a zoomed-in chart', (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      // Zoom in first (about center) via two wheel steps.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+      );
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+      );
+      await tester.pump();
+      final zoomed = tester.widget<LineChart>(chart).data;
+
+      // Drag left with the mouse -> window should move right (minX increases).
+      final gesture =
+          await tester.startGesture(center, kind: PointerDeviceKind.mouse);
+      await gesture.moveBy(const Offset(-60, 0));
+      await gesture.up();
+      await tester.pump();
+
+      final panned = tester.widget<LineChart>(chart).data;
+      expect(panned.minX, greaterThan(zoomed.minX));
+    });
+
+    testWidgets('touch one-finger drag does NOT pan (still scrubs)',
+        (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+      );
+      await tester.pump();
+      final zoomed = tester.widget<LineChart>(chart).data;
+
+      final gesture =
+          await tester.startGesture(center, kind: PointerDeviceKind.touch);
+      await gesture.moveBy(const Offset(-60, 0));
+      await gesture.up();
+      await tester.pump();
+
+      final after = tester.widget<LineChart>(chart).data;
+      expect(after.minX, zoomed.minX); // unchanged: one finger scrubs, no pan
+    });
+
+    testWidgets('mouse hover selects the nearest sample', (tester) async {
+      int? selected;
+      await tester.pumpWidget(
+        _buildChart(
+          profile: _makeProfile(points: 20),
+          onPointSelected: (i) => selected = i,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      await tester.sendEventToBinding(
+        pointer.hover(topLeft + Offset(size.width * 0.5, size.height * 0.5)),
+      );
+      await tester.pump();
+
+      expect(selected, isNotNull);
+      expect(selected, inInclusiveRange(0, 19));
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "desktop pan and hover"`
+Expected: FAIL — mouse drag does not pan yet (`panned.minX` equals `zoomed.minX`), and hover does not call `onPointSelected`.
+
+- [ ] **Step 3: Add the `_doubleTapHold` flag and the hover-index helper**
+
+Below the `_trackpadAnchor` field (Task 5), add:
+
+```dart
+  // True between a double-tap-down and the gesture's end; lets a held-finger
+  // drag pan instead of scrub. Toggled in a later task; false here.
+  bool _doubleTapHold = false;
+
+  // Index of the last sample reported via hover, to de-dupe onPointSelected.
+  int? _lastHoverIndex;
+```
+
+Add this helper next to `_plotInsets`:
+
+```dart
+  /// Nearest profile sample index under a hover at [localPos], or null if the
+  /// profile is empty. Maps the cursor X through the current viewport to a
+  /// timestamp, then finds the closest sample.
+  int? _hoverIndex(
+    Offset localPos,
+    Size box,
+    ({double left, double top, double right, double bottom}) insets,
+  ) {
+    if (widget.profile.isEmpty) return null;
+    final focal = chartFocalFraction(
+      localPos,
+      box,
+      left: insets.left,
+      right: insets.right,
+      top: insets.top,
+      bottom: insets.bottom,
+    );
+    final totalMaxTime =
+        widget.profile.map((p) => p.timestamp).reduce(math.max).toDouble();
+    final t = (_viewport.offsetX + focal.fx * _viewport.visibleWidth) *
+        totalMaxTime;
+    var best = 0;
+    var bestDist = double.infinity;
+    for (var i = 0; i < widget.profile.length; i++) {
+      final d = (widget.profile[i].timestamp - t).abs();
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    }
+    return best;
+  }
+```
+
+(`math` is already imported in this file as `import 'dart:math' as math;` — it is used at `:1227`.)
+
+- [ ] **Step 4: Route the single-pointer drag by intent**
+
+Replace the early-return guard in `onScaleUpdate` (the `if (details.pointerCount < 2) return;` line added in Task 4) with:
+
+```dart
+              if (details.pointerCount < 2) {
+                final intent = chartDragIntent(
+                  kind: _activePointerKind,
+                  pointerCount: details.pointerCount,
+                  doubleTapHold: _doubleTapHold,
+                );
+                if (intent != ChartDragIntent.pan) return; // touch scrub
+                setState(() {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final plotW = (box.width - insets.left - insets.right)
+                      .clamp(1.0, double.infinity);
+                  final plotH = (box.height - insets.top - insets.bottom)
+                      .clamp(1.0, double.infinity);
+                  final d = details.focalPointDelta;
+                  _viewport = _viewport.pannedBy(
+                    -d.dx / plotW / _viewport.zoom,
+                    -d.dy / plotH / _viewport.zoom,
+                  );
+                });
+                return;
+              }
+```
+
+- [ ] **Step 5: Add hover-select + exit-clear**
+
+In the `Listener` (Task 5), add `onPointerHover`:
+
+```dart
+              onPointerHover: (event) {
+                _activePointerKind = PointerDeviceKind.mouse;
+                final idx = _hoverIndex(
+                  event.localPosition,
+                  constraints.biggest,
+                  _plotInsets(constraints.maxWidth, units),
+                );
+                if (idx != _lastHoverIndex) {
+                  _lastHoverIndex = idx;
+                  widget.onPointSelected?.call(idx);
+                }
+              },
+```
+
+Wrap the `Listener`'s `child:` (the `_buildChart(...)` call at `:1154`) in a `MouseRegion` so the selection clears when the cursor leaves:
+
+```dart
+              child: MouseRegion(
+                onExit: (_) {
+                  if (_lastHoverIndex != null) {
+                    _lastHoverIndex = null;
+                    widget.onPointSelected?.call(null);
+                  }
+                },
+                child: _buildChart(
+                  context,
+                  units,
+                  availableWidth: constraints.maxWidth,
+                  hasTemperatureData: hasTemperatureData,
+                  hasPressureData: hasPressureData,
+                  hasHeartRateData: hasHeartRateData,
+                ),
+              ),
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "desktop pan and hover"`
+Expected: PASS. Then run the whole file to confirm no regressions: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "feat: desktop hover select and click-drag pan on profile chart"
+```
+
+---
+
+### Task 7: Double-tap-and-hold to pan (touch)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (state field near `:457`; `dispose`; `onDoubleTapDown`/`onDoubleTap`; add `onScaleEnd`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+
+**Interfaces:**
+- Consumes: `_doubleTapHold` (Task 6), `_viewport`, `_plotInsets`.
+- Produces: nothing new for later tasks (final task).
+
+- [ ] **Step 1: Write the failing widget test**
+
+Append to `dive_profile_chart_test.dart` (add `import 'dart:ui';` only if `PointerDeviceKind` needs it — it comes from `package:flutter/gestures.dart`, already imported in Task 4):
+
+```dart
+  group('double-tap-hold pan', () {
+    testWidgets('double-tap then hold-drag pans a zoomed-in chart',
+        (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      // Zoom in so there is room to pan.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+      );
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+      );
+      await tester.pump();
+      final zoomed = tester.widget<LineChart>(chart).data;
+
+      // First tap (quick) then a second touch that is held and dragged.
+      await tester.tapAt(center, kind: PointerDeviceKind.touch);
+      final hold =
+          await tester.startGesture(center, kind: PointerDeviceKind.touch);
+      await hold.moveBy(const Offset(-60, 0));
+      await hold.up();
+      await tester.pump();
+
+      final panned = tester.widget<LineChart>(chart).data;
+      expect(panned.minX, greaterThan(zoomed.minX));
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "double-tap-hold pan"`
+Expected: FAIL — `_doubleTapHold` never becomes true, so the held touch drag scrubs and `panned.minX` equals `zoomed.minX`.
+
+- [ ] **Step 3: Add the timer import and field**
+
+Ensure `import 'dart:async';` is present at the top of `dive_profile_chart.dart` (add it with the other `dart:` imports if missing). Below the `_lastHoverIndex` field (Task 6), add:
+
+```dart
+  // Fallback that clears _doubleTapHold if a double-tap-down is not followed by
+  // a drag (so a later normal drag is not misrouted to pan).
+  Timer? _doubleTapHoldTimer;
+```
+
+- [ ] **Step 4: Set/clear the hold flag**
+
+Replace the `onDoubleTapDown` handler (added in Task 4) with:
+
+```dart
+            onDoubleTapDown: (details) {
+              _lastTapDownLocal = details.localPosition;
+              _doubleTapHold = true;
+              _doubleTapHoldTimer?.cancel();
+              _doubleTapHoldTimer = Timer(
+                const Duration(milliseconds: 400),
+                () => _doubleTapHold = false,
+              );
+            },
+```
+
+At the very start of the `onDoubleTap` handler body (added in Task 4), before the `setState`, add:
+
+```dart
+              _doubleTapHold = false;
+              _doubleTapHoldTimer?.cancel();
+```
+
+Add an `onScaleEnd` handler to the `GestureDetector` (next to `onScaleStart`/`onScaleUpdate`):
+
+```dart
+            onScaleEnd: (details) {
+              _doubleTapHold = false;
+              _doubleTapHoldTimer?.cancel();
+            },
+```
+
+- [ ] **Step 5: Cancel the timer in `dispose`**
+
+Find the state's `dispose()` (if none exists, add one overriding `State.dispose`) and cancel the timer before `super.dispose()`:
+
+```dart
+  @override
+  void dispose() {
+    _doubleTapHoldTimer?.cancel();
+    super.dispose();
+  }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --name "double-tap-hold pan"`
+Expected: PASS. If the synthetic double-tap timing does not trip the recognizer, adjust the gesture timing in the test (insert `await tester.pump(const Duration(milliseconds: 50));` between the tap and the hold) — the spec sanctions finalizing this gesture's thresholds under TDD. Then run the whole file: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+flutter analyze
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "feat: double-tap-hold to pan on profile chart (touch)"
+```
+
+---
+
+## Final verification (after Task 7)
+
+- [ ] Run the full dive-log widget suite to confirm no regressions across the chart, panel, and detail page:
+
+```bash
+flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart \
+  test/features/dive_log/presentation/widgets/dive_profile_panel_test.dart \
+  test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart \
+  test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+```
+Expected: all PASS.
+
+- [ ] Confirm `dart format .` reports no changes and `flutter analyze` is clean.
+- [ ] Manual device check (not automated): on macOS/desktop verify wheel + trackpad pinch zoom to the cursor and click-drag pans; on a phone verify one-finger scrub, two-finger pinch+pan, and double-tap-hold pan. (The two-finger-scroll and double-tap-hold pan **signs/thresholds** are the spec's TDD-finalized items — adjust if they feel inverted on hardware.)
+
+## Notes on coverage vs. the spec
+
+- Spec "Component 1 — ProfileChartViewport" → Task 1. "Component 2 — pure helpers" → Tasks 2-3. "Component 3 — input routing" → Tasks 4-7. "Component 4 — coexistence/edges" → Task 4 (buttons-about-center, reset, hint, plot-rect focal correction) + Task 6 (hover/scrub coexistence) + Task 7 (double-tap state machine).
+- The spec's desktop hover behavior is implemented as driving the existing `onPointSelected` selection path (Task 6). fl_chart may also surface its native hover tooltip; the de-dupe via `_lastHoverIndex` keeps selection idempotent.
+- Out-of-scope items (X-only zoom, rubber-band, inertia, scrollbars, persisted/cross-instance zoom, other profile charts) get no task, per the spec.

--- a/docs/superpowers/specs/2026-06-21-dive-profile-chart-zoom-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-21-dive-profile-chart-zoom-navigation-design.md
@@ -2,7 +2,7 @@
 
 - **Source:** Direct user report (no tracked GitHub issue yet): "Zooming in on the dive profile chart always keeps the focus anchored in the upper-left corner. Navigating a zoomed-in chart is also tedious and unintuitive."
 - **Date:** 2026-06-21
-- **Status:** Approved design, pending implementation plan
+- **Status:** Implemented in PR #372 — see the implementation plan at `docs/superpowers/plans/2026-06-21-dive-profile-chart-zoom-navigation.md`; macOS device-verified.
 - **Chart widget:** `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (~3,730 lines)
 - **Chart library:** `fl_chart ^1.1.1` (zoom/pan is hand-rolled on top of it, not fl_chart's transform)
 - **Sibling spec:** `2026-06-21-map-touchpad-interaction-design.md` — shares the "key off `PointerDeviceKind`, anchor zoom at the cursor" philosophy. Read both together.

--- a/docs/superpowers/specs/2026-06-21-dive-profile-chart-zoom-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-21-dive-profile-chart-zoom-navigation-design.md
@@ -1,0 +1,261 @@
+# Dive profile chart zoom & navigation — design
+
+- **Source:** Direct user report (no tracked GitHub issue yet): "Zooming in on the dive profile chart always keeps the focus anchored in the upper-left corner. Navigating a zoomed-in chart is also tedious and unintuitive."
+- **Date:** 2026-06-21
+- **Status:** Approved design, pending implementation plan
+- **Chart widget:** `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (~3,730 lines)
+- **Chart library:** `fl_chart ^1.1.1` (zoom/pan is hand-rolled on top of it, not fl_chart's transform)
+- **Sibling spec:** `2026-06-21-map-touchpad-interaction-design.md` — shares the "key off `PointerDeviceKind`, anchor zoom at the cursor" philosophy. Read both together.
+
+## Problem
+
+The interactive dive profile chart (depth-over-time, shown on the dive detail page and the master/detail panel) has two interaction defects:
+
+1. **Zoom always anchors to the upper-left corner.** Zooming in via the legend buttons, the mouse wheel, or double-tap shrinks the visible window toward `(time = 0, surface)` instead of toward the cursor, the pinch point, or even the chart center.
+2. **Navigating a zoomed-in chart is tedious and unintuitive.** Once zoomed, there is no drag-to-pan and no scrollbar; the only way to move the window is a two-finger scale gesture or a full zoom reset.
+
+### Root causes (verified against the current code)
+
+The chart does not use fl_chart's built-in transform. It keeps its own `_zoomLevel` + normalized `_panOffsetX/_panOffsetY` in widget `State` and, every build, computes the visible `minX/maxX/minY/maxY` window and hands it to `LineChartData` (which clips with `FlClipData.all()`).
+
+- **Upper-left anchoring is baked into the math.** The window's edges are computed as `visibleMinX = _panOffsetX * totalMaxTime` and `visibleMinDepth = _panOffsetY * totalMaxDepth` (`dive_profile_chart.dart:1238-1246`). The button, wheel, and double-tap zoom paths change **only `_zoomLevel`** and then clamp the offsets; none of them adjusts `_panOffsetX/Y` to keep the cursor or center fixed. With the default offsets at `0`, the left/top edges stay pinned at `t = 0` / surface while the window shrinks — i.e. zoom toward the upper-left.
+  - `_zoomIn()` / `_zoomOut()`: `dive_profile_chart.dart:893-905`
+  - Mouse-wheel zoom (`Listener.onPointerSignal`): `:1137-1153` — `event.localPosition` is available but **unused**.
+  - Double-tap (`onDoubleTap`): `:1128-1136` — jumps to `_zoomLevel = 2.0` (or resets) with no focal anchoring.
+  - Pinch (`onScaleUpdate`): `:1087-1127` — folds the focal point into a pan *delta* only; the zoom itself is `_previousZoom * details.scale`, so the pinch center is not held fixed either. The pan math divides by `constraints.maxWidth/Height` (`:1112`), the **full widget box**, not the inner plot area.
+- **No pan affordance when zoomed.** Single-finger / mouse drag is deliberately reserved for tooltip scrubbing (`LineTouchData.touchCallback`, `:1584-1617`); `onScaleUpdate` early-returns for `pointerCount < 2` (`:1091`). So only a multi-pointer scale gesture pans, and only when `_zoomLevel > 1.0`. On desktop there is no mouse-drag pan and no scrollbar at all.
+
+### State today (unchanged by this design unless noted)
+
+- Zoom is **uniform on both axes** — a single `_zoomLevel` scales time and depth together (`:1239-1240`).
+- Zoom/pan is **local widget state** in `_DiveProfileChartState` (`:457-469`), not a Riverpod provider. It is per-instance and ephemeral. There are three live instances: `dive_detail_page.dart:1249` and `:4898`, and `dive_profile_panel.dart:364`.
+- The depth axis is **inverted** by negating values (`minY: -visibleMaxDepth`, `maxY: -visibleMinDepth`, `:1313-1316`).
+- Tick intervals adapt to the visible range via `_calculateTimeInterval` / `_calculateDepthInterval` (`:2811-2824`), keyed off `visibleRangeX/Y` — they keep working unchanged once those values come from the new viewport.
+- A shared scrub index lives in `profileTrackingIndexProvider` (`StateProvider.family<int?, String>` keyed by dive ID); a "zoom hint" string shows while `_zoomLevel > 1.0` (`:1052-1063`).
+
+## Decisions (from product review)
+
+1. **Keep the uniform 2-D zoom model** (time and depth scale together), but make zoom **anchor under the cursor** (mouse/trackpad) or **under the pinch focal point** (touch), never the corner. Switching to time-only/X-axis zoom was considered and explicitly rejected.
+2. **Add intuitive navigation** for a zoomed-in chart, resolving the long-standing collision between "drag to pan" and "drag to scrub the tooltip" by **branching on the active pointer kind** and reserving one-finger touch drag for scrubbing.
+3. **Implementation follows the map sibling spec's house pattern**: branch on `PointerDeviceKind`, take trackpad/wheel zoom through a passive `Listener` keyed to the reliable cursor `localPosition`, and lift the zoom/pan/anchor math into a small, immutable, unit-tested value object.
+
+## Core principle: key off the active pointer kind, not the platform
+
+The same single device can be both "touch" and "trackpad" — an iPad with a Magic Keyboard trackpad is `TargetPlatform.iOS` yet needs cursor/hover behavior. So a single-pointer drag means **pan** when the live pointer is a mouse and **scrub** when it is a finger. Behavior is chosen from the **active `PointerDeviceKind`**, corrected on the first real pointer event, not from `defaultTargetPlatform`.
+
+## Interaction model (end state)
+
+**Desktop (mouse / trackpad):**
+
+| Input | Action | Anchor |
+|---|---|---|
+| Hover | Move tooltip (read depth/time/values) | cursor |
+| Click-drag | Pan (2-D) | — |
+| Mouse wheel | Zoom | **cursor** (`localPosition`) |
+| Trackpad pinch | Zoom | **cursor** (`localPosition`) |
+| Trackpad two-finger scroll | Pan | — |
+
+**Touch:**
+
+| Input | Action | Anchor |
+|---|---|---|
+| One-finger drag | Scrub tooltip (**unchanged from today**) | — |
+| Two-finger pinch | Zoom | pinch focal point |
+| Two-finger drag | Pan | — |
+| Double-tap-and-**hold**, then drag | Pan | — |
+| Double-tap (quick, no hold) | Zoom toggle (in / reset) | **tap point** |
+
+A quick double-tap and a double-tap-with-hold are distinguishable because the held variant is followed by movement while the finger stays down.
+
+## Design
+
+New file: `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart` — a pure immutable value object plus two pure helpers. All gesture handling in `dive_profile_chart.dart` is rewritten to map an old viewport to a new one.
+
+### Component 1 — `ProfileChartViewport` (immutable value object)
+
+Models the visible window as normalized fractions `[0,1]` of the total data range, independent of pixel size and of the data totals. It is the single place anchoring can be right or wrong.
+
+```dart
+@immutable
+class ProfileChartViewport {
+  final double zoom;     // >= 1.0
+  final double offsetX;  // normalized left edge, in [0, 1 - 1/zoom]
+  final double offsetY;  // normalized top edge (0 = surface), in [0, 1 - 1/zoom]
+  const ProfileChartViewport({this.zoom = 1, this.offsetX = 0, this.offsetY = 0});
+
+  static const double minZoom = 1.0, maxZoom = 10.0;
+  static const ProfileChartViewport reset = ProfileChartViewport();
+  bool get isZoomed => zoom > 1.0;
+
+  double get visibleWidth  => 1.0 / zoom; // fraction of total time range
+  double get visibleHeight => 1.0 / zoom; // fraction of total depth range
+
+  /// Zoom by [factor] (>1 = in) keeping the data point under the focal point fixed.
+  /// focalX/focalY are fractions (0..1) of the VISIBLE PLOT AREA under the cursor/pinch
+  /// (0 = left / top edge).
+  ProfileChartViewport zoomedAt(double focalX, double focalY, double factor) {
+    final newZoom = (zoom * factor).clamp(minZoom, maxZoom);
+    if (newZoom == zoom) return this;
+    final anchorX = offsetX + focalX / zoom; // data fraction under focus, before zoom
+    final anchorY = offsetY + focalY / zoom;
+    return ProfileChartViewport(
+      zoom: newZoom,
+      offsetX: anchorX - focalX / newZoom,   // keep it under focus, after zoom
+      offsetY: anchorY - focalY / newZoom,
+    )._clamped();
+  }
+
+  /// Pan by a normalized delta (fractions of the TOTAL range).
+  ProfileChartViewport pannedBy(double dx, double dy) =>
+      ProfileChartViewport(zoom: zoom, offsetX: offsetX + dx, offsetY: offsetY + dy)._clamped();
+
+  ProfileChartViewport _clamped() {
+    final maxOff = 1.0 - 1.0 / zoom;
+    return ProfileChartViewport(
+      zoom: zoom,
+      offsetX: offsetX.clamp(0.0, maxOff),
+      offsetY: offsetY.clamp(0.0, maxOff),
+    );
+  }
+}
+```
+
+Derivation of the anchor term: the visible window in normalized data coords is `[offsetX, offsetX + 1/zoom]`. The data fraction under a focal at `focalX` of the visible width is `a = offsetX + focalX/zoom`. To keep `a` at the same fraction after zooming to `newZoom`, solve `a = offsetX' + focalX/newZoom`, giving `offsetX' = a - focalX/newZoom`. The whole upper-left bug is the absence of this `- focalX/newZoom` term today.
+
+The widget keeps one field, `ProfileChartViewport _viewport = ProfileChartViewport.reset`, and re-sources the existing window computation (`dive_profile_chart.dart:1238-1246`) from it:
+
+```dart
+final visibleMinX     = _viewport.offsetX * totalMaxTime;
+final visibleMaxX     = (_viewport.offsetX + _viewport.visibleWidth)  * totalMaxTime;
+final visibleMinDepth = _viewport.offsetY * totalMaxDepth;
+final visibleMaxDepth = (_viewport.offsetY + _viewport.visibleHeight) * totalMaxDepth;
+// existing axis inversion (negation) at :1313-1316 is unchanged.
+```
+
+The viewport works purely in normalized "fraction of total, 0 = surface" space; the depth-axis inversion remains a later, untouched step.
+
+### Component 2 — pure helpers (focal mapping + drag intent)
+
+Both live in `profile_chart_viewport.dart`, pure and unit-testable.
+
+**Plot-rect focal mapping.** fl_chart reserves gutters for axis titles (left depth labels, bottom time labels, optional right-axis metric). A gesture's `localPosition` is in the full widget box, but the data window maps only to the inner plot rect, so the focal fraction must be computed against the plot rect — this is the accuracy fix that makes zoom land exactly under the cursor:
+
+```dart
+({double fx, double fy}) chartFocalFraction(
+  Offset localPos, Size box,
+  {required double left, required double right, required double top, required double bottom}) {
+  final plotW = box.width  - left - right;
+  final plotH = box.height - top  - bottom;
+  return (
+    fx: ((localPos.dx - left) / plotW).clamp(0.0, 1.0),
+    fy: ((localPos.dy - top)  / plotH).clamp(0.0, 1.0),
+  );
+}
+```
+
+The reserved extents are the values we already pass to `SideTitles.reservedSize` / axis-title configs, so the plot rect is derived each build and recomputed if a toggle (e.g. the right-axis metric) changes a gutter.
+
+**Drag intent.** A single pure decision function replaces the scattered `pointerCount`/platform checks:
+
+```dart
+enum ChartDragIntent { pan, scrub, zoomPan, none }
+
+ChartDragIntent chartDragIntent({
+  required PointerDeviceKind kind,
+  required int pointerCount,
+  required bool doubleTapHold,
+}) {
+  if (pointerCount >= 2) return ChartDragIntent.zoomPan;          // pinch + pan together
+  if (doubleTapHold)     return ChartDragIntent.pan;              // double-tap-hold drag
+  return kind == PointerDeviceKind.touch
+      ? ChartDragIntent.scrub                                      // one-finger touch = scrub
+      : ChartDragIntent.pan;                                       // mouse click-drag = pan
+}
+```
+
+### Component 3 — input routing in `dive_profile_chart.dart`
+
+A passive outer `Listener` (which never competes in the gesture arena) handles the desktop/trackpad paths reliably; an inner `GestureDetector` (`onScale*`, `onDoubleTapDown`, `onDoubleTap`) handles touch and mouse-drag. Active pointer kind is tracked exactly like the map spec: an initial platform guess, corrected on the first `onPointerHover` / `onPointerDown` / `onPointerPanZoomStart`, with `setState` only when the kind changes.
+
+| Source | Handler | Viewport op |
+|---|---|---|
+| Mouse wheel | `Listener.onPointerSignal` (`PointerScrollEvent`) | `zoomedAt(focalFromCursor, up ? 1.1 : 1/1.1)` |
+| Trackpad pinch | `Listener.onPointerPanZoomUpdate` (`e.scale`) | `zoomedAt(focalFromCursor, scaleDelta)` |
+| Trackpad two-finger scroll | same event (`e.localPan`) | `pannedBy(panDelta)` — one event does both |
+| Mouse hover / exit | `Listener.onPointerHover` / `onExit` | set / clear tooltip tracking index (no viewport change) |
+| Mouse click-drag | `GestureDetector.onScaleUpdate`, `pointerCount==1`, kind != touch | `pannedBy(focalPointDelta)` |
+| Touch one-finger drag | `onScaleUpdate`, `pointerCount==1`, kind == touch | none — fall through to fl_chart scrub (unchanged) |
+| Touch pinch + two-finger drag | `onScaleUpdate`, `pointerCount>=2` | `zoomedAt(focal, e.scale)` **and** `pannedBy(focalDelta)` |
+| Touch double-tap (quick) | `onDoubleTap` | zoom toggle, anchored at the tap point via `zoomedAt` |
+| Touch double-tap-hold + drag | `_doubleTapHold` flag + `onScaleUpdate` | `pannedBy(focalDelta)` |
+
+Why trackpad zoom goes through the passive `Listener`, not `onScaleUpdate`: a trackpad pinch is delivered as `PointerPanZoom*` events whose **`localPosition` (the cursor) is reliable**, whereas `ScaleGestureRecognizer`'s synthesized multi-touch focal point is buggy on desktop (the basis the map spec relies on). fl_chart's own recognizers ignore `PointerPanZoom*`, so a passive outer `Listener` receives them cleanly without stealing gestures the chart needs.
+
+Pixel-to-normalized conversions live in the widget (they need plot dimensions); the viewport stays dimensionless. For a content drag of `dpx` pixels, the normalized pan is `-dpx / plotW / zoom` (drag content right → window moves left).
+
+Continuous gestures (touch pinch/pan via `onScaleUpdate`, trackpad pinch/scroll via `onPointerPanZoomUpdate`) report **cumulative** `scale`/`pan` measured from gesture start, so their handlers snapshot the gesture-start `ProfileChartViewport` (the way today's code records `_previousZoom`/`_previousPan` at `onScaleStart`, `:1087-1090`) and apply the cumulative `scale`/`pan` against that snapshot on each update — not against the live viewport, which would compound. The discrete mouse-wheel path instead applies its `1.1` step incrementally per event. Exact pan sign per source (mouse drag vs two-finger scroll) and the slop/timeout thresholds for double-tap-hold are finalized under TDD.
+
+### Component 4 — coexistence, edges, and "free" wins
+
+- **Tooltip coexistence.** Desktop hover maps cursor-X → nearest sample and feeds the *existing* tooltip path (`profileTrackingIndexProvider` + fl_chart's showing-indicator), so hover renders identically to today's touch scrub; `onExit` clears it. Touch one-finger scrub is untouched. Panning uses a different gesture from the tooltip on every device (desktop: a drag has no hover; touch: two-finger / double-tap-hold vs one-finger), so the tooltip never fights the pan.
+- **Double-tap state machine.** `onDoubleTapDown` records the point and sets `_doubleTapHold`; a quick `onDoubleTap` toggles zoom **anchored at the tapped point** (`zoomedAt(tapFocal, …)`) instead of the corner; if movement begins while `_doubleTapHold` is set, the single-pointer touch drag routes to `pannedBy` instead of scrub; the flag clears on pointer-up or once the tap resolves.
+- **Buttons zoom about center (free win).** The legend's `_zoomIn`/`_zoomOut` (`:893-905`) have no cursor, so they call `zoomedAt(0.5, 0.5, 1.5)` / `(…, 1/1.5)`. Today they collapse toward the top-left; routing them through the same `zoomedAt` fixes the buttons with no bespoke code.
+- **Edge behavior & reset.** `_clamped()` hard-stops at the data edges (no rubber-band in v1). The legend reset button and double-tap-when-zoomed set `_viewport = ProfileChartViewport.reset`. The zoom-hint text (`:1052-1063`) now keys off `_viewport.isZoomed`.
+- **Scope of state.** Zoom stays local per `_DiveProfileChartState`, so the three chart instances keep independent, ephemeral zoom exactly as today. No new provider.
+
+## Testing strategy (TDD)
+
+The payoff of the pure viewport and helpers is that the hard logic tests without pumping widgets.
+
+- **Unit — `ProfileChartViewport`:**
+  - **Anchor invariant (proves the bug dead):** for random `(focalX, focalY, factor, startViewport)`, the data fraction under the focal point is unchanged after `zoomedAt` (within ε).
+  - `zoomedAt(0.5, 0.5, 2)` from reset → `zoom == 2`, `offsetX == offsetY == 0.25` (center held).
+  - Focal at a corner pins that corner: `zoomedAt(0, 0, 2)` keeps offsets `0`; `zoomedAt(1, 1, 2)` → offsets `0.5`.
+  - `pannedBy` clamps to `[0, 1 - 1/zoom]` (cannot pan past edges).
+  - Zoom clamps to `[1, 10]`; `zoomedAt` beyond a rail is a no-op returning `this`.
+  - Zoom-in then zoom-out at one focal round-trips to (approximately) the start.
+- **Unit — `chartFocalFraction`:** cursor at the left gutter → `fx == 0`; at the right edge → `fx == 1`; a mid pixel maps to the expected fraction given reserved sizes; out-of-plot positions clamp to `[0,1]`.
+- **Unit — `chartDragIntent`:** full matrix — `(mouse, 1, false) → pan`; `(touch, 1, false) → scrub`; `(touch, 1, true) → pan`; `(any, 2, _) → zoomPan`.
+- **Widget:**
+  - Mouse wheel up over an off-center point raises zoom **and keeps the data point under the cursor** (assert the resulting visible window).
+  - `TestPointer(kind: trackpad)` `panZoomStart` / `panZoomUpdate(scale > 1)` anchored off-center → zoom increases, anchor approximately fixed; `localPan` pans.
+  - Mouse hover sets the tracking index for the sample under the cursor; `onExit` clears it.
+  - **Mouse click-drag pans, but a touch one-finger drag does NOT pan (still scrubs)** — the regression guard for the collision.
+  - Legend zoom-in / zoom-out buttons zoom about the center.
+  - Double-tap (quick) toggles zoom about the tapped point. (Double-tap-hold-drag pan may be the one behavior finalized purely under TDD.)
+- **Regression:** existing `dive_profile_chart` widget tests stay green.
+
+## Out of scope
+
+- Switching to X-only / time-axis zoom (uniform 2-D kept by decision).
+- Rubber-band / elastic over-pan and pan inertia / fling (instant follow in v1).
+- Scrollbars or an overview minimap (gesture-based navigation chosen).
+- Cross-instance or persisted zoom state (stays local and ephemeral).
+- The other profile charts (`profile_editor_chart.dart`, `dive_planner/.../plan_profile_chart.dart`, `core/.../overlaid_profile_chart.dart`) — they have no zoom/pan and are untouched.
+- Any change to series, decompression overlays, units, or tooltip *content*.
+
+## Risks & trade-offs
+
+- **Plot-rect accuracy.** Anchoring exactly under the cursor needs the true plot rect minus axis gutters; if a reserved gutter changes dynamically (e.g. toggling the right-axis metric), it is recomputed each build from the configured reserved sizes.
+- **Double-tap-hold gesture** is the fiddly part (timing/slop); finalized under TDD. If it proves flaky it is not load-bearing — two-finger drag still provides touch panning.
+- **Gesture-arena cooperation.** The passive `Listener` must not claim gestures fl_chart or the `GestureDetector` need; safe because fl_chart's recognizers ignore `PointerPanZoom*`, and the single-pointer touch branch returns early so fl_chart keeps the scrub.
+- **Hover vs touch tooltip.** Hover must feed the same tooltip path as the touch scrub so the two never double-render; on touch nothing changes.
+
+## Affected files
+
+New:
+- `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart` (immutable `ProfileChartViewport` + pure `chartFocalFraction` and `chartDragIntent`)
+- `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart` (+ widget tests; location per existing test layout)
+
+Modified:
+- `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` — replace the three zoom/pan doubles (`:457-469`) with one `_viewport`; add `Listener.onPointerPanZoom*` + `onPointerHover`/`onExit` + pointer-kind tracking; rework `onScaleStart/Update` (`:1087-1127`) and `onPointerSignal` (`:1137-1153`) to branch on `chartDragIntent` and anchor via `zoomedAt`; re-source the window computation (`:1238-1246`) from the viewport; route `_zoomIn`/`_zoomOut` (`:893-905`) and double-tap (`:1128-1136`) through `zoomedAt`; key the zoom hint (`:1052-1063`) off `_viewport.isZoomed`.
+
+Unchanged:
+- `dive_profile_legend.dart` — same `onZoomIn`/`onZoomOut`/`onResetZoom` callbacks; no transform logic there.
+- `profile_tracking_provider.dart` / `profile_legend_provider.dart` / `profile_range_provider.dart` — series visibility, scrub index, and range-selection are orthogonal to the viewport.
+
+## References
+
+- Sibling spec: `docs/superpowers/specs/2026-06-21-map-touchpad-interaction-design.md` (same `PointerDeviceKind` / zoom-to-cursor philosophy)
+- flutter/flutter#136029 — desktop trackpad pinch wrong focal point (why trackpad zoom keys off the raw cursor `localPosition`)
+- `dive_profile_chart.dart` current zoom/pan: state `:457-469`, reset `:507-513`, buttons `:893-912`, hint `:1052-1063`, gestures `:1081-1153`, window `:1238-1246`, chart/clip `:1311-1318`, scrub callback `:1584-1617`, tick intervals `:2811-2824`

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1301,15 +1301,22 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     top: insets.top,
                     bottom: insets.bottom,
                   );
-                  // scale and localPan are cumulative from the gesture start.
+                  // scale and pan are cumulative from the gesture start.
                   var vp = _gestureStartViewport.zoomedAt(
                     focal.fx,
                     focal.fy,
                     event.scale,
                   );
+                  // Use the GLOBAL pan delta (event.pan), NOT event.localPan:
+                  // on macOS the trackpad PointerPanZoom localPan is contaminated
+                  // by the widget's global->local translation (the translation is
+                  // wrongly applied to the pan vector), making it a huge constant
+                  // (~ -(widget global origin)) that pins the view to a corner.
+                  // The chart has no rotation/scale, so the global pan delta IS
+                  // the correct local delta.
                   vp = vp.pannedBy(
-                    -event.localPan.dx / plotW / vp.zoom,
-                    -event.localPan.dy / plotH / vp.zoom,
+                    -event.pan.dx / plotW / vp.zoom,
+                    -event.pan.dy / plotH / vp.zoom,
                   );
                   _viewport = vp;
                 });

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -478,9 +478,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   // Cursor position at the start of a trackpad pan/zoom gesture.
   Offset _trackpadAnchor = Offset.zero;
 
-  // True between a double-tap-down and the gesture's end; lets a held-finger
-  // drag pan instead of scrub. Toggled in a later task; false here.
-  // ignore: prefer_final_fields — mutated in Task 7 (double-tap-hold pan).
+  // True between a double-tap-down and the finger lifting; lets a held-finger
+  // drag pan instead of scrub.
   bool _doubleTapHold = false;
 
   // Index of the last sample reported via hover, to de-dupe onPointSelected.
@@ -1211,8 +1210,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             },
             onDoubleTapDown: (details) {
               _lastTapDownLocal = details.localPosition;
+              _doubleTapHold = true;
             },
             onDoubleTap: () {
+              _doubleTapHold = false;
               setState(() {
                 if (_viewport.isZoomed) {
                   _viewport = ProfileChartViewport.reset;
@@ -1268,10 +1269,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               onPointerUp: (event) {
                 if (_activePointerCount > 0) _activePointerCount--;
                 _lastPointerLocal = null;
+                _doubleTapHold = false;
               },
               onPointerCancel: (event) {
                 if (_activePointerCount > 0) _activePointerCount--;
                 _lastPointerLocal = null;
+                _doubleTapHold = false;
               },
               onPointerPanZoomStart: (event) {
                 _activePointerKind = PointerDeviceKind.trackpad;

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -930,6 +930,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         : null;
     final hasRightAxisName =
         effectiveRightAxisMetric != null && rightAxisRange != null;
+    // ref.read (NOT _hasGasStrip's ref.watch): _plotInsets runs from gesture
+    // callbacks, outside build, where ref.watch must not be used.
+    final hasGasStrip = _gasStripVisible(
+      ref.read(profileLegendProvider).showGas,
+    );
 
     return (
       left:
@@ -941,7 +946,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           DiveProfileChart.rightAxisSize(availableWidth),
       bottom:
           DiveProfileChart._bottomAxisNameSize +
-          (_hasGasStrip
+          (hasGasStrip
               ? DiveProfileChart._bottomTickReservedSize +
                     DiveProfileChart.gasTimelineHeight
               : DiveProfileChart._bottomTickReservedSize),
@@ -1412,10 +1417,16 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// supplied AND the user has not hidden the strip via the chart options
   /// menu — keeps the chart self-contained and lets us cheaply branch in
   /// the layout code without nullable bookkeeping at every call site.
-  bool get _hasGasStrip =>
+  bool _gasStripVisible(bool showGas) =>
       (widget.gasSegments?.isNotEmpty ?? false) &&
       (widget.diveDurationSeconds != null && widget.diveDurationSeconds! > 0) &&
-      ref.watch(profileLegendProvider.select((s) => s.showGas));
+      showGas;
+
+  // ref.watch is correct here: _hasGasStrip is only read from build().
+  // Gesture paths must use _gasStripVisible with ref.read (see _plotInsets).
+  bool get _hasGasStrip => _gasStripVisible(
+    ref.watch(profileLegendProvider.select((s) => s.showGas)),
+  );
 
   Widget _buildChart(
     BuildContext context,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -490,6 +490,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   // in the Listener.onPointerMove mouse-pan path (bypasses gesture arena).
   Offset? _lastPointerLocal;
 
+  // Number of pointers currently down. onPointerMove only pans for a genuine
+  // single-pointer drag, so a multi-finger touch never leaks into the pan path
+  // (this is what keeps Task 7's double-tap-hold pan single-finger-only).
+  int _activePointerCount = 0;
+
   // Tooltip memoization
   int? _lastTooltipSpotIndex;
   List<LineTooltipItem?> _lastTooltipItems = [];
@@ -1161,39 +1166,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               _startFocalPoint = details.localFocalPoint;
             },
             onScaleUpdate: (details) {
-              if (details.pointerCount < 2) {
-                // single-pointer: mouse drag pans, touch one-finger scrubs (falls through)
-                final intent = chartDragIntent(
-                  kind: _activePointerKind,
-                  pointerCount: details.pointerCount,
-                  doubleTapHold: _doubleTapHold,
-                );
-                if (intent != ChartDragIntent.pan) return; // touch scrub
-                setState(() {
-                  final box = constraints.biggest;
-                  final insets = _plotInsets(constraints.maxWidth, units);
-                  final plotW = (box.width - insets.left - insets.right).clamp(
-                    1.0,
-                    double.infinity,
-                  );
-                  final plotH = (box.height - insets.top - insets.bottom).clamp(
-                    1.0,
-                    double.infinity,
-                  );
-                  final d = details.focalPointDelta;
-                  _viewport = _viewport.pannedBy(
-                    -d.dx / plotW / _viewport.zoom,
-                    -d.dy / plotH / _viewport.zoom,
-                  );
-                });
-                return;
-              }
+              // Single-pointer drags are handled by Listener.onPointerMove
+              // (mouse pan) and fl_chart's own recognizer (touch scrub); they
+              // never reach onScaleUpdate, which only ever fires for a pinch.
+              if (details.pointerCount < 2) return;
 
-              // pointerCount >= 2: pinch. Keep the Task 5 touch-only guard.
               // Trackpad pinch is handled by the Listener's onPointerPanZoomUpdate
-              // (reliable cursor anchor); the ScaleGestureRecognizer's synthesized
-              // focal point is unreliable on desktop. Touch focal points are correct,
-              // so touch pinch is handled here.
+              // (reliable cursor anchor); touch focal points are correct, so touch
+              // pinch is handled here.
               if (_activePointerKind != PointerDeviceKind.touch) return;
 
               setState(() {
@@ -1253,6 +1233,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             },
             child: Listener(
               onPointerDown: (event) {
+                _activePointerCount++;
                 _activePointerKind = event.kind;
                 _lastPointerLocal = event.localPosition;
               },
@@ -1262,7 +1243,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 if (prev == null) return;
                 final intent = chartDragIntent(
                   kind: _activePointerKind,
-                  pointerCount: 1,
+                  pointerCount: _activePointerCount,
                   doubleTapHold: _doubleTapHold,
                 );
                 if (intent != ChartDragIntent.pan) return;
@@ -1284,8 +1265,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   );
                 });
               },
-              onPointerUp: (event) => _lastPointerLocal = null,
-              onPointerCancel: (event) => _lastPointerLocal = null,
+              onPointerUp: (event) {
+                if (_activePointerCount > 0) _activePointerCount--;
+                _lastPointerLocal = null;
+              },
+              onPointerCancel: (event) {
+                if (_activePointerCount > 0) _activePointerCount--;
+                _lastPointerLocal = null;
+              },
               onPointerPanZoomStart: (event) {
                 _activePointerKind = PointerDeviceKind.trackpad;
                 _gestureStartViewport = _viewport;

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -469,7 +469,6 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
   // Active pointer kind, corrected on the first real pointer event. Chooses
   // pan-vs-scrub for single-pointer drags and is set by trackpad gestures.
-  // ignore: unused_field — read by Task 6 (single-pointer drag routing).
   PointerDeviceKind _activePointerKind =
       (defaultTargetPlatform == TargetPlatform.iOS ||
           defaultTargetPlatform == TargetPlatform.android)
@@ -478,6 +477,18 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
   // Cursor position at the start of a trackpad pan/zoom gesture.
   Offset _trackpadAnchor = Offset.zero;
+
+  // True between a double-tap-down and the gesture's end; lets a held-finger
+  // drag pan instead of scrub. Toggled in a later task; false here.
+  // ignore: prefer_final_fields — mutated in Task 7 (double-tap-hold pan).
+  bool _doubleTapHold = false;
+
+  // Index of the last sample reported via hover, to de-dupe onPointSelected.
+  int? _lastHoverIndex;
+
+  // Last raw pointer position during a drag; used to compute per-move deltas
+  // in the Listener.onPointerMove mouse-pan path (bypasses gesture arena).
+  Offset? _lastPointerLocal;
 
   // Tooltip memoization
   int? _lastTooltipSpotIndex;
@@ -933,6 +944,41 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     );
   }
 
+  /// Nearest profile sample index under a hover at [localPos], or null if the
+  /// profile is empty. Maps the cursor X through the current viewport to a
+  /// timestamp, then finds the closest sample.
+  int? _hoverIndex(
+    Offset localPos,
+    Size box,
+    ({double left, double top, double right, double bottom}) insets,
+  ) {
+    if (widget.profile.isEmpty) return null;
+    final focal = chartFocalFraction(
+      localPos,
+      box,
+      left: insets.left,
+      right: insets.right,
+      top: insets.top,
+      bottom: insets.bottom,
+    );
+    final totalMaxTime = widget.profile
+        .map((p) => p.timestamp)
+        .reduce(math.max)
+        .toDouble();
+    final t =
+        (_viewport.offsetX + focal.fx * _viewport.visibleWidth) * totalMaxTime;
+    var best = 0;
+    var bestDist = double.infinity;
+    for (var i = 0; i < widget.profile.length; i++) {
+      final d = (widget.profile[i].timestamp - t).abs();
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    }
+    return best;
+  }
+
   // Buttons have no cursor, so they zoom about the visible center.
   void _zoomIn() {
     setState(() => _viewport = _viewport.zoomedAt(0.5, 0.5, 1.5));
@@ -1115,10 +1161,35 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               _startFocalPoint = details.localFocalPoint;
             },
             onScaleUpdate: (details) {
-              // Single-pointer drags (mouse pan / touch scrub) are wired in a
-              // later task; for now only multi-touch pinch+pan acts here.
-              if (details.pointerCount < 2) return;
+              if (details.pointerCount < 2) {
+                // single-pointer: mouse drag pans, touch one-finger scrubs (falls through)
+                final intent = chartDragIntent(
+                  kind: _activePointerKind,
+                  pointerCount: details.pointerCount,
+                  doubleTapHold: _doubleTapHold,
+                );
+                if (intent != ChartDragIntent.pan) return; // touch scrub
+                setState(() {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final plotW = (box.width - insets.left - insets.right).clamp(
+                    1.0,
+                    double.infinity,
+                  );
+                  final plotH = (box.height - insets.top - insets.bottom).clamp(
+                    1.0,
+                    double.infinity,
+                  );
+                  final d = details.focalPointDelta;
+                  _viewport = _viewport.pannedBy(
+                    -d.dx / plotW / _viewport.zoom,
+                    -d.dy / plotH / _viewport.zoom,
+                  );
+                });
+                return;
+              }
 
+              // pointerCount >= 2: pinch. Keep the Task 5 touch-only guard.
               // Trackpad pinch is handled by the Listener's onPointerPanZoomUpdate
               // (reliable cursor anchor); the ScaleGestureRecognizer's synthesized
               // focal point is unreliable on desktop. Touch focal points are correct,
@@ -1181,7 +1252,40 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               });
             },
             child: Listener(
-              onPointerDown: (event) => _activePointerKind = event.kind,
+              onPointerDown: (event) {
+                _activePointerKind = event.kind;
+                _lastPointerLocal = event.localPosition;
+              },
+              onPointerMove: (event) {
+                final prev = _lastPointerLocal;
+                _lastPointerLocal = event.localPosition;
+                if (prev == null) return;
+                final intent = chartDragIntent(
+                  kind: _activePointerKind,
+                  pointerCount: 1,
+                  doubleTapHold: _doubleTapHold,
+                );
+                if (intent != ChartDragIntent.pan) return;
+                setState(() {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final plotW = (box.width - insets.left - insets.right).clamp(
+                    1.0,
+                    double.infinity,
+                  );
+                  final plotH = (box.height - insets.top - insets.bottom).clamp(
+                    1.0,
+                    double.infinity,
+                  );
+                  final d = event.localPosition - prev;
+                  _viewport = _viewport.pannedBy(
+                    -d.dx / plotW / _viewport.zoom,
+                    -d.dy / plotH / _viewport.zoom,
+                  );
+                });
+              },
+              onPointerUp: (event) => _lastPointerLocal = null,
+              onPointerCancel: (event) => _lastPointerLocal = null,
               onPointerPanZoomStart: (event) {
                 _activePointerKind = PointerDeviceKind.trackpad;
                 _gestureStartViewport = _viewport;
@@ -1238,13 +1342,33 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   });
                 }
               },
-              child: _buildChart(
-                context,
-                units,
-                availableWidth: constraints.maxWidth,
-                hasTemperatureData: hasTemperatureData,
-                hasPressureData: hasPressureData,
-                hasHeartRateData: hasHeartRateData,
+              onPointerHover: (event) {
+                _activePointerKind = PointerDeviceKind.mouse;
+                final idx = _hoverIndex(
+                  event.localPosition,
+                  constraints.biggest,
+                  _plotInsets(constraints.maxWidth, units),
+                );
+                if (idx != _lastHoverIndex) {
+                  _lastHoverIndex = idx;
+                  widget.onPointSelected?.call(idx);
+                }
+              },
+              child: MouseRegion(
+                onExit: (_) {
+                  if (_lastHoverIndex != null) {
+                    _lastHoverIndex = null;
+                    widget.onPointSelected?.call(null);
+                  }
+                },
+                child: _buildChart(
+                  context,
+                  units,
+                  availableWidth: constraints.maxWidth,
+                  hasTemperatureData: hasTemperatureData,
+                  hasPressureData: hasPressureData,
+                  hasHeartRateData: hasHeartRateData,
+                ),
               ),
             ),
           ),

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -23,6 +23,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_l
 import 'package:submersion/features/dive_log/presentation/widgets/gas_colors.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
 
 /// Structured row emitted via [DiveProfileChart.onTooltipData] so callers
 /// can render the tooltip externally (e.g., below the chart).
@@ -454,19 +455,16 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
   }
 
-  // Zoom/pan state
-  double _zoomLevel = 1.0;
-  double _panOffsetX = 0.0; // Normalized offset (0-1 range based on total data)
-  double _panOffsetY = 0.0;
+  // Zoom/pan state — see profile_chart_viewport.dart.
+  ProfileChartViewport _viewport = ProfileChartViewport.reset;
 
-  // For gesture handling
-  double _previousZoom = 1.0;
-  Offset _previousPan = Offset.zero;
+  // Snapshot of the viewport at the start of a continuous gesture; continuous
+  // gestures report cumulative scale/pan, so we apply them against this.
+  ProfileChartViewport _gestureStartViewport = ProfileChartViewport.reset;
   Offset _startFocalPoint = Offset.zero;
 
-  // Zoom limits
-  static const double _minZoom = 1.0;
-  static const double _maxZoom = 10.0;
+  // Local position of the most recent (double-)tap, for tap-anchored zoom.
+  Offset _lastTapDownLocal = Offset.zero;
 
   // Tooltip memoization
   int? _lastTooltipSpotIndex;
@@ -505,11 +503,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   }
 
   void _resetZoom() {
-    setState(() {
-      _zoomLevel = 1.0;
-      _panOffsetX = 0.0;
-      _panOffsetY = 0.0;
-    });
+    setState(() => _viewport = ProfileChartViewport.reset);
   }
 
   /// Build and emit [TooltipRow] data for external rendering when
@@ -890,25 +884,49 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     widget.onTooltipData!(rows);
   }
 
+  /// The plot-rect insets (reserved axis gutters) for the current build, so a
+  /// gesture's local position can be mapped to a plot-area fraction. Mirrors
+  /// the axis reservations used for the gas-strip overlay (left/right at
+  /// :2265-2270, bottom at :1379-1382). Top has no titles, so its inset is 0.
+  ({double left, double top, double right, double bottom}) _plotInsets(
+    double availableWidth,
+    UnitFormatter units,
+  ) {
+    final legendNotifier = ref.read(profileLegendProvider.notifier);
+    final preferredMetric = legendNotifier.getEffectiveRightAxisMetric();
+    final effectiveRightAxisMetric = preferredMetric != null
+        ? _getEffectiveRightAxisMetric(preferredMetric)
+        : null;
+    final rightAxisRange = effectiveRightAxisMetric != null
+        ? _getMetricRange(effectiveRightAxisMetric, units)
+        : null;
+    final hasRightAxisName =
+        effectiveRightAxisMetric != null && rightAxisRange != null;
+
+    return (
+      left:
+          DiveProfileChart._leftRightAxisNameSize +
+          DiveProfileChart.leftAxisSize(availableWidth),
+      top: 0,
+      right:
+          (hasRightAxisName ? DiveProfileChart._leftRightAxisNameSize : 0) +
+          DiveProfileChart.rightAxisSize(availableWidth),
+      bottom:
+          DiveProfileChart._bottomAxisNameSize +
+          (_hasGasStrip
+              ? DiveProfileChart._bottomTickReservedSize +
+                    DiveProfileChart.gasTimelineHeight
+              : DiveProfileChart._bottomTickReservedSize),
+    );
+  }
+
+  // Buttons have no cursor, so they zoom about the visible center.
   void _zoomIn() {
-    setState(() {
-      _zoomLevel = (_zoomLevel * 1.5).clamp(_minZoom, _maxZoom);
-      _clampPanOffsets();
-    });
+    setState(() => _viewport = _viewport.zoomedAt(0.5, 0.5, 1.5));
   }
 
   void _zoomOut() {
-    setState(() {
-      _zoomLevel = (_zoomLevel / 1.5).clamp(_minZoom, _maxZoom);
-      _clampPanOffsets();
-    });
-  }
-
-  void _clampPanOffsets() {
-    // Calculate maximum allowed pan based on zoom level
-    final maxPan = 1.0 - (1.0 / _zoomLevel);
-    _panOffsetX = _panOffsetX.clamp(0.0, maxPan);
-    _panOffsetY = _panOffsetY.clamp(0.0, maxPan);
+    setState(() => _viewport = _viewport.zoomedAt(0.5, 0.5, 1 / 1.5));
   }
 
   @override
@@ -1024,9 +1042,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             // Chart header with legend and zoom controls (decluttered)
             DiveProfileLegend(
               config: legendConfig,
-              zoomLevel: _zoomLevel,
-              minZoom: _minZoom,
-              maxZoom: _maxZoom,
+              zoomLevel: _viewport.zoom,
+              minZoom: ProfileChartViewport.minZoom,
+              maxZoom: ProfileChartViewport.maxZoom,
               onZoomIn: _zoomIn,
               onZoomOut: _zoomOut,
               onResetZoom: _resetZoom,
@@ -1049,12 +1067,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               ),
             ),
             // Zoom hint
-            if (_zoomLevel > 1.0)
+            if (_viewport.isZoomed)
               Padding(
                 padding: const EdgeInsets.only(top: 4),
                 child: Text(
                   context.l10n.diveLog_profile_zoomHint(
-                    _zoomLevel.toStringAsFixed(1),
+                    _viewport.zoom.toStringAsFixed(1),
                   ),
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: colorScheme.onSurfaceVariant,
@@ -1080,74 +1098,85 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           label: context.l10n.diveLog_profile_semantics_chart,
           child: GestureDetector(
             onScaleStart: (details) {
-              _previousZoom = _zoomLevel;
-              _previousPan = Offset(_panOffsetX, _panOffsetY);
+              _gestureStartViewport = _viewport;
               _startFocalPoint = details.localFocalPoint;
             },
             onScaleUpdate: (details) {
-              // Only apply zoom/pan for multi-touch (pinch) gestures.
-              // Single-finger drag is handled by fl_chart's touchCallback
-              // without gesture arena disambiguation delay.
+              // Single-pointer drags (mouse pan / touch scrub) are wired in a
+              // later task; for now only multi-touch pinch+pan acts here.
               if (details.pointerCount < 2) return;
 
               setState(() {
-                // Handle zoom
-                final newZoom = (_previousZoom * details.scale).clamp(
-                  _minZoom,
-                  _maxZoom,
+                final box = constraints.biggest;
+                final insets = _plotInsets(constraints.maxWidth, units);
+                final plotW = (box.width - insets.left - insets.right).clamp(
+                  1.0,
+                  double.infinity,
                 );
-
-                // Handle pan
-                final panDelta = details.localFocalPoint - _startFocalPoint;
-
-                // Convert pixel delta to normalized offset based on chart size
-                final chartWidth = constraints.maxWidth;
-                final chartHeight = constraints.maxHeight;
-
-                // Only apply pan if zoomed in
-                if (newZoom > 1.0) {
-                  final normalizedDeltaX = -panDelta.dx / chartWidth / newZoom;
-                  final normalizedDeltaY = -panDelta.dy / chartHeight / newZoom;
-
-                  _panOffsetX = (_previousPan.dx + normalizedDeltaX).clamp(
-                    0.0,
-                    1.0 - (1.0 / newZoom),
-                  );
-                  _panOffsetY = (_previousPan.dy + normalizedDeltaY).clamp(
-                    0.0,
-                    1.0 - (1.0 / newZoom),
-                  );
-                } else {
-                  _panOffsetX = 0.0;
-                  _panOffsetY = 0.0;
-                }
-
-                _zoomLevel = newZoom;
+                final plotH = (box.height - insets.top - insets.bottom).clamp(
+                  1.0,
+                  double.infinity,
+                );
+                final focal = chartFocalFraction(
+                  _startFocalPoint,
+                  box,
+                  left: insets.left,
+                  right: insets.right,
+                  top: insets.top,
+                  bottom: insets.bottom,
+                );
+                // scale is cumulative from gesture start -> apply to snapshot.
+                var vp = _gestureStartViewport.zoomedAt(
+                  focal.fx,
+                  focal.fy,
+                  details.scale,
+                );
+                final panPx = details.localFocalPoint - _startFocalPoint;
+                vp = vp.pannedBy(
+                  -panPx.dx / plotW / vp.zoom,
+                  -panPx.dy / plotH / vp.zoom,
+                );
+                _viewport = vp;
               });
             },
+            onDoubleTapDown: (details) {
+              _lastTapDownLocal = details.localPosition;
+            },
             onDoubleTap: () {
-              if (_zoomLevel > 1.0) {
-                _resetZoom();
-              } else {
-                setState(() {
-                  _zoomLevel = 2.0;
-                });
-              }
+              setState(() {
+                if (_viewport.isZoomed) {
+                  _viewport = ProfileChartViewport.reset;
+                } else {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final focal = chartFocalFraction(
+                    _lastTapDownLocal,
+                    box,
+                    left: insets.left,
+                    right: insets.right,
+                    top: insets.top,
+                    bottom: insets.bottom,
+                  );
+                  _viewport = _viewport.zoomedAt(focal.fx, focal.fy, 2.0);
+                }
+              });
             },
             child: Listener(
               onPointerSignal: (event) {
-                // Handle mouse scroll wheel for zoom
                 if (event is PointerScrollEvent) {
                   setState(() {
-                    final scrollDelta = event.scrollDelta.dy;
-                    if (scrollDelta < 0) {
-                      // Scroll up = zoom in
-                      _zoomLevel = (_zoomLevel * 1.1).clamp(_minZoom, _maxZoom);
-                    } else {
-                      // Scroll down = zoom out
-                      _zoomLevel = (_zoomLevel / 1.1).clamp(_minZoom, _maxZoom);
-                    }
-                    _clampPanOffsets();
+                    final box = constraints.biggest;
+                    final insets = _plotInsets(constraints.maxWidth, units);
+                    final focal = chartFocalFraction(
+                      event.localPosition,
+                      box,
+                      left: insets.left,
+                      right: insets.right,
+                      top: insets.top,
+                      bottom: insets.bottom,
+                    );
+                    final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
+                    _viewport = _viewport.zoomedAt(focal.fx, focal.fy, factor);
                   });
                 }
               },
@@ -1235,14 +1264,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     );
     final totalMaxDepth = maxDepthValueDisplay * 1.1; // Add 10% padding
 
-    // Apply zoom and pan to calculate visible bounds
-    final visibleRangeX = totalMaxTime / _zoomLevel;
-    final visibleRangeY = totalMaxDepth / _zoomLevel;
+    // Apply zoom and pan to calculate visible bounds (see ProfileChartViewport).
+    final visibleRangeX = totalMaxTime * _viewport.visibleWidth;
+    final visibleRangeY = totalMaxDepth * _viewport.visibleHeight;
 
-    final visibleMinX = _panOffsetX * totalMaxTime;
+    final visibleMinX = _viewport.offsetX * totalMaxTime;
     final visibleMaxX = visibleMinX + visibleRangeX;
 
-    final visibleMinDepth = _panOffsetY * totalMaxDepth;
+    final visibleMinDepth = _viewport.offsetY * totalMaxDepth;
     final visibleMaxDepth = visibleMinDepth + visibleRangeY;
 
     // Temperature bounds (if showing) - convert to user's preferred unit

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1119,6 +1119,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               // later task; for now only multi-touch pinch+pan acts here.
               if (details.pointerCount < 2) return;
 
+              // Trackpad pinch is handled by the Listener's onPointerPanZoomUpdate
+              // (reliable cursor anchor); the ScaleGestureRecognizer's synthesized
+              // focal point is unreliable on desktop. Touch focal points are correct,
+              // so touch pinch is handled here.
+              if (_activePointerKind != PointerDeviceKind.touch) return;
+
               setState(() {
                 final box = constraints.biggest;
                 final insets = _plotInsets(constraints.maxWidth, units);

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1,8 +1,9 @@
 import 'dart:math' as math;
 
 import 'package:fl_chart/fl_chart.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/constants/enums.dart';
@@ -465,6 +466,18 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
   // Local position of the most recent (double-)tap, for tap-anchored zoom.
   Offset _lastTapDownLocal = Offset.zero;
+
+  // Active pointer kind, corrected on the first real pointer event. Chooses
+  // pan-vs-scrub for single-pointer drags and is set by trackpad gestures.
+  // ignore: unused_field — read by Task 6 (single-pointer drag routing).
+  PointerDeviceKind _activePointerKind =
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android)
+      ? PointerDeviceKind.touch
+      : PointerDeviceKind.mouse;
+
+  // Cursor position at the start of a trackpad pan/zoom gesture.
+  Offset _trackpadAnchor = Offset.zero;
 
   // Tooltip memoization
   int? _lastTooltipSpotIndex;
@@ -1162,6 +1175,45 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               });
             },
             child: Listener(
+              onPointerDown: (event) => _activePointerKind = event.kind,
+              onPointerPanZoomStart: (event) {
+                _activePointerKind = PointerDeviceKind.trackpad;
+                _gestureStartViewport = _viewport;
+                _trackpadAnchor = event.localPosition;
+              },
+              onPointerPanZoomUpdate: (event) {
+                setState(() {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final plotW = (box.width - insets.left - insets.right).clamp(
+                    1.0,
+                    double.infinity,
+                  );
+                  final plotH = (box.height - insets.top - insets.bottom).clamp(
+                    1.0,
+                    double.infinity,
+                  );
+                  final focal = chartFocalFraction(
+                    _trackpadAnchor,
+                    box,
+                    left: insets.left,
+                    right: insets.right,
+                    top: insets.top,
+                    bottom: insets.bottom,
+                  );
+                  // scale and localPan are cumulative from the gesture start.
+                  var vp = _gestureStartViewport.zoomedAt(
+                    focal.fx,
+                    focal.fy,
+                    event.scale,
+                  );
+                  vp = vp.pannedBy(
+                    -event.localPan.dx / plotW / vp.zoom,
+                    -event.localPan.dy / plotH / vp.zoom,
+                  );
+                  _viewport = vp;
+                });
+              },
               onPointerSignal: (event) {
                 if (event is PointerScrollEvent) {
                   setState(() {

--- a/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
 /// Immutable description of the dive profile chart's visible window, expressed
@@ -78,4 +79,23 @@ class ProfileChartViewport {
     fx: ((localPos.dx - left) / plotW).clamp(0.0, 1.0),
     fy: ((localPos.dy - top) / plotH).clamp(0.0, 1.0),
   );
+}
+
+/// What a drag/scale event should do on the profile chart.
+enum ChartDragIntent { pan, scrub, zoomPan, none }
+
+/// Decides the meaning of an in-progress gesture from the active pointer kind,
+/// the pointer count, and whether a double-tap-hold is active. Keying off the
+/// pointer kind (not the platform) is what lets one-finger touch keep scrubbing
+/// while a mouse drag pans.
+ChartDragIntent chartDragIntent({
+  required PointerDeviceKind kind,
+  required int pointerCount,
+  required bool doubleTapHold,
+}) {
+  if (pointerCount >= 2) return ChartDragIntent.zoomPan;
+  if (doubleTapHold) return ChartDragIntent.pan;
+  return kind == PointerDeviceKind.touch
+      ? ChartDragIntent.scrub
+      : ChartDragIntent.pan;
 }

--- a/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
@@ -59,3 +59,23 @@ class ProfileChartViewport {
     );
   }
 }
+
+/// Maps a gesture's [localPos] (in the full widget [box]) to a fraction
+/// (0..1, clamped) of the inner plot rect, given the reserved axis gutters.
+/// fl_chart reserves [left]/[right]/[top]/[bottom] for axis names + tick
+/// labels (+ the gas strip), so the data window only fills the inner rect.
+({double fx, double fy}) chartFocalFraction(
+  Offset localPos,
+  Size box, {
+  required double left,
+  required double right,
+  required double top,
+  required double bottom,
+}) {
+  final plotW = (box.width - left - right).clamp(1.0, double.infinity);
+  final plotH = (box.height - top - bottom).clamp(1.0, double.infinity);
+  return (
+    fx: ((localPos.dx - left) / plotW).clamp(0.0, 1.0),
+    fy: ((localPos.dy - top) / plotH).clamp(0.0, 1.0),
+  );
+}

--- a/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/widgets.dart';
+
+/// Immutable description of the dive profile chart's visible window, expressed
+/// as normalized fractions [0,1] of the total data range. Resolution- and
+/// data-independent, so the anchor math is unit-testable with plain numbers.
+///
+/// `offsetX`/`offsetY` are the normalized left/top edges of the visible window
+/// (`offsetY == 0` is the surface). The window spans `1/zoom` of each axis, so
+/// both offsets are valid in `[0, 1 - 1/zoom]`.
+@immutable
+class ProfileChartViewport {
+  final double zoom; // >= 1.0
+  final double offsetX;
+  final double offsetY;
+
+  const ProfileChartViewport({
+    this.zoom = 1,
+    this.offsetX = 0,
+    this.offsetY = 0,
+  });
+
+  static const double minZoom = 1.0;
+  static const double maxZoom = 10.0;
+  static const ProfileChartViewport reset = ProfileChartViewport();
+
+  bool get isZoomed => zoom > 1.0;
+  double get visibleWidth => 1.0 / zoom;
+  double get visibleHeight => 1.0 / zoom;
+
+  /// Zoom by [factor] (>1 = in, <1 = out) keeping the data point under the
+  /// focal point fixed. [focalX]/[focalY] are fractions (0..1) of the visible
+  /// plot area under the cursor/pinch (0 = left/top edge).
+  ProfileChartViewport zoomedAt(double focalX, double focalY, double factor) {
+    final newZoom = (zoom * factor).clamp(minZoom, maxZoom);
+    if (newZoom == zoom) return this;
+    final anchorX =
+        offsetX + focalX / zoom; // data fraction under focus, before
+    final anchorY = offsetY + focalY / zoom;
+    return ProfileChartViewport(
+      zoom: newZoom,
+      offsetX: anchorX - focalX / newZoom, // keep it under focus, after
+      offsetY: anchorY - focalY / newZoom,
+    )._clamped();
+  }
+
+  /// Pan by a normalized delta (fractions of the total range).
+  ProfileChartViewport pannedBy(double dx, double dy) => ProfileChartViewport(
+    zoom: zoom,
+    offsetX: offsetX + dx,
+    offsetY: offsetY + dy,
+  )._clamped();
+
+  ProfileChartViewport _clamped() {
+    final maxOff = 1.0 - 1.0 / zoom;
+    return ProfileChartViewport(
+      zoom: zoom,
+      offsetX: offsetX.clamp(0.0, maxOff),
+      offsetY: offsetY.clamp(0.0, maxOff),
+    );
+  }
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2126,4 +2126,45 @@ void main() {
       expect(selected, inInclusiveRange(0, 19));
     });
   });
+
+  group('double-tap-hold pan', () {
+    testWidgets('double-tap then hold-drag pans a zoomed-in chart', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      // Zoom in so there is room to pan.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.pump();
+      final zoomed = tester.widget<LineChart>(chart).data;
+
+      // First tap (quick) then a second touch that is held and dragged.
+      await tester.tapAt(center, kind: PointerDeviceKind.touch);
+      await tester.pump(const Duration(milliseconds: 50));
+      final hold = await tester.startGesture(
+        center,
+        kind: PointerDeviceKind.touch,
+      );
+      await hold.moveBy(const Offset(-60, 0));
+      await hold.up();
+      await tester.pumpAndSettle();
+
+      final panned = tester.widget<LineChart>(chart).data;
+      expect(panned.minX, greaterThan(zoomed.minX));
+    });
+  });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2037,4 +2037,93 @@ void main() {
       },
     );
   });
+
+  group('desktop pan and hover', () {
+    testWidgets('mouse click-drag pans a zoomed-in chart', (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      // Zoom in first (about center) via two wheel steps.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.pump();
+      final zoomed = tester.widget<LineChart>(chart).data;
+
+      // Drag left with the mouse -> window should move right (minX increases).
+      final gesture = await tester.startGesture(
+        center,
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(-60, 0));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      final panned = tester.widget<LineChart>(chart).data;
+      expect(panned.minX, greaterThan(zoomed.minX));
+    });
+
+    testWidgets('touch one-finger drag does NOT pan (still scrubs)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.pump();
+      final zoomed = tester.widget<LineChart>(chart).data;
+
+      final gesture = await tester.startGesture(
+        center,
+        kind: PointerDeviceKind.touch,
+      );
+      await gesture.moveBy(const Offset(-60, 0));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      final after = tester.widget<LineChart>(chart).data;
+      expect(after.minX, zoomed.minX); // unchanged: one finger scrubs, no pan
+    });
+
+    testWidgets('mouse hover selects the nearest sample', (tester) async {
+      int? selected;
+      await tester.pumpWidget(
+        _buildChart(
+          profile: _makeProfile(points: 20),
+          onPointSelected: (i) => selected = i,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      await tester.sendEventToBinding(
+        pointer.hover(topLeft + Offset(size.width * 0.5, size.height * 0.5)),
+      );
+      await tester.pump();
+
+      expect(selected, isNotNull);
+      expect(selected, inInclusiveRange(0, 19));
+    });
+  });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -1,4 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -1905,6 +1906,59 @@ void main() {
       expect(find.byType(DiveProfileChart), findsOneWidget);
 
       FlutterError.onError = origOnError;
+    });
+  });
+
+  // Reads the primary fl_chart LineChartData (the depth/time plot is first).
+  LineChartData primaryChartData(WidgetTester tester) =>
+      tester.widget<LineChart>(find.byType(LineChart).first).data;
+
+  group('zoom anchoring', () {
+    testWidgets('mouse wheel up zooms in WITHOUT pinning the left edge to 0', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final before = primaryChartData(tester);
+      expect(before.minX, 0.0); // at zoom 1 the window starts at t=0
+
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+      // Cursor in the right third of the plot.
+      final cursor = topLeft + Offset(size.width * 0.75, size.height * 0.5);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: cursor,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.pump();
+
+      final after = primaryChartData(tester);
+      // Zoomed in: visible time range shrank.
+      expect(after.maxX - after.minX, lessThan(before.maxX - before.minX));
+      // Anchored toward the cursor, not the corner: left edge moved off 0.
+      expect(after.minX, greaterThan(0.0));
+    });
+
+    testWidgets('mouse wheel down at max-out keeps the full window', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, 100)),
+      );
+      await tester.pump();
+
+      final after = primaryChartData(tester);
+      expect(after.minX, 0.0); // cannot zoom out past 1.0
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -1271,6 +1271,34 @@ void main() {
       },
     );
 
+    testWidgets(
+      'gesture on a gas-strip dive does not watch a provider outside build',
+      (tester) async {
+        // _plotInsets (called from gesture handlers, outside build) reads the
+        // gas-strip flag. On a gas-strip dive that flag must NOT use ref.watch
+        // (illegal outside build) — a wheel zoom here must not throw.
+        await tester.pumpWidget(
+          _buildChart(
+            profile: _makeProfile(points: 20),
+            gasSegments: makeSegments(),
+            diveDurationSeconds: 300,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final chart = find.byType(LineChart).first;
+        await tester.sendEventToBinding(
+          PointerScrollEvent(
+            position: tester.getCenter(chart),
+            scrollDelta: const Offset(0, -100),
+          ),
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('does not render GasTimelineStrip when segments is empty', (
       tester,
     ) async {

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -1987,5 +1987,54 @@ void main() {
       expect(after.maxX - after.minX, lessThan(before.maxX - before.minX));
       expect(after.minX, greaterThan(0.0)); // anchored toward the cursor
     });
+
+    testWidgets(
+      'trackpad two-finger scroll pan shifts the visible window rightward',
+      (tester) async {
+        await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+        await tester.pumpAndSettle();
+
+        final chart = find.byType(LineChart).first;
+        final center = tester.getCenter(chart);
+
+        // Zoom in twice at center so there is room to pan. Each scroll uses
+        // factor 1.1; after two scrolls zoom ~= 1.21 and offsetX ~= 0.087
+        // (the window sits just inside the left edge with space to pan right).
+        await tester.sendEventToBinding(
+          PointerScrollEvent(
+            position: center,
+            scrollDelta: const Offset(0, -100),
+          ),
+        );
+        await tester.sendEventToBinding(
+          PointerScrollEvent(
+            position: center,
+            scrollDelta: const Offset(0, -100),
+          ),
+        );
+        await tester.pump();
+
+        final zoomedMinX = primaryChartData(tester).minX;
+        // Confirm we are actually zoomed in (offsetX > 0 means minX > 0).
+        expect(zoomedMinX, greaterThan(0.0));
+
+        // Drive a trackpad two-finger scroll to the left (negative dx).
+        // The handler applies: offsetX += -localPan.dx / plotW / zoom.
+        // With localPan.dx = -60: delta = +60 / plotW / zoom > 0, so
+        // offsetX increases and minX increases (window shifts rightward).
+        final anchor = center;
+        final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+        await tester.sendEventToBinding(pointer.panZoomStart(anchor));
+        await tester.sendEventToBinding(
+          pointer.panZoomUpdate(anchor, pan: const Offset(-60, 0)),
+        );
+        await tester.sendEventToBinding(pointer.panZoomEnd());
+        await tester.pump();
+
+        final pannedMinX = primaryChartData(tester).minX;
+        // The visible window shifted rightward: minX must have increased.
+        expect(pannedMinX, greaterThan(zoomedMinX));
+      },
+    );
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -1961,4 +1961,31 @@ void main() {
       expect(after.minX, 0.0); // cannot zoom out past 1.0
     });
   });
+
+  group('trackpad interaction', () {
+    testWidgets('trackpad pinch zooms in anchored off-center (not at 0)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+      final anchor = topLeft + Offset(size.width * 0.7, size.height * 0.5);
+
+      final before = tester.widget<LineChart>(chart).data;
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      await tester.sendEventToBinding(pointer.panZoomStart(anchor));
+      await tester.sendEventToBinding(
+        pointer.panZoomUpdate(anchor, scale: 2.0),
+      );
+      await tester.sendEventToBinding(pointer.panZoomEnd());
+      await tester.pump();
+
+      final after = tester.widget<LineChart>(chart).data;
+      expect(after.maxX - after.minX, lessThan(before.maxX - before.minX));
+      expect(after.minX, greaterThan(0.0)); // anchored toward the cursor
+    });
+  });
 }

--- a/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
 
@@ -85,6 +86,74 @@ void main() {
       expect(back.zoom, closeTo(1.0, 1e-9));
       expect(back.offsetX, closeTo(0.0, 1e-9));
       expect(back.offsetY, closeTo(0.0, 1e-9));
+    });
+  });
+
+  group('chartFocalFraction', () {
+    const box = Size(200, 100);
+    const insets = (left: 40.0, right: 10.0, top: 0.0, bottom: 24.0);
+    // plotW = 200-40-10 = 150 ; plotH = 100-0-24 = 76
+
+    test('left/top gutter maps to 0', () {
+      final f = chartFocalFraction(
+        const Offset(40, 0),
+        box,
+        left: insets.left,
+        right: insets.right,
+        top: insets.top,
+        bottom: insets.bottom,
+      );
+      expect(f.fx, closeTo(0.0, 1e-9));
+      expect(f.fy, closeTo(0.0, 1e-9));
+    });
+
+    test('right/bottom plot edge maps to 1', () {
+      final f = chartFocalFraction(
+        const Offset(190, 76),
+        box,
+        left: insets.left,
+        right: insets.right,
+        top: insets.top,
+        bottom: insets.bottom,
+      );
+      expect(f.fx, closeTo(1.0, 1e-9));
+      expect(f.fy, closeTo(1.0, 1e-9));
+    });
+
+    test('mid plot maps to the expected fraction', () {
+      final f = chartFocalFraction(
+        const Offset(115, 38),
+        box,
+        left: insets.left,
+        right: insets.right,
+        top: insets.top,
+        bottom: insets.bottom,
+      );
+      expect(f.fx, closeTo(0.5, 1e-9)); // (115-40)/150
+      expect(f.fy, closeTo(0.5, 1e-9)); // (38-0)/76
+    });
+
+    test('positions outside the plot clamp to [0,1]', () {
+      final lo = chartFocalFraction(
+        const Offset(0, -50),
+        box,
+        left: insets.left,
+        right: insets.right,
+        top: insets.top,
+        bottom: insets.bottom,
+      );
+      expect(lo.fx, 0.0);
+      expect(lo.fy, 0.0);
+      final hi = chartFocalFraction(
+        const Offset(500, 500),
+        box,
+        left: insets.left,
+        right: insets.right,
+        top: insets.top,
+        bottom: insets.bottom,
+      );
+      expect(hi.fx, 1.0);
+      expect(hi.fy, 1.0);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
@@ -154,6 +155,58 @@ void main() {
       );
       expect(hi.fx, 1.0);
       expect(hi.fy, 1.0);
+    });
+  });
+
+  group('chartDragIntent', () {
+    test('two or more pointers always zoom+pan', () {
+      for (final k in [PointerDeviceKind.touch, PointerDeviceKind.mouse]) {
+        expect(
+          chartDragIntent(kind: k, pointerCount: 2, doubleTapHold: false),
+          ChartDragIntent.zoomPan,
+        );
+      }
+    });
+
+    test('single mouse/trackpad pointer pans', () {
+      expect(
+        chartDragIntent(
+          kind: PointerDeviceKind.mouse,
+          pointerCount: 1,
+          doubleTapHold: false,
+        ),
+        ChartDragIntent.pan,
+      );
+      expect(
+        chartDragIntent(
+          kind: PointerDeviceKind.trackpad,
+          pointerCount: 1,
+          doubleTapHold: false,
+        ),
+        ChartDragIntent.pan,
+      );
+    });
+
+    test('single touch pointer scrubs', () {
+      expect(
+        chartDragIntent(
+          kind: PointerDeviceKind.touch,
+          pointerCount: 1,
+          doubleTapHold: false,
+        ),
+        ChartDragIntent.scrub,
+      );
+    });
+
+    test('single touch pointer pans during double-tap-hold', () {
+      expect(
+        chartDragIntent(
+          kind: PointerDeviceKind.touch,
+          pointerCount: 1,
+          doubleTapHold: true,
+        ),
+        ChartDragIntent.pan,
+      );
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
+
+// Data fraction (0..1 of total range) currently under a focal point that sits
+// at `focal` (0..1) of the visible window.
+double _dataUnderFocal(double offset, double zoom, double focal) =>
+    offset + focal / zoom;
+
+void main() {
+  group('ProfileChartViewport', () {
+    test('reset is unzoomed at the origin', () {
+      const vp = ProfileChartViewport.reset;
+      expect(vp.zoom, 1.0);
+      expect(vp.offsetX, 0.0);
+      expect(vp.offsetY, 0.0);
+      expect(vp.isZoomed, isFalse);
+      expect(vp.visibleWidth, 1.0);
+      expect(vp.visibleHeight, 1.0);
+    });
+
+    test('zoomedAt center keeps the center centered', () {
+      final vp = ProfileChartViewport.reset.zoomedAt(0.5, 0.5, 2);
+      expect(vp.zoom, 2.0);
+      expect(vp.offsetX, closeTo(0.25, 1e-9));
+      expect(vp.offsetY, closeTo(0.25, 1e-9));
+      expect(vp.isZoomed, isTrue);
+    });
+
+    test('zoomedAt top-left pins the top-left corner', () {
+      final vp = ProfileChartViewport.reset.zoomedAt(0, 0, 2);
+      expect(vp.offsetX, closeTo(0.0, 1e-9));
+      expect(vp.offsetY, closeTo(0.0, 1e-9));
+    });
+
+    test('zoomedAt bottom-right pins the bottom-right corner', () {
+      final vp = ProfileChartViewport.reset.zoomedAt(1, 1, 2);
+      expect(vp.offsetX, closeTo(0.5, 1e-9));
+      expect(vp.offsetY, closeTo(0.5, 1e-9));
+    });
+
+    test('anchor invariant: the data point under the focal stays fixed', () {
+      const cases = [
+        [0.3, 0.7, 2.0],
+        [0.2, 0.5, 3.0],
+        [0.6, 0.4, 1.5],
+      ];
+      for (final c in cases) {
+        const start = ProfileChartViewport(
+          zoom: 2,
+          offsetX: 0.25,
+          offsetY: 0.25,
+        );
+        final before = _dataUnderFocal(start.offsetX, start.zoom, c[0]);
+        final after = start.zoomedAt(c[0], c[1], c[2]);
+        final now = _dataUnderFocal(after.offsetX, after.zoom, c[0]);
+        expect(now, closeTo(before, 1e-9), reason: 'case $c');
+      }
+    });
+
+    test('pannedBy clamps to [0, 1 - 1/zoom]', () {
+      const vp = ProfileChartViewport(zoom: 2, offsetX: 0.25, offsetY: 0.25);
+      final left = vp.pannedBy(-1, -1);
+      expect(left.offsetX, 0.0);
+      expect(left.offsetY, 0.0);
+      final right = vp.pannedBy(1, 1);
+      expect(right.offsetX, closeTo(0.5, 1e-9)); // maxOff = 1 - 1/2
+      expect(right.offsetY, closeTo(0.5, 1e-9));
+    });
+
+    test('zoom clamps to [minZoom, maxZoom] and is a no-op at the rail', () {
+      // Zooming out from reset cannot go below 1.0 -> unchanged instance.
+      final out = ProfileChartViewport.reset.zoomedAt(0.5, 0.5, 0.5);
+      expect(out.zoom, 1.0);
+      expect(out.offsetX, 0.0);
+      // At max zoom, zooming further in is a no-op.
+      const atMax = ProfileChartViewport(zoom: 10, offsetX: 0.4, offsetY: 0.4);
+      final stillMax = atMax.zoomedAt(0.5, 0.5, 2);
+      expect(stillMax.zoom, 10.0);
+      expect(stillMax.offsetX, 0.4);
+    });
+
+    test('zoom in then out at the same focal round-trips to the origin', () {
+      final there = ProfileChartViewport.reset.zoomedAt(0.3, 0.7, 2);
+      final back = there.zoomedAt(0.3, 0.7, 0.5);
+      expect(back.zoom, closeTo(1.0, 1e-9));
+      expect(back.offsetX, closeTo(0.0, 1e-9));
+      expect(back.offsetY, closeTo(0.0, 1e-9));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The interactive dive profile chart had two long-standing interaction defects:

1. **Zoom always anchored to the upper-left corner.** Zooming via the buttons, mouse wheel, or double-tap shrank the visible window toward `(time = 0, surface)` instead of toward the cursor / pinch / tap point.
2. **Navigating a zoomed-in chart was tedious.** There was no drag-to-pan and no scrollbar — once zoomed, the only way to move the window was a multi-pointer scale gesture or a full reset.

## Solution

Zoom now anchors under the **cursor** (mouse / trackpad / wheel) or the **pinch focal point** (touch), and navigation is intuitive and branched on the active `PointerDeviceKind` rather than the platform (an iPad with a Magic Keyboard trackpad gets desktop behavior).

### Architecture

- New immutable **`ProfileChartViewport`** value object + two pure helpers (`chartFocalFraction`, `chartDragIntent`) in `profile_chart_viewport.dart` — all the zoom/pan/anchor math lifted out of the widget and unit-tested with plain numbers. The upper-left bug was a *missing* `- focalX / newZoom` term; `zoomedAt` adds it so the data point under the focal point stays fixed.
- `dive_profile_chart.dart` rewired so the visible window derives from one `_viewport`; every input routes through it. Uniform 2-D zoom and the inverted depth axis are preserved; state stays local to the widget.

### Interaction model

**Desktop (mouse / trackpad):** hover → tooltip · click-drag → pan · wheel → zoom-to-cursor · trackpad pinch → zoom-to-cursor · two-finger scroll → pan

**Touch:** one-finger drag → tooltip scrub (unchanged) · two-finger pinch → zoom-to-focal · two-finger drag → pan · double-tap → zoom-to-tap / reset · double-tap-and-hold → pan

### Notable deviations (forced by fl_chart's gesture arena; documented in code)

- **Mouse click-drag pan** is implemented via a passive `Listener.onPointerMove` — fl_chart's internal `PanGestureRecognizer` wins the arena for single-pointer drags, so `GestureDetector.onScaleUpdate` never sees them. It's gated to a genuine single pointer by a live `_activePointerCount`, so a one-finger touch still scrubs.
- **Trackpad pinch** is gated out of `onScaleUpdate` so the reliable-cursor `Listener.onPointerPanZoomUpdate` is the sole handler — the `ScaleGestureRecognizer`'s synthesized focal point is unreliable on desktop (the same issue the sibling map-touchpad spec documents).

## Testing

- **16 unit tests** for the pure pieces, led by an **anchor-invariant property test** proving the data point under the focal point is unchanged across zoom (this *is* the bug-fix proof).
- **87 widget tests**, including the **touch-one-finger-drag-still-scrubs** regression guard, plus wheel / trackpad / touch zoom anchoring, two-finger-scroll pan, mouse click-drag pan, hover-select, and double-tap-hold pan.
- `flutter analyze` clean · `dart format` clean · pre-push full suite green.
- **Known harness limitation:** a two-finger **touch** pinch cannot be synthesized in `flutter_test` (fl_chart wins the gesture arena). That path pre-existed this PR; the only change to it is an already-true `kind == touch` guard.

## Device-test watch item

On desktop, a click-drag pan may momentarily clear the tooltip selection at drag-end (fl_chart's `FlPanEndEvent` → `onPointSelected(null)`); it self-heals on the next hover. This is the one behavior the automated suite structurally can't assert.

## Docs

Design spec and implementation plan under `docs/superpowers/`.