### PR TITLE
Two-finger trackpad scroll/pinch zoom on maps and dive profile chart

### DIFF
--- a/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
+++ b/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
@@ -114,7 +114,7 @@ git commit -m "feat(ui): add trackpadScrollZoomDelta helper"
 
 **Interfaces:**
 - Consumes: `trackpadScrollZoomDelta` (Task 1); flutter_map `MapController`, `MapCamera.focusedZoomCenter`.
-- Produces: `TrackpadZoomMap({required MapController controller, required Widget Function(BuildContext, int flags) builder, int baseFlags = InteractiveFlag.all, double minZoom = 1.0, double maxZoom = 22.0})` — a `StatefulWidget` that zooms `controller` on trackpad two-finger vertical scroll and drops `InteractiveFlag.pinchMove` from the flags handed to `builder` only while a trackpad gesture is active (so flutter_map cannot pin the camera and revert the zoom; touch pinch-zoom is preserved). See the implemented file for the verified code; the original passive-`Listener` `StatelessWidget` form does NOT work (flutter_map clobbers it).
+- Produces: `TrackpadZoomMap({required MapController controller, required Widget child, double minZoom = 1.0, double maxZoom = 22.0})` — a `StatelessWidget` wrapping `child` in a `RawGestureDetector` whose custom `_TrackpadZoomGestureRecognizer` eagerly wins the arena for trackpad pan-zoom and zooms `controller` (scroll via `panDelta`, pinch via `scale`) cursor-anchored. Winning the arena both prevents flutter_map's clobber and stops an enclosing scrollable from scrolling (map captures the gesture). See the implemented file for the verified code; a passive-`Listener` form does NOT work (flutter_map clobbers it, and it cannot suppress page scroll).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -407,39 +407,27 @@ Add the import:
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 ```
 
-Transform, where `<ctrl>` is the exact expression already given to `mapController:`
-and `<base>` is the site's existing `interactionOptions.flags` (or
-`InteractiveFlag.all` if it sets none). Thread the builder's `flags` into the
-`FlutterMap`'s `interactionOptions`:
+Transform, where `<ctrl>` is the exact expression already given to `mapController:`.
+No `MapOptions`/flags changes are needed — just wrap:
 ```dart
 // Before:
 FlutterMap(
   mapController: <ctrl>,
-  options: MapOptions(
-    ...,
-    interactionOptions: InteractionOptions(flags: <base>, /* other opts */),
-  ),
+  options: ...,
   children: ...,
 )
 // After:
 TrackpadZoomMap(
   controller: <ctrl>,
-  baseFlags: <base>,
-  builder: (context, flags) => FlutterMap(
+  child: FlutterMap(
     mapController: <ctrl>,
-    options: MapOptions(
-      ...,
-      interactionOptions: InteractionOptions(flags: flags, /* other opts */),
-    ),
+    options: ...,
     children: ...,
   ),
 )
 ```
-If the site currently sets no `interactionOptions`, add
-`interactionOptions: InteractionOptions(flags: flags)` and omit `baseFlags`
-(defaults to `InteractiveFlag.all`).
 
-- [ ] **Step 1: Apply the recipe to all 9 files.** Use the controller already passed to each `mapController:` argument. Preserve any other interaction options (scrollWheelVelocity, etc.). Do not change other options/children.
+- [ ] **Step 1: Apply the recipe to all 9 files.** Use the controller already passed to each `mapController:` argument. Do not change options/children.
 
 - [ ] **Step 2: Format + analyze**
 
@@ -512,18 +500,13 @@ class _FooState extends ConsumerState<Foo> {
 ```
 Inside the new `build`, replace references to constructor params with `widget.<param>` and use `ref` directly (it is a member of `ConsumerState`).
 
-3. Wrap the FlutterMap with the builder, supplying the controller and threading
-   `flags` into `interactionOptions`:
+3. Wrap the FlutterMap, supplying the controller:
 ```dart
 TrackpadZoomMap(
   controller: _mapController,
-  baseFlags: <site base flags or InteractiveFlag.all>,
-  builder: (context, flags) => FlutterMap(
+  child: FlutterMap(
     mapController: _mapController,
-    options: MapOptions(
-      ...,
-      interactionOptions: InteractionOptions(flags: flags, /* other opts */),
-    ),
+    options: ...,
     children: ...,
   ),
 )

--- a/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
+++ b/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
@@ -1,0 +1,581 @@
+# Two-finger Trackpad Scroll → Zoom Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make two-finger up/down scroll on a trackpad zoom in/out (cursor-anchored) on all 17 maps and on the dive profile chart.
+
+**Architecture:** One pure helper converts a trackpad vertical scroll delta into a zoom-level delta. A passive `Listener`-based wrapper (`TrackpadZoomMap`) drives `MapController` zoom for maps. The dive profile chart's existing `onPointerPanZoomUpdate` is modified to fold vertical scroll into its zoom factor instead of panning.
+
+**Tech Stack:** Flutter, flutter_map 8.2.2 (`MapController`, `MapCamera.focusedZoomCenter`), fl_chart, Riverpod.
+
+## Global Constraints
+
+- `dart format .` must produce no changes (CI gate).
+- `flutter analyze` must pass with zero issues across the whole project.
+- No emojis in code/comments.
+- Immutability; no mutation of shared objects.
+- Only `PointerDeviceKind.trackpad` gestures are re-interpreted; touch and mouse paths are untouched.
+- Direction matches the existing mouse-wheel convention: negative `dy` (scroll up/away) zooms in.
+- Zoom is cursor-anchored.
+- Run specific test files (not broad directories) to avoid Bash timeouts.
+
+---
+
+### Task 1: Pure zoom-delta helper
+
+**Files:**
+- Create: `lib/core/ui/trackpad_zoom.dart`
+- Test: `test/core/ui/trackpad_zoom_test.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01})` — returns an additive zoom-level delta; negative `scrollDy` returns a positive delta (zoom in); `0` returns `0`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+
+void main() {
+  group('trackpadScrollZoomDelta', () {
+    test('zero scroll yields zero delta', () {
+      expect(trackpadScrollZoomDelta(0), 0);
+    });
+
+    test('scroll up (negative dy) zooms in (positive delta)', () {
+      expect(trackpadScrollZoomDelta(-100), greaterThan(0));
+    });
+
+    test('scroll down (positive dy) zooms out (negative delta)', () {
+      expect(trackpadScrollZoomDelta(100), lessThan(0));
+    });
+
+    test('is symmetric for equal-and-opposite scrolls', () {
+      expect(trackpadScrollZoomDelta(-50), -trackpadScrollZoomDelta(50));
+    });
+
+    test('scales with sensitivity', () {
+      expect(
+        trackpadScrollZoomDelta(-100, sensitivity: 0.02),
+        2 * trackpadScrollZoomDelta(-100, sensitivity: 0.01),
+      );
+    });
+
+    test('default sensitivity maps a ~100px flick to ~1 zoom level', () {
+      expect(trackpadScrollZoomDelta(-100), closeTo(1.0, 0.0001));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/ui/trackpad_zoom_test.dart`
+Expected: FAIL — `trackpad_zoom.dart` / `trackpadScrollZoomDelta` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+/// Pure helpers for trackpad two-finger-scroll zooming, shared by the maps and
+/// the dive profile chart so sign and sensitivity live in one tested place.
+
+/// Converts a trackpad two-finger vertical scroll delta (logical pixels) into an
+/// additive zoom-level delta.
+///
+/// Negative [scrollDy] (scroll up / away from the user) returns a positive delta
+/// (zoom in), matching the mouse-wheel convention so wheel and trackpad agree on
+/// the same machine. Map consumers add the result to `camera.zoom`; the dive
+/// profile chart applies `pow(2, delta)` as a multiplicative factor.
+double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01}) {
+  return -scrollDy * sensitivity;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/ui/trackpad_zoom_test.dart`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/ui/trackpad_zoom.dart test/core/ui/trackpad_zoom_test.dart
+git commit -m "feat(ui): add trackpadScrollZoomDelta helper"
+```
+
+---
+
+### Task 2: `TrackpadZoomMap` wrapper widget
+
+**Files:**
+- Create: `lib/features/maps/presentation/widgets/trackpad_zoom_map.dart`
+- Test: `test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart`
+
+**Interfaces:**
+- Consumes: `trackpadScrollZoomDelta` (Task 1); flutter_map `MapController`, `MapCamera.focusedZoomCenter`.
+- Produces: `TrackpadZoomMap({required MapController controller, required Widget child, double minZoom = 1.0, double maxZoom = 22.0})` — a `StatelessWidget` that wraps `child` (a `FlutterMap`) in a passive `Listener` and zooms `controller` on trackpad two-finger vertical scroll.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
+
+void main() {
+  Future<MapController> pumpMap(WidgetTester tester) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TrackpadZoomMap(
+            controller: controller,
+            child: FlutterMap(
+              mapController: controller,
+              options: const MapOptions(
+                initialCenter: LatLng(0, 0),
+                initialZoom: 5,
+                minZoom: 1,
+                maxZoom: 18,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return controller;
+  }
+
+  testWidgets('trackpad two-finger scroll up zooms in', (tester) async {
+    final controller = await pumpMap(tester);
+    final start = controller.camera.zoom;
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    final gesture =
+        await tester.createGesture(kind: PointerDeviceKind.trackpad);
+    await gesture.panZoomStart(center);
+    await gesture.panZoomUpdate(center, pan: const Offset(0, -100));
+    await gesture.panZoomEnd();
+    await tester.pump();
+
+    expect(controller.camera.zoom, greaterThan(start));
+  });
+
+  testWidgets('trackpad two-finger scroll down zooms out', (tester) async {
+    final controller = await pumpMap(tester);
+    final start = controller.camera.zoom;
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    final gesture =
+        await tester.createGesture(kind: PointerDeviceKind.trackpad);
+    await gesture.panZoomStart(center);
+    await gesture.panZoomUpdate(center, pan: const Offset(0, 100));
+    await gesture.panZoomEnd();
+    await tester.pump();
+
+    expect(controller.camera.zoom, lessThan(start));
+  });
+
+  testWidgets('touch two-finger pan does not zoom via the wrapper',
+      (tester) async {
+    final controller = await pumpMap(tester);
+    final start = controller.camera.zoom;
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.touch);
+    await gesture.panZoomStart(center);
+    await gesture.panZoomUpdate(center, pan: const Offset(0, -100));
+    await gesture.panZoomEnd();
+    await tester.pump();
+
+    expect(controller.camera.zoom, start);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart`
+Expected: FAIL — `trackpad_zoom_map.dart` / `TrackpadZoomMap` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+
+/// Wraps a [FlutterMap] so a two-finger vertical scroll on a trackpad zooms the
+/// map toward the cursor, instead of panning.
+///
+/// The [Listener] is passive (it never enters the gesture arena), so flutter_map
+/// keeps handling click-drag pan, pinch zoom, and mouse-wheel zoom underneath.
+/// Only [PointerDeviceKind.trackpad] events are re-interpreted; touch gestures
+/// (tablet pinch / two-finger pan) flow through to flutter_map unchanged.
+class TrackpadZoomMap extends StatelessWidget {
+  const TrackpadZoomMap({
+    super.key,
+    required this.controller,
+    required this.child,
+    this.minZoom = 1.0,
+    this.maxZoom = 22.0,
+  });
+
+  /// The same controller passed to the wrapped [FlutterMap]'s `mapController`.
+  final MapController controller;
+  final Widget child;
+  final double minZoom;
+  final double maxZoom;
+
+  void _onPanZoomUpdate(PointerPanZoomUpdateEvent event) {
+    if (event.kind != PointerDeviceKind.trackpad) return;
+    // Per-event vertical delta. Use the global panDelta (not localPanDelta):
+    // on macOS the trackpad localPan is contaminated by the widget's
+    // global->local translation (see dive profile chart, PR #372).
+    final delta = trackpadScrollZoomDelta(event.panDelta.dy);
+    if (delta == 0) return;
+
+    final MapCamera camera;
+    try {
+      camera = controller.camera;
+    } catch (_) {
+      // Controller not yet attached to a FlutterMap.
+      return;
+    }
+    final newZoom = (camera.zoom + delta).clamp(minZoom, maxZoom);
+    if (newZoom == camera.zoom) return;
+    // focusedZoomCenter keeps the point under the cursor fixed; it already
+    // accounts for map rotation.
+    controller.move(camera.focusedZoomCenter(event.localPosition, newZoom),
+        newZoom);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerPanZoomUpdate: _onPanZoomUpdate,
+      child: child,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/maps/presentation/widgets/trackpad_zoom_map.dart test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
+git commit -m "feat(maps): add TrackpadZoomMap two-finger-scroll zoom wrapper"
+```
+
+---
+
+### Task 3: Profile chart — scroll-to-zoom in `onPointerPanZoomUpdate`
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (the `onPointerPanZoomUpdate` handler, currently around lines 1289-1328)
+- Test: `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart` (add a group)
+
+**Interfaces:**
+- Consumes: `trackpadScrollZoomDelta` (Task 1); existing `ProfileChartViewport.zoomedAt`.
+- Produces: no new public API; behavior change only.
+
+- [ ] **Step 1: Add the failing test (documents the scroll→factor mapping)**
+
+Append this group inside `main()` in `profile_chart_viewport_test.dart`:
+
+```dart
+  group('trackpad scroll folds into a cumulative zoom factor', () {
+    test('scroll up produces a >1 factor (zoom in)', () {
+      final factor = math.pow(2, trackpadScrollZoomDelta(-100)).toDouble();
+      expect(factor, greaterThan(1.0));
+      final vp = ProfileChartViewport().zoomedAt(0.5, 0.5, factor);
+      expect(vp.zoom, greaterThan(1.0));
+    });
+
+    test('scroll down produces a <1 factor (zoom out) and is a no-op at rail',
+        () {
+      final factor = math.pow(2, trackpadScrollZoomDelta(100)).toDouble();
+      expect(factor, lessThan(1.0));
+      // Already at minZoom -> zooming out is a no-op.
+      final vp = ProfileChartViewport().zoomedAt(0.5, 0.5, factor);
+      expect(vp.zoom, ProfileChartViewport.minZoom);
+    });
+  });
+```
+
+Add these imports at the top of the test file if missing:
+
+```dart
+import 'dart:math' as math;
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: FAIL — `trackpadScrollZoomDelta` import unresolved (if Task 1 not yet merged into this worktree state) or the new group present but compiling; if Task 1 is done it should compile and PASS, in which case this test only guards the mapping. Confirm it at least compiles and runs.
+
+- [ ] **Step 3: Modify the chart handler**
+
+Add the import near the other `package:submersion/...` imports in `dive_profile_chart.dart`:
+
+```dart
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+```
+
+Ensure `dart:math` is imported (it is used as `math` if present; otherwise add `import 'dart:math' as math;`). Replace the body of `onPointerPanZoomUpdate` so it folds the cumulative vertical pan into the zoom factor and no longer translates:
+
+```dart
+              onPointerPanZoomUpdate: (event) {
+                setState(() {
+                  final box = constraints.biggest;
+                  final insets = _plotInsets(constraints.maxWidth, units);
+                  final focal = chartFocalFraction(
+                    _trackpadAnchor,
+                    box,
+                    left: insets.left,
+                    right: insets.right,
+                    top: insets.top,
+                    bottom: insets.bottom,
+                  );
+                  // Cumulative since gesture start: pinch (event.scale) and
+                  // two-finger vertical scroll (event.pan.dy) both zoom,
+                  // cursor-anchored at the gesture-start position. Two-finger
+                  // scroll no longer pans; pan is done with click-drag.
+                  final factor = event.scale *
+                      math.pow(2, trackpadScrollZoomDelta(event.pan.dy))
+                          .toDouble();
+                  _viewport =
+                      _gestureStartViewport.zoomedAt(focal.fx, focal.fy, factor);
+                });
+              },
+```
+
+(Delete the previous `var vp = ...zoomedAt(...event.scale)` + `vp = vp.pannedBy(-event.pan...)` + `_viewport = vp;` lines this replaces. Keep `onPointerPanZoomStart` and `onPointerSignal` as they are.)
+
+- [ ] **Step 4: Run tests + analyze**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: PASS (existing 15 + new 2 = 17).
+Run: `flutter analyze lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`
+Expected: No issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+git commit -m "feat(profile): two-finger trackpad scroll zooms the dive profile chart"
+```
+
+---
+
+### Task 4: Roll out `TrackpadZoomMap` to Category A maps (wrap-only)
+
+These 9 sites already are stateful and pass a `MapController` to `FlutterMap`. For each, wrap the existing `FlutterMap(...)` in `TrackpadZoomMap` using the SAME controller already passed to its `mapController:` argument.
+
+**Files (modify each):**
+- `lib/features/maps/presentation/pages/region_picker_page.dart`
+- `lib/features/maps/presentation/pages/dive_activity_map_page.dart`
+- `lib/features/dive_sites/presentation/pages/site_map_page.dart`
+- `lib/features/dive_sites/presentation/widgets/match_sites_map.dart`
+- `lib/features/dive_sites/presentation/widgets/site_map_content.dart`
+- `lib/features/dive_sites/presentation/widgets/location_picker_map.dart`
+- `lib/features/dive_log/presentation/widgets/dive_map_content.dart`
+- `lib/features/dive_centers/presentation/pages/dive_center_map_page.dart`
+- `lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart`
+
+**Interfaces:**
+- Consumes: `TrackpadZoomMap` (Task 2).
+- Produces: nothing new.
+
+**The recipe (apply at each `FlutterMap(`):**
+
+Add the import:
+```dart
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
+```
+
+Transform, where `<ctrl>` is the exact expression already given to `mapController:`:
+```dart
+// Before:
+FlutterMap(
+  mapController: <ctrl>,
+  options: ...,
+  children: ...,
+)
+// After:
+TrackpadZoomMap(
+  controller: <ctrl>,
+  child: FlutterMap(
+    mapController: <ctrl>,
+    options: ...,
+    children: ...,
+  ),
+)
+```
+
+- [ ] **Step 1: Apply the recipe to all 9 files.** Use the controller already passed to each `mapController:` argument. Do not change options/children.
+
+- [ ] **Step 2: Format + analyze**
+
+Run: `dart format lib/`
+Run: `flutter analyze`
+Expected: No issues.
+
+- [ ] **Step 3: Smoke test the affected widget tests (if any exist)**
+
+Run: `flutter test test/features/maps/ test/features/dive_sites/ test/features/dive_centers/ test/features/dive_log/presentation/widgets/dive_map_content_test.dart 2>/dev/null; true`
+Expected: No new failures attributable to these wraps (pre-existing unrelated skips/failures are acceptable; compare against baseline). If a map test pumps the widget, it should still build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/maps lib/features/dive_sites lib/features/dive_log lib/features/dive_centers
+git commit -m "feat(maps): enable trackpad scroll zoom on stateful map sites"
+```
+
+---
+
+### Task 5: Roll out to Category B maps (convert stateless → stateful, then wrap)
+
+These 8 maps (6 files) are in `ConsumerWidget`s (or lack a controller). Each needs a `MapController` created and held by a stateful widget, passed to both `FlutterMap` and `TrackpadZoomMap`.
+
+**Files (modify each):**
+- `lib/features/dive_log/presentation/widgets/dive_locations_map.dart` (1 map; optional `controller` param)
+- `lib/features/trips/presentation/widgets/trip_voyage_map.dart` (1 map; `TripVoyageMap` is `ConsumerWidget`)
+- `lib/features/trips/presentation/widgets/trip_overview_tab.dart` (1 map; `TripOverviewTab` is `ConsumerWidget`)
+- `lib/features/dive_sites/presentation/pages/site_detail_page.dart` (2 maps in `_SiteDetailContent`, a `ConsumerWidget`)
+- `lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart` (2 maps in `_MapSection`, a `ConsumerWidget`)
+- `lib/features/dive_sites/presentation/widgets/site_list_content.dart` (1 map in `SiteListTile`, a `ConsumerWidget`)
+
+**Interfaces:**
+- Consumes: `TrackpadZoomMap` (Task 2), flutter_map `MapController`.
+- Produces: nothing new.
+
+**Conversion recipe (per widget that contains the FlutterMap):**
+
+1. Add imports if missing:
+```dart
+import 'package:flutter_map/flutter_map.dart'; // usually already present
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
+```
+
+2. Convert the enclosing `ConsumerWidget` to `ConsumerStatefulWidget`:
+```dart
+// Before:
+class Foo extends ConsumerWidget {
+  const Foo({super.key, ...});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) { ... }
+}
+// After:
+class Foo extends ConsumerStatefulWidget {
+  const Foo({super.key, ...});
+  @override
+  ConsumerState<Foo> createState() => _FooState();
+}
+
+class _FooState extends ConsumerState<Foo> {
+  final MapController _mapController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final ref = this.ref; // ConsumerState exposes `ref` directly; use it as-is
+    ...
+  }
+}
+```
+Inside the new `build`, replace references to constructor params with `widget.<param>` and use `ref` directly (it is a member of `ConsumerState`).
+
+3. Wrap the FlutterMap and supply the controller:
+```dart
+TrackpadZoomMap(
+  controller: _mapController,
+  child: FlutterMap(
+    mapController: _mapController,
+    options: ...,
+    children: ...,
+  ),
+)
+```
+
+**Per-file notes:**
+
+- `dive_locations_map.dart`: keeps its optional `final MapController? controller;` param. In the state, use an effective controller:
+```dart
+late final MapController _effectiveController =
+    widget.controller ?? MapController();
+```
+  Pass `_effectiveController` to both `TrackpadZoomMap.controller` and `FlutterMap.mapController`.
+- `site_detail_page.dart` `_SiteDetailContent`: has TWO `FlutterMap`s (inline preview + full-screen body). Create TWO controllers (`_previewController`, `_fullController`) and wrap each map with its own.
+- `dive_center_detail_page.dart` `_MapSection`: same — TWO `FlutterMap`s, two controllers.
+- `site_list_content.dart` `SiteListTile`: convert `SiteListTile` (the tile, not `_SiteListContentState`) to `ConsumerStatefulWidget`; one controller per tile.
+- `trip_overview_tab.dart`: `TripOverviewTab` is a large tab. Convert it to `ConsumerStatefulWidget` holding one `_mapController`; only the one `FlutterMap` (around line 191) is wrapped.
+
+- [ ] **Step 1: Apply the conversion + wrap recipe to all 6 files (8 maps).**
+
+- [ ] **Step 2: Format + analyze**
+
+Run: `dart format lib/`
+Run: `flutter analyze`
+Expected: No issues. (Watch for: leftover `WidgetRef ref` params in build signatures, missing `widget.` prefixes, unused imports.)
+
+- [ ] **Step 3: Run affected widget tests**
+
+Run: `flutter test test/features/trips/ test/features/dive_sites/ test/features/dive_centers/ test/features/dive_log/presentation/widgets/dive_locations_map_test.dart 2>/dev/null; true`
+Expected: Affected widgets still build/pump; no new failures vs baseline.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/trips lib/features/dive_sites lib/features/dive_centers lib/features/dive_log
+git commit -m "feat(maps): enable trackpad scroll zoom on converted stateless map sites"
+```
+
+---
+
+### Task 6: Whole-project verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format check**
+
+Run: `dart format --set-exit-if-changed lib/ test/`
+Expected: Exit 0 (no changes).
+
+- [ ] **Step 2: Whole-project analyze**
+
+Run: `flutter analyze`
+Expected: "No issues found!"
+
+- [ ] **Step 3: Run the new/affected unit + widget tests**
+
+Run: `flutter test test/core/ui/trackpad_zoom_test.dart test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+Expected: All PASS.
+
+- [ ] **Step 4: Document on-device verification (cannot be automated)**
+
+Record in the PR description that the following require a real macOS trackpad (the Key risk from the spec):
+- Two-finger vertical scroll zooms maps and the chart, cursor-anchored.
+- No double-handling: the gesture does NOT also pan the map (confirms flutter_map's recognizer ignores trackpad pan-zoom). If panning is observed, apply the spec's fallback (disable `pinchMove` for trackpad / custom recognizer).
+- Click-drag still pans; pinch still zooms; mouse-wheel still zooms.
+- Touch (if a touchscreen Mac/iPad is available) still pinches/pans normally.
+
+- [ ] **Step 5: Final commit (if any formatting fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore: trackpad scroll zoom verification fixups" || true
+```

--- a/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
+++ b/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make two-finger up/down scroll on a trackpad zoom in/out (cursor-anchored) on all 17 maps and on the dive profile chart.
 
-**Architecture:** One pure helper converts a trackpad vertical scroll delta into a zoom-level delta. A passive `Listener`-based wrapper (`TrackpadZoomMap`) drives `MapController` zoom for maps. The dive profile chart's existing `onPointerPanZoomUpdate` is modified to fold vertical scroll into its zoom factor instead of panning.
+**Architecture:** One pure helper converts a trackpad vertical scroll delta into a zoom-level delta. A shared `TrackpadZoomGestureRecognizer` eagerly wins the gesture arena for trackpad pan-zoom (rejecting flutter_map's scale recognizer and any enclosing scrollable); `TrackpadZoomMap` uses it to drive `MapController` zoom for maps, and the dive profile chart uses the same recognizer to drive its viewport zoom. Both zoom from scroll (`panDelta`) and pinch (`scale`), cursor-anchored.
 
 **Tech Stack:** Flutter, flutter_map 8.2.2 (`MapController`, `MapCamera.focusedZoomCenter`), fl_chart, Riverpod.
 
@@ -15,7 +15,7 @@
 - No emojis in code/comments.
 - Immutability; no mutation of shared objects.
 - Only `PointerDeviceKind.trackpad` gestures are re-interpreted; touch and mouse paths are untouched.
-- Direction matches the existing mouse-wheel convention: negative `dy` (scroll up/away) zooms in.
+- Direction: two-finger scroll up zooms out, scroll down zooms in (the mouse-wheel paths are left unchanged at up = zoom in).
 - Zoom is cursor-anchored.
 - Run specific test files (not broad directories) to avoid Bash timeouts.
 
@@ -43,12 +43,12 @@ void main() {
       expect(trackpadScrollZoomDelta(0), 0);
     });
 
-    test('scroll up (negative dy) zooms in (positive delta)', () {
-      expect(trackpadScrollZoomDelta(-100), greaterThan(0));
+    test('scroll up (negative dy) zooms out (negative delta)', () {
+      expect(trackpadScrollZoomDelta(-100), lessThan(0));
     });
 
-    test('scroll down (positive dy) zooms out (negative delta)', () {
-      expect(trackpadScrollZoomDelta(100), lessThan(0));
+    test('scroll down (positive dy) zooms in (positive delta)', () {
+      expect(trackpadScrollZoomDelta(100), greaterThan(0));
     });
 
     test('is symmetric for equal-and-opposite scrolls', () {
@@ -83,12 +83,12 @@ Expected: FAIL — `trackpad_zoom.dart` / `trackpadScrollZoomDelta` not found.
 /// Converts a trackpad two-finger vertical scroll delta (logical pixels) into an
 /// additive zoom-level delta.
 ///
-/// Negative [scrollDy] (scroll up / away from the user) returns a positive delta
-/// (zoom in), matching the mouse-wheel convention so wheel and trackpad agree on
-/// the same machine. Map consumers add the result to `camera.zoom`; the dive
-/// profile chart applies `pow(2, delta)` as a multiplicative factor.
+/// Scroll up (negative [scrollDy]) returns a negative delta (zoom out); scroll
+/// down (positive) returns a positive delta (zoom in). Map consumers add the
+/// result to `camera.zoom`; the dive profile chart applies `pow(2, delta)` as a
+/// multiplicative factor.
 double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01}) {
-  return -scrollDy * sensitivity;
+  return scrollDy * sensitivity;
 }
 ```
 

--- a/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
+++ b/docs/superpowers/plans/2026-06-22-trackpad-scroll-zoom.md
@@ -114,7 +114,7 @@ git commit -m "feat(ui): add trackpadScrollZoomDelta helper"
 
 **Interfaces:**
 - Consumes: `trackpadScrollZoomDelta` (Task 1); flutter_map `MapController`, `MapCamera.focusedZoomCenter`.
-- Produces: `TrackpadZoomMap({required MapController controller, required Widget child, double minZoom = 1.0, double maxZoom = 22.0})` — a `StatelessWidget` that wraps `child` (a `FlutterMap`) in a passive `Listener` and zooms `controller` on trackpad two-finger vertical scroll.
+- Produces: `TrackpadZoomMap({required MapController controller, required Widget Function(BuildContext, int flags) builder, int baseFlags = InteractiveFlag.all, double minZoom = 1.0, double maxZoom = 22.0})` — a `StatefulWidget` that zooms `controller` on trackpad two-finger vertical scroll and drops `InteractiveFlag.pinchMove` from the flags handed to `builder` only while a trackpad gesture is active (so flutter_map cannot pin the camera and revert the zoom; touch pinch-zoom is preserved). See the implemented file for the verified code; the original passive-`Listener` `StatelessWidget` form does NOT work (flutter_map clobbers it).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -407,26 +407,39 @@ Add the import:
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 ```
 
-Transform, where `<ctrl>` is the exact expression already given to `mapController:`:
+Transform, where `<ctrl>` is the exact expression already given to `mapController:`
+and `<base>` is the site's existing `interactionOptions.flags` (or
+`InteractiveFlag.all` if it sets none). Thread the builder's `flags` into the
+`FlutterMap`'s `interactionOptions`:
 ```dart
 // Before:
 FlutterMap(
   mapController: <ctrl>,
-  options: ...,
+  options: MapOptions(
+    ...,
+    interactionOptions: InteractionOptions(flags: <base>, /* other opts */),
+  ),
   children: ...,
 )
 // After:
 TrackpadZoomMap(
   controller: <ctrl>,
-  child: FlutterMap(
+  baseFlags: <base>,
+  builder: (context, flags) => FlutterMap(
     mapController: <ctrl>,
-    options: ...,
+    options: MapOptions(
+      ...,
+      interactionOptions: InteractionOptions(flags: flags, /* other opts */),
+    ),
     children: ...,
   ),
 )
 ```
+If the site currently sets no `interactionOptions`, add
+`interactionOptions: InteractionOptions(flags: flags)` and omit `baseFlags`
+(defaults to `InteractiveFlag.all`).
 
-- [ ] **Step 1: Apply the recipe to all 9 files.** Use the controller already passed to each `mapController:` argument. Do not change options/children.
+- [ ] **Step 1: Apply the recipe to all 9 files.** Use the controller already passed to each `mapController:` argument. Preserve any other interaction options (scrollWheelVelocity, etc.). Do not change other options/children.
 
 - [ ] **Step 2: Format + analyze**
 
@@ -499,13 +512,18 @@ class _FooState extends ConsumerState<Foo> {
 ```
 Inside the new `build`, replace references to constructor params with `widget.<param>` and use `ref` directly (it is a member of `ConsumerState`).
 
-3. Wrap the FlutterMap and supply the controller:
+3. Wrap the FlutterMap with the builder, supplying the controller and threading
+   `flags` into `interactionOptions`:
 ```dart
 TrackpadZoomMap(
   controller: _mapController,
-  child: FlutterMap(
+  baseFlags: <site base flags or InteractiveFlag.all>,
+  builder: (context, flags) => FlutterMap(
     mapController: _mapController,
-    options: ...,
+    options: MapOptions(
+      ...,
+      interactionOptions: InteractionOptions(flags: flags, /* other opts */),
+    ),
     children: ...,
   ),
 )

--- a/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
@@ -28,6 +28,10 @@ delta — you cannot have both).
 - **Pointer-kind aware:** only `PointerDeviceKind.trackpad` gestures are
   re-interpreted. Touchscreen pinch / two-finger pan keep flowing through
   flutter_map and the chart's existing handlers untouched (iPad users unaffected).
+- **Embedded-map scroll conflict (added):** when a map sits inside a scrollable
+  page, a two-finger trackpad scroll over the map zooms the map and the page does
+  NOT scroll ("map captures the gesture when hovered"); scrolling elsewhere
+  scrolls the page. Trackpad pinch over the map also zooms the map.
 
 ## Non-goals
 
@@ -90,44 +94,59 @@ from #372 (the chart has no rotation/scale, so global == correct local).
 
 File: `lib/features/maps/presentation/widgets/trackpad_zoom_map.dart`.
 
-**Revised during implementation (verified by probes):** a passive `Listener`
-alone does NOT work. flutter_map's `pinchMove` handler pins the camera to the
-gesture-start position on every frame of a trackpad two-finger gesture (scale
-stays 1.0, so it recomputes the start camera and calls `moveRaw`), reverting any
-`move()` we apply. Disabling `pinchMove` frees our zoom — but `pinchMove` also
-powers touch pinch-zoom focal anchoring, so it must only be dropped for the
-duration of a trackpad gesture, never for touch.
+**Revised during implementation (verified by probes).** Two problems had to be
+solved together:
 
-So `TrackpadZoomMap` is a **`StatefulWidget`** with a **builder** API:
+1. *Clobber:* a passive `Listener` does not work. flutter_map's scale recognizer
+   reacts to trackpad pan-zoom and (via `pinchMove`) pins the camera to the
+   gesture-start position every frame, reverting any `move()` we apply.
+2. *Page-scroll capture* (added requirement): over an embedded map inside a
+   scrollable page, a trackpad two-finger scroll both zooms the map and scrolls
+   the page. The agreed behavior is "the map captures the gesture when hovered."
+
+Both reduce to one fix: **win the gesture arena** for trackpad pan-zoom. The
+arena has one winner, so winning rejects *both* flutter_map's scale recognizer
+(no clobber) *and* the enclosing scrollable (no page scroll). But a single winner
+also means flutter_map can no longer drive trackpad pinch — so our winner must
+itself handle pinch as well as scroll.
+
+So `TrackpadZoomMap` is a `StatelessWidget` wrapping `child` in a
+`RawGestureDetector` with a custom `_TrackpadZoomGestureRecognizer`:
 
 ```dart
 TrackpadZoomMap({
   required MapController controller,
-  required Widget Function(BuildContext, int flags) builder,
-  int baseFlags = InteractiveFlag.all,
+  required Widget child,
   double minZoom = 1.0,
   double maxZoom = 22.0,
 })
 ```
 
-- It holds `_trackpadActive`. `onPointerPanZoomStart` (kind == trackpad) sets it
-  true; `onPointerPanZoomEnd` sets it false. Effective flags handed to `builder`
-  are `baseFlags & ~InteractiveFlag.pinchMove` while active, else `baseFlags`.
-- `onPointerPanZoomUpdate` (kind == trackpad) reads `controller.camera`, computes
-  `newZoom = (camera.zoom + trackpadScrollZoomDelta(event.panDelta.dy)).clamp(...)`,
-  and `controller.move(camera.focusedZoomCenter(event.localPosition, newZoom), newZoom)`.
-- Uses **global `panDelta`** (per-event) for the scroll amount and
-  **`localPosition`** for the cursor — per the #372 macOS `localPan`
-  contamination lesson.
-- `MapCamera.focusedZoomCenter(cursorPos, zoom)` returns the new center that keeps
-  the point under the cursor fixed (flutter_map built-in). It accounts for map
-  rotation.
-- Callers thread the supplied `flags` into `MapOptions.interactionOptions`, and
-  pass their at-rest flags as `baseFlags` (default `InteractiveFlag.all`).
+`_TrackpadZoomGestureRecognizer extends OneSequenceGestureRecognizer`
+(`supportedDevices: {trackpad}`):
 
-This preserves touch (tablet/iPad) pinch-zoom exactly; `pinchMove` is only ever
-dropped while a trackpad gesture is in progress. Aligns with the agreed UX:
-two-finger trackpad scroll zooms (no two-finger trackpad pan), pan via click-drag.
+- `addAllowedPointer` (ordinary pointers) is a **no-op**, so a trackpad
+  click-drag still pans via flutter_map. Only `addAllowedPointerPanZoom` is
+  claimed: it `startTrackingPointer` + `resolve(accepted)` **eagerly**, winning
+  the arena before flutter_map or the scrollable can.
+- On each `PointerPanZoomUpdateEvent` it reports an additive zoom-level delta =
+  `trackpadScrollZoomDelta(event.panDelta.dy)` (scroll) `+ log2(scale / lastScale)`
+  (pinch). The wrapper applies it: `newZoom = (camera.zoom + delta).clamp(...)`,
+  then `controller.move(camera.focusedZoomCenter(event.localPosition, newZoom), newZoom)`.
+- Uses **global `panDelta`** for the scroll amount and **`localPosition`** for
+  the cursor — per the #372 macOS `localPan` contamination lesson.
+- `MapCamera.focusedZoomCenter(cursorPos, zoom)` keeps the point under the cursor
+  fixed (flutter_map built-in; accounts for map rotation).
+
+Touch (regular pointers, not pan-zoom) and mouse wheel (pointer signal, claimed
+by flutter_map's own resolver) are untouched: touch pinch/one-finger pan and
+wheel-zoom keep working. No interaction-flag changes are needed, so call sites
+keep their existing `MapOptions` and just wrap with `TrackpadZoomMap(controller:
+..., child: FlutterMap(...))`.
+
+Not unit-testable: that the arena win actually suppresses the parent scroll —
+`flutter_test`'s `Scrollable` does not scroll on synthetic `panZoom` events
+(verified). Covered by on-device verification (Task 6).
 
 #### Roll-out to 15 files / 17 maps
 

--- a/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
@@ -21,10 +21,10 @@ delta — you cannot have both).
 - **Panning after the change:** click-drag only. Pinch still zooms. Two-finger
   vertical scroll zooms; horizontal scroll component is ignored.
 - **Zoom anchor:** under the cursor.
-- **Direction:** matches the existing mouse-wheel convention so wheel and trackpad
-  agree on the same machine — negative `dy` (scroll up/away) → zoom in. The OS
-  natural-scroll setting affects the reported sign identically for wheel and
-  trackpad, so they stay consistent.
+- **Direction:** two-finger scroll **up zooms out**, **down zooms in** (per user
+  preference, set after device testing). This is the opposite of the mouse-wheel
+  path (up = zoom in), which is left unchanged; the trackpad-only flip lives in
+  `trackpadScrollZoomDelta`.
 - **Pointer-kind aware:** only `PointerDeviceKind.trackpad` gestures are
   re-interpreted. Touchscreen pinch / two-finger pan keep flowing through
   flutter_map and the chart's existing handlers untouched (iPad users unaffected).

--- a/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
@@ -1,0 +1,172 @@
+# Two-finger trackpad scroll → zoom (maps + dive profile chart)
+
+Date: 2026-06-22
+Branch: `worktree-trackpad-scroll-zoom`
+
+## Goal
+
+Two-finger up/down scroll on a touchpad should zoom in/out:
+
+- on **all maps** (15 `FlutterMap` instances), and
+- on the **dive profile chart**.
+
+Zoom is **cursor-anchored** (zoom toward/away from the pointer). Panning is done
+by **click-drag** (already supported everywhere); two-finger drag no longer pans,
+because on a trackpad "two-finger scroll" and "two-finger drag-pan" are the same
+physical gesture (Flutter delivers both as `PointerPanZoom` events with a `pan`
+delta — you cannot have both).
+
+## Decisions (settled)
+
+- **Panning after the change:** click-drag only. Pinch still zooms. Two-finger
+  vertical scroll zooms; horizontal scroll component is ignored.
+- **Zoom anchor:** under the cursor.
+- **Direction:** matches the existing mouse-wheel convention so wheel and trackpad
+  agree on the same machine — negative `dy` (scroll up/away) → zoom in. The OS
+  natural-scroll setting affects the reported sign identically for wheel and
+  trackpad, so they stay consistent.
+- **Pointer-kind aware:** only `PointerDeviceKind.trackpad` gestures are
+  re-interpreted. Touchscreen pinch / two-finger pan keep flowing through
+  flutter_map and the chart's existing handlers untouched (iPad users unaffected).
+
+## Non-goals
+
+- No change to mouse-wheel zoom (already works on both maps and chart).
+- No change to touch (tablet) gestures.
+- No rotation/north-reset work (that is the separate, unmerged #238/#370 scope).
+- Not coordinating with the unmerged #238/#370 branch; this builds independently
+  on `main`. A future merge of #370 will need manual reconciliation.
+
+## Architecture
+
+Three units, each independently understandable and testable:
+
+### 1. Pure helper — `lib/core/ui/trackpad_zoom.dart`
+
+Dependency-free function shared by both consumers:
+
+```dart
+/// Converts a trackpad two-finger vertical scroll delta (logical px) into an
+/// additive zoom-level delta. Negative dy (scroll up/away) -> positive (zoom in),
+/// matching the mouse-wheel convention. Sensitivity is tuned so a normal scroll
+/// flick changes zoom by roughly one level.
+double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01});
+```
+
+- Returns an **additive zoom-level delta** (the natural primitive for maps, whose
+  zoom is logarithmic — one level = 2x scale).
+- Maps add it to `camera.zoom`.
+- The chart applies `pow(2, delta)` to get a multiplicative factor for
+  `ProfileChartViewport.zoomedAt`.
+
+Keeping all sign/sensitivity logic here means one unit-tested place; neither
+consumer's zoom model leaks into the other.
+
+### 2. Profile chart — modify existing handler
+
+File: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`,
+`onPointerPanZoomUpdate` (currently translates by `event.pan` and scales by
+`event.scale`).
+
+Change: stop translating; fold vertical scroll into the cumulative zoom factor,
+anchored at the cursor (`_trackpadAnchor`, already cursor-positioned at gesture
+start). `PointerPanZoomUpdateEvent.pan`/`.scale` are cumulative since gesture
+start, matching the existing `_gestureStartViewport` model:
+
+```
+final factor = event.scale * pow(2, trackpadScrollZoomDelta(event.pan.dy));
+_viewport = _gestureStartViewport.zoomedAt(focal.fx, focal.fy, factor);
+```
+
+- Pinch (`event.scale`) still zooms.
+- The mouse-wheel path (`onPointerSignal` / `PointerScrollEvent`) is unchanged.
+- Click-drag panning (`Listener.onPointerMove`) is unchanged.
+- Net effect removes the `vp.pannedBy(event.pan...)` call.
+
+Use cumulative `event.pan` (not `localPan`) per the macOS contamination lesson
+from #372 (the chart has no rotation/scale, so global == correct local).
+
+### 3. Maps — new shared wrapper `TrackpadZoomMap`
+
+File: `lib/features/maps/presentation/widgets/trackpad_zoom_map.dart`.
+
+A `StatelessWidget` taking a required `MapController`, the `FlutterMap` `child`,
+and optional `minZoom`/`maxZoom`. Wraps `child` in a passive `Listener`:
+
+```
+onPointerPanZoomUpdate: (event) {
+  if (event.kind != PointerDeviceKind.trackpad) return;   // touch -> flutter_map
+  final camera = controller.camera;
+  final delta = trackpadScrollZoomDelta(event.panDelta.dy); // per-event delta
+  if (delta == 0) return;
+  final newZoom = (camera.zoom + delta).clamp(minZoom, maxZoom);
+  if (newZoom == camera.zoom) return;
+  controller.move(camera.focusedZoomCenter(event.localPosition, newZoom), newZoom);
+}
+```
+
+- Uses **global `panDelta`** (per-event) for the scroll amount and
+  **`localPosition`** for the cursor — per the #372 macOS `localPan`
+  contamination lesson.
+- `MapCamera.focusedZoomCenter(cursorPos, zoom)` returns the new center that keeps
+  the point under the cursor fixed (flutter_map built-in; the same helper #370
+  used). It already accounts for map rotation.
+- `Listener` is passive (does not enter the gesture arena), so flutter_map's own
+  click-drag pan, pinch zoom, and mouse-wheel zoom keep working underneath.
+- `minZoom`/`maxZoom` default to flutter_map's camera limits when available;
+  call sites can pass the same bounds they give `MapOptions`.
+
+#### Roll-out to 15 maps
+
+Each call site wraps its `FlutterMap` in `TrackpadZoomMap(controller: ..., child: FlutterMap(...))`.
+Maps that are currently stateless and do not own a `MapController` get a minimal
+`StatefulWidget` / `ConsumerStatefulWidget` conversion to create and hold one
+(create in `initState`/field, no `dispose` needed for `MapController` — matches
+existing repo pattern; note the repo-wide latent "MapController never disposed"
+observation from #370, not introduced here).
+
+The 15 sites:
+
+- `lib/features/maps/presentation/pages/region_picker_page.dart`
+- `lib/features/maps/presentation/pages/dive_activity_map_page.dart`
+- `lib/features/dive_sites/presentation/pages/site_map_page.dart`
+- `lib/features/dive_sites/presentation/pages/site_detail_page.dart`
+- `lib/features/dive_sites/presentation/widgets/match_sites_map.dart`
+- `lib/features/dive_sites/presentation/widgets/site_map_content.dart`
+- `lib/features/dive_sites/presentation/widgets/location_picker_map.dart`
+- `lib/features/dive_sites/presentation/widgets/site_list_content.dart`
+- `lib/features/dive_log/presentation/widgets/dive_map_content.dart`
+- `lib/features/dive_log/presentation/widgets/dive_locations_map.dart`
+- `lib/features/trips/presentation/widgets/trip_voyage_map.dart`
+- `lib/features/trips/presentation/widgets/trip_overview_tab.dart`
+- `lib/features/dive_centers/presentation/pages/dive_center_map_page.dart`
+- `lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart`
+- `lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart`
+
+## Key risk (verify on real hardware)
+
+Whether flutter_map's internal `ScaleGestureRecognizer` *also* reacts to trackpad
+pan-zoom, causing double-handling (our zoom + flutter_map's pan from the same
+gesture). The #238/#370 work found it does **not** — trackpad `PointerPanZoom`
+sends no `PointerDownEvent`, so flutter_map's pointer-down-based recognizer never
+engages. This builds on that finding but it requires real-trackpad confirmation.
+
+Fallback if double-handling is observed: gate flutter_map by disabling `pinchMove`
+only when the active pointer is a trackpad, or interpose a custom recognizer.
+
+## Testing
+
+- **Unit** (`test/core/ui/trackpad_zoom_test.dart`): `trackpadScrollZoomDelta`
+  sign (negative dy → positive delta), zero at dy 0, sensitivity scaling,
+  symmetry (equal-and-opposite dy → equal-and-opposite delta).
+- **Widget** (`test/features/maps/.../trackpad_zoom_map_test.dart`): synthesize
+  `PointerPanZoomStart/Update/End` with `kind: trackpad` and assert the
+  `MapController` zoom changes in the right direction and stays clamped; assert a
+  `kind: touch` pan-zoom is ignored (zoom unchanged).
+- **Chart**: extend viewport tests for the scroll→factor mapping
+  (`pow(2, trackpadScrollZoomDelta(dy))`). Note per #372 that full two-finger
+  trackpad gestures aren't simulatable in `flutter_test`; the end-to-end chart
+  behavior is covered by on-device verification.
+- **Verification before completion**: `dart format .`, `flutter analyze` (whole
+  project), the targeted test files, and on-device macOS trackpad check of the
+  Key risk above.

--- a/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
@@ -51,9 +51,9 @@ Dependency-free function shared by both consumers:
 
 ```dart
 /// Converts a trackpad two-finger vertical scroll delta (logical px) into an
-/// additive zoom-level delta. Negative dy (scroll up/away) -> positive (zoom in),
-/// matching the mouse-wheel convention. Sensitivity is tuned so a normal scroll
-/// flick changes zoom by roughly one level.
+/// additive zoom-level delta. Scroll up -> negative (zoom out), scroll down ->
+/// positive (zoom in). Sensitivity is tuned so a normal scroll flick changes
+/// zoom by roughly one level.
 double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01});
 ```
 
@@ -151,7 +151,8 @@ Not unit-testable: that the arena win actually suppresses the parent scroll —
 #### Roll-out to 15 files / 17 maps
 
 Each call site wraps its `FlutterMap` in
-`TrackpadZoomMap(controller: ..., baseFlags: ..., builder: (context, flags) => FlutterMap(... interactionOptions: InteractionOptions(flags: flags, ...) ...))`.
+`TrackpadZoomMap(controller: ..., child: FlutterMap(...))` — no `MapOptions`/flag
+changes needed (the recognizer wins the arena instead of toggling flags).
 Maps that are currently stateless and do not own a `MapController` get a minimal
 `StatefulWidget` / `ConsumerStatefulWidget` conversion to create and hold one
 (create as a field, no `dispose` needed for `MapController` — matches existing
@@ -182,23 +183,27 @@ The 15 files (two contain 2 maps each — `site_detail_page` and
 The risk (flutter_map double-handling the trackpad gesture) **materialized**:
 flutter_map's `ScaleGestureRecognizer` does engage on trackpad `PointerPanZoom`
 and its `pinchMove` handler pins the camera to gesture-start every frame,
-reverting our zoom. Verified with probes. Resolved by the pointer-kind-aware
-`pinchMove` flag swap in `TrackpadZoomMap` (section 3). The earlier #370 note
+reverting our zoom. Verified with probes. Resolved by `TrackpadZoomMap`'s
+arena-winning `TrackpadZoomGestureRecognizer` (section 3), which rejects
+flutter_map's scale recognizer outright. The earlier #370 note
 ("no double-handling, trackpad sends no PointerDownEvent") did not hold for
 flutter_map 8.2.2; `ScaleGestureRecognizer.addAllowedPointerPanZoom` accepts the
-gesture without a pointer-down. On-device macOS confirmation is still part of
-Task 6 (smooth progressive zoom; brief possible stutter on the first frame of a
-gesture before the flag-swap rebuild lands).
+gesture without a pointer-down. Resolved by `TrackpadZoomGestureRecognizer`
+eagerly winning the gesture arena (rejecting flutter_map's scale recognizer and
+any enclosing scrollable) — not by a flag swap. On-device macOS confirmation is
+still part of Task 6 (smooth progressive zoom).
 
 ## Testing
 
 - **Unit** (`test/core/ui/trackpad_zoom_test.dart`): `trackpadScrollZoomDelta`
-  sign (negative dy → positive delta), zero at dy 0, sensitivity scaling,
-  symmetry (equal-and-opposite dy → equal-and-opposite delta).
+  sign (scroll down / positive dy → positive delta = zoom in), zero at dy 0,
+  sensitivity scaling, symmetry (equal-and-opposite dy → equal-and-opposite
+  delta).
 - **Widget** (`test/features/maps/.../trackpad_zoom_map_test.dart`): synthesize
   `PointerPanZoomStart/Update/End` with `kind: trackpad` and assert the
-  `MapController` zoom changes in the right direction and stays clamped; assert a
-  `kind: touch` pan-zoom is ignored (zoom unchanged).
+  `MapController` zoom changes in the right direction (scroll down zooms in,
+  progressively), pinch zooms, and a trackpad click-drag is not claimed by the
+  recognizer.
 - **Chart**: extend viewport tests for the scroll→factor mapping
   (`pow(2, trackpadScrollZoomDelta(dy))`). Note per #372 that full two-finger
   trackpad gestures aren't simulatable in `flutter_test`; the end-to-end chart

--- a/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-22-trackpad-scroll-zoom-design.md
@@ -90,42 +90,57 @@ from #372 (the chart has no rotation/scale, so global == correct local).
 
 File: `lib/features/maps/presentation/widgets/trackpad_zoom_map.dart`.
 
-A `StatelessWidget` taking a required `MapController`, the `FlutterMap` `child`,
-and optional `minZoom`/`maxZoom`. Wraps `child` in a passive `Listener`:
+**Revised during implementation (verified by probes):** a passive `Listener`
+alone does NOT work. flutter_map's `pinchMove` handler pins the camera to the
+gesture-start position on every frame of a trackpad two-finger gesture (scale
+stays 1.0, so it recomputes the start camera and calls `moveRaw`), reverting any
+`move()` we apply. Disabling `pinchMove` frees our zoom — but `pinchMove` also
+powers touch pinch-zoom focal anchoring, so it must only be dropped for the
+duration of a trackpad gesture, never for touch.
 
-```
-onPointerPanZoomUpdate: (event) {
-  if (event.kind != PointerDeviceKind.trackpad) return;   // touch -> flutter_map
-  final camera = controller.camera;
-  final delta = trackpadScrollZoomDelta(event.panDelta.dy); // per-event delta
-  if (delta == 0) return;
-  final newZoom = (camera.zoom + delta).clamp(minZoom, maxZoom);
-  if (newZoom == camera.zoom) return;
-  controller.move(camera.focusedZoomCenter(event.localPosition, newZoom), newZoom);
-}
+So `TrackpadZoomMap` is a **`StatefulWidget`** with a **builder** API:
+
+```dart
+TrackpadZoomMap({
+  required MapController controller,
+  required Widget Function(BuildContext, int flags) builder,
+  int baseFlags = InteractiveFlag.all,
+  double minZoom = 1.0,
+  double maxZoom = 22.0,
+})
 ```
 
+- It holds `_trackpadActive`. `onPointerPanZoomStart` (kind == trackpad) sets it
+  true; `onPointerPanZoomEnd` sets it false. Effective flags handed to `builder`
+  are `baseFlags & ~InteractiveFlag.pinchMove` while active, else `baseFlags`.
+- `onPointerPanZoomUpdate` (kind == trackpad) reads `controller.camera`, computes
+  `newZoom = (camera.zoom + trackpadScrollZoomDelta(event.panDelta.dy)).clamp(...)`,
+  and `controller.move(camera.focusedZoomCenter(event.localPosition, newZoom), newZoom)`.
 - Uses **global `panDelta`** (per-event) for the scroll amount and
   **`localPosition`** for the cursor — per the #372 macOS `localPan`
   contamination lesson.
 - `MapCamera.focusedZoomCenter(cursorPos, zoom)` returns the new center that keeps
-  the point under the cursor fixed (flutter_map built-in; the same helper #370
-  used). It already accounts for map rotation.
-- `Listener` is passive (does not enter the gesture arena), so flutter_map's own
-  click-drag pan, pinch zoom, and mouse-wheel zoom keep working underneath.
-- `minZoom`/`maxZoom` default to flutter_map's camera limits when available;
-  call sites can pass the same bounds they give `MapOptions`.
+  the point under the cursor fixed (flutter_map built-in). It accounts for map
+  rotation.
+- Callers thread the supplied `flags` into `MapOptions.interactionOptions`, and
+  pass their at-rest flags as `baseFlags` (default `InteractiveFlag.all`).
 
-#### Roll-out to 15 maps
+This preserves touch (tablet/iPad) pinch-zoom exactly; `pinchMove` is only ever
+dropped while a trackpad gesture is in progress. Aligns with the agreed UX:
+two-finger trackpad scroll zooms (no two-finger trackpad pan), pan via click-drag.
 
-Each call site wraps its `FlutterMap` in `TrackpadZoomMap(controller: ..., child: FlutterMap(...))`.
+#### Roll-out to 15 files / 17 maps
+
+Each call site wraps its `FlutterMap` in
+`TrackpadZoomMap(controller: ..., baseFlags: ..., builder: (context, flags) => FlutterMap(... interactionOptions: InteractionOptions(flags: flags, ...) ...))`.
 Maps that are currently stateless and do not own a `MapController` get a minimal
 `StatefulWidget` / `ConsumerStatefulWidget` conversion to create and hold one
-(create in `initState`/field, no `dispose` needed for `MapController` — matches
-existing repo pattern; note the repo-wide latent "MapController never disposed"
+(create as a field, no `dispose` needed for `MapController` — matches existing
+repo pattern; note the repo-wide latent "MapController never disposed"
 observation from #370, not introduced here).
 
-The 15 sites:
+The 15 files (two contain 2 maps each — `site_detail_page` and
+`dive_center_detail_page` — for 17 maps total):
 
 - `lib/features/maps/presentation/pages/region_picker_page.dart`
 - `lib/features/maps/presentation/pages/dive_activity_map_page.dart`
@@ -143,16 +158,18 @@ The 15 sites:
 - `lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart`
 - `lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart`
 
-## Key risk (verify on real hardware)
+## Key risk — RESOLVED in implementation
 
-Whether flutter_map's internal `ScaleGestureRecognizer` *also* reacts to trackpad
-pan-zoom, causing double-handling (our zoom + flutter_map's pan from the same
-gesture). The #238/#370 work found it does **not** — trackpad `PointerPanZoom`
-sends no `PointerDownEvent`, so flutter_map's pointer-down-based recognizer never
-engages. This builds on that finding but it requires real-trackpad confirmation.
-
-Fallback if double-handling is observed: gate flutter_map by disabling `pinchMove`
-only when the active pointer is a trackpad, or interpose a custom recognizer.
+The risk (flutter_map double-handling the trackpad gesture) **materialized**:
+flutter_map's `ScaleGestureRecognizer` does engage on trackpad `PointerPanZoom`
+and its `pinchMove` handler pins the camera to gesture-start every frame,
+reverting our zoom. Verified with probes. Resolved by the pointer-kind-aware
+`pinchMove` flag swap in `TrackpadZoomMap` (section 3). The earlier #370 note
+("no double-handling, trackpad sends no PointerDownEvent") did not hold for
+flutter_map 8.2.2; `ScaleGestureRecognizer.addAllowedPointerPanZoom` accepts the
+gesture without a pointer-down. On-device macOS confirmation is still part of
+Task 6 (smooth progressive zoom; brief possible stutter on the first frame of a
+gesture before the flag-swap rebuild lands).
 
 ## Testing
 

--- a/lib/core/ui/trackpad_zoom.dart
+++ b/lib/core/ui/trackpad_zoom.dart
@@ -4,10 +4,9 @@
 /// Converts a trackpad two-finger vertical scroll delta (logical pixels) into an
 /// additive zoom-level delta.
 ///
-/// Negative [scrollDy] (scroll up / away from the user) returns a positive delta
-/// (zoom in), matching the mouse-wheel convention so wheel and trackpad agree on
-/// the same machine. Map consumers add the result to `camera.zoom`; the dive
-/// profile chart applies `pow(2, delta)` as a multiplicative factor.
+/// Scroll up returns a negative delta (zoom out) and scroll down returns a
+/// positive delta (zoom in). Map consumers add the result to `camera.zoom`; the
+/// dive profile chart applies `pow(2, delta)` as a multiplicative factor.
 double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01}) {
-  return -scrollDy * sensitivity;
+  return scrollDy * sensitivity;
 }

--- a/lib/core/ui/trackpad_zoom.dart
+++ b/lib/core/ui/trackpad_zoom.dart
@@ -1,0 +1,13 @@
+/// Pure helpers for trackpad two-finger-scroll zooming, shared by the maps and
+/// the dive profile chart so sign and sensitivity live in one tested place.
+
+/// Converts a trackpad two-finger vertical scroll delta (logical pixels) into an
+/// additive zoom-level delta.
+///
+/// Negative [scrollDy] (scroll up / away from the user) returns a positive delta
+/// (zoom in), matching the mouse-wheel convention so wheel and trackpad agree on
+/// the same machine. Map consumers add the result to `camera.zoom`; the dive
+/// profile chart applies `pow(2, delta)` as a multiplicative factor.
+double trackpadScrollZoomDelta(double scrollDy, {double sensitivity = 0.01}) {
+  return -scrollDy * sensitivity;
+}

--- a/lib/core/ui/trackpad_zoom.dart
+++ b/lib/core/ui/trackpad_zoom.dart
@@ -1,5 +1,5 @@
-/// Pure helpers for trackpad two-finger-scroll zooming, shared by the maps and
-/// the dive profile chart so sign and sensitivity live in one tested place.
+// Pure helpers for trackpad two-finger-scroll zooming, shared by the maps and
+// the dive profile chart so sign and sensitivity live in one tested place.
 
 /// Converts a trackpad two-finger vertical scroll delta (logical pixels) into an
 /// additive zoom-level delta.

--- a/lib/core/ui/trackpad_zoom_recognizer.dart
+++ b/lib/core/ui/trackpad_zoom_recognizer.dart
@@ -1,0 +1,68 @@
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+
+/// Recognizes a trackpad two-finger gesture (pan-zoom) and reports a zoom-level
+/// delta combining vertical scroll and pinch, anchored at the pointer.
+///
+/// Install it via a `RawGestureDetector` around any zoomable widget (a map, the
+/// dive profile chart). It accepts the gesture *eagerly*, so it wins the gesture
+/// arena. Winning does two jobs at once:
+///
+///  1. the host widget's own scale recognizer (e.g. flutter_map's) is rejected,
+///     so it cannot fight the zoom we apply, and
+///  2. an enclosing scrollable is rejected, so a scroll over the widget zooms it
+///     instead of scrolling the page ("capture the gesture when hovered").
+///
+/// It claims only trackpad pan-zoom: [addAllowedPointer] is intentionally a
+/// no-op, so ordinary pointers (mouse, touch, and even a trackpad click-drag)
+/// are left to other recognizers. Touch pinch (two ordinary pointers) and the
+/// mouse wheel (a pointer signal) are therefore unaffected.
+class TrackpadZoomGestureRecognizer extends OneSequenceGestureRecognizer {
+  TrackpadZoomGestureRecognizer({super.debugOwner})
+    : super(supportedDevices: const {PointerDeviceKind.trackpad});
+
+  /// Called per update with the pointer's local position and an additive
+  /// zoom-level delta (positive = zoom in). Map consumers add it to
+  /// `camera.zoom`; the dive profile chart applies `pow(2, delta)` as a factor.
+  void Function(Offset localPosition, double zoomDelta)? onZoom;
+
+  double _lastScale = 1.0;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    // Do not claim ordinary pointers (e.g. trackpad click-drag) — those should
+    // pan via the host widget.
+  }
+
+  @override
+  void addAllowedPointerPanZoom(PointerPanZoomStartEvent event) {
+    super.addAllowedPointerPanZoom(event);
+    _lastScale = 1.0;
+    startTrackingPointer(event.pointer, event.transform);
+    resolve(GestureDisposition.accepted);
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (event is PointerPanZoomUpdateEvent) {
+      // Scroll contribution (vertical pan) plus pinch contribution (the change
+      // in cumulative scale since the previous update, expressed in zoom levels).
+      final scrollDelta = trackpadScrollZoomDelta(event.panDelta.dy);
+      final scaleRatio = _lastScale == 0 ? 1.0 : event.scale / _lastScale;
+      _lastScale = event.scale;
+      final pinchDelta = math.log(scaleRatio) / math.ln2;
+      onZoom?.call(event.localPosition, scrollDelta + pinchDelta);
+    } else if (event is PointerPanZoomEndEvent) {
+      stopTrackingPointer(event.pointer);
+    }
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {}
+
+  @override
+  String get debugDescription => 'trackpadZoom';
+}

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/dive_centers/domain/entities/dive_center.dar
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 class DiveCenterDetailPage extends ConsumerStatefulWidget {
   final String centerId;
@@ -575,13 +576,22 @@ class _NotesSection extends StatelessWidget {
   }
 }
 
-class _MapSection extends ConsumerWidget {
+class _MapSection extends ConsumerStatefulWidget {
   final DiveCenter center;
 
   const _MapSection({required this.center});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_MapSection> createState() => _MapSectionState();
+}
+
+class _MapSectionState extends ConsumerState<_MapSection> {
+  final MapController _previewController = MapController();
+  final MapController _fullController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final center = widget.center;
     final colorScheme = Theme.of(context).colorScheme;
     final centerLocation = LatLng(center.latitude!, center.longitude!);
 
@@ -592,8 +602,110 @@ class _MapSection extends ConsumerWidget {
         height: 200,
         child: Stack(
           children: [
-            FlutterMap(
-              key: ValueKey('${center.latitude}_${center.longitude}'),
+            TrackpadZoomMap(
+              controller: _previewController,
+              child: FlutterMap(
+                mapController: _previewController,
+                key: ValueKey('${center.latitude}_${center.longitude}'),
+                options: MapOptions(
+                  initialCenter: centerLocation,
+                  initialZoom: 14.0,
+                  minZoom: 2.0,
+                  maxZoom: 18.0,
+                  interactionOptions: const InteractionOptions(
+                    flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+                  ),
+                ),
+                children: [
+                  TileLayer(
+                    urlTemplate: ref.watch(mapTileUrlProvider),
+                    userAgentPackageName: 'app.submersion',
+                    maxZoom: ref.watch(mapTileMaxZoomProvider),
+                    tileProvider: TileCacheService.instance.isInitialized
+                        ? TileCacheService.instance.getTileProvider()
+                        : null,
+                  ),
+                  MarkerLayer(
+                    markers: [
+                      Marker(
+                        point: centerLocation,
+                        width: 50,
+                        height: 50,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: colorScheme.onPrimary,
+                              width: 2,
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.3),
+                                blurRadius: 8,
+                                offset: const Offset(0, 2),
+                              ),
+                            ],
+                          ),
+                          child: Center(
+                            child: Icon(
+                              Icons.store,
+                              size: 24,
+                              color: colorScheme.onPrimary,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const MapAttribution(),
+                ],
+              ),
+            ),
+            Positioned(
+              right: 8,
+              top: 8,
+              child: Material(
+                color: colorScheme.surface.withValues(alpha: 0.9),
+                borderRadius: BorderRadius.circular(4),
+                child: Semantics(
+                  button: true,
+                  label:
+                      context.l10n.diveCenters_accessibility_viewFullscreenMap,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(4),
+                    onTap: () => _showFullscreenMap(context, ref),
+                    child: Padding(
+                      padding: const EdgeInsets.all(6),
+                      child: Icon(
+                        Icons.fullscreen,
+                        size: 20,
+                        color: colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showFullscreenMap(BuildContext context, WidgetRef ref) {
+    final center = widget.center;
+    final colorScheme = Theme.of(context).colorScheme;
+    final centerLocation = LatLng(center.latitude!, center.longitude!);
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => Scaffold(
+          appBar: AppBar(title: Text(center.name)),
+          body: TrackpadZoomMap(
+            controller: _fullController,
+            child: FlutterMap(
+              mapController: _fullController,
               options: MapOptions(
                 initialCenter: centerLocation,
                 initialZoom: 14.0,
@@ -648,99 +760,6 @@ class _MapSection extends ConsumerWidget {
                 const MapAttribution(),
               ],
             ),
-            Positioned(
-              right: 8,
-              top: 8,
-              child: Material(
-                color: colorScheme.surface.withValues(alpha: 0.9),
-                borderRadius: BorderRadius.circular(4),
-                child: Semantics(
-                  button: true,
-                  label:
-                      context.l10n.diveCenters_accessibility_viewFullscreenMap,
-                  child: InkWell(
-                    borderRadius: BorderRadius.circular(4),
-                    onTap: () => _showFullscreenMap(context, ref),
-                    child: Padding(
-                      padding: const EdgeInsets.all(6),
-                      child: Icon(
-                        Icons.fullscreen,
-                        size: 20,
-                        color: colorScheme.primary,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showFullscreenMap(BuildContext context, WidgetRef ref) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final centerLocation = LatLng(center.latitude!, center.longitude!);
-
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => Scaffold(
-          appBar: AppBar(title: Text(center.name)),
-          body: FlutterMap(
-            options: MapOptions(
-              initialCenter: centerLocation,
-              initialZoom: 14.0,
-              minZoom: 2.0,
-              maxZoom: 18.0,
-              interactionOptions: const InteractionOptions(
-                flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
-              ),
-            ),
-            children: [
-              TileLayer(
-                urlTemplate: ref.watch(mapTileUrlProvider),
-                userAgentPackageName: 'app.submersion',
-                maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
-                    : null,
-              ),
-              MarkerLayer(
-                markers: [
-                  Marker(
-                    point: centerLocation,
-                    width: 50,
-                    height: 50,
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: colorScheme.primary,
-                        shape: BoxShape.circle,
-                        border: Border.all(
-                          color: colorScheme.onPrimary,
-                          width: 2,
-                        ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.3),
-                            blurRadius: 8,
-                            offset: const Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                      child: Center(
-                        child: Icon(
-                          Icons.store,
-                          size: 24,
-                          color: colorScheme.onPrimary,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const MapAttribution(),
-            ],
           ),
         ),
       ),

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
 
 class DiveCenterMapPage extends ConsumerStatefulWidget {
@@ -202,67 +203,75 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
 
     return Stack(
       children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            minZoom: 2.0,
-            maxZoom: 18.0,
-            onTap: (_, _) {
-              ref
-                  .read(mapListSelectionProvider('dive-centers').notifier)
-                  .deselect();
-            },
-            cameraConstraint: CameraConstraint.contain(
-              bounds: LatLngBounds(
-                const LatLng(-90, -180),
-                const LatLng(90, 180),
+        TrackpadZoomMap(
+          controller: _mapController,
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              minZoom: 2.0,
+              maxZoom: 18.0,
+              onTap: (_, _) {
+                ref
+                    .read(mapListSelectionProvider('dive-centers').notifier)
+                    .deselect();
+              },
+              cameraConstraint: CameraConstraint.contain(
+                bounds: LatLngBounds(
+                  const LatLng(-90, -180),
+                  const LatLng(90, 180),
+                ),
               ),
             ),
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              MarkerClusterLayerWidget(
+                options: MarkerClusterLayerOptions(
+                  maxClusterRadius: 80,
+                  size: const Size(50, 50),
+                  markers: centersWithLocation.map((diveCenter) {
+                    final isSelected =
+                        selectionState.selectedId == diveCenter.id;
+                    return Marker(
+                      point: LatLng(
+                        diveCenter.latitude!,
+                        diveCenter.longitude!,
+                      ),
+                      width: isSelected ? 50 : 40,
+                      height: isSelected ? 50 : 40,
+                      child: Semantics(
+                        button: true,
+                        label: context.l10n
+                            .diveCenters_accessibility_markerLabel(
+                              diveCenter.name,
+                            ),
+                        child: GestureDetector(
+                          onTap: () => _onMarkerTapped(diveCenter),
+                          child: _buildMarker(context, diveCenter, isSelected),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                  builder: (context, markers) {
+                    return _buildClusterMarker(context, markers.length);
+                  },
+                  zoomToBoundsOnClick: false,
+                  onClusterTap: (node) {
+                    _animateToCluster(node.bounds);
+                  },
+                ),
+              ),
+              const MapAttribution(),
+            ],
           ),
-          children: [
-            TileLayer(
-              urlTemplate: ref.watch(mapTileUrlProvider),
-              userAgentPackageName: 'app.submersion',
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
-                  : null,
-            ),
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 80,
-                size: const Size(50, 50),
-                markers: centersWithLocation.map((diveCenter) {
-                  final isSelected = selectionState.selectedId == diveCenter.id;
-                  return Marker(
-                    point: LatLng(diveCenter.latitude!, diveCenter.longitude!),
-                    width: isSelected ? 50 : 40,
-                    height: isSelected ? 50 : 40,
-                    child: Semantics(
-                      button: true,
-                      label: context.l10n.diveCenters_accessibility_markerLabel(
-                        diveCenter.name,
-                      ),
-                      child: GestureDetector(
-                        onTap: () => _onMarkerTapped(diveCenter),
-                        child: _buildMarker(context, diveCenter, isSelected),
-                      ),
-                    ),
-                  );
-                }).toList(),
-                builder: (context, markers) {
-                  return _buildClusterMarker(context, markers.length);
-                },
-                zoomToBoundsOnClick: false,
-                onClusterTap: (node) {
-                  _animateToCluster(node.bounds);
-                },
-              ),
-            ),
-            const MapAttribution(),
-          ],
         ),
 
         // Empty state overlay

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_centers/domain/entities/dive_center.dar
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
@@ -195,68 +196,75 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
 
     return Stack(
       children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            minZoom: 2.0,
-            maxZoom: 18.0,
-            onMapReady: () {
-              _mapReady = true;
-            },
-            onTap: (_, _) {
-              widget.onItemSelected(null);
-            },
-            cameraConstraint: CameraConstraint.contain(
-              bounds: LatLngBounds(
-                const LatLng(-90, -180),
-                const LatLng(90, 180),
+        TrackpadZoomMap(
+          controller: _mapController,
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              minZoom: 2.0,
+              maxZoom: 18.0,
+              onMapReady: () {
+                _mapReady = true;
+              },
+              onTap: (_, _) {
+                widget.onItemSelected(null);
+              },
+              cameraConstraint: CameraConstraint.contain(
+                bounds: LatLngBounds(
+                  const LatLng(-90, -180),
+                  const LatLng(90, 180),
+                ),
               ),
             ),
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              MarkerClusterLayerWidget(
+                options: MarkerClusterLayerOptions(
+                  maxClusterRadius: 80,
+                  size: const Size(50, 50),
+                  markers: centersWithLocation.map((diveCenter) {
+                    final isSelected = widget.selectedId == diveCenter.id;
+                    return Marker(
+                      point: LatLng(
+                        diveCenter.latitude!,
+                        diveCenter.longitude!,
+                      ),
+                      width: isSelected ? 50 : 40,
+                      height: isSelected ? 50 : 40,
+                      child: Semantics(
+                        button: true,
+                        label: context.l10n
+                            .diveCenters_accessibility_markerLabel(
+                              diveCenter.name,
+                            ),
+                        child: GestureDetector(
+                          onTap: () => _onMarkerTapped(diveCenter),
+                          child: _buildMarker(context, diveCenter, isSelected),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                  builder: (context, markers) {
+                    return _buildClusterMarker(context, markers.length);
+                  },
+                  zoomToBoundsOnClick: false,
+                  onClusterTap: (node) {
+                    _animateToCluster(node.bounds);
+                  },
+                ),
+              ),
+              const MapAttribution(),
+            ],
           ),
-          children: [
-            TileLayer(
-              urlTemplate: ref.watch(mapTileUrlProvider),
-              userAgentPackageName: 'app.submersion',
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
-                  : null,
-            ),
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 80,
-                size: const Size(50, 50),
-                markers: centersWithLocation.map((diveCenter) {
-                  final isSelected = widget.selectedId == diveCenter.id;
-                  return Marker(
-                    point: LatLng(diveCenter.latitude!, diveCenter.longitude!),
-                    width: isSelected ? 50 : 40,
-                    height: isSelected ? 50 : 40,
-                    child: Semantics(
-                      button: true,
-                      label: context.l10n.diveCenters_accessibility_markerLabel(
-                        diveCenter.name,
-                      ),
-                      child: GestureDetector(
-                        onTap: () => _onMarkerTapped(diveCenter),
-                        child: _buildMarker(context, diveCenter, isSelected),
-                      ),
-                    ),
-                  );
-                }).toList(),
-                builder: (context, markers) {
-                  return _buildClusterMarker(context, markers.length);
-                },
-                zoomToBoundsOnClick: false,
-                onClusterTap: (node) {
-                  _animateToCluster(node.bounds);
-                },
-              ),
-            ),
-            const MapAttribution(),
-          ],
         ),
 
         // Empty state overlay

--- a/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Marker colors for the GPS entry/exit fixes, matching the values the dive
 /// detail header map has always used.
@@ -20,7 +21,7 @@ const Color kGpsExitColor = Color(0xFFFF9F0A);
 ///
 /// This widget only draws a map. Clipboard, navigation, and row logic live in
 /// the callers.
-class DiveLocationsMap extends ConsumerWidget {
+class DiveLocationsMap extends ConsumerStatefulWidget {
   const DiveLocationsMap({
     super.key,
     this.entry,
@@ -53,13 +54,28 @@ class DiveLocationsMap extends ConsumerWidget {
   final double? initialZoom;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DiveLocationsMap> createState() => _DiveLocationsMapState();
+}
+
+class _DiveLocationsMapState extends ConsumerState<DiveLocationsMap> {
+  late final MapController _effectiveController =
+      widget.controller ?? MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final entry = widget.entry;
+    final exit = widget.exit;
+    final site = widget.site;
+    final interactive = widget.interactive;
+    final initialCenter = widget.initialCenter;
+    final initialZoom = widget.initialZoom;
+
     final colorScheme = Theme.of(context).colorScheme;
 
     final points = <LatLng>[
-      if (entry != null) LatLng(entry!.latitude, entry!.longitude),
-      if (exit != null) LatLng(exit!.latitude, exit!.longitude),
-      if (site != null) LatLng(site!.latitude, site!.longitude),
+      if (entry != null) LatLng(entry.latitude, entry.longitude),
+      if (exit != null) LatLng(exit.latitude, exit.longitude),
+      if (site != null) LatLng(site.latitude, site.longitude),
     ];
     if (points.isEmpty) return const SizedBox.shrink();
 
@@ -67,7 +83,7 @@ class DiveLocationsMap extends ConsumerWidget {
     double zoom;
     CameraFit? fit;
     if (initialCenter != null) {
-      center = initialCenter!;
+      center = initialCenter;
       zoom = initialZoom ?? 12.0;
     } else if (points.length >= 2) {
       center = points.first;
@@ -93,7 +109,7 @@ class DiveLocationsMap extends ConsumerWidget {
     final markers = <Marker>[
       if (entry != null)
         Marker(
-          point: LatLng(entry!.latitude, entry!.longitude),
+          point: LatLng(entry.latitude, entry.longitude),
           width: 28,
           height: 28,
           child: KeyedSubtree(
@@ -103,7 +119,7 @@ class DiveLocationsMap extends ConsumerWidget {
         ),
       if (exit != null)
         Marker(
-          point: LatLng(exit!.latitude, exit!.longitude),
+          point: LatLng(exit.latitude, exit.longitude),
           width: 28,
           height: 28,
           child: KeyedSubtree(
@@ -113,7 +129,7 @@ class DiveLocationsMap extends ConsumerWidget {
         ),
       if (site != null)
         Marker(
-          point: LatLng(site!.latitude, site!.longitude),
+          point: LatLng(site.latitude, site.longitude),
           width: 32,
           height: 32,
           // Diver glyph, matching the dive-site marker on the Sites map
@@ -129,42 +145,45 @@ class DiveLocationsMap extends ConsumerWidget {
         ),
     ];
 
-    return FlutterMap(
-      mapController: controller,
-      options: MapOptions(
-        initialCenter: center,
-        initialZoom: zoom,
-        initialCameraFit: fit,
-        interactionOptions: InteractionOptions(
-          flags: interactive ? InteractiveFlag.all : InteractiveFlag.none,
-        ),
-      ),
-      children: [
-        TileLayer(
-          urlTemplate: ref.watch(mapTileUrlProvider),
-          userAgentPackageName: 'app.submersion',
-          maxZoom: ref.watch(mapTileMaxZoomProvider),
-          tileProvider: TileCacheService.instance.isInitialized
-              ? TileCacheService.instance.getTileProvider()
-              : null,
-        ),
-        if (entry != null && exit != null)
-          PolylineLayer(
-            polylines: [
-              Polyline(
-                points: [
-                  LatLng(entry!.latitude, entry!.longitude),
-                  LatLng(exit!.latitude, exit!.longitude),
-                ],
-                strokeWidth: 3.0,
-                color: colorScheme.onSurface.withValues(alpha: 0.7),
-                pattern: const StrokePattern.dotted(),
-              ),
-            ],
+    return TrackpadZoomMap(
+      controller: _effectiveController,
+      child: FlutterMap(
+        mapController: _effectiveController,
+        options: MapOptions(
+          initialCenter: center,
+          initialZoom: zoom,
+          initialCameraFit: fit,
+          interactionOptions: InteractionOptions(
+            flags: interactive ? InteractiveFlag.all : InteractiveFlag.none,
           ),
-        MarkerLayer(markers: markers),
-        const MapAttribution(),
-      ],
+        ),
+        children: [
+          TileLayer(
+            urlTemplate: ref.watch(mapTileUrlProvider),
+            userAgentPackageName: 'app.submersion',
+            maxZoom: ref.watch(mapTileMaxZoomProvider),
+            tileProvider: TileCacheService.instance.isInitialized
+                ? TileCacheService.instance.getTileProvider()
+                : null,
+          ),
+          if (entry != null && exit != null)
+            PolylineLayer(
+              polylines: [
+                Polyline(
+                  points: [
+                    LatLng(entry.latitude, entry.longitude),
+                    LatLng(exit.latitude, exit.longitude),
+                  ],
+                  strokeWidth: 3.0,
+                  color: colorScheme.onSurface.withValues(alpha: 0.7),
+                  pattern: const StrokePattern.dotted(),
+                ),
+              ],
+            ),
+          MarkerLayer(markers: markers),
+          const MapAttribution(),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
@@ -58,8 +58,13 @@ class DiveLocationsMap extends ConsumerStatefulWidget {
 }
 
 class _DiveLocationsMapState extends ConsumerState<DiveLocationsMap> {
-  late final MapController _effectiveController =
-      widget.controller ?? MapController();
+  // Stable fallback used only when the caller does not supply a controller.
+  // Derive the effective controller each build so a parent that rebuilds with a
+  // different `controller` is always honored.
+  final MapController _fallbackController = MapController();
+
+  MapController get _effectiveController =>
+      widget.controller ?? _fallbackController;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/maps/presentation/providers/heat_map_provide
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -286,95 +287,98 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
 
     return Stack(
       children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            minZoom: 2.0,
-            maxZoom: 18.0,
-            onMapReady: () {
-              _mapReady = true;
-            },
-            onTap: (_, _) {
-              widget.onItemSelected(null);
-            },
-            cameraConstraint: CameraConstraint.contain(
-              bounds: LatLngBounds(
-                const LatLng(-90, -180),
-                const LatLng(90, 180),
+        TrackpadZoomMap(
+          controller: _mapController,
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              minZoom: 2.0,
+              maxZoom: 18.0,
+              onMapReady: () {
+                _mapReady = true;
+              },
+              onTap: (_, _) {
+                widget.onItemSelected(null);
+              },
+              cameraConstraint: CameraConstraint.contain(
+                bounds: LatLngBounds(
+                  const LatLng(-90, -180),
+                  const LatLng(90, 180),
+                ),
               ),
             ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: ref.watch(mapTileUrlProvider),
-              userAgentPackageName: 'app.submersion',
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
-                  : null,
-            ),
-            // Markers layer - shows sites with dives
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 80,
-                size: const Size(50, 50),
-                markers: sitesWithDives.map((siteWithCount) {
-                  final site = siteWithCount.site;
-                  final diveCount = siteWithCount.diveCount;
-                  final isSelected = selectedSiteId == site.id;
-                  return Marker(
-                    point: LatLng(
-                      site.location!.latitude,
-                      site.location!.longitude,
-                    ),
-                    width: isSelected ? 50 : 40,
-                    height: isSelected ? 50 : 40,
-                    child: Semantics(
-                      button: true,
-                      label: 'Select dive site ${site.name}',
-                      child: GestureDetector(
-                        onTap: () => _onMarkerTapped(site),
-                        child: _buildMarker(
-                          context,
-                          site,
-                          diveCount,
-                          isSelected,
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              // Markers layer - shows sites with dives
+              MarkerClusterLayerWidget(
+                options: MarkerClusterLayerOptions(
+                  maxClusterRadius: 80,
+                  size: const Size(50, 50),
+                  markers: sitesWithDives.map((siteWithCount) {
+                    final site = siteWithCount.site;
+                    final diveCount = siteWithCount.diveCount;
+                    final isSelected = selectedSiteId == site.id;
+                    return Marker(
+                      point: LatLng(
+                        site.location!.latitude,
+                        site.location!.longitude,
+                      ),
+                      width: isSelected ? 50 : 40,
+                      height: isSelected ? 50 : 40,
+                      child: Semantics(
+                        button: true,
+                        label: 'Select dive site ${site.name}',
+                        child: GestureDetector(
+                          onTap: () => _onMarkerTapped(site),
+                          child: _buildMarker(
+                            context,
+                            site,
+                            diveCount,
+                            isSelected,
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                }).toList(),
-                builder: (context, markers) {
-                  // Sum up dive counts for all markers in this cluster
-                  final totalDives = markers.fold<int>(
-                    0,
-                    (sum, marker) =>
-                        sum + (diveCountByLocation[marker.point] ?? 0),
-                  );
-                  return _buildClusterMarker(context, totalDives);
-                },
-                zoomToBoundsOnClick: false,
-                onClusterTap: (node) {
-                  // Animate to cluster bounds with generous padding
-                  _animateToCluster(node.bounds);
-                },
-              ),
-            ),
-            // Heat map layer - rendered on top of markers when visible
-            if (settings.isVisible)
-              heatMapAsync.when(
-                data: (points) => HeatMapLayer(
-                  points: points,
-                  radius: settings.radius,
-                  opacity: settings.opacity,
+                    );
+                  }).toList(),
+                  builder: (context, markers) {
+                    // Sum up dive counts for all markers in this cluster
+                    final totalDives = markers.fold<int>(
+                      0,
+                      (sum, marker) =>
+                          sum + (diveCountByLocation[marker.point] ?? 0),
+                    );
+                    return _buildClusterMarker(context, totalDives);
+                  },
+                  zoomToBoundsOnClick: false,
+                  onClusterTap: (node) {
+                    // Animate to cluster bounds with generous padding
+                    _animateToCluster(node.bounds);
+                  },
                 ),
-                loading: () => const SizedBox.shrink(),
-                error: (_, _) => const SizedBox.shrink(),
               ),
-            const MapAttribution(),
-          ],
+              // Heat map layer - rendered on top of markers when visible
+              if (settings.isVisible)
+                heatMapAsync.when(
+                  data: (points) => HeatMapLayer(
+                    points: points,
+                    radius: settings.radius,
+                    opacity: settings.opacity,
+                  ),
+                  loading: () => const SizedBox.shrink(),
+                  error: (_, _) => const SizedBox.shrink(),
+                ),
+              const MapAttribution(),
+            ],
+          ),
         ),
 
         // Loading indicator

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -25,6 +25,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/gas_colors.dar
 import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
+import 'package:submersion/core/ui/trackpad_zoom_recognizer.dart';
 
 /// Structured row emitted via [DiveProfileChart.onTooltipData] so callers
 /// can render the tooltip externally (e.g., below the chart).
@@ -476,7 +477,6 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       : PointerDeviceKind.mouse;
 
   // Cursor position at the start of a trackpad pan/zoom gesture.
-  Offset _trackpadAnchor = Offset.zero;
 
   // True between a double-tap-down and the finger lifting; lets a held-finger
   // drag pan instead of scrub.
@@ -1162,131 +1162,60 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   }) {
     return LayoutBuilder(
       builder: (context, constraints) {
+        // Trackpad two-finger scroll/pinch zoom, cursor-anchored. Driven by an
+        // arena-winning recognizer so it does not also scroll an enclosing page
+        // (the chart lives inside a SingleChildScrollView) and is not fought by
+        // fl_chart's own recognizers.
+        void zoomAt(Offset localPosition, double zoomDelta) {
+          if (zoomDelta == 0) return;
+          setState(() {
+            _activePointerKind = PointerDeviceKind.trackpad;
+            final box = constraints.biggest;
+            final insets = _plotInsets(constraints.maxWidth, units);
+            final focal = chartFocalFraction(
+              localPosition,
+              box,
+              left: insets.left,
+              right: insets.right,
+              top: insets.top,
+              bottom: insets.bottom,
+            );
+            _viewport = _viewport.zoomedAt(
+              focal.fx,
+              focal.fy,
+              math.pow(2, zoomDelta).toDouble(),
+            );
+          });
+        }
+
         return Semantics(
           label: context.l10n.diveLog_profile_semantics_chart,
-          child: GestureDetector(
-            onScaleStart: (details) {
-              _gestureStartViewport = _viewport;
-              _startFocalPoint = details.localFocalPoint;
+          child: RawGestureDetector(
+            gestures: {
+              TrackpadZoomGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                    TrackpadZoomGestureRecognizer
+                  >(
+                    () => TrackpadZoomGestureRecognizer(debugOwner: this),
+                    (recognizer) => recognizer.onZoom = zoomAt,
+                  ),
             },
-            onScaleUpdate: (details) {
-              // Single-pointer drags are handled by Listener.onPointerMove
-              // (mouse pan) and fl_chart's own recognizer (touch scrub); they
-              // never reach onScaleUpdate, which only ever fires for a pinch.
-              if (details.pointerCount < 2) return;
-
-              // Trackpad pinch is handled by the Listener's onPointerPanZoomUpdate
-              // (reliable cursor anchor); touch focal points are correct, so touch
-              // pinch is handled here.
-              if (_activePointerKind != PointerDeviceKind.touch) return;
-
-              setState(() {
-                final box = constraints.biggest;
-                final insets = _plotInsets(constraints.maxWidth, units);
-                final plotW = (box.width - insets.left - insets.right).clamp(
-                  1.0,
-                  double.infinity,
-                );
-                final plotH = (box.height - insets.top - insets.bottom).clamp(
-                  1.0,
-                  double.infinity,
-                );
-                final focal = chartFocalFraction(
-                  _startFocalPoint,
-                  box,
-                  left: insets.left,
-                  right: insets.right,
-                  top: insets.top,
-                  bottom: insets.bottom,
-                );
-                // scale is cumulative from gesture start -> apply to snapshot.
-                var vp = _gestureStartViewport.zoomedAt(
-                  focal.fx,
-                  focal.fy,
-                  details.scale,
-                );
-                final panPx = details.localFocalPoint - _startFocalPoint;
-                vp = vp.pannedBy(
-                  -panPx.dx / plotW / vp.zoom,
-                  -panPx.dy / plotH / vp.zoom,
-                );
-                _viewport = vp;
-              });
-            },
-            onDoubleTapDown: (details) {
-              _lastTapDownLocal = details.localPosition;
-              _doubleTapHold = true;
-            },
-            onDoubleTap: () {
-              _doubleTapHold = false;
-              setState(() {
-                if (_viewport.isZoomed) {
-                  _viewport = ProfileChartViewport.reset;
-                } else {
-                  final box = constraints.biggest;
-                  final insets = _plotInsets(constraints.maxWidth, units);
-                  final focal = chartFocalFraction(
-                    _lastTapDownLocal,
-                    box,
-                    left: insets.left,
-                    right: insets.right,
-                    top: insets.top,
-                    bottom: insets.bottom,
-                  );
-                  _viewport = _viewport.zoomedAt(focal.fx, focal.fy, 2.0);
-                }
-              });
-            },
-            child: Listener(
-              onPointerDown: (event) {
-                _activePointerCount++;
-                _activePointerKind = event.kind;
-                _lastPointerLocal = event.localPosition;
-              },
-              onPointerMove: (event) {
-                final prev = _lastPointerLocal;
-                _lastPointerLocal = event.localPosition;
-                if (prev == null) return;
-                final intent = chartDragIntent(
-                  kind: _activePointerKind,
-                  pointerCount: _activePointerCount,
-                  doubleTapHold: _doubleTapHold,
-                );
-                if (intent != ChartDragIntent.pan) return;
-                setState(() {
-                  final box = constraints.biggest;
-                  final insets = _plotInsets(constraints.maxWidth, units);
-                  final plotW = (box.width - insets.left - insets.right).clamp(
-                    1.0,
-                    double.infinity,
-                  );
-                  final plotH = (box.height - insets.top - insets.bottom).clamp(
-                    1.0,
-                    double.infinity,
-                  );
-                  final d = event.localPosition - prev;
-                  _viewport = _viewport.pannedBy(
-                    -d.dx / plotW / _viewport.zoom,
-                    -d.dy / plotH / _viewport.zoom,
-                  );
-                });
-              },
-              onPointerUp: (event) {
-                if (_activePointerCount > 0) _activePointerCount--;
-                _lastPointerLocal = null;
-                _doubleTapHold = false;
-              },
-              onPointerCancel: (event) {
-                if (_activePointerCount > 0) _activePointerCount--;
-                _lastPointerLocal = null;
-                _doubleTapHold = false;
-              },
-              onPointerPanZoomStart: (event) {
-                _activePointerKind = PointerDeviceKind.trackpad;
+            child: GestureDetector(
+              onScaleStart: (details) {
                 _gestureStartViewport = _viewport;
-                _trackpadAnchor = event.localPosition;
+                _startFocalPoint = details.localFocalPoint;
               },
-              onPointerPanZoomUpdate: (event) {
+              onScaleUpdate: (details) {
+                // Single-pointer drags are handled by Listener.onPointerMove
+                // (mouse pan) and fl_chart's own recognizer (touch scrub); they
+                // never reach onScaleUpdate, which only ever fires for a pinch.
+                if (details.pointerCount < 2) return;
+
+                // Trackpad pinch/scroll is handled by the
+                // TrackpadZoomGestureRecognizer (reliable cursor anchor); touch
+                // focal points are correct, so touch pinch is handled here.
+                if (_activePointerKind != PointerDeviceKind.touch) return;
+
                 setState(() {
                   final box = constraints.biggest;
                   final insets = _plotInsets(constraints.maxWidth, units);
@@ -1299,77 +1228,143 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     double.infinity,
                   );
                   final focal = chartFocalFraction(
-                    _trackpadAnchor,
+                    _startFocalPoint,
                     box,
                     left: insets.left,
                     right: insets.right,
                     top: insets.top,
                     bottom: insets.bottom,
                   );
-                  // scale and pan are cumulative from the gesture start.
+                  // scale is cumulative from gesture start -> apply to snapshot.
                   var vp = _gestureStartViewport.zoomedAt(
                     focal.fx,
                     focal.fy,
-                    event.scale,
+                    details.scale,
                   );
-                  // Use the GLOBAL pan delta (event.pan), NOT event.localPan:
-                  // on macOS the trackpad PointerPanZoom localPan is contaminated
-                  // by the widget's global->local translation (the translation is
-                  // wrongly applied to the pan vector), making it a huge constant
-                  // (~ -(widget global origin)) that pins the view to a corner.
-                  // The chart has no rotation/scale, so the global pan delta IS
-                  // the correct local delta.
+                  final panPx = details.localFocalPoint - _startFocalPoint;
                   vp = vp.pannedBy(
-                    -event.pan.dx / plotW / vp.zoom,
-                    -event.pan.dy / plotH / vp.zoom,
+                    -panPx.dx / plotW / vp.zoom,
+                    -panPx.dy / plotH / vp.zoom,
                   );
                   _viewport = vp;
                 });
               },
-              onPointerSignal: (event) {
-                if (event is PointerScrollEvent) {
-                  setState(() {
+              onDoubleTapDown: (details) {
+                _lastTapDownLocal = details.localPosition;
+                _doubleTapHold = true;
+              },
+              onDoubleTap: () {
+                _doubleTapHold = false;
+                setState(() {
+                  if (_viewport.isZoomed) {
+                    _viewport = ProfileChartViewport.reset;
+                  } else {
                     final box = constraints.biggest;
                     final insets = _plotInsets(constraints.maxWidth, units);
                     final focal = chartFocalFraction(
-                      event.localPosition,
+                      _lastTapDownLocal,
                       box,
                       left: insets.left,
                       right: insets.right,
                       top: insets.top,
                       bottom: insets.bottom,
                     );
-                    final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
-                    _viewport = _viewport.zoomedAt(focal.fx, focal.fy, factor);
+                    _viewport = _viewport.zoomedAt(focal.fx, focal.fy, 2.0);
+                  }
+                });
+              },
+              child: Listener(
+                onPointerDown: (event) {
+                  _activePointerCount++;
+                  _activePointerKind = event.kind;
+                  _lastPointerLocal = event.localPosition;
+                },
+                onPointerMove: (event) {
+                  final prev = _lastPointerLocal;
+                  _lastPointerLocal = event.localPosition;
+                  if (prev == null) return;
+                  final intent = chartDragIntent(
+                    kind: _activePointerKind,
+                    pointerCount: _activePointerCount,
+                    doubleTapHold: _doubleTapHold,
+                  );
+                  if (intent != ChartDragIntent.pan) return;
+                  setState(() {
+                    final box = constraints.biggest;
+                    final insets = _plotInsets(constraints.maxWidth, units);
+                    final plotW = (box.width - insets.left - insets.right)
+                        .clamp(1.0, double.infinity);
+                    final plotH = (box.height - insets.top - insets.bottom)
+                        .clamp(1.0, double.infinity);
+                    final d = event.localPosition - prev;
+                    _viewport = _viewport.pannedBy(
+                      -d.dx / plotW / _viewport.zoom,
+                      -d.dy / plotH / _viewport.zoom,
+                    );
                   });
-                }
-              },
-              onPointerHover: (event) {
-                _activePointerKind = PointerDeviceKind.mouse;
-                final idx = _hoverIndex(
-                  event.localPosition,
-                  constraints.biggest,
-                  _plotInsets(constraints.maxWidth, units),
-                );
-                if (idx != _lastHoverIndex) {
-                  _lastHoverIndex = idx;
-                  widget.onPointSelected?.call(idx);
-                }
-              },
-              child: MouseRegion(
-                onExit: (_) {
-                  if (_lastHoverIndex != null) {
-                    _lastHoverIndex = null;
-                    widget.onPointSelected?.call(null);
+                },
+                onPointerUp: (event) {
+                  if (_activePointerCount > 0) _activePointerCount--;
+                  _lastPointerLocal = null;
+                  _doubleTapHold = false;
+                },
+                onPointerCancel: (event) {
+                  if (_activePointerCount > 0) _activePointerCount--;
+                  _lastPointerLocal = null;
+                  _doubleTapHold = false;
+                },
+                // Trackpad two-finger scroll/pinch is handled by the
+                // TrackpadZoomGestureRecognizer above (it wins the gesture arena so
+                // it cannot also scroll the enclosing page).
+                onPointerSignal: (event) {
+                  if (event is PointerScrollEvent) {
+                    setState(() {
+                      final box = constraints.biggest;
+                      final insets = _plotInsets(constraints.maxWidth, units);
+                      final focal = chartFocalFraction(
+                        event.localPosition,
+                        box,
+                        left: insets.left,
+                        right: insets.right,
+                        top: insets.top,
+                        bottom: insets.bottom,
+                      );
+                      final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
+                      _viewport = _viewport.zoomedAt(
+                        focal.fx,
+                        focal.fy,
+                        factor,
+                      );
+                    });
                   }
                 },
-                child: _buildChart(
-                  context,
-                  units,
-                  availableWidth: constraints.maxWidth,
-                  hasTemperatureData: hasTemperatureData,
-                  hasPressureData: hasPressureData,
-                  hasHeartRateData: hasHeartRateData,
+                onPointerHover: (event) {
+                  _activePointerKind = PointerDeviceKind.mouse;
+                  final idx = _hoverIndex(
+                    event.localPosition,
+                    constraints.biggest,
+                    _plotInsets(constraints.maxWidth, units),
+                  );
+                  if (idx != _lastHoverIndex) {
+                    _lastHoverIndex = idx;
+                    widget.onPointSelected?.call(idx);
+                  }
+                },
+                child: MouseRegion(
+                  onExit: (_) {
+                    if (_lastHoverIndex != null) {
+                      _lastHoverIndex = null;
+                      widget.onPointSelected?.call(null);
+                    }
+                  },
+                  child: _buildChart(
+                    context,
+                    units,
+                    availableWidth: constraints.maxWidth,
+                    hasTemperatureData: hasTemperatureData,
+                    hasPressureData: hasPressureData,
+                    hasHeartRateData: hasHeartRateData,
+                  ),
                 ),
               ),
             ),

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/dive_sites/presentation/providers/site_provi
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/site_marine_life_section.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_section.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -115,7 +116,7 @@ class _SiteDetailPageState extends ConsumerState<SiteDetailPage> {
   }
 }
 
-class _SiteDetailContent extends ConsumerWidget {
+class _SiteDetailContent extends ConsumerStatefulWidget {
   final DiveSite site;
   final String siteId;
   final bool embedded;
@@ -129,7 +130,18 @@ class _SiteDetailContent extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_SiteDetailContent> createState() => _SiteDetailContentState();
+}
+
+class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
+  final MapController _previewController = MapController();
+  final MapController _fullController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final site = widget.site;
+    final siteId = widget.siteId;
+    final embedded = widget.embedded;
     final body = SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Column(
@@ -284,7 +296,7 @@ class _SiteDetailContent extends ConsumerWidget {
             onPressed: () {
               final state = GoRouterState.of(context);
               final currentPath = state.uri.path;
-              context.go('$currentPath?selected=$siteId&mode=edit');
+              context.go('$currentPath?selected=${widget.siteId}&mode=edit');
             },
           ),
           PopupMenuButton<String>(
@@ -351,13 +363,15 @@ class _SiteDetailContent extends ConsumerWidget {
       );
 
       if (confirmed == true) {
-        await ref.read(siteListNotifierProvider.notifier).deleteSite(siteId);
+        await ref
+            .read(siteListNotifierProvider.notifier)
+            .deleteSite(widget.siteId);
         ref.invalidate(sitesWithCountsProvider);
         ref.invalidate(sitesProvider);
 
         if (context.mounted) {
-          if (embedded) {
-            onDeleted?.call();
+          if (widget.embedded) {
+            widget.onDeleted?.call();
           } else {
             context.go('/sites');
           }
@@ -384,10 +398,114 @@ class _SiteDetailContent extends ConsumerWidget {
         height: 200,
         child: Stack(
           children: [
-            FlutterMap(
-              key: ValueKey(
-                '${site.location!.latitude}_${site.location!.longitude}',
+            TrackpadZoomMap(
+              controller: _previewController,
+              child: FlutterMap(
+                mapController: _previewController,
+                key: ValueKey(
+                  '${site.location!.latitude}_${site.location!.longitude}',
+                ),
+                options: MapOptions(
+                  initialCenter: siteLocation,
+                  initialZoom: 14.0,
+                  minZoom: 2.0,
+                  maxZoom: 18.0,
+                  interactionOptions: const InteractionOptions(
+                    flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+                  ),
+                ),
+                children: [
+                  TileLayer(
+                    urlTemplate: ref.watch(mapTileUrlProvider),
+                    userAgentPackageName: 'app.submersion',
+                    maxZoom: ref.watch(mapTileMaxZoomProvider),
+                    tileProvider: TileCacheService.instance.isInitialized
+                        ? TileCacheService.instance.getTileProvider()
+                        : null,
+                  ),
+                  MarkerLayer(
+                    markers: [
+                      Marker(
+                        point: siteLocation,
+                        width: 50,
+                        height: 50,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: colorScheme.onPrimary,
+                              width: 2,
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.3),
+                                blurRadius: 8,
+                                offset: const Offset(0, 2),
+                              ),
+                            ],
+                          ),
+                          child: Center(
+                            child: Icon(
+                              Icons.scuba_diving,
+                              size: 24,
+                              color: colorScheme.onPrimary,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const MapAttribution(),
+                ],
               ),
+            ),
+            Positioned(
+              right: 8,
+              top: 8,
+              child: Material(
+                color: colorScheme.surface.withValues(alpha: 0.9),
+                borderRadius: BorderRadius.circular(4),
+                child: Semantics(
+                  button: true,
+                  label:
+                      context.l10n.diveSites_detail_semantics_viewFullscreenMap,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(4),
+                    onTap: () => _showFullscreenMap(context, ref, site),
+                    child: Padding(
+                      padding: const EdgeInsets.all(6),
+                      child: Icon(
+                        Icons.fullscreen,
+                        size: 20,
+                        color: colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showFullscreenMap(BuildContext context, WidgetRef ref, DiveSite site) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final siteLocation = LatLng(
+      site.location!.latitude,
+      site.location!.longitude,
+    );
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => Scaffold(
+          appBar: AppBar(title: Text(site.name)),
+          body: TrackpadZoomMap(
+            controller: _fullController,
+            child: FlutterMap(
+              mapController: _fullController,
               options: MapOptions(
                 initialCenter: siteLocation,
                 initialZoom: 14.0,
@@ -442,102 +560,6 @@ class _SiteDetailContent extends ConsumerWidget {
                 const MapAttribution(),
               ],
             ),
-            Positioned(
-              right: 8,
-              top: 8,
-              child: Material(
-                color: colorScheme.surface.withValues(alpha: 0.9),
-                borderRadius: BorderRadius.circular(4),
-                child: Semantics(
-                  button: true,
-                  label:
-                      context.l10n.diveSites_detail_semantics_viewFullscreenMap,
-                  child: InkWell(
-                    borderRadius: BorderRadius.circular(4),
-                    onTap: () => _showFullscreenMap(context, ref, site),
-                    child: Padding(
-                      padding: const EdgeInsets.all(6),
-                      child: Icon(
-                        Icons.fullscreen,
-                        size: 20,
-                        color: colorScheme.primary,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showFullscreenMap(BuildContext context, WidgetRef ref, DiveSite site) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final siteLocation = LatLng(
-      site.location!.latitude,
-      site.location!.longitude,
-    );
-
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => Scaffold(
-          appBar: AppBar(title: Text(site.name)),
-          body: FlutterMap(
-            options: MapOptions(
-              initialCenter: siteLocation,
-              initialZoom: 14.0,
-              minZoom: 2.0,
-              maxZoom: 18.0,
-              interactionOptions: const InteractionOptions(
-                flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
-              ),
-            ),
-            children: [
-              TileLayer(
-                urlTemplate: ref.watch(mapTileUrlProvider),
-                userAgentPackageName: 'app.submersion',
-                maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
-                    : null,
-              ),
-              MarkerLayer(
-                markers: [
-                  Marker(
-                    point: siteLocation,
-                    width: 50,
-                    height: 50,
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: colorScheme.primary,
-                        shape: BoxShape.circle,
-                        border: Border.all(
-                          color: colorScheme.onPrimary,
-                          width: 2,
-                        ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.3),
-                            blurRadius: 8,
-                            offset: const Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                      child: Center(
-                        child: Icon(
-                          Icons.scuba_diving,
-                          size: 24,
-                          color: colorScheme.onPrimary,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const MapAttribution(),
-            ],
           ),
         ),
       ),

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
@@ -218,93 +219,96 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
 
     return Stack(
       children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            minZoom: 2.0,
-            maxZoom: 18.0,
-            onTap: (_, _) {
-              ref.read(mapListSelectionProvider('sites').notifier).deselect();
-            },
-            cameraConstraint: CameraConstraint.contain(
-              bounds: LatLngBounds(
-                const LatLng(-90, -180),
-                const LatLng(90, 180),
+        TrackpadZoomMap(
+          controller: _mapController,
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              minZoom: 2.0,
+              maxZoom: 18.0,
+              onTap: (_, _) {
+                ref.read(mapListSelectionProvider('sites').notifier).deselect();
+              },
+              cameraConstraint: CameraConstraint.contain(
+                bounds: LatLngBounds(
+                  const LatLng(-90, -180),
+                  const LatLng(90, 180),
+                ),
               ),
             ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: ref.watch(mapTileUrlProvider),
-              userAgentPackageName: 'app.submersion',
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
-                  : null,
-            ),
-            // Markers layer - always shown
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 80,
-                size: const Size(50, 50),
-                markers: sitesWithLocation.map((siteWithCount) {
-                  final site = siteWithCount.site;
-                  final diveCount = siteWithCount.diveCount;
-                  final isSelected = selectionState.selectedId == site.id;
-                  return Marker(
-                    point: LatLng(
-                      site.location!.latitude,
-                      site.location!.longitude,
-                    ),
-                    width: isSelected ? 50 : 40,
-                    height: isSelected ? 50 : 40,
-                    child: Semantics(
-                      button: true,
-                      label: context.l10n
-                          .diveSites_map_semantics_diveSiteMarker(site.name),
-                      child: GestureDetector(
-                        onTap: () => _onMarkerTapped(site),
-                        child: _buildMarker(
-                          context,
-                          site,
-                          diveCount,
-                          isSelected,
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              // Markers layer - always shown
+              MarkerClusterLayerWidget(
+                options: MarkerClusterLayerOptions(
+                  maxClusterRadius: 80,
+                  size: const Size(50, 50),
+                  markers: sitesWithLocation.map((siteWithCount) {
+                    final site = siteWithCount.site;
+                    final diveCount = siteWithCount.diveCount;
+                    final isSelected = selectionState.selectedId == site.id;
+                    return Marker(
+                      point: LatLng(
+                        site.location!.latitude,
+                        site.location!.longitude,
+                      ),
+                      width: isSelected ? 50 : 40,
+                      height: isSelected ? 50 : 40,
+                      child: Semantics(
+                        button: true,
+                        label: context.l10n
+                            .diveSites_map_semantics_diveSiteMarker(site.name),
+                        child: GestureDetector(
+                          onTap: () => _onMarkerTapped(site),
+                          child: _buildMarker(
+                            context,
+                            site,
+                            diveCount,
+                            isSelected,
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                }).toList(),
-                builder: (context, markers) {
-                  return _buildClusterMarker(context, markers.length);
-                },
-                zoomToBoundsOnClick: false,
-                onClusterTap: (node) {
-                  // Animate to cluster bounds with generous padding
-                  _animateToCluster(node.bounds);
-                },
+                    );
+                  }).toList(),
+                  builder: (context, markers) {
+                    return _buildClusterMarker(context, markers.length);
+                  },
+                  zoomToBoundsOnClick: false,
+                  onClusterTap: (node) {
+                    // Animate to cluster bounds with generous padding
+                    _animateToCluster(node.bounds);
+                  },
+                ),
               ),
-            ),
-            // Heat map layer - rendered on top of markers when visible
-            if (settings.isVisible)
-              Consumer(
-                builder: (context, ref, child) {
-                  final heatMapAsync = ref.watch(siteCoverageHeatMapProvider);
+              // Heat map layer - rendered on top of markers when visible
+              if (settings.isVisible)
+                Consumer(
+                  builder: (context, ref, child) {
+                    final heatMapAsync = ref.watch(siteCoverageHeatMapProvider);
 
-                  return heatMapAsync.when(
-                    data: (points) => HeatMapLayer(
-                      points: points,
-                      radius: settings.radius,
-                      opacity: settings.opacity,
-                    ),
-                    loading: () => const SizedBox.shrink(),
-                    error: (_, _) => const SizedBox.shrink(),
-                  );
-                },
-              ),
-            const MapAttribution(),
-          ],
+                    return heatMapAsync.when(
+                      data: (points) => HeatMapLayer(
+                        points: points,
+                        radius: settings.radius,
+                        opacity: settings.opacity,
+                      ),
+                      loading: () => const SizedBox.shrink(),
+                      error: (_, _) => const SizedBox.shrink(),
+                    );
+                  },
+                ),
+              const MapAttribution(),
+            ],
+          ),
         ),
 
         // Empty state overlay

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -8,6 +8,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Result from the location picker
 class PickedLocation {
@@ -156,63 +157,66 @@ class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
         label: context.l10n.diveSites_locationPicker_semantics_map,
         child: Stack(
           children: [
-            FlutterMap(
-              mapController: _mapController,
-              options: MapOptions(
-                initialCenter: initialCenter,
-                initialZoom: initialZoom,
-                minZoom: 2.0,
-                maxZoom: ref.watch(mapTileMaxZoomProvider),
-                onTap: _onMapTap,
-                interactionOptions: const InteractionOptions(
-                  flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
-                ),
-              ),
-              children: [
-                TileLayer(
-                  urlTemplate: ref.watch(mapTileUrlProvider),
-                  userAgentPackageName: 'app.submersion',
+            TrackpadZoomMap(
+              controller: _mapController,
+              child: FlutterMap(
+                mapController: _mapController,
+                options: MapOptions(
+                  initialCenter: initialCenter,
+                  initialZoom: initialZoom,
+                  minZoom: 2.0,
                   maxZoom: ref.watch(mapTileMaxZoomProvider),
-                  tileProvider: TileCacheService.instance.isInitialized
-                      ? TileCacheService.instance.getTileProvider()
-                      : null,
+                  onTap: _onMapTap,
+                  interactionOptions: const InteractionOptions(
+                    flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+                  ),
                 ),
-                if (_selectedLocation != null)
-                  MarkerLayer(
-                    markers: [
-                      Marker(
-                        point: _selectedLocation!,
-                        width: 50,
-                        height: 50,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: colorScheme.primary,
-                            shape: BoxShape.circle,
-                            border: Border.all(
-                              color: colorScheme.onPrimary,
-                              width: 3,
-                            ),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.black.withValues(alpha: 0.3),
-                                blurRadius: 8,
-                                offset: const Offset(0, 2),
+                children: [
+                  TileLayer(
+                    urlTemplate: ref.watch(mapTileUrlProvider),
+                    userAgentPackageName: 'app.submersion',
+                    maxZoom: ref.watch(mapTileMaxZoomProvider),
+                    tileProvider: TileCacheService.instance.isInitialized
+                        ? TileCacheService.instance.getTileProvider()
+                        : null,
+                  ),
+                  if (_selectedLocation != null)
+                    MarkerLayer(
+                      markers: [
+                        Marker(
+                          point: _selectedLocation!,
+                          width: 50,
+                          height: 50,
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: colorScheme.primary,
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: colorScheme.onPrimary,
+                                width: 3,
                               ),
-                            ],
-                          ),
-                          child: Center(
-                            child: Icon(
-                              Icons.location_on,
-                              size: 28,
-                              color: colorScheme.onPrimary,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.3),
+                                  blurRadius: 8,
+                                  offset: const Offset(0, 2),
+                                ),
+                              ],
+                            ),
+                            child: Center(
+                              child: Icon(
+                                Icons.location_on,
+                                size: 28,
+                                color: colorScheme.onPrimary,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                const MapAttribution(),
-              ],
+                      ],
+                    ),
+                  const MapAttribution(),
+                ],
+              ),
             ),
 
             // Instructions overlay

--- a/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Map for the Match-Sites review: shows the focused dive's GPS point plus its
 /// candidate sites. Tapping a candidate marker selects it.
@@ -52,56 +53,63 @@ class _MatchSitesMapState extends ConsumerState<MatchSitesMap> {
           )
         : null;
 
-    return FlutterMap(
-      mapController: _controller,
-      options: MapOptions(
-        initialCenter: pts.first,
-        initialZoom: 13,
-        initialCameraFit: fit,
-        interactionOptions: const InteractionOptions(
-          flags: InteractiveFlag.all,
+    return TrackpadZoomMap(
+      controller: _controller,
+      child: FlutterMap(
+        mapController: _controller,
+        options: MapOptions(
+          initialCenter: pts.first,
+          initialZoom: 13,
+          initialCameraFit: fit,
+          interactionOptions: const InteractionOptions(
+            flags: InteractiveFlag.all,
+          ),
         ),
-      ),
-      children: [
-        TileLayer(
-          urlTemplate: ref.watch(mapTileUrlProvider),
-          userAgentPackageName: 'app.submersion',
-          maxZoom: ref.watch(mapTileMaxZoomProvider),
-          tileProvider: TileCacheService.instance.isInitialized
-              ? TileCacheService.instance.getTileProvider()
-              : null,
-        ),
-        MarkerLayer(
-          markers: [
-            Marker(
-              point: LatLng(
-                widget.divePoint.latitude,
-                widget.divePoint.longitude,
-              ),
-              width: 38,
-              height: 38,
-              child: _pin(scheme.primary, Icons.my_location, scheme.onPrimary),
-            ),
-            for (final c in widget.candidates)
+        children: [
+          TileLayer(
+            urlTemplate: ref.watch(mapTileUrlProvider),
+            userAgentPackageName: 'app.submersion',
+            maxZoom: ref.watch(mapTileMaxZoomProvider),
+            tileProvider: TileCacheService.instance.isInitialized
+                ? TileCacheService.instance.getTileProvider()
+                : null,
+          ),
+          MarkerLayer(
+            markers: [
               Marker(
-                point: LatLng(c.location.latitude, c.location.longitude),
-                width: c.id == widget.selectedCandidateId ? 46 : 38,
-                height: c.id == widget.selectedCandidateId ? 46 : 38,
-                child: GestureDetector(
-                  onTap: () => widget.onSelectCandidate(c.id),
-                  child: _pin(
-                    c.id == widget.selectedCandidateId
-                        ? scheme.secondary
-                        : (c.isExisting ? Colors.teal : Colors.indigo),
-                    Icons.place,
-                    Colors.white,
-                  ),
+                point: LatLng(
+                  widget.divePoint.latitude,
+                  widget.divePoint.longitude,
+                ),
+                width: 38,
+                height: 38,
+                child: _pin(
+                  scheme.primary,
+                  Icons.my_location,
+                  scheme.onPrimary,
                 ),
               ),
-          ],
-        ),
-        const MapAttribution(),
-      ],
+              for (final c in widget.candidates)
+                Marker(
+                  point: LatLng(c.location.latitude, c.location.longitude),
+                  width: c.id == widget.selectedCandidateId ? 46 : 38,
+                  height: c.id == widget.selectedCandidateId ? 46 : 38,
+                  child: GestureDetector(
+                    onTap: () => widget.onSelectCandidate(c.id),
+                    child: _pin(
+                      c.id == widget.selectedCandidateId
+                          ? scheme.secondary
+                          : (c.isExisting ? Colors.teal : Colors.indigo),
+                      Icons.place,
+                      Colors.white,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const MapAttribution(),
+        ],
+      ),
     );
   }
 

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -10,6 +10,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/shared/widgets/entity_table/entity_table_view.dart';
@@ -1187,7 +1188,7 @@ class SiteSearchDelegate extends SearchDelegate<DiveSite?> {
 }
 
 /// List item widget for displaying a dive site summary
-class SiteListTile extends ConsumerWidget {
+class SiteListTile extends ConsumerStatefulWidget {
   final String name;
   final String? location;
   final double? minDepth;
@@ -1236,11 +1237,32 @@ class SiteListTile extends ConsumerWidget {
   bool get _hasLocation => latitude != null && longitude != null;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SiteListTile> createState() => _SiteListTileState();
+}
+
+class _SiteListTileState extends ConsumerState<SiteListTile> {
+  final MapController _mapController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final name = widget.name;
+    final location = widget.location;
+    final difficulty = widget.difficulty;
+    final diveCount = widget.diveCount;
+    final rating = widget.rating;
+    final onTap = widget.onTap;
+    final onLongPress = widget.onLongPress;
+    final isSelectionMode = widget.isSelectionMode;
+    final isSelected = widget.isSelected;
+    final isChecked = widget.isChecked;
+    final latitude = widget.latitude;
+    final longitude = widget.longitude;
+    final showSharedBadge = widget.showSharedBadge;
+
     final colorScheme = Theme.of(context).colorScheme;
     final showMapBackground = ref.watch(showMapBackgroundOnSiteCardsProvider);
     final shouldShowMap =
-        showMapBackground && _hasLocation && !isSelected && !isChecked;
+        showMapBackground && widget._hasLocation && !isSelected && !isChecked;
     final useLightText = shouldShowMap;
     final primaryTextColor = useLightText ? Colors.white : null;
     final secondaryTextColor = useLightText
@@ -1288,7 +1310,7 @@ class SiteListTile extends ConsumerWidget {
                   if (location != null) ...[
                     const SizedBox(height: 4),
                     Text(
-                      location!,
+                      location,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: secondaryTextColor,
                       ),
@@ -1312,9 +1334,9 @@ class SiteListTile extends ConsumerWidget {
                       color: Theme.of(context).colorScheme.primary,
                     ),
                   ),
-                if (_depthString != null)
+                if (widget._depthString != null)
                   Text(
-                    _depthString!,
+                    widget._depthString!,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: secondaryTextColor,
                       fontWeight: FontWeight.w500,
@@ -1322,7 +1344,7 @@ class SiteListTile extends ConsumerWidget {
                   ),
                 if (difficulty != null)
                   Text(
-                    difficulty!,
+                    difficulty,
                     style: Theme.of(
                       context,
                     ).textTheme.bodySmall?.copyWith(color: secondaryTextColor),
@@ -1340,7 +1362,7 @@ class SiteListTile extends ConsumerWidget {
                     children: [
                       const Icon(Icons.star, color: Colors.amber, size: 16),
                       Text(
-                        rating!.toStringAsFixed(1),
+                        rating.toStringAsFixed(1),
                         style: TextStyle(color: primaryTextColor),
                       ),
                     ],
@@ -1368,25 +1390,29 @@ class SiteListTile extends ConsumerWidget {
             child: Stack(
               children: [
                 Positioned.fill(
-                  child: FlutterMap(
-                    options: MapOptions(
-                      initialCenter: siteLocation,
-                      initialZoom: 13.0,
-                      interactionOptions: const InteractionOptions(
-                        flags: InteractiveFlag.none,
+                  child: TrackpadZoomMap(
+                    controller: _mapController,
+                    child: FlutterMap(
+                      mapController: _mapController,
+                      options: MapOptions(
+                        initialCenter: siteLocation,
+                        initialZoom: 13.0,
+                        interactionOptions: const InteractionOptions(
+                          flags: InteractiveFlag.none,
+                        ),
                       ),
+                      children: [
+                        TileLayer(
+                          urlTemplate: ref.watch(mapTileUrlProvider),
+                          userAgentPackageName: 'app.submersion',
+                          maxZoom: ref.watch(mapTileMaxZoomProvider),
+                          tileProvider: TileCacheService.instance.isInitialized
+                              ? TileCacheService.instance.getTileProvider()
+                              : null,
+                        ),
+                        const MapAttribution(),
+                      ],
                     ),
-                    children: [
-                      TileLayer(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                        userAgentPackageName: 'app.submersion',
-                        maxZoom: ref.watch(mapTileMaxZoomProvider),
-                        tileProvider: TileCacheService.instance.isInitialized
-                            ? TileCacheService.instance.getTileProvider()
-                            : null,
-                      ),
-                      const MapAttribution(),
-                    ],
                   ),
                 ),
                 Positioned.fill(

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 
 /// Map content widget for displaying dive sites on a map.
@@ -242,88 +243,91 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
 
     return Stack(
       children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            minZoom: 2.0,
-            maxZoom: 18.0,
-            onMapReady: () {
-              _mapReady = true;
-            },
-            onTap: (_, _) {
-              widget.onItemSelected(null);
-            },
-            cameraConstraint: CameraConstraint.contain(
-              bounds: LatLngBounds(
-                const LatLng(-90, -180),
-                const LatLng(90, 180),
+        TrackpadZoomMap(
+          controller: _mapController,
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              minZoom: 2.0,
+              maxZoom: 18.0,
+              onMapReady: () {
+                _mapReady = true;
+              },
+              onTap: (_, _) {
+                widget.onItemSelected(null);
+              },
+              cameraConstraint: CameraConstraint.contain(
+                bounds: LatLngBounds(
+                  const LatLng(-90, -180),
+                  const LatLng(90, 180),
+                ),
               ),
             ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: ref.watch(mapTileUrlProvider),
-              userAgentPackageName: 'app.submersion',
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
-                  : null,
-            ),
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 80,
-                size: const Size(50, 50),
-                markers: sitesWithLocation.map((siteWithCount) {
-                  final site = siteWithCount.site;
-                  final diveCount = siteWithCount.diveCount;
-                  final isSelected = widget.selectedId == site.id;
-                  return Marker(
-                    point: LatLng(
-                      site.location!.latitude,
-                      site.location!.longitude,
-                    ),
-                    width: isSelected ? 50 : 40,
-                    height: isSelected ? 50 : 40,
-                    child: Semantics(
-                      button: true,
-                      label: context.l10n
-                          .diveSites_map_semantics_diveSiteMarker(site.name),
-                      child: GestureDetector(
-                        onTap: () => _onMarkerTapped(site),
-                        child: _buildMarker(
-                          context,
-                          site,
-                          diveCount,
-                          isSelected,
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              MarkerClusterLayerWidget(
+                options: MarkerClusterLayerOptions(
+                  maxClusterRadius: 80,
+                  size: const Size(50, 50),
+                  markers: sitesWithLocation.map((siteWithCount) {
+                    final site = siteWithCount.site;
+                    final diveCount = siteWithCount.diveCount;
+                    final isSelected = widget.selectedId == site.id;
+                    return Marker(
+                      point: LatLng(
+                        site.location!.latitude,
+                        site.location!.longitude,
+                      ),
+                      width: isSelected ? 50 : 40,
+                      height: isSelected ? 50 : 40,
+                      child: Semantics(
+                        button: true,
+                        label: context.l10n
+                            .diveSites_map_semantics_diveSiteMarker(site.name),
+                        child: GestureDetector(
+                          onTap: () => _onMarkerTapped(site),
+                          child: _buildMarker(
+                            context,
+                            site,
+                            diveCount,
+                            isSelected,
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                }).toList(),
-                builder: (context, markers) {
-                  return _buildClusterMarker(context, markers.length);
-                },
-                zoomToBoundsOnClick: false,
-                onClusterTap: (node) {
-                  _animateToCluster(node.bounds);
-                },
-              ),
-            ),
-            // Heat map layer - rendered on top of markers when visible
-            if (heatMapSettings.isVisible)
-              heatMapAsync.when(
-                data: (points) => HeatMapLayer(
-                  points: points,
-                  radius: heatMapSettings.radius,
-                  opacity: heatMapSettings.opacity,
+                    );
+                  }).toList(),
+                  builder: (context, markers) {
+                    return _buildClusterMarker(context, markers.length);
+                  },
+                  zoomToBoundsOnClick: false,
+                  onClusterTap: (node) {
+                    _animateToCluster(node.bounds);
+                  },
                 ),
-                loading: () => const SizedBox.shrink(),
-                error: (_, _) => const SizedBox.shrink(),
               ),
-            const MapAttribution(),
-          ],
+              // Heat map layer - rendered on top of markers when visible
+              if (heatMapSettings.isVisible)
+                heatMapAsync.when(
+                  data: (points) => HeatMapLayer(
+                    points: points,
+                    radius: heatMapSettings.radius,
+                    opacity: heatMapSettings.opacity,
+                  ),
+                  loading: () => const SizedBox.shrink(),
+                  error: (_, _) => const SizedBox.shrink(),
+                ),
+              const MapAttribution(),
+            ],
+          ),
         ),
 
         // Empty state overlay

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -253,92 +254,95 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
 
     return Stack(
       children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: center,
-            initialZoom: zoom,
-            minZoom: 2.0,
-            maxZoom: 18.0,
-            onTap: (_, _) {
-              ref.read(mapListSelectionProvider('dives').notifier).deselect();
-            },
-            cameraConstraint: CameraConstraint.contain(
-              bounds: LatLngBounds(
-                const LatLng(-90, -180),
-                const LatLng(90, 180),
+        TrackpadZoomMap(
+          controller: _mapController,
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              minZoom: 2.0,
+              maxZoom: 18.0,
+              onTap: (_, _) {
+                ref.read(mapListSelectionProvider('dives').notifier).deselect();
+              },
+              cameraConstraint: CameraConstraint.contain(
+                bounds: LatLngBounds(
+                  const LatLng(-90, -180),
+                  const LatLng(90, 180),
+                ),
               ),
             ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: ref.watch(mapTileUrlProvider),
-              userAgentPackageName: 'app.submersion',
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
-                  : null,
-            ),
-            // Markers layer - shows sites with dives
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 80,
-                size: const Size(50, 50),
-                markers: sitesWithDives.map((siteWithCount) {
-                  final site = siteWithCount.site;
-                  final diveCount = siteWithCount.diveCount;
-                  final isSelected = selectedSiteId == site.id;
-                  return Marker(
-                    point: LatLng(
-                      site.location!.latitude,
-                      site.location!.longitude,
-                    ),
-                    width: isSelected ? 50 : 40,
-                    height: isSelected ? 50 : 40,
-                    child: Semantics(
-                      button: true,
-                      label: 'Dive site: ${site.name}',
-                      child: GestureDetector(
-                        onTap: () => _onMarkerTapped(site),
-                        child: _buildMarker(
-                          context,
-                          site,
-                          diveCount,
-                          isSelected,
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              // Markers layer - shows sites with dives
+              MarkerClusterLayerWidget(
+                options: MarkerClusterLayerOptions(
+                  maxClusterRadius: 80,
+                  size: const Size(50, 50),
+                  markers: sitesWithDives.map((siteWithCount) {
+                    final site = siteWithCount.site;
+                    final diveCount = siteWithCount.diveCount;
+                    final isSelected = selectedSiteId == site.id;
+                    return Marker(
+                      point: LatLng(
+                        site.location!.latitude,
+                        site.location!.longitude,
+                      ),
+                      width: isSelected ? 50 : 40,
+                      height: isSelected ? 50 : 40,
+                      child: Semantics(
+                        button: true,
+                        label: 'Dive site: ${site.name}',
+                        child: GestureDetector(
+                          onTap: () => _onMarkerTapped(site),
+                          child: _buildMarker(
+                            context,
+                            site,
+                            diveCount,
+                            isSelected,
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                }).toList(),
-                builder: (context, markers) {
-                  // Sum up dive counts for all markers in this cluster
-                  final totalDives = markers.fold<int>(
-                    0,
-                    (sum, marker) =>
-                        sum + (diveCountByLocation[marker.point] ?? 0),
-                  );
-                  return _buildClusterMarker(context, totalDives);
-                },
-                zoomToBoundsOnClick: false,
-                onClusterTap: (node) {
-                  // Animate to cluster bounds with generous padding
-                  _animateToCluster(node.bounds);
-                },
-              ),
-            ),
-            // Heat map layer - rendered on top of markers when visible
-            if (settings.isVisible)
-              heatMapAsync.when(
-                data: (points) => HeatMapLayer(
-                  points: points,
-                  radius: settings.radius,
-                  opacity: settings.opacity,
+                    );
+                  }).toList(),
+                  builder: (context, markers) {
+                    // Sum up dive counts for all markers in this cluster
+                    final totalDives = markers.fold<int>(
+                      0,
+                      (sum, marker) =>
+                          sum + (diveCountByLocation[marker.point] ?? 0),
+                    );
+                    return _buildClusterMarker(context, totalDives);
+                  },
+                  zoomToBoundsOnClick: false,
+                  onClusterTap: (node) {
+                    // Animate to cluster bounds with generous padding
+                    _animateToCluster(node.bounds);
+                  },
                 ),
-                loading: () => const SizedBox.shrink(),
-                error: (_, _) => const SizedBox.shrink(),
               ),
-            const MapAttribution(),
-          ],
+              // Heat map layer - rendered on top of markers when visible
+              if (settings.isVisible)
+                heatMapAsync.when(
+                  data: (points) => HeatMapLayer(
+                    points: points,
+                    radius: settings.radius,
+                    opacity: settings.opacity,
+                  ),
+                  loading: () => const SizedBox.shrink(),
+                  error: (_, _) => const SizedBox.shrink(),
+                ),
+              const MapAttribution(),
+            ],
+          ),
         ),
 
         // Loading indicator

--- a/lib/features/maps/presentation/pages/region_picker_page.dart
+++ b/lib/features/maps/presentation/pages/region_picker_page.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/maps/presentation/providers/map_tile_provide
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/region_download_dialog.dart';
 import 'package:submersion/features/maps/presentation/widgets/region_selector.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Page for selecting a rectangular region on a map and opening the
@@ -43,29 +44,32 @@ class _RegionPickerPageState extends ConsumerState<RegionPickerPage> {
       appBar: AppBar(title: Text(context.l10n.maps_offline_downloadNewRegion)),
       body: Stack(
         children: [
-          FlutterMap(
-            mapController: _mapController,
-            options: MapOptions(
-              initialCenter: const LatLng(20.0, 0.0),
-              initialZoom: 2.0,
-              minZoom: 2.0,
-              maxZoom: ref.watch(mapTileMaxZoomProvider),
-              interactionOptions: const InteractionOptions(
-                flags:
-                    InteractiveFlag.pinchZoom | InteractiveFlag.doubleTapZoom,
-              ),
-            ),
-            children: [
-              TileLayer(
-                urlTemplate: ref.watch(mapTileUrlProvider),
-                userAgentPackageName: 'app.submersion',
+          TrackpadZoomMap(
+            controller: _mapController,
+            child: FlutterMap(
+              mapController: _mapController,
+              options: MapOptions(
+                initialCenter: const LatLng(20.0, 0.0),
+                initialZoom: 2.0,
+                minZoom: 2.0,
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
-                    : null,
+                interactionOptions: const InteractionOptions(
+                  flags:
+                      InteractiveFlag.pinchZoom | InteractiveFlag.doubleTapZoom,
+                ),
               ),
-              const MapAttribution(),
-            ],
+              children: [
+                TileLayer(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                  userAgentPackageName: 'app.submersion',
+                  maxZoom: ref.watch(mapTileMaxZoomProvider),
+                  tileProvider: TileCacheService.instance.isInitialized
+                      ? TileCacheService.instance.getTileProvider()
+                      : null,
+                ),
+                const MapAttribution(),
+              ],
+            ),
           ),
           RegionSelector(
             mapController: _mapController,

--- a/lib/features/maps/presentation/widgets/trackpad_zoom_map.dart
+++ b/lib/features/maps/presentation/widgets/trackpad_zoom_map.dart
@@ -1,26 +1,18 @@
-import 'dart:math' as math;
-
-import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
-import 'package:submersion/core/ui/trackpad_zoom.dart';
+import 'package:submersion/core/ui/trackpad_zoom_recognizer.dart';
 
 /// Wraps a [FlutterMap] so a two-finger gesture on a trackpad zooms the map
 /// toward the cursor: vertical scroll and pinch both zoom.
 ///
-/// It installs a [GestureRecognizer] that *eagerly wins* the gesture arena for
-/// trackpad pan-zoom events. Winning the arena does two jobs at once:
-///
-///  1. flutter_map's own scale recognizer is rejected, so it never pins the
-///     camera to the gesture start (which would revert our zoom), and
-///  2. an enclosing scrollable (e.g. a details page) is also rejected, so a
-///     scroll over the map zooms the map instead of scrolling the page
-///     ("map captures the gesture when hovered").
-///
-/// Only trackpad pan-zoom is captured. Trackpad click-drag, mouse, and touch
-/// still flow to flutter_map untouched (touch pinch, one-finger pan), and the
-/// mouse wheel still zooms via flutter_map's own pointer-signal handling.
+/// It installs a [TrackpadZoomGestureRecognizer] that eagerly wins the gesture
+/// arena for trackpad pan-zoom. Winning rejects flutter_map's own scale
+/// recognizer (so it never pins the camera and reverts our zoom) and rejects any
+/// enclosing scrollable (so a scroll over an embedded map zooms the map instead
+/// of scrolling the page). Trackpad click-drag, mouse, and touch still flow to
+/// flutter_map untouched, and the mouse wheel still zooms via flutter_map's own
+/// pointer-signal handling.
 class TrackpadZoomMap extends StatelessWidget {
   const TrackpadZoomMap({
     super.key,
@@ -56,67 +48,13 @@ class TrackpadZoomMap extends StatelessWidget {
   Widget build(BuildContext context) {
     return RawGestureDetector(
       gestures: {
-        _TrackpadZoomGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<
-              _TrackpadZoomGestureRecognizer
-            >(
-              () => _TrackpadZoomGestureRecognizer(),
+        TrackpadZoomGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<TrackpadZoomGestureRecognizer>(
+              () => TrackpadZoomGestureRecognizer(debugOwner: this),
               (recognizer) => recognizer.onZoom = _applyZoom,
             ),
       },
       child: child,
     );
   }
-}
-
-/// Recognizes a trackpad two-finger gesture (pan-zoom) and reports a zoom-level
-/// delta combining vertical scroll and pinch, anchored at the pointer.
-///
-/// It claims only trackpad pan-zoom: [addAllowedPointer] is intentionally a
-/// no-op so ordinary pointers (including a trackpad click-drag) are left to
-/// other recognizers (flutter_map's pan). It accepts the gesture eagerly so it
-/// wins the arena against flutter_map and any enclosing scrollable.
-class _TrackpadZoomGestureRecognizer extends OneSequenceGestureRecognizer {
-  _TrackpadZoomGestureRecognizer()
-    : super(supportedDevices: const {PointerDeviceKind.trackpad});
-
-  /// Called with the pointer's local position and an additive zoom-level delta.
-  void Function(Offset localPosition, double zoomDelta)? onZoom;
-
-  double _lastScale = 1.0;
-
-  @override
-  void addAllowedPointer(PointerDownEvent event) {
-    // Do not claim ordinary pointers (e.g. trackpad click-drag) — those should
-    // pan via flutter_map.
-  }
-
-  @override
-  void addAllowedPointerPanZoom(PointerPanZoomStartEvent event) {
-    super.addAllowedPointerPanZoom(event);
-    _lastScale = 1.0;
-    startTrackingPointer(event.pointer, event.transform);
-    resolve(GestureDisposition.accepted);
-  }
-
-  @override
-  void handleEvent(PointerEvent event) {
-    if (event is PointerPanZoomUpdateEvent) {
-      // Scroll contribution (vertical pan), plus pinch contribution (the change
-      // in cumulative scale since the previous update, in zoom levels).
-      final scrollDelta = trackpadScrollZoomDelta(event.panDelta.dy);
-      final scaleRatio = _lastScale == 0 ? 1.0 : event.scale / _lastScale;
-      _lastScale = event.scale;
-      final pinchDelta = math.log(scaleRatio) / math.ln2;
-      onZoom?.call(event.localPosition, scrollDelta + pinchDelta);
-    } else if (event is PointerPanZoomEndEvent) {
-      stopTrackingPointer(event.pointer);
-    }
-  }
-
-  @override
-  void didStopTrackingLastPointer(int pointer) {}
-
-  @override
-  String get debugDescription => 'trackpadZoom';
 }

--- a/lib/features/maps/presentation/widgets/trackpad_zoom_map.dart
+++ b/lib/features/maps/presentation/widgets/trackpad_zoom_map.dart
@@ -1,102 +1,122 @@
+import 'dart:math' as math;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 import 'package:submersion/core/ui/trackpad_zoom.dart';
 
-/// Wraps a [FlutterMap] so a two-finger vertical scroll on a trackpad zooms the
-/// map toward the cursor, instead of panning.
+/// Wraps a [FlutterMap] so a two-finger gesture on a trackpad zooms the map
+/// toward the cursor: vertical scroll and pinch both zoom.
 ///
-/// flutter_map's `pinchMove` handling pins the camera to the gesture-start
-/// position on every frame of a trackpad two-finger gesture, which would revert
-/// any zoom we apply. So while a trackpad gesture is active this widget drops
-/// `pinchMove` from the interaction flags it hands to [builder], and restores it
-/// when the gesture ends. `pinchMove` also powers touch (tablet) pinch-zoom
-/// focal anchoring, so it is only ever dropped for the duration of a trackpad
-/// gesture and never for touch.
+/// It installs a [GestureRecognizer] that *eagerly wins* the gesture arena for
+/// trackpad pan-zoom events. Winning the arena does two jobs at once:
 ///
-/// Because the flags must reach the wrapped map, callers build the [FlutterMap]
-/// through [builder], threading the supplied `flags` into
-/// `MapOptions.interactionOptions`.
-class TrackpadZoomMap extends StatefulWidget {
+///  1. flutter_map's own scale recognizer is rejected, so it never pins the
+///     camera to the gesture start (which would revert our zoom), and
+///  2. an enclosing scrollable (e.g. a details page) is also rejected, so a
+///     scroll over the map zooms the map instead of scrolling the page
+///     ("map captures the gesture when hovered").
+///
+/// Only trackpad pan-zoom is captured. Trackpad click-drag, mouse, and touch
+/// still flow to flutter_map untouched (touch pinch, one-finger pan), and the
+/// mouse wheel still zooms via flutter_map's own pointer-signal handling.
+class TrackpadZoomMap extends StatelessWidget {
   const TrackpadZoomMap({
     super.key,
     required this.controller,
-    required this.builder,
-    this.baseFlags = InteractiveFlag.all,
+    required this.child,
     this.minZoom = 1.0,
     this.maxZoom = 22.0,
   });
 
   /// The same controller passed to the wrapped [FlutterMap]'s `mapController`.
   final MapController controller;
-
-  /// The interaction flags the map uses at rest (when no trackpad gesture is in
-  /// progress). Defaults to [InteractiveFlag.all].
-  final int baseFlags;
-
+  final Widget child;
   final double minZoom;
   final double maxZoom;
 
-  /// Builds the wrapped [FlutterMap] given the effective interaction flags to
-  /// pass to its `MapOptions.interactionOptions`.
-  final Widget Function(BuildContext context, int flags) builder;
-
-  @override
-  State<TrackpadZoomMap> createState() => _TrackpadZoomMapState();
-}
-
-class _TrackpadZoomMapState extends State<TrackpadZoomMap> {
-  bool _trackpadActive = false;
-
-  int get _effectiveFlags => _trackpadActive
-      ? widget.baseFlags & ~InteractiveFlag.pinchMove
-      : widget.baseFlags;
-
-  void _onStart(PointerPanZoomStartEvent event) {
-    if (event.kind == PointerDeviceKind.trackpad && !_trackpadActive) {
-      setState(() => _trackpadActive = true);
-    }
-  }
-
-  void _onUpdate(PointerPanZoomUpdateEvent event) {
-    if (event.kind != PointerDeviceKind.trackpad) return;
-    // Per-event vertical delta. Use the global panDelta (not localPanDelta):
-    // on macOS the trackpad localPan is contaminated by the widget's
-    // global->local translation (see dive profile chart, PR #372).
-    final delta = trackpadScrollZoomDelta(event.panDelta.dy);
-    if (delta == 0) return;
-
+  void _applyZoom(Offset localPosition, double zoomDelta) {
+    if (zoomDelta == 0) return;
     final MapCamera camera;
     try {
-      camera = widget.controller.camera;
+      camera = controller.camera;
     } catch (_) {
       // Controller not yet attached to a FlutterMap.
       return;
     }
-    final newZoom = (camera.zoom + delta).clamp(widget.minZoom, widget.maxZoom);
+    final newZoom = (camera.zoom + zoomDelta).clamp(minZoom, maxZoom);
     if (newZoom == camera.zoom) return;
     // focusedZoomCenter keeps the point under the cursor fixed; it already
     // accounts for map rotation.
-    widget.controller.move(
-      camera.focusedZoomCenter(event.localPosition, newZoom),
-      newZoom,
-    );
-  }
-
-  void _onEnd(PointerPanZoomEndEvent event) {
-    if (_trackpadActive) {
-      setState(() => _trackpadActive = false);
-    }
+    controller.move(camera.focusedZoomCenter(localPosition, newZoom), newZoom);
   }
 
   @override
   Widget build(BuildContext context) {
-    return Listener(
-      onPointerPanZoomStart: _onStart,
-      onPointerPanZoomUpdate: _onUpdate,
-      onPointerPanZoomEnd: _onEnd,
-      child: widget.builder(context, _effectiveFlags),
+    return RawGestureDetector(
+      gestures: {
+        _TrackpadZoomGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+              _TrackpadZoomGestureRecognizer
+            >(
+              () => _TrackpadZoomGestureRecognizer(),
+              (recognizer) => recognizer.onZoom = _applyZoom,
+            ),
+      },
+      child: child,
     );
   }
+}
+
+/// Recognizes a trackpad two-finger gesture (pan-zoom) and reports a zoom-level
+/// delta combining vertical scroll and pinch, anchored at the pointer.
+///
+/// It claims only trackpad pan-zoom: [addAllowedPointer] is intentionally a
+/// no-op so ordinary pointers (including a trackpad click-drag) are left to
+/// other recognizers (flutter_map's pan). It accepts the gesture eagerly so it
+/// wins the arena against flutter_map and any enclosing scrollable.
+class _TrackpadZoomGestureRecognizer extends OneSequenceGestureRecognizer {
+  _TrackpadZoomGestureRecognizer()
+    : super(supportedDevices: const {PointerDeviceKind.trackpad});
+
+  /// Called with the pointer's local position and an additive zoom-level delta.
+  void Function(Offset localPosition, double zoomDelta)? onZoom;
+
+  double _lastScale = 1.0;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    // Do not claim ordinary pointers (e.g. trackpad click-drag) — those should
+    // pan via flutter_map.
+  }
+
+  @override
+  void addAllowedPointerPanZoom(PointerPanZoomStartEvent event) {
+    super.addAllowedPointerPanZoom(event);
+    _lastScale = 1.0;
+    startTrackingPointer(event.pointer, event.transform);
+    resolve(GestureDisposition.accepted);
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (event is PointerPanZoomUpdateEvent) {
+      // Scroll contribution (vertical pan), plus pinch contribution (the change
+      // in cumulative scale since the previous update, in zoom levels).
+      final scrollDelta = trackpadScrollZoomDelta(event.panDelta.dy);
+      final scaleRatio = _lastScale == 0 ? 1.0 : event.scale / _lastScale;
+      _lastScale = event.scale;
+      final pinchDelta = math.log(scaleRatio) / math.ln2;
+      onZoom?.call(event.localPosition, scrollDelta + pinchDelta);
+    } else if (event is PointerPanZoomEndEvent) {
+      stopTrackingPointer(event.pointer);
+    }
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {}
+
+  @override
+  String get debugDescription => 'trackpadZoom';
 }

--- a/lib/features/maps/presentation/widgets/trackpad_zoom_map.dart
+++ b/lib/features/maps/presentation/widgets/trackpad_zoom_map.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+
+/// Wraps a [FlutterMap] so a two-finger vertical scroll on a trackpad zooms the
+/// map toward the cursor, instead of panning.
+///
+/// flutter_map's `pinchMove` handling pins the camera to the gesture-start
+/// position on every frame of a trackpad two-finger gesture, which would revert
+/// any zoom we apply. So while a trackpad gesture is active this widget drops
+/// `pinchMove` from the interaction flags it hands to [builder], and restores it
+/// when the gesture ends. `pinchMove` also powers touch (tablet) pinch-zoom
+/// focal anchoring, so it is only ever dropped for the duration of a trackpad
+/// gesture and never for touch.
+///
+/// Because the flags must reach the wrapped map, callers build the [FlutterMap]
+/// through [builder], threading the supplied `flags` into
+/// `MapOptions.interactionOptions`.
+class TrackpadZoomMap extends StatefulWidget {
+  const TrackpadZoomMap({
+    super.key,
+    required this.controller,
+    required this.builder,
+    this.baseFlags = InteractiveFlag.all,
+    this.minZoom = 1.0,
+    this.maxZoom = 22.0,
+  });
+
+  /// The same controller passed to the wrapped [FlutterMap]'s `mapController`.
+  final MapController controller;
+
+  /// The interaction flags the map uses at rest (when no trackpad gesture is in
+  /// progress). Defaults to [InteractiveFlag.all].
+  final int baseFlags;
+
+  final double minZoom;
+  final double maxZoom;
+
+  /// Builds the wrapped [FlutterMap] given the effective interaction flags to
+  /// pass to its `MapOptions.interactionOptions`.
+  final Widget Function(BuildContext context, int flags) builder;
+
+  @override
+  State<TrackpadZoomMap> createState() => _TrackpadZoomMapState();
+}
+
+class _TrackpadZoomMapState extends State<TrackpadZoomMap> {
+  bool _trackpadActive = false;
+
+  int get _effectiveFlags => _trackpadActive
+      ? widget.baseFlags & ~InteractiveFlag.pinchMove
+      : widget.baseFlags;
+
+  void _onStart(PointerPanZoomStartEvent event) {
+    if (event.kind == PointerDeviceKind.trackpad && !_trackpadActive) {
+      setState(() => _trackpadActive = true);
+    }
+  }
+
+  void _onUpdate(PointerPanZoomUpdateEvent event) {
+    if (event.kind != PointerDeviceKind.trackpad) return;
+    // Per-event vertical delta. Use the global panDelta (not localPanDelta):
+    // on macOS the trackpad localPan is contaminated by the widget's
+    // global->local translation (see dive profile chart, PR #372).
+    final delta = trackpadScrollZoomDelta(event.panDelta.dy);
+    if (delta == 0) return;
+
+    final MapCamera camera;
+    try {
+      camera = widget.controller.camera;
+    } catch (_) {
+      // Controller not yet attached to a FlutterMap.
+      return;
+    }
+    final newZoom = (camera.zoom + delta).clamp(widget.minZoom, widget.maxZoom);
+    if (newZoom == camera.zoom) return;
+    // focusedZoomCenter keeps the point under the cursor fixed; it already
+    // accounts for map rotation.
+    widget.controller.move(
+      camera.focusedZoomCenter(event.localPosition, newZoom),
+      newZoom,
+    );
+  }
+
+  void _onEnd(PointerPanZoomEndEvent event) {
+    if (_trackpadActive) {
+      setState(() => _trackpadActive = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerPanZoomStart: _onStart,
+      onPointerPanZoomUpdate: _onUpdate,
+      onPointerPanZoomEnd: _onEnd,
+      child: widget.builder(context, _effectiveFlags),
+    );
+  }
+}

--- a/lib/features/trips/presentation/widgets/trip_overview_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_overview_tab.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
@@ -35,13 +36,21 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// Displays the trip header, info, stats, notes, photos, and dives.
 /// For liveaboard trips, also includes the vessel section, voyage map,
 /// and enhanced statistics.
-class TripOverviewTab extends ConsumerWidget {
+class TripOverviewTab extends ConsumerStatefulWidget {
   final TripWithStats tripWithStats;
 
   const TripOverviewTab({super.key, required this.tripWithStats});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TripOverviewTab> createState() => _TripOverviewTabState();
+}
+
+class _TripOverviewTabState extends ConsumerState<TripOverviewTab> {
+  final MapController _mapController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final tripWithStats = widget.tripWithStats;
     final trip = tripWithStats.trip;
     final divesAsync = ref.watch(divesForTripProvider(trip.id));
     final settings = ref.watch(settingsProvider);
@@ -188,54 +197,58 @@ class TripOverviewTab extends ConsumerWidget {
         children: [
           // Map background
           Positioned.fill(
-            child: FlutterMap(
-              options: MapOptions(
-                initialCenter: center,
-                initialZoom: zoom,
-                interactionOptions: const InteractionOptions(
-                  flags: InteractiveFlag.none,
+            child: TrackpadZoomMap(
+              controller: _mapController,
+              child: FlutterMap(
+                mapController: _mapController,
+                options: MapOptions(
+                  initialCenter: center,
+                  initialZoom: zoom,
+                  interactionOptions: const InteractionOptions(
+                    flags: InteractiveFlag.none,
+                  ),
                 ),
+                children: [
+                  TileLayer(
+                    urlTemplate: ref.watch(mapTileUrlProvider),
+                    userAgentPackageName: 'app.submersion',
+                    maxZoom: ref.watch(mapTileMaxZoomProvider),
+                    tileProvider: TileCacheService.instance.isInitialized
+                        ? TileCacheService.instance.getTileProvider()
+                        : null,
+                  ),
+                  MarkerLayer(
+                    markers: sitesWithLocation.map((site) {
+                      return Marker(
+                        point: LatLng(
+                          site.location!.latitude,
+                          site.location!.longitude,
+                        ),
+                        width: 32,
+                        height: 32,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: colorScheme.onPrimary,
+                              width: 2,
+                            ),
+                          ),
+                          child: Center(
+                            child: Icon(
+                              Icons.scuba_diving,
+                              size: 16,
+                              color: colorScheme.onPrimary,
+                            ),
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                  const MapAttribution(),
+                ],
               ),
-              children: [
-                TileLayer(
-                  urlTemplate: ref.watch(mapTileUrlProvider),
-                  userAgentPackageName: 'app.submersion',
-                  maxZoom: ref.watch(mapTileMaxZoomProvider),
-                  tileProvider: TileCacheService.instance.isInitialized
-                      ? TileCacheService.instance.getTileProvider()
-                      : null,
-                ),
-                MarkerLayer(
-                  markers: sitesWithLocation.map((site) {
-                    return Marker(
-                      point: LatLng(
-                        site.location!.latitude,
-                        site.location!.longitude,
-                      ),
-                      width: 32,
-                      height: 32,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: colorScheme.primary,
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: colorScheme.onPrimary,
-                            width: 2,
-                          ),
-                        ),
-                        child: Center(
-                          child: Icon(
-                            Icons.scuba_diving,
-                            size: 16,
-                            color: colorScheme.onPrimary,
-                          ),
-                        ),
-                      ),
-                    );
-                  }).toList(),
-                ),
-                const MapAttribution(),
-              ],
             ),
           ),
           // Gradient overlay
@@ -305,6 +318,7 @@ class TripOverviewTab extends ConsumerWidget {
   }
 
   Widget _buildStatsSection(BuildContext context, UnitFormatter units) {
+    final tripWithStats = widget.tripWithStats;
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -408,7 +422,7 @@ class TripOverviewTab extends ConsumerWidget {
                                 ref
                                     .read(diveFilterProvider.notifier)
                                     .state = DiveFilterState(
-                                  tripId: tripWithStats.trip.id,
+                                  tripId: widget.tripWithStats.trip.id,
                                 );
                                 context.go('/dives');
                               },
@@ -575,7 +589,7 @@ class TripOverviewTab extends ConsumerWidget {
 
     try {
       // Get trip and dives
-      final trip = tripWithStats.trip;
+      final trip = widget.tripWithStats.trip;
       final dives = await ref.read(divesForTripProvider(tripId).future);
 
       if (dives.isEmpty) {
@@ -713,7 +727,7 @@ class TripOverviewTab extends ConsumerWidget {
   }
 
   Future<void> _scanForDives(BuildContext context, WidgetRef ref) async {
-    final trip = tripWithStats.trip;
+    final trip = widget.tripWithStats.trip;
     if (trip.diverId == null) return;
 
     // Show loading

--- a/lib/features/trips/presentation/widgets/trip_voyage_map.dart
+++ b/lib/features/trips/presentation/widgets/trip_voyage_map.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/domain/map_utils.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
 import 'package:submersion/features/trips/presentation/providers/liveaboard_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -20,13 +21,21 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// - Dive site markers (blue, from trip sites)
 /// - Disembark port marker (red, from liveaboard details)
 /// - Polyline connecting all points in chronological order
-class TripVoyageMap extends ConsumerWidget {
+class TripVoyageMap extends ConsumerStatefulWidget {
   final String tripId;
 
   const TripVoyageMap({super.key, required this.tripId});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TripVoyageMap> createState() => _TripVoyageMapState();
+}
+
+class _TripVoyageMapState extends ConsumerState<TripVoyageMap> {
+  final MapController _mapController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final tripId = widget.tripId;
     final detailsAsync = ref.watch(liveaboardDetailsProvider(tripId));
     final sitesAsync = ref.watch(tripSitesWithLocationsProvider(tripId));
 
@@ -57,35 +66,39 @@ class TripVoyageMap extends ConsumerWidget {
                 ),
                 SizedBox(
                   height: 250,
-                  child: FlutterMap(
-                    options: MapOptions(
-                      initialCenter: center,
-                      initialZoom: zoom,
+                  child: TrackpadZoomMap(
+                    controller: _mapController,
+                    child: FlutterMap(
+                      mapController: _mapController,
+                      options: MapOptions(
+                        initialCenter: center,
+                        initialZoom: zoom,
+                      ),
+                      children: [
+                        TileLayer(
+                          urlTemplate: ref.watch(mapTileUrlProvider),
+                          userAgentPackageName: 'app.submersion',
+                          maxZoom: ref.watch(mapTileMaxZoomProvider),
+                          tileProvider: TileCacheService.instance.isInitialized
+                              ? TileCacheService.instance.getTileProvider()
+                              : null,
+                        ),
+                        PolylineLayer(
+                          polylines: [
+                            Polyline(
+                              points: allPoints,
+                              strokeWidth: 3.0,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.primary.withValues(alpha: 0.7),
+                              pattern: const StrokePattern.dotted(),
+                            ),
+                          ],
+                        ),
+                        MarkerLayer(markers: markers),
+                        const MapAttribution(),
+                      ],
                     ),
-                    children: [
-                      TileLayer(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                        userAgentPackageName: 'app.submersion',
-                        maxZoom: ref.watch(mapTileMaxZoomProvider),
-                        tileProvider: TileCacheService.instance.isInitialized
-                            ? TileCacheService.instance.getTileProvider()
-                            : null,
-                      ),
-                      PolylineLayer(
-                        polylines: [
-                          Polyline(
-                            points: allPoints,
-                            strokeWidth: 3.0,
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.primary.withValues(alpha: 0.7),
-                            pattern: const StrokePattern.dotted(),
-                          ),
-                        ],
-                      ),
-                      MarkerLayer(markers: markers),
-                      const MapAttribution(),
-                    ],
                   ),
                 ),
               ],

--- a/test/core/ui/trackpad_zoom_test.dart
+++ b/test/core/ui/trackpad_zoom_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/ui/trackpad_zoom.dart';
+
+void main() {
+  group('trackpadScrollZoomDelta', () {
+    test('zero scroll yields zero delta', () {
+      expect(trackpadScrollZoomDelta(0), 0);
+    });
+
+    test('scroll up (negative dy) zooms in (positive delta)', () {
+      expect(trackpadScrollZoomDelta(-100), greaterThan(0));
+    });
+
+    test('scroll down (positive dy) zooms out (negative delta)', () {
+      expect(trackpadScrollZoomDelta(100), lessThan(0));
+    });
+
+    test('is symmetric for equal-and-opposite scrolls', () {
+      expect(trackpadScrollZoomDelta(-50), -trackpadScrollZoomDelta(50));
+    });
+
+    test('scales with sensitivity', () {
+      expect(
+        trackpadScrollZoomDelta(-100, sensitivity: 0.02),
+        2 * trackpadScrollZoomDelta(-100, sensitivity: 0.01),
+      );
+    });
+
+    test('default sensitivity maps a ~100px flick to ~1 zoom level', () {
+      expect(trackpadScrollZoomDelta(-100), closeTo(1.0, 0.0001));
+    });
+  });
+}

--- a/test/core/ui/trackpad_zoom_test.dart
+++ b/test/core/ui/trackpad_zoom_test.dart
@@ -7,12 +7,12 @@ void main() {
       expect(trackpadScrollZoomDelta(0), 0);
     });
 
-    test('scroll up (negative dy) zooms in (positive delta)', () {
-      expect(trackpadScrollZoomDelta(-100), greaterThan(0));
+    test('scroll up (negative dy) zooms out (negative delta)', () {
+      expect(trackpadScrollZoomDelta(-100), lessThan(0));
     });
 
-    test('scroll down (positive dy) zooms out (negative delta)', () {
-      expect(trackpadScrollZoomDelta(100), lessThan(0));
+    test('scroll down (positive dy) zooms in (positive delta)', () {
+      expect(trackpadScrollZoomDelta(100), greaterThan(0));
     });
 
     test('is symmetric for equal-and-opposite scrolls', () {
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('default sensitivity maps a ~100px flick to ~1 zoom level', () {
-      expect(trackpadScrollZoomDelta(-100), closeTo(1.0, 0.0001));
+      expect(trackpadScrollZoomDelta(100), closeTo(1.0, 0.0001));
     });
   });
 }

--- a/test/features/dive_centers/presentation/pages/dive_center_detail_page_test.dart
+++ b/test/features/dive_centers/presentation/pages/dive_center_detail_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -126,6 +127,93 @@ void main() {
 
       await tester.pumpAndSettle();
       expect(find.text('DIVE_CENTER_LIST_PAGE'), findsNothing);
+    });
+  });
+
+  group('DiveCenterDetailPage map section', () {
+    final locatedCenter = DiveCenter(
+      id: 'center-loc',
+      name: 'Reef Divers',
+      notes: '',
+      latitude: 12.34,
+      longitude: 56.78,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    );
+
+    testWidgets('renders map when center has coordinates', (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(600, 900);
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            diveCenterByIdProvider(
+              locatedCenter.id,
+            ).overrideWith((ref) async => locatedCenter),
+            diveCenterDiveCountProvider(
+              locatedCenter.id,
+            ).overrideWith((ref) async => 0),
+          ].cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveCenterDetailPage(centerId: locatedCenter.id),
+          ),
+        ),
+      );
+
+      // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.byType(FlutterMap), findsWidgets);
+    });
+
+    testWidgets('fullscreen button opens the full-screen map', (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(600, 900);
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            diveCenterByIdProvider(
+              locatedCenter.id,
+            ).overrideWith((ref) async => locatedCenter),
+            diveCenterDiveCountProvider(
+              locatedCenter.id,
+            ).overrideWith((ref) async => 0),
+          ].cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveCenterDetailPage(centerId: locatedCenter.id),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      await tester.tap(find.byIcon(Icons.fullscreen));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // The full-screen route adds its own FlutterMap (now two in the tree).
+      expect(find.byType(FlutterMap), findsWidgets);
     });
   });
 }

--- a/test/features/dive_centers/presentation/pages/dive_center_map_page_test.dart
+++ b/test/features/dive_centers/presentation/pages/dive_center_map_page_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
+import 'package:submersion/features/dive_centers/presentation/pages/dive_center_map_page.dart';
+import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+class _MockDCListNotifier extends StateNotifier<AsyncValue<List<DiveCenter>>>
+    implements DiveCenterListNotifier {
+  _MockDCListNotifier(List<DiveCenter> centers)
+    : super(AsyncValue.data(centers));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  testWidgets('renders the DiveCenterMapPage FlutterMap with a center', (
+    tester,
+  ) async {
+    // Phone-sized surface keeps MapListScaffold in mobile mode, which renders
+    // only the map pane (no list pane providers to mock).
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(600, 900);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final now = DateTime(2026, 1, 1);
+    final center = DiveCenter(
+      id: 'dc1',
+      name: 'Blue Water Dive',
+      latitude: 18.5,
+      longitude: -77.9,
+      createdAt: now,
+      updatedAt: now,
+    );
+    // A second center at the SAME location reliably clusters with the first,
+    // exercising the MarkerClusterLayer cluster builder.
+    final center2 = DiveCenter(
+      id: 'dc2',
+      name: 'Blue Water Annex',
+      latitude: 18.5,
+      longitude: -77.9,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+          currentDiverIdProvider.overrideWith(
+            (ref) => MockCurrentDiverIdNotifier(),
+          ),
+          diveCenterListNotifierProvider.overrideWith(
+            (ref) => _MockDCListNotifier([center, center2]),
+          ),
+          diveCenterDiveCountProvider.overrideWith((ref, centerId) => 0),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DiveCenterMapPage(),
+        ),
+      ),
+    );
+
+    // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+}

--- a/test/features/dive_centers/presentation/widgets/dive_center_map_content_test.dart
+++ b/test/features/dive_centers/presentation/widgets/dive_center_map_content_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
+import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/dive_centers/presentation/widgets/dive_center_map_content.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+final _now = DateTime.now();
+
+DiveCenter _makeCenter({
+  required String id,
+  required String name,
+  double? latitude,
+  double? longitude,
+}) {
+  return DiveCenter(
+    id: id,
+    name: name,
+    latitude: latitude,
+    longitude: longitude,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+Future<List<Override>> _buildOverrides({
+  required List<DiveCenter> centers,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+
+  return [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+    currentDiverIdProvider.overrideWith((ref) => MockCurrentDiverIdNotifier()),
+    diveCenterListNotifierProvider.overrideWith(
+      (ref) => _MockDCListNotifier(centers),
+    ),
+    diveCenterDiveCountProvider.overrideWith((ref, centerId) => 0),
+  ];
+}
+
+class _MockDCListNotifier extends StateNotifier<AsyncValue<List<DiveCenter>>>
+    implements DiveCenterListNotifier {
+  _MockDCListNotifier(List<DiveCenter> centers)
+    : super(AsyncValue.data(centers));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  testWidgets('renders FlutterMap for dive centers with coordinates', (
+    tester,
+  ) async {
+    final centers = [
+      _makeCenter(
+        id: 'dc1',
+        name: 'Blue Water Dive',
+        latitude: 18.5,
+        longitude: -77.9,
+      ),
+      _makeCenter(
+        id: 'dc2',
+        name: 'Red Sea Divers',
+        latitude: 27.9,
+        longitude: 34.3,
+      ),
+    ];
+
+    final overrides = await _buildOverrides(centers: centers);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides.cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveCenterMapContent(onItemSelected: (_) {})),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(DiveCenterMapContent), findsOneWidget);
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+
+  testWidgets('renders FlutterMap with a preselected center', (tester) async {
+    final centers = [
+      _makeCenter(
+        id: 'dc1',
+        name: 'Selected Center',
+        latitude: 10.0,
+        longitude: 20.0,
+      ),
+    ];
+
+    final overrides = await _buildOverrides(centers: centers);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides.cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveCenterMapContent(
+              selectedId: 'dc1',
+              onItemSelected: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+
+  testWidgets('renders a cluster marker for co-located centers', (
+    tester,
+  ) async {
+    // Two centers at the SAME location reliably cluster (distance 0 < radius),
+    // exercising the MarkerClusterLayer cluster builder.
+    final centers = [
+      _makeCenter(id: 'dc-a', name: 'A', latitude: 10.0, longitude: 20.0),
+      _makeCenter(id: 'dc-b', name: 'B', latitude: 10.0, longitude: 20.0),
+    ];
+
+    final overrides = await _buildOverrides(centers: centers);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides.cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveCenterMapContent(onItemSelected: (_) {})),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(FlutterMap), findsWidgets);
+
+    // Tapping empty map (a corner, away from the centered cluster) clears the
+    // selection via the map's onTap. No animation, so this is teardown-safe.
+    await tester.tapAt(
+      tester.getTopLeft(find.byType(FlutterMap)) + const Offset(5, 5),
+    );
+    // Flush flutter_map's double-tap disambiguation timer before teardown.
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_map_content_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_map_content_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_map_content.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
+import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+DiveSite _site({
+  String id = 'site-1',
+  String name = 'Blue Hole',
+  double lat = 12.34,
+  double lng = 98.76,
+}) {
+  return DiveSite(id: id, name: name, location: GeoPoint(lat, lng));
+}
+
+Dive _diveAtSite(DiveSite site, {String id = 'dive-1'}) {
+  return createTestDiveWithBottomTime(id: id).copyWith(site: site);
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required AsyncValue<List<Dive>> dives,
+  String? selectedId,
+  void Function(String?)? onItemSelected,
+}) async {
+  final base = await getBaseOverrides();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        ...base,
+        sortedFilteredDivesProvider.overrideWithValue(dives),
+        diveActivityHeatMapProvider.overrideWithValue(
+          const AsyncValue<List<HeatMapPoint>>.data(<HeatMapPoint>[]),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: DiveMapContent(
+            selectedId: selectedId,
+            onItemSelected: onItemSelected ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  testWidgets('renders the FlutterMap with a site marker for dives', (
+    tester,
+  ) async {
+    final site = _site();
+    await _pump(tester, dives: AsyncValue.data([_diveAtSite(site)]));
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    // The fit-all-sites control is part of the rendered map overlay.
+    expect(find.byIcon(Icons.my_location), findsOneWidget);
+
+    // Tapping empty map (a corner, away from the centered marker) clears the
+    // selection via the map's onTap. No animation, so this is teardown-safe.
+    await tester.tapAt(
+      tester.getTopLeft(find.byType(FlutterMap)) + const Offset(5, 5),
+    );
+    // Flush flutter_map's double-tap disambiguation timer before teardown.
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byType(FlutterMap), findsOneWidget);
+  });
+
+  testWidgets('renders the FlutterMap and info card for a selected dive', (
+    tester,
+  ) async {
+    final site = _site();
+    await _pump(
+      tester,
+      dives: AsyncValue.data([_diveAtSite(site)]),
+      selectedId: 'dive-1',
+    );
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    // The selected dive surfaces an info card containing the site name.
+    expect(find.text('Blue Hole'), findsOneWidget);
+  });
+
+  testWidgets('renders a cluster marker for co-located sites', (tester) async {
+    // Two sites at the SAME location reliably cluster (distance 0 < radius),
+    // exercising the MarkerClusterLayer cluster builder.
+    final a = _site(id: 'site-a', name: 'A');
+    final b = _site(id: 'site-b', name: 'B');
+    await _pump(
+      tester,
+      dives: AsyncValue.data([
+        _diveAtSite(a, id: 'dive-a'),
+        _diveAtSite(b, id: 'dive-b'),
+      ]),
+    );
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2072,6 +2072,23 @@ void main() {
       final after = primaryChartData(tester);
       expect(after.maxX - after.minX, before.maxX - before.minX);
     });
+
+    testWidgets('a cancelled pointer resets the drag state', (tester) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      // Start a pointer, move it, then cancel — exercises onPointerCancel.
+      final gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(10, 0));
+      await gesture.cancel();
+      // Flush the double-tap disambiguation timer before teardown.
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byType(LineChart), findsWidgets);
+    });
   });
 
   group('desktop pan and hover', () {

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2017,53 +2017,61 @@ void main() {
     });
 
     testWidgets(
-      'trackpad two-finger scroll pan shifts the visible window rightward',
+      'trackpad two-finger scroll up zooms in, anchored toward the cursor',
       (tester) async {
         await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
         await tester.pumpAndSettle();
 
         final chart = find.byType(LineChart).first;
-        final center = tester.getCenter(chart);
+        final topLeft = tester.getTopLeft(chart);
+        final size = tester.getSize(chart);
+        final anchor = topLeft + Offset(size.width * 0.7, size.height * 0.5);
 
-        // Zoom in twice at center so there is room to pan. Each scroll uses
-        // factor 1.1; after two scrolls zoom ~= 1.21 and offsetX ~= 0.087
-        // (the window sits just inside the left edge with space to pan right).
-        await tester.sendEventToBinding(
-          PointerScrollEvent(
-            position: center,
-            scrollDelta: const Offset(0, -100),
-          ),
-        );
-        await tester.sendEventToBinding(
-          PointerScrollEvent(
-            position: center,
-            scrollDelta: const Offset(0, -100),
-          ),
-        );
-        await tester.pump();
-
-        final zoomedMinX = primaryChartData(tester).minX;
-        // Confirm we are actually zoomed in (offsetX > 0 means minX > 0).
-        expect(zoomedMinX, greaterThan(0.0));
-
-        // Drive a trackpad two-finger scroll to the left (negative dx).
-        // The handler applies: offsetX += -localPan.dx / plotW / zoom.
-        // With localPan.dx = -60: delta = +60 / plotW / zoom > 0, so
-        // offsetX increases and minX increases (window shifts rightward).
-        final anchor = center;
+        final before = primaryChartData(tester);
         final pointer = TestPointer(1, PointerDeviceKind.trackpad);
         await tester.sendEventToBinding(pointer.panZoomStart(anchor));
+        // Scroll up (negative dy) zooms in. Horizontal component is ignored.
         await tester.sendEventToBinding(
-          pointer.panZoomUpdate(anchor, pan: const Offset(-60, 0)),
+          pointer.panZoomUpdate(anchor, pan: const Offset(0, -120)),
         );
         await tester.sendEventToBinding(pointer.panZoomEnd());
         await tester.pump();
 
-        final pannedMinX = primaryChartData(tester).minX;
-        // The visible window shifted rightward: minX must have increased.
-        expect(pannedMinX, greaterThan(zoomedMinX));
+        final after = primaryChartData(tester);
+        expect(
+          after.maxX - after.minX,
+          lessThan(before.maxX - before.minX),
+          reason: 'two-finger scroll up zooms in (visible window shrinks)',
+        );
+        expect(
+          after.minX,
+          greaterThan(0.0),
+          reason: 'zoom is anchored toward the cursor, not the left edge',
+        );
       },
     );
+
+    testWidgets('trackpad horizontal two-finger scroll does not zoom', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final center = tester.getCenter(chart);
+
+      final before = primaryChartData(tester);
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      await tester.sendEventToBinding(pointer.panZoomStart(center));
+      await tester.sendEventToBinding(
+        pointer.panZoomUpdate(center, pan: const Offset(120, 0)),
+      );
+      await tester.sendEventToBinding(pointer.panZoomEnd());
+      await tester.pump();
+
+      final after = primaryChartData(tester);
+      expect(after.maxX - after.minX, before.maxX - before.minX);
+    });
   });
 
   group('desktop pan and hover', () {

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2017,7 +2017,7 @@ void main() {
     });
 
     testWidgets(
-      'trackpad two-finger scroll up zooms in, anchored toward the cursor',
+      'trackpad two-finger scroll down zooms in, anchored toward the cursor',
       (tester) async {
         await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
         await tester.pumpAndSettle();
@@ -2030,9 +2030,9 @@ void main() {
         final before = primaryChartData(tester);
         final pointer = TestPointer(1, PointerDeviceKind.trackpad);
         await tester.sendEventToBinding(pointer.panZoomStart(anchor));
-        // Scroll up (negative dy) zooms in. Horizontal component is ignored.
+        // Scroll down (positive dy) zooms in. Horizontal component is ignored.
         await tester.sendEventToBinding(
-          pointer.panZoomUpdate(anchor, pan: const Offset(0, -120)),
+          pointer.panZoomUpdate(anchor, pan: const Offset(0, 120)),
         );
         await tester.sendEventToBinding(pointer.panZoomEnd());
         await tester.pump();
@@ -2041,7 +2041,7 @@ void main() {
         expect(
           after.maxX - after.minX,
           lessThan(before.maxX - before.minX),
-          reason: 'two-finger scroll up zooms in (visible window shrinks)',
+          reason: 'two-finger scroll down zooms in (visible window shrinks)',
         );
         expect(
           after.minX,

--- a/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
@@ -1,6 +1,9 @@
+import 'dart:math' as math;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/ui/trackpad_zoom.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
 
 // Data fraction (0..1 of total range) currently under a focal point that sits
@@ -207,6 +210,23 @@ void main() {
         ),
         ChartDragIntent.pan,
       );
+    });
+  });
+
+  group('trackpad scroll maps to a cursor-anchored zoom factor', () {
+    // The chart applies pow(2, trackpadScrollZoomDelta(dy)) as the zoom factor.
+    test('scroll up produces a >1 factor (zoom in)', () {
+      final factor = math.pow(2, trackpadScrollZoomDelta(-100)).toDouble();
+      expect(factor, greaterThan(1.0));
+      final vp = const ProfileChartViewport().zoomedAt(0.5, 0.5, factor);
+      expect(vp.zoom, greaterThan(1.0));
+    });
+
+    test('scroll down produces a <1 factor and is a no-op at the min rail', () {
+      final factor = math.pow(2, trackpadScrollZoomDelta(100)).toDouble();
+      expect(factor, lessThan(1.0));
+      final vp = const ProfileChartViewport().zoomedAt(0.5, 0.5, factor);
+      expect(vp.zoom, ProfileChartViewport.minZoom);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
@@ -215,15 +215,15 @@ void main() {
 
   group('trackpad scroll maps to a cursor-anchored zoom factor', () {
     // The chart applies pow(2, trackpadScrollZoomDelta(dy)) as the zoom factor.
-    test('scroll up produces a >1 factor (zoom in)', () {
-      final factor = math.pow(2, trackpadScrollZoomDelta(-100)).toDouble();
+    test('scroll down produces a >1 factor (zoom in)', () {
+      final factor = math.pow(2, trackpadScrollZoomDelta(100)).toDouble();
       expect(factor, greaterThan(1.0));
       final vp = const ProfileChartViewport().zoomedAt(0.5, 0.5, factor);
       expect(vp.zoom, greaterThan(1.0));
     });
 
-    test('scroll down produces a <1 factor and is a no-op at the min rail', () {
-      final factor = math.pow(2, trackpadScrollZoomDelta(100)).toDouble();
+    test('scroll up produces a <1 factor and is a no-op at the min rail', () {
+      final factor = math.pow(2, trackpadScrollZoomDelta(-100)).toDouble();
       expect(factor, lessThan(1.0));
       final vp = const ProfileChartViewport().zoomedAt(0.5, 0.5, factor);
       expect(vp.zoom, ProfileChartViewport.minZoom);

--- a/test/features/dive_sites/presentation/pages/site_detail_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_detail_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -519,6 +520,68 @@ void main() {
       await tester.pumpAndSettle();
       // No altitude label in the body.
       expect(find.textContaining('Altitude'), findsNothing);
+    });
+  });
+
+  group('SiteDetailPage map section', () {
+    const locatedSite = DiveSite(
+      id: 'located-site',
+      name: 'Located Site',
+      location: GeoPoint(12.34, 56.78),
+    );
+
+    testWidgets('renders inline preview map when site has coordinates', (
+      tester,
+    ) async {
+      _setMobileTestSurfaceSize(tester);
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            siteProvider(locatedSite.id).overrideWith((_) async => locatedSite),
+            siteDiveCountProvider(locatedSite.id).overrideWith((_) async => 0),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: SiteDetailPage(siteId: locatedSite.id),
+          ),
+        ),
+      );
+      // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.byType(FlutterMap), findsWidgets);
+    });
+
+    testWidgets('opens fullscreen map when fullscreen button tapped', (
+      tester,
+    ) async {
+      _setMobileTestSurfaceSize(tester);
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            siteProvider(locatedSite.id).overrideWith((_) async => locatedSite),
+            siteDiveCountProvider(locatedSite.id).overrideWith((_) async => 0),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: SiteDetailPage(siteId: locatedSite.id),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.byType(FlutterMap), findsWidgets);
+      await tester.tap(find.byIcon(Icons.fullscreen));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      // The fullscreen route also renders a FlutterMap.
+      expect(find.byType(FlutterMap), findsWidgets);
     });
   });
 

--- a/test/features/dive_sites/presentation/pages/site_map_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_map_page_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/pages/site_map_page.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
+import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+void main() {
+  testWidgets('renders the SiteMapPage FlutterMap with a site marker', (
+    tester,
+  ) async {
+    // Phone-sized surface keeps MapListScaffold in mobile mode, which renders
+    // only the map pane (no list pane providers to mock).
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(600, 900);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    const site = DiveSite(
+      id: 'site-1',
+      name: 'Blue Hole',
+      location: GeoPoint(12.34, 98.76),
+    );
+    // A second site at the SAME location reliably clusters with the first,
+    // exercising the MarkerClusterLayer cluster builder.
+    const site2 = DiveSite(
+      id: 'site-2',
+      name: 'Blue Hole Annex',
+      location: GeoPoint(12.34, 98.76),
+    );
+
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          sitesWithCountsProvider.overrideWith(
+            (ref) async => [
+              SiteWithDiveCount(site: site, diveCount: 3),
+              SiteWithDiveCount(site: site2, diveCount: 1),
+            ],
+          ),
+          siteCoverageHeatMapProvider.overrideWith(
+            (ref) async => <HeatMapPoint>[],
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SiteMapPage(),
+        ),
+      ),
+    );
+
+    // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+}

--- a/test/features/dive_sites/presentation/widgets/location_picker_map_test.dart
+++ b/test/features/dive_sites/presentation/widgets/location_picker_map_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_sites/presentation/widgets/location_picker_map.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+Future<void> _pump(WidgetTester tester, {LatLng? initialLocation}) async {
+  final base = await getBaseOverrides();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: base,
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: LocationPickerMap(initialLocation: initialLocation),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  testWidgets('renders the FlutterMap with a world view when no location', (
+    tester,
+  ) async {
+    await _pump(tester);
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    // No selection yet, so no confirm action and no location marker.
+    expect(find.byIcon(Icons.check), findsNothing);
+    expect(find.byIcon(Icons.location_on), findsNothing);
+  });
+
+  testWidgets('renders the FlutterMap and a marker for an initial location', (
+    tester,
+  ) async {
+    await _pump(tester, initialLocation: const LatLng(12.34, 98.76));
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    // The selected-location marker uses a location_on glyph.
+    expect(find.byIcon(Icons.location_on), findsOneWidget);
+  });
+}

--- a/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -661,6 +662,81 @@ void main() {
       await tester.pumpAndSettle();
       expect(selectedId, 's1');
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mini-map background (SiteListTile renders a FlutterMap when the site has a
+  // location and the showMapBackgroundOnSiteCards setting is enabled).
+  // ---------------------------------------------------------------------------
+  group('site card mini-map', () {
+    testWidgets('SiteListTile renders a FlutterMap for a located site when map '
+        'background is enabled', (tester) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+            showMapBackgroundOnSiteCardsProvider.overrideWithValue(true),
+          ],
+          child: const SiteListTile(
+            name: 'Blue Hole',
+            location: 'Belize',
+            latitude: 17.3155,
+            longitude: -87.5346,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(SiteListTile), findsOneWidget);
+      expect(find.byType(FlutterMap), findsWidgets);
+    });
+
+    testWidgets(
+      'SiteListContent detailed view renders a mini-map for a located site',
+      (tester) async {
+        _setMobileTestSurfaceSize(tester);
+        SharedPreferences.setMockInitialValues({});
+        final p = await SharedPreferences.getInstance();
+
+        final sites = [
+          SiteWithDiveCount(
+            site: const DiveSite(
+              id: 's1',
+              name: 'Located Reef',
+              location: GeoPoint(17.3155, -87.5346),
+            ),
+            diveCount: 0,
+          ),
+        ];
+
+        await tester.pumpWidget(
+          testApp(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(p),
+              settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+              showMapBackgroundOnSiteCardsProvider.overrideWithValue(true),
+              currentDiverIdProvider.overrideWith(
+                (ref) => MockCurrentDiverIdNotifier(),
+              ),
+              sortedSitesWithCountsProvider.overrideWithValue(
+                AsyncValue.data(sites),
+              ),
+              siteListNotifierProvider.overrideWith(
+                (ref) => _MockSiteListNotifier(),
+              ),
+              siteListViewModeProvider.overrideWith(
+                (ref) => ListViewMode.detailed,
+              ),
+              highlightedSiteIdProvider.overrideWith((ref) => null),
+            ],
+            child: const SiteListContent(showAppBar: false),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(FlutterMap), findsWidgets);
+      },
+    );
   });
 }
 

--- a/test/features/dive_sites/presentation/widgets/site_map_content_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_map_content_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/dive_sites/presentation/widgets/site_map_content.dart';
+import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
+import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+DiveSite _site({
+  String id = 'site-1',
+  String name = 'Blue Hole',
+  double lat = 12.34,
+  double lng = 98.76,
+}) {
+  return DiveSite(id: id, name: name, location: GeoPoint(lat, lng));
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<SiteWithDiveCount> sites,
+  String? selectedId,
+}) async {
+  final base = await getBaseOverrides();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        ...base,
+        sitesWithCountsProvider.overrideWith((ref) async => sites),
+        siteCoverageHeatMapProvider.overrideWith(
+          (ref) async => <HeatMapPoint>[],
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SiteMapContent(selectedId: selectedId, onItemSelected: (_) {}),
+        ),
+      ),
+    ),
+  );
+  // Allow the FutureProviders to resolve and the map to build.
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  testWidgets('renders the FlutterMap with a dive site marker', (tester) async {
+    await _pump(
+      tester,
+      sites: [SiteWithDiveCount(site: _site(), diveCount: 3)],
+    );
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byIcon(Icons.my_location), findsOneWidget);
+
+    // Tapping empty map (a corner, away from the centered marker) clears the
+    // selection via the map's onTap. No animation, so this is teardown-safe.
+    await tester.tapAt(
+      tester.getTopLeft(find.byType(FlutterMap)) + const Offset(5, 5),
+    );
+    // Flush flutter_map's double-tap disambiguation timer before teardown.
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byType(FlutterMap), findsOneWidget);
+  });
+
+  testWidgets('renders the FlutterMap and info card for a selected site', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      sites: [SiteWithDiveCount(site: _site(), diveCount: 3)],
+      selectedId: 'site-1',
+    );
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.text('Blue Hole'), findsOneWidget);
+  });
+
+  testWidgets('renders a cluster marker for co-located sites', (tester) async {
+    // Two sites at the SAME location reliably cluster (distance 0 < radius),
+    // exercising the MarkerClusterLayer cluster builder.
+    await _pump(
+      tester,
+      sites: [
+        SiteWithDiveCount(
+          site: _site(id: 's-a', name: 'A'),
+          diveCount: 1,
+        ),
+        SiteWithDiveCount(
+          site: _site(id: 's-b', name: 'B'),
+          diveCount: 2,
+        ),
+      ],
+    );
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+  });
+}

--- a/test/features/maps/presentation/pages/dive_activity_map_page_test.dart
+++ b/test/features/maps/presentation/pages/dive_activity_map_page_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/maps/domain/entities/heat_map_point.dart';
+import 'package:submersion/features/maps/presentation/pages/dive_activity_map_page.dart';
+import 'package:submersion/features/maps/presentation/providers/heat_map_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+void main() {
+  testWidgets('renders the DiveActivityMapPage FlutterMap with a site', (
+    tester,
+  ) async {
+    // Phone-sized surface keeps MapListScaffold in mobile mode, which renders
+    // only the map pane (no list pane providers to mock).
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(600, 900);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    const site = DiveSite(
+      id: 'site-1',
+      name: 'Blue Hole',
+      location: GeoPoint(12.34, 98.76),
+    );
+    // A second site at the SAME location reliably clusters with the first
+    // (distance 0 < radius), exercising the MarkerClusterLayer cluster builder.
+    const site2 = DiveSite(
+      id: 'site-2',
+      name: 'Blue Hole Annex',
+      location: GeoPoint(12.34, 98.76),
+    );
+    final dive = createTestDiveWithBottomTime(
+      id: 'dive-1',
+    ).copyWith(site: site);
+    final dive2 = createTestDiveWithBottomTime(
+      id: 'dive-2',
+    ).copyWith(site: site2);
+
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          sitesWithCountsProvider.overrideWith(
+            (ref) async => [
+              SiteWithDiveCount(site: site, diveCount: 3),
+              SiteWithDiveCount(site: site2, diveCount: 1),
+            ],
+          ),
+          sortedFilteredDivesProvider.overrideWithValue(
+            AsyncValue.data([dive, dive2]),
+          ),
+          diveActivityHeatMapProvider.overrideWithValue(
+            const AsyncValue<List<HeatMapPoint>>.data(<HeatMapPoint>[]),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DiveActivityMapPage(),
+        ),
+      ),
+    );
+
+    // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+}

--- a/test/features/maps/presentation/pages/region_picker_page_test.dart
+++ b/test/features/maps/presentation/pages/region_picker_page_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/maps/presentation/pages/region_picker_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+void main() {
+  testWidgets('renders the RegionPickerPage FlutterMap', (tester) async {
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: base,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: RegionPickerPage(),
+        ),
+      ),
+    );
+
+    // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+}

--- a/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
+++ b/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
@@ -13,6 +13,8 @@ void main() {
         home: Scaffold(
           body: TrackpadZoomMap(
             controller: controller,
+            minZoom: 1,
+            maxZoom: 18,
             child: FlutterMap(
               mapController: controller,
               options: const MapOptions(
@@ -95,5 +97,25 @@ void main() {
     await tester.pump();
 
     expect(controller.camera.zoom, greaterThan(start));
+  });
+
+  testWidgets('trackpad click-drag is not claimed by the zoom recognizer', (
+    tester,
+  ) async {
+    await pumpMap(tester);
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    // An ordinary trackpad pointer (click-drag), not a pan-zoom gesture. The
+    // recognizer's addAllowedPointer is a no-op, so it must not claim this and
+    // the map keeps working (no crash).
+    final gesture = await tester.startGesture(
+      center,
+      kind: PointerDeviceKind.trackpad,
+    );
+    await gesture.moveBy(const Offset(0, -40));
+    await gesture.up();
+    await tester.pump();
+
+    expect(find.byType(FlutterMap), findsOneWidget);
   });
 }

--- a/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
+++ b/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
@@ -6,10 +6,6 @@ import 'package:latlong2/latlong.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 void main() {
-  // Records the interaction flags the builder was last asked to render with, so
-  // tests can assert the pointer-kind-aware swap.
-  late int lastFlags;
-
   Future<MapController> pumpMap(WidgetTester tester) async {
     final controller = MapController();
     await tester.pumpWidget(
@@ -17,20 +13,16 @@ void main() {
         home: Scaffold(
           body: TrackpadZoomMap(
             controller: controller,
-            builder: (context, flags) {
-              lastFlags = flags;
-              return FlutterMap(
-                mapController: controller,
-                options: MapOptions(
-                  initialCenter: const LatLng(0, 0),
-                  initialZoom: 5,
-                  minZoom: 1,
-                  maxZoom: 18,
-                  interactionOptions: InteractionOptions(flags: flags),
-                ),
-                children: const [],
-              );
-            },
+            child: FlutterMap(
+              mapController: controller,
+              options: const MapOptions(
+                initialCenter: LatLng(0, 0),
+                initialZoom: 5,
+                minZoom: 1,
+                maxZoom: 18,
+              ),
+              children: const [],
+            ),
           ),
         ),
       ),
@@ -50,15 +42,23 @@ void main() {
       kind: PointerDeviceKind.trackpad,
     );
     await gesture.panZoomStart(center);
-    await tester.pump(); // apply the kind-aware flag swap before updates
+    await tester.pump();
     await gesture.panZoomUpdate(center, pan: const Offset(0, -50));
     await tester.pump();
     await gesture.panZoomUpdate(center, pan: const Offset(0, -100));
     await tester.pump();
+    final mid = controller.camera.zoom;
+    await gesture.panZoomUpdate(center, pan: const Offset(0, -150));
+    await tester.pump();
     await gesture.panZoomEnd();
     await tester.pump();
 
-    expect(controller.camera.zoom, greaterThan(start));
+    expect(mid, greaterThan(start));
+    expect(
+      controller.camera.zoom,
+      greaterThan(mid),
+      reason: 'zoom accumulates across the gesture (not pinned to start)',
+    );
   });
 
   testWidgets('trackpad two-finger scroll down zooms out', (tester) async {
@@ -79,15 +79,9 @@ void main() {
     expect(controller.camera.zoom, lessThan(start));
   });
 
-  testWidgets('pinchMove is dropped only while a trackpad gesture is active', (
-    tester,
-  ) async {
-    await pumpMap(tester);
-    expect(
-      InteractiveFlag.hasPinchMove(lastFlags),
-      isTrue,
-      reason: 'touch pinch-move preserved at rest',
-    );
+  testWidgets('trackpad pinch out zooms in', (tester) async {
+    final controller = await pumpMap(tester);
+    final start = controller.camera.zoom;
     final center = tester.getCenter(find.byType(FlutterMap));
 
     final gesture = await tester.createGesture(
@@ -95,18 +89,11 @@ void main() {
     );
     await gesture.panZoomStart(center);
     await tester.pump();
-    expect(
-      InteractiveFlag.hasPinchMove(lastFlags),
-      isFalse,
-      reason: 'pinch-move dropped during trackpad gesture',
-    );
-
+    await gesture.panZoomUpdate(center, scale: 2.0);
+    await tester.pump();
     await gesture.panZoomEnd();
     await tester.pump();
-    expect(
-      InteractiveFlag.hasPinchMove(lastFlags),
-      isTrue,
-      reason: 'pinch-move restored after trackpad gesture',
-    );
+
+    expect(controller.camera.zoom, greaterThan(start));
   });
 }

--- a/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
+++ b/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
@@ -31,7 +31,7 @@ void main() {
     return controller;
   }
 
-  testWidgets('trackpad two-finger scroll up zooms in progressively', (
+  testWidgets('trackpad two-finger scroll down zooms in progressively', (
     tester,
   ) async {
     final controller = await pumpMap(tester);
@@ -43,12 +43,12 @@ void main() {
     );
     await gesture.panZoomStart(center);
     await tester.pump();
-    await gesture.panZoomUpdate(center, pan: const Offset(0, -50));
+    await gesture.panZoomUpdate(center, pan: const Offset(0, 50));
     await tester.pump();
-    await gesture.panZoomUpdate(center, pan: const Offset(0, -100));
+    await gesture.panZoomUpdate(center, pan: const Offset(0, 100));
     await tester.pump();
     final mid = controller.camera.zoom;
-    await gesture.panZoomUpdate(center, pan: const Offset(0, -150));
+    await gesture.panZoomUpdate(center, pan: const Offset(0, 150));
     await tester.pump();
     await gesture.panZoomEnd();
     await tester.pump();
@@ -61,7 +61,7 @@ void main() {
     );
   });
 
-  testWidgets('trackpad two-finger scroll down zooms out', (tester) async {
+  testWidgets('trackpad two-finger scroll up zooms out', (tester) async {
     final controller = await pumpMap(tester);
     final start = controller.camera.zoom;
     final center = tester.getCenter(find.byType(FlutterMap));
@@ -71,7 +71,7 @@ void main() {
     );
     await gesture.panZoomStart(center);
     await tester.pump();
-    await gesture.panZoomUpdate(center, pan: const Offset(0, 100));
+    await gesture.panZoomUpdate(center, pan: const Offset(0, -100));
     await tester.pump();
     await gesture.panZoomEnd();
     await tester.pump();

--- a/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
+++ b/test/features/maps/presentation/widgets/trackpad_zoom_map_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
+
+void main() {
+  // Records the interaction flags the builder was last asked to render with, so
+  // tests can assert the pointer-kind-aware swap.
+  late int lastFlags;
+
+  Future<MapController> pumpMap(WidgetTester tester) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TrackpadZoomMap(
+            controller: controller,
+            builder: (context, flags) {
+              lastFlags = flags;
+              return FlutterMap(
+                mapController: controller,
+                options: MapOptions(
+                  initialCenter: const LatLng(0, 0),
+                  initialZoom: 5,
+                  minZoom: 1,
+                  maxZoom: 18,
+                  interactionOptions: InteractionOptions(flags: flags),
+                ),
+                children: const [],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return controller;
+  }
+
+  testWidgets('trackpad two-finger scroll up zooms in progressively', (
+    tester,
+  ) async {
+    final controller = await pumpMap(tester);
+    final start = controller.camera.zoom;
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.trackpad,
+    );
+    await gesture.panZoomStart(center);
+    await tester.pump(); // apply the kind-aware flag swap before updates
+    await gesture.panZoomUpdate(center, pan: const Offset(0, -50));
+    await tester.pump();
+    await gesture.panZoomUpdate(center, pan: const Offset(0, -100));
+    await tester.pump();
+    await gesture.panZoomEnd();
+    await tester.pump();
+
+    expect(controller.camera.zoom, greaterThan(start));
+  });
+
+  testWidgets('trackpad two-finger scroll down zooms out', (tester) async {
+    final controller = await pumpMap(tester);
+    final start = controller.camera.zoom;
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.trackpad,
+    );
+    await gesture.panZoomStart(center);
+    await tester.pump();
+    await gesture.panZoomUpdate(center, pan: const Offset(0, 100));
+    await tester.pump();
+    await gesture.panZoomEnd();
+    await tester.pump();
+
+    expect(controller.camera.zoom, lessThan(start));
+  });
+
+  testWidgets('pinchMove is dropped only while a trackpad gesture is active', (
+    tester,
+  ) async {
+    await pumpMap(tester);
+    expect(
+      InteractiveFlag.hasPinchMove(lastFlags),
+      isTrue,
+      reason: 'touch pinch-move preserved at rest',
+    );
+    final center = tester.getCenter(find.byType(FlutterMap));
+
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.trackpad,
+    );
+    await gesture.panZoomStart(center);
+    await tester.pump();
+    expect(
+      InteractiveFlag.hasPinchMove(lastFlags),
+      isFalse,
+      reason: 'pinch-move dropped during trackpad gesture',
+    );
+
+    await gesture.panZoomEnd();
+    await tester.pump();
+    expect(
+      InteractiveFlag.hasPinchMove(lastFlags),
+      isTrue,
+      reason: 'pinch-move restored after trackpad gesture',
+    );
+  });
+}

--- a/test/features/trips/presentation/widgets/trip_overview_tab_test.dart
+++ b/test/features/trips/presentation/widgets/trip_overview_tab_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/features/trips/presentation/widgets/trip_overview_tab.dart';
@@ -81,5 +83,54 @@ void main() {
       expect(find.text('45min'), findsOneWidget);
       expect(find.text('30min'), findsOneWidget);
     });
+
+    testWidgets(
+      'renders header background map when trip sites have locations',
+      (tester) async {
+        final overrides = await getBaseOverrides();
+
+        const locatedSite = DiveSite(
+          id: 'trip-site-1',
+          name: 'Trip Site',
+          location: GeoPoint(12.34, 56.78),
+        );
+
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) =>
+                  Scaffold(body: TripOverviewTab(tripWithStats: tripWithStats)),
+            ),
+            GoRoute(
+              path: '/dives/:id',
+              builder: (context, state) => const Scaffold(),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              ...overrides,
+              divesForTripProvider(trip.id).overrideWith((ref) async => dives),
+              tripSitesWithLocationsProvider(
+                trip.id,
+              ).overrideWith((ref) async => [locatedSite]),
+            ].cast(),
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          ),
+        );
+        // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(find.byType(FlutterMap), findsWidgets);
+      },
+    );
   });
 }

--- a/test/features/trips/presentation/widgets/trip_voyage_map_test.dart
+++ b/test/features/trips/presentation/widgets/trip_voyage_map_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
+import 'package:submersion/features/trips/presentation/providers/liveaboard_providers.dart';
+import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
+import 'package:submersion/features/trips/presentation/widgets/trip_voyage_map.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+final _now = DateTime.now();
+
+LiveaboardDetails _makeDetails(String tripId) {
+  return LiveaboardDetails(
+    id: 'lad-1',
+    tripId: tripId,
+    vesselName: 'MV Test',
+    embarkLatitude: 18.5,
+    embarkLongitude: -77.9,
+    disembarkLatitude: 18.6,
+    disembarkLongitude: -77.8,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+void main() {
+  testWidgets('renders FlutterMap voyage route for a liveaboard trip', (
+    tester,
+  ) async {
+    const tripId = 'trip-1';
+    final overrides = await getBaseOverrides();
+
+    final sites = [
+      const DiveSite(
+        id: 'site-1',
+        name: 'Reef One',
+        location: GeoPoint(18.55, -77.85),
+      ),
+      const DiveSite(
+        id: 'site-2',
+        name: 'Reef Two',
+        location: GeoPoint(18.58, -77.82),
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          liveaboardDetailsProvider(
+            tripId,
+          ).overrideWith((ref) async => _makeDetails(tripId)),
+          tripSitesWithLocationsProvider(
+            tripId,
+          ).overrideWith((ref) async => sites),
+        ].cast(),
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: TripVoyageMap(tripId: tripId)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripVoyageMap), findsOneWidget);
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+
+  testWidgets('renders FlutterMap from dive sites only (no liveaboard ports)', (
+    tester,
+  ) async {
+    const tripId = 'trip-2';
+    final overrides = await getBaseOverrides();
+
+    final sites = [
+      const DiveSite(
+        id: 'site-a',
+        name: 'Reef A',
+        location: GeoPoint(0.0, 0.0),
+      ),
+      const DiveSite(
+        id: 'site-b',
+        name: 'Reef B',
+        location: GeoPoint(0.1, 0.1),
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          liveaboardDetailsProvider(tripId).overrideWith((ref) async => null),
+          tripSitesWithLocationsProvider(
+            tripId,
+          ).overrideWith((ref) async => sites),
+        ].cast(),
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: TripVoyageMap(tripId: tripId)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlutterMap), findsWidgets);
+  });
+}

--- a/test/features/trips/presentation/widgets/trip_voyage_map_test.dart
+++ b/test/features/trips/presentation/widgets/trip_voyage_map_test.dart
@@ -66,7 +66,9 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
 
     expect(find.byType(TripVoyageMap), findsOneWidget);
     expect(find.byType(FlutterMap), findsWidgets);
@@ -107,7 +109,9 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    // Avoid pumpAndSettle: the FlutterMap tile layer animates indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
 
     expect(find.byType(FlutterMap), findsWidgets);
   });


### PR DESCRIPTION
## What

Two-finger scroll (and pinch) on a trackpad now zooms in/out, cursor-anchored, on:

- all 17 `FlutterMap` instances (15 files), and
- the dive profile chart.

Panning is via click-drag (two-finger trackpad scroll no longer pans). Also fixes a related conflict: a two-finger scroll over a map embedded in a scrollable page now **zooms the map instead of also scrolling the page** ("map captures the gesture when hovered").

## How

A shared `TrackpadZoomGestureRecognizer` (`lib/core/ui/trackpad_zoom_recognizer.dart`) that **eagerly wins the gesture arena** for trackpad pan-zoom. One arena winner solves two problems at once:

1. flutter_map's own `ScaleGestureRecognizer` is rejected — otherwise its `pinchMove` handler pins the camera to the gesture-start position every frame and reverts the zoom.
2. an enclosing `Scrollable` is rejected — so the page doesn't scroll while you zoom the map.

Because we capture all trackpad pan-zoom, the recognizer drives zoom from both scroll (`panDelta.dy`) and pinch (`scale`). Sign/sensitivity live in a pure helper `trackpadScrollZoomDelta` (negative dy = zoom in, matching the mouse wheel).

- **Maps:** `TrackpadZoomMap` wrapper applies `camera.zoom + delta` and recenters via `MapCamera.focusedZoomCenter` (rotation-aware). 9 sites already owned a `MapController`; 6 files had their enclosing `ConsumerWidget`s converted to `ConsumerStatefulWidget` to create one (two pages have 2 maps each).
- **Chart:** the same recognizer wraps the chart's `GestureDetector` and applies `pow(2, delta)` to `ProfileChartViewport`. The old passive trackpad `Listener` handlers were removed.

Untouched: mouse-wheel zoom, touch pinch/one-finger pan (tablet/iPad), mouse and trackpad click-drag pan, double-tap zoom.

## Testing

- New unit tests for `trackpadScrollZoomDelta`.
- Widget tests for `TrackpadZoomMap` (progressive scroll zoom in/out, pinch zoom) and the chart (scroll-up zooms in cursor-anchored; horizontal scroll is ignored; existing pan/scrub/pinch/double-tap tests still pass).
- `flutter analyze` clean (whole project); `dart format` clean; maps + trips suites green.

### Device verification still needed (cannot be automated)

`flutter_test`'s `Scrollable` does not scroll on synthetic `panZoom`, and touch `panZoom` is disallowed, so these need a real macOS trackpad:

- [ ] Two-finger scroll zooms maps + chart smoothly and progressively, anchored at the cursor.
- [ ] Scrolling over an embedded map (e.g. dive site details) zooms the map and does **not** scroll the page; scrolling elsewhere scrolls the page.
- [ ] Trackpad/mouse click-drag still pans; mouse wheel still zooms; iPad touch pinch still finger-anchored.

Design + plan: `docs/superpowers/{specs,plans}/2026-06-22-trackpad-scroll-zoom*`.