### PR TITLE
fix(ble): identify Halcyon Symbios Handset instead of HUD (#357)

### DIFF
--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -10,6 +10,17 @@
 // instead of the real model ("G2 HUD", model 0x42). The same alias-vs-product
 // gap affects "Galileo 3" (product "G3"), "A1" ("Aladin A1") and "A2"
 // ("Aladin A2"). Model codes below come from descriptor.c.
+//
+// Regression for issue #357: a Halcyon Symbios Handset (an all-digit BLE
+// serial) was always identified as a HUD. Both Symbios descriptor rows
+// ("Symbios HUD" model 1, "Symbios Handset" model 7) share dc_filter_halcyon,
+// which matched the serial against the UNION {1, 7}, so both rows passed for
+// any Symbios serial and the first (HUD) always won. dc_match_halcyon
+// disambiguates by the serial's [4:6] digits (01 = HUD, 07 = Handset), so each
+// row must filter on its own model. The serials below are synthetic: only the
+// model-code digits [4:6] are significant, so the surrounding manufacture-date
+// and unit-number digits are zeroed (the bug was first reported against real
+// Symbios devices in issue #288).
 
 #include <assert.h>
 #include <stdio.h>
@@ -79,12 +90,31 @@ static void test_non_uwatec_device_unaffected(void) {
     printf("PASS: test_non_uwatec_device_unaffected\n");
 }
 
+// Issue #357: a Handset serial (model-code digits [4:6] = "07") must resolve to
+// the "Symbios Handset" descriptor (model 7), not the "Symbios HUD" row
+// (model 1) that previously always won because both rows matched the union
+// {1, 7}.
+static void test_symbios_handset_resolves_to_handset(void) {
+    expect_ble_match("0000070000", "Symbios Handset", 7);
+    printf("PASS: test_symbios_handset_resolves_to_handset\n");
+}
+
+// Issue #357 regression guard: a HUD serial (model-code digits [4:6] = "01")
+// must keep resolving to the "Symbios HUD" descriptor and must not be captured
+// by the Handset row once each row filters on its own model.
+static void test_symbios_hud_resolves_to_hud(void) {
+    expect_ble_match("0000010000", "Symbios HUD", 1);
+    printf("PASS: test_symbios_hud_resolves_to_hud\n");
+}
+
 int main(void) {
     test_hud_resolves_to_g2_hud();
     test_other_short_aliases_resolve();
     test_alias_match_is_case_insensitive();
     test_exact_product_names_unchanged();
     test_non_uwatec_device_unaffected();
+    test_symbios_handset_resolves_to_handset();
+    test_symbios_hud_resolves_to_hud();
     printf("\nAll descriptor match integration tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes #357 — a Halcyon Symbios **Handset** was always identified as a **HUD**.

The two Symbios rows in the libdivecomputer fork's `descriptor.c` share `dc_filter_halcyon`, which matched the BLE serial against the **union** of both models `{1 HUD, 7 Handset}`. `dc_filter_internal` returns true if *any* model matches, so **both** descriptor rows passed for any Symbios serial, and the wrapper's matcher kept the first one (HUD). The per-model data was already available — `dc_match_halcyon` compares the serial's digits `[4:6]` against the model code (`01` = HUD, `07` = Handset) — the filter just wasn't using each row's own model.

## Fix

In the fork (`submersion-patches`), `dc_filter_halcyon` now filters against the descriptor's own model via `dc_descriptor_get_model(descriptor)` instead of the union array, so each row only claims its own serials. This PR bumps the submodule pointer to that commit.

Single shared-C change — covers macOS/iOS/Android/Windows/Linux (unlike the per-platform BLE characteristic work in #356).

## Test

Added a regression test to `test_descriptor_match_integration.c` that links the real descriptor table and resolves **synthetic** serials whose only significant part is the model-code digits `[4:6]` (manufacture-date and unit-number digits zeroed, so no real device identifiers are embedded):

| Serial | digits[4:6] | Before | After |
| --- | --- | --- | --- |
| `0000070000` (Handset) | `07` | `Symbios HUD/0x01` | `Symbios Handset/0x07` |
| `0000010000` (HUD) | `01` | `Symbios HUD/0x01` | `Symbios HUD/0x01` |

All four native test executables pass.

## Notes

- **Cosmetic only** — downloads are unaffected (both models run identical code) and already confirmed working by the reporter in #288 / #356.
- Hardware verification with a real Symbios Handset and HUD is still pending.
- **Submodule range:** `submersion-patches` is a linear patch branch, so the bump `ed581d0 -> ea56ff5` also carries the already-pushed OSTC commit `44515a4` ("Advance hw_ostc3 reads by the bytes actually read", #280). It rides along because it is an ancestor of the Halcyon fix; it touches `hw_ostc3.c` only (disjoint from `descriptor.c`).
