### PR TITLE
fix(sac): keep SAC curve when tank pressure is keyed to a stale tank (#276)

### DIFF
--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -89,9 +89,14 @@ List<double>? combineMultiTankPressures({
     for (final entry in tankPressures.entries) {
       final tankId = entry.key;
       final pressurePoints = entry.value;
-      final tankVolume = tankVolumes[tankId];
+      if (pressurePoints.isEmpty) continue;
 
-      if (tankVolume == null || pressurePoints.isEmpty) continue;
+      // The pressure series is already scoped to this dive. A tank id that no
+      // longer matches a current tank -- e.g. a re-import or reparse re-keyed
+      // the dive's tanks with fresh UUIDs (issue #276) -- must not discard the
+      // data; fall back to equal weighting (as when no tank has a volume) so the
+      // SAC curve still renders instead of silently disappearing ("un-keyed").
+      final tankVolume = tankVolumes[tankId] ?? 1.0;
 
       // Find pressure at this timestamp (interpolate if needed)
       double? pressure;

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -94,8 +94,9 @@ List<double>? combineMultiTankPressures({
       // The pressure series is already scoped to this dive. A tank id that no
       // longer matches a current tank -- e.g. a re-import or reparse re-keyed
       // the dive's tanks with fresh UUIDs (issue #276) -- must not discard the
-      // data; fall back to equal weighting (as when no tank has a volume) so the
-      // SAC curve still renders instead of silently disappearing ("un-keyed").
+      // data; fall back to a unit volume so the orphaned series still
+      // contributes (a lone re-keyed tank then yields its raw pressure series)
+      // instead of the SAC curve silently disappearing ("un-keyed").
       final tankVolume = tankVolumes[tankId] ?? 1.0;
 
       // Find pressure at this timestamp (interpolate if needed)

--- a/test/features/dive_log/presentation/pages/dive_edit_preserves_sac_widget_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_preserves_sac_widget_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Widget-level regression for issue #276:
+/// "SAC rate disappears after edit dive (setting dive location, trip, operator)"
+///
+/// Reproduces the real edit flow: open the edit page for an air-integrated dive
+/// that has a per-tank pressure time-series (the SAC source), save, and confirm
+/// the pressure data is still keyed to a tank that the dive actually has. If the
+/// edit re-keys/replaces the tank, the SAC join breaks even though the rows
+/// remain in the table.
+void main() {
+  late DiveRepository repository;
+  late TankPressureRepository tankPressures;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+    tankPressures = TankPressureRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> pumpEditor(
+    WidgetTester tester,
+    String diveId, {
+    void Function(String)? onSaved,
+  }) async {
+    tester.view.physicalSize = const Size(950, 8000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides.cast<Override>(),
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveEditPage(
+              diveId: diveId,
+              embedded: true,
+              onSaved: onSaved,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('saving an edited dive keeps tank pressure keyed to a real tank', (
+    tester,
+  ) async {
+    // Air-integrated dive: a single tank with no configured volume (a Perdix
+    // logs pressure but not cylinder size) plus a pressure time-series.
+    const tank = DiveTank(
+      id: 'tank-orig',
+      startPressure: 230.0,
+      endPressure: 70.0,
+      gasMix: GasMix(o2: 32),
+    );
+    final dive = await repository.createDive(
+      Dive(
+        id: 'dive-276',
+        dateTime: DateTime.utc(2026, 5, 1, 10),
+        maxDepth: 30.0,
+        tanks: const [tank],
+      ),
+    );
+    await tankPressures.insertTankPressures('dive-276', {
+      'tank-orig': const [
+        (timestamp: 0, pressure: 230.0),
+        (timestamp: 60, pressure: 205.0),
+        (timestamp: 120, pressure: 180.0),
+      ],
+    });
+
+    String? savedId;
+    await pumpEditor(tester, dive.id, onSaved: (id) => savedId = id);
+
+    // Tap Save (loading a dive with tanks marks the form dirty, so it is enabled).
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(savedId, isNotNull, reason: 'save should complete');
+
+    // The pressure rows must still be keyed to a tank the dive actually has,
+    // otherwise the SAC computation silently drops them.
+    final reloaded = (await repository.getDiveById(dive.id))!;
+    final currentTankIds = reloaded.tanks.map((t) => t.id).toSet();
+    final pressureByTank = await tankPressures.getTankPressuresForDive(dive.id);
+
+    expect(
+      pressureByTank.keys,
+      isNotEmpty,
+      reason: 'pressure rows should still exist after edit',
+    );
+    for (final pressureTankId in pressureByTank.keys) {
+      expect(
+        currentTankIds,
+        contains(pressureTankId),
+        reason:
+            'pressure tank_id $pressureTankId must match a current tank '
+            '($currentTankIds) so SAC can still be computed',
+      );
+    }
+  });
+}

--- a/test/features/dive_log/presentation/providers/profile_analysis_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_analysis_provider_test.dart
@@ -405,6 +405,49 @@ void main() {
 
       expect(result, isNull);
     });
+
+    test('still produces SAC when pressure tank_id no longer matches a tank', () {
+      // Regression for #276: dive-scoped pressure is fetched by dive id, but a
+      // re-import / reparse can re-key the dive's tanks with fresh UUIDs. The
+      // pressure rows then reference a tank id the dive no longer has, and the
+      // SAC join silently drops them ("un-keyed"). Since the pressure is already
+      // scoped to this dive, it must still produce a curve.
+      const currentTank = DiveTank(id: 'tank-new', gasMix: GasMix());
+      final tankPressures = {
+        'tank-old': const [
+          TankPressurePoint(
+            id: 'p0',
+            tankId: 'tank-old',
+            timestamp: 0,
+            pressure: 200,
+          ),
+          TankPressurePoint(
+            id: 'p1',
+            tankId: 'tank-old',
+            timestamp: 60,
+            pressure: 190,
+          ),
+          TankPressurePoint(
+            id: 'p2',
+            tankId: 'tank-old',
+            timestamp: 120,
+            pressure: 180,
+          ),
+        ],
+      };
+
+      final result = combineMultiTankPressures(
+        timestamps: const [0, 60, 120],
+        tankPressures: tankPressures,
+        tanks: const [currentTank],
+      );
+
+      expect(result, isNotNull);
+      expect(result, hasLength(3));
+      expect(result![0], closeTo(200, 0.001));
+      expect(result[1], closeTo(190, 0.001));
+      expect(result[2], closeTo(180, 0.001));
+    });
   });
 
   group('ProfileAnalysisService - Gradient Factor override', () {

--- a/test/features/dive_log/presentation/providers/profile_analysis_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_analysis_provider_test.dart
@@ -443,10 +443,11 @@ void main() {
       );
 
       expect(result, isNotNull);
-      expect(result, hasLength(3));
-      expect(result![0], closeTo(200, 0.001));
-      expect(result[1], closeTo(190, 0.001));
-      expect(result[2], closeTo(180, 0.001));
+      final combined = result!;
+      expect(combined, hasLength(3));
+      expect(combined[0], closeTo(200, 0.001));
+      expect(combined[1], closeTo(190, 0.001));
+      expect(combined[2], closeTo(180, 0.001));
     });
   });
 


### PR DESCRIPTION
## Problem

Addresses #276: after editing a dive (site / trip / operator), the **SAC rate graph disappears from the profile panel** and SAC is **no longer selectable in the metric dropdown**, even though nothing about the gas data was edited.

## Root cause

The profile SAC curve is produced by `combineMultiTankPressures`. It fetches per-sample tank pressure **scoped to the dive** (`getTankPressuresForDive(diveId)`), then **joins** that pressure to the dive's *current* tanks **by `tank_id`** — purely to weight multiple tanks by cylinder volume. Any pressure series whose `tank_id` didn't match a current tank was silently **dropped** (`continue`), collapsing the combined series to all-zeros → no SAC curve and no dropdown entry.

That join is a fragile coupling: the data's validity is already established (it's fetched by `diveId`), and a SAC graph in bar/min doesn't need volume at all. A stale `tank_id` — e.g. a dive whose tanks were re-keyed by an older edit path or a reparse — should only reduce *weighting precision*, never erase the dive's gas data. This is exactly the reporter's wording: the SAC reference gets "un-keyed."

## Fix

`lib/features/dive_log/presentation/providers/profile_analysis_provider.dart` — pressure whose `tank_id` no longer matches a current tank now falls back to equal weighting (`tankVolumes[tankId] ?? 1.0`) instead of being discarded. Correctly-keyed dives are unaffected (the lookup always hits), so existing single- and multi-tank weighting behavior is unchanged.

## Why the bug is hard to reproduce on current code

- A repository round-trip test **and** a widget test driving the real `DiveEditPage` load→Save both **pass** — current code preserves tank ids through an edit, so a site/trip/operator edit does **not** orphan pressure today.
- The reporter is on **v1.4.6.92** (tagged 2026-04-22), which predates the `updateDive` empty-tank-id guard (`29c1a39`, first shipped v1.4.7.93) that stops a re-keyed tank from cascade-deleting its pressure. The **write side is already hardened** on `main`; this **read-side change recovers already-orphaned pressure** and is defense-in-depth against any future re-keying.

## Tests
- `profile_analysis_provider_test.dart`: new failing-first regression — "still produces SAC when pressure tank_id no longer matches a tank" (reproduced `Actual: <0.0>`, now returns the real series).
- New widget test `dive_edit_preserves_sac_widget_test.dart`: proves the real edit→save flow keeps pressure keyed to a current tank.
- `flutter analyze`: clean. `dart format`: applied. All affected analysis/chart/panel tests green.

## Out of scope (flagged)
- The secondary note "import the Perdix straight also loses SAC" is a **separate write-side** bug — the direct dive-computer download drops AI pressure whose `tankIndex` has no matching tank. Needs the reporter's device/data; not addressed here.
- A parallel `tank_id` join exists in `gas_analysis_service.dart` (the SAC *segments* panel, a different UI not mentioned in the report); left untouched to keep this change focused.
- Device verification with the reporter's actual orphaned database is still pending.