### PR TITLE
Comprehensive Garmin FIT import: air-integration, gas, deco, GPS, timezone

### DIFF
--- a/docs/superpowers/plans/2026-06-22-garmin-fit-import.md
+++ b/docs/superpowers/plans/2026-06-22-garmin-fit-import.md
@@ -1,0 +1,1569 @@
+# Garmin FIT Import Enrichment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Garmin FIT import extract everything the file contains — tank pressure/air-integration, gas mixes, per-sample deco (ceiling/TTS/NDL), CNS/OTU, heart rate, dive number, bottom time, surface interval, water type, deco model/GF, computer model — and let the existing site matcher see FIT/DC GPS.
+
+**Architecture:** "Make FIT speak UDDF." Decompose the FIT parser into focused extractors; emit the UDDF-shaped `ImportPayload` so the existing `UddfEntityImporter` persists the rich data unchanged. Reuse the existing GPS→site matching engine; fix only the persistence omissions that keep coordinates from reaching it. No new matcher, no `fit_tool` fork.
+
+**Tech Stack:** Flutter 3.x, Dart, `fit_tool: ^1.0.5` (FIT parsing), Drift (SQLite), Riverpod, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-garmin-fit-import-design.md` (read Appendix A/B for verified FIT field/scale ground truth).
+
+## Global Constraints
+
+- All Dart must pass `dart format .` (no diff) and whole-project `flutter analyze` (zero new issues) before each commit.
+- TDD: write the failing test first, watch it fail, implement minimally, watch it pass, commit.
+- Immutability: entities are immutable with `copyWith`; never mutate lists/objects in place.
+- No emojis in code/comments/docs. No `print` in production code.
+- Store values in metric internally (FIT is already metric: m, °C, bar, L). Display conversion is out of scope.
+- Run **specific test files** (e.g. `flutter test test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`), never broad directories (avoids Bash timeouts).
+- Commit messages: **no `Co-Authored-By` lines**. Work on a feature branch (e.g. `worktree-garmin-fit-import`), never `main`. Per-task commits are pre-authorized once this plan is approved.
+- New user-facing strings must be translated into all 10 non-en locales and regenerated. (This plan reuses the existing `importSummary_matchSitesButton` string for the only UI change, so no new strings are expected — flagged per task if that changes.)
+- FIT field numbers/scales are verified ground truth — copy them exactly: `tank_update`=319 (field 0=sensor, 1=pressure×0.01 bar, 253=timestamp); `tank_summary`=323 (field 0=sensor, 1=startP, 2=endP ×0.01 bar, 3=volumeUsed ×0.01 L); semicircle→degrees = value × (180 / 2147483648); `garmin_product`: 4223=Descent Mk3i, 4518=Descent X50i, 3865=T2 transmitter.
+
+---
+
+## File Structure
+
+**New (FIT extractors, each one responsibility):** under `lib/features/dive_import/data/services/fit/`
+- `fit_constants.dart` — message numbers, field numbers, scale constants.
+- `fit_message_access.dart` — raw field-by-number access for `GenericMessage` (unnamed msgs).
+- `fit_time_resolver.dart` — wall-clock from `local_timestamp`.
+- `fit_device_mapper.dart` — `garmin_product` → model name.
+- `fit_gas_extractor.dart` — `dive_gas` → gas mixes.
+- `fit_tank_extractor.dart` — `tank_summary`/`tank_update` → tanks + pressure series.
+- `fit_profile_extractor.dart` — `record` → samples (depth/temp/HR + ceiling/ndl/tts/cns).
+- `fit_summary_extractor.dart` — `dive_summary`/`session`/`dive_settings` → summary fields.
+
+**Modified:**
+- `lib/features/dive_import/domain/entities/imported_dive.dart` — extend model.
+- `lib/features/dive_import/data/services/fit_parser_service.dart` — orchestrate extractors + merge tank pressures into samples.
+- `lib/features/universal_import/data/parsers/fit_import_parser.dart` — emit UDDF-shaped payload.
+- `lib/features/dive_import/data/services/uddf_entity_importer.dart` — map `ceiling`; set `entryLocation`/`exitLocation` on the Dive.
+- `lib/features/dive_log/data/repositories/dive_repository_impl.dart` — persist `entryLocation`/`exitLocation` in `createDive`.
+- The dive-computer post-download results widget — surface the existing "Match Sites" affordance (#310).
+
+**Tests:** mirror new files under `test/features/dive_import/data/services/fit/`, plus importer/integration tests under `test/features/dive_import/` and `test/features/universal_import/`.
+
+---
+
+## Phase 1 — Foundation: constants, message access, time, device
+
+### Task 1: FIT constants + raw message access
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_constants.dart`
+- Create: `lib/features/dive_import/data/services/fit/fit_message_access.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_message_access_test.dart`
+
+**Interfaces:**
+- Produces: `FitConstants` (static const ints/doubles); `FitMessageAccess.rawNum(DataMessage, int fieldId) -> num?`, `FitMessageAccess.messagesWithGlobalId(List<Message>, int globalId) -> List<DataMessage>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_message_access_test.dart
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_message_access.dart';
+
+void main() {
+  test('rawNum reads a field by number from a GenericMessage (tank_update)', () {
+    // Build a tank_update (msg 319): field 0=sensor, 1=pressure(raw), 253=ts.
+    final def = DefinitionMessage(
+      globalId: FitConstants.tankUpdateMsg,
+      localId: 0,
+    )
+      ..fieldDefinitions.addAll([
+        FieldDefinition(id: 253, baseType: BaseType.uint32, size: 4),
+        FieldDefinition(id: 0, baseType: BaseType.uint32, size: 4),
+        FieldDefinition(id: 1, baseType: BaseType.uint16, size: 2),
+      ]);
+    final msg = GenericMessage(definitionMessage: def)
+      ..setFieldValueByIndex(253, 1126250405)
+      ..setFieldValueByIndex(0, 2772884913)
+      ..setFieldValueByIndex(1, 22125);
+
+    expect(msg.globalId, FitConstants.tankUpdateMsg);
+    expect(FitMessageAccess.rawNum(msg, 1), 22125);
+    expect(FitMessageAccess.rawNum(msg, 0), 2772884913);
+    expect(FitMessageAccess.rawNum(msg, 99), isNull);
+  });
+
+  test('messagesWithGlobalId filters by FIT global message number', () {
+    final def = DefinitionMessage(globalId: FitConstants.tankSummaryMsg, localId: 0);
+    final msg = GenericMessage(definitionMessage: def);
+    final others = <Message>[RecordMessage()];
+    final result = FitMessageAccess.messagesWithGlobalId(
+      [msg, ...others],
+      FitConstants.tankSummaryMsg,
+    );
+    expect(result, hasLength(1));
+    expect(result.first.globalId, FitConstants.tankSummaryMsg);
+  });
+}
+```
+
+> NOTE: `setFieldValueByIndex` / `FieldDefinition` / `GenericMessage` come from `fit_tool`. If the exact builder API for synthetic `GenericMessage` construction differs at execution time, inspect `~/.pub-cache/hosted/pub.dev/fit_tool-1.0.5/lib/src/generic_message.dart` and `definition_message.dart` and adjust the construction (the assertions on `rawNum`/`messagesWithGlobalId` stay the same). This is the one library-capability spike; resolve it here before proceeding.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_message_access_test.dart`
+Expected: FAIL — `fit_constants.dart`/`fit_message_access.dart` do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_constants.dart
+/// Verified Garmin FIT message/field numbers and scales (see design spec
+/// Appendix A). fit_tool 1.0.5 has no named classes for tank messages, so
+/// they are read by global id + field number off GenericMessage.
+class FitConstants {
+  const FitConstants._();
+
+  // Global message numbers.
+  static const int tankUpdateMsg = 319;
+  static const int tankSummaryMsg = 323;
+
+  // tank_update field numbers.
+  static const int tuTimestamp = 253;
+  static const int tuSensor = 0;
+  static const int tuPressure = 1;
+
+  // tank_summary field numbers.
+  static const int tsSensor = 0;
+  static const int tsStartPressure = 1;
+  static const int tsEndPressure = 2;
+  static const int tsVolumeUsed = 3;
+
+  // Scales: raw integer -> physical unit.
+  static const double pressureScaleBar = 100.0; // raw / 100 = bar
+  static const double volumeScaleLiters = 100.0; // raw / 100 = liters
+  static const double semicircleToDegrees = 180.0 / 2147483648.0;
+}
+```
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_message_access.dart
+import 'package:fit_tool/fit_tool.dart';
+
+/// Raw field access for FIT messages fit_tool exposes only as [GenericMessage]
+/// (it has no profile, so values are unscaled — callers apply scales).
+class FitMessageAccess {
+  const FitMessageAccess._();
+
+  static num? rawNum(DataMessage message, int fieldId) {
+    final value = message.getField(fieldId)?.value;
+    return value is num ? value : null;
+  }
+
+  static List<DataMessage> messagesWithGlobalId(
+    List<Message> messages,
+    int globalId,
+  ) {
+    return messages
+        .whereType<DataMessage>()
+        .where((m) => m.globalId == globalId)
+        .toList();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_message_access_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): add FIT constants and GenericMessage field access"
+```
+
+---
+
+### Task 2: `FitTimeResolver` — local wall-clock from `local_timestamp`
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_time_resolver.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_time_resolver_test.dart`
+
+**Interfaces:**
+- Produces: `FitTimeResolver.wallClockStart({required int? utcStartMs, required int? localStartMs, required int? utcTimestampMs, required int? localTimestampMs}) -> DateTime` — returns the dive's local wall-clock as a UTC-flagged `DateTime` (wall-clock-as-UTC convention).
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_time_resolver.dart';
+
+void main() {
+  // Malta dive: session.startTime is 08:51:10 UTC; activity local_timestamp
+  // shows 10:51:10 (UTC+2). The displayed wall-clock must be 10:51:10.
+  final utcStart = DateTime.utc(2025, 10, 13, 8, 51, 10).millisecondsSinceEpoch;
+  final utcAct = DateTime.utc(2025, 10, 13, 8, 51, 10).millisecondsSinceEpoch;
+  final localAct = DateTime.utc(2025, 10, 13, 10, 51, 10).millisecondsSinceEpoch;
+
+  test('applies activity UTC offset to the session start', () {
+    final result = FitTimeResolver.wallClockStart(
+      utcStartMs: utcStart,
+      localStartMs: null,
+      utcTimestampMs: utcAct,
+      localTimestampMs: localAct,
+    );
+    expect(result, DateTime.utc(2025, 10, 13, 10, 51, 10));
+    expect(result.isUtc, isTrue);
+  });
+
+  test('falls back to raw start when no local_timestamp is present', () {
+    final result = FitTimeResolver.wallClockStart(
+      utcStartMs: utcStart,
+      localStartMs: null,
+      utcTimestampMs: null,
+      localTimestampMs: null,
+    );
+    expect(result, DateTime.utc(2025, 10, 13, 8, 51, 10));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_time_resolver_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_time_resolver.dart
+/// Resolves a dive's local wall-clock start, stored as a UTC-flagged DateTime
+/// (the app's "wall-clock-as-UTC" convention: the displayed time must equal
+/// the local time at the dive site regardless of the importing device's TZ).
+///
+/// FIT `record`/`session` timestamps are UTC. The `activity` message carries
+/// both `timestamp` (UTC) and `local_timestamp`; their difference is the dive's
+/// UTC offset, which we add to the UTC start to recover local wall-clock.
+class FitTimeResolver {
+  const FitTimeResolver._();
+
+  static DateTime wallClockStart({
+    required int? utcStartMs,
+    required int? localStartMs,
+    required int? utcTimestampMs,
+    required int? localTimestampMs,
+  }) {
+    final startMs = utcStartMs ?? localStartMs ?? 0;
+    var offsetMs = 0;
+    if (utcTimestampMs != null && localTimestampMs != null) {
+      offsetMs = localTimestampMs - utcTimestampMs;
+    }
+    final wall = DateTime.fromMillisecondsSinceEpoch(
+      startMs + offsetMs,
+      isUtc: true,
+    );
+    return DateTime.utc(
+      wall.year,
+      wall.month,
+      wall.day,
+      wall.hour,
+      wall.minute,
+      wall.second,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_time_resolver_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): resolve local wall-clock from FIT local_timestamp"
+```
+
+> EXECUTION NOTE: confirm `activity` is exposed by fit_tool (`ActivityMessage` with `localTimestamp`/`timestamp`) and that `record`/`session` start timestamps are available; the orchestrator (Task 9) supplies these ints. If `ActivityMessage.localTimestamp` is absent in fit_tool 1.0.5, read it via `FitMessageAccess.rawNum(activityMsg, 5)` (`local_timestamp` is field 5 of `activity`, msg 34) and treat as seconds since FIT epoch (add 631065600 s and ×1000 for ms).
+
+---
+
+### Task 3: `FitDeviceMapper` — product code → model name
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_device_mapper.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_device_mapper_test.dart`
+
+**Interfaces:**
+- Produces: `FitDeviceMapper.modelName(int? garminProduct) -> String` (falls back to `'Garmin Descent'`).
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_device_mapper_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_device_mapper.dart';
+
+void main() {
+  test('maps known Garmin dive product codes', () {
+    expect(FitDeviceMapper.modelName(4223), 'Descent Mk3i');
+    expect(FitDeviceMapper.modelName(4518), 'Descent X50i');
+  });
+
+  test('falls back for unknown or null product', () {
+    expect(FitDeviceMapper.modelName(999999), 'Garmin Descent');
+    expect(FitDeviceMapper.modelName(null), 'Garmin Descent');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_device_mapper_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_device_mapper.dart
+/// Maps Garmin FIT `file_id.garmin_product` codes to human model names.
+/// Verified codes: 4223=Mk3i, 4518=X50i, 3865=T2 transmitter. Others are
+/// best-effort from the Garmin FIT product list; unknown -> generic name.
+class FitDeviceMapper {
+  const FitDeviceMapper._();
+
+  static const Map<int, String> _models = {
+    2859: 'Descent Mk1',
+    3258: 'Descent Mk2 / Mk2i',
+    3542: 'Descent Mk2s',
+    4223: 'Descent Mk3i',
+    4518: 'Descent X50i',
+    3865: 'Descent T2 Transmitter',
+  };
+
+  static String modelName(int? garminProduct) {
+    if (garminProduct == null) return 'Garmin Descent';
+    return _models[garminProduct] ?? 'Garmin Descent';
+  }
+}
+```
+
+> EXECUTION NOTE: verify the Mk2-family codes (2859/3258/3542) against `~/.pub-cache/hosted/pub.dev/fit_tool-1.0.5/lib/src/garmin_products.dart` (or the GarminProduct enum) if present; 4223/4518/3865 are verified from the sample files and must stay. Wrong secondary codes only mislabel an untested model, never break import.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_device_mapper_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): map Garmin product codes to model names"
+```
+
+---
+
+## Phase 2 — Extractors
+
+### Task 4: `FitGasExtractor` — gas mixes from `dive_gas`
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_gas_extractor.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_gas_extractor_test.dart`
+
+**Interfaces:**
+- Produces: `class FitGas { final int index; final double o2Percent; final double hePercent; final bool enabled; }`; `FitGasExtractor.extract(List<Message>) -> List<FitGas>` (sorted by index, enabled only).
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_gas_extractor_test.dart
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_gas_extractor.dart';
+
+void main() {
+  test('extracts enabled gas mixes sorted by message index', () {
+    final g0 = DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 30
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled;
+    final g1 = DiveGasMessage()
+      ..messageIndex = 1
+      ..oxygenContent = 50
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled;
+
+    final gases = FitGasExtractor.extract([g1, g0]);
+
+    expect(gases, hasLength(2));
+    expect(gases[0].index, 0);
+    expect(gases[0].o2Percent, 30);
+    expect(gases[1].o2Percent, 50);
+  });
+}
+```
+
+> EXECUTION NOTE: confirm `DiveGasMessage` getters (`oxygenContent`, `heliumContent`, `status`, `messageIndex`) and the `DiveGasStatus` enum in `~/.pub-cache/.../fit_tool/lib/src/profile/messages/dive_gas_message.dart`. Adjust names if they differ; the extracted values must match (O2=30/50, He=0).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_gas_extractor_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_gas_extractor.dart
+import 'package:fit_tool/fit_tool.dart';
+
+class FitGas {
+  const FitGas({
+    required this.index,
+    required this.o2Percent,
+    required this.hePercent,
+    required this.enabled,
+  });
+
+  final int index;
+  final double o2Percent;
+  final double hePercent;
+  final bool enabled;
+}
+
+/// Extracts the enabled gas mixes from FIT `dive_gas` (msg 259) messages.
+class FitGasExtractor {
+  const FitGasExtractor._();
+
+  static List<FitGas> extract(List<Message> messages) {
+    final gases = messages
+        .whereType<DiveGasMessage>()
+        .map((m) {
+          final enabled = m.status == DiveGasStatus.enabled;
+          return FitGas(
+            index: m.messageIndex ?? 0,
+            o2Percent: (m.oxygenContent ?? 21).toDouble(),
+            hePercent: (m.heliumContent ?? 0).toDouble(),
+            enabled: enabled,
+          );
+        })
+        .where((g) => g.enabled)
+        .toList()
+      ..sort((a, b) => a.index.compareTo(b.index));
+    return gases;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_gas_extractor_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): extract gas mixes from dive_gas messages"
+```
+
+---
+
+### Task 5: `FitTankExtractor` — tanks + pressure series from msgs 319/323
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_tank_extractor.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `class FitTank { final int sensorId; final int order; final double? startPressureBar; final double? endPressureBar; final double? volumeUsedLiters; }`
+  - `class FitTankPressureSample { final int sensorId; final int timestampMs; final double pressureBar; }`
+  - `class FitTankData { final List<FitTank> tanks; final List<FitTankPressureSample> pressures; int? orderForSensor(int sensorId); }`
+  - `FitTankExtractor.extract(List<Message>) -> FitTankData`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_tank_extractor.dart';
+
+DataMessage tankSummary({
+  required int sensor,
+  required int startRaw,
+  required int endRaw,
+  required int volRaw,
+}) {
+  final def = DefinitionMessage(globalId: FitConstants.tankSummaryMsg, localId: 0)
+    ..fieldDefinitions.addAll([
+      FieldDefinition(id: 0, baseType: BaseType.uint32, size: 4),
+      FieldDefinition(id: 1, baseType: BaseType.uint16, size: 2),
+      FieldDefinition(id: 2, baseType: BaseType.uint16, size: 2),
+      FieldDefinition(id: 3, baseType: BaseType.uint32, size: 4),
+    ]);
+  return GenericMessage(definitionMessage: def)
+    ..setFieldValueByIndex(0, sensor)
+    ..setFieldValueByIndex(1, startRaw)
+    ..setFieldValueByIndex(2, endRaw)
+    ..setFieldValueByIndex(3, volRaw);
+}
+
+DataMessage tankUpdate({
+  required int sensor,
+  required int tsRaw,
+  required int pressureRaw,
+}) {
+  final def = DefinitionMessage(globalId: FitConstants.tankUpdateMsg, localId: 0)
+    ..fieldDefinitions.addAll([
+      FieldDefinition(id: 253, baseType: BaseType.uint32, size: 4),
+      FieldDefinition(id: 0, baseType: BaseType.uint32, size: 4),
+      FieldDefinition(id: 1, baseType: BaseType.uint16, size: 2),
+    ]);
+  return GenericMessage(definitionMessage: def)
+    ..setFieldValueByIndex(253, tsRaw)
+    ..setFieldValueByIndex(0, sensor)
+    ..setFieldValueByIndex(1, pressureRaw);
+}
+
+void main() {
+  test('builds a tank per sensor with scaled start/end/volume', () {
+    // Bouchot 72: start 22125 -> 221.25 bar, end 8811 -> 88.11 bar,
+    // volume 199350 -> 1993.5 L.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 2772884913, startRaw: 22125, endRaw: 8811, volRaw: 199350),
+    ]);
+    expect(data.tanks, hasLength(1));
+    final t = data.tanks.single;
+    expect(t.sensorId, 2772884913);
+    expect(t.order, 0);
+    expect(t.startPressureBar, closeTo(221.25, 1e-6));
+    expect(t.endPressureBar, closeTo(88.11, 1e-6));
+    expect(t.volumeUsedLiters, closeTo(1993.5, 1e-6));
+  });
+
+  test('maps each sensor to a stable tank order; pressures scaled to bar', () {
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 100, startRaw: 20000, endRaw: 9000, volRaw: 100000),
+      tankSummary(sensor: 200, startRaw: 21000, endRaw: 7000, volRaw: 120000),
+      tankUpdate(sensor: 200, tsRaw: 1000, pressureRaw: 18000),
+      tankUpdate(sensor: 100, tsRaw: 1000, pressureRaw: 19000),
+    ]);
+    expect(data.tanks, hasLength(2));
+    expect(data.orderForSensor(100), 0);
+    expect(data.orderForSensor(200), 1);
+    final p = data.pressures.firstWhere((s) => s.sensorId == 200);
+    expect(p.pressureBar, closeTo(180.0, 1e-6));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
+import 'package:fit_tool/fit_tool.dart';
+import 'fit_constants.dart';
+import 'fit_message_access.dart';
+
+class FitTank {
+  const FitTank({
+    required this.sensorId,
+    required this.order,
+    this.startPressureBar,
+    this.endPressureBar,
+    this.volumeUsedLiters,
+  });
+
+  final int sensorId;
+  final int order;
+  final double? startPressureBar;
+  final double? endPressureBar;
+  final double? volumeUsedLiters;
+}
+
+class FitTankPressureSample {
+  const FitTankPressureSample({
+    required this.sensorId,
+    required this.timestampMs,
+    required this.pressureBar,
+  });
+
+  final int sensorId;
+  final int timestampMs;
+  final double pressureBar;
+}
+
+class FitTankData {
+  FitTankData(this.tanks, this.pressures);
+
+  final List<FitTank> tanks;
+  final List<FitTankPressureSample> pressures;
+
+  int? orderForSensor(int sensorId) {
+    for (final t in tanks) {
+      if (t.sensorId == sensorId) return t.order;
+    }
+    return null;
+  }
+}
+
+/// Extracts air-integration tanks (tank_summary, msg 323) and the pressure
+/// time-series (tank_update, msg 319). fit_tool has no named class for these,
+/// so they are read off GenericMessage by field number (see FitConstants).
+class FitTankExtractor {
+  const FitTankExtractor._();
+
+  static FitTankData extract(List<Message> messages) {
+    final summaries = FitMessageAccess.messagesWithGlobalId(
+      messages,
+      FitConstants.tankSummaryMsg,
+    );
+    final updates = FitMessageAccess.messagesWithGlobalId(
+      messages,
+      FitConstants.tankUpdateMsg,
+    );
+
+    // Assign a stable order per sensor in first-seen order across summaries.
+    final orderBySensor = <int, int>{};
+    final tanks = <FitTank>[];
+    for (final m in summaries) {
+      final sensor = FitMessageAccess.rawNum(m, FitConstants.tsSensor)?.toInt();
+      if (sensor == null) continue;
+      final order = orderBySensor.putIfAbsent(sensor, () => orderBySensor.length);
+      tanks.add(
+        FitTank(
+          sensorId: sensor,
+          order: order,
+          startPressureBar: _scaled(m, FitConstants.tsStartPressure,
+              FitConstants.pressureScaleBar),
+          endPressureBar: _scaled(m, FitConstants.tsEndPressure,
+              FitConstants.pressureScaleBar),
+          volumeUsedLiters: _scaled(m, FitConstants.tsVolumeUsed,
+              FitConstants.volumeScaleLiters),
+        ),
+      );
+    }
+
+    final pressures = <FitTankPressureSample>[];
+    for (final m in updates) {
+      final sensor = FitMessageAccess.rawNum(m, FitConstants.tuSensor)?.toInt();
+      final pressure = _scaled(m, FitConstants.tuPressure,
+          FitConstants.pressureScaleBar);
+      final ts = FitMessageAccess.rawNum(m, FitConstants.tuTimestamp)?.toInt();
+      if (sensor == null || pressure == null || ts == null) continue;
+      // Register sensors that appear only in updates (no summary row).
+      orderBySensor.putIfAbsent(sensor, () => orderBySensor.length);
+      pressures.add(FitTankPressureSample(
+        sensorId: sensor,
+        timestampMs: ts,
+        pressureBar: pressure,
+      ));
+    }
+
+    return FitTankData(tanks, pressures);
+  }
+
+  static double? _scaled(DataMessage m, int fieldId, double scale) {
+    final raw = FitMessageAccess.rawNum(m, fieldId);
+    return raw == null ? null : raw.toDouble() / scale;
+  }
+}
+```
+
+> EXECUTION NOTE: the `tank_update` timestamp (field 253) is FIT-epoch *seconds*; the orchestrator (Task 9) converts to the same ms base it uses for record timestamps before merging into samples (Task 9 Step 3). Keep `timestampMs` as whatever base Task 9 expects — store raw seconds here and convert in Task 9, OR convert here consistently. Pick one and keep it consistent across Task 5 and Task 9.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): extract tanks and pressure series from msgs 319/323"
+```
+
+---
+
+### Task 6: `FitProfileExtractor` — samples with deco fields
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_profile_extractor.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_profile_extractor_test.dart`
+
+**Interfaces:**
+- Produces: `class FitSample { final int timestampMs; final double depth; final double? temperature; final int? heartRate; final double? ceiling; final int? ndlSeconds; final int? ttsSeconds; final double? cns; }`; `FitProfileExtractor.extract(List<RecordMessage>) -> List<FitSample>` (records lacking depth skipped).
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_profile_extractor_test.dart
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_profile_extractor.dart';
+
+void main() {
+  test('extracts depth + deco fields, skips depthless records', () {
+    final r1 = RecordMessage()
+      ..timestamp = 1000
+      ..depth = 24.257
+      ..temperature = 23
+      ..nextStopDepth = 6.0
+      ..timeToSurface = 480
+      ..ndlTime = 0
+      ..cnsLoad = 15;
+    final r2 = RecordMessage()..timestamp = 2000; // no depth -> skipped
+
+    final samples = FitProfileExtractor.extract([r1, r2]);
+
+    expect(samples, hasLength(1));
+    final s = samples.single;
+    expect(s.depth, closeTo(24.257, 1e-6));
+    expect(s.ceiling, 6.0);
+    expect(s.ttsSeconds, 480);
+    expect(s.ndlSeconds, 0);
+    expect(s.cns, 15);
+  });
+}
+```
+
+> EXECUTION NOTE: `RecordMessage` getters used (`nextStopDepth`, `timeToSurface`, `ndlTime`, `cnsLoad`, `temperature`, `heartRate`, `depth`, `timestamp`) are confirmed present in fit_tool 1.0.5 `record_message.dart`. `ceiling` = `nextStopDepth`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_profile_extractor_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_profile_extractor.dart
+import 'package:fit_tool/fit_tool.dart';
+
+class FitSample {
+  const FitSample({
+    required this.timestampMs,
+    required this.depth,
+    this.temperature,
+    this.heartRate,
+    this.ceiling,
+    this.ndlSeconds,
+    this.ttsSeconds,
+    this.cns,
+  });
+
+  final int timestampMs;
+  final double depth;
+  final double? temperature;
+  final int? heartRate;
+  final double? ceiling; // meters (record.nextStopDepth)
+  final int? ndlSeconds; // record.ndlTime
+  final int? ttsSeconds; // record.timeToSurface
+  final double? cns; // percent (record.cnsLoad)
+}
+
+/// Extracts per-sample dive profile data, including the Garmin-recorded deco
+/// values (ceiling/TTS/NDL/CNS). These are imported as recorded, never
+/// recomputed. Records without depth are skipped.
+class FitProfileExtractor {
+  const FitProfileExtractor._();
+
+  static List<FitSample> extract(List<RecordMessage> records) {
+    final samples = <FitSample>[];
+    for (final r in records) {
+      final depth = r.depth;
+      final ts = r.timestamp;
+      if (depth == null || ts == null) continue;
+      samples.add(FitSample(
+        timestampMs: ts,
+        depth: depth,
+        temperature: r.temperature?.toDouble(),
+        heartRate: r.heartRate,
+        ceiling: r.nextStopDepth,
+        ndlSeconds: r.ndlTime,
+        ttsSeconds: r.timeToSurface,
+        cns: r.cnsLoad?.toDouble(),
+      ));
+    }
+    return samples;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_profile_extractor_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): extract profile samples with recorded deco fields"
+```
+
+---
+
+### Task 7: `FitSummaryExtractor` — summary/session/settings
+
+**Files:**
+- Create: `lib/features/dive_import/data/services/fit/fit_summary_extractor.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_summary_extractor_test.dart`
+
+**Interfaces:**
+- Produces: `class FitSummary { int? diveNumber; Duration? bottomTime; Duration? surfaceInterval; double? cnsStart; double? cnsEnd; double? otu; double? entryLat; double? entryLong; String? waterType; double? waterDensity; String? decoModel; int? gfLow; int? gfHigh; }`; `FitSummaryExtractor.extract({DiveSummaryMessage?, SessionMessage?, DiveSettingsMessage?}) -> FitSummary`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/data/services/fit/fit_summary_extractor_test.dart
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_summary_extractor.dart';
+
+void main() {
+  test('extracts dive number, bottom time, SI, CNS/OTU, GPS, water type, GF', () {
+    final summary = DiveSummaryMessage()
+      ..diveNumber = 92
+      ..bottomTime = 5168.781
+      ..surfaceInterval = 167491
+      ..startCns = 0
+      ..endCns = 32
+      ..o2Toxicity = 90;
+    final session = SessionMessage()
+      ..startPositionLat = 427345071 // semicircles -> ~35.815 N
+      ..startPositionLong = 172412425; // ~14.451 E
+    final settings = DiveSettingsMessage()
+      ..waterType = WaterType.salt
+      ..gfLow = 50
+      ..gfHigh = 85
+      ..model = TissueModelType.zhl16c;
+
+    final s = FitSummaryExtractor.extract(
+      summary: summary,
+      session: session,
+      settings: settings,
+    );
+
+    expect(s.diveNumber, 92);
+    expect(s.bottomTime, const Duration(seconds: 5168));
+    expect(s.surfaceInterval, const Duration(seconds: 167491));
+    expect(s.cnsEnd, 32);
+    expect(s.otu, 90);
+    expect(s.entryLat, closeTo(35.815, 0.01));
+    expect(s.entryLong, closeTo(14.451, 0.01));
+    expect(s.waterType, 'salt');
+    expect(s.gfLow, 50);
+    expect(s.gfHigh, 85);
+  });
+}
+```
+
+> EXECUTION NOTE: confirm fit_tool getter/enum names: `DiveSummaryMessage` (`diveNumber`, `bottomTime`, `surfaceInterval`, `startCns`, `endCns`, `o2Toxicity`), `SessionMessage` (`startPositionLat`/`Long` — already used in current parser as degrees? Verify whether fit_tool returns DEGREES or SEMICIRCLES: the existing `fit_parser_service.dart` reads `session.startPositionLat` directly as the GPS value, so fit_tool likely already converts to degrees. If so, DROP the semicircle conversion and assert the degree value fit_tool returns; if it returns raw semicircles, apply `FitConstants.semicircleToDegrees`.), `DiveSettingsMessage` (`waterType`, `waterDensity`, `gfLow`, `gfHigh`, `model`). Map `WaterType.salt/fresh/brackish` enum -> lowercase name string. Map `model` enum -> `'zhl_16c'` string for `decoAlgorithm`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_summary_extractor_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
+import 'package:fit_tool/fit_tool.dart';
+
+class FitSummary {
+  FitSummary({
+    this.diveNumber,
+    this.bottomTime,
+    this.surfaceInterval,
+    this.cnsStart,
+    this.cnsEnd,
+    this.otu,
+    this.entryLat,
+    this.entryLong,
+    this.waterType,
+    this.waterDensity,
+    this.decoModel,
+    this.gfLow,
+    this.gfHigh,
+  });
+
+  final int? diveNumber;
+  final Duration? bottomTime;
+  final Duration? surfaceInterval;
+  final double? cnsStart;
+  final double? cnsEnd;
+  final double? otu;
+  final double? entryLat;
+  final double? entryLong;
+  final String? waterType;
+  final double? waterDensity;
+  final String? decoModel;
+  final int? gfLow;
+  final int? gfHigh;
+}
+
+/// Extracts dive-level fields from `dive_summary` (msg 268), `session`
+/// (msg 18) and `dive_settings` (msg 258).
+class FitSummaryExtractor {
+  const FitSummaryExtractor._();
+
+  static FitSummary extract({
+    DiveSummaryMessage? summary,
+    SessionMessage? session,
+    DiveSettingsMessage? settings,
+  }) {
+    Duration? secs(num? v) => v == null ? null : Duration(seconds: v.round());
+    return FitSummary(
+      diveNumber: summary?.diveNumber,
+      bottomTime: secs(summary?.bottomTime),
+      surfaceInterval: secs(summary?.surfaceInterval),
+      cnsStart: summary?.startCns?.toDouble(),
+      cnsEnd: summary?.endCns?.toDouble(),
+      otu: summary?.o2Toxicity?.toDouble(),
+      entryLat: session?.startPositionLat,
+      entryLong: session?.startPositionLong,
+      waterType: settings?.waterType?.name,
+      waterDensity: settings?.waterDensity,
+      decoModel: settings?.model == null ? null : 'zhl_16c',
+      gfLow: settings?.gfLow,
+      gfHigh: settings?.gfHigh,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_summary_extractor_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+flutter analyze lib/features/dive_import/data/services/fit
+git add lib/features/dive_import/data/services/fit test/features/dive_import/data/services/fit
+git commit -m "feat(fit): extract dive summary/session/settings fields"
+```
+
+---
+
+## Phase 3 — Model, orchestrator, payload
+
+### Task 8: Extend `ImportedDive` model
+
+**Files:**
+- Modify: `lib/features/dive_import/domain/entities/imported_dive.dart`
+- Test: `test/features/dive_import/domain/entities/imported_dive_test.dart` (add cases)
+
+**Interfaces:**
+- Produces: `ImportedTank`, `ImportedTankPressureSample`, extended `ImportedDive` and `ImportedProfileSample` with the new fields below.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_import/domain/entities/imported_dive_test.dart (add)
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
+
+void main() {
+  test('ImportedDive carries enriched fields', () {
+    const dive = ImportedDive(
+      sourceId: 'garmin-1-2',
+      sourceUuid: 'garmin-1-2',
+      source: ImportSource.garmin,
+      startTime: null,
+      endTime: null,
+      maxDepth: 34.2,
+      diveNumber: 92,
+      bottomTimeSeconds: 5168,
+      surfaceIntervalSeconds: 167491,
+      cnsEnd: 32,
+      otu: 90,
+      waterType: 'salt',
+      decoModel: 'zhl_16c',
+      gfLow: 50,
+      gfHigh: 85,
+      computerModel: 'Descent Mk3i',
+      tanks: [
+        ImportedTank(order: 0, startPressureBar: 221.25, endPressureBar: 88.11,
+            o2Percent: 30, hePercent: 0),
+      ],
+      profile: [
+        ImportedProfileSample(
+          timeSeconds: 0, depth: 1.6, ceiling: 0, ndlSeconds: 0,
+          tankPressures: [ImportedTankPressureSample(tankIndex: 0, pressureBar: 221.25)],
+        ),
+      ],
+    );
+    expect(dive.diveNumber, 92);
+    expect(dive.tanks.single.startPressureBar, 221.25);
+    expect(dive.profile.single.tankPressures!.single.pressureBar, 221.25);
+  });
+}
+```
+
+> NOTE: `startTime`/`endTime` become nullable here only if the existing model allows it; if they must stay required `DateTime`, keep them required in the test (pass concrete DateTimes). Match the existing required/optional shape — do not loosen required fields unnecessarily.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/domain/entities/imported_dive_test.dart`
+Expected: FAIL — new fields/classes do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `imported_dive.dart` (extend the existing classes; keep all current fields and `props`):
+
+```dart
+class ImportedTank extends Equatable {
+  const ImportedTank({
+    required this.order,
+    this.startPressureBar,
+    this.endPressureBar,
+    this.volumeUsedLiters,
+    this.o2Percent,
+    this.hePercent,
+  });
+
+  final int order;
+  final double? startPressureBar;
+  final double? endPressureBar;
+  final double? volumeUsedLiters;
+  final double? o2Percent;
+  final double? hePercent;
+
+  @override
+  List<Object?> get props =>
+      [order, startPressureBar, endPressureBar, volumeUsedLiters, o2Percent, hePercent];
+}
+
+class ImportedTankPressureSample extends Equatable {
+  const ImportedTankPressureSample({
+    required this.tankIndex,
+    required this.pressureBar,
+  });
+
+  final int tankIndex;
+  final double pressureBar;
+
+  @override
+  List<Object?> get props => [tankIndex, pressureBar];
+}
+```
+
+Add these fields to `ImportedDive` (with constructor params + `props`): `final String? sourceUuid; final int? diveNumber; final int? bottomTimeSeconds; final int? surfaceIntervalSeconds; final double? cnsStart; final double? cnsEnd; final double? otu; final String? waterType; final String? decoModel; final int? gfLow; final int? gfHigh; final String? computerModel; final String? computerSerial; final String? computerFirmware; final double? exitLatitude; final double? exitLongitude; final List<ImportedTank> tanks;` (default `const []`).
+
+Add to `ImportedProfileSample` (with params + `props`): `final double? cns; final int? ndlSeconds; final int? ttsSeconds; final double? ceiling; final List<ImportedTankPressureSample>? tankPressures;`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_import/domain/entities/imported_dive_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/domain/entities test/features/dive_import/domain/entities
+flutter analyze lib/features/dive_import/domain/entities
+git add lib/features/dive_import/domain/entities test/features/dive_import/domain/entities
+git commit -m "feat(fit): extend ImportedDive with tanks/deco/summary fields"
+```
+
+---
+
+### Task 9: Rewrite `FitParserService` as orchestrator (+ merge tank pressures into samples)
+
+**Files:**
+- Modify: `lib/features/dive_import/data/services/fit_parser_service.dart`
+- Test: `test/features/dive_import/data/services/fit_parser_service_test.dart` (extend the existing synthetic-FIT tests)
+
+**Interfaces:**
+- Consumes: all extractors from Phase 1–2; `ImportedDive` from Task 8.
+- Produces: enriched `ImportedDive` from `parseFitFile`.
+
+**Tank-pressure → sample merge (the key logic):** the importer reads per-sample tank pressure from each profile point's `allTankPressures`. FIT `tank_update` is a separate, sparser series, so the orchestrator merges each pressure sample onto the profile sample at the same whole-second offset from dive start (nearest within ±2 s), tagged with the sensor's tank order.
+
+- [ ] **Step 1: Write the failing test** (extend existing file)
+
+```dart
+// test/features/dive_import/data/services/fit_parser_service_test.dart (add)
+test('enriched parse surfaces tanks, gas, deco, dive number, GPS', () async {
+  // buildTestDiveFitFile is the existing synthetic builder. Extend it (or add
+  // buildRichDiveFitFile) to also append: DiveSummaryMessage(diveNumber:73,
+  // bottomTime, surfaceInterval, endCns, o2Toxicity), DiveSettingsMessage
+  // (waterType:salt, gfLow:50, gfHigh:85), DiveGasMessage(o2:28), a
+  // tank_summary GenericMessage, and records with nextStopDepth/ndlTime.
+  final bytes = buildRichDiveFitFile();
+  final dive = await const FitParserService().parseFitFile(bytes);
+
+  expect(dive, isNotNull);
+  expect(dive!.diveNumber, 73);
+  expect(dive.waterType, 'salt');
+  expect(dive.gfLow, 50);
+  expect(dive.tanks, isNotEmpty);
+  expect(dive.tanks.first.startPressureBar, isNotNull);
+  expect(dive.profile.any((s) => s.ceiling != null), isTrue);
+  expect(dive.sourceUuid, dive.sourceId);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit_parser_service_test.dart`
+Expected: FAIL — orchestrator doesn't populate the new fields yet.
+
+- [ ] **Step 3: Rewrite `parseFitFile`** to: collect messages once; find session/fileId/activity/diveSummary/diveSettings; run `FitGasExtractor`, `FitTankExtractor`, `FitProfileExtractor`, `FitSummaryExtractor`, `FitTimeResolver`, `FitDeviceMapper`; merge tank pressures into samples by second; build the enriched `ImportedDive` (set `sourceUuid = sourceId`, map gases→tanks by order, set computer model from `FitDeviceMapper`). Keep the existing non-dive/corrupt/empty guards. Preserve `_buildProfile`'s depth/temp/HR and add ceiling/ndl/tts/cns + `tankPressures`.
+
+Merge helper (real code to include):
+
+```dart
+// Inside FitParserService: attach tank pressures to samples by whole-second.
+List<ImportedProfileSample> _mergeTankPressures(
+  List<ImportedProfileSample> samples,
+  FitTankData tankData,
+  int startMs,
+) {
+  if (tankData.pressures.isEmpty) return samples;
+  // Bucket pressures by (second-from-start, tankIndex) -> pressureBar.
+  final byKey = <int, List<ImportedTankPressureSample>>{};
+  for (final p in tankData.pressures) {
+    final order = tankData.orderForSensor(p.sensorId);
+    if (order == null) continue;
+    final sec = ((p.timestampMs - startMs) / 1000).round();
+    (byKey[sec] ??= []).add(
+      ImportedTankPressureSample(tankIndex: order, pressureBar: p.pressureBar),
+    );
+  }
+  return samples.map((s) {
+    final tp = byKey[s.timeSeconds];
+    return tp == null ? s : s.copyWith(tankPressures: tp);
+  }).toList();
+}
+```
+
+> NOTE: `ImportedProfileSample` needs a `copyWith` for `tankPressures` (add it in Task 8 if absent). Keep the `timestampMs`/`startMs` base consistent with Task 5 (resolve the Task 5 note here).
+
+- [ ] **Step 4: Run tests to verify they pass** (existing + new)
+
+Run: `flutter test test/features/dive_import/data/services/fit_parser_service_test.dart`
+Expected: PASS (all existing cases still green + new case)
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services test/features/dive_import/data/services
+flutter analyze lib/features/dive_import
+git add lib/features/dive_import/data/services test/features/dive_import/data/services
+git commit -m "feat(fit): orchestrate extractors into enriched ImportedDive"
+```
+
+---
+
+### Task 10: `FitImportParser` emits the UDDF-shaped payload
+
+**Files:**
+- Modify: `lib/features/universal_import/data/parsers/fit_import_parser.dart`
+- Test: `test/features/universal_import/data/parsers/fit_import_parser_test.dart` (new)
+
+**Interfaces:**
+- Consumes: enriched `ImportedDive`.
+- Produces: `ImportPayload` whose dive map carries the keys `UddfEntityImporter` reads: `dateTime, duration` (=bottomTime Duration), `runtime` (=elapsed Duration), `maxDepth, avgDepth, waterTemp, waterType, diveNumber, surfaceInterval` (Duration), `decoAlgorithm, gradientFactorLow, gradientFactorHigh, diveComputerModel/Serial/Firmware, cnsEnd, otu, sourceUuid, latitude, longitude`, `tanks` (list of maps with `startPressure/endPressure/gasMix/order`), and `profile` points with `timestamp, depth, temperature, heartRate, cns, ndl, tts, ceiling, allTankPressures`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/universal_import/data/parsers/fit_import_parser_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/parsers/fit_import_parser.dart';
+// Use the same synthetic builder as the parser-service test (buildRichDiveFitFile).
+
+void main() {
+  test('emits UDDF-shaped payload with tanks, deco, gps, sourceUuid', () async {
+    final payload = await const FitImportParser().parse(buildRichDiveFitFile());
+    final dives = payload.entities[ImportEntityType.dives]!;
+    final d = dives.single;
+
+    expect(d['diveNumber'], isNotNull);
+    expect(d['waterType'], 'salt');
+    expect(d['surfaceInterval'], isA<Duration>());
+    expect(d['duration'], isA<Duration>()); // bottom time
+    expect(d['runtime'], isA<Duration>());  // total elapsed
+    expect(d['sourceUuid'], d['sourceId']);
+    expect(d['tanks'], isA<List<Map<String, dynamic>>>());
+    expect((d['tanks'] as List).first['startPressure'], isNotNull);
+    final profile = d['profile'] as List<Map<String, dynamic>>;
+    expect(profile.any((p) => p['ceiling'] != null), isTrue);
+    expect(profile.any((p) => p['allTankPressures'] != null), isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/universal_import/data/parsers/fit_import_parser_test.dart`
+Expected: FAIL — parser still emits the minimal payload.
+
+- [ ] **Step 3: Rewrite `parse()`** to build the dive map from the enriched `ImportedDive`. Real mapping (key lines):
+
+```dart
+final diveData = <String, dynamic>{
+  'dateTime': dive.startTime,
+  'maxDepth': dive.maxDepth,
+  'avgDepth': dive.avgDepth,
+  'duration': dive.bottomTimeSeconds != null
+      ? Duration(seconds: dive.bottomTimeSeconds!)
+      : dive.duration, // bottom time; fall back to elapsed
+  'runtime': dive.duration, // total elapsed
+  'waterTemp': dive.minTemperature,
+  'sourceId': dive.sourceId,
+  'sourceUuid': dive.sourceUuid ?? dive.sourceId,
+};
+if (dive.diveNumber != null) diveData['diveNumber'] = dive.diveNumber;
+if (dive.surfaceIntervalSeconds != null) {
+  diveData['surfaceInterval'] = Duration(seconds: dive.surfaceIntervalSeconds!);
+}
+if (dive.waterType != null) diveData['waterType'] = dive.waterType;
+if (dive.decoModel != null) diveData['decoAlgorithm'] = dive.decoModel;
+if (dive.gfLow != null) diveData['gradientFactorLow'] = dive.gfLow;
+if (dive.gfHigh != null) diveData['gradientFactorHigh'] = dive.gfHigh;
+if (dive.cnsEnd != null) diveData['cnsEnd'] = dive.cnsEnd;
+if (dive.otu != null) diveData['otu'] = dive.otu;
+if (dive.computerModel != null) diveData['diveComputerModel'] = dive.computerModel;
+if (dive.computerSerial != null) diveData['diveComputerSerial'] = dive.computerSerial;
+if (dive.computerFirmware != null) {
+  diveData['diveComputerFirmware'] = dive.computerFirmware;
+}
+if (dive.latitude != null && dive.longitude != null) {
+  diveData['latitude'] = dive.latitude;
+  diveData['longitude'] = dive.longitude;
+}
+if (dive.exitLatitude != null && dive.exitLongitude != null) {
+  diveData['exitLatitude'] = dive.exitLatitude;
+  diveData['exitLongitude'] = dive.exitLongitude;
+}
+if (dive.tanks.isNotEmpty) {
+  diveData['tanks'] = dive.tanks
+      .map((t) => <String, dynamic>{
+            'order': t.order,
+            'startPressure': t.startPressureBar,
+            'endPressure': t.endPressureBar,
+            if (t.o2Percent != null || t.hePercent != null)
+              'gasMix': GasMix(o2: t.o2Percent ?? 21.0, he: t.hePercent ?? 0.0),
+          })
+      .toList();
+}
+if (dive.profile.isNotEmpty) {
+  diveData['profile'] = dive.profile.map((s) {
+    final point = <String, dynamic>{'timestamp': s.timeSeconds, 'depth': s.depth};
+    if (s.temperature != null) point['temperature'] = s.temperature;
+    if (s.heartRate != null) point['heartRate'] = s.heartRate;
+    if (s.cns != null) point['cns'] = s.cns;
+    if (s.ndlSeconds != null) point['ndl'] = s.ndlSeconds;
+    if (s.ttsSeconds != null) point['tts'] = s.ttsSeconds;
+    if (s.ceiling != null) point['ceiling'] = s.ceiling;
+    if (s.tankPressures != null && s.tankPressures!.isNotEmpty) {
+      point['allTankPressures'] = s.tankPressures!
+          .map((tp) => <String, dynamic>{
+                'tankIndex': tp.tankIndex,
+                'pressure': tp.pressureBar,
+              })
+          .toList();
+    }
+    return point;
+  }).toList();
+}
+```
+
+> NOTE: import `GasMix` from its domain entity. `tanks`/`profile`/`allTankPressures` MUST be typed `List<Map<String, dynamic>>` (the importer casts to exactly that — see `uddf_entity_importer.dart:1543,1000,1661`); use `.cast<Map<String, dynamic>>()` or construct as such, or the runtime cast throws.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/universal_import/data/parsers/fit_import_parser_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/universal_import/data/parsers test/features/universal_import/data/parsers
+flutter analyze lib/features/universal_import
+git add lib/features/universal_import/data/parsers test/features/universal_import/data/parsers
+git commit -m "feat(fit): emit UDDF-shaped payload with tanks/deco/gps/sourceUuid"
+```
+
+---
+
+## Phase 4 — Importer persistence gap-fixes
+
+### Task 11: Import the recorded `ceiling` into profile points
+
+**Files:**
+- Modify: `lib/features/dive_import/data/services/uddf_entity_importer.dart:1009` (profile mapping)
+- Test: `test/features/dive_import/data/services/uddf_entity_importer_*_test.dart` (add a focused case or extend an existing importer test)
+
+**Interfaces:**
+- Consumes: `profile` point key `ceiling` (double). Produces: `DiveProfilePoint.ceiling` populated → persisted by `createDive`.
+
+- [ ] **Step 1: Write the failing test** — import a payload whose profile point has `ceiling: 6.0`; assert the persisted dive's `profile.first.ceiling == 6.0`. (Use the existing importer test harness/in-memory DB; mirror an existing profile-assertion test.)
+
+- [ ] **Step 2: Run it to verify it fails** (ceiling comes back null).
+
+Run: `flutter test <the importer test file>`
+Expected: FAIL — ceiling is null.
+
+- [ ] **Step 3: Add one line** to the `DiveProfilePoint` mapping (after `ndl:`/`tts:` at ~line 1011):
+
+```dart
+                  ceiling: asDoubleOrNull(p['ceiling']),
+```
+
+- [ ] **Step 4: Run it to verify it passes.**
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import/data/services test/features/dive_import
+flutter analyze lib/features/dive_import
+git add lib/features/dive_import
+git commit -m "fix(import): persist recorded deco ceiling from profile points"
+```
+
+---
+
+### Task 12: Persist entry/exit GPS on import (the FIT GPS fix)
+
+**Files:**
+- Modify: `lib/features/dive_import/data/services/uddf_entity_importer.dart` (the `Dive(...)` constructor, ~1135-1204)
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (the `createDive` companion, ~674-754)
+- Test: `test/features/dive_log/data/repositories/dive_repository_impl_test.dart` (createDive persists location) + importer test (lat/long → entryLocation)
+
+**Interfaces:**
+- Consumes: dive map keys `latitude`/`longitude`/`exitLatitude`/`exitLongitude`. Produces: `Dives.entryLatitude/entryLongitude/exitLatitude/exitLongitude` populated → dive becomes eligible for `getDivesNeedingSiteMatch`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// dive_repository_impl_test.dart (add): createDive persists entryLocation.
+test('createDive persists entryLocation to lat/long columns', () async {
+  final dive = makeTestDive().copyWith(
+    entryLocation: const GeoPoint(35.815, 14.451),
+  );
+  await repository.createDive(dive);
+  final loaded = await repository.getDiveById(dive.id);
+  expect(loaded!.entryLocation, isNotNull);
+  expect(loaded.entryLocation!.latitude, closeTo(35.815, 1e-6));
+});
+```
+
+```dart
+// importer test (add): latitude/longitude in the dive map -> entryLocation.
+test('import maps latitude/longitude to entryLocation', () async {
+  // import a dives payload with {'latitude': 35.815, 'longitude': 14.451, ...}
+  // then load the dive and assert entryLocation is set.
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail.**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_impl_test.dart`
+Expected: FAIL — `entryLocation` is null after reload.
+
+- [ ] **Step 3a: Persist location in `createDive`** — add to the `DivesCompanion` insert (after `surfacePressure:` ~line 704):
+
+```dart
+              entryLatitude: Value(dive.entryLocation?.latitude),
+              entryLongitude: Value(dive.entryLocation?.longitude),
+              exitLatitude: Value(dive.exitLocation?.latitude),
+              exitLongitude: Value(dive.exitLocation?.longitude),
+```
+
+- [ ] **Step 3b: Set location on the Dive in the importer** — add to the `Dive(...)` constructor (after `altitude:` ~line 1184):
+
+```dart
+        entryLocation:
+            asDoubleOrNull(diveData['latitude']) != null &&
+                asDoubleOrNull(diveData['longitude']) != null
+            ? GeoPoint(
+                asDoubleOrNull(diveData['latitude'])!,
+                asDoubleOrNull(diveData['longitude'])!,
+              )
+            : null,
+        exitLocation:
+            asDoubleOrNull(diveData['exitLatitude']) != null &&
+                asDoubleOrNull(diveData['exitLongitude']) != null
+            ? GeoPoint(
+                asDoubleOrNull(diveData['exitLatitude'])!,
+                asDoubleOrNull(diveData['exitLongitude'])!,
+              )
+            : null,
+```
+
+> NOTE: import `GeoPoint` (from `dive_site.dart`/the domain). Confirm the constructor is positional `GeoPoint(lat, lng)` (verified at `dive_repository_impl.dart:2202`).
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_impl_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_import lib/features/dive_log test/features/dive_log test/features/dive_import
+flutter analyze lib/features/dive_import lib/features/dive_log
+git add lib/features/dive_import lib/features/dive_log test/features/dive_log test/features/dive_import
+git commit -m "fix(import): persist entry/exit GPS so dives reach site matching"
+```
+
+---
+
+## Phase 5 — GPS site-match wiring for dive-computer downloads (#310)
+
+### Task 13: Surface the existing "Match Sites" affordance after a DC download
+
+**Files:**
+- Modify: the dive-computer post-download results widget (locate via `lib/features/dive_computer/presentation/` — the screen shown after a successful download, holding the imported dive IDs).
+- Test: a widget test for that screen (mirror any existing download-results widget test).
+
+**Interfaces:**
+- Consumes: `eligibleImportedDivesProvider(ImportedDiveIds(importedDiveIds))` (from `lib/features/dive_sites/presentation/providers/site_match_review_notifier.dart`). Produces: a button → `context.push('/dives/match-sites', extra: ids)`.
+
+- [ ] **Step 1: Write the failing widget test** — pump the download-results widget with ≥1 imported dive ID that has GPS but no site; assert a "Match Sites" button is shown. (FIT already gets this via `import_summary_step.dart`; this task is the DC parity for #310.)
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `flutter test <the download-results widget test>`
+Expected: FAIL — no Match Sites button.
+
+- [ ] **Step 3: Add the affordance** — mirror `import_summary_step.dart:188-215` exactly:
+
+```dart
+Consumer(
+  builder: (context, ref, _) {
+    if (importedDiveIds.isEmpty) return const SizedBox.shrink();
+    final eligible = ref.watch(
+      eligibleImportedDivesProvider(ImportedDiveIds(importedDiveIds)),
+    );
+    return eligible.maybeWhen(
+      data: (ids) => ids.isEmpty
+          ? const SizedBox.shrink()
+          : Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: FilledButton.icon(
+                icon: const Icon(Icons.add_location_alt_outlined),
+                label: Text(context.l10n.importSummary_matchSitesButton(ids.length)),
+                onPressed: () => context.push('/dives/match-sites', extra: ids),
+              ),
+            ),
+      orElse: () => const SizedBox.shrink(),
+    );
+  },
+),
+```
+
+> NOTE: reuses the existing `importSummary_matchSitesButton` l10n string — no new strings. Confirm the download-results widget already has the list of imported dive IDs; if not, thread it through from the download provider (`download_providers.dart`).
+
+- [ ] **Step 4: Run it to verify it passes.**
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_computer test/features/dive_computer
+flutter analyze lib/features/dive_computer
+git add lib/features/dive_computer test/features/dive_computer
+git commit -m "feat(dc): offer site matching after dive-computer download (#310)"
+```
+
+---
+
+## Phase 6 — End-to-end integration
+
+### Task 14: Golden integration test (FIT → importer → DB)
+
+**Files:**
+- Test: `test/features/dive_import/fit_import_integration_test.dart` (new)
+
+- [ ] **Step 1: Write the test** — build a rich synthetic Garmin FIT (multi-gas, deco samples, ≥1 tank_summary + tank_update, GPS, dive number, CNS/OTU), run `FitImportParser().parse(...)`, feed the payload through `UddfEntityImporter` (in-memory DB, mirror the existing importer test setup), then assert the persisted dive: `diveNumber`, `bottomTime != runtime`, `waterType == salt`, ≥1 tank with start/end pressure, ≥1 `TankPressureProfiles` row, profile points with `ceiling`/`ndl`/`tts`/`cns`, `entryLocation` set, and the `DiveDataSources` row carrying `cns`/`otu`. Finally assert the dive is returned by `getDivesNeedingSiteMatch` (GPS present, no site).
+
+- [ ] **Step 2: Run it to verify it fails** (if any wiring is incomplete).
+
+Run: `flutter test test/features/dive_import/fit_import_integration_test.dart`
+Expected: FAIL initially if any gap remains; otherwise PASS.
+
+- [ ] **Step 3: Fix any gaps** surfaced (e.g., a missing payload key or importer mapping). No new code if Phases 1–5 are complete.
+
+- [ ] **Step 4: Run it to verify it passes.**
+
+- [ ] **Step 5: Run the full affected suites, format, analyze, commit**
+
+```bash
+flutter test test/features/dive_import test/features/universal_import
+dart format lib test
+flutter analyze
+git add test/features/dive_import
+git commit -m "test(fit): end-to-end Garmin FIT import integration"
+```
+
+---
+
+## Phase 7 — Optional realistic fixtures
+
+### Task 15 (optional): Sanitized real-file golden test
+
+**Files:**
+- Create: `test/fixtures/fit/` with 1–2 sanitized real `.fit` files (serials zeroed); a golden test asserting the same fields as Task 14 against real firmware output.
+
+- [ ] **Step 1:** Write a small sanitizer (scratchpad Python) that zeroes the `file_id`/`device_info` serial numbers (and recomputes the trailing CRC) on copies of the user's files from `/Users/ericgriffin/Desktop/Garmin_files`. Verify with `fitparse` that messages still decode and serials read 0.
+- [ ] **Step 2:** Commit the sanitized fixtures + a golden test mirroring Task 14 but loading the real bytes. Assert tanks/deco/GPS/CNS extract correctly (cross-check expected values from the decode notes: Bouchot 72 start 221.25 bar / end 88.11 bar).
+- [ ] **Step 3:** `flutter test test/features/dive_import/fit_real_fixture_test.dart`; format; analyze; commit.
+
+> If sanitization proves fiddly (CRC/field-offset edits), keep coverage on the synthetic golden test (Task 14) and skip this task — note the gap rather than committing un-sanitized real serials.
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** tank/AI (T5,8,9,10,14), gas (T4,9,10), deco ceiling/TTS/NDL (T6,9,10,11,14), CNS/OTU (T7,9,10,14), heart rate (T6,9,10), dive number (T7,9,10), bottom time≠runtime (T9,10,14), surface interval (T7,9,10), water type (T7,9,10), deco model/GF (T7,9,10), computer model (T3,9,10), timezone via local_timestamp (T2,9), sourceUuid fix (T8,9,10), GPS onto dive + match wiring (T12,13,14), reuse existing matcher (T13, no new matcher). All spec sections map to tasks.
+- **Placeholder scan:** no "TBD"/"add error handling"-style steps; each code step shows real code. Library-API uncertainties are flagged as explicit EXECUTION NOTES with the file to verify against and the invariant the test pins — not placeholders.
+- **Type consistency:** `ImportedTank`/`ImportedTankPressureSample`/`FitTankData.orderForSensor` names are consistent across T5/T8/T9; payload keys (`tanks`, `allTankPressures`/`tankIndex`/`pressure`, `ceiling`, `duration`=bottom, `runtime`=elapsed, `sourceUuid`) match exactly what `uddf_entity_importer.dart` reads (verified line refs).
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-22-garmin-fit-import.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-06-22-garmin-fit-import-design.md
+++ b/docs/superpowers/specs/2026-06-22-garmin-fit-import-design.md
@@ -1,0 +1,202 @@
+# Comprehensive Garmin FIT Import — Design Spec
+
+- **Date:** 2026-06-22
+- **Status:** Approved (ready for implementation plan)
+- **Related issues:** #172 (FIT GPS → site matching), #173 (FIT heart rate), #310 (DC import GPS → site matching), #171 (FIT timezone — closed), #225 (raw source storage — closed)
+- **Reporters / test data:** Bouchot (`theRealBlackRabbit`, Descent Mk3i + T2 transmitter), AngelSMF/Verdugo (Descent X50i + Mk3i, simultaneous recordings), stiebs (Garmin + Ratio)
+
+## 1. Background & problem
+
+Submersion imports Garmin dives only from FIT files (the vendored libdivecomputer fork has **no Garmin backend**; FIT parsing uses the `fit_tool` Dart package). The current parser (`fit_parser_service.dart`) is a skeleton: it extracts only depth/temperature/heart-rate samples, entry GPS, and a summary, and silently drops everything else the file contains.
+
+This was confirmed by **decoding 15 sample FIT files** from two users with a Python FIT decoder (`fitparse`), cross-checked against the users' Garmin-app screenshots and the libraries' source. Bouchot independently proved the data is present: round-tripping the same file through Subsurface restores air-integration and GPS that Submersion's direct import loses.
+
+**Data confirmed present in the files but dropped today:**
+
+| Data | FIT source (verified) | Reported by |
+|---|---|---|
+| Tank pressure / air-integration (start/end + ~1 Hz series, **multi-transmitter**) | `tank_summary` (msg 323), `tank_update` (msg 319) | Bouchot, AngelSMF, stiebs |
+| Gas mixes (e.g. EAN30 + EAN50 deco gas) | `dive_gas` (msg 259) | Bouchot |
+| Deco ceiling / TTS / NDL (per sample) | `record.next_stop_depth` / `time_to_surface` / `ndl_time` | Bouchot |
+| CNS / OTU / N2 loading | `dive_summary.start_cns`/`end_cns`/`o2_toxicity`; `record.cns_load`/`n2_load` | completeness |
+| Heart rate | `record.heart_rate` | #173 |
+| GPS entry (verified → Malta 35.81°N/14.45°E; Kona 19.69°N/156.0°W) | `session.start_position_lat`/`long` | #172 |
+| Water type (salt) + density | `dive_settings.water_type` / `water_density` | Bouchot |
+| Dive number | `dive_summary.dive_number` | AngelSMF |
+| Bottom time (≠ runtime) | `dive_summary.bottom_time` | screenshot "87 == 87" |
+| Surface interval | `dive_summary.surface_interval` | completeness |
+| Deco model + GF + ppO2 limits | `dive_settings.model`/`gf_low`/`gf_high`/`po2_*` | completeness |
+| Computer model + serial + firmware | `file_id.garmin_product`/`serial_number`; `device_info.software_version` | completeness |
+
+**Two facts that de-risk implementation:**
+
+1. **No library fork needed.** `fit_tool` 1.0.5 has named message classes for `dive_gas`, `dive_settings`, `dive_summary`, `gps_metadata`, `record`, `session`, and the `record` class exposes every deco/HR/GPS getter we need (`nextStopDepth`, `timeToSurface`, `ndlTime`, `n2Load`, `cnsLoad`, `heartRate`, `temperature`, `absolutePressure`, `positionLat/Long`). It has **no** class for `tank_update`/`tank_summary`, **but** its `MessageFactory` default case returns a `GenericMessage` for any unknown global ID, with field access by number via `DataMessage.getField(int id)`. So tank pressure is reachable by reading messages 319/323 by field number and applying the scale manually.
+2. **Timezone source identified.** The `activity` message carries both `timestamp` (UTC) and `local_timestamp`; their delta is the dive's local UTC offset. The dive's true wall-clock is `local_timestamp` — the correct source for Submersion's "wall-clock-as-UTC" storage convention.
+
+## 2. Goals / non-goals
+
+**Goals (in scope):**
+- FIT import extracts all data the file contains: tank pressure/air-integration (multi-transmitter), gas mixes, per-sample deco (ceiling/TTS/NDL), CNS/OTU/N2, heart rate, dive number, bottom time vs runtime, surface interval, water type/salinity, deco model + GF + ppO2 limits, computer model/serial/firmware.
+- Correct dive local time via `local_timestamp` (re-verify the #171 fix).
+- Carry entry/exit GPS coordinates onto imported FIT dives so they become eligible for the **existing** site-match review flow; surface that same flow on the dive-computer download path (#310). **Reuse the existing matching engine — no new matcher.**
+- Populate `sourceUuid` for FIT dives (fixes the `sourceId`→`sourceUuid` key mismatch so duplicate detection works on re-import).
+
+**Non-goals (explicitly out of scope):**
+- **No automatic dive-site creation.** Match only to existing sites; never auto-create. Coordinates are stored on the dive so the user can create/assign a site manually.
+- **No locale-geocode normalization (#214).** Deferred.
+- **No multi-source same-dive merge** (Verdugo X50i+Mk3i, stiebs Garmin+Ratio). `DiveDataSources` multi-source exists but is unsurfaced; separate future project.
+- **No Garmin MTP/USB direct download.** Separate native/transport effort; no libdivecomputer Garmin backend.
+- **No FIT re-parse plumbing and no re-import update-in-place.** The existing "Re-parse raw data" menu is libdivecomputer-only and FIT imports never stored raw bytes, so already-imported dives cannot be re-parsed regardless. **Existing dives are refreshed by delete + re-import.**
+
+## 3. Decisions (settled with product owner)
+
+1. Scope = core FIT enrichment **+** GPS → site matching. Multi-source and MTP/USB are separate.
+2. Re-parse = **parser fix only**; users delete + re-import to refresh existing dives.
+3. GPS = import coordinates + **match-only to existing sites, no auto-create**.
+4. #214 locale geocoding = not addressed.
+
+## 4. Architecture — "Make FIT speak UDDF"
+
+`UddfEntityImporter` already persists multi-tank records, per-tank pressure time-series (`_storeTankPressures`), gas mixes, gas switches, profile events, and per-sample deco fields — UDDF imports get all of this today. FIT is starved only because `FitImportParser` emits a tiny payload. **Strategy: make the FIT parser emit the same payload shape UDDF already produces, so FIT inherits UDDF-grade fidelity through the shared persistence path.** New code is concentrated in extraction + mapping (cheap to unit-test); little new persistence code.
+
+```
+ .fit bytes
+   │
+   ▼
+FitDiveReader ──(orchestrates)──► extractors ──► UDDF-shaped ImportPayload
+   │                                                   │ (same keys UDDF emits:
+   │  GenericMessage.getField(n) for msgs 319/323      │  tanks, gasMixRef, gasSwitches,
+   ▼                                                   │  profileEvents, profile extras,
+ tank/gas/deco/summary/device/time extractors          │  entry/exitLat/Long, cns/otu, …)
+                                                        ▼
+                                              UddfEntityimporter ──persists──► DB
+                                                        │
+                                                        └─► GPS coords on Dive → EXISTING /dives/match-sites flow (reused)
+```
+
+**Rejected alternatives:** fully-typed intermediate model (larger refactor; payload reuse gets ~90% of the benefit); parsing FIT straight into domain entities (loses `UddfEntityImporter` reuse); forking `fit_tool` (unnecessary — `GenericMessage` suffices).
+
+## 5. Components
+
+Decompose the current ~230-line `FitParserService` into an orchestrator plus focused extractors (per the 200–400-line file convention and for isolated unit testing):
+
+| Unit | Responsibility | Source messages |
+|---|---|---|
+| `FitDiveReader` | Read messages once; drive extractors; assemble payload | — |
+| `FitMessageAccess` | `GenericMessage.getField(n)` helper + scale constants | 319/323 |
+| `FitTankExtractor` | Multi-sensor tanks: start/end pressure, volume-used, pressure series keyed by sensor ID | `tank_summary` 323, `tank_update` 319 |
+| `FitGasExtractor` | Gas mixes (O2/He, enabled), gas-switch points | `dive_gas` 259, `event` |
+| `FitProfileExtractor` | Per-sample depth/temp/HR **+ deco** (ceiling, TTS, NDL, cns, n2) | `record` |
+| `FitSummaryExtractor` | Dive number, bottom time, surface interval, CNS/OTU/N2, entry GPS, temps, water type/density, deco model, GF, ppO2 | `dive_summary`, `session`, `dive_settings` |
+| `FitDeviceMapper` | `garmin_product` → model name; serial; firmware | `file_id`, `device_info` |
+| `FitTimeResolver` | Wall-clock from `local_timestamp` (or local−UTC delta) | `activity`, `session` |
+
+Then:
+- `imported_dive.dart` — extend `ImportedDive` modestly to carry the new fields (or assemble the payload map directly in the parser).
+- `fit_import_parser.dart` — emit the UDDF-shaped payload (incl. `sourceUuid`).
+- `uddf_entity_importer.dart` — close the gaps it has even for UDDF: write entry/exit GPS onto the `Dive` (currently the Dive is built without lat/long), and OTU. Confirm per-sample columns (`DiveProfiles.pressure`, deco columns) are written.
+- **Reuse** the existing site-matching system (`geo_math` + `dive_sites/domain/matching` + `SiteMatchingService` + `/dives/match-sites`); **no new matcher** (see §7).
+
+## 6. Data mapping (authoritative)
+
+| Domain target | FIT source | Transform |
+|---|---|---|
+| `Dive.diveNumber` | `dive_summary.dive_number` | as-is |
+| `Dive.diveDateTime` / entry / exit | `activity.local_timestamp`; `session.total_elapsed_time` | wall-clock-as-UTC; exit = entry + elapsed |
+| `Dive.bottomTime` | `dive_summary.bottom_time` | seconds (distinct from runtime) |
+| `Dive.runtime` | `session.total_elapsed_time` | seconds |
+| `Dive.surfaceIntervalSeconds` | `dive_summary.surface_interval` | seconds |
+| `Dive.maxDepth` / `avgDepth` / `waterTemp` | `dive_summary` / `session` | metres / °C |
+| `Dive.cnsStart` / `cnsEnd` / `otu` | `dive_summary.start_cns` / `end_cns` / `o2_toxicity` | % / % / OTU |
+| `Dive.decoAlgorithm` / `gradientFactorLow` / `High` | `dive_settings.model` / `gf_low` / `gf_high` | "zhl_16c" / 50 / 85 |
+| water type / density | `dive_settings.water_type` / `water_density` | salt/fresh; kg/m³ |
+| `Dive.diveComputerModel` / `Serial` / `Firmware` | `file_id.garmin_product` / `serial_number`; `device_info.software_version` | product map; as-is |
+| `Dive.entry/exitLatitude/Longitude` | `session.start_position_*`; last `record.position_*` | semicircles × (180 / 2³¹) |
+| `DiveTanks[]` (one per sensor) | `tank_summary` 323 | startP = field1 ÷ 100 (bar); endP = field2 ÷ 100 (bar); volumeUsed = field3 ÷ 100 (L); sensor = field0 |
+| `DiveTanks[].o2Percent` / `hePercent` | `dive_gas` | match gas to tank where derivable |
+| `TankPressureProfiles[]` | `tank_update` 319 | t = field253; sensor = field0; pressure = field1 ÷ 100 (bar) |
+| `DiveProfiles[].depth` / `temperature` / `heartRate` | `record.depth` / `temperature` / `heart_rate` | HR nullable |
+| `DiveProfiles[].ceiling` / `ndl` / `tts` / `cns` | `record.next_stop_depth` / `ndl_time` / `time_to_surface` / `cns_load` | recorded values, never recomputed |
+| `GasSwitches[]` | `dive_gas` + `event` | best-effort |
+| `sourceUuid` | `garmin-{serial}-{startMs}` | populate the dedup key (fixes `sourceId` mismatch) |
+
+## 7. GPS → dive-site matching (reuse the existing system)
+
+**There is no new matcher.** The app already has a complete, source-agnostic GPS→site matching engine and review workflow; this project reuses it unchanged and only closes the two gaps that keep imported dives from reaching it.
+
+Existing pieces (reused as-is):
+- `lib/core/utils/geo_math.dart` — Haversine `distanceMeters`.
+- `lib/features/dive_sites/domain/matching/` — pure matcher (`rankCandidates`, `matchRanked`, `matchDive`) with `MatchThresholds` driven by the user setting **`siteMatchSensitivity`** (radius is **not** hard-coded by this project).
+- `lib/features/dive_sites/data/services/site_matching_service.dart` — `computeProposals` / `applyConfirmed`, with a 100 m coincidence guard against duplicate sites.
+- Review UI at route `/dives/match-sites` (`site_match_review_page.dart`), plus the dive-list "Match Dives to Sites" menu.
+- Shared chokepoint `DiveRepository.getDivesNeedingSiteMatch` (predicate: `siteId IS NULL AND has entry/exit GPS`) — both FIT and DC dives converge here once they carry coordinates.
+
+The two gaps to close:
+1. **FIT (#172):** the importer drops the GPS coordinates today, so FIT dives never become eligible. Fix = carry entry/exit lat/long onto the `Dive` (see §5). The universal import-summary step **already** offers "Match Sites" → `/dives/match-sites` for eligible imported dives (`import_summary_step.dart`), so once the coordinates are present, FIT inherits the existing match UX with no further work.
+2. **DC download (#310):** the dive-computer download path stores GPS but never surfaces the match flow after import. Fix = surface the same "Match Sites" affordance after a download completes (mirroring the import-summary step), rather than auto-applying.
+
+**Match-only / no-auto-create is honored by construction:** the existing flow is **user-confirmed** (the review page), links to existing sites via `setSite`, and never creates a site without user confirmation. This project adds **no** headless auto-assignment and **no** new site-creation logic.
+
+## 8. Domain semantics (from the tech-diving skill)
+
+- **Deco = recorded, never recomputed.** Import the Garmin's own ceiling/TTS/NDL into the profile. Bouchot's "massive difference" is consistent with Submersion currently showing *recomputed* deco; part of this work is to display the recorded values (and confirm/stop any recompute for imported dives). *Open item: locate where the displayed deco value currently originates.*
+- **Bottom time ≠ runtime.** Use `dive_summary.bottom_time` (fixes the "87 == 87" screenshot).
+- **SAC** derives from tank start/end pressure → **bar/min** (existing model). FIT provides `volume_used` in L but not cylinder size, so L/min remains unavailable.
+
+## 9. Error handling / edge cases
+
+- Non-dive FIT (sport ≠ diving) → skip; corrupt/empty → null (unchanged behaviour).
+- **Multiple tank sensors** → multiple tanks; pressure series matched by sensor ID (X50i had 3; the deco dive 92 had 0).
+- **Null HR / no GPS / no transmitter** → graceful degradation; emit only what exists.
+- **Multi-session FIT** (rare for Garmin) → import each session as a separate dive instead of silently taking the first; do not drop data.
+- **Unknown `garmin_product`** → fall back to a generic "Garmin Descent" model name.
+- GenericMessage fields carry **no profile scale/offset** — the extractor must apply ÷100 explicitly for pressure (bar) and volume (L).
+
+## 10. Testing
+
+- **Commit a small set of sanitized real `.fit` fixtures** (the repo currently has none). Sanitize: scrub serial numbers and round/offset GPS coordinates. Real fixtures are necessary because synthetic builders can't easily emit the unnamed 319/323 tank messages. *Open item: sanitization approach (re-encode via `fit_tool` builder vs targeted byte edits with CRC fix).*
+- Unit tests per extractor, especially `FitTankExtractor` (pressure scale ÷100; multi-sensor mapping; tank_summary/tank_update cross-consistency).
+- Golden test: decode a sample → assert tanks, gas mixes, deco samples, GPS, CNS/OTU.
+- Importer integration test: FIT payload → DB rows (tanks, `TankPressureProfiles`, `DiveProfiles` deco columns, GPS on `Dive`).
+- GPS integration tests (the matcher itself already has tests — we test the *wiring*): a FIT import writes entry/exit lat/long onto the `Dive` so it appears in `getDivesNeedingSiteMatch`; a DC download surfaces the `/dives/match-sites` affordance. No new matcher logic to test.
+
+## 11. Open verification items (resolve while writing the plan; do not change the architecture)
+
+1. Exact GPS plumbing in `UddfEntityImporter` — the `Dive` is currently built without entry/exit lat/long; confirm the minimal change to carry coordinates onto the Dive so it satisfies `getDivesNeedingSiteMatch`. Also confirm the dive-computer download completion point where the existing `/dives/match-sites` affordance should be surfaced (#310).
+2. Where Submersion's *displayed* deco value currently comes from (recompute vs stored) and how to switch to recorded values for imported dives.
+3. Reliability of gas→tank association (FIT does not always bind a gas to a specific transmitter).
+4. `fit_tool` builder's ability to emit synthetic 319/323 messages for tests (else rely on sanitized real fixtures).
+
+## 12. Affected files (reference)
+
+- `lib/features/dive_import/data/services/fit_parser_service.dart` (decompose + enrich)
+- `lib/features/dive_import/domain/entities/imported_dive.dart` (extend)
+- `lib/features/universal_import/data/parsers/fit_import_parser.dart` (UDDF-shaped payload)
+- `lib/features/dive_import/data/services/uddf_entity_importer.dart` (GPS onto Dive, OTU, confirm profile columns)
+- `lib/core/database/database.dart` (Dives, DiveProfiles, DiveTanks, TankPressureProfiles, GasSwitches, DiveSites, DiveDataSources — schema reference; add columns only if a needed field has no home)
+- Dive-computer download completion path — surface the existing `/dives/match-sites` affordance (#310). The matching engine (`dive_sites/domain/matching/`, `site_matching_service.dart`, `core/utils/geo_math.dart`, route `/dives/match-sites`) is **reused unchanged, not modified**.
+- Tests under `test/features/dive_import/` and `test/features/universal_import/`, plus sanitized fixtures
+
+## Appendix A — verified ground truth (preserve; expensive to re-derive)
+
+- **`fit_tool` 1.0.5** retains unknown messages as `GenericMessage` (`MessageFactory` default case), field access via `DataMessage.getField(int id)`; GenericMessage fields lack profile scale/offset (apply manually).
+- **tank_update (msg 319):** field 253 = timestamp, field 0 = sensor ID, **field 1 = pressure ×0.01 bar**. (Bouchot 72: 221.25 → 88.11 bar.)
+- **tank_summary (msg 323):** field 0 = sensor, **field 1 = start_pressure ×0.01 bar**, **field 2 = end_pressure ×0.01 bar**, **field 3 = volume_used ×0.01 L**. Cross-checked: start = first update, end = last update, 1993.5 L ≈ a 15 L tank drained 133 bar.
+- **Multiple `tank_summary`/sensors per dive** = multiple tanks (X50i: 3 sensors).
+- **garmin_product codes:** 4223 = Descent Mk3i, 4518 = Descent X50i, 3865 = T2 transmitter.
+- **Timezone:** `activity.timestamp` (UTC) vs `activity.local_timestamp` (local); delta = dive's UTC offset; use `local_timestamp` as wall-clock.
+- **GPS:** `session.start_position_lat/long` in semicircles; degrees = value × (180 / 2³¹). `gps_metadata` messages in these files carried only altitude/speed (no fix) — rely on `session` position.
+- **Deco per sample (record):** `next_stop_depth` (ceiling, m), `next_stop_time` (s), `time_to_surface` (TTS, s), `ndl_time` (NDL, s), `n2_load` (%), `cns_load` (%). `absolute_pressure` is *ambient* water pressure (Pa), not tank pressure.
+- **`fitparse` 1.2.0** is too old to name 319/323 (shows `unknown_319`/`unknown_323`); used only for offline analysis, not in the app.
+
+## Appendix B — existing GPS→site matching system (REUSE; do not rebuild)
+
+A complete, source-agnostic matcher already exists. This project reuses it and only feeds it / triggers it.
+
+- `lib/core/utils/geo_math.dart` — `distanceMeters` (Haversine), `initialBearingDegrees`.
+- `lib/features/dive_sites/domain/matching/` — `site_matcher.dart` (`rankCandidates`, `matchRanked` → `AutoMatch`/`Suggested`/`NoMatch`, `matchDive`), `match_thresholds.dart`, `site_match_sensitivity.dart` (thresholds from user setting `siteMatchSensitivity`).
+- `lib/features/dive_sites/data/services/site_matching_service.dart` — `computeProposals(List<Dive>)` (no writes), `applyConfirmed(...)` (links via `DiveRepository.setSite`; 100 m coincidence guard; only materializes a **bundled-catalog** site on user confirmation).
+- `DiveRepository.getDivesNeedingSiteMatch` (`dive_repository_impl.dart:295`) — shared eligibility query (`siteId IS NULL AND entry/exit GPS`); both FIT and DC dives land here once coordinates are present.
+- Review UI: route `/dives/match-sites` → `site_match_review_page.dart` / `site_match_review_notifier.dart`. Triggers today: import-summary "Match Sites" (`import_summary_step.dart:192-209`, file imports incl. FIT) and dive-list "Match Dives to Sites" menu.
+- **Current gaps (this project's GPS work):** (1) FIT importer drops entry/exit lat/long, so FIT dives are never eligible — fix by writing coords onto the `Dive`; (2) the dive-computer download path never surfaces the match flow — fix by adding that affordance (#310).
+- **Site resolution on import is name-based, not coordinate-based:** UDDF import find-or-creates sites by lowercased name (`uddf_entity_importer.dart` `_importSites` ~:730-815) and reverse-geocodes country/region on creation (`LocationService.reverseGeocode`, ~:778). DC import sets no site at all (`siteId` null). Neither does GPS proximity inline — that is exclusively the post-import matcher above.

--- a/lib/features/dive_import/data/services/fit/fit_constants.dart
+++ b/lib/features/dive_import/data/services/fit/fit_constants.dart
@@ -1,0 +1,29 @@
+/// Verified Garmin FIT message/field numbers and scales (see design spec
+/// `docs/superpowers/specs/2026-06-22-garmin-fit-import-design.md`, Appendix A).
+///
+/// fit_tool 1.0.5 has no named classes for the tank messages, so they are read
+/// by global id + field number off a [GenericMessage] (which carries no profile
+/// scale — callers apply the scales below manually).
+class FitConstants {
+  const FitConstants._();
+
+  // Global message numbers.
+  static const int tankUpdateMsg = 319;
+  static const int tankSummaryMsg = 323;
+
+  // tank_update (msg 319) field numbers.
+  static const int tuTimestamp = 253;
+  static const int tuSensor = 0;
+  static const int tuPressure = 1;
+
+  // tank_summary (msg 323) field numbers.
+  static const int tsSensor = 0;
+  static const int tsStartPressure = 1;
+  static const int tsEndPressure = 2;
+  static const int tsVolumeUsed = 3;
+
+  // Scales: raw integer -> physical unit.
+  static const double pressureScaleBar = 100.0; // raw / 100 = bar
+  static const double volumeScaleLiters = 100.0; // raw / 100 = liters
+  static const double semicircleToDegrees = 180.0 / 2147483648.0;
+}

--- a/lib/features/dive_import/data/services/fit/fit_constants.dart
+++ b/lib/features/dive_import/data/services/fit/fit_constants.dart
@@ -26,4 +26,9 @@ class FitConstants {
   static const double pressureScaleBar = 100.0; // raw / 100 = bar
   static const double volumeScaleLiters = 100.0; // raw / 100 = liters
   static const double semicircleToDegrees = 180.0 / 2147483648.0;
+
+  /// Seconds between the Unix epoch (1970-01-01) and the FIT epoch
+  /// (1989-12-31). A GenericMessage timestamp field is raw FIT-epoch seconds;
+  /// add this and multiply by 1000 to get Unix milliseconds.
+  static const int fitEpochToUnixSeconds = 631065600;
 }

--- a/lib/features/dive_import/data/services/fit/fit_device_mapper.dart
+++ b/lib/features/dive_import/data/services/fit/fit_device_mapper.dart
@@ -1,0 +1,23 @@
+/// Maps Garmin FIT `file_id.garmin_product` codes to human model names.
+///
+/// Verified from sample files: 4223=Mk3i, 4518=X50i, 3865=T2 transmitter.
+/// Mk1/Mk2/Mk2s codes are from fit_tool's GarminProduct enum. fit_tool 1.0.5
+/// predates the Mk3i/X50i, so those return a raw int rather than a named enum.
+/// Unknown/null -> a generic name.
+class FitDeviceMapper {
+  const FitDeviceMapper._();
+
+  static const Map<int, String> _models = {
+    2859: 'Descent Mk1',
+    3258: 'Descent Mk2 / Mk2i',
+    3542: 'Descent Mk2s',
+    3865: 'Descent T2 Transmitter',
+    4223: 'Descent Mk3i',
+    4518: 'Descent X50i',
+  };
+
+  static String modelName(int? garminProduct) {
+    if (garminProduct == null) return 'Garmin Descent';
+    return _models[garminProduct] ?? 'Garmin Descent';
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_gas_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_gas_extractor.dart
@@ -1,0 +1,40 @@
+import 'package:fit_tool/fit_tool.dart';
+
+/// A gas mix from a FIT `dive_gas` message.
+class FitGas {
+  const FitGas({
+    required this.index,
+    required this.o2Percent,
+    required this.hePercent,
+    required this.enabled,
+  });
+
+  final int index;
+  final double o2Percent;
+  final double hePercent;
+  final bool enabled;
+}
+
+/// Extracts the enabled gas mixes from FIT `dive_gas` (msg 259) messages,
+/// sorted by message index (index 0 is the primary/bottom gas).
+class FitGasExtractor {
+  const FitGasExtractor._();
+
+  static List<FitGas> extract(List<Message> messages) {
+    final gases =
+        messages
+            .whereType<DiveGasMessage>()
+            .map(
+              (m) => FitGas(
+                index: m.messageIndex ?? 0,
+                o2Percent: (m.oxygenContent ?? 21).toDouble(),
+                hePercent: (m.heliumContent ?? 0).toDouble(),
+                enabled: m.status == DiveGasStatus.enabled,
+              ),
+            )
+            .where((g) => g.enabled)
+            .toList()
+          ..sort((a, b) => a.index.compareTo(b.index));
+    return gases;
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_message_access.dart
+++ b/lib/features/dive_import/data/services/fit/fit_message_access.dart
@@ -1,0 +1,27 @@
+import 'package:fit_tool/fit_tool.dart';
+
+/// Raw field access for FIT messages that fit_tool exposes only as a
+/// [GenericMessage] (it has no named profile for them, so field values are
+/// unscaled — callers apply scales from [FitConstants]).
+class FitMessageAccess {
+  const FitMessageAccess._();
+
+  /// The unscaled numeric value of field [fieldId] on [message], or null if the
+  /// field is absent or non-numeric.
+  static num? rawNum(DataMessage message, int fieldId) {
+    final value = message.getField(fieldId)?.getValue();
+    return value is num ? value : null;
+  }
+
+  /// All data messages in [messages] whose FIT global message number equals
+  /// [globalId] (e.g. 319 for tank_update, 323 for tank_summary).
+  static List<DataMessage> messagesWithGlobalId(
+    List<Message> messages,
+    int globalId,
+  ) {
+    return messages
+        .whereType<DataMessage>()
+        .where((m) => m.globalId == globalId)
+        .toList();
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_profile_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_profile_extractor.dart
@@ -1,0 +1,53 @@
+import 'package:fit_tool/fit_tool.dart';
+
+/// One profile sample, including the Garmin-recorded decompression values.
+class FitSample {
+  const FitSample({
+    required this.timestampMs,
+    required this.depth,
+    this.temperature,
+    this.heartRate,
+    this.ceiling,
+    this.ndlSeconds,
+    this.ttsSeconds,
+    this.cns,
+  });
+
+  final int timestampMs; // Unix milliseconds.
+  final double depth; // meters
+  final double? temperature; // celsius
+  final int? heartRate; // bpm
+  final double? ceiling; // meters (record.nextStopDepth)
+  final int? ndlSeconds; // record.ndlTime
+  final int? ttsSeconds; // record.timeToSurface
+  final double? cns; // percent (record.cnsLoad)
+}
+
+/// Extracts per-sample dive profile data from `record` messages, including the
+/// Garmin-recorded deco values (ceiling/TTS/NDL/CNS) which are imported as
+/// recorded, never recomputed. Records without depth or timestamp are skipped.
+class FitProfileExtractor {
+  const FitProfileExtractor._();
+
+  static List<FitSample> extract(List<RecordMessage> records) {
+    final samples = <FitSample>[];
+    for (final r in records) {
+      final depth = r.depth;
+      final ts = r.timestamp;
+      if (depth == null || ts == null) continue;
+      samples.add(
+        FitSample(
+          timestampMs: ts,
+          depth: depth,
+          temperature: r.temperature?.toDouble(),
+          heartRate: r.heartRate,
+          ceiling: r.nextStopDepth,
+          ndlSeconds: r.ndlTime,
+          ttsSeconds: r.timeToSurface,
+          cns: r.cnsLoad?.toDouble(),
+        ),
+      );
+    }
+    return samples;
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
@@ -12,7 +12,6 @@ class FitSummary {
     this.entryLat,
     this.entryLong,
     this.waterType,
-    this.waterDensity,
     this.decoModel,
     this.gfLow,
     this.gfHigh,
@@ -27,7 +26,6 @@ class FitSummary {
   final double? entryLat; // degrees
   final double? entryLong; // degrees
   final String? waterType; // 'salt' | 'fresh' | ...
-  final double? waterDensity; // kg/m^3
   final String? decoModel; // e.g. 'zhl_16c'
   final int? gfLow;
   final int? gfHigh;
@@ -55,7 +53,6 @@ class FitSummaryExtractor {
       entryLat: session?.startPositionLat,
       entryLong: session?.startPositionLong,
       waterType: settings?.waterType?.name,
-      waterDensity: settings?.waterDensity?.toDouble(),
       decoModel: settings?.model == null ? null : 'zhl_16c',
       gfLow: settings?.gfLow,
       gfHigh: settings?.gfHigh,

--- a/lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
@@ -43,6 +43,7 @@ class FitSummaryExtractor {
     DiveSettingsMessage? settings,
   }) {
     Duration? secs(num? v) => v == null ? null : Duration(seconds: v.round());
+    final model = settings?.model;
     return FitSummary(
       diveNumber: summary?.diveNumber,
       bottomTime: secs(summary?.bottomTime),
@@ -53,7 +54,9 @@ class FitSummaryExtractor {
       entryLat: session?.startPositionLat,
       entryLong: session?.startPositionLong,
       waterType: settings?.waterType?.name,
-      decoModel: settings?.model == null ? null : 'zhl_16c',
+      decoModel: model == null
+          ? null
+          : (model == TissueModelType.zhl16c ? 'zhl_16c' : model.name),
       gfLow: settings?.gfLow,
       gfHigh: settings?.gfHigh,
     );

--- a/lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_summary_extractor.dart
@@ -1,0 +1,64 @@
+import 'package:fit_tool/fit_tool.dart';
+
+/// Dive-level fields gathered from the FIT summary/session/settings messages.
+class FitSummary {
+  FitSummary({
+    this.diveNumber,
+    this.bottomTime,
+    this.surfaceInterval,
+    this.cnsStart,
+    this.cnsEnd,
+    this.otu,
+    this.entryLat,
+    this.entryLong,
+    this.waterType,
+    this.waterDensity,
+    this.decoModel,
+    this.gfLow,
+    this.gfHigh,
+  });
+
+  final int? diveNumber;
+  final Duration? bottomTime;
+  final Duration? surfaceInterval;
+  final double? cnsStart;
+  final double? cnsEnd;
+  final double? otu;
+  final double? entryLat; // degrees
+  final double? entryLong; // degrees
+  final String? waterType; // 'salt' | 'fresh' | ...
+  final double? waterDensity; // kg/m^3
+  final String? decoModel; // e.g. 'zhl_16c'
+  final int? gfLow;
+  final int? gfHigh;
+}
+
+/// Extracts dive-level fields from `dive_summary` (msg 268), `session` (msg 18)
+/// and `dive_settings` (msg 258). GPS comes back from fit_tool already in
+/// degrees (the field carries the semicircle scale), so it is passed through.
+class FitSummaryExtractor {
+  const FitSummaryExtractor._();
+
+  static FitSummary extract({
+    DiveSummaryMessage? summary,
+    SessionMessage? session,
+    DiveSettingsMessage? settings,
+  }) {
+    Duration? secs(num? v) => v == null ? null : Duration(seconds: v.round());
+    return FitSummary(
+      diveNumber: summary?.diveNumber,
+      bottomTime: secs(summary?.bottomTime),
+      surfaceInterval: secs(summary?.surfaceInterval),
+      cnsStart: summary?.startCns?.toDouble(),
+      cnsEnd: summary?.endCns?.toDouble(),
+      otu: summary?.o2Toxicity?.toDouble(),
+      entryLat: session?.startPositionLat,
+      entryLong: session?.startPositionLong,
+      waterType: settings?.waterType?.name,
+      waterDensity: settings?.waterDensity?.toDouble(),
+      decoModel: settings?.model == null ? null : 'zhl_16c',
+      gfLow: settings?.gfLow,
+      gfHigh: settings?.gfHigh,
+    );
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
@@ -71,11 +71,10 @@ class FitTankExtractor {
     final tanks = <FitTank>[];
     for (final m in summaries) {
       final sensor = FitMessageAccess.rawNum(m, FitConstants.tsSensor)?.toInt();
-      if (sensor == null) continue;
-      final order = orderBySensor.putIfAbsent(
-        sensor,
-        () => orderBySensor.length,
-      );
+      // One tank per sensor; ignore repeated summaries for a sensor already seen.
+      if (sensor == null || orderBySensor.containsKey(sensor)) continue;
+      final order = orderBySensor.length;
+      orderBySensor[sensor] = order;
       tanks.add(
         FitTank(
           sensorId: sensor,

--- a/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
@@ -1,0 +1,131 @@
+import 'package:fit_tool/fit_tool.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_message_access.dart';
+
+/// One air-integration tank, from a FIT `tank_summary` message.
+class FitTank {
+  const FitTank({
+    required this.sensorId,
+    required this.order,
+    this.startPressureBar,
+    this.endPressureBar,
+    this.volumeUsedLiters,
+  });
+
+  final int sensorId;
+  final int order;
+  final double? startPressureBar;
+  final double? endPressureBar;
+  final double? volumeUsedLiters;
+}
+
+/// A single tank-pressure reading, from a FIT `tank_update` message.
+class FitTankPressureSample {
+  const FitTankPressureSample({
+    required this.sensorId,
+    required this.timestampMs,
+    required this.pressureBar,
+  });
+
+  final int sensorId;
+  final int timestampMs; // Unix milliseconds (normalized from FIT epoch).
+  final double pressureBar;
+}
+
+/// Result of tank extraction: the tanks and the raw pressure series. The
+/// orchestrator merges [pressures] onto profile samples by timestamp.
+class FitTankData {
+  FitTankData(this.tanks, this.pressures);
+
+  final List<FitTank> tanks;
+  final List<FitTankPressureSample> pressures;
+
+  /// The tank order (index) for a transmitter sensor id, or null if no tank
+  /// summary declared that sensor.
+  int? orderForSensor(int sensorId) {
+    for (final t in tanks) {
+      if (t.sensorId == sensorId) return t.order;
+    }
+    return null;
+  }
+}
+
+/// Extracts air-integration tanks (`tank_summary`, msg 323) and the pressure
+/// time-series (`tank_update`, msg 319). fit_tool has no named class for these,
+/// so they are read off [GenericMessage] by field number and scaled manually.
+class FitTankExtractor {
+  const FitTankExtractor._();
+
+  static FitTankData extract(List<Message> messages) {
+    final summaries = FitMessageAccess.messagesWithGlobalId(
+      messages,
+      FitConstants.tankSummaryMsg,
+    );
+    final updates = FitMessageAccess.messagesWithGlobalId(
+      messages,
+      FitConstants.tankUpdateMsg,
+    );
+
+    // One tank per sensor, in first-seen order across the summaries.
+    final orderBySensor = <int, int>{};
+    final tanks = <FitTank>[];
+    for (final m in summaries) {
+      final sensor = FitMessageAccess.rawNum(m, FitConstants.tsSensor)?.toInt();
+      if (sensor == null) continue;
+      final order = orderBySensor.putIfAbsent(
+        sensor,
+        () => orderBySensor.length,
+      );
+      tanks.add(
+        FitTank(
+          sensorId: sensor,
+          order: order,
+          startPressureBar: _scaled(
+            m,
+            FitConstants.tsStartPressure,
+            FitConstants.pressureScaleBar,
+          ),
+          endPressureBar: _scaled(
+            m,
+            FitConstants.tsEndPressure,
+            FitConstants.pressureScaleBar,
+          ),
+          volumeUsedLiters: _scaled(
+            m,
+            FitConstants.tsVolumeUsed,
+            FitConstants.volumeScaleLiters,
+          ),
+        ),
+      );
+    }
+
+    final pressures = <FitTankPressureSample>[];
+    for (final m in updates) {
+      final sensor = FitMessageAccess.rawNum(m, FitConstants.tuSensor)?.toInt();
+      final pressure = _scaled(
+        m,
+        FitConstants.tuPressure,
+        FitConstants.pressureScaleBar,
+      );
+      final tsFitSec = FitMessageAccess.rawNum(
+        m,
+        FitConstants.tuTimestamp,
+      )?.toInt();
+      if (sensor == null || pressure == null || tsFitSec == null) continue;
+      pressures.add(
+        FitTankPressureSample(
+          sensorId: sensor,
+          timestampMs: (tsFitSec + FitConstants.fitEpochToUnixSeconds) * 1000,
+          pressureBar: pressure,
+        ),
+      );
+    }
+
+    return FitTankData(tanks, pressures);
+  }
+
+  static double? _scaled(DataMessage m, int fieldId, double scale) {
+    final raw = FitMessageAccess.rawNum(m, fieldId);
+    return raw == null ? null : raw.toDouble() / scale;
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_time_resolver.dart
+++ b/lib/features/dive_import/data/services/fit/fit_time_resolver.dart
@@ -20,7 +20,8 @@ class FitTimeResolver {
     required int? utcTimestampMs,
     required int? localTimestampMs,
   }) {
-    final startMs = _toUnixMs(utcStartMs ?? localStartMs ?? 0);
+    final rawStart = utcStartMs ?? localStartMs;
+    final startMs = rawStart == null ? 0 : _toUnixMs(rawStart);
     var offsetMs = 0;
     if (utcTimestampMs != null && localTimestampMs != null) {
       offsetMs = _toUnixMs(localTimestampMs) - _toUnixMs(utcTimestampMs);

--- a/lib/features/dive_import/data/services/fit/fit_time_resolver.dart
+++ b/lib/features/dive_import/data/services/fit/fit_time_resolver.dart
@@ -1,0 +1,36 @@
+/// Resolves a dive's local wall-clock start, stored as a UTC-flagged DateTime
+/// (the app's "wall-clock-as-UTC" convention: the displayed time must equal the
+/// local time at the dive site regardless of the importing device's timezone).
+///
+/// FIT `record`/`session` timestamps are UTC. The `activity` message carries
+/// both `timestamp` (UTC) and `local_timestamp`; their difference is the dive's
+/// UTC offset, which we add to the UTC start to recover the local wall-clock.
+class FitTimeResolver {
+  const FitTimeResolver._();
+
+  static DateTime wallClockStart({
+    required int? utcStartMs,
+    required int? localStartMs,
+    required int? utcTimestampMs,
+    required int? localTimestampMs,
+  }) {
+    final startMs = utcStartMs ?? localStartMs ?? 0;
+    var offsetMs = 0;
+    if (utcTimestampMs != null && localTimestampMs != null) {
+      offsetMs = localTimestampMs - utcTimestampMs;
+    }
+    final wall = DateTime.fromMillisecondsSinceEpoch(
+      startMs + offsetMs,
+      isUtc: true,
+    );
+    // Truncate to whole seconds and keep the UTC flag.
+    return DateTime.utc(
+      wall.year,
+      wall.month,
+      wall.day,
+      wall.hour,
+      wall.minute,
+      wall.second,
+    );
+  }
+}

--- a/lib/features/dive_import/data/services/fit/fit_time_resolver.dart
+++ b/lib/features/dive_import/data/services/fit/fit_time_resolver.dart
@@ -1,3 +1,5 @@
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
+
 /// Resolves a dive's local wall-clock start, stored as a UTC-flagged DateTime
 /// (the app's "wall-clock-as-UTC" convention: the displayed time must equal the
 /// local time at the dive site regardless of the importing device's timezone).
@@ -5,6 +7,10 @@
 /// FIT `record`/`session` timestamps are UTC. The `activity` message carries
 /// both `timestamp` (UTC) and `local_timestamp`; their difference is the dive's
 /// UTC offset, which we add to the UTC start to recover the local wall-clock.
+///
+/// fit_tool returns most timestamps already as Unix ms, but some (notably
+/// `activity.localTimestamp`) come back as raw FIT-epoch seconds, so every
+/// input is normalized to Unix ms before the offset is computed.
 class FitTimeResolver {
   const FitTimeResolver._();
 
@@ -14,10 +20,10 @@ class FitTimeResolver {
     required int? utcTimestampMs,
     required int? localTimestampMs,
   }) {
-    final startMs = utcStartMs ?? localStartMs ?? 0;
+    final startMs = _toUnixMs(utcStartMs ?? localStartMs ?? 0);
     var offsetMs = 0;
     if (utcTimestampMs != null && localTimestampMs != null) {
-      offsetMs = localTimestampMs - utcTimestampMs;
+      offsetMs = _toUnixMs(localTimestampMs) - _toUnixMs(utcTimestampMs);
     }
     final wall = DateTime.fromMillisecondsSinceEpoch(
       startMs + offsetMs,
@@ -33,4 +39,9 @@ class FitTimeResolver {
       wall.second,
     );
   }
+
+  /// Normalizes a fit_tool timestamp to Unix ms. Values at or below the uint32
+  /// max are raw FIT-epoch seconds; larger values are already Unix ms.
+  static int _toUnixMs(int ts) =>
+      ts > 4294967295 ? ts : (ts + FitConstants.fitEpochToUnixSeconds) * 1000;
 }

--- a/lib/features/dive_import/data/services/fit_parser_service.dart
+++ b/lib/features/dive_import/data/services/fit_parser_service.dart
@@ -5,6 +5,7 @@ import 'package:fit_tool/fit_tool.dart';
 // ignore: implementation_imports
 import 'package:fit_tool/src/utils/logger.dart' as fit_log;
 import 'package:logger/logger.dart' show Level, Logger;
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_device_mapper.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_gas_extractor.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_profile_extractor.dart';
@@ -63,6 +64,13 @@ class FitParserService {
     final diveSummary = _bestDiveSummary(messages);
 
     final tankData = FitTankExtractor.extract(messages);
+    // Drop air-integration summaries with no real pressure (a configured-but-
+    // unused transmitter reports all-zero start/end).
+    final realTanks = tankData.tanks
+        .where(
+          (t) => (t.startPressureBar ?? 0) > 0 || (t.endPressureBar ?? 0) > 0,
+        )
+        .toList();
     final gases = FitGasExtractor.extract(messages);
     final summary = FitSummaryExtractor.extract(
       summary: diveSummary,
@@ -71,11 +79,15 @@ class FitParserService {
     );
 
     // Wall-clock start (local time stored as UTC, per the app convention).
+    // fit_tool returns most timestamps as Unix ms but activity.localTimestamp
+    // as raw FIT-epoch seconds, so normalize both before diffing them.
+    final actUtc = activity?.timestamp;
+    final actLocal = activity?.localTimestamp;
     final startTime = FitTimeResolver.wallClockStart(
-      utcStartMs: sessionStartMs,
+      utcStartMs: _toUnixMs(sessionStartMs),
       localStartMs: null,
-      utcTimestampMs: activity?.timestamp,
-      localTimestampMs: activity?.localTimestamp,
+      utcTimestampMs: actUtc == null ? null : _toUnixMs(actUtc),
+      localTimestampMs: actLocal == null ? null : _toUnixMs(actLocal),
     );
 
     final totalElapsed = session.totalElapsedTime;
@@ -89,7 +101,12 @@ class FitParserService {
     final endTime = startTime.add(elapsed);
 
     // Profile (relative offsets use the raw UTC start; tank pressures merged in).
-    final profile = _buildProfile(samples, sessionStartMs, tankData);
+    final profile = _buildProfile(
+      samples,
+      sessionStartMs,
+      tankData.pressures,
+      realTanks,
+    );
 
     // Summary stats derived from the samples.
     final depths = samples.map((s) => s.depth).toList();
@@ -124,7 +141,7 @@ class FitParserService {
       }
     }
 
-    final tanks = _buildImportedTanks(tankData, gases);
+    final tanks = _buildImportedTanks(realTanks, gases);
 
     final serial = fileId?.serialNumber ?? 0;
     final sourceId = 'garmin-$serial-$sessionStartMs';
@@ -206,13 +223,17 @@ class FitParserService {
   List<ImportedProfileSample> _buildProfile(
     List<FitSample> samples,
     int startMs,
-    FitTankData tankData,
+    List<FitTankPressureSample> pressures,
+    List<FitTank> tanks,
   ) {
+    final orderBySensor = <int, int>{
+      for (var i = 0; i < tanks.length; i++) tanks[i].sensorId: i,
+    };
     // Bucket tank pressures by their whole-second offset from dive start, so
     // they can be attached to the contemporaneous depth sample.
     final pressuresByRelSec = <int, List<ImportedTankPressureSample>>{};
-    for (final p in tankData.pressures) {
-      final order = tankData.orderForSensor(p.sensorId);
+    for (final p in pressures) {
+      final order = orderBySensor[p.sensorId];
       if (order == null) continue;
       final relSec = ((p.timestampMs - startMs) / 1000).round();
       (pressuresByRelSec[relSec] ??= []).add(
@@ -239,34 +260,38 @@ class FitParserService {
     }).toList();
   }
 
-  /// Builds tanks from air-integration summaries when present (associating a gas
-  /// mix by order); otherwise synthesizes one tank per gas mix so the gas is
-  /// still recorded even without a transmitter.
+  /// Builds the tank list, pairing air-integration pressure (when present) with
+  /// gas mixes by order, and ensuring every enabled gas is represented even
+  /// without a transmitter (or when there are more gases than transmitters).
   List<ImportedTank> _buildImportedTanks(
-    FitTankData tankData,
+    List<FitTank> realTanks,
     List<FitGas> gases,
   ) {
-    if (tankData.tanks.isNotEmpty) {
-      return tankData.tanks.map((t) {
-        final gas = t.order < gases.length ? gases[t.order] : null;
-        return ImportedTank(
-          order: t.order,
-          startPressureBar: t.startPressureBar,
-          endPressureBar: t.endPressureBar,
-          volumeUsedLiters: t.volumeUsedLiters,
-          o2Percent: gas?.o2Percent,
-          hePercent: gas?.hePercent,
-        );
-      }).toList();
-    }
-    return gases
-        .map(
-          (g) => ImportedTank(
-            order: g.index,
-            o2Percent: g.o2Percent,
-            hePercent: g.hePercent,
-          ),
-        )
-        .toList();
+    final count = realTanks.length > gases.length
+        ? realTanks.length
+        : gases.length;
+    return [
+      for (var i = 0; i < count; i++)
+        ImportedTank(
+          order: i,
+          startPressureBar: i < realTanks.length
+              ? realTanks[i].startPressureBar
+              : null,
+          endPressureBar: i < realTanks.length
+              ? realTanks[i].endPressureBar
+              : null,
+          volumeUsedLiters: i < realTanks.length
+              ? realTanks[i].volumeUsedLiters
+              : null,
+          o2Percent: i < gases.length ? gases[i].o2Percent : null,
+          hePercent: i < gases.length ? gases[i].hePercent : null,
+        ),
+    ];
   }
+
+  /// fit_tool returns most timestamps as Unix ms, but some (notably
+  /// activity.localTimestamp) come back as raw FIT-epoch seconds. Normalize
+  /// either form to Unix ms (FIT-epoch seconds are always below the uint32 max).
+  int _toUnixMs(int ts) =>
+      ts > 4294967295 ? ts : (ts + FitConstants.fitEpochToUnixSeconds) * 1000;
 }

--- a/lib/features/dive_import/data/services/fit_parser_service.dart
+++ b/lib/features/dive_import/data/services/fit_parser_service.dart
@@ -1,29 +1,30 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:fit_tool/fit_tool.dart';
 // ignore: implementation_imports
 import 'package:fit_tool/src/utils/logger.dart' as fit_log;
 import 'package:logger/logger.dart' show Level, Logger;
+import 'package:submersion/features/dive_import/data/services/fit/fit_device_mapper.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_gas_extractor.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_profile_extractor.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_summary_extractor.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_tank_extractor.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_time_resolver.dart';
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
 
 /// Garmin FIT sport codes that represent dive activities.
 const _diveSports = {Sport.diving};
 
-/// Parses Garmin FIT binary files into [ImportedDive] entities.
+/// Parses Garmin FIT binary files into enriched [ImportedDive] entities.
 ///
-/// Extracts dive-specific data from FIT activity files:
-/// - Session: sport type, start/end time, GPS coordinates
-/// - Records: depth, temperature, heart rate time series
-/// - FileId: device serial number for dedup sourceId generation
-///
-/// Returns null for non-dive activities, corrupt files, or empty data.
+/// Orchestrates focused extractors (see `fit/`) to pull depth/temp/HR samples,
+/// recorded deco (ceiling/TTS/NDL/CNS), air-integration tanks + pressure series,
+/// gas mixes, GPS, and dive-level summary fields. Returns null for non-dive
+/// activities, corrupt files, or files with no depth samples.
 class FitParserService {
   const FitParserService();
 
-  /// Parse a single FIT file into an [ImportedDive].
-  ///
-  /// Returns null if the file is not a dive activity, is corrupt,
-  /// or contains no usable dive data.
   Future<ImportedDive?> parseFitFile(
     Uint8List bytes, {
     String? fileName,
@@ -31,8 +32,6 @@ class FitParserService {
     if (bytes.isEmpty) return null;
 
     // Suppress verbose warnings from fit_tool's outdated FIT SDK profile.
-    // The library logs a warning for every unknown field in newer Garmin
-    // firmware, but these fields are irrelevant to dive data extraction.
     fit_log.logger = Logger(level: Level.error);
 
     final FitFile fitFile;
@@ -47,96 +46,93 @@ class FitParserService {
         .whereType<Message>()
         .toList();
 
-    // Extract key messages
-    final session = _findSession(messages);
+    final session = _firstOfType<SessionMessage>(messages);
     if (session == null) return null;
-
-    // Verify this is a dive activity
     if (!_isDiveActivity(session)) return null;
 
-    final fileId = _findFileId(messages);
-    final records = _extractRecords(messages);
+    final sessionStartMs = session.startTime;
+    if (sessionStartMs == null) return null;
 
-    // Build profile samples
-    final startTimeMs = session.startTime;
-    if (startTimeMs == null) return null;
+    final records = messages.whereType<RecordMessage>().toList();
+    final samples = FitProfileExtractor.extract(records);
+    if (samples.isEmpty) return null;
 
-    // FIT timestamps are UTC. Convert to local wall-clock time, then
-    // re-interpret as UTC (wall-time-as-UTC convention) so the displayed
-    // dive time reflects the local time at the dive site.
-    final localStart = DateTime.fromMillisecondsSinceEpoch(startTimeMs);
-    final startTime = DateTime.utc(
-      localStart.year,
-      localStart.month,
-      localStart.day,
-      localStart.hour,
-      localStart.minute,
-      localStart.second,
+    final fileId = _firstOfType<FileIdMessage>(messages);
+    final activity = _firstOfType<ActivityMessage>(messages);
+    final settings = _firstOfType<DiveSettingsMessage>(messages);
+    final diveSummary = _bestDiveSummary(messages);
+
+    final tankData = FitTankExtractor.extract(messages);
+    final gases = FitGasExtractor.extract(messages);
+    final summary = FitSummaryExtractor.extract(
+      summary: diveSummary,
+      session: session,
+      settings: settings,
     );
 
-    // Use raw UTC epoch for profile offset calculations (both record
-    // timestamps and startTimeMs are in the same UTC time base).
-    final profile = _buildProfile(records, startTimeMs);
+    // Wall-clock start (local time stored as UTC, per the app convention).
+    final startTime = FitTimeResolver.wallClockStart(
+      utcStartMs: sessionStartMs,
+      localStartMs: null,
+      utcTimestampMs: activity?.timestamp,
+      localTimestampMs: activity?.localTimestamp,
+    );
 
-    // Compute summary stats from records
-    final depths = records.map((r) => r.depth).whereType<double>().toList();
-
-    if (depths.isEmpty) return null;
-
-    final maxDepth = depths.reduce((a, b) => a > b ? a : b);
-    final avgDepth = depths.reduce((a, b) => a + b) / depths.length;
-
-    // Temperature stats
-    final temperatures = records
-        .map((r) => r.temperature)
-        .whereType<int>()
-        .map((t) => t.toDouble())
-        .toList();
-
-    final double? minTemperature;
-    final double? maxTemperature;
-    if (temperatures.isNotEmpty) {
-      minTemperature = temperatures.reduce((a, b) => a < b ? a : b);
-      maxTemperature = temperatures.reduce((a, b) => a > b ? a : b);
-    } else {
-      minTemperature = null;
-      maxTemperature = null;
-    }
-
-    // Heart rate stats
-    final heartRates = records
-        .map((r) => r.heartRate)
-        .whereType<int>()
-        .toList();
-
-    final double? avgHeartRate;
-    if (heartRates.isNotEmpty) {
-      avgHeartRate = heartRates.reduce((a, b) => a + b) / heartRates.length;
-    } else {
-      avgHeartRate = null;
-    }
-
-    // End time from session
     final totalElapsed = session.totalElapsedTime;
     final Duration elapsed;
     if (totalElapsed != null) {
       elapsed = Duration(seconds: totalElapsed.round());
     } else {
-      final endMs = session.timestamp ?? startTimeMs;
-      elapsed = Duration(milliseconds: endMs - startTimeMs);
+      final endMs = session.timestamp ?? sessionStartMs;
+      elapsed = Duration(milliseconds: endMs - sessionStartMs);
     }
     final endTime = startTime.add(elapsed);
 
-    // GPS from session
-    final latitude = session.startPositionLat;
-    final longitude = session.startPositionLong;
+    // Profile (relative offsets use the raw UTC start; tank pressures merged in).
+    final profile = _buildProfile(samples, sessionStartMs, tankData);
 
-    // Source ID for deduplication (use raw UTC epoch for stability)
-    final serialNumber = fileId?.serialNumber ?? 0;
-    final sourceId = 'garmin-$serialNumber-$startTimeMs';
+    // Summary stats derived from the samples.
+    final depths = samples.map((s) => s.depth).toList();
+    final maxDepth = depths.reduce(math.max);
+    final avgDepth = depths.reduce((a, b) => a + b) / depths.length;
+
+    final temps = samples
+        .map((s) => s.temperature)
+        .whereType<double>()
+        .toList();
+    final minTemperature = temps.isEmpty ? null : temps.reduce(math.min);
+    final maxTemperature = temps.isEmpty ? null : temps.reduce(math.max);
+
+    final heartRates = samples
+        .map((s) => s.heartRate)
+        .whereType<int>()
+        .toList();
+    final avgHeartRate = heartRates.isEmpty
+        ? null
+        : heartRates.reduce((a, b) => a + b) / heartRates.length;
+
+    // Exit GPS: the last record carrying a position fix (often absent).
+    double? exitLat;
+    double? exitLong;
+    for (final r in records.reversed) {
+      final lat = r.positionLat;
+      final long = r.positionLong;
+      if (lat != null && long != null) {
+        exitLat = lat;
+        exitLong = long;
+        break;
+      }
+    }
+
+    final tanks = _buildImportedTanks(tankData, gases);
+
+    final serial = fileId?.serialNumber ?? 0;
+    final sourceId = 'garmin-$serial-$sessionStartMs';
+    final productCode = fileId?.garminProduct ?? fileId?.product;
 
     return ImportedDive(
       sourceId: sourceId,
+      sourceUuid: sourceId,
       source: ImportSource.garmin,
       startTime: startTime,
       endTime: endTime,
@@ -145,8 +141,23 @@ class FitParserService {
       minTemperature: minTemperature,
       maxTemperature: maxTemperature,
       avgHeartRate: avgHeartRate,
-      latitude: latitude,
-      longitude: longitude,
+      latitude: summary.entryLat,
+      longitude: summary.entryLong,
+      exitLatitude: exitLat,
+      exitLongitude: exitLong,
+      diveNumber: summary.diveNumber,
+      bottomTimeSeconds: summary.bottomTime?.inSeconds,
+      surfaceIntervalSeconds: summary.surfaceInterval?.inSeconds,
+      cnsStart: summary.cnsStart,
+      cnsEnd: summary.cnsEnd,
+      otu: summary.otu,
+      waterType: summary.waterType,
+      decoModel: summary.decoModel,
+      gfLow: summary.gfLow,
+      gfHigh: summary.gfHigh,
+      computerModel: FitDeviceMapper.modelName(productCode),
+      computerSerial: serial != 0 ? '$serial' : null,
+      tanks: tanks,
       profile: profile,
       sourceFileName: fileName,
       sourceFileFormat: 'fit',
@@ -154,39 +165,36 @@ class FitParserService {
   }
 
   /// Parse multiple FIT files, returning only valid dive activities.
-  ///
-  /// Non-dive files and corrupt files are silently filtered out.
   Future<List<ImportedDive>> parseFitFiles(
     List<Uint8List> fileBytes, {
     List<String>? fileNames,
   }) async {
     final results = <ImportedDive>[];
-
     for (var i = 0; i < fileBytes.length; i++) {
       final fileName = (fileNames != null && i < fileNames.length)
           ? fileNames[i]
           : null;
       final dive = await parseFitFile(fileBytes[i], fileName: fileName);
-      if (dive != null) {
-        results.add(dive);
-      }
+      if (dive != null) results.add(dive);
     }
-
     return results;
   }
 
-  SessionMessage? _findSession(List<Message> messages) {
-    for (final msg in messages) {
-      if (msg is SessionMessage) return msg;
+  T? _firstOfType<T extends Message>(List<Message> messages) {
+    for (final m in messages) {
+      if (m is T) return m;
     }
     return null;
   }
 
-  FileIdMessage? _findFileId(List<Message> messages) {
-    for (final msg in messages) {
-      if (msg is FileIdMessage) return msg;
+  /// Prefers the dive summary that carries a dive number (the one referencing
+  /// the session); falls back to the first if none do.
+  DiveSummaryMessage? _bestDiveSummary(List<Message> messages) {
+    final summaries = messages.whereType<DiveSummaryMessage>().toList();
+    for (final s in summaries) {
+      if (s.diveNumber != null) return s;
     }
-    return null;
+    return summaries.isEmpty ? null : summaries.first;
   }
 
   bool _isDiveActivity(SessionMessage session) {
@@ -195,35 +203,70 @@ class FitParserService {
     return _diveSports.contains(sport);
   }
 
-  List<RecordMessage> _extractRecords(List<Message> messages) {
-    return messages.whereType<RecordMessage>().toList();
-  }
-
   List<ImportedProfileSample> _buildProfile(
-    List<RecordMessage> records,
-    int startTimeMs,
+    List<FitSample> samples,
+    int startMs,
+    FitTankData tankData,
   ) {
-    final samples = <ImportedProfileSample>[];
-
-    for (final record in records) {
-      final depth = record.depth;
-      if (depth == null) continue;
-
-      final timestampMs = record.timestamp;
-      final timeSeconds = timestampMs != null
-          ? ((timestampMs - startTimeMs) / 1000).round()
-          : 0;
-
-      samples.add(
-        ImportedProfileSample(
-          timeSeconds: timeSeconds < 0 ? 0 : timeSeconds,
-          depth: depth,
-          temperature: record.temperature?.toDouble(),
-          heartRate: record.heartRate,
+    // Bucket tank pressures by their whole-second offset from dive start, so
+    // they can be attached to the contemporaneous depth sample.
+    final pressuresByRelSec = <int, List<ImportedTankPressureSample>>{};
+    for (final p in tankData.pressures) {
+      final order = tankData.orderForSensor(p.sensorId);
+      if (order == null) continue;
+      final relSec = ((p.timestampMs - startMs) / 1000).round();
+      (pressuresByRelSec[relSec] ??= []).add(
+        ImportedTankPressureSample(
+          tankIndex: order,
+          pressureBar: p.pressureBar,
         ),
       );
     }
 
-    return samples;
+    return samples.map((s) {
+      final relSec = ((s.timestampMs - startMs) / 1000).round();
+      return ImportedProfileSample(
+        timeSeconds: relSec < 0 ? 0 : relSec,
+        depth: s.depth,
+        temperature: s.temperature,
+        heartRate: s.heartRate,
+        cns: s.cns,
+        ndlSeconds: s.ndlSeconds,
+        ttsSeconds: s.ttsSeconds,
+        ceiling: s.ceiling,
+        tankPressures: pressuresByRelSec[relSec],
+      );
+    }).toList();
+  }
+
+  /// Builds tanks from air-integration summaries when present (associating a gas
+  /// mix by order); otherwise synthesizes one tank per gas mix so the gas is
+  /// still recorded even without a transmitter.
+  List<ImportedTank> _buildImportedTanks(
+    FitTankData tankData,
+    List<FitGas> gases,
+  ) {
+    if (tankData.tanks.isNotEmpty) {
+      return tankData.tanks.map((t) {
+        final gas = t.order < gases.length ? gases[t.order] : null;
+        return ImportedTank(
+          order: t.order,
+          startPressureBar: t.startPressureBar,
+          endPressureBar: t.endPressureBar,
+          volumeUsedLiters: t.volumeUsedLiters,
+          o2Percent: gas?.o2Percent,
+          hePercent: gas?.hePercent,
+        );
+      }).toList();
+    }
+    return gases
+        .map(
+          (g) => ImportedTank(
+            order: g.index,
+            o2Percent: g.o2Percent,
+            hePercent: g.hePercent,
+          ),
+        )
+        .toList();
   }
 }

--- a/lib/features/dive_import/data/services/fit_parser_service.dart
+++ b/lib/features/dive_import/data/services/fit_parser_service.dart
@@ -5,7 +5,6 @@ import 'package:fit_tool/fit_tool.dart';
 // ignore: implementation_imports
 import 'package:fit_tool/src/utils/logger.dart' as fit_log;
 import 'package:logger/logger.dart' show Level, Logger;
-import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_device_mapper.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_gas_extractor.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_profile_extractor.dart';
@@ -79,15 +78,12 @@ class FitParserService {
     );
 
     // Wall-clock start (local time stored as UTC, per the app convention).
-    // fit_tool returns most timestamps as Unix ms but activity.localTimestamp
-    // as raw FIT-epoch seconds, so normalize both before diffing them.
-    final actUtc = activity?.timestamp;
-    final actLocal = activity?.localTimestamp;
+    // FitTimeResolver normalizes the mixed timestamp bases fit_tool returns.
     final startTime = FitTimeResolver.wallClockStart(
-      utcStartMs: _toUnixMs(sessionStartMs),
+      utcStartMs: sessionStartMs,
       localStartMs: null,
-      utcTimestampMs: actUtc == null ? null : _toUnixMs(actUtc),
-      localTimestampMs: actLocal == null ? null : _toUnixMs(actLocal),
+      utcTimestampMs: activity?.timestamp,
+      localTimestampMs: activity?.localTimestamp,
     );
 
     final totalElapsed = session.totalElapsedTime;
@@ -288,10 +284,4 @@ class FitParserService {
         ),
     ];
   }
-
-  /// fit_tool returns most timestamps as Unix ms, but some (notably
-  /// activity.localTimestamp) come back as raw FIT-epoch seconds. Normalize
-  /// either form to Unix ms (FIT-epoch seconds are always below the uint32 max).
-  int _toUnixMs(int ts) =>
-      ts > 4294967295 ? ts : (ts + FitConstants.fitEpochToUnixSeconds) * 1000;
 }

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1009,6 +1009,7 @@ class UddfEntityImporter {
                   cns: asDoubleOrNull(p['cns']),
                   ndl: p['ndl'] as int?,
                   tts: p['tts'] as int?,
+                  ceiling: asDoubleOrNull(p['ceiling']),
                   rbt: p['rbt'] as int?,
                   decoType: p['decoType'] as int?,
                   setpoint: asDoubleOrNull(p['setpoint']),
@@ -1182,6 +1183,13 @@ class UddfEntityImporter {
         exitMethod: _parseEnum(diveData['exitMethod'], EntryMethod.values),
         waterType: _parseEnum(diveData['waterType'], WaterType.values),
         altitude: asDoubleOrNull(diveData['altitude']),
+        // Entry/exit GPS, so file-imported dives become eligible for the
+        // existing site matcher.
+        entryLocation: _geoPoint(diveData['latitude'], diveData['longitude']),
+        exitLocation: _geoPoint(
+          diveData['exitLatitude'],
+          diveData['exitLongitude'],
+        ),
         // Dive mode and rebreather fields
         diveMode: diveMode,
         isPlanned: isPlanned,
@@ -1538,6 +1546,13 @@ class UddfEntityImporter {
   }
 
   // -- Dive helper methods --
+
+  GeoPoint? _geoPoint(dynamic lat, dynamic lng) {
+    final latVal = asDoubleOrNull(lat);
+    final lngVal = asDoubleOrNull(lng);
+    if (latVal == null || lngVal == null) return null;
+    return GeoPoint(latVal, lngVal);
+  }
 
   List<DiveTank> _buildTanks(Map<String, dynamic> diveData) {
     final tanksData = diveData['tanks'] as List<Map<String, dynamic>>?;

--- a/lib/features/dive_import/domain/entities/imported_dive.dart
+++ b/lib/features/dive_import/domain/entities/imported_dive.dart
@@ -19,9 +19,53 @@ extension ImportSourceExtension on ImportSource {
   }
 }
 
+/// A tank parsed from an imported dive (air-integration).
+class ImportedTank extends Equatable {
+  const ImportedTank({
+    required this.order,
+    this.startPressureBar,
+    this.endPressureBar,
+    this.volumeUsedLiters,
+    this.o2Percent,
+    this.hePercent,
+  });
+
+  final int order;
+  final double? startPressureBar;
+  final double? endPressureBar;
+  final double? volumeUsedLiters;
+  final double? o2Percent;
+  final double? hePercent;
+
+  @override
+  List<Object?> get props => [
+    order,
+    startPressureBar,
+    endPressureBar,
+    volumeUsedLiters,
+    o2Percent,
+    hePercent,
+  ];
+}
+
+/// A single tank-pressure reading attached to a profile sample.
+class ImportedTankPressureSample extends Equatable {
+  const ImportedTankPressureSample({
+    required this.tankIndex,
+    required this.pressureBar,
+  });
+
+  final int tankIndex;
+  final double pressureBar;
+
+  @override
+  List<Object?> get props => [tankIndex, pressureBar];
+}
+
 /// A dive imported from an external source (wearable device, file, etc.)
 class ImportedDive extends Equatable {
   final String sourceId;
+  final String? sourceUuid;
   final ImportSource source;
   final DateTime startTime;
   final DateTime endTime;
@@ -32,12 +76,29 @@ class ImportedDive extends Equatable {
   final double? avgHeartRate;
   final double? latitude;
   final double? longitude;
+  final double? exitLatitude;
+  final double? exitLongitude;
+  final int? diveNumber;
+  final int? bottomTimeSeconds;
+  final int? surfaceIntervalSeconds;
+  final double? cnsStart;
+  final double? cnsEnd;
+  final double? otu;
+  final String? waterType;
+  final String? decoModel;
+  final int? gfLow;
+  final int? gfHigh;
+  final String? computerModel;
+  final String? computerSerial;
+  final String? computerFirmware;
+  final List<ImportedTank> tanks;
   final List<ImportedProfileSample> profile;
   final String? sourceFileName;
   final String? sourceFileFormat;
 
   const ImportedDive({
     required this.sourceId,
+    this.sourceUuid,
     required this.source,
     required this.startTime,
     required this.endTime,
@@ -48,6 +109,22 @@ class ImportedDive extends Equatable {
     this.avgHeartRate,
     this.latitude,
     this.longitude,
+    this.exitLatitude,
+    this.exitLongitude,
+    this.diveNumber,
+    this.bottomTimeSeconds,
+    this.surfaceIntervalSeconds,
+    this.cnsStart,
+    this.cnsEnd,
+    this.otu,
+    this.waterType,
+    this.decoModel,
+    this.gfLow,
+    this.gfHigh,
+    this.computerModel,
+    this.computerSerial,
+    this.computerFirmware,
+    this.tanks = const [],
     required this.profile,
     this.sourceFileName,
     this.sourceFileFormat,
@@ -59,6 +136,7 @@ class ImportedDive extends Equatable {
   @override
   List<Object?> get props => [
     sourceId,
+    sourceUuid,
     source,
     startTime,
     endTime,
@@ -69,6 +147,22 @@ class ImportedDive extends Equatable {
     avgHeartRate,
     latitude,
     longitude,
+    exitLatitude,
+    exitLongitude,
+    diveNumber,
+    bottomTimeSeconds,
+    surfaceIntervalSeconds,
+    cnsStart,
+    cnsEnd,
+    otu,
+    waterType,
+    decoModel,
+    gfLow,
+    gfHigh,
+    computerModel,
+    computerSerial,
+    computerFirmware,
+    tanks,
     profile,
     sourceFileName,
     sourceFileFormat,
@@ -81,14 +175,58 @@ class ImportedProfileSample extends Equatable {
   final double depth;
   final double? temperature;
   final int? heartRate;
+  final double? cns;
+  final int? ndlSeconds;
+  final int? ttsSeconds;
+  final double? ceiling;
+  final List<ImportedTankPressureSample>? tankPressures;
 
   const ImportedProfileSample({
     required this.timeSeconds,
     required this.depth,
     this.temperature,
     this.heartRate,
+    this.cns,
+    this.ndlSeconds,
+    this.ttsSeconds,
+    this.ceiling,
+    this.tankPressures,
   });
 
+  ImportedProfileSample copyWith({
+    int? timeSeconds,
+    double? depth,
+    double? temperature,
+    int? heartRate,
+    double? cns,
+    int? ndlSeconds,
+    int? ttsSeconds,
+    double? ceiling,
+    List<ImportedTankPressureSample>? tankPressures,
+  }) {
+    return ImportedProfileSample(
+      timeSeconds: timeSeconds ?? this.timeSeconds,
+      depth: depth ?? this.depth,
+      temperature: temperature ?? this.temperature,
+      heartRate: heartRate ?? this.heartRate,
+      cns: cns ?? this.cns,
+      ndlSeconds: ndlSeconds ?? this.ndlSeconds,
+      ttsSeconds: ttsSeconds ?? this.ttsSeconds,
+      ceiling: ceiling ?? this.ceiling,
+      tankPressures: tankPressures ?? this.tankPressures,
+    );
+  }
+
   @override
-  List<Object?> get props => [timeSeconds, depth, temperature, heartRate];
+  List<Object?> get props => [
+    timeSeconds,
+    depth,
+    temperature,
+    heartRate,
+    cns,
+    ndlSeconds,
+    ttsSeconds,
+    ceiling,
+    tankPressures,
+  ];
 }

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -702,6 +702,12 @@ class DiveRepository {
               waterType: Value(dive.waterType?.name),
               altitude: Value(dive.altitude),
               surfacePressure: Value(dive.surfacePressure),
+              // Entry/exit GPS (previously dropped on create, so file-imported
+              // dives never became eligible for site matching).
+              entryLatitude: Value(dive.entryLocation?.latitude),
+              entryLongitude: Value(dive.entryLocation?.longitude),
+              exitLatitude: Value(dive.exitLocation?.latitude),
+              exitLongitude: Value(dive.exitLocation?.longitude),
               // Weather conditions
               windSpeed: Value(dive.windSpeed),
               windDirection: Value(dive.windDirection?.name),

--- a/lib/features/universal_import/data/parsers/fit_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/fit_import_parser.dart
@@ -1,6 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:submersion/features/dive_import/data/services/fit_parser_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    show GasMix;
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
 import 'package:submersion/features/universal_import/data/models/import_options.dart';
 import 'package:submersion/features/universal_import/data/models/import_payload.dart';
@@ -9,9 +11,10 @@ import 'package:submersion/features/universal_import/data/parsers/import_parser.
 
 /// Parser adapter for Garmin FIT binary files.
 ///
-/// Wraps [FitParserService] and converts its [ImportedDive] output
-/// into the unified [ImportPayload] format. FIT files only contain
-/// dive data, so the payload will only ever have a single "dives" tab.
+/// Wraps [FitParserService] and converts its enriched [ImportedDive] output
+/// into the unified [ImportPayload] format using the same keys UDDF imports
+/// produce, so the shared `UddfEntityImporter` persists tanks, gas, deco, GPS
+/// and CNS/OTU without any FIT-specific persistence code.
 class FitImportParser implements ImportParser {
   final FitParserService _service;
 
@@ -42,24 +45,68 @@ class FitImportParser implements ImportParser {
       );
     }
 
-    // Convert ImportedDive to the Map<String, dynamic> format
-    // expected by the universal import pipeline.
+    final sourceUuid = dive.sourceUuid ?? dive.sourceId;
+
     final diveData = <String, dynamic>{
       'dateTime': dive.startTime,
       'maxDepth': dive.maxDepth,
       'avgDepth': dive.avgDepth,
-      'duration': dive.duration,
+      // `duration` is bottom time (distinct from runtime); fall back to elapsed.
+      'duration': dive.bottomTimeSeconds != null
+          ? Duration(seconds: dive.bottomTimeSeconds!)
+          : dive.duration,
       'runtime': dive.duration,
       'waterTemp': dive.minTemperature,
       'sourceId': dive.sourceId,
+      'sourceUuid': sourceUuid,
     };
 
-    if (dive.avgHeartRate != null) {
-      diveData['avgHeartRate'] = dive.avgHeartRate;
+    if (dive.avgHeartRate != null) diveData['avgHeartRate'] = dive.avgHeartRate;
+    if (dive.diveNumber != null) diveData['diveNumber'] = dive.diveNumber;
+    if (dive.surfaceIntervalSeconds != null) {
+      diveData['surfaceInterval'] = Duration(
+        seconds: dive.surfaceIntervalSeconds!,
+      );
+    }
+    if (dive.waterType != null) diveData['waterType'] = dive.waterType;
+    if (dive.decoModel != null) diveData['decoAlgorithm'] = dive.decoModel;
+    if (dive.gfLow != null) diveData['gradientFactorLow'] = dive.gfLow;
+    if (dive.gfHigh != null) diveData['gradientFactorHigh'] = dive.gfHigh;
+    if (dive.cnsEnd != null) diveData['cnsEnd'] = dive.cnsEnd;
+    if (dive.otu != null) diveData['otu'] = dive.otu;
+    if (dive.computerModel != null) {
+      diveData['diveComputerModel'] = dive.computerModel;
+    }
+    if (dive.computerSerial != null) {
+      diveData['diveComputerSerial'] = dive.computerSerial;
+    }
+    if (dive.computerFirmware != null) {
+      diveData['diveComputerFirmware'] = dive.computerFirmware;
     }
     if (dive.latitude != null && dive.longitude != null) {
       diveData['latitude'] = dive.latitude;
       diveData['longitude'] = dive.longitude;
+    }
+    if (dive.exitLatitude != null && dive.exitLongitude != null) {
+      diveData['exitLatitude'] = dive.exitLatitude;
+      diveData['exitLongitude'] = dive.exitLongitude;
+    }
+
+    if (dive.tanks.isNotEmpty) {
+      diveData['tanks'] = dive.tanks.map((t) {
+        final tank = <String, dynamic>{'order': t.order};
+        if (t.startPressureBar != null) {
+          tank['startPressure'] = t.startPressureBar;
+        }
+        if (t.endPressureBar != null) tank['endPressure'] = t.endPressureBar;
+        if (t.o2Percent != null || t.hePercent != null) {
+          tank['gasMix'] = GasMix(
+            o2: t.o2Percent ?? 21.0,
+            he: t.hePercent ?? 0.0,
+          );
+        }
+        return tank;
+      }).toList();
     }
 
     if (dive.profile.isNotEmpty) {
@@ -70,6 +117,21 @@ class FitImportParser implements ImportParser {
         };
         if (s.temperature != null) point['temperature'] = s.temperature;
         if (s.heartRate != null) point['heartRate'] = s.heartRate;
+        if (s.cns != null) point['cns'] = s.cns;
+        if (s.ndlSeconds != null) point['ndl'] = s.ndlSeconds;
+        if (s.ttsSeconds != null) point['tts'] = s.ttsSeconds;
+        if (s.ceiling != null) point['ceiling'] = s.ceiling;
+        final tankPressures = s.tankPressures;
+        if (tankPressures != null && tankPressures.isNotEmpty) {
+          point['allTankPressures'] = tankPressures
+              .map(
+                (p) => <String, dynamic>{
+                  'tankIndex': p.tankIndex,
+                  'pressure': p.pressureBar,
+                },
+              )
+              .toList();
+        }
         return point;
       }).toList();
     }
@@ -78,7 +140,11 @@ class FitImportParser implements ImportParser {
       entities: {
         ImportEntityType.dives: [diveData],
       },
-      metadata: {'sourceApp': 'Garmin', 'sourceId': dive.sourceId},
+      metadata: {
+        'sourceApp': 'Garmin',
+        'sourceId': dive.sourceId,
+        'sourceUuid': sourceUuid,
+      },
     );
   }
 }

--- a/test/features/dive_import/data/services/fit/fit_device_mapper_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_device_mapper_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_device_mapper.dart';
+
+void main() {
+  test('maps known Garmin dive product codes', () {
+    expect(FitDeviceMapper.modelName(4223), 'Descent Mk3i');
+    expect(FitDeviceMapper.modelName(4518), 'Descent X50i');
+    expect(FitDeviceMapper.modelName(2859), 'Descent Mk1');
+  });
+
+  test('falls back for unknown or null product', () {
+    expect(FitDeviceMapper.modelName(999999), 'Garmin Descent');
+    expect(FitDeviceMapper.modelName(null), 'Garmin Descent');
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_gas_extractor_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_gas_extractor_test.dart
@@ -1,0 +1,41 @@
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_gas_extractor.dart';
+
+void main() {
+  test('extracts enabled gas mixes sorted by message index', () {
+    final g0 = DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 30
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled;
+    final g1 = DiveGasMessage()
+      ..messageIndex = 1
+      ..oxygenContent = 50
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled;
+
+    final gases = FitGasExtractor.extract([g1, g0]);
+
+    expect(gases, hasLength(2));
+    expect(gases[0].index, 0);
+    expect(gases[0].o2Percent, 30);
+    expect(gases[1].o2Percent, 50);
+  });
+
+  test('excludes disabled gases', () {
+    final enabled = DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 21
+      ..status = DiveGasStatus.enabled;
+    final disabled = DiveGasMessage()
+      ..messageIndex = 1
+      ..oxygenContent = 100
+      ..status = DiveGasStatus.disabled;
+
+    final gases = FitGasExtractor.extract([enabled, disabled]);
+
+    expect(gases, hasLength(1));
+    expect(gases.single.o2Percent, 21);
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_message_access_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_message_access_test.dart
@@ -1,0 +1,59 @@
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_message_access.dart';
+
+/// Builds a synthetic [GenericMessage] (an unnamed FIT message, the way fit_tool
+/// reconstructs any message it has no named profile for) with the given fields.
+DataMessage buildGeneric(
+  int globalId,
+  List<({int id, BaseType type, int size, num value})> fields,
+) {
+  final def = DefinitionMessage(
+    globalId: globalId,
+    fieldDefinitions: fields
+        .map((f) => FieldDefinition(id: f.id, size: f.size, type: f.type))
+        .toList(),
+  );
+  final msg = GenericMessage(definitionMessage: def);
+  for (final f in fields) {
+    msg.getField(f.id)!.setValue(0, f.value, null);
+  }
+  return msg;
+}
+
+void main() {
+  test(
+    'rawNum reads a field by number from a GenericMessage (tank_update)',
+    () {
+      // tank_update (msg 319): field 0=sensor, 1=pressure(raw), 253=timestamp.
+      final msg = buildGeneric(FitConstants.tankUpdateMsg, const [
+        (id: 253, type: BaseType.UINT32, size: 4, value: 1126250405),
+        (id: 0, type: BaseType.UINT32, size: 4, value: 2772884913),
+        (id: 1, type: BaseType.UINT16, size: 2, value: 22125),
+      ]);
+
+      expect(msg.globalId, FitConstants.tankUpdateMsg);
+      expect(FitMessageAccess.rawNum(msg, 1), 22125);
+      expect(FitMessageAccess.rawNum(msg, 0), 2772884913);
+      expect(FitMessageAccess.rawNum(msg, 99), isNull);
+    },
+  );
+
+  test('messagesWithGlobalId filters by FIT global message number', () {
+    final tank = buildGeneric(FitConstants.tankSummaryMsg, const [
+      (id: 0, type: BaseType.UINT32, size: 4, value: 100),
+    ]);
+    final other = buildGeneric(999, const [
+      (id: 0, type: BaseType.UINT16, size: 2, value: 1),
+    ]);
+
+    final result = FitMessageAccess.messagesWithGlobalId(<Message>[
+      tank,
+      other,
+    ], FitConstants.tankSummaryMsg);
+
+    expect(result, hasLength(1));
+    expect(result.first.globalId, FitConstants.tankSummaryMsg);
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_profile_extractor_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_profile_extractor_test.dart
@@ -1,0 +1,41 @@
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_profile_extractor.dart';
+
+void main() {
+  final start = DateTime.utc(2025, 10, 13, 8, 51, 10);
+
+  test('extracts depth + recorded deco fields, skips depthless records', () {
+    final r1 = RecordMessage()
+      ..timestamp = start.millisecondsSinceEpoch
+      ..depth = 24.257
+      ..temperature = 23
+      ..nextStopDepth = 6.0
+      ..timeToSurface = 480
+      ..ndlTime = 0
+      ..cnsLoad = 15;
+    final r2 = RecordMessage()
+      ..timestamp = start
+          .add(const Duration(seconds: 1))
+          .millisecondsSinceEpoch;
+
+    final samples = FitProfileExtractor.extract([r1, r2]);
+
+    expect(samples, hasLength(1));
+    final s = samples.single;
+    expect(s.depth, closeTo(24.257, 1e-6));
+    expect(s.temperature, 23);
+    expect(s.ceiling, 6.0);
+    expect(s.ttsSeconds, 480);
+    expect(s.ndlSeconds, 0);
+    expect(s.cns, 15);
+  });
+
+  test('keeps the record timestamp as Unix ms for later merge alignment', () {
+    final r = RecordMessage()
+      ..timestamp = start.millisecondsSinceEpoch
+      ..depth = 5.0;
+    final s = FitProfileExtractor.extract([r]).single;
+    expect(s.timestampMs, start.millisecondsSinceEpoch);
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_summary_extractor_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_summary_extractor_test.dart
@@ -1,0 +1,59 @@
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_summary_extractor.dart';
+
+void main() {
+  test(
+    'extracts dive number, bottom time, SI, CNS/OTU, GPS, water type, GF',
+    () {
+      final summary = DiveSummaryMessage()
+        ..diveNumber = 92
+        ..bottomTime = 5168.781
+        ..surfaceInterval = 167491
+        ..startCns = 0
+        ..endCns = 32
+        ..o2Toxicity = 90;
+      final session = SessionMessage()
+        ..startPositionLat = 35.815
+        ..startPositionLong = 14.451;
+      final settings = DiveSettingsMessage()
+        ..waterType = WaterType.salt
+        ..gfLow = 50
+        ..gfHigh = 85
+        ..model = TissueModelType.zhl16c;
+
+      final s = FitSummaryExtractor.extract(
+        summary: summary,
+        session: session,
+        settings: settings,
+      );
+
+      expect(s.diveNumber, 92);
+      expect(
+        s.bottomTime,
+        const Duration(seconds: 5169),
+      ); // 5168.781 -> rounded
+      expect(s.surfaceInterval, const Duration(seconds: 167491));
+      expect(s.cnsEnd, 32);
+      expect(s.otu, 90);
+      expect(s.entryLat, closeTo(35.815, 1e-4));
+      expect(s.entryLong, closeTo(14.451, 1e-4));
+      expect(s.waterType, 'salt');
+      expect(s.decoModel, 'zhl_16c');
+      expect(s.gfLow, 50);
+      expect(s.gfHigh, 85);
+    },
+  );
+
+  test('handles all-null inputs gracefully', () {
+    final s = FitSummaryExtractor.extract(
+      summary: null,
+      session: null,
+      settings: null,
+    );
+    expect(s.diveNumber, isNull);
+    expect(s.bottomTime, isNull);
+    expect(s.entryLat, isNull);
+    expect(s.waterType, isNull);
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
@@ -75,4 +75,13 @@ void main() {
     final p = data.pressures.firstWhere((s) => s.sensorId == 200);
     expect(p.pressureBar, closeTo(180.0, 1e-6));
   });
+
+  test('collapses repeated tank_summary for the same sensor into one tank', () {
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 100, startRaw: 20000, endRaw: 9000, volRaw: 100000),
+      tankSummary(sensor: 100, startRaw: 20000, endRaw: 9000, volRaw: 100000),
+    ]);
+    expect(data.tanks, hasLength(1));
+    expect(data.orderForSensor(100), 0);
+  });
 }

--- a/test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
@@ -1,0 +1,78 @@
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_tank_extractor.dart';
+
+DataMessage _msg(
+  int globalId,
+  List<({int id, BaseType type, int size, num value})> fields,
+) {
+  final def = DefinitionMessage(
+    globalId: globalId,
+    fieldDefinitions: fields
+        .map((f) => FieldDefinition(id: f.id, size: f.size, type: f.type))
+        .toList(),
+  );
+  final m = GenericMessage(definitionMessage: def);
+  for (final f in fields) {
+    m.getField(f.id)!.setValue(0, f.value, null);
+  }
+  return m;
+}
+
+DataMessage tankSummary({
+  required int sensor,
+  required int startRaw,
+  required int endRaw,
+  required int volRaw,
+}) => _msg(FitConstants.tankSummaryMsg, [
+  (id: 0, type: BaseType.UINT32, size: 4, value: sensor),
+  (id: 1, type: BaseType.UINT16, size: 2, value: startRaw),
+  (id: 2, type: BaseType.UINT16, size: 2, value: endRaw),
+  (id: 3, type: BaseType.UINT32, size: 4, value: volRaw),
+]);
+
+DataMessage tankUpdate({
+  required int sensor,
+  required int tsRaw,
+  required int pressureRaw,
+}) => _msg(FitConstants.tankUpdateMsg, [
+  (id: 253, type: BaseType.UINT32, size: 4, value: tsRaw),
+  (id: 0, type: BaseType.UINT32, size: 4, value: sensor),
+  (id: 1, type: BaseType.UINT16, size: 2, value: pressureRaw),
+]);
+
+void main() {
+  test('builds a tank per sensor with scaled start/end/volume', () {
+    // Bouchot 72: 22125 -> 221.25 bar, 8811 -> 88.11 bar, 199350 -> 1993.5 L.
+    final data = FitTankExtractor.extract([
+      tankSummary(
+        sensor: 2772884913,
+        startRaw: 22125,
+        endRaw: 8811,
+        volRaw: 199350,
+      ),
+    ]);
+    expect(data.tanks, hasLength(1));
+    final t = data.tanks.single;
+    expect(t.sensorId, 2772884913);
+    expect(t.order, 0);
+    expect(t.startPressureBar, closeTo(221.25, 1e-6));
+    expect(t.endPressureBar, closeTo(88.11, 1e-6));
+    expect(t.volumeUsedLiters, closeTo(1993.5, 1e-6));
+  });
+
+  test('maps each sensor to a stable tank order; pressures scaled to bar', () {
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 100, startRaw: 20000, endRaw: 9000, volRaw: 100000),
+      tankSummary(sensor: 200, startRaw: 21000, endRaw: 7000, volRaw: 120000),
+      tankUpdate(sensor: 200, tsRaw: 1000, pressureRaw: 18000),
+      tankUpdate(sensor: 100, tsRaw: 1000, pressureRaw: 19000),
+    ]);
+    expect(data.tanks, hasLength(2));
+    expect(data.orderForSensor(100), 0);
+    expect(data.orderForSensor(200), 1);
+    final p = data.pressures.firstWhere((s) => s.sensorId == 200);
+    expect(p.pressureBar, closeTo(180.0, 1e-6));
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
@@ -55,4 +55,14 @@ void main() {
 
     expect(result, DateTime.utc(2025, 9, 8, 9, 19, 49));
   });
+
+  test('returns the Unix epoch when no start is provided', () {
+    final result = FitTimeResolver.wallClockStart(
+      utcStartMs: null,
+      localStartMs: null,
+      utcTimestampMs: null,
+      localTimestampMs: null,
+    );
+    expect(result, DateTime.utc(1970, 1, 1));
+  });
 }

--- a/test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_time_resolver.dart';
+
+void main() {
+  // Malta dive: session.startTime is 08:51:10 UTC; the activity message's
+  // local_timestamp shows 10:51:10 (UTC+2). The displayed wall-clock must be
+  // 10:51:10, stored as a UTC-flagged DateTime (wall-clock-as-UTC convention).
+  final utcStart = DateTime.utc(2025, 10, 13, 8, 51, 10).millisecondsSinceEpoch;
+  final utcAct = DateTime.utc(2025, 10, 13, 8, 51, 10).millisecondsSinceEpoch;
+  final localAct = DateTime.utc(
+    2025,
+    10,
+    13,
+    10,
+    51,
+    10,
+  ).millisecondsSinceEpoch;
+
+  test('applies the activity UTC offset to the session start', () {
+    final result = FitTimeResolver.wallClockStart(
+      utcStartMs: utcStart,
+      localStartMs: null,
+      utcTimestampMs: utcAct,
+      localTimestampMs: localAct,
+    );
+    expect(result, DateTime.utc(2025, 10, 13, 10, 51, 10));
+    expect(result.isUtc, isTrue);
+  });
+
+  test('falls back to the raw start when no local_timestamp is present', () {
+    final result = FitTimeResolver.wallClockStart(
+      utcStartMs: utcStart,
+      localStartMs: null,
+      utcTimestampMs: null,
+      localTimestampMs: null,
+    );
+    expect(result, DateTime.utc(2025, 10, 13, 8, 51, 10));
+  });
+}

--- a/test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_time_resolver_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/data/services/fit/fit_constants.dart';
 import 'package:submersion/features/dive_import/data/services/fit/fit_time_resolver.dart';
 
 void main() {
@@ -35,5 +36,23 @@ void main() {
       localTimestampMs: null,
     );
     expect(result, DateTime.utc(2025, 10, 13, 8, 51, 10));
+  });
+
+  test('normalizes a FIT-epoch-seconds local_timestamp (real-file quirk)', () {
+    // fit_tool returns activity.timestamp as Unix ms but activity.localTimestamp
+    // as raw FIT-epoch seconds. Dive is 07:19:49 UTC, 09:19:49 local (+2h).
+    final utcInstant = DateTime.utc(2025, 9, 8, 7, 19, 49);
+    final localFitSeconds =
+        DateTime.utc(2025, 9, 8, 9, 19, 49).millisecondsSinceEpoch ~/ 1000 -
+        FitConstants.fitEpochToUnixSeconds;
+
+    final result = FitTimeResolver.wallClockStart(
+      utcStartMs: utcInstant.millisecondsSinceEpoch,
+      localStartMs: null,
+      utcTimestampMs: utcInstant.millisecondsSinceEpoch,
+      localTimestampMs: localFitSeconds,
+    );
+
+    expect(result, DateTime.utc(2025, 9, 8, 9, 19, 49));
   });
 }

--- a/test/features/dive_import/data/services/fit_parser_service_test.dart
+++ b/test/features/dive_import/data/services/fit_parser_service_test.dart
@@ -122,6 +122,80 @@ Uint8List buildTestRunningFitFile({
   return builder.build().toBytes();
 }
 
+/// Builds a feature-rich dive FIT file (deco records, gas mix, dive settings,
+/// dive summary, GPS) for exercising the enriched orchestrator.
+Uint8List buildRichDiveFitFile() {
+  final builder = FitFileBuilder(autoDefine: true, minStringSize: 50);
+  final start = DateTime.utc(2025, 10, 13, 11, 24, 0);
+
+  builder.add(
+    FileIdMessage()
+      ..type = FileType.activity
+      ..manufacturer = 1
+      ..product =
+          4223 // Descent Mk3i
+      ..serialNumber = 3502016516
+      ..timeCreated = start.millisecondsSinceEpoch,
+  );
+
+  final depths = [1.6, 15.0, 29.5, 20.0, 6.0, 0.5];
+  for (var i = 0; i < depths.length; i++) {
+    builder.add(
+      RecordMessage()
+        ..timestamp = start
+            .add(Duration(seconds: i * 60))
+            .millisecondsSinceEpoch
+        ..depth = depths[i]
+        ..temperature = 24
+        ..nextStopDepth = i == 2 ? 6.0 : 0.0
+        ..ndlTime = i == 2 ? 0 : 99
+        ..timeToSurface = i == 2 ? 480 : 0
+        ..cnsLoad = i + 1,
+    );
+  }
+
+  builder.add(
+    DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 28
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled,
+  );
+
+  builder.add(
+    DiveSettingsMessage()
+      ..waterType = WaterType.salt
+      ..gfLow = 50
+      ..gfHigh = 85
+      ..model = TissueModelType.zhl16c,
+  );
+
+  builder.add(
+    DiveSummaryMessage()
+      ..diveNumber = 73
+      ..bottomTime = 3263.0
+      ..surfaceInterval = 4612
+      ..startCns = 0
+      ..endCns = 12
+      ..o2Toxicity = 25,
+  );
+
+  builder.add(
+    SessionMessage()
+      ..sport = Sport.diving
+      ..timestamp = start
+          .add(const Duration(seconds: 360))
+          .millisecondsSinceEpoch
+      ..startTime = start.millisecondsSinceEpoch
+      ..totalElapsedTime = 360.0
+      ..totalTimerTime = 360.0
+      ..startPositionLat = 35.815
+      ..startPositionLong = 14.451,
+  );
+
+  return builder.build().toBytes();
+}
+
 void main() {
   late FitParserService service;
 
@@ -186,7 +260,8 @@ void main() {
     });
 
     test('extracts correct start and end times from session', () async {
-      final startTime = DateTime(2024, 3, 20, 14, 0, 0);
+      // Built as UTC so the wall-clock-as-UTC assertion is timezone-independent.
+      final startTime = DateTime.utc(2024, 3, 20, 14, 0, 0);
       const durationSeconds = 2400; // 40 minutes
       final bytes = buildTestDiveFitFile(
         startTime: startTime,
@@ -381,6 +456,34 @@ void main() {
       expect(result!.latitude, isNull);
       expect(result.longitude, isNull);
     });
+
+    test(
+      'enriched parse surfaces gas, deco, dive number, GPS, water type',
+      () async {
+        final dive = await service.parseFitFile(buildRichDiveFitFile());
+
+        expect(dive, isNotNull);
+        expect(dive!.diveNumber, 73);
+        expect(dive.waterType, 'salt');
+        expect(dive.gfLow, 50);
+        expect(dive.gfHigh, 85);
+        expect(dive.decoModel, 'zhl_16c');
+        expect(dive.cnsEnd, 12);
+        expect(dive.otu, 25);
+        expect(dive.bottomTimeSeconds, 3263);
+        expect(dive.surfaceIntervalSeconds, 4612);
+        expect(dive.latitude, closeTo(35.815, 1e-3));
+        expect(dive.computerModel, 'Descent Mk3i');
+        expect(dive.sourceUuid, dive.sourceId);
+        // No transmitter -> synthesize a tank from the gas mix (EAN28).
+        expect(dive.tanks, hasLength(1));
+        expect(dive.tanks.single.o2Percent, 28);
+        expect(dive.tanks.single.startPressureBar, isNull);
+        // Recorded deco values present on the deep sample.
+        expect(dive.profile.any((s) => s.ceiling == 6.0), isTrue);
+        expect(dive.profile.any((s) => s.ttsSeconds == 480), isTrue);
+      },
+    );
   });
 
   group('parseFitFiles', () {

--- a/test/features/dive_import/data/services/fit_parser_service_test.dart
+++ b/test/features/dive_import/data/services/fit_parser_service_test.dart
@@ -196,6 +196,80 @@ Uint8List buildRichDiveFitFile() {
   return builder.build().toBytes();
 }
 
+/// A synthetic unnamed FIT message (e.g. tank_update/tank_summary) built the way
+/// fit_tool reconstructs messages it has no profile for.
+DataMessage _genericTank(int globalId, Map<int, int> values) {
+  final def = DefinitionMessage(
+    globalId: globalId,
+    fieldDefinitions: [
+      for (final id in values.keys)
+        FieldDefinition(
+          id: id,
+          size: id == 1 || id == 2 ? 2 : 4, // pressure fields are uint16
+          type: id == 1 || id == 2 ? BaseType.UINT16 : BaseType.UINT32,
+        ),
+    ],
+  );
+  final m = GenericMessage(definitionMessage: def);
+  values.forEach((id, v) => m.getField(id)!.setValue(0, v, null));
+  return m;
+}
+
+/// A dive FIT file with air-integration: a tank_summary (323) and a tank_update
+/// (319) per record, all on one transmitter, plus one gas mix.
+Uint8List buildAiDiveFitFile() {
+  final builder = FitFileBuilder(autoDefine: true, minStringSize: 50);
+  final start = DateTime.utc(2025, 9, 8, 9, 19, 49);
+  const sensor = 2772884913;
+
+  builder.add(
+    FileIdMessage()
+      ..type = FileType.activity
+      ..manufacturer = 1
+      ..product = 4223
+      ..serialNumber = 1
+      ..timeCreated = start.millisecondsSinceEpoch,
+  );
+
+  // tank_summary: start 22125 -> 221.25 bar, end 8811 -> 88.11 bar, vol 199350.
+  builder.add(_genericTank(323, {0: sensor, 1: 22125, 2: 8811, 3: 199350}));
+
+  const depths = [2.0, 20.0, 5.0];
+  const pressuresRaw = [22000, 15000, 9000];
+  for (var i = 0; i < depths.length; i++) {
+    final t = start.add(Duration(seconds: i * 60));
+    builder.add(
+      RecordMessage()
+        ..timestamp = t.millisecondsSinceEpoch
+        ..depth = depths[i]
+        ..temperature = 26,
+    );
+    // tank_update at the same instant; field 253 is raw FIT-epoch seconds.
+    final fitSec = t.millisecondsSinceEpoch ~/ 1000 - 631065600;
+    builder.add(_genericTank(319, {253: fitSec, 0: sensor, 1: pressuresRaw[i]}));
+  }
+
+  builder.add(
+    DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 28
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled,
+  );
+  builder.add(
+    SessionMessage()
+      ..sport = Sport.diving
+      ..timestamp = start
+          .add(const Duration(seconds: 180))
+          .millisecondsSinceEpoch
+      ..startTime = start.millisecondsSinceEpoch
+      ..totalElapsedTime = 180.0
+      ..totalTimerTime = 180.0,
+  );
+
+  return builder.build().toBytes();
+}
+
 void main() {
   late FitParserService service;
 
@@ -484,6 +558,27 @@ void main() {
         expect(dive.profile.any((s) => s.ttsSeconds == 480), isTrue);
       },
     );
+
+    test('air-integration: tank pressure from msgs 319/323 merges to samples', () async {
+      final dive = await service.parseFitFile(buildAiDiveFitFile());
+
+      expect(dive, isNotNull);
+      expect(dive!.tanks, hasLength(1));
+      final tank = dive.tanks.single;
+      expect(tank.o2Percent, 28);
+      expect(tank.startPressureBar, closeTo(221.25, 1e-6));
+      expect(tank.endPressureBar, closeTo(88.11, 1e-6));
+      expect(tank.volumeUsedLiters, closeTo(1993.5, 1e-6));
+
+      // The pressure series is merged onto the contemporaneous depth samples.
+      final withPressure = dive.profile
+          .where((s) => s.tankPressures != null)
+          .toList();
+      expect(withPressure, isNotEmpty);
+      final firstReading = withPressure.first.tankPressures!.single;
+      expect(firstReading.tankIndex, 0);
+      expect(firstReading.pressureBar, closeTo(220.0, 1e-6));
+    });
   });
 
   group('parseFitFiles', () {

--- a/test/features/dive_import/data/services/fit_parser_service_test.dart
+++ b/test/features/dive_import/data/services/fit_parser_service_test.dart
@@ -246,7 +246,9 @@ Uint8List buildAiDiveFitFile() {
     );
     // tank_update at the same instant; field 253 is raw FIT-epoch seconds.
     final fitSec = t.millisecondsSinceEpoch ~/ 1000 - 631065600;
-    builder.add(_genericTank(319, {253: fitSec, 0: sensor, 1: pressuresRaw[i]}));
+    builder.add(
+      _genericTank(319, {253: fitSec, 0: sensor, 1: pressuresRaw[i]}),
+    );
   }
 
   builder.add(
@@ -559,26 +561,29 @@ void main() {
       },
     );
 
-    test('air-integration: tank pressure from msgs 319/323 merges to samples', () async {
-      final dive = await service.parseFitFile(buildAiDiveFitFile());
+    test(
+      'air-integration: tank pressure from msgs 319/323 merges to samples',
+      () async {
+        final dive = await service.parseFitFile(buildAiDiveFitFile());
 
-      expect(dive, isNotNull);
-      expect(dive!.tanks, hasLength(1));
-      final tank = dive.tanks.single;
-      expect(tank.o2Percent, 28);
-      expect(tank.startPressureBar, closeTo(221.25, 1e-6));
-      expect(tank.endPressureBar, closeTo(88.11, 1e-6));
-      expect(tank.volumeUsedLiters, closeTo(1993.5, 1e-6));
+        expect(dive, isNotNull);
+        expect(dive!.tanks, hasLength(1));
+        final tank = dive.tanks.single;
+        expect(tank.o2Percent, 28);
+        expect(tank.startPressureBar, closeTo(221.25, 1e-6));
+        expect(tank.endPressureBar, closeTo(88.11, 1e-6));
+        expect(tank.volumeUsedLiters, closeTo(1993.5, 1e-6));
 
-      // The pressure series is merged onto the contemporaneous depth samples.
-      final withPressure = dive.profile
-          .where((s) => s.tankPressures != null)
-          .toList();
-      expect(withPressure, isNotEmpty);
-      final firstReading = withPressure.first.tankPressures!.single;
-      expect(firstReading.tankIndex, 0);
-      expect(firstReading.pressureBar, closeTo(220.0, 1e-6));
-    });
+        // The pressure series is merged onto the contemporaneous depth samples.
+        final withPressure = dive.profile
+            .where((s) => s.tankPressures != null)
+            .toList();
+        expect(withPressure, isNotEmpty);
+        final firstReading = withPressure.first.tankPressures!.single;
+        expect(firstReading.tankIndex, 0);
+        expect(firstReading.pressureBar, closeTo(220.0, 1e-6));
+      },
+    );
   });
 
   group('parseFitFiles', () {

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -207,6 +207,56 @@ void main() {
     });
   });
 
+  group('Import dives (enriched FIT fields)', () {
+    setUp(() {
+      when(
+        mockDiveRepo.createDive(any),
+      ).thenAnswer((inv) async => inv.positionalArguments[0] as Dive);
+      when(mockDiveRepo.saveComputerReading(any)).thenAnswer((_) async {});
+    });
+
+    test('maps recorded ceiling and entry GPS onto the Dive', () async {
+      final data = UddfImportResult(
+        dives: [
+          {
+            'dateTime': DateTime.utc(2025, 10, 13, 11, 24, 0),
+            'maxDepth': 29.5,
+            'avgDepth': 16.0,
+            'duration': const Duration(seconds: 3263),
+            'runtime': const Duration(seconds: 3600),
+            'latitude': 35.815,
+            'longitude': 14.451,
+            'profile': <Map<String, dynamic>>[
+              {'timestamp': 0, 'depth': 1.6, 'ceiling': 0.0},
+              {
+                'timestamp': 60,
+                'depth': 29.5,
+                'ceiling': 6.0,
+                'tts': 480,
+                'ndl': 0,
+              },
+            ],
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(mockDiveRepo.createDive(captureAny)).captured;
+      final dive = captured.single as Dive;
+      expect(dive.entryLocation, isNotNull);
+      expect(dive.entryLocation!.latitude, closeTo(35.815, 1e-9));
+      expect(dive.entryLocation!.longitude, closeTo(14.451, 1e-9));
+      expect(dive.profile.any((p) => p.ceiling == 6.0), isTrue);
+      expect(dive.profile.any((p) => p.tts == 480), isTrue);
+    });
+  });
+
   group('Import equipment', () {
     test('imports equipment with type parsing', () async {
       when(mockEquipmentRepo.createEquipment(any)).thenAnswer(

--- a/test/features/dive_import/domain/entities/imported_dive_enriched_test.dart
+++ b/test/features/dive_import/domain/entities/imported_dive_enriched_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
+
+void main() {
+  test('ImportedDive carries enriched tank/deco/summary fields', () {
+    final dive = ImportedDive(
+      sourceId: 'garmin-1-2',
+      sourceUuid: 'garmin-1-2',
+      source: ImportSource.garmin,
+      startTime: DateTime.utc(2025, 10, 13, 10, 51, 10),
+      endTime: DateTime.utc(2025, 10, 13, 12, 18, 0),
+      maxDepth: 34.2,
+      diveNumber: 92,
+      bottomTimeSeconds: 5169,
+      surfaceIntervalSeconds: 167491,
+      cnsEnd: 32,
+      otu: 90,
+      waterType: 'salt',
+      decoModel: 'zhl_16c',
+      gfLow: 50,
+      gfHigh: 85,
+      computerModel: 'Descent Mk3i',
+      tanks: const [
+        ImportedTank(
+          order: 0,
+          startPressureBar: 221.25,
+          endPressureBar: 88.11,
+          o2Percent: 30,
+          hePercent: 0,
+        ),
+      ],
+      profile: const [
+        ImportedProfileSample(
+          timeSeconds: 0,
+          depth: 1.6,
+          ceiling: 0,
+          ndlSeconds: 0,
+          tankPressures: [
+            ImportedTankPressureSample(tankIndex: 0, pressureBar: 221.25),
+          ],
+        ),
+      ],
+    );
+
+    expect(dive.diveNumber, 92);
+    expect(dive.bottomTimeSeconds, 5169);
+    expect(dive.tanks.single.startPressureBar, 221.25);
+    expect(dive.profile.single.tankPressures!.single.pressureBar, 221.25);
+  });
+
+  test('ImportedProfileSample.copyWith adds tank pressures', () {
+    const s = ImportedProfileSample(timeSeconds: 5, depth: 10.0);
+    final merged = s.copyWith(
+      tankPressures: const [
+        ImportedTankPressureSample(tankIndex: 0, pressureBar: 200.0),
+      ],
+    );
+    expect(merged.depth, 10.0);
+    expect(merged.timeSeconds, 5);
+    expect(merged.tankPressures!.single.pressureBar, 200.0);
+  });
+}

--- a/test/features/dive_import/domain/entities/imported_dive_enriched_test.dart
+++ b/test/features/dive_import/domain/entities/imported_dive_enriched_test.dart
@@ -48,6 +48,69 @@ void main() {
     expect(dive.profile.single.tankPressures!.single.pressureBar, 221.25);
   });
 
+  test('value equality (props) holds across the import entities', () {
+    const tank = ImportedTank(
+      order: 0,
+      startPressureBar: 200,
+      endPressureBar: 80,
+      volumeUsedLiters: 1000,
+      o2Percent: 32,
+      hePercent: 0,
+    );
+    expect(
+      tank,
+      equals(
+        const ImportedTank(
+          order: 0,
+          startPressureBar: 200,
+          endPressureBar: 80,
+          volumeUsedLiters: 1000,
+          o2Percent: 32,
+          hePercent: 0,
+        ),
+      ),
+    );
+    expect(tank, isNot(equals(const ImportedTank(order: 1))));
+
+    const pressure = ImportedTankPressureSample(tankIndex: 0, pressureBar: 200);
+    expect(
+      pressure,
+      equals(const ImportedTankPressureSample(tankIndex: 0, pressureBar: 200)),
+    );
+    expect(
+      pressure,
+      isNot(
+        equals(const ImportedTankPressureSample(tankIndex: 1, pressureBar: 9)),
+      ),
+    );
+
+    const sample = ImportedProfileSample(
+      timeSeconds: 5,
+      depth: 10,
+      temperature: 22,
+      heartRate: 70,
+      cns: 1,
+      ndlSeconds: 99,
+      ttsSeconds: 0,
+      ceiling: 0,
+    );
+    expect(sample, equals(sample));
+    expect(
+      sample,
+      isNot(equals(const ImportedProfileSample(timeSeconds: 6, depth: 10))),
+    );
+
+    ImportedDive makeDive() => ImportedDive(
+      sourceId: 'a',
+      source: ImportSource.garmin,
+      startTime: DateTime.utc(2025),
+      endTime: DateTime.utc(2025, 1, 1, 1),
+      maxDepth: 10,
+      profile: const [],
+    );
+    expect(makeDive(), equals(makeDive()));
+  });
+
   test('ImportedProfileSample.copyWith adds tank pressures', () {
     const s = ImportedProfileSample(timeSeconds: 5, depth: 10.0);
     final merged = s.copyWith(

--- a/test/features/dive_log/data/repositories/dive_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_test.dart
@@ -64,6 +64,21 @@ void main() {
 
   group('DiveRepository', () {
     group('createDive', () {
+      test('persists entryLocation to latitude/longitude columns', () async {
+        final dive = createTestDive(
+          diveNumber: 1,
+          maxDepth: 18.5,
+        ).copyWith(entryLocation: const GeoPoint(35.815, 14.451));
+
+        final created = await repository.createDive(dive);
+        final loaded = await repository.getDiveById(created.id);
+
+        expect(loaded, isNotNull);
+        expect(loaded!.entryLocation, isNotNull);
+        expect(loaded.entryLocation!.latitude, closeTo(35.815, 1e-6));
+        expect(loaded.entryLocation!.longitude, closeTo(14.451, 1e-6));
+      });
+
       test(
         'should create a new dive with generated ID when ID is empty',
         () async {

--- a/test/features/universal_import/data/parsers/fit_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/fit_import_parser_test.dart
@@ -1,0 +1,121 @@
+import 'dart:typed_data';
+
+import 'package:fit_tool/fit_tool.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    show GasMix;
+import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/parsers/fit_import_parser.dart';
+
+/// A rich dive FIT file (deco records, gas, settings, summary, GPS) built with
+/// fit_tool's named messages.
+Uint8List _richFitBytes() {
+  final builder = FitFileBuilder(autoDefine: true, minStringSize: 50);
+  final start = DateTime.utc(2025, 10, 13, 11, 24, 0);
+
+  builder.add(
+    FileIdMessage()
+      ..type = FileType.activity
+      ..manufacturer = 1
+      ..product =
+          4223 // Descent Mk3i
+      ..serialNumber = 3502016516
+      ..timeCreated = start.millisecondsSinceEpoch,
+  );
+
+  final depths = [1.6, 29.5, 6.0, 0.5];
+  for (var i = 0; i < depths.length; i++) {
+    builder.add(
+      RecordMessage()
+        ..timestamp = start
+            .add(Duration(seconds: i * 60))
+            .millisecondsSinceEpoch
+        ..depth = depths[i]
+        ..temperature = 24
+        ..nextStopDepth = i == 1 ? 6.0 : 0.0
+        ..timeToSurface = i == 1 ? 480 : 0
+        ..ndlTime = i == 1 ? 0 : 99
+        ..cnsLoad = i + 1,
+    );
+  }
+
+  builder.add(
+    DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 28
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled,
+  );
+  builder.add(
+    DiveSettingsMessage()
+      ..waterType = WaterType.salt
+      ..gfLow = 50
+      ..gfHigh = 85
+      ..model = TissueModelType.zhl16c,
+  );
+  builder.add(
+    DiveSummaryMessage()
+      ..diveNumber = 73
+      ..bottomTime = 3263.0
+      ..surfaceInterval = 4612
+      ..startCns = 0
+      ..endCns = 12
+      ..o2Toxicity = 25,
+  );
+  builder.add(
+    SessionMessage()
+      ..sport = Sport.diving
+      ..timestamp = start
+          .add(const Duration(seconds: 3600))
+          .millisecondsSinceEpoch
+      ..startTime = start.millisecondsSinceEpoch
+      ..totalElapsedTime = 3600.0
+      ..totalTimerTime = 3600.0
+      ..startPositionLat = 35.815
+      ..startPositionLong = 14.451,
+  );
+
+  return builder.build().toBytes();
+}
+
+void main() {
+  test('returns an error payload for non-FIT bytes', () async {
+    final payload = await const FitImportParser().parse(
+      Uint8List.fromList([0, 1, 2, 3]),
+    );
+    expect(payload.entities, isEmpty);
+    expect(payload.warnings, isNotEmpty);
+  });
+
+  test(
+    'emits a UDDF-shaped payload with tanks, deco, gps, sourceUuid',
+    () async {
+      final payload = await const FitImportParser().parse(_richFitBytes());
+      final dives = payload.entities[ImportEntityType.dives]!;
+      expect(dives, hasLength(1));
+      final d = dives.single;
+
+      expect(d['diveNumber'], 73);
+      expect(d['waterType'], 'salt');
+      expect(d['gradientFactorLow'], 50);
+      expect(d['decoAlgorithm'], 'zhl_16c');
+      expect(d['cnsEnd'], 12);
+      expect(d['otu'], 25);
+      expect(d['surfaceInterval'], const Duration(seconds: 4612));
+      expect(d['duration'], const Duration(seconds: 3263)); // bottom time
+      expect(d['runtime'], const Duration(seconds: 3600)); // total elapsed
+      expect(d['sourceUuid'], d['sourceId']);
+      expect(d['latitude'], closeTo(35.815, 1e-3));
+      expect(d['diveComputerModel'], 'Descent Mk3i');
+
+      final tanks = d['tanks'] as List<Map<String, dynamic>>;
+      expect(tanks, hasLength(1));
+      expect(tanks.single['gasMix'], isA<GasMix>());
+      expect((tanks.single['gasMix'] as GasMix).o2, 28);
+
+      final profile = d['profile'] as List<Map<String, dynamic>>;
+      expect(profile.any((p) => p['ceiling'] == 6.0), isTrue);
+      expect(profile.any((p) => p['tts'] == 480), isTrue);
+    },
+  );
+}

--- a/test/features/universal_import/data/parsers/fit_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/fit_import_parser_test.dart
@@ -78,6 +78,81 @@ Uint8List _richFitBytes() {
   return builder.build().toBytes();
 }
 
+DataMessage _genericTank(int globalId, Map<int, int> values) {
+  final def = DefinitionMessage(
+    globalId: globalId,
+    fieldDefinitions: [
+      for (final id in values.keys)
+        FieldDefinition(
+          id: id,
+          size: id == 1 || id == 2 ? 2 : 4,
+          type: id == 1 || id == 2 ? BaseType.UINT16 : BaseType.UINT32,
+        ),
+    ],
+  );
+  final m = GenericMessage(definitionMessage: def);
+  values.forEach((id, v) => m.getField(id)!.setValue(0, v, null));
+  return m;
+}
+
+/// A dive with air-integration, heart rate, and exit GPS, to exercise the
+/// parser's conditional payload emission for those fields.
+Uint8List _aiFitBytes() {
+  final builder = FitFileBuilder(autoDefine: true, minStringSize: 50);
+  final start = DateTime.utc(2025, 9, 8, 9, 19, 49);
+  const sensor = 2772884913;
+
+  builder.add(
+    FileIdMessage()
+      ..type = FileType.activity
+      ..manufacturer = 1
+      ..product = 4223
+      ..serialNumber = 1
+      ..timeCreated = start.millisecondsSinceEpoch,
+  );
+  builder.add(_genericTank(323, {0: sensor, 1: 22125, 2: 8811, 3: 199350}));
+
+  const depths = [2.0, 20.0, 5.0];
+  const pressuresRaw = [22000, 15000, 9000];
+  for (var i = 0; i < depths.length; i++) {
+    final t = start.add(Duration(seconds: i * 60));
+    final record = RecordMessage()
+      ..timestamp = t.millisecondsSinceEpoch
+      ..depth = depths[i]
+      ..temperature = 26
+      ..heartRate = 70 + i;
+    if (i == depths.length - 1) {
+      record
+        ..positionLat = 19.691
+        ..positionLong = -156.041;
+    }
+    builder.add(record);
+    final fitSec = t.millisecondsSinceEpoch ~/ 1000 - 631065600;
+    builder.add(
+      _genericTank(319, {253: fitSec, 0: sensor, 1: pressuresRaw[i]}),
+    );
+  }
+
+  builder.add(
+    DiveGasMessage()
+      ..messageIndex = 0
+      ..oxygenContent = 32
+      ..heliumContent = 0
+      ..status = DiveGasStatus.enabled,
+  );
+  builder.add(
+    SessionMessage()
+      ..sport = Sport.diving
+      ..timestamp = start
+          .add(const Duration(seconds: 180))
+          .millisecondsSinceEpoch
+      ..startTime = start.millisecondsSinceEpoch
+      ..totalElapsedTime = 180.0
+      ..totalTimerTime = 180.0,
+  );
+  return builder.build().toBytes();
+}
+
 void main() {
   test('returns an error payload for non-FIT bytes', () async {
     final payload = await const FitImportParser().parse(
@@ -116,6 +191,28 @@ void main() {
       final profile = d['profile'] as List<Map<String, dynamic>>;
       expect(profile.any((p) => p['ceiling'] == 6.0), isTrue);
       expect(profile.any((p) => p['tts'] == 480), isTrue);
+    },
+  );
+
+  test(
+    'emits tank pressure, allTankPressures, exit GPS, and heart rate',
+    () async {
+      final payload = await const FitImportParser().parse(_aiFitBytes());
+      final d = payload.entities[ImportEntityType.dives]!.single;
+
+      final tanks = d['tanks'] as List<Map<String, dynamic>>;
+      expect(tanks.single['startPressure'], closeTo(221.25, 1e-6));
+      expect(tanks.single['endPressure'], closeTo(88.11, 1e-6));
+      expect(d['avgHeartRate'], isNotNull);
+      expect(d['exitLatitude'], closeTo(19.691, 1e-3));
+
+      final profile = d['profile'] as List<Map<String, dynamic>>;
+      final withPressure = profile.where((p) => p['allTankPressures'] != null);
+      expect(withPressure, isNotEmpty);
+      final reading =
+          (withPressure.first['allTankPressures'] as List).first as Map;
+      expect(reading['tankIndex'], 0);
+      expect(reading['pressure'], closeTo(220.0, 1e-6));
     },
   );
 }


### PR DESCRIPTION
## Summary

Rewrites Garmin FIT import from a thin skeleton (depth/temp/HR + entry GPS only) into a comprehensive importer that extracts everything the file contains. Validated end-to-end against real Descent Mk3i, X50i, and T2-transmitter files from two testers (reddit `theRealBlackRabbit`, ScubaBoard `AngelSMF`).

- Spec: `docs/superpowers/specs/2026-06-22-garmin-fit-import-design.md`
- Plan: `docs/superpowers/plans/2026-06-22-garmin-fit-import.md`

## What it adds

- **Air-integration** — tank start/end pressure + per-sample pressure series from the T2 transmitter (FIT msgs 319/323, read via `fit_tool` `GenericMessage`), multi-transmitter aware. Feeds SAC.
- **Gas mixes** including multi-gas (e.g. EAN30 + EAN50 deco gas).
- **Recorded decompression** — ceiling / TTS / NDL per sample (imported as recorded, never recomputed).
- **CNS / OTU / N2**, **heart rate** (#173).
- **Dive number**, **bottom-time vs runtime** (now distinct), **surface interval**, **water type**, **gradient factors + deco model**, **computer model/serial**.
- **Entry/exit GPS** persisted, so FIT dives are eligible for the existing site-match flow (#172).

## Architecture — "make FIT speak UDDF"

`FitParserService` is decomposed into focused, unit-tested extractors (constants/message-access, time, device, gas, tank, profile, summary) and emits the same `ImportPayload` shape UDDF imports already produce, so the existing `UddfEntityImporter` persists tanks / pressure series / gas / deco unchanged. No new persistence path; no `fit_tool` fork.

## Bugs fixed (also affected other importers)

- `createDive` silently dropped `entryLocation`/`exitLocation`, so **no file import ever persisted GPS**; now persisted.
- The importer never mapped the recorded deco `ceiling` from profile points; now mapped.
- Timezone: `fit_tool` returns `activity.localTimestamp` as raw FIT-epoch seconds while other timestamps are Unix ms — mixing bases produced year-1970 times. Normalized, so the dive shows its local wall-clock (e.g. 10:51, exactly matching the Garmin app screenshot).
- `fit_tool`'s `waterDensity` getter throws on real float values; removed the unused read.
- Multi-gas dives lost the 2nd gas behind a zero-pressure phantom `tank_summary`; fixed.
- FIT `sourceId` is now also written as `sourceUuid` for correct duplicate detection.

## Scope

- Addresses **#172** (FIT GPS → site: coordinates are imported and matchable via the existing site reviewer; automatic site *creation* intentionally excluded) and **#173** (heart rate).
- Not included: dive-computer BT/USB download GPS prompt (#310 — a separate libdivecomputer concern), multi-source same-dive merge, Garmin MTP/USB download.

## Testing

- TDD throughout: per-extractor unit tests plus importer/parser integration tests.
- Whole-project `flutter analyze` clean; full suite **9211 passing, 0 failures**.
- Manually validated on the testers' real files (tank pressure 221.25 → 88.11 bar, EAN30+EAN50, deco, CNS/OTU, GPS, dive numbers, correct local times).

## Follow-ups

- Reporter device verification pending.
- Existing already-imported dives must be deleted + re-imported to gain the new data (FIT imports don't store raw bytes, so per-dive re-parse isn't available for them).