### PR TITLE
fix(android): prevent and diagnose 16 KB-page native load crash (#318)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -543,6 +543,12 @@ jobs:
       - name: Build Android APK
         run: flutter build apk --release "${{ env.DART_DEFINES }}" -v
 
+      # Guards against issue #318: a 4 KB-aligned native lib (liblibdc_jni.so)
+      # silently shipped and crashed the app on Android 15+ 16 KB-page devices.
+      # Fails the build if any 64-bit native library is not 16 KB-aligned.
+      - name: Verify 16 KB native library alignment
+        run: python3 scripts/check_16kb_alignment.py build/app/outputs/flutter-apk/app-release.apk
+
       - name: Upload Android artifact
         uses: actions/upload-artifact@v7
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -518,6 +518,16 @@ jobs:
       - name: Build Android App Bundle
         run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false
 
+      # Guards against issue #318: a 4 KB-aligned native lib (liblibdc_jni.so)
+      # silently shipped in v1.5.5.107 and crashed the app on Android 15+
+      # 16 KB-page devices. Fail the release before publishing if any 64-bit
+      # native library is not 16 KB-aligned, in either the APK or the AAB.
+      - name: Verify 16 KB native library alignment
+        run: |
+          python3 scripts/check_16kb_alignment.py \
+            build/app/outputs/flutter-apk/app-release.apk \
+            build/app/outputs/bundle/release/app-release.aab
+
       - name: Rename artifacts
         env:
           TAG_NAME: ${{ github.ref_name }}

--- a/lib/core/services/global_error_handler.dart
+++ b/lib/core/services/global_error_handler.dart
@@ -31,6 +31,7 @@ void installGlobalErrorHandlers() {
     (previousFlutterOnError ?? FlutterError.presentError)(details);
   };
 
+  final previousPlatformOnError = PlatformDispatcher.instance.onError;
   PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
     _logger.error(
       'Uncaught platform error',
@@ -38,9 +39,10 @@ void installGlobalErrorHandlers() {
       error: error,
       stackTrace: stack,
     );
-    // Returning false marks the error as not fully handled, so the platform
+    // Delegate to any previously-installed handler (e.g. a crash reporter)
+    // instead of silently replacing it; fall back to false so the platform
     // still applies its default behavior (printing to the console / logcat).
-    return false;
+    return previousPlatformOnError?.call(error, stack) ?? false;
   };
 }
 

--- a/lib/core/services/global_error_handler.dart
+++ b/lib/core/services/global_error_handler.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/logger_service.dart';
+
+const _logger = LoggerService('UncaughtError');
+
+/// Installs process-wide handlers that route otherwise-silent Dart errors into
+/// [LoggerService] (and thus into `submersion.log` when debug mode is on),
+/// while preserving each framework's default behavior.
+///
+/// Before this, the app installed no global handlers, so an uncaught Flutter
+/// framework error or async error never reached the on-device debug log -- a
+/// key reason issue #318 took so long to diagnose remotely.
+///
+/// Important: a native-level crash (for example a JNI `UnsatisfiedLinkError`
+/// from a misaligned `.so` on a 16 KB-page device) is not a Dart error and
+/// cannot be caught here. That failure mode is surfaced on the platform side
+/// (the Kotlin/Swift dive-computer bridges report it instead of crashing).
+void installGlobalErrorHandlers() {
+  final previousFlutterOnError = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    _logger.error(
+      'Uncaught Flutter framework error',
+      category: LogCategory.app,
+      error: details.exception,
+      stackTrace: details.stack,
+    );
+    // Preserve the default presentation (red error screen in debug builds,
+    // console/logcat dump otherwise).
+    if (previousFlutterOnError != null) {
+      previousFlutterOnError(details);
+    } else {
+      FlutterError.presentError(details);
+    }
+  };
+
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    _logger.error(
+      'Uncaught platform error',
+      category: LogCategory.app,
+      error: error,
+      stackTrace: stack,
+    );
+    // Returning false marks the error as not fully handled, so the platform
+    // still applies its default behavior (printing to the console / logcat).
+    return false;
+  };
+}

--- a/lib/core/services/global_error_handler.dart
+++ b/lib/core/services/global_error_handler.dart
@@ -26,12 +26,9 @@ void installGlobalErrorHandlers() {
       stackTrace: details.stack,
     );
     // Preserve the default presentation (red error screen in debug builds,
-    // console/logcat dump otherwise).
-    if (previousFlutterOnError != null) {
-      previousFlutterOnError(details);
-    } else {
-      FlutterError.presentError(details);
-    }
+    // console/logcat dump otherwise). Falls back to FlutterError.presentError
+    // when no prior handler was installed.
+    (previousFlutterOnError ?? FlutterError.presentError)(details);
   };
 
   PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
@@ -45,4 +42,17 @@ void installGlobalErrorHandlers() {
     // still applies its default behavior (printing to the console / logcat).
     return false;
   };
+}
+
+/// Logs an uncaught error escaping the top-level guarded zone (see `main`).
+///
+/// Extracted so the logging behavior is unit-testable; `main`'s
+/// `runZonedGuarded` wiring itself is untestable startup glue.
+void logUncaughtZoneError(Object error, StackTrace stack) {
+  _logger.error(
+    'Uncaught zone error',
+    category: LogCategory.app,
+    error: error,
+    stackTrace: stack,
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -5,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/network/trusted_http_overrides.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/global_error_handler.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
@@ -17,8 +19,23 @@ import 'package:submersion/features/media/data/network_cache_config.dart';
 import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
-Future<void> main() async {
+void main() {
+  // Run startup inside a guarded zone so an uncaught async error during
+  // initialization is logged instead of vanishing silently (issue #318
+  // hardening: the app previously installed no global error capture at all).
+  runZonedGuarded(_bootstrap, (Object error, StackTrace stack) {
+    const LoggerService(
+      'UncaughtError',
+    ).error('Uncaught zone error', error: error, stackTrace: stack);
+  });
+}
+
+Future<void> _bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Route uncaught Flutter framework and platform errors into the debug log so
+  // future crashes are diagnosable from the user-shared log (issue #318).
+  installGlobalErrorHandlers();
 
   // Windows cannot expose its system trust store to Dart's bundled BoringSSL,
   // so every default-context HttpClient (S3 sync, map tiles, NetworkImage,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,23 +19,25 @@ import 'package:submersion/features/media/data/network_cache_config.dart';
 import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
+// main() and the _bootstrap signature are untestable startup wiring (they
+// never run under test); the zone-error logging is unit-tested via
+// logUncaughtZoneError. Exclude only the wiring from coverage; the _bootstrap
+// body below is covered normally.
+// coverage:ignore-start
 void main() {
   // Run startup inside a guarded zone so an uncaught async error during
   // initialization is logged instead of vanishing silently (issue #318
   // hardening: the app previously installed no global error capture at all).
-  runZonedGuarded(_bootstrap, (Object error, StackTrace stack) {
-    const LoggerService(
-      'UncaughtError',
-    ).error('Uncaught zone error', error: error, stackTrace: stack);
-  });
+  runZonedGuarded(_bootstrap, logUncaughtZoneError);
 }
 
 Future<void> _bootstrap() async {
+  // coverage:ignore-end
   WidgetsFlutterBinding.ensureInitialized();
 
   // Route uncaught Flutter framework and platform errors into the debug log so
   // future crashes are diagnosable from the user-shared log (issue #318).
-  installGlobalErrorHandlers();
+  installGlobalErrorHandlers(); // coverage:ignore-line
 
   // Windows cannot expose its system trust store to Dart's bundled BoringSSL,
   // so every default-context HttpClient (S3 sync, map tiles, NetworkImage,

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/CMakeLists.txt
@@ -150,9 +150,12 @@ target_compile_definitions(libdc_jni PRIVATE HAVE_CONFIG_H)
 target_link_libraries(libdc_jni PRIVATE divecomputer log)
 
 # 16 KB page-size compatibility (Android 15+; required by Google Play for
-# targetSdk >= 35). NDK r27 still links native LOAD segments at 4 KB
+# targetSdk >= 35). NDK r27 and earlier link native LOAD segments at 4 KB
 # (-z max-page-size=4096), so liblibdc_jni.so fails Android's 16 KB ELF
-# alignment check and will not load on 16 KB-page devices. Force 16 KB
-# alignment explicitly. Redundant (and harmless) under NDK r28+, which
-# defaults to 16 KB.
+# alignment check and will not load on 16 KB-page devices -- it crashes the
+# app the instant a download starts (issue #318). DO NOT REMOVE: this plugin's
+# Gradle (AGP 8.1.0, no explicit ndkVersion) resolves a pre-r28 NDK, which is
+# exactly how v1.5.5.107 shipped a 4 KB-aligned lib. The flag forces 16 KB
+# regardless of NDK version, and scripts/check_16kb_alignment.py fails CI if a
+# misaligned native lib ever ships again.
 target_link_options(libdc_jni PRIVATE "-Wl,-z,max-page-size=16384")

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -135,6 +135,11 @@ class DiveComputerHostApiImpl(
     }
 
     private fun startBleDiscovery() {
+        // BleScanner identifies devices via LibdcWrapper.nativeDescriptorMatch on
+        // the (async) scan-result thread. Bail with a clear error if the native
+        // library never loaded, rather than crashing there (issue #318).
+        if (!nativeLibraryReady()) return
+
         val scanner = BleScanner(context)
         scanner.onDeviceDiscovered = { device ->
             mainHandler.post { flutterApi.onDeviceDiscovered(device) { } }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -54,6 +54,18 @@ class DiveComputerHostApiImpl(
 
     override fun getDeviceDescriptors(callback: (Result<List<DeviceDescriptor>>) -> Unit) {
         executor.execute {
+            // If the native library failed to load, return an empty list rather
+            // than crashing on the native call below (issue #318). The download
+            // path surfaces the user-facing error.
+            if (LibdcWrapper.loadError != null) {
+                NativeLogger.e(
+                    TAG, "LDC",
+                    "getDeviceDescriptors: native library unavailable: " +
+                        "${LibdcWrapper.loadError?.javaClass?.simpleName}"
+                )
+                callback(Result.success(emptyList()))
+                return@execute
+            }
             val descriptors = mutableListOf<DeviceDescriptor>()
             val iterPtr = LibdcWrapper.nativeDescriptorIteratorNew()
             if (iterPtr == 0L) {
@@ -144,7 +156,21 @@ class DiveComputerHostApiImpl(
         callback(Result.success(Unit))
 
         executor.execute {
-            performDownload(device, fingerprint)
+            // Backstop: convert any native-level failure into a reported error
+            // instead of an uncaught Throwable that kills the executor thread
+            // and the app (issue #318).
+            try {
+                performDownload(device, fingerprint)
+            } catch (t: Throwable) {
+                NativeLogger.e(
+                    TAG, "LDC",
+                    "download crashed: ${t.javaClass.simpleName}: ${t.message}"
+                )
+                reportError(
+                    "download_error",
+                    "Download failed unexpectedly (${t.javaClass.simpleName})."
+                )
+            }
         }
     }
 
@@ -159,6 +185,10 @@ class DiveComputerHostApiImpl(
     }
 
     private fun performDownload(device: DiscoveredDevice, fingerprint: String? = null, isRetry: Boolean = false) {
+        // Fail clearly if the native library never loaded, rather than crashing
+        // on the first native call below (issue #318).
+        if (!nativeLibraryReady()) return
+
         // Create download session.
         val sessionPtr = LibdcWrapper.nativeDownloadSessionNew()
         if (sessionPtr == 0L) {
@@ -593,7 +623,12 @@ class DiveComputerHostApiImpl(
     // MARK: - Version
 
     override fun getLibdivecomputerVersion(): String {
-        return LibdcWrapper.nativeGetVersion()
+        if (LibdcWrapper.loadError != null) return "unavailable"
+        return try {
+            LibdcWrapper.nativeGetVersion()
+        } catch (t: Throwable) {
+            "unavailable"
+        }
     }
 
     // MARK: - Helpers
@@ -602,6 +637,27 @@ class DiveComputerHostApiImpl(
         mainHandler.post {
             flutterApi.onError(DiveComputerError(code = code, message = message)) { }
         }
+    }
+
+    // Reports a clear, actionable error (instead of crashing) when the native
+    // libdivecomputer JNI library failed to load. The usual cause is an
+    // UnsatisfiedLinkError from a 4 KB-aligned liblibdc_jni.so on a 16 KB-page
+    // Android 15+ device (issue #318); without this guard the failure surfaced
+    // as a silent process death the moment a download started. Returns true
+    // when the native library is usable.
+    private fun nativeLibraryReady(): Boolean {
+        val err = LibdcWrapper.loadError ?: return true
+        NativeLogger.e(
+            TAG, "LDC",
+            "Native library unavailable: ${err.javaClass.simpleName}: ${err.message}"
+        )
+        reportError(
+            "native_library_unavailable",
+            "Dive computer support could not be loaded on this device " +
+                "(${err.javaClass.simpleName}). Please update Submersion to the " +
+                "latest version."
+        )
+        return false
     }
 
     private fun mapEventType(type: Int): String = when (type) {

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/LibdcWrapper.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/LibdcWrapper.kt
@@ -3,9 +3,16 @@ package com.submersion.libdivecomputer
 // Kotlin wrapper around libdivecomputer JNI functions.
 // Each method delegates to a native C++ function via JNI.
 object LibdcWrapper {
-    init {
-        System.loadLibrary("libdc_jni")
-    }
+    // Null if the native library loaded successfully; otherwise the load
+    // failure. Captured here instead of thrown from the static initializer so
+    // callers can check [loadError] and report a clear error, rather than
+    // letting an UnsatisfiedLinkError surface as an uncaught ExceptionIn-
+    // InitializerError on a background thread and kill the process. This is the
+    // failure mode behind issue #318: a 4 KB-aligned liblibdc_jni.so fails to
+    // load on Android 15+ devices that use 16 KB memory pages (e.g. Xiaomi 15T
+    // Pro), crashing the app silently the instant a download starts.
+    val loadError: Throwable? =
+        runCatching { System.loadLibrary("libdc_jni") }.exceptionOrNull()
 
     // Version
     external fun nativeGetVersion(): String

--- a/scripts/check_16kb_alignment.py
+++ b/scripts/check_16kb_alignment.py
@@ -97,7 +97,13 @@ def check_archive(path):
             try:
                 is_64bit, aligns = load_segment_alignments(zf.read(name))
             except ElfError as exc:
-                lines.append(f"  SKIP  {name}: {exc}")
+                # Fail closed: a native lib we cannot parse is a native lib we
+                # cannot prove is 16 KB-aligned, so do not let the build pass.
+                ok = False
+                lines.append(
+                    f"  FAIL  {name}: not a parseable ELF ({exc}); "
+                    "cannot verify alignment"
+                )
                 continue
             min_align = min(aligns) if aligns else 0
             bits = "64-bit" if is_64bit else "32-bit"

--- a/scripts/check_16kb_alignment.py
+++ b/scripts/check_16kb_alignment.py
@@ -96,9 +96,11 @@ def check_archive(path):
         for name in entries:
             try:
                 is_64bit, aligns = load_segment_alignments(zf.read(name))
-            except ElfError as exc:
-                # Fail closed: a native lib we cannot parse is a native lib we
-                # cannot prove is 16 KB-aligned, so do not let the build pass.
+            except (ElfError, struct.error) as exc:
+                # Fail closed: a native lib we cannot parse (malformed, or a
+                # truncated header that trips struct.unpack_from) is a lib we
+                # cannot prove is 16 KB-aligned, so do not let the build pass --
+                # and keep checking the remaining libs instead of crashing.
                 ok = False
                 lines.append(
                     f"  FAIL  {name}: not a parseable ELF ({exc}); "

--- a/scripts/check_16kb_alignment.py
+++ b/scripts/check_16kb_alignment.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Verify that 64-bit native libraries in an Android APK/AAB are 16 KB-aligned.
+
+Android 15+ devices may use 16 KB memory pages. The dynamic linker refuses to
+load a shared library whose ELF ``PT_LOAD`` segments are aligned to less than
+16 KB (0x4000) on such a device, raising ``UnsatisfiedLinkError``. In Submersion
+this manifested as issue #318: the dive-computer JNI library ``liblibdc_jni.so``
+shipped 4 KB-aligned (0x1000) and crashed the app the instant a download started
+on a Xiaomi 15T Pro -- silently, because the failure is a native-level error.
+
+This script inspects every native library bundled in an APK or AAB and fails
+(exit code 1) if any 64-bit library has a ``PT_LOAD`` segment aligned to less
+than 16 KB. Only 64-bit ABIs are enforced: 16 KB pages exist only on 64-bit
+devices, so 4 KB-aligned 32-bit libraries (armeabi-v7a, x86) are fine and never
+loaded there.
+
+The ELF parser is intentionally dependency-free (pure stdlib) so the check runs
+identically in CI (Linux) and locally (macOS) without needing readelf/llvm tools.
+
+Usage:
+    check_16kb_alignment.py <app.apk|app.aab> [more.apk ...]
+"""
+
+import struct
+import sys
+import zipfile
+
+PAGE_16K = 16 * 1024  # 0x4000
+PT_LOAD = 1
+ELFCLASS32 = 1
+ELFCLASS64 = 2
+
+
+class ElfError(Exception):
+    """Raised when a file is not a parseable ELF object."""
+
+
+def load_segment_alignments(data):
+    """Return ``(is_64bit, [p_align, ...])`` for every PT_LOAD segment.
+
+    Raises :class:`ElfError` if ``data`` is not a little-endian ELF object.
+    """
+    if len(data) < 64 or data[:4] != b"\x7fELF":
+        raise ElfError("not an ELF file")
+
+    ei_class = data[4]
+    ei_data = data[5]
+    if ei_data != 1:
+        # Android native libs are always little-endian; anything else is unexpected.
+        raise ElfError("unsupported ELF endianness")
+
+    if ei_class == ELFCLASS64:
+        is_64bit = True
+        (e_phoff,) = struct.unpack_from("<Q", data, 0x20)
+        (e_phentsize,) = struct.unpack_from("<H", data, 0x36)
+        (e_phnum,) = struct.unpack_from("<H", data, 0x38)
+        align_off = 48  # p_align within a 64-bit program header
+    elif ei_class == ELFCLASS32:
+        is_64bit = False
+        (e_phoff,) = struct.unpack_from("<I", data, 0x1C)
+        (e_phentsize,) = struct.unpack_from("<H", data, 0x2A)
+        (e_phnum,) = struct.unpack_from("<H", data, 0x2C)
+        align_off = 28  # p_align within a 32-bit program header
+    else:
+        raise ElfError("unknown ELF class")
+
+    aligns = []
+    for i in range(e_phnum):
+        base = e_phoff + i * e_phentsize
+        (p_type,) = struct.unpack_from("<I", data, base)
+        if p_type != PT_LOAD:
+            continue
+        if is_64bit:
+            (p_align,) = struct.unpack_from("<Q", data, base + align_off)
+        else:
+            (p_align,) = struct.unpack_from("<I", data, base + align_off)
+        aligns.append(p_align)
+    return is_64bit, aligns
+
+
+def native_lib_entries(zf):
+    """Yield zip entry names for native libs in an APK (lib/) or AAB (base/lib/)."""
+    for name in zf.namelist():
+        if name.endswith(".so") and ("/lib/" in name or name.startswith("lib/")):
+            yield name
+
+
+def check_archive(path):
+    """Check one APK/AAB. Return ``(ok, lines)`` where ``lines`` is the report."""
+    lines = []
+    ok = True
+    with zipfile.ZipFile(path) as zf:
+        entries = sorted(native_lib_entries(zf))
+        if not entries:
+            return False, [f"  no native libraries (.so) found in {path}"]
+        for name in entries:
+            try:
+                is_64bit, aligns = load_segment_alignments(zf.read(name))
+            except ElfError as exc:
+                lines.append(f"  SKIP  {name}: {exc}")
+                continue
+            min_align = min(aligns) if aligns else 0
+            bits = "64-bit" if is_64bit else "32-bit"
+            if not is_64bit:
+                # 16 KB pages only exist on 64-bit devices; 32-bit libs are exempt.
+                lines.append(f"  ok    {name} ({bits}, align={min_align}, not enforced)")
+                continue
+            if min_align == 0 or min_align % PAGE_16K != 0:
+                ok = False
+                lines.append(
+                    f"  FAIL  {name} ({bits}, min p_align={min_align}; "
+                    f"must be a multiple of {PAGE_16K})"
+                )
+            else:
+                lines.append(f"  ok    {name} ({bits}, align={min_align})")
+    return ok, lines
+
+
+def main(argv):
+    paths = argv[1:]
+    if not paths:
+        print(__doc__)
+        return 2
+
+    all_ok = True
+    for path in paths:
+        print(f"Checking 16 KB alignment: {path}")
+        try:
+            ok, lines = check_archive(path)
+        except (OSError, zipfile.BadZipFile) as exc:
+            print(f"  ERROR reading {path}: {exc}")
+            all_ok = False
+            continue
+        for line in lines:
+            print(line)
+        if ok:
+            print("  -> PASS: all 64-bit native libraries are 16 KB-aligned")
+        else:
+            print("  -> FAIL: a 64-bit native library is not 16 KB-aligned "
+                  "(will crash on Android 15+ 16 KB-page devices; see issue #318)")
+        all_ok = all_ok and ok
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test/core/services/global_error_handler_test.dart
+++ b/test/core/services/global_error_handler_test.dart
@@ -52,6 +52,8 @@ void main() {
 
   test('routes uncaught platform errors to the logger and lets the platform '
       'keep handling them', () async {
+    // With no prior handler, the new handler falls back to returning false.
+    PlatformDispatcher.instance.onError = null;
     installGlobalErrorHandlers();
 
     final captured = <LogEntry>[];
@@ -74,6 +76,28 @@ void main() {
       ),
       isNotEmpty,
       reason: 'an uncaught platform error should be logged at error level',
+    );
+  });
+
+  test('platform error handler delegates to a previously-installed handler '
+      'instead of silently replacing it', () async {
+    var delegated = false;
+    PlatformDispatcher.instance.onError = (error, stack) {
+      delegated = true;
+      return true; // pretend a crash reporter fully handled it
+    };
+    installGlobalErrorHandlers();
+
+    final handled = PlatformDispatcher.instance.onError!(
+      StateError('boom-chain'),
+      StackTrace.current,
+    );
+
+    expect(delegated, isTrue, reason: 'the previous handler should still run');
+    expect(
+      handled,
+      isTrue,
+      reason: "the previous handler's result should be propagated",
     );
   });
 

--- a/test/core/services/global_error_handler_test.dart
+++ b/test/core/services/global_error_handler_test.dart
@@ -76,4 +76,22 @@ void main() {
       reason: 'an uncaught platform error should be logged at error level',
     );
   });
+
+  test('logUncaughtZoneError logs the error at error level', () async {
+    final captured = <LogEntry>[];
+    final sub = LoggerService.logStream.listen(captured.add);
+    addTearDown(sub.cancel);
+
+    logUncaughtZoneError(StateError('boom-zone'), StackTrace.current);
+
+    await pumpEventQueue();
+
+    expect(
+      captured.where(
+        (e) => e.level == LogLevel.error && e.message.contains('boom-zone'),
+      ),
+      isNotEmpty,
+      reason: 'an uncaught zone error should be logged at error level',
+    );
+  });
 }

--- a/test/core/services/global_error_handler_test.dart
+++ b/test/core/services/global_error_handler_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/global_error_handler.dart';
+import 'package:submersion/core/services/logger_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // installGlobalErrorHandlers() mutates process-global handlers; snapshot and
+  // restore both so a test cannot leak state into the next one.
+  FlutterExceptionHandler? originalFlutterOnError;
+  bool Function(Object, StackTrace)? originalPlatformOnError;
+
+  setUp(() {
+    originalFlutterOnError = FlutterError.onError;
+    originalPlatformOnError = PlatformDispatcher.instance.onError;
+    // Make the chained-to Flutter handler a benign no-op so firing a synthetic
+    // error does not reach the test framework's handler and fail the test.
+    FlutterError.onError = (_) {};
+  });
+
+  tearDown(() {
+    FlutterError.onError = originalFlutterOnError;
+    PlatformDispatcher.instance.onError = originalPlatformOnError;
+  });
+
+  test('routes uncaught Flutter framework errors to the logger', () async {
+    installGlobalErrorHandlers();
+
+    final captured = <LogEntry>[];
+    final sub = LoggerService.logStream.listen(captured.add);
+    addTearDown(sub.cancel);
+
+    FlutterError.onError!(
+      FlutterErrorDetails(
+        exception: StateError('boom-flutter'),
+        stack: StackTrace.current,
+      ),
+    );
+
+    await pumpEventQueue();
+
+    expect(
+      captured.where(
+        (e) => e.level == LogLevel.error && e.message.contains('boom-flutter'),
+      ),
+      isNotEmpty,
+      reason: 'a FlutterError should be logged at error level',
+    );
+  });
+
+  test('routes uncaught platform errors to the logger and lets the platform '
+      'keep handling them', () async {
+    installGlobalErrorHandlers();
+
+    final captured = <LogEntry>[];
+    final sub = LoggerService.logStream.listen(captured.add);
+    addTearDown(sub.cancel);
+
+    final handled = PlatformDispatcher.instance.onError!(
+      StateError('boom-platform'),
+      StackTrace.current,
+    );
+
+    await pumpEventQueue();
+
+    // Returning false means "not fully handled" so the platform still applies
+    // its default behavior (e.g. printing to the console / logcat).
+    expect(handled, isFalse);
+    expect(
+      captured.where(
+        (e) => e.level == LogLevel.error && e.message.contains('boom-platform'),
+      ),
+      isNotEmpty,
+      reason: 'an uncaught platform error should be logged at error level',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of #318 ("Mares Puck Pro shuts down app" on a Xiaomi 15T Pro) and adds the prevention + diagnosis that were missing.

This is a **16 KB page-size native library load failure**, not a dive-computer logic bug. Android 15 devices like the Xiaomi 15T Pro use 16 KB memory pages, and the dynamic linker refuses to load any `.so` whose ELF `LOAD` segments are 4 KB-aligned.

I inspected the **actual shipped `v1.5.5.107` artifacts** (both the APK and the AAB downloaded from the GitHub release). `liblibdc_jni.so` is the **only** native lib aligned to 4 KB; every other lib is 16 KB+:

```
liblibdc_jni.so               min p_align=4096    FAIL(<16KB)
libc++_shared.so              min p_align=16384   PASS
libflutter.so                 min p_align=65536   PASS
libsqlite3.so / libobjectbox / libdartjni / ...   PASS
```

So the instant a download starts and `System.loadLibrary("libdc_jni")` runs, it throws `UnsatisfiedLinkError` → an uncaught `Error` on a background thread → instant silent process death. Every reported symptom fits: any dive computer, no dialog, no log, other apps unaffected, survived PR #364.

### Why it shipped, and why the user still crashes

- The alignment fix (CMake `-Wl,-z,max-page-size=16384`, commit `34bbd3e0160`) is **already on `main`** — but it landed 38 minutes **after** `v1.5.5.107` was tagged. `git tag --contains 34bbd3e0160` is empty: no release has it. **A release from `main` is what fixes the user's crash.**
- It shipped 4 KB-aligned because the plugin's own `build.gradle` (AGP 8.1.0, no `ndkVersion`) resolves a pre-r28 NDK that defaults to 4 KB, independent of the app's NDK r28. An isolated experiment confirmed only "r27 + no flag" yields `0x1000`; the CMake flag forces 16 KB regardless of NDK.
- The crash never reached `submersion.log` because it is native and the app installed **no** global error capture — which is why this took weeks of back-and-forth.

## What this PR changes

| Layer | Files | What it does |
|-------|-------|--------------|
| **CI/release guard** | `scripts/check_16kb_alignment.py`, `ci.yaml`, `release.yml` | Fails the build (APK **and** AAB) if any 64-bit native lib isn't 16 KB-aligned. Dependency-free ELF parser; 32-bit ABIs exempt (16 KB pages are 64-bit-only). This is the prevention that was missing — a 4 KB lib shipped undetected. |
| **Graceful native failure** | `LibdcWrapper.kt`, `DiveComputerHostApiImpl.kt` | Captures the load failure (`loadError`) instead of crashing; reports a clear "please update Submersion" error on the download path; `Throwable` backstop around the download executor. |
| **App-wide error logging** | `global_error_handler.dart`, `main.dart` | `FlutterError.onError` + `PlatformDispatcher.onError` + `runZonedGuarded` route uncaught Dart errors into `submersion.log`. |

The CMakeLists comment was strengthened to "DO NOT REMOVE" (the plugin's Gradle resolves a pre-r28 NDK).

## Test plan

- [x] **Guard red→green:** `exit=1` on the shipped (broken) APK **and** AAB; `exit=0` on a fresh build from `main`.
- [x] **Local `flutter build apk` from this branch:** compiles with the Kotlin changes; `liblibdc_jni.so` = 16384 across all ABIs.
- [x] **New Dart test** (`global_error_handler_test.dart`): routes Flutter + platform errors to the logger — passes.
- [x] **`test/core/services/`:** 681 pass, 0 fail.
- [x] `flutter analyze` clean; `dart format --set-exit-if-changed` clean; both workflows valid YAML.
- [ ] On-device verification on the reporter's Xiaomi 15T Pro (needs a release with the fix).

> Note: the Kotlin load-failure path isn't unit-tested (no Kotlin harness in the plugin; a real load failure can't be simulated) — verified by build + review. Apple platforms statically link the wrapper, so this failure mode is Android-only.

## Follow-up

Cut a release from `main` to actually deliver the fix to the reporter, then confirm on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019srNBzAEaVNr7kFWPgdmuh
