### PR TITLE
feat(dive-profile): graph ascent rate (#242)

### DIFF
--- a/docs/superpowers/specs/2026-06-23-ascent-rate-graphing-design.md
+++ b/docs/superpowers/specs/2026-06-23-ascent-rate-graphing-design.md
@@ -1,0 +1,194 @@
+# Ascent Rate Graphing — Design (issue #242)
+
+Date: 2026-06-23
+Branch: `worktree-issue-242-ascent-rate-not-graphed`
+Status: Approved (design choices confirmed with user)
+
+## Problem
+
+Reported in [#242](https://github.com/submersion-app/submersion/issues/242): the dive
+profile graph does not show ascent rate, even when the "Ascent Rate" legend toggle is
+checked. The reporter (UDDF import from Subsurface, Teric computer) sees "Ascent Rate
+Warning" event markers but no ascent-rate visualization.
+
+### Root cause (confirmed)
+
+The "Ascent Rate" overlay toggle is bound to `ProfileLegendState.showAscentRateColors`,
+but that flag only adds a "Rate" row to the chart tooltip. **No `lineBarsData` entry or
+depth-line coloring ever consumes the ascent-rate data**, so toggling it on renders
+nothing on the plot. The field is documented as "Whether to color depth line by ascent
+rate", but git history shows the depth line was always drawn in a single solid colour
+(`AppColors.chartDepth`) — the coloring was never implemented. This is an unfinished
+feature, not a regression.
+
+The data itself is fine: `AscentRateCalculator.calculateProfileRates` derives
+`List<AscentRatePoint>` purely from profile depth/time samples, so it is populated for
+every dive including UDDF imports (the warning markers the reporter sees are generated
+from the same data). The fix is entirely in the presentation layer.
+
+## Goals
+
+1. Make the existing "Ascent Rate" toggle actually visualize ascent rate on the plot.
+2. Add a precise, readable ascent-rate magnitude line as a distinct, optional overlay.
+3. No data-layer, import, persistence, or sync changes.
+
+Non-goals: changing how ascent rate is calculated; touching the multi-computer depth
+rendering; adding a new persisted user setting (the new line toggle is session-only).
+
+## Design
+
+Two independent, user-toggleable visualizations, both fed by the already-computed
+`analysis.ascentRates` (already passed to `DiveProfileChart.ascentRates`).
+
+### Part 1 — Depth-line band coloring (full velocity coloring)
+
+Reuses the existing toggle `showAscentRateColors` (already defaults **on** via
+`settings.showAscentRateColors`).
+
+- When the toggle is on (single-computer path only), the depth line is split into
+  consecutive runs by `AscentRatePoint.category` and each run is coloured via the
+  existing `_getAscentRateColor`:
+  - `safe` (≤9 m/min) → green
+  - `warning` (9–12 m/min) → orange
+  - `danger` (>12 m/min) → red
+- `AscentRatePoint.category` is magnitude-based (`categorize()` uses `.abs()`), so fast
+  descents colour too — this is full "velocity coloring", matching dive-computer
+  convention.
+- Adjacent runs share their boundary sample so the line stays continuous (no gaps).
+- Each segment keeps a subtle gradient fill in its own category colour (low alpha),
+  Subsurface-style.
+- When the toggle is **off**, render today's single solid `AppColors.chartDepth` segment
+  with fill (unchanged behaviour).
+- Multi-computer mode (`computerProfiles.length >= 2`) is untouched — it keeps
+  per-computer colours.
+
+New private builder `_buildVelocityColoredDepthLines(colorScheme, units)` replaces the
+single-segment branch inside `_buildGasColoredDepthLines`. The existing
+`_buildSingleDepthSegment(color, units, start, end, showFill)` is reused per run.
+
+### Part 2 — Separate ascent-rate line + right-axis metric
+
+New session-only toggle `showAscentRateLine` (default off; no persisted setting, mirroring
+`showMod`). Gated on the same data availability as Part 1 (`config.hasAscentRates`).
+
+- New private builder `_buildAscentRateLine(chartMaxDepth)`: a lime, dashed
+  `LineChartBarData` plotting **signed** rate (m/min) via
+  `_mapValueToDepth(signedRate, chartMaxDepth, min, max)` so descents dip below and
+  ascents rise above the vertical mid-plot. No fill.
+- New right-axis metric `ProfileRightAxisMetric.ascentRate` so the user can select it for a
+  labelled m/min scale (consistent with SAC / Heart Rate). It is **not** added to
+  `fallbackPriority`, so it never auto-claims the axis.
+
+#### Axis range alignment (correctness-critical)
+
+The line and the right-axis tick labels must use the **same** range or the labels lie.
+Introduce a single helper:
+
+```
+({double min, double max})? _ascentRateAxisRange()
+  // null when ascentRates is null/empty
+  // maxAbs = max(|rateMetersPerMin|) over points
+  // span   = max(maxAbs, criticalThreshold * 1.25)   // floor ≈ 15 m/min so the scale is meaningful
+  // return (min: -span, max: span)                    // symmetric about 0
+```
+
+Used by both `_getMetricRange(ascentRate)` and the `build()`-time min/max passed to
+`_buildAscentRateLine`. Values are stored in m/min (metres); unit conversion happens at
+display time.
+
+#### Enum + four switch arms (all in `dive_profile_chart.dart`)
+
+`ProfileRightAxisMetric.ascentRate(displayName: 'Ascent Rate', shortName: 'Rate',
+color: lime, unitSuffix: null, category: primary)`.
+
+- `_hasDataForMetric` → `widget.ascentRates != null && widget.ascentRates!.isNotEmpty`
+- `_getMetricRange` → `_ascentRateAxisRange()`
+- `_formatRightAxisValue` → `units.convertDepth(value).toStringAsFixed(0)` (m/min → ft/min)
+- `_rightAxisLabel` → explicit case `'$name (${units.depthSymbol}/min)'` (don't rely on the
+  static `unitSuffix` default, which can't honour units)
+
+The generic `_mapDepthToMetricValue` already handles a symmetric linear range for tick
+positioning — no change.
+
+### Tooltip
+
+The existing "Rate" tooltip row is gated on `_showAscentRateColors`. Change the gate to
+`_showAscentRateColors || _showAscentRateLine` in **both** tooltip paths (external
+`_emitExternalTooltip` and the built-in `LineTouchTooltipData` builder).
+
+### State / provider (`profile_legend_provider.dart`)
+
+Add `showAscentRateLine` to `ProfileLegendState`: field, constructor default `false`,
+`copyWith`, `==`, `hashCode`, and `activeSecondaryCount`. Add `toggleAscentRateLine()` to
+the `ProfileLegend` notifier. Not initialised from settings (default false).
+
+### Legend (`dive_profile_legend.dart`)
+
+In the "Overlays" section, add a new toggle item below the existing "Ascent Rate" item:
+- label `context.l10n.diveLog_legend_label_ascentRateLine`
+- color `Colors.lime`
+- `isEnabled: legendState.showAscentRateLine`, `onTap: legendNotifier.toggleAscentRateLine`
+
+Update `_MoreOptionsButton._activeSecondaryCount` to count it when
+`config.hasAscentRates && legendState.showAscentRateLine`.
+
+The existing "Ascent Rate" item (label `diveLog_legend_label_ascentRate`) is unchanged and
+now drives the band coloring.
+
+### Chart wiring (`dive_profile_chart.dart` `lineBarsData`)
+
+Add after the existing overlay lines:
+```
+if (_showAscentRateLine && widget.ascentRates != null)
+  _buildAscentRateLine(totalMaxDepth),
+```
+Sync `_showAscentRateLine = legendState.showAscentRateLine;` alongside the other
+`legendState` syncs in `build()`.
+
+### Localization
+
+New key `diveLog_legend_label_ascentRateLine` = "Ascent Rate Line" added to all 11
+`lib/l10n/arb/app_*.arb` files (en + ar, de, es, fr, he, hu, it, nl, pt, zh — translated,
+not English fallbacks), then `flutter gen-l10n` (via build_runner) regenerated. The
+existing `diveLog_legend_label_ascentRate` ("Ascent Rate") is reused for the coloring
+toggle. No new metric display-name key is required — `ProfileRightAxisMetric.displayName`
+is a hard-coded enum string like the other metrics.
+
+## Behaviour change
+
+Because `showAscentRateColors` already defaults on, once Part 1 lands every dive with a
+fast ascent shows green/orange/red velocity coloring by default. This is the feature
+finally working as labelled; no migration needed.
+
+## Testing (TDD — failing tests first)
+
+Follow existing chart test patterns (pump `DiveProfileChart`, read `LineChart`
+`LineChartData`). Mark new pure helpers `@visibleForTesting` where unit testing is cleaner
+than widget extraction.
+
+1. **Band coloring**: a profile spanning safe/warning/danger yields multiple depth
+   segments whose colours map to category; a uniform profile yields a single segment;
+   toggle off → single solid `AppColors.chartDepth` segment.
+2. **Rate line**: present in `lineBarsData` when `showAscentRateLine` on, absent when off;
+   lime + dashed; signed mapping (a descent sample maps below mid-plot, an ascent above).
+3. **Axis range helper**: `_ascentRateAxisRange` symmetric, honours the floor, null when
+   no data.
+4. **Metric switch arms**: `_hasDataForMetric`, `_getMetricRange`, `_formatRightAxisValue`
+   (m→ft conversion), `_rightAxisLabel` for `ascentRate`.
+5. **Provider**: `toggleAscentRateLine` flips state; `activeSecondaryCount` reflects it.
+6. **Tooltip**: "Rate" row shown when either toggle on, hidden when both off.
+7. **Regression**: existing dive_profile_chart tests still pass (update any that assert a
+   single depth segment when coloring is on).
+
+## Files touched
+
+- `lib/core/constants/profile_metrics.dart` — add `ascentRate` enum value.
+- `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` — velocity
+  coloring builder, rate-line builder, range helper, 4 switch arms, `lineBarsData` +
+  `build()` sync, tooltip gate.
+- `lib/features/dive_log/presentation/providers/profile_legend_provider.dart` — new
+  toggle state + method.
+- `lib/features/dive_log/presentation/widgets/dive_profile_legend.dart` — new legend item
+  + active count.
+- `lib/l10n/arb/app_*.arb` (11) + regenerated `app_localizations*.dart`.
+- Tests under `test/features/dive_log/...` (new + updates).

--- a/lib/core/constants/profile_metrics.dart
+++ b/lib/core/constants/profile_metrics.dart
@@ -34,6 +34,13 @@ enum ProfileRightAxisMetric {
     unitSuffix: null, // Uses unit formatter (bar/min or L/min)
     category: ProfileMetricCategory.primary,
   ),
+  ascentRate(
+    displayName: 'Ascent Rate',
+    shortName: 'Rate',
+    color: Colors.lime,
+    unitSuffix: null, // Uses unit formatter (depth/min)
+    category: ProfileMetricCategory.primary,
+  ),
   ndl(
     displayName: 'NDL',
     shortName: 'NDL',

--- a/lib/core/deco/ascent_rate_calculator.dart
+++ b/lib/core/deco/ascent_rate_calculator.dart
@@ -78,6 +78,12 @@ class AscentRateViolation {
 
 /// Calculator for ascent rates and violations.
 class AscentRateCalculator {
+  /// Default warning threshold in m/min (safe -> warning band boundary).
+  static const double defaultWarningThreshold = 9.0;
+
+  /// Default critical threshold in m/min (warning -> danger band boundary).
+  static const double defaultCriticalThreshold = 12.0;
+
   /// Warning threshold in m/min (default 9)
   final double warningThreshold;
 
@@ -95,8 +101,8 @@ class AscentRateCalculator {
   final int smoothingWindowSeconds;
 
   const AscentRateCalculator({
-    this.warningThreshold = 9.0,
-    this.criticalThreshold = 12.0,
+    this.warningThreshold = defaultWarningThreshold,
+    this.criticalThreshold = defaultCriticalThreshold,
     this.smoothingWindow = 3,
     this.smoothingWindowSeconds = 15,
   });

--- a/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
@@ -27,6 +27,11 @@ class ProfileLegendState {
   final bool showHeartRate;
   final bool showSac;
   final bool showAscentRateColors;
+
+  /// Separate ascent-rate magnitude line (m/min). Session-only, no persisted
+  /// setting (mirrors [showMod]); distinct from [showAscentRateColors], which
+  /// tints the depth line by velocity band.
+  final bool showAscentRateLine;
   final bool showEvents;
   final bool showMaxDepthMarker;
   final bool showPressureMarkers;
@@ -70,6 +75,7 @@ class ProfileLegendState {
     this.showHeartRate = false,
     this.showSac = false,
     this.showAscentRateColors = true,
+    this.showAscentRateLine = false,
     this.showEvents = true,
     this.showMaxDepthMarker = true,
     this.showPressureMarkers = true,
@@ -110,6 +116,7 @@ class ProfileLegendState {
     if (showHeartRate) count++;
     if (showSac) count++;
     if (showAscentRateColors) count++;
+    if (showAscentRateLine) count++;
     if (showMaxDepthMarker) count++;
     if (showPressureMarkers) count++;
     if (showGasSwitchMarkers) count++;
@@ -142,6 +149,7 @@ class ProfileLegendState {
     bool? showHeartRate,
     bool? showSac,
     bool? showAscentRateColors,
+    bool? showAscentRateLine,
     bool? showEvents,
     bool? showMaxDepthMarker,
     bool? showPressureMarkers,
@@ -177,6 +185,7 @@ class ProfileLegendState {
       showHeartRate: showHeartRate ?? this.showHeartRate,
       showSac: showSac ?? this.showSac,
       showAscentRateColors: showAscentRateColors ?? this.showAscentRateColors,
+      showAscentRateLine: showAscentRateLine ?? this.showAscentRateLine,
       showEvents: showEvents ?? this.showEvents,
       showMaxDepthMarker: showMaxDepthMarker ?? this.showMaxDepthMarker,
       showPressureMarkers: showPressureMarkers ?? this.showPressureMarkers,
@@ -216,6 +225,7 @@ class ProfileLegendState {
           showHeartRate == other.showHeartRate &&
           showSac == other.showSac &&
           showAscentRateColors == other.showAscentRateColors &&
+          showAscentRateLine == other.showAscentRateLine &&
           showEvents == other.showEvents &&
           showMaxDepthMarker == other.showMaxDepthMarker &&
           showPressureMarkers == other.showPressureMarkers &&
@@ -250,6 +260,7 @@ class ProfileLegendState {
     showHeartRate,
     showSac,
     showAscentRateColors,
+    showAscentRateLine,
     showEvents,
     showMaxDepthMarker,
     showPressureMarkers,
@@ -368,6 +379,10 @@ class ProfileLegend extends _$ProfileLegend {
 
   void toggleAscentRateColors() {
     state = state.copyWith(showAscentRateColors: !state.showAscentRateColors);
+  }
+
+  void toggleAscentRateLine() {
+    state = state.copyWith(showAscentRateLine: !state.showAscentRateLine);
   }
 
   void toggleEvents() {

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -253,6 +253,24 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     return (labelText + valueText).trimRight();
   }
 
+  /// Symmetric m/min range for the ascent-rate line and the right axis so both
+  /// share one scale. Returns null when there is no ascent-rate data. The floor
+  /// keeps the scale meaningful for gentle dives.
+  @visibleForTesting
+  static ({double min, double max})? ascentRateAxisRange(
+    List<AscentRatePoint>? rates,
+  ) {
+    if (rates == null || rates.isEmpty) return null;
+    var maxAbs = 0.0;
+    for (final r in rates) {
+      final a = r.rateMetersPerMin.abs();
+      if (a > maxAbs) maxAbs = a;
+    }
+    const floorSpan = 15.0; // ~ criticalThreshold (12 m/min) * 1.25
+    final span = math.max(maxAbs, floorSpan);
+    return (min: -span, max: span);
+  }
+
   const DiveProfileChart({
     super.key,
     required this.profile,
@@ -321,6 +339,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   // Decompression visualization toggles
   bool _showCeiling = true;
   bool _showAscentRateColors = true;
+  bool _showAscentRateLine = false;
   bool _showEvents = true;
 
   // Profile marker toggles
@@ -601,7 +620,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     // Ascent rate
-    if (_showAscentRateColors &&
+    if ((_showAscentRateColors || _showAscentRateLine) &&
         widget.ascentRates != null &&
         spot.spotIndex < widget.ascentRates!.length) {
       final ascentRate = widget.ascentRates![spot.spotIndex];
@@ -1020,6 +1039,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     _showSac = legendState.showSac;
     _showCeiling = legendState.showCeiling;
     _showAscentRateColors = legendState.showAscentRateColors;
+    _showAscentRateLine = legendState.showAscentRateLine;
     _showEvents = legendState.showEvents;
     _showMaxDepthMarkerLocal = legendState.showMaxDepthMarker;
     _showPressureMarkersLocal = legendState.showPressureMarkers;
@@ -1726,6 +1746,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               if (_showSac && hasSacData && minSac != null && maxSac != null)
                 _buildSacLine(totalMaxDepth, minSac, maxSac),
 
+              // Ascent-rate magnitude line (separate overlay; signed m/min)
+              if (_showAscentRateLine && widget.ascentRates != null)
+                _buildAscentRateLine(totalMaxDepth),
+
               // Ceiling line (if showing and data available)
               if (_showCeiling && widget.ceilingCurve != null)
                 _buildCeilingLine(units),
@@ -2006,7 +2030,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     // - Descent: cyan (distinct from air blue)
                     // - Safe ascent: lime green (distinct from nitrox green)
                     // - Warning/danger: orange/red (already distinct)
-                    if (_showAscentRateColors) {
+                    if (_showAscentRateColors || _showAscentRateLine) {
                       Color rateColor = Colors.grey;
                       String arrow = '—';
                       double convertedRate = 0.0;
@@ -2648,6 +2672,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     if (cpProfiles != null && cpProfiles.length >= 2) {
       return _buildMultiComputerDepthLines(cpProfiles, units);
     }
+    // When the ascent-rate overlay is on, colour the depth line by velocity
+    // band; otherwise draw a single solid depth-coloured segment.
+    final ascentRates = widget.ascentRates;
+    if (_showAscentRateColors &&
+        ascentRates != null &&
+        ascentRates.length == widget.profile.length &&
+        widget.profile.length >= 2) {
+      return _buildVelocityColoredDepthLines(units, ascentRates);
+    }
     const depthColor = AppColors.chartDepth;
     return [
       _buildSingleDepthSegment(
@@ -2658,6 +2691,42 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         showFill: true,
       ),
     ];
+  }
+
+  /// Build depth-line segments coloured by ascent-rate band ("velocity
+  /// coloring", green/orange/red). The profile is split into consecutive runs
+  /// of the same [AscentRateCategory] and each run is drawn in its band colour.
+  /// Adjacent runs share their boundary sample so the coloured pieces join
+  /// without a gap, and every run keeps the gradient fill so the plot still
+  /// reads as a continuous depth area.
+  List<LineChartBarData> _buildVelocityColoredDepthLines(
+    UnitFormatter units,
+    List<AscentRatePoint> ascentRates,
+  ) {
+    final n = widget.profile.length;
+    final lines = <LineChartBarData>[];
+    var start = 0;
+    while (start < n) {
+      var end = start;
+      while (end + 1 < n &&
+          ascentRates[end + 1].category == ascentRates[start].category) {
+        end++;
+      }
+      // sublist end is exclusive; include the next run's first sample (end + 2)
+      // as a shared connecting point when a next run exists.
+      final sublistEnd = (end + 1 < n) ? end + 2 : end + 1;
+      lines.add(
+        _buildSingleDepthSegment(
+          _getAscentRateColor(ascentRates[start].category),
+          units,
+          start,
+          sublistEnd,
+          showFill: true,
+        ),
+      );
+      start = end + 1;
+    }
+    return lines;
   }
 
   /// Build one depth line per computer for multi-computer rendering.
@@ -2997,6 +3066,41 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       isStrokeCapRound: true,
       dotData: const FlDotData(show: false),
       dashArray: [6, 3], // Distinctive dash pattern for SAC
+    );
+  }
+
+  /// Build the separate ascent-rate magnitude line: signed rate (m/min) mapped
+  /// into the depth plot area so ascents rise above and descents dip below the
+  /// vertical mid-plot. Self-scaled via [DiveProfileChart.ascentRateAxisRange]
+  /// so the line and the optional right-axis labels share one scale.
+  LineChartBarData _buildAscentRateLine(double chartMaxDepth) {
+    final ascentRates = widget.ascentRates!;
+    final range = DiveProfileChart.ascentRateAxisRange(ascentRates)!;
+    final spots = <FlSpot>[];
+    for (var i = 0; i < widget.profile.length && i < ascentRates.length; i++) {
+      // Normalisation is unit-invariant, so map the stored m/min value
+      // directly; the right axis converts to the user's unit at label time.
+      spots.add(
+        FlSpot(
+          widget.profile[i].timestamp.toDouble(),
+          -_mapValueToDepth(
+            ascentRates[i].rateMetersPerMin,
+            chartMaxDepth,
+            range.min,
+            range.max,
+          ),
+        ),
+      );
+    }
+    return LineChartBarData(
+      spots: spots,
+      isCurved: true,
+      curveSmoothness: 0.2,
+      color: Colors.lime,
+      barWidth: 2,
+      isStrokeCapRound: true,
+      dotData: const FlDotData(show: false),
+      dashArray: const [5, 3],
     );
   }
 
@@ -3678,6 +3782,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         return widget.profile.any((p) => p.heartRate != null);
       case ProfileRightAxisMetric.sac:
         return widget.sacCurve != null && widget.sacCurve!.any((s) => s > 0);
+      case ProfileRightAxisMetric.ascentRate:
+        return widget.ascentRates != null && widget.ascentRates!.isNotEmpty;
       case ProfileRightAxisMetric.ndl:
         return widget.ndlCurve != null && widget.ndlCurve!.isNotEmpty;
       case ProfileRightAxisMetric.ppO2:
@@ -3767,6 +3873,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         if (sacs.isEmpty) return null;
         return (min: 0.0, max: sacs.reduce(math.max) * 1.2);
 
+      case ProfileRightAxisMetric.ascentRate:
+        return DiveProfileChart.ascentRateAxisRange(widget.ascentRates);
+
       case ProfileRightAxisMetric.ndl:
         return (min: 0.0, max: 3600.0); // 0-60 minutes
 
@@ -3827,6 +3936,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // SAC stored in bar/min -> convert pressure component to user unit
       case ProfileRightAxisMetric.sac:
         return units.convertPressure(value).toStringAsFixed(1);
+      // Ascent rate stored in m/min -> convert depth component to user unit
+      case ProfileRightAxisMetric.ascentRate:
+        return units.convertDepth(value).toStringAsFixed(0);
       // Mean depth stored in meters -> convert to user unit
       case ProfileRightAxisMetric.meanDepth:
         return units.convertDepth(value).toStringAsFixed(0);
@@ -3861,6 +3973,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         return '$name (${units.depthSymbol})';
       case ProfileRightAxisMetric.sac:
         return '$name (${units.pressureSymbol}/min)';
+      case ProfileRightAxisMetric.ascentRate:
+        return '$name (${units.depthSymbol}/min)';
       default:
         final suffix = metric.unitSuffix;
         if (suffix != null) return '$name ($suffix)';

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -266,7 +266,10 @@ class DiveProfileChart extends ConsumerStatefulWidget {
       final a = r.rateMetersPerMin.abs();
       if (a > maxAbs) maxAbs = a;
     }
-    const floorSpan = 15.0; // ~ criticalThreshold (12 m/min) * 1.25
+    // Floor the scale a little above the danger threshold so the warning/danger
+    // bands are always on-axis; derived from the calculator's threshold so the
+    // two cannot drift apart.
+    const floorSpan = AscentRateCalculator.defaultCriticalThreshold * 1.25;
     final span = math.max(maxAbs, floorSpan);
     return (min: -span, max: span);
   }
@@ -2694,37 +2697,41 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   }
 
   /// Build depth-line segments coloured by ascent-rate band ("velocity
-  /// coloring", green/orange/red). The profile is split into consecutive runs
-  /// of the same [AscentRateCategory] and each run is drawn in its band colour.
-  /// Adjacent runs share their boundary sample so the coloured pieces join
-  /// without a gap, and every run keeps the gradient fill so the plot still
-  /// reads as a continuous depth area.
+  /// coloring", green/orange/red).
+  ///
+  /// Each line segment between samples i-1 and i is coloured by the velocity
+  /// recorded at point i ([AscentRateCalculator] stores the rate for the
+  /// segment that *ends* at i; index 0 is a zero placeholder). Consecutive
+  /// same-band segments are merged into one polyline, so every bar spans at
+  /// least two points (the final sample never collapses to a 1-point dot) and
+  /// every run keeps the gradient fill so the plot reads as a continuous depth
+  /// area.
   List<LineChartBarData> _buildVelocityColoredDepthLines(
     UnitFormatter units,
     List<AscentRatePoint> ascentRates,
   ) {
     final n = widget.profile.length;
     final lines = <LineChartBarData>[];
-    var start = 0;
-    while (start < n) {
-      var end = start;
-      while (end + 1 < n &&
-          ascentRates[end + 1].category == ascentRates[start].category) {
-        end++;
+    var segStart = 1; // first drawable segment connects points 0 and 1
+    while (segStart < n) {
+      var segEnd = segStart;
+      while (segEnd + 1 < n &&
+          ascentRates[segEnd + 1].category == ascentRates[segStart].category) {
+        segEnd++;
       }
-      // sublist end is exclusive; include the next run's first sample (end + 2)
-      // as a shared connecting point when a next run exists.
-      final sublistEnd = (end + 1 < n) ? end + 2 : end + 1;
+      // Segments [segStart..segEnd] cover points [segStart-1 .. segEnd]; the
+      // sublist end is exclusive, so segEnd + 1 includes point segEnd. Adjacent
+      // runs share their boundary sample, so the coloured pieces join cleanly.
       lines.add(
         _buildSingleDepthSegment(
-          _getAscentRateColor(ascentRates[start].category),
+          _getAscentRateColor(ascentRates[segStart].category),
           units,
-          start,
-          sublistEnd,
+          segStart - 1,
+          segEnd + 1,
           showFill: true,
         ),
       );
-      start = end + 1;
+      segStart = segEnd + 1;
     }
     return lines;
   }

--- a/lib/features/dive_log/presentation/widgets/dive_profile_legend.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_legend.dart
@@ -288,6 +288,7 @@ class _MoreOptionsButton extends ConsumerWidget {
     if (config.hasHeartRateData && legendState.showHeartRate) count++;
     if (config.hasSacCurve && legendState.showSac) count++;
     if (config.hasAscentRates && legendState.showAscentRateColors) count++;
+    if (config.hasAscentRates && legendState.showAscentRateLine) count++;
     if (config.hasMaxDepthMarker && legendState.showMaxDepthMarker) count++;
     if (config.hasPressureMarkers && legendState.showPressureMarkers) count++;
     if (config.hasGasSwitches && legendState.showGasSwitchMarkers) count++;
@@ -466,6 +467,14 @@ class _ChartOptionsDialog extends StatelessWidget {
           color: Colors.lime.shade700,
           isEnabled: legendState.showAscentRateColors,
           onTap: legendNotifier.toggleAscentRateColors,
+        ),
+      if (config.hasAscentRates)
+        _buildToggleItem(
+          context,
+          label: context.l10n.diveLog_legend_label_ascentRateLine,
+          color: Colors.lime,
+          isEnabled: legendState.showAscentRateLine,
+          onTap: legendNotifier.toggleAscentRateLine,
         ),
       if (config.hasGasData)
         _buildGasToggleItem(

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1378,6 +1378,7 @@
   "diveLog_fullscreenProfile_close": "إغلاق ملء الشاشة",
   "diveLog_fullscreenProfile_title": "ملف الغوصة #{number}",
   "diveLog_legend_label_ascentRate": "معدل الصعود",
+  "diveLog_legend_label_ascentRateLine": "خط معدل الصعود",
   "diveLog_legend_label_ceiling": "السقف",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "العمق",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1378,6 +1378,7 @@
   "diveLog_fullscreenProfile_close": "Vollbild schließen",
   "diveLog_fullscreenProfile_title": "Tauchgang #{number} Profil",
   "diveLog_legend_label_ascentRate": "Aufstiegsgeschwindigkeit",
+  "diveLog_legend_label_ascentRateLine": "Aufstiegsgeschwindigkeit (Linie)",
   "diveLog_legend_label_ceiling": "Ceiling",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Tiefe",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2059,6 +2059,7 @@
   "diveLog_fullscreenProfile_close": "Close fullscreen",
   "diveLog_fullscreenProfile_title": "Dive #{number} Profile",
   "diveLog_legend_label_ascentRate": "Ascent Rate",
+  "diveLog_legend_label_ascentRateLine": "Ascent Rate Line",
   "diveLog_legend_label_ceiling": "Ceiling",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Depth",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1378,6 +1378,7 @@
   "diveLog_fullscreenProfile_close": "Cerrar pantalla completa",
   "diveLog_fullscreenProfile_title": "Perfil de inmersión #{number}",
   "diveLog_legend_label_ascentRate": "Velocidad de ascenso",
+  "diveLog_legend_label_ascentRateLine": "Linea de velocidad de ascenso",
   "diveLog_legend_label_ceiling": "Techo",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Profundidad",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1344,6 +1344,7 @@
   "diveLog_fullscreenProfile_close": "Fermer le plein ecran",
   "diveLog_fullscreenProfile_title": "Profil de la plongee n{number}",
   "diveLog_legend_label_ascentRate": "Vitesse de remontee",
+  "diveLog_legend_label_ascentRateLine": "Courbe de vitesse de remontee",
   "diveLog_legend_label_ceiling": "Plafond",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Profondeur",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1344,6 +1344,7 @@
   "diveLog_fullscreenProfile_close": "סגירת מסך מלא",
   "diveLog_fullscreenProfile_title": "פרופיל צלילה #{number}",
   "diveLog_legend_label_ascentRate": "קצב עלייה",
+  "diveLog_legend_label_ascentRateLine": "קו קצב עלייה",
   "diveLog_legend_label_ceiling": "תקרה",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "עומק",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1344,6 +1344,7 @@
   "diveLog_fullscreenProfile_close": "Teljes kepernyo bezarasa",
   "diveLog_fullscreenProfile_title": "Merules #{number} profil",
   "diveLog_legend_label_ascentRate": "Felszallasi sebesseg",
+  "diveLog_legend_label_ascentRateLine": "Felszallasi sebesseg vonal",
   "diveLog_legend_label_ceiling": "Plafon",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Melyseg",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1344,6 +1344,7 @@
   "diveLog_fullscreenProfile_close": "Chiudi schermo intero",
   "diveLog_fullscreenProfile_title": "Profilo immersione #{number}",
   "diveLog_legend_label_ascentRate": "Velocita di risalita",
+  "diveLog_legend_label_ascentRateLine": "Linea velocita di risalita",
   "diveLog_legend_label_ceiling": "Ceiling",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Profondita",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -6970,6 +6970,12 @@ abstract class AppLocalizations {
   /// **'Ascent Rate'**
   String get diveLog_legend_label_ascentRate;
 
+  /// No description provided for @diveLog_legend_label_ascentRateLine.
+  ///
+  /// In en, this message translates to:
+  /// **'Ascent Rate Line'**
+  String get diveLog_legend_label_ascentRateLine;
+
   /// No description provided for @diveLog_legend_label_ceiling.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -4040,6 +4040,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'معدل الصعود';
 
   @override
+  String get diveLog_legend_label_ascentRateLine => 'خط معدل الصعود';
+
+  @override
   String get diveLog_legend_label_ceiling => 'السقف';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -4138,6 +4138,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Aufstiegsgeschwindigkeit';
 
   @override
+  String get diveLog_legend_label_ascentRateLine =>
+      'Aufstiegsgeschwindigkeit (Linie)';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Ceiling';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -4065,6 +4065,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Ascent Rate';
 
   @override
+  String get diveLog_legend_label_ascentRateLine => 'Ascent Rate Line';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Ceiling';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -4139,6 +4139,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Velocidad de ascenso';
 
   @override
+  String get diveLog_legend_label_ascentRateLine =>
+      'Linea de velocidad de ascenso';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Techo';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -4163,6 +4163,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Vitesse de remontee';
 
   @override
+  String get diveLog_legend_label_ascentRateLine =>
+      'Courbe de vitesse de remontee';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Plafond';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -4023,6 +4023,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'קצב עלייה';
 
   @override
+  String get diveLog_legend_label_ascentRateLine => 'קו קצב עלייה';
+
+  @override
   String get diveLog_legend_label_ceiling => 'תקרה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -4125,6 +4125,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Felszallasi sebesseg';
 
   @override
+  String get diveLog_legend_label_ascentRateLine =>
+      'Felszallasi sebesseg vonal';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Plafon';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -4144,6 +4144,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Velocita di risalita';
 
   @override
+  String get diveLog_legend_label_ascentRateLine =>
+      'Linea velocita di risalita';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Ceiling';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -4109,6 +4109,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Opstijgsnelheid';
 
   @override
+  String get diveLog_legend_label_ascentRateLine => 'Opstijgsnelheid (lijn)';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Plafond';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -4142,6 +4142,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => 'Taxa de Subida';
 
   @override
+  String get diveLog_legend_label_ascentRateLine => 'Linha da Taxa de Subida';
+
+  @override
   String get diveLog_legend_label_ceiling => 'Teto';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -3935,6 +3935,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_legend_label_ascentRate => '上升速率';
 
   @override
+  String get diveLog_legend_label_ascentRateLine => '上升速率曲线';
+
+  @override
   String get diveLog_legend_label_ceiling => '上升限制';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1378,6 +1378,7 @@
   "diveLog_fullscreenProfile_close": "Volledig scherm sluiten",
   "diveLog_fullscreenProfile_title": "Duik #{number} profiel",
   "diveLog_legend_label_ascentRate": "Opstijgsnelheid",
+  "diveLog_legend_label_ascentRateLine": "Opstijgsnelheid (lijn)",
   "diveLog_legend_label_ceiling": "Plafond",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Diepte",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1378,6 +1378,7 @@
   "diveLog_fullscreenProfile_close": "Fechar tela cheia",
   "diveLog_fullscreenProfile_title": "Perfil do Mergulho #{number}",
   "diveLog_legend_label_ascentRate": "Taxa de Subida",
+  "diveLog_legend_label_ascentRateLine": "Linha da Taxa de Subida",
   "diveLog_legend_label_ceiling": "Teto",
   "diveLog_legend_label_cns": "CNS%",
   "diveLog_legend_label_depth": "Profundidade",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1505,6 +1505,7 @@
   "diveLog_fullscreenProfile_close": "关闭全屏",
   "diveLog_fullscreenProfile_title": "潜水 #{number} 轮廓",
   "diveLog_legend_label_ascentRate": "上升速率",
+  "diveLog_legend_label_ascentRateLine": "上升速率曲线",
   "diveLog_legend_label_ceiling": "上升限制",
   "diveLog_legend_label_cns": "中枢神经系统%",
   "diveLog_legend_label_depth": "深度",

--- a/test/core/constants/profile_metrics_test.dart
+++ b/test/core/constants/profile_metrics_test.dart
@@ -52,4 +52,21 @@ void main() {
       expect(info.ndlActual, MetricDataSource.calculated);
     });
   });
+
+  group('ProfileRightAxisMetric.ascentRate', () {
+    test('has expected display metadata', () {
+      const metric = ProfileRightAxisMetric.ascentRate;
+      expect(metric.displayName, 'Ascent Rate');
+      expect(metric.shortName, 'Rate');
+      expect(metric.category, ProfileMetricCategory.primary);
+    });
+
+    test('is excluded from the auto fallback chain', () {
+      // Ascent rate must never auto-claim the right axis; it is opt-in only.
+      expect(
+        ProfileRightAxisMetric.fallbackPriority,
+        isNot(contains(ProfileRightAxisMetric.ascentRate)),
+      );
+    });
+  });
 }

--- a/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
@@ -172,6 +172,69 @@ void main() {
     });
   });
 
+  group('showAscentRateLine', () {
+    test('defaults to false (session-only, no setting)', () {
+      const state = ProfileLegendState();
+      expect(state.showAscentRateLine, isFalse);
+    });
+
+    test('copyWith sets showAscentRateLine to true', () {
+      const state = ProfileLegendState();
+      final updated = state.copyWith(showAscentRateLine: true);
+      expect(updated.showAscentRateLine, isTrue);
+    });
+
+    test('copyWith without showAscentRateLine preserves current value', () {
+      const state = ProfileLegendState(showAscentRateLine: true);
+      final updated = state.copyWith(showSac: true);
+      expect(updated.showAscentRateLine, isTrue);
+    });
+
+    test('equality distinguishes showAscentRateLine true vs false', () {
+      const on = ProfileLegendState(showAscentRateLine: true);
+      const off = ProfileLegendState(showAscentRateLine: false);
+      expect(on, isNot(equals(off)));
+    });
+
+    test('activeSecondaryCount includes showAscentRateLine', () {
+      const state = ProfileLegendState(
+        showAscentRateLine: true,
+        showCeiling: false,
+        showAscentRateColors: false,
+        showMaxDepthMarker: false,
+        showPressureMarkers: false,
+        showGasSwitchMarkers: false,
+      );
+      expect(state.activeSecondaryCount, 1);
+    });
+  });
+
+  group('ProfileLegend.toggleAscentRateLine', () {
+    ProviderContainer makeContainer() => ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith((ref) => _StubSettingsNotifier()),
+      ],
+    );
+
+    test('toggles showAscentRateLine from false to true', () {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(profileLegendProvider.notifier);
+      expect(container.read(profileLegendProvider).showAscentRateLine, isFalse);
+      notifier.toggleAscentRateLine();
+      expect(container.read(profileLegendProvider).showAscentRateLine, isTrue);
+    });
+
+    test('toggles showAscentRateLine from true back to false', () {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(profileLegendProvider.notifier);
+      notifier.toggleAscentRateLine();
+      notifier.toggleAscentRateLine();
+      expect(container.read(profileLegendProvider).showAscentRateLine, isFalse);
+    });
+  });
+
   group('ProfileLegend.build gas timeline hydration', () {
     test('showGas starts true when defaultShowGasTimeline is true', () {
       final container = ProviderContainer(

--- a/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
@@ -196,6 +196,22 @@ void main() {
       expect(on, isNot(equals(off)));
     });
 
+    test('hashCode includes showAscentRateLine', () {
+      // Empty maps keep the hash deterministic: the state's hashCode spreads
+      // Map.entries, whose MapEntry values hash by identity.
+      const on = ProfileLegendState(
+        showAscentRateLine: true,
+        sectionExpanded: {},
+        showTankPressure: {},
+      );
+      const off = ProfileLegendState(
+        showAscentRateLine: false,
+        sectionExpanded: {},
+        showTankPressure: {},
+      );
+      expect(on.hashCode, isNot(off.hashCode));
+    });
+
     test('activeSecondaryCount includes showAscentRateLine', () {
       const state = ProfileLegendState(
         showAscentRateLine: true,

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -4,14 +4,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/deco/ascent_rate_calculator.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/theme/app_colors.dart';
 
 import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
 import 'package:submersion/features/dive_log/data/services/profile_markers_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_legend_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -2219,5 +2222,187 @@ void main() {
       final panned = tester.widget<LineChart>(chart).data;
       expect(panned.minX, greaterThan(zoomed.minX));
     });
+  });
+
+  group('ascent rate visualization (#242)', () {
+    // Categories chosen to exercise green/orange/red depth segments.
+    List<AscentRatePoint> ratesSpanningBands(List<DiveProfilePoint> profile) {
+      return List.generate(profile.length, (i) {
+        final category = i < 4
+            ? AscentRateCategory.safe
+            : i < 8
+            ? AscentRateCategory.warning
+            : AscentRateCategory.danger;
+        final rate = i < 4
+            ? 3.0
+            : i < 8
+            ? 10.0
+            : 13.0;
+        return AscentRatePoint(
+          timestamp: profile[i].timestamp,
+          depth: profile[i].depth,
+          rateMetersPerMin: rate,
+          category: category,
+        );
+      });
+    }
+
+    // Builds the chart against an explicit container so legend toggles and the
+    // right-axis metric can be driven directly (the session-only ascent-rate
+    // line has no settings hook).
+    Widget buildWithLegend({
+      required List<DiveProfilePoint> profile,
+      required List<AscentRatePoint> ascentRates,
+      void Function(ProfileLegend notifier)? configure,
+    }) {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+      if (configure != null) {
+        configure(container.read(profileLegendProvider.notifier));
+      }
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              height: 300,
+              child: DiveProfileChart(
+                profile: profile,
+                ascentRates: ascentRates,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    test('ascentRateAxisRange is symmetric and respects the floor', () {
+      final gentle = [
+        const AscentRatePoint(
+          timestamp: 0,
+          depth: 0,
+          rateMetersPerMin: 3,
+          category: AscentRateCategory.safe,
+        ),
+      ];
+      final r1 = DiveProfileChart.ascentRateAxisRange(gentle)!;
+      expect(r1.min, -15.0);
+      expect(r1.max, 15.0);
+
+      final steep = [
+        const AscentRatePoint(
+          timestamp: 0,
+          depth: 0,
+          rateMetersPerMin: -20,
+          category: AscentRateCategory.danger,
+        ),
+      ];
+      final r2 = DiveProfileChart.ascentRateAxisRange(steep)!;
+      expect(r2.min, -20.0);
+      expect(r2.max, 20.0);
+    });
+
+    test('ascentRateAxisRange returns null when there is no data', () {
+      expect(DiveProfileChart.ascentRateAxisRange(const []), isNull);
+      expect(DiveProfileChart.ascentRateAxisRange(null), isNull);
+    });
+
+    testWidgets('colors the depth line by velocity band when enabled', (
+      tester,
+    ) async {
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        _buildChart(profile: profile, ascentRates: ratesSpanningBands(profile)),
+      );
+      await tester.pumpAndSettle();
+
+      final colors = primaryChartData(
+        tester,
+      ).lineBarsData.map((b) => b.color).toSet();
+      expect(colors, contains(Colors.green));
+      expect(colors, contains(Colors.orange));
+      expect(colors, contains(Colors.red));
+    });
+
+    testWidgets('depth line is one solid segment when coloring is disabled', (
+      tester,
+    ) async {
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        buildWithLegend(
+          profile: profile,
+          ascentRates: ratesSpanningBands(profile),
+          configure: (n) => n.toggleAscentRateColors(), // default on -> off
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final bars = primaryChartData(tester).lineBarsData;
+      expect(bars.where((b) => b.color == AppColors.chartDepth).length, 1);
+      expect(
+        bars.any(
+          (b) =>
+              b.color == Colors.green ||
+              b.color == Colors.orange ||
+              b.color == Colors.red,
+        ),
+        isFalse,
+      );
+    });
+
+    bool hasRateLine(WidgetTester t) => primaryChartData(
+      t,
+    ).lineBarsData.any((b) => b.color == Colors.lime && b.dashArray != null);
+
+    testWidgets('does not render the ascent-rate line by default', (
+      tester,
+    ) async {
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        buildWithLegend(
+          profile: profile,
+          ascentRates: ratesSpanningBands(profile),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(hasRateLine(tester), isFalse);
+    });
+
+    testWidgets('renders the ascent-rate line when toggled on', (tester) async {
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        buildWithLegend(
+          profile: profile,
+          ascentRates: ratesSpanningBands(profile),
+          configure: (n) => n.toggleAscentRateLine(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(hasRateLine(tester), isTrue);
+    });
+
+    testWidgets(
+      'labels the right axis when the ascentRate metric is selected',
+      (tester) async {
+        final profile = _makeProfile(points: 12);
+        await tester.pumpWidget(
+          buildWithLegend(
+            profile: profile,
+            ascentRates: ratesSpanningBands(profile),
+            configure: (n) =>
+                n.setRightAxisMetric(ProfileRightAxisMetric.ascentRate),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.textContaining('Rate ('), findsOneWidget);
+      },
+    );
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2331,6 +2331,37 @@ void main() {
       expect(colors, contains(Colors.red));
     });
 
+    testWidgets('a band change at the final sample still draws a line', (
+      tester,
+    ) async {
+      // Rate is recorded at point i for the segment (i-1 -> i). When only the
+      // last sample is danger, its segment must render as a >=2-point line, not
+      // a 1-point dot.
+      final profile = _makeProfile(points: 8);
+      final rates = List.generate(profile.length, (i) {
+        final danger = i == profile.length - 1;
+        return AscentRatePoint(
+          timestamp: profile[i].timestamp,
+          depth: profile[i].depth,
+          rateMetersPerMin: danger ? 13.0 : 3.0,
+          category: danger
+              ? AscentRateCategory.danger
+              : AscentRateCategory.safe,
+        );
+      });
+
+      await tester.pumpWidget(
+        _buildChart(profile: profile, ascentRates: rates),
+      );
+      await tester.pumpAndSettle();
+
+      final redBars = primaryChartData(
+        tester,
+      ).lineBarsData.where((b) => b.color == Colors.red).toList();
+      expect(redBars, isNotEmpty);
+      expect(redBars.every((b) => b.spots.length >= 2), isTrue);
+    });
+
     testWidgets('depth line is one solid segment when coloring is disabled', (
       tester,
     ) async {

--- a/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
@@ -144,6 +144,25 @@ void main() {
       expect(find.text('SAC Rate'), findsOneWidget);
     });
 
+    testWidgets('Overlays section shows both ascent-rate toggles', (
+      tester,
+    ) async {
+      await openDialog(tester);
+      // The band-coloring toggle ("Ascent Rate") and the separate magnitude
+      // line toggle ("Ascent Rate Line") are distinct controls.
+      expect(find.text('Ascent Rate'), findsOneWidget);
+      expect(find.text('Ascent Rate Line'), findsOneWidget);
+    });
+
+    testWidgets('tapping Ascent Rate Line toggles without crashing', (
+      tester,
+    ) async {
+      await openDialog(tester);
+      await tester.tap(find.text('Ascent Rate Line'));
+      await tester.pumpAndSettle();
+      expect(find.text('Ascent Rate Line'), findsOneWidget);
+    });
+
     testWidgets('tapping collapsed section expands it', (tester) async {
       await openDialog(tester);
       // Markers starts collapsed -- tap to expand


### PR DESCRIPTION
## Problem

Reported in #242: the dive profile graph never shows ascent rate, even when the **Ascent Rate** toggle is checked. The reporter (UDDF import from Subsurface, Teric) sees *Ascent Rate Warning* markers but no rate itself.

**Root cause:** the `showAscentRateColors` toggle only added a "Rate" row to the hover tooltip — no chart series ever consumed the computed `ascentRates`, so enabling it drew nothing on the plot. The warning markers come from a separate event path, which is why they appeared but the rate did not. The data is derived from the profile's depth/time samples, so it is present for imported dives too. This has been the case since the feature was introduced (an unfinished feature, not a regression).

## Changes (presentation layer only)

- **Velocity coloring** — the single-computer depth line is split into runs by ascent-rate band and tinted green (≤9) / orange (9–12) / red (>12 m/min), matching dive-computer convention. Reuses the existing **Ascent Rate** toggle. Multi-computer rendering is untouched.
- **Separate rate line** — a new session-only **Ascent Rate Line** overlay draws a lime dashed signed-rate line, plus a new `ProfileRightAxisMetric.ascentRate` so it can label the right axis in the diver's depth unit per minute. A shared `ascentRateAxisRange()` keeps the line and the axis labels on one scale.
- The tooltip "Rate" row now shows for either overlay; new l10n key `diveLog_legend_label_ascentRateLine` translated across all 11 locales.

No data-layer, import, settings, or sync changes. The new enum value is name-serialized, so persisted right-axis-metric preferences are unaffected.

## Behavior note

`showAscentRateColors` already defaults on, so dives with a fast ascent now show green/orange/red velocity coloring by default — the feature finally working as labeled.

## Testing

- `flutter analyze`: clean
- Full suite: **9207 passed, 0 failed**
- New tests (TDD red→green): velocity-band coloring, rate-line presence/absence, right-axis range helper + labels, provider toggle, legend toggle.

Visual/device confirmation on a real dive profile is still worth a look (widget tests assert the underlying `LineChartData`, not pixels).

Design spec: `docs/superpowers/specs/2026-06-23-ascent-rate-graphing-design.md`

Fixes #242