### PR TITLE
fix(dashboard): refresh home tab dive providers on direct DB writes (#217)

### DIFF
--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -36,8 +36,23 @@ class DashboardAlerts {
   }
 }
 
-/// Recent dives provider (last 5)
+/// Recent dives shown on the home tab (newest 3).
+///
+/// Self-invalidates on any `dives`-table write -- a dive computer import or an
+/// iCloud sync applying remote changes directly to the DB -- so the home tab
+/// reflects new dives without an app restart (issue #217). [divesProvider]
+/// already self-invalidates on the same tick, so today this is belt-and-braces;
+/// keeping the subscription here means the home tab stays correct even if this
+/// provider is ever changed to read recent dives independently of
+/// [divesProvider], and makes its reactivity contract explicit at the call
+/// site instead of relying on transitive propagation two providers away.
 final recentDivesProvider = FutureProvider<List<Dive>>((ref) async {
+  final repository = ref.watch(diveRepositoryProvider);
+  final sub = repository.watchDivesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
+
   final allDives = await ref.watch(divesProvider.future);
   // Dives are already sorted by date descending in the repository
   final recent = allDives.take(3).toList();
@@ -51,7 +66,6 @@ final recentDivesProvider = FutureProvider<List<Dive>>((ref) async {
         .where((id) => !cache.containsKey(id))
         .toList();
     if (uncached.isNotEmpty) {
-      final repository = ref.read(diveRepositoryProvider);
       final profiles = await repository.getBatchProfileSummaries(uncached);
       ref.read(batchProfileCacheProvider.notifier).state = {
         ...cache,

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -193,12 +193,14 @@ final statisticsVersionProvider = StateProvider<int>((ref) => 0);
 
 /// Statistics provider (filtered by current diver).
 ///
+/// Feeds the dashboard HeroHeader headline totals (total dives, etc.).
 /// Self-invalidates whenever the `dives` table is written -- e.g. a dive
 /// computer import or an iCloud sync applying remote changes directly to the DB
-/// -- so the dashboard HeroHeader stats refresh without an app restart. This is
-/// the same dives-table tick the dive list and [divesProvider] already use; the
-/// dashboard stat that feeds the "recent dives" area was reactive via
-/// [divesProvider] but the headline totals were not (issue #217).
+/// -- so those totals refresh without an app restart, using the same
+/// dives-table tick the dive list and [divesProvider] already use. The
+/// dashboard's recent-dives section was already reactive (its providers read
+/// [divesProvider], which self-invalidates on the same tick); these headline
+/// totals were the remaining gap (issue #217).
 final diveStatisticsProvider = FutureProvider<DiveStatistics>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
   final currentDiverId = ref.watch(currentDiverIdProvider);

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -191,10 +191,21 @@ final batchProfileCacheProvider =
 /// to re-fetch, while keepAlive prevents disposal between navigations.
 final statisticsVersionProvider = StateProvider<int>((ref) => 0);
 
-/// Statistics provider (filtered by current diver)
+/// Statistics provider (filtered by current diver).
+///
+/// Self-invalidates whenever the `dives` table is written -- e.g. a dive
+/// computer import or an iCloud sync applying remote changes directly to the DB
+/// -- so the dashboard HeroHeader stats refresh without an app restart. This is
+/// the same dives-table tick the dive list and [divesProvider] already use; the
+/// dashboard stat that feeds the "recent dives" area was reactive via
+/// [divesProvider] but the headline totals were not (issue #217).
 final diveStatisticsProvider = FutureProvider<DiveStatistics>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
   final currentDiverId = ref.watch(currentDiverIdProvider);
+  final sub = repository.watchDivesChanges().listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(sub.cancel);
   return repository.getStatistics(diverId: currentDiverId);
 });
 

--- a/test/features/dashboard/presentation/providers/recent_dives_reactivity_test.dart
+++ b/test/features/dashboard/presentation/providers/recent_dives_reactivity_test.dart
@@ -14,10 +14,12 @@ import '../../../../helpers/mock_providers.dart';
 /// showing the pre-import slice (e.g. dive 144 in place of the new 145) until an
 /// app restart.
 ///
-/// `recentDivesProvider` reads [divesProvider], which self-invalidates on any
-/// `dives`-table write (see [DiveRepository.watchDivesChanges]). This guards
-/// that the home tab recent-dives list reflects a direct DB write -- the same
-/// path an import or a sync takes -- without any manual invalidation.
+/// `recentDivesProvider` self-invalidates on any `dives`-table write -- both
+/// directly (its own [DiveRepository.watchDivesChanges] subscription) and
+/// transitively through [divesProvider], which self-invalidates on the same
+/// tick. This guards that the home tab recent-dives list reflects a direct DB
+/// write -- the same path an import or a sync takes -- without any manual
+/// invalidation.
 void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues({});

--- a/test/features/dashboard/presentation/providers/recent_dives_reactivity_test.dart
+++ b/test/features/dashboard/presentation/providers/recent_dives_reactivity_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+import '../../../../helpers/mock_providers.dart';
+
+/// Regression test for issue #217: the home tab "recent dives" card showed
+/// stale data after a dive-computer import or an iCloud sync wrote the dives
+/// table directly. The dive LIST refreshed but the home tab did not, so it kept
+/// showing the pre-import slice (e.g. dive 144 in place of the new 145) until an
+/// app restart.
+///
+/// `recentDivesProvider` reads [divesProvider], which self-invalidates on any
+/// `dives`-table write (see [DiveRepository.watchDivesChanges]). This guards
+/// that the home tab recent-dives list reflects a direct DB write -- the same
+/// path an import or a sync takes -- without any manual invalidation.
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() => ProviderContainer(
+    overrides: [
+      // Null current diver => getAllDives returns every dive (no filter),
+      // matching the dives created below (which have a null diverId).
+      currentDiverIdProvider.overrideWith(
+        (ref) => MockCurrentDiverIdNotifier(),
+      ),
+    ],
+  );
+
+  test(
+    'recentDivesProvider reflects a dive written while the dashboard was not '
+    'listening (issue #217)',
+    () async {
+      final repository = DiveRepository();
+      // Pre-existing dives. All share the helper's entryTime, so newest-first
+      // ordering falls back to diveNumber DESC => [3, 2, 1].
+      for (final n in [1, 2, 3]) {
+        await repository.createDive(
+          createTestDiveWithBottomTime(id: 'd$n', diveNumber: n),
+        );
+      }
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // Dashboard is on screen: an active listener builds the provider chain,
+      // exactly like RecentDivesCard watching recentDivesProvider.
+      final onScreen = container.listen(recentDivesProvider, (_, _) {});
+      final initial = await container.read(recentDivesProvider.future);
+      expect(
+        initial.map((d) => d.diveNumber).toList(),
+        [3, 2, 1],
+        reason: 'pre-import recent dives',
+      );
+
+      // User leaves the dashboard to run the import flow. The card unmounts, so
+      // it stops listening. recentDivesProvider is a kept-alive (non
+      // autoDispose) FutureProvider, so it retains its stale cached slice.
+      onScreen.close();
+
+      // The dive-computer import (or an iCloud sync) writes a new most-recent
+      // dive straight to the database -- no notifier mutation.
+      await repository.createDive(
+        createTestDiveWithBottomTime(id: 'd4', diveNumber: 4),
+      );
+
+      // User returns to the dashboard: the card re-subscribes.
+      final backOnScreen = container.listen(recentDivesProvider, (_, _) {});
+      addTearDown(backOnScreen.close);
+
+      // Poll until the dives-table tick -> invalidate -> rebuild settles.
+      List<int?> numbers = const [];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final dives = await container.read(recentDivesProvider.future);
+        numbers = dives.map((d) => d.diveNumber).toList();
+        if (numbers.contains(4)) break;
+      }
+
+      expect(
+        numbers,
+        [4, 3, 2],
+        reason:
+            'After an import/sync writes a new most-recent dive while the '
+            'dashboard was backgrounded, the home tab recent-dives list must '
+            'show it on return (issue #217), not the stale pre-import slice.',
+      );
+    },
+  );
+}

--- a/test/features/dive_log/presentation/providers/dive_providers_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_providers_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 
 import '../../../../helpers/test_database.dart';
 import '../../../../helpers/mock_providers.dart';
@@ -111,4 +112,53 @@ void main() {
       );
     },
   );
+
+  test('diveStatisticsProvider auto-refreshes after a direct dives-table write '
+      '(dashboard HeroHeader / issue #217 sync scenario)', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        // Null current diver => statistics count every dive (no filter).
+        currentDiverIdProvider.overrideWith(
+          (ref) => MockCurrentDiverIdNotifier(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // The dashboard HeroHeader keeps diveStatisticsProvider alive by watching
+    // it, mirroring an on-screen home tab.
+    final sub = container.listen(diveStatisticsProvider, (_, _) {});
+    addTearDown(sub.close);
+
+    final initial = await container.read(diveStatisticsProvider.future);
+    expect(initial.totalDives, 1);
+
+    // A dive-computer import or an iCloud sync writes a new dive straight to
+    // the dives table (no manual invalidation), exactly like the home tab's
+    // data source.
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd2', diveNumber: 2),
+    );
+
+    // Poll until the dives-table tick -> invalidate -> rebuild settles.
+    int total = initial.totalDives;
+    for (var i = 0; i < 50; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      total = (await container.read(diveStatisticsProvider.future)).totalDives;
+      if (total == 2) break;
+    }
+
+    expect(
+      total,
+      2,
+      reason:
+          'diveStatisticsProvider feeds the dashboard HeroHeader; it must '
+          'refresh after a dives-table write (import/sync) so the home tab '
+          'stats reflect new dives without an app restart (issue #217).',
+    );
+  });
 }


### PR DESCRIPTION
## Issue

[#217](https://github.com/submersion-app/submersion/issues/217) — the home tab showed stale **recent dives** (e.g. `147, 146, 144` instead of `147, 146, 145`) and stale **headline stats** after a dive-computer import or an iCloud sync wrote the dives table directly. The dive list refreshed; the dashboard did not, until an app restart.

## Root cause

The dashboard's dive-derived `FutureProvider`s are non-autoDispose, so they retain a stale cached value across navigation and only refresh when something invalidates them. A sync/import writes the DB directly, bypassing the notifier paths that call `ref.invalidate`.

- `recentDivesProvider` reads `divesProvider`, which gained a `watchDivesChanges()` self-subscription in `d7b759275e1` (2026-06-08, **after** this issue was filed). That **transitively fixed the reported recent-dives symptom** — a faithful navigate-away → write → navigate-back test passes on current `main`.
- `diveStatisticsProvider` (the HeroHeader totals) had **no** such subscription, so after a **sync** the home tab's headline stats stayed stale. This is the remaining user-visible gap (and matches the issue's `device sync` label).

Confirmed it is *not* a sort bug: the home (`getAllDives`) and list (`getDiveSummaries`) paths share the same primary sort key `coalesce(entry_time, dive_date_time) DESC`, so a disagreement can only come from stale data.

## Fix

Give the dashboard's dive providers their own dives-table-tick self-subscription, matching the established `divesProvider`/`diveProvider` idiom:

- **`diveStatisticsProvider`** — now self-invalidates on `watchDivesChanges()` (the real fix; red→green test).
- **`recentDivesProvider`** — hardened with its own direct subscription so the *reported* provider is reactive locally, not only via a two-hop chain through `divesProvider`.

## Tests

- `recent_dives_reactivity_test.dart` (new) — models the exact issue scenario (dashboard backgrounded during import) and asserts the recent-dives list refreshes on return.
- `dive_providers_test.dart` — added a `diveStatisticsProvider` reactivity test (**red** before the fix).
- `flutter analyze`: clean. Full suite green (pre-push hook).

## Verification note

Since the recent-dives symptom is already fixed on current `main`, the user-visible delta here is the **HeroHeader stats refreshing after a sync**. End-to-end device verification of the sync path is still pending.

Closes #217