### PR TITLE
fix(dive-sites): stop save from overriding cleared Country/Region

### DIFF
--- a/lib/core/providers/location_service_provider.dart
+++ b/lib/core/providers/location_service_provider.dart
@@ -1,0 +1,11 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/location_service.dart';
+
+/// Injectable handle to [LocationService].
+///
+/// Production resolves to the process-wide singleton. Tests override this with
+/// a fake to supply deterministic geocoding results without real network or
+/// platform-channel calls.
+final locationServiceProvider = Provider<LocationService>(
+  (ref) => LocationService.instance,
+);

--- a/lib/features/dive_sites/presentation/pages/site_edit_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_edit_page.dart
@@ -3,11 +3,11 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/providers/location_service_provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
-import 'package:submersion/core/services/location_service.dart';
 import 'package:submersion/core/deco/altitude_calculator.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -1420,7 +1420,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     setState(() => _isGettingLocation = true);
 
     try {
-      final locationService = LocationService.instance;
+      final locationService = ref.read(locationServiceProvider);
       final result = await locationService.getCurrentLocation(
         includeGeocoding: true,
       );
@@ -2032,10 +2032,16 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
           ? units.altitudeToMeters(altitudeInput)
           : null;
 
-      String? country = _countryController.text.trim().isEmpty
+      // Location fields persist exactly as shown. We deliberately do NOT
+      // reverse-geocode empty country/region on save: an empty field is
+      // indistinguishable from one the user intentionally cleared, so silently
+      // refilling it makes a cleared field un-clearable and overrides the
+      // user's edits. Auto-fill happens only on explicit request, via the
+      // "Use my location" / "Pick from map" actions (which fill empty fields).
+      final String? country = _countryController.text.trim().isEmpty
           ? null
           : _countryController.text.trim();
-      String? region = _regionController.text.trim().isEmpty
+      final String? region = _regionController.text.trim().isEmpty
           ? null
           : _regionController.text.trim();
       final String? city = _cityController.text.trim().isEmpty
@@ -2047,23 +2053,6 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
       final String? bodyOfWater = _bodyOfWaterController.text.trim().isEmpty
           ? null
           : _bodyOfWaterController.text.trim();
-
-      if (location != null && (country == null || region == null)) {
-        try {
-          final geocodeResult = await LocationService.instance.reverseGeocode(
-            location.latitude,
-            location.longitude,
-          );
-          if (country == null && geocodeResult.country != null) {
-            country = geocodeResult.country;
-          }
-          if (region == null && geocodeResult.region != null) {
-            region = geocodeResult.region;
-          }
-        } catch (e) {
-          // Geocoding is best-effort
-        }
-      }
 
       final diverId =
           _originalSite?.diverId ??

--- a/test/features/dive_sites/presentation/pages/site_edit_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_page_test.dart
@@ -16,10 +16,11 @@ import 'package:submersion/core/services/location_service.dart';
 
 import '../../../../helpers/test_database.dart';
 
-/// A [LocationService] whose reverse geocoding returns fixed values, so tests
-/// can prove the edit form never re-imposes geocoded names over the user's
-/// chosen (or deliberately cleared) location fields. Only [reverseGeocode] is
-/// exercised; any other call throws via [noSuchMethod].
+/// A [LocationService] returning fixed [country]/[region] for both geocoding
+/// entry points, so tests can (a) prove the edit form never re-imposes geocoded
+/// names over the user's chosen or cleared fields, and (b) drive "Use my
+/// location" deterministically. Only [reverseGeocode] and [getCurrentLocation]
+/// are exercised; any other call throws via [noSuchMethod].
 class _FakeLocationService implements LocationService {
   _FakeLocationService({this.country, this.region});
 
@@ -31,6 +32,18 @@ class _FakeLocationService implements LocationService {
     double latitude,
     double longitude,
   ) async => (country: country, region: region, locality: null);
+
+  @override
+  Future<LocationResult?> getCurrentLocation({
+    bool includeGeocoding = true,
+    Duration timeout = const Duration(seconds: 15),
+  }) async => LocationResult(
+    latitude: 12.3,
+    longitude: 45.6,
+    accuracy: 5,
+    country: country,
+    region: region,
+  );
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -960,9 +973,7 @@ void main() {
           '',
         );
         await tester.tap(find.text('Save'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pumpAndSettle();
 
         final saved = await repo.getSiteById(seeded.id);
         expect(saved, isNotNull);
@@ -1031,9 +1042,7 @@ void main() {
           '',
         );
         await tester.tap(find.text('Save'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pumpAndSettle();
 
         final saved = await repo.getSiteById(seeded.id);
         expect(saved, isNotNull);
@@ -1043,5 +1052,66 @@ void main() {
         expect(saved.region, 'Bonaire');
       },
     );
+
+    testWidgets(
+      'Use my location fills empty Country/Region (the suggestion path is '
+      'preserved)',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 3200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
+              allDiversProvider.overrideWith((_) async => const <Diver>[]),
+              shareByDefaultProvider.overrideWith((_) async => false),
+              locationServiceProvider.overrideWithValue(
+                _FakeLocationService(
+                  country: 'Geocoded Country',
+                  region: 'Geocoded Region',
+                ),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SiteEditPage(
+                  embedded: true,
+                  onSaved: (_) {},
+                  onCancel: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The Location group rests collapsed; expand it to reach the GPS
+        // controls, then capture a position.
+        await tester.tap(find.text('Add GPS position or altitude'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Use My Location'));
+        await tester.pumpAndSettle();
+
+        // Explicit capture still fills the empty fields — the suggestion the
+        // reporter values is intact; only the silent save-time override is gone.
+        expect(find.text('Geocoded Country'), findsOneWidget);
+        expect(find.text('Geocoded Region'), findsOneWidget);
+      },
+    );
+  });
+
+  group('locationServiceProvider', () {
+    test('defaults to the LocationService singleton', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(
+        container.read(locationServiceProvider),
+        same(LocationService.instance),
+      );
+    });
   });
 }

--- a/test/features/dive_sites/presentation/pages/site_edit_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_page_test.dart
@@ -11,8 +11,30 @@ import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/core/providers/location_service_provider.dart';
+import 'package:submersion/core/services/location_service.dart';
 
 import '../../../../helpers/test_database.dart';
+
+/// A [LocationService] whose reverse geocoding returns fixed values, so tests
+/// can prove the edit form never re-imposes geocoded names over the user's
+/// chosen (or deliberately cleared) location fields. Only [reverseGeocode] is
+/// exercised; any other call throws via [noSuchMethod].
+class _FakeLocationService implements LocationService {
+  _FakeLocationService({this.country, this.region});
+
+  final String? country;
+  final String? region;
+
+  @override
+  Future<({String? country, String? region, String? locality})> reverseGeocode(
+    double latitude,
+    double longitude,
+  ) async => (country: country, region: region, locality: null);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 Widget _buildHarness({
   required SharedPreferences prefs,
@@ -877,5 +899,149 @@ void main() {
       expect(saved.island, 'Malapascua');
       expect(saved.bodyOfWater, 'Visayan Sea');
     });
+  });
+
+  group('location auto-fill does not override user edits', () {
+    testWidgets(
+      'clearing Region on a site with coordinates persists empty, not a '
+      'geocoded value',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 3200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        // A Grand Turk site whose coordinates reverse-geocode to a region the
+        // user wants gone. diverId stays null so no Divers FK row is needed.
+        final repo = SiteRepository();
+        final seeded = await repo.createSite(
+          const DiveSite(
+            id: '',
+            name: 'Grand Turk Wall',
+            country: 'Turks and Caicos Islands',
+            region: 'St. Croix',
+            location: GeoPoint(21.4665, -71.139),
+          ),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
+              allDiversProvider.overrideWith((_) async => const <Diver>[]),
+              shareByDefaultProvider.overrideWith((_) async => false),
+              validatedCurrentDiverIdProvider.overrideWith((_) async => null),
+              siteProvider(seeded.id).overrideWith((_) async => seeded),
+              locationServiceProvider.overrideWithValue(
+                _FakeLocationService(
+                  country: 'Turks and Caicos Islands',
+                  region: 'St. Croix',
+                ),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SiteEditPage(
+                  siteId: seeded.id,
+                  embedded: true,
+                  onSaved: (_) {},
+                  onCancel: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Remove the auto-suggested region the user does not want.
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Region'),
+          '',
+        );
+        await tester.tap(find.text('Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final saved = await repo.getSiteById(seeded.id);
+        expect(saved, isNotNull);
+        // The cleared region stays cleared instead of reverting to St. Croix.
+        expect(saved!.region, isNull);
+        // Coordinates and the untouched country are preserved.
+        expect(saved.location, isNotNull);
+        expect(saved.country, 'Turks and Caicos Islands');
+      },
+    );
+
+    testWidgets(
+      'clearing Country on a site with coordinates persists empty, not a '
+      'geocoded value',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 3200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        // A Bonaire site whose coordinates reverse-geocode to 'Caribbean
+        // Netherlands' — the value the user keeps having to fight.
+        final repo = SiteRepository();
+        final seeded = await repo.createSite(
+          const DiveSite(
+            id: '',
+            name: 'Bonaire House Reef',
+            country: 'Caribbean Netherlands',
+            region: 'Bonaire',
+            location: GeoPoint(12.16, -68.28),
+          ),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
+              allDiversProvider.overrideWith((_) async => const <Diver>[]),
+              shareByDefaultProvider.overrideWith((_) async => false),
+              validatedCurrentDiverIdProvider.overrideWith((_) async => null),
+              siteProvider(seeded.id).overrideWith((_) async => seeded),
+              locationServiceProvider.overrideWithValue(
+                _FakeLocationService(
+                  country: 'Caribbean Netherlands',
+                  region: 'Bonaire',
+                ),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SiteEditPage(
+                  siteId: seeded.id,
+                  embedded: true,
+                  onSaved: (_) {},
+                  onCancel: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Country'),
+          '',
+        );
+        await tester.tap(find.text('Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final saved = await repo.getSiteById(seeded.id);
+        expect(saved, isNotNull);
+        // The cleared country stays cleared instead of reverting to the
+        // geocoder's 'Caribbean Netherlands'.
+        expect(saved!.country, isNull);
+        expect(saved.region, 'Bonaire');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Problem

Reported on [ScubaBoard](https://scubaboard.com/community/threads/submersion-free-open-source-dive-log-app-all-platforms-looking-for-dive-computer-testers.667061/post-10785072) against v1.5.5: when editing a dive site, the location fields fight the user's edits.

- **Region** reverts to "St. Croix" on a Grand Turk site even after being removed before saving.
- **Country** changes "Bonaire" → "Caribbean Netherlands".

The reporter appreciates the auto-suggestions but wants manual edits to be permanent.

## Root cause

`SiteEditPage._saveSite` silently reverse-geocoded empty `country`/`region` on **every save**:

```dart
if (location != null && (country == null || region == null)) {
  final geocodeResult = await LocationService.instance.reverseGeocode(...);
  if (country == null && geocodeResult.country != null) country = geocodeResult.country;
  if (region  == null && geocodeResult.region  != null) region  = geocodeResult.region;
}
```

An empty field is indistinguishable from one the user **intentionally cleared**, so as long as the site had GPS coordinates, every save re-derived the field from the geocoder — making a cleared field un-clearable.

A *typed* value was already safe: the capture-time fills (`_useMyLocation` / `_pickFromMap`) are `isEmpty`-guarded, the repository stores `country`/`region` verbatim, and the autocomplete (`RawAutocomplete`) never auto-commits. The geocoder is the **sole** source of the strings "Caribbean Netherlands" / "St. Croix" (they are not in `iso_countries.dart`), so the Country symptom is the *same* empty-refill, not a separate typed-value override.

## Fix

- Remove the save-time reverse-geocode refill so location fields persist exactly as entered.
- Auto-fill is now strictly opt-in via the existing **Use my location** / **Pick from map** actions (which fill empty fields only) — the suggestion behavior the reporter likes is untouched.
- Add `locationServiceProvider` so the form's geocoding is injectable. `LocationService.instance` is otherwise a hard singleton whose desktop Nominatim call is blocked in `flutter_test` (returns null), which would let a naive test pass against the buggy code.

## Tests

Two new widget tests in `site_edit_page_test.dart` seed a coordinates-bearing site, clear Region / Country with a fake geocoder returning the unwanted value, and assert it is not re-imposed on save. Both fail before the fix and pass after.

- `site_edit_page_test.dart`: 25/25
- `dive_sites/.../pages/` (incl. merge save path): 82/82
- `flutter analyze`: no issues · `dart format`: clean

## Follow-ups

- Device verification by the reporter is still pending (this is a behavior fix; the tests prove the data path).
- Optional: a regression test that locks in the preserved "Use my location fills an empty country/region" behavior (omitted here to keep the change surgical).