### PR TITLE
feat(dive-log): bulk-edit engine + selection mechanics (#150)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-bulk-dive-editing-engine.md
+++ b/docs/superpowers/plans/2026-06-23-bulk-dive-editing-engine.md
@@ -1,0 +1,1869 @@
+# Bulk Dive Editing — Engine + Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the fully-tested data engine for bulk-editing dives (set-based repository writes, an orchestration service, and per-dive undo) plus the enhanced multi-select gestures, so the upcoming bulk-edit form has a correct, sync-safe foundation to call into.
+
+**Architecture:** New bulk methods on `DiveRepository`, `BuddyRepository`, and `SpeciesRepository` perform set-based SQL writes (never looping `updateDive`). A `BulkDiveEditService` composes them inside one Drift transaction, captures a per-dive `BulkEditSnapshot` before mutating, and fires a single `SyncEventBus.notifyLocalChange()`. The dive list gains a selection anchor for shift-click ranges and a date-range selector. The bulk-edit *form* (reusing `DiveEditPage` in a bulk mode) is a separate follow-up plan that consumes this engine.
+
+**Tech Stack:** Dart/Flutter, Drift (SQLite ORM, companions), Riverpod, flutter_test.
+
+## Global Constraints
+
+- **Never loop `updateDive`** for bulk writes — it delete-and-re-inserts every child row. Use set-based `UPDATE ... WHERE id IN` / targeted inserts.
+- Every touched row is marked for sync: `_syncRepository.markRecordPending(entityType: <camelCaseTable>, recordId: <id>, localUpdatedAt: now)`; every deletion: `_syncRepository.logDeletion(entityType: <camelCaseTable>, recordId: <id>)`. `now` is always `final now = DateTime.now().millisecondsSinceEpoch;` (int).
+- `entityType` strings (exact): `'dives'`, `'diveTanks'`, `'diveWeights'`, `'diveEquipment'`, `'diveBuddies'`, `'sightings'`, `'diveTags'`.
+- **New bulk repository methods do NOT call `SyncEventBus.notifyLocalChange()` and do NOT open their own transaction.** `BulkDiveEditService` owns the transaction boundary and calls `notifyLocalChange()` exactly once. (The pre-existing `bulkUpdateTrip`/`bulkAddTags`/etc. keep their self-contained behavior; we are adding new methods alongside them.)
+- **Name-clash rule:** Drift generates row classes `Dive`, `DiveTank`, `DiveWeight`, `Sighting` that collide with the domain entities. In every new/edited file, import domain entities `as domain` (or a distinct prefix) and use Drift row classes unprefixed. Reconstruct companions from Drift rows with `row.toCompanion(false)` (so prior NULLs are written back, not left absent).
+- Enums persist via `.name` (e.g. `tankRole`, `weightType`, `waterType`), except `diveMode`/`scrType` which use `.code` (see `updateDive`).
+- Repositories use the implicit default constructor and resolve the DB via `DatabaseService.instance.database`; tests use `setUpTestDatabase()` / `tearDownTestDatabase()` from `test/helpers/test_database.dart` and construct `DiveRepository()` directly.
+- Test imports: `import 'package:drift/drift.dart' hide isNull, isNotNull;` (drift and flutter_test both export those matchers) and `import '.../entities/dive.dart' as domain;`.
+- New user-facing strings extend the existing `diveLog_*` l10n namespace and must be added to all 10 non-English ARB files (`lib/l10n/arb/app_<locale>.arb`) and regenerated with `flutter gen-l10n`.
+- Run `dart format .` before every commit. Commit messages: conventional prefixes, no `Co-Authored-By` lines.
+
+---
+
+## Phase 1 — DiveRepository bulk write methods
+
+All Phase 1 tasks add methods to `lib/features/dive_log/data/repositories/dive_repository_impl.dart` and tests to a new file `test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`. They mirror the verbatim shape of the existing `bulkUpdateTrip` (`dive_repository_impl.dart:3625`).
+
+### Task 1: `bulkUpdateFields` — generic scalar set-based update
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (add method in the "Bulk Operations" section near line 3625)
+- Test: `test/features/dive_log/data/repositories/dive_repository_bulk_test.dart` (new)
+
+**Interfaces:**
+- Produces: `Future<void> bulkUpdateFields(List<String> diveIds, DivesCompanion partial)` — writes only the columns present (non-`absent`) in `partial` to every dive in `diveIds`, forcing `updatedAt = now`; marks each dive pending. No transaction, no notify.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart' as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> seed(String id, {String notes = ''}) =>
+      repository.createDive(domain.Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: notes));
+
+  group('bulkUpdateFields', () {
+    test('writes only the given columns, bumps updatedAt, skips other dives', () async {
+      await seed('d1', notes: 'keep');
+      await seed('d2', notes: 'keep2');
+      await seed('d3', notes: 'untouched');
+
+      await repository.bulkUpdateFields(
+        ['d1', 'd2'],
+        const DivesCompanion(rating: Value(5), waterType: Value('salt')),
+      );
+
+      final r1 = await (db.select(db.dives)..where((t) => t.id.equals('d1'))).getSingle();
+      final r3 = await (db.select(db.dives)..where((t) => t.id.equals('d3'))).getSingle();
+      expect(r1.rating, 5);
+      expect(r1.waterType, 'salt');
+      expect(r1.notes, 'keep'); // untouched column preserved
+      expect(r3.rating, isNull); // dive outside the id list untouched
+      expect(r3.waterType, isNull);
+    });
+
+    test('is a no-op for an empty id list', () async {
+      await repository.bulkUpdateFields(const [], const DivesCompanion(rating: Value(3)));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: FAIL — `The method 'bulkUpdateFields' isn't defined for the type 'DiveRepository'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  /// Bulk-set the columns present in [partial] on every dive in [diveIds].
+  /// Absent columns are left untouched (Drift writes only present columns).
+  /// Forces `updatedAt = now` and marks each dive pending. Does NOT open a
+  /// transaction or notify sync — BulkDiveEditService owns those.
+  Future<void> bulkUpdateFields(
+    List<String> diveIds,
+    DivesCompanion partial,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds)))
+        .write(partial.copyWith(updatedAt: Value(now)));
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+git commit -m "feat(dive-log): add DiveRepository.bulkUpdateFields generic bulk scalar update"
+```
+
+### Task 2: `bulkAppendNotes` — concatenate text to many dives' notes
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart`
+- Test: `test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+
+**Interfaces:**
+- Produces: `Future<void> bulkAppendNotes(List<String> diveIds, String textToAppend)` — appends `textToAppend` to each dive's notes via a single SQL `||` update (existing-empty notes get just the text), bumps `updatedAt`, marks pending.
+
+- [ ] **Step 1: Write the failing test** (add inside `main()`)
+
+```dart
+  group('bulkAppendNotes', () {
+    test('appends to existing notes and to empty notes', () async {
+      await seed('a', notes: 'Cozumel');
+      await seed('b', notes: '');
+
+      await repository.bulkAppendNotes(['a', 'b'], '\nGreat viz');
+
+      final ra = await (db.select(db.dives)..where((t) => t.id.equals('a'))).getSingle();
+      final rb = await (db.select(db.dives)..where((t) => t.id.equals('b'))).getSingle();
+      expect(ra.notes, 'Cozumel\nGreat viz');
+      expect(rb.notes, '\nGreat viz');
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart -p vm --plain-name bulkAppendNotes`
+Expected: FAIL — `bulkAppendNotes` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  /// Append [textToAppend] to the notes of every dive in [diveIds].
+  Future<void> bulkAppendNotes(List<String> diveIds, String textToAppend) async {
+    if (diveIds.isEmpty || textToAppend.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final placeholders = List.filled(diveIds.length, '?').join(', ');
+    await _db.customUpdate(
+      "UPDATE dives SET notes = COALESCE(notes, '') || ?, updated_at = ? "
+      'WHERE id IN ($placeholders)',
+      variables: [
+        Variable.withString(textToAppend),
+        Variable.withInt(now),
+        ...diveIds.map(Variable.withString),
+      ],
+      updates: {_db.dives},
+    );
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add DiveRepository.bulkAppendNotes"
+```
+
+### Task 3: `bulkReplaceTags`
+
+**Files:** Modify repo; test file above.
+
+**Interfaces:**
+- Produces: `Future<void> bulkReplaceTags(List<String> diveIds, List<String> tagIds)` — sets each dive's tag membership to exactly `tagIds` (delete-all-for-dives + re-insert), logging deletions and marking inserts pending.
+
+Note: `diveTags` references `Tags`; the test disables FK enforcement so it can exercise the junction logic without seeding the tag catalog.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+  group('bulkReplaceTags', () {
+    setUp(() async {
+      await db.customStatement('PRAGMA foreign_keys = OFF'); // test-only isolation
+    });
+
+    test('replaces existing tag membership with the given set', () async {
+      await seed('d1');
+      await repository.bulkAddTags(['d1'], ['old-tag']); // pre-existing membership
+
+      await repository.bulkReplaceTags(['d1'], ['t1', 't2']);
+
+      final rows = await (db.select(db.diveTags)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.tagId).toSet(), {'t1', 't2'});
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart --plain-name bulkReplaceTags`
+Expected: FAIL — `bulkReplaceTags` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  /// Replace each dive's tag membership with exactly [tagIds].
+  Future<void> bulkReplaceTags(List<String> diveIds, List<String> tagIds) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(_db.diveTags)
+          ..where((t) => t.diveId.isIn(diveIds)))
+        .get();
+    await (_db.delete(_db.diveTags)..where((t) => t.diveId.isIn(diveIds))).go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(entityType: 'diveTags', recordId: row.id);
+    }
+    for (final diveId in diveIds) {
+      for (final tagId in tagIds) {
+        final id = _uuid.v4();
+        await _db.into(_db.diveTags).insert(DiveTagsCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              tagId: Value(tagId),
+              createdAt: Value(now),
+            ));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveTags', recordId: id, localUpdatedAt: now);
+      }
+    }
+    await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds)))
+        .write(DivesCompanion(updatedAt: Value(now)));
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+          entityType: 'dives', recordId: diveId, localUpdatedAt: now);
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add DiveRepository.bulkReplaceTags"
+```
+
+### Task 4: Equipment bulk Add / Remove / Replace
+
+**Files:** Modify repo; test file above.
+
+**Interfaces:**
+- Produces:
+  - `Future<void> bulkAddEquipment(List<String> diveIds, List<String> equipmentIds)`
+  - `Future<void> bulkRemoveEquipment(List<String> diveIds, List<String> equipmentIds)`
+  - `Future<void> bulkReplaceEquipment(List<String> diveIds, List<String> equipmentIds)`
+  - `diveEquipment` is a composite-key junction (`{diveId, equipmentId}`, no `id`); the sync recordId convention is `'$diveId|$equipmentId'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+  group('bulk equipment', () {
+    setUp(() async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+    });
+
+    test('add then remove adjusts membership; replace overwrites', () async {
+      await seed('d1');
+      await repository.bulkAddEquipment(['d1'], ['e1', 'e2']);
+      var rows = await (db.select(db.diveEquipment)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.equipmentId).toSet(), {'e1', 'e2'});
+
+      await repository.bulkRemoveEquipment(['d1'], ['e1']);
+      rows = await (db.select(db.diveEquipment)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.equipmentId).toSet(), {'e2'});
+
+      await repository.bulkReplaceEquipment(['d1'], ['e9']);
+      rows = await (db.select(db.diveEquipment)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.equipmentId).toSet(), {'e9'});
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart --plain-name "bulk equipment"`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  Future<void> _bumpDives(List<String> diveIds, int now) async {
+    await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds)))
+        .write(DivesCompanion(updatedAt: Value(now)));
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+          entityType: 'dives', recordId: diveId, localUpdatedAt: now);
+    }
+  }
+
+  Future<void> bulkAddEquipment(List<String> diveIds, List<String> equipmentIds) async {
+    if (diveIds.isEmpty || equipmentIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final equipmentId in equipmentIds) {
+        await _db.into(_db.diveEquipment).insertOnConflictUpdate(
+            DiveEquipmentCompanion(
+                diveId: Value(diveId), equipmentId: Value(equipmentId)));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveEquipment',
+            recordId: '$diveId|$equipmentId',
+            localUpdatedAt: now);
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
+  Future<void> bulkRemoveEquipment(List<String> diveIds, List<String> equipmentIds) async {
+    if (diveIds.isEmpty || equipmentIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(_db.diveEquipment)
+          ..where((t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds)))
+        .get();
+    await (_db.delete(_db.diveEquipment)
+          ..where((t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds)))
+        .go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(
+          entityType: 'diveEquipment',
+          recordId: '${row.diveId}|${row.equipmentId}');
+    }
+    await _bumpDives(diveIds, now);
+  }
+
+  Future<void> bulkReplaceEquipment(List<String> diveIds, List<String> equipmentIds) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(_db.diveEquipment)
+          ..where((t) => t.diveId.isIn(diveIds)))
+        .get();
+    await (_db.delete(_db.diveEquipment)..where((t) => t.diveId.isIn(diveIds))).go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(
+          entityType: 'diveEquipment',
+          recordId: '${row.diveId}|${row.equipmentId}');
+    }
+    for (final diveId in diveIds) {
+      for (final equipmentId in equipmentIds) {
+        await _db.into(_db.diveEquipment).insertOnConflictUpdate(
+            DiveEquipmentCompanion(
+                diveId: Value(diveId), equipmentId: Value(equipmentId)));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveEquipment',
+            recordId: '$diveId|$equipmentId',
+            localUpdatedAt: now);
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add bulk equipment add/remove/replace"
+```
+
+### Task 5: Tanks bulk Add (with `onlyIfEmpty`) + Replace
+
+**Files:** Modify repo; test file above.
+
+**Interfaces:**
+- Consumes: `domain.DiveTank` (fields: `name`, `volume`, `workingPressure`, `startPressure`, `endPressure`, `gasMix` (`.o2`, `.he`), `role` (`.name`), `material` (`.name`), `order`, `presetName`).
+- Produces:
+  - `Future<void> bulkAddTank(List<String> diveIds, domain.DiveTank tank, {bool onlyIfEmpty = false})` — appends one new tank (fresh UUID, `tankOrder` = current tank count) to each dive; when `onlyIfEmpty`, skips dives that already have any tank.
+  - `Future<void> bulkReplaceTanks(List<String> diveIds, List<domain.DiveTank> tanks)` — sets each dive's tank list to `tanks` (fresh UUID + sequential `tankOrder` per dive). Note: replace cascades to delete `tank_pressure_profiles`/`gas_switches` for the old tanks.
+
+Tanks reference only `Dives`, so the test does not need FK off (it seeds dives).
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+  group('bulk tanks', () {
+    const al80 = domain.DiveTank(
+      id: '',
+      name: 'AL80',
+      volume: 11.1,
+      gasMix: domain.GasMix(o2: 21, he: 0),
+    );
+
+    test('bulkAddTank appends; onlyIfEmpty skips dives that already have a tank', () async {
+      await seed('empty');
+      await seed('hasTank');
+      await repository.bulkAddTank(['hasTank'], al80); // give it one first
+
+      await repository.bulkAddTank(['empty', 'hasTank'], al80, onlyIfEmpty: true);
+
+      final emptyTanks =
+          await (db.select(db.diveTanks)..where((t) => t.diveId.equals('empty'))).get();
+      final hasTankTanks =
+          await (db.select(db.diveTanks)..where((t) => t.diveId.equals('hasTank'))).get();
+      expect(emptyTanks.length, 1); // got the tank
+      expect(emptyTanks.single.tankName, 'AL80');
+      expect(emptyTanks.single.tankOrder, 0);
+      expect(hasTankTanks.length, 1); // skipped — still just the original
+    });
+
+    test('bulkReplaceTanks overwrites the whole list', () async {
+      await seed('d1');
+      await repository.bulkAddTank(['d1'], al80);
+      await repository.bulkReplaceTanks(['d1'], const [
+        domain.DiveTank(id: '', name: 'D12', volume: 24, gasMix: domain.GasMix(o2: 32)),
+      ]);
+      final rows = await (db.select(db.diveTanks)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1);
+      expect(rows.single.tankName, 'D12');
+      expect(rows.single.o2Percent, 32);
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart --plain-name "bulk tanks"`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  DiveTanksCompanion _tankCompanion(String id, String diveId, domain.DiveTank t, int order) =>
+      DiveTanksCompanion(
+        id: Value(id),
+        diveId: Value(diveId),
+        volume: Value(t.volume),
+        workingPressure: Value(t.workingPressure),
+        startPressure: Value(t.startPressure),
+        endPressure: Value(t.endPressure),
+        o2Percent: Value(t.gasMix.o2),
+        hePercent: Value(t.gasMix.he),
+        tankOrder: Value(order),
+        tankRole: Value(t.role.name),
+        tankMaterial: Value(t.material?.name),
+        tankName: Value(t.name),
+        presetName: Value(t.presetName),
+      );
+
+  Future<void> bulkAddTank(
+    List<String> diveIds,
+    domain.DiveTank tank, {
+    bool onlyIfEmpty = false,
+  }) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final changed = <String>[];
+    for (final diveId in diveIds) {
+      final existing =
+          await (_db.select(_db.diveTanks)..where((t) => t.diveId.equals(diveId))).get();
+      if (onlyIfEmpty && existing.isNotEmpty) continue;
+      final tankId = _uuid.v4();
+      await _db.into(_db.diveTanks).insert(_tankCompanion(tankId, diveId, tank, existing.length));
+      await _syncRepository.markRecordPending(
+          entityType: 'diveTanks', recordId: tankId, localUpdatedAt: now);
+      changed.add(diveId);
+    }
+    if (changed.isNotEmpty) await _bumpDives(changed, now);
+  }
+
+  Future<void> bulkReplaceTanks(List<String> diveIds, List<domain.DiveTank> tanks) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing =
+          await (_db.select(_db.diveTanks)..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(_db.diveTanks)..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(entityType: 'diveTanks', recordId: row.id);
+      }
+      for (var i = 0; i < tanks.length; i++) {
+        final tankId = _uuid.v4();
+        await _db.into(_db.diveTanks).insert(_tankCompanion(tankId, diveId, tanks[i], i));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveTanks', recordId: tankId, localUpdatedAt: now);
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add bulk tank add (onlyIfEmpty) and replace"
+```
+
+### Task 6: Weights bulk Add + Replace
+
+**Files:** Modify repo; test file above.
+
+**Interfaces:**
+- Consumes: `domain.DiveWeight` (fields: `id`, `weightType` (`.name`), `amountKg`, `notes`).
+- Produces: `bulkAddWeights(List<String> diveIds, List<domain.DiveWeight> weights)` and `bulkReplaceWeights(List<String> diveIds, List<domain.DiveWeight> weights)` — owned rows; fresh UUID per dive per weight; `createdAt = now`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+  group('bulk weights', () {
+    final belt = domain.DiveWeight(id: '', weightType: domain.WeightType.belt, amountKg: 4, notes: '');
+
+    test('add appends; replace overwrites', () async {
+      await seed('d1');
+      await repository.bulkAddWeights(['d1'], [belt]);
+      var rows = await (db.select(db.diveWeights)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1);
+      expect(rows.single.amountKg, 4);
+
+      await repository.bulkReplaceWeights(['d1'], [
+        domain.DiveWeight(id: '', weightType: domain.WeightType.integrated, amountKg: 6, notes: ''),
+      ]);
+      rows = await (db.select(db.diveWeights)..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1);
+      expect(rows.single.amountKg, 6);
+    });
+  });
+```
+
+(If `WeightType` enum values differ, use the project's actual values — check `lib/features/dive_log/domain/entities/dive.dart` `enum WeightType`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart --plain-name "bulk weights"`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  DiveWeightsCompanion _weightCompanion(String id, String diveId, domain.DiveWeight w, int now) =>
+      DiveWeightsCompanion(
+        id: Value(id),
+        diveId: Value(diveId),
+        weightType: Value(w.weightType.name),
+        amountKg: Value(w.amountKg),
+        notes: Value(w.notes),
+        createdAt: Value(now),
+      );
+
+  Future<void> bulkAddWeights(List<String> diveIds, List<domain.DiveWeight> weights) async {
+    if (diveIds.isEmpty || weights.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final w in weights) {
+        final id = _uuid.v4();
+        await _db.into(_db.diveWeights).insert(_weightCompanion(id, diveId, w, now));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveWeights', recordId: id, localUpdatedAt: now);
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
+  Future<void> bulkReplaceWeights(List<String> diveIds, List<domain.DiveWeight> weights) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing =
+          await (_db.select(_db.diveWeights)..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(_db.diveWeights)..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(entityType: 'diveWeights', recordId: row.id);
+      }
+      for (final w in weights) {
+        final id = _uuid.v4();
+        await _db.into(_db.diveWeights).insert(_weightCompanion(id, diveId, w, now));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveWeights', recordId: id, localUpdatedAt: now);
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add bulk weights add and replace"
+```
+
+---
+
+## Phase 2 — Buddy & Species repository bulk methods
+
+### Task 7: `BuddyRepository` bulk Add / Remove / Replace
+
+**Files:**
+- Modify: `lib/features/buddies/data/repositories/buddy_repository.dart`
+- Test: `test/features/buddies/data/repositories/buddy_repository_bulk_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `domain.BuddyWithRole` (`buddy.id`, `role` (`.name`)).
+- Produces:
+  - `bulkAddBuddies(List<String> diveIds, List<domain.BuddyWithRole> buddies)` — upsert per (dive, buddy), preserving role.
+  - `bulkRemoveBuddies(List<String> diveIds, List<String> buddyIds)`
+  - `bulkReplaceBuddies(List<String> diveIds, List<domain.BuddyWithRole> buddies)`
+  - None call `notifyLocalChange` or open a transaction.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart' as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late BuddyRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db.customStatement('PRAGMA foreign_keys = OFF'); // skip seeding dives/buddies catalogs
+    repository = BuddyRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  domain.BuddyWithRole bwr(String id) => domain.BuddyWithRole(
+        buddy: domain.Buddy(
+          id: id,
+          name: 'B$id',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+        role: BuddyRole.buddy,
+      );
+
+  test('bulkAddBuddies links each buddy to each dive', () async {
+    await repository.bulkAddBuddies(['d1', 'd2'], [bwr('x'), bwr('y')]);
+    final d1 = await (db.select(db.diveBuddies)..where((t) => t.diveId.equals('d1'))).get();
+    expect(d1.map((r) => r.buddyId).toSet(), {'x', 'y'});
+    final d2 = await (db.select(db.diveBuddies)..where((t) => t.diveId.equals('d2'))).get();
+    expect(d2.length, 2);
+  });
+
+  test('bulkReplaceBuddies overwrites; bulkRemoveBuddies subtracts', () async {
+    await repository.bulkAddBuddies(['d1'], [bwr('x'), bwr('y')]);
+    await repository.bulkReplaceBuddies(['d1'], [bwr('z')]);
+    var rows = await (db.select(db.diveBuddies)..where((t) => t.diveId.equals('d1'))).get();
+    expect(rows.map((r) => r.buddyId).toSet(), {'z'});
+
+    await repository.bulkRemoveBuddies(['d1'], ['z']);
+    rows = await (db.select(db.diveBuddies)..where((t) => t.diveId.equals('d1'))).get();
+    expect(rows, isEmpty);
+  });
+}
+```
+
+(Confirm `domain.Buddy`'s required constructor params against `lib/features/buddies/domain/entities/buddy.dart` before running.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/buddies/data/repositories/buddy_repository_bulk_test.dart`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Write minimal implementation** (add to `BuddyRepository`, mirroring `setBuddiesForDive`/`addBuddyToDive`)
+
+```dart
+  Future<void> _bumpDive(String diveId, int now) async {
+    await (_db.update(_db.dives)..where((t) => t.id.equals(diveId)))
+        .write(DivesCompanion(updatedAt: Value(now)));
+    await _syncRepository.markRecordPending(
+        entityType: 'dives', recordId: diveId, localUpdatedAt: now);
+  }
+
+  Future<void> bulkAddBuddies(
+    List<String> diveIds,
+    List<domain.BuddyWithRole> buddies,
+  ) async {
+    if (diveIds.isEmpty || buddies.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final bwr in buddies) {
+        final existing = await (_db.select(_db.diveBuddies)
+              ..where((t) => t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id)))
+            .getSingleOrNull();
+        if (existing != null) {
+          await (_db.update(_db.diveBuddies)
+                ..where((t) => t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id)))
+              .write(DiveBuddiesCompanion(role: Value(bwr.role.name)));
+          await _syncRepository.markRecordPending(
+              entityType: 'diveBuddies', recordId: existing.id, localUpdatedAt: now);
+        } else {
+          final id = _uuid.v4();
+          await _db.into(_db.diveBuddies).insert(DiveBuddiesCompanion(
+                id: Value(id),
+                diveId: Value(diveId),
+                buddyId: Value(bwr.buddy.id),
+                role: Value(bwr.role.name),
+                createdAt: Value(now),
+              ));
+          await _syncRepository.markRecordPending(
+              entityType: 'diveBuddies', recordId: id, localUpdatedAt: now);
+        }
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+
+  Future<void> bulkRemoveBuddies(List<String> diveIds, List<String> buddyIds) async {
+    if (diveIds.isEmpty || buddyIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(_db.diveBuddies)
+          ..where((t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds)))
+        .get();
+    await (_db.delete(_db.diveBuddies)
+          ..where((t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds)))
+        .go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(entityType: 'diveBuddies', recordId: row.id);
+    }
+    for (final diveId in diveIds) {
+      await _bumpDive(diveId, now);
+    }
+  }
+
+  Future<void> bulkReplaceBuddies(
+    List<String> diveIds,
+    List<domain.BuddyWithRole> buddies,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing =
+          await (_db.select(_db.diveBuddies)..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(_db.diveBuddies)..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(entityType: 'diveBuddies', recordId: row.id);
+      }
+      for (final bwr in buddies) {
+        final id = _uuid.v4();
+        await _db.into(_db.diveBuddies).insert(DiveBuddiesCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              buddyId: Value(bwr.buddy.id),
+              role: Value(bwr.role.name),
+              createdAt: Value(now),
+            ));
+        await _syncRepository.markRecordPending(
+            entityType: 'diveBuddies', recordId: id, localUpdatedAt: now);
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/buddies/data/repositories/buddy_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(buddies): add bulk buddy add/remove/replace for dives"
+```
+
+### Task 8: `SpeciesRepository` bulk Add + Replace sightings
+
+**Files:**
+- Modify: `lib/features/marine_life/data/repositories/species_repository.dart`
+- Test: `test/features/marine_life/data/repositories/species_repository_bulk_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `domain.Sighting` (uses `speciesId`, `count`, `notes`; `id`/`diveId` are re-keyed per dive).
+- Produces: `bulkAddSightings(List<String> diveIds, List<domain.Sighting> sightings)` and `bulkReplaceSightings(List<String> diveIds, List<domain.Sighting> sightings)`. No notify/transaction.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/marine_life/data/repositories/species_repository_bulk_test.dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart' as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late SpeciesRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    repository = SpeciesRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  domain.Sighting s(String speciesId, {int count = 1}) => domain.Sighting(
+        id: '',
+        diveId: '',
+        speciesId: speciesId,
+        speciesName: '',
+        count: count,
+      );
+
+  test('bulkAddSightings inserts a sighting per dive per template', () async {
+    await repository.bulkAddSightings(['d1', 'd2'], [s('turtle', count: 2)]);
+    final d1 = await (db.select(db.sightings)..where((t) => t.diveId.equals('d1'))).get();
+    expect(d1.single.speciesId, 'turtle');
+    expect(d1.single.count, 2);
+    final d2 = await (db.select(db.sightings)..where((t) => t.diveId.equals('d2'))).get();
+    expect(d2.length, 1);
+  });
+
+  test('bulkReplaceSightings overwrites per dive', () async {
+    await repository.bulkAddSightings(['d1'], [s('turtle')]);
+    await repository.bulkReplaceSightings(['d1'], [s('shark')]);
+    final rows = await (db.select(db.sightings)..where((t) => t.diveId.equals('d1'))).get();
+    expect(rows.single.speciesId, 'shark');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/marine_life/data/repositories/species_repository_bulk_test.dart`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  Future<void> _bumpDive(String diveId, int now) async {
+    await (_db.update(_db.dives)..where((t) => t.id.equals(diveId)))
+        .write(DivesCompanion(updatedAt: Value(now)));
+    await _syncRepository.markRecordPending(
+        entityType: 'dives', recordId: diveId, localUpdatedAt: now);
+  }
+
+  Future<void> bulkAddSightings(
+    List<String> diveIds,
+    List<domain.Sighting> sightings,
+  ) async {
+    if (diveIds.isEmpty || sightings.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final sighting in sightings) {
+        final id = _uuid.v4();
+        await _db.into(_db.sightings).insert(SightingsCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              speciesId: Value(sighting.speciesId),
+              count: Value(sighting.count),
+              notes: Value(sighting.notes),
+            ));
+        await _syncRepository.markRecordPending(
+            entityType: 'sightings', recordId: id, localUpdatedAt: now);
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+
+  Future<void> bulkReplaceSightings(
+    List<String> diveIds,
+    List<domain.Sighting> sightings,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing =
+          await (_db.select(_db.sightings)..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(_db.sightings)..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(entityType: 'sightings', recordId: row.id);
+      }
+      for (final sighting in sightings) {
+        final id = _uuid.v4();
+        await _db.into(_db.sightings).insert(SightingsCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              speciesId: Value(sighting.speciesId),
+              count: Value(sighting.count),
+              notes: Value(sighting.notes),
+            ));
+        await _syncRepository.markRecordPending(
+            entityType: 'sightings', recordId: id, localUpdatedAt: now);
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/marine_life/data/repositories/species_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(marine-life): add bulk sightings add and replace"
+```
+
+---
+
+## Phase 3 — Request/Snapshot models, orchestration service, undo
+
+### Task 9: `BulkEditRequest` + collection-op model
+
+**Files:**
+- Create: `lib/features/dive_log/domain/entities/bulk_edit_request.dart`
+- Test: `test/features/dive_log/domain/entities/bulk_edit_request_test.dart` (new)
+
+**Interfaces:**
+- Produces:
+  - `enum BulkCollectionMode { add, remove, replace }`
+  - `sealed class BulkCollectionOp` with subclasses `TagsOp(mode, tagIds)`, `EquipmentOp(mode, equipmentIds)`, `BuddiesOp(mode, buddies)`, `TanksOp(mode, tanks, onlyIfEmpty)`, `WeightsOp(mode, weights)`, `SightingsOp(mode, sightings)`.
+  - `class BulkEditRequest { List<String> diveIds; DivesCompanion scalars; String? notesAppend; List<BulkCollectionOp> ops; bool get hasScalarChanges; }`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
+
+void main() {
+  test('hasScalarChanges is false for an all-absent companion', () {
+    const req = BulkEditRequest(diveIds: ['a'], scalars: DivesCompanion());
+    expect(req.hasScalarChanges, isFalse);
+  });
+
+  test('hasScalarChanges is true when any column is present', () {
+    const req = BulkEditRequest(diveIds: ['a'], scalars: DivesCompanion(rating: Value(5)));
+    expect(req.hasScalarChanges, isTrue);
+  });
+
+  test('TagsOp carries mode and ids', () {
+    const op = TagsOp(mode: BulkCollectionMode.add, tagIds: ['t1']);
+    expect(op.mode, BulkCollectionMode.add);
+    expect(op.tagIds, ['t1']);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/domain/entities/bulk_edit_request_test.dart`
+Expected: FAIL — file/types not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart';
+
+enum BulkCollectionMode { add, remove, replace }
+
+sealed class BulkCollectionOp {
+  const BulkCollectionOp();
+}
+
+class TagsOp extends BulkCollectionOp {
+  final BulkCollectionMode mode;
+  final List<String> tagIds;
+  const TagsOp({required this.mode, required this.tagIds});
+}
+
+class EquipmentOp extends BulkCollectionOp {
+  final BulkCollectionMode mode;
+  final List<String> equipmentIds;
+  const EquipmentOp({required this.mode, required this.equipmentIds});
+}
+
+class BuddiesOp extends BulkCollectionOp {
+  final BulkCollectionMode mode;
+  final List<BuddyWithRole> buddies; // ids for remove read from .buddy.id
+  const BuddiesOp({required this.mode, required this.buddies});
+}
+
+class TanksOp extends BulkCollectionOp {
+  final BulkCollectionMode mode; // add | replace
+  final List<DiveTank> tanks;
+  final bool onlyIfEmpty;
+  const TanksOp({required this.mode, required this.tanks, this.onlyIfEmpty = false});
+}
+
+class WeightsOp extends BulkCollectionOp {
+  final BulkCollectionMode mode; // add | replace
+  final List<DiveWeight> weights;
+  const WeightsOp({required this.mode, required this.weights});
+}
+
+class SightingsOp extends BulkCollectionOp {
+  final BulkCollectionMode mode; // add | replace
+  final List<Sighting> sightings;
+  const SightingsOp({required this.mode, required this.sightings});
+}
+
+class BulkEditRequest {
+  final List<String> diveIds;
+  final DivesCompanion scalars;
+  final String? notesAppend;
+  final List<BulkCollectionOp> ops;
+
+  const BulkEditRequest({
+    required this.diveIds,
+    this.scalars = const DivesCompanion(),
+    this.notesAppend,
+    this.ops = const [],
+  });
+
+  /// True when at least one column of [scalars] is present (non-absent).
+  bool get hasScalarChanges => scalars.toColumns(false).isNotEmpty;
+}
+```
+
+(`Companion.toColumns(false)` returns only present columns — the canonical Drift way to detect a non-empty companion.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/entities/bulk_edit_request_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add BulkEditRequest and collection-op model"
+```
+
+### Task 10: `BulkEditSnapshot` model
+
+**Files:**
+- Create: `lib/features/dive_log/domain/entities/bulk_edit_snapshot.dart`
+
+**Interfaces:**
+- Produces: `class BulkEditSnapshot` holding `List<Dive> priorDiveRows` (Drift rows) plus nullable per-collection prior membership maps keyed by diveId: `Map<String, List<String>>? priorTagIds`, `priorEquipmentIds`; `Map<String, List<BuddyWithRole>>? priorBuddies`; `Map<String, List<DiveTank>>? priorTanks` (Drift rows); `Map<String, List<DiveWeight>>? priorWeights` (Drift rows); `Map<String, List<Sighting>>? priorSightings` (Drift rows). A `null` map means that collection was untouched and must not be restored.
+
+This task is a pure data holder, exercised by the service tests (Task 11/12). No standalone test.
+
+- [ ] **Step 1: Write the implementation**
+
+```dart
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+
+/// Captured prior state for undoing one bulk edit. All collections are keyed by
+/// diveId. A null map = that collection was not touched and must not be restored.
+class BulkEditSnapshot {
+  final List<Dive> priorDiveRows; // Drift rows (scalar + notes undo via toCompanion)
+  final Map<String, List<String>>? priorTagIds;
+  final Map<String, List<String>>? priorEquipmentIds;
+  final Map<String, List<BuddyWithRole>>? priorBuddies;
+  final Map<String, List<DiveTank>>? priorTanks; // Drift DiveTanks rows
+  final Map<String, List<DiveWeight>>? priorWeights; // Drift DiveWeights rows
+  final Map<String, List<Sighting>>? priorSightings; // Drift Sightings rows
+
+  const BulkEditSnapshot({
+    required this.priorDiveRows,
+    this.priorTagIds,
+    this.priorEquipmentIds,
+    this.priorBuddies,
+    this.priorTanks,
+    this.priorWeights,
+    this.priorSightings,
+  });
+}
+```
+
+Note the name clashes: here `Dive`, `DiveTank`, `DiveWeight`, `Sighting` are the **Drift row** types from `database.dart`; `BuddyWithRole` is the domain type. The service file (Task 11) imports domain entities `as domain` to keep them distinct.
+
+- [ ] **Step 2: Commit** (no test yet — covered by the service)
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add BulkEditSnapshot data holder"
+```
+
+### Task 11: `BulkDiveEditService.apply` — transactional apply + snapshot
+
+**Files:**
+- Create: `lib/features/dive_log/data/services/bulk_dive_edit_service.dart`
+- Test: `test/features/dive_log/data/services/bulk_dive_edit_service_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `DiveRepository`, `BuddyRepository`, `SpeciesRepository` bulk methods (Phase 1-2); `BulkEditRequest`; `BulkEditSnapshot`.
+- Produces: `class BulkDiveEditService { BulkDiveEditService(this._diveRepo, this._buddyRepo, this._speciesRepo); Future<BulkEditSnapshot> apply(BulkEditRequest req); }` — captures prior state, runs all writes inside one `db.transaction`, fires one `notifyLocalChange()`, returns the snapshot.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/services/bulk_dive_edit_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart' as domain;
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late BulkDiveEditService service;
+  late DiveRepository diveRepo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    diveRepo = DiveRepository();
+    service = BulkDiveEditService(diveRepo, BuddyRepository(), SpeciesRepository());
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> seed(String id) =>
+      diveRepo.createDive(domain.Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: ''));
+
+  test('apply writes scalars + notes-append + a tag op and returns a snapshot', () async {
+    await seed('d1');
+    await seed('d2');
+
+    final snap = await service.apply(BulkEditRequest(
+      diveIds: const ['d1', 'd2'],
+      scalars: const DivesCompanion(rating: Value(4)),
+      notesAppend: ' trip',
+      ops: const [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['t1'])],
+    ));
+
+    final r1 = await (db.select(db.dives)..where((t) => t.id.equals('d1'))).getSingle();
+    expect(r1.rating, 4);
+    expect(r1.notes, ' trip');
+    final tags = await (db.select(db.diveTags)..where((t) => t.diveId.equals('d1'))).get();
+    expect(tags.single.tagId, 't1');
+    expect(snap.priorDiveRows.length, 2);
+    expect(snap.priorTagIds, isNotNull); // tag op was touched
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/services/bulk_dive_edit_service_test.dart`
+Expected: FAIL — service not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_snapshot.dart';
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+
+class BulkDiveEditService {
+  BulkDiveEditService(this._diveRepo, this._buddyRepo, this._speciesRepo);
+
+  final DiveRepository _diveRepo;
+  final BuddyRepository _buddyRepo;
+  final SpeciesRepository _speciesRepo;
+
+  AppDatabase get _db => DatabaseService.instance.database;
+
+  Future<BulkEditSnapshot> apply(BulkEditRequest req) async {
+    final ids = req.diveIds;
+    if (ids.isEmpty) {
+      return const BulkEditSnapshot(priorDiveRows: []);
+    }
+
+    // Capture prior state BEFORE mutating (reads outside the transaction).
+    final priorDiveRows =
+        await (_db.select(_db.dives)..where((t) => t.id.isIn(ids))).get();
+
+    Map<String, List<String>>? priorTagIds;
+    Map<String, List<String>>? priorEquipmentIds;
+    Map<String, List<BuddyWithRole>>? priorBuddies;
+    Map<String, List<DiveTank>>? priorTanks;
+    Map<String, List<DiveWeight>>? priorWeights;
+    Map<String, List<Sighting>>? priorSightings;
+
+    for (final op in req.ops) {
+      switch (op) {
+        case TagsOp():
+          final rows =
+              await (_db.select(_db.diveTags)..where((t) => t.diveId.isIn(ids))).get();
+          priorTagIds = {for (final id in ids) id: <String>[]};
+          for (final r in rows) {
+            priorTagIds[r.diveId]!.add(r.tagId);
+          }
+        case EquipmentOp():
+          final rows =
+              await (_db.select(_db.diveEquipment)..where((t) => t.diveId.isIn(ids))).get();
+          priorEquipmentIds = {for (final id in ids) id: <String>[]};
+          for (final r in rows) {
+            priorEquipmentIds[r.diveId]!.add(r.equipmentId);
+          }
+        case BuddiesOp():
+          priorBuddies = {
+            for (final id in ids) id: await _buddyRepo.getBuddiesForDive(id),
+          };
+        case TanksOp():
+          final rows =
+              await (_db.select(_db.diveTanks)..where((t) => t.diveId.isIn(ids))).get();
+          priorTanks = {for (final id in ids) id: <DiveTank>[]};
+          for (final r in rows) {
+            priorTanks[r.diveId]!.add(r);
+          }
+        case WeightsOp():
+          final rows =
+              await (_db.select(_db.diveWeights)..where((t) => t.diveId.isIn(ids))).get();
+          priorWeights = {for (final id in ids) id: <DiveWeight>[]};
+          for (final r in rows) {
+            priorWeights[r.diveId]!.add(r);
+          }
+        case SightingsOp():
+          final rows =
+              await (_db.select(_db.sightings)..where((t) => t.diveId.isIn(ids))).get();
+          priorSightings = {for (final id in ids) id: <Sighting>[]};
+          for (final r in rows) {
+            priorSightings[r.diveId]!.add(r);
+          }
+      }
+    }
+
+    await _db.transaction(() async {
+      if (req.hasScalarChanges) {
+        await _diveRepo.bulkUpdateFields(ids, req.scalars);
+      }
+      if (req.notesAppend != null && req.notesAppend!.isNotEmpty) {
+        await _diveRepo.bulkAppendNotes(ids, req.notesAppend!);
+      }
+      for (final op in req.ops) {
+        await _applyOp(ids, op);
+      }
+    });
+
+    SyncEventBus.notifyLocalChange();
+
+    return BulkEditSnapshot(
+      priorDiveRows: priorDiveRows,
+      priorTagIds: priorTagIds,
+      priorEquipmentIds: priorEquipmentIds,
+      priorBuddies: priorBuddies,
+      priorTanks: priorTanks,
+      priorWeights: priorWeights,
+      priorSightings: priorSightings,
+    );
+  }
+
+  Future<void> _applyOp(List<String> ids, BulkCollectionOp op) async {
+    switch (op) {
+      case TagsOp(:final mode, :final tagIds):
+        switch (mode) {
+          case BulkCollectionMode.add:
+            await _diveRepo.bulkAddTags(ids, tagIds);
+          case BulkCollectionMode.remove:
+            await _diveRepo.bulkRemoveTags(ids, tagIds);
+          case BulkCollectionMode.replace:
+            await _diveRepo.bulkReplaceTags(ids, tagIds);
+        }
+      case EquipmentOp(:final mode, :final equipmentIds):
+        switch (mode) {
+          case BulkCollectionMode.add:
+            await _diveRepo.bulkAddEquipment(ids, equipmentIds);
+          case BulkCollectionMode.remove:
+            await _diveRepo.bulkRemoveEquipment(ids, equipmentIds);
+          case BulkCollectionMode.replace:
+            await _diveRepo.bulkReplaceEquipment(ids, equipmentIds);
+        }
+      case BuddiesOp(:final mode, :final buddies):
+        switch (mode) {
+          case BulkCollectionMode.add:
+            await _buddyRepo.bulkAddBuddies(ids, buddies);
+          case BulkCollectionMode.remove:
+            await _buddyRepo
+                .bulkRemoveBuddies(ids, buddies.map((b) => b.buddy.id).toList());
+          case BulkCollectionMode.replace:
+            await _buddyRepo.bulkReplaceBuddies(ids, buddies);
+        }
+      case TanksOp(:final mode, :final tanks, :final onlyIfEmpty):
+        if (mode == BulkCollectionMode.replace) {
+          await _diveRepo.bulkReplaceTanks(ids, tanks);
+        } else {
+          for (final tank in tanks) {
+            await _diveRepo.bulkAddTank(ids, tank, onlyIfEmpty: onlyIfEmpty);
+          }
+        }
+      case WeightsOp(:final mode, :final weights):
+        if (mode == BulkCollectionMode.replace) {
+          await _diveRepo.bulkReplaceWeights(ids, weights);
+        } else {
+          await _diveRepo.bulkAddWeights(ids, weights);
+        }
+      case SightingsOp(:final mode, :final sightings):
+        if (mode == BulkCollectionMode.replace) {
+          await _speciesRepo.bulkReplaceSightings(ids, sightings);
+        } else {
+          await _speciesRepo.bulkAddSightings(ids, sightings);
+        }
+    }
+  }
+
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/services/bulk_dive_edit_service_test.dart` and `flutter analyze lib/features/dive_log/data/services/bulk_dive_edit_service.dart`
+Expected: PASS; analyze clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add BulkDiveEditService.apply with snapshot capture"
+```
+
+### Task 12: `BulkDiveEditService.undo`
+
+**Files:**
+- Modify: `lib/features/dive_log/data/services/bulk_dive_edit_service.dart`
+- Test: `bulk_dive_edit_service_test.dart`
+
+**Interfaces:**
+- Produces: `Future<void> undo(BulkEditSnapshot snapshot)` — restores each prior dive row's scalar columns (`row.toCompanion(false)` + fresh `updatedAt`), and for every non-null collection map, restores that dive's prior membership (replace-with-prior). One transaction, one notify.
+
+- [ ] **Step 1: Write the failing test** (append to the service test)
+
+```dart
+  test('undo restores prior scalar values and tag membership', () async {
+    await seed('d1');
+    await diveRepo.bulkUpdateFields(['d1'], const DivesCompanion(rating: Value(2)));
+    await diveRepo.bulkReplaceTags(['d1'], ['orig']);
+
+    final snap = await service.apply(BulkEditRequest(
+      diveIds: const ['d1'],
+      scalars: const DivesCompanion(rating: Value(9)),
+      ops: const [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['new'])],
+    ));
+
+    await service.undo(snap);
+
+    final r = await (db.select(db.dives)..where((t) => t.id.equals('d1'))).getSingle();
+    expect(r.rating, 2); // restored
+    final tags = await (db.select(db.diveTags)..where((t) => t.diveId.equals('d1'))).get();
+    expect(tags.single.tagId, 'orig'); // restored
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/services/bulk_dive_edit_service_test.dart --plain-name undo`
+Expected: FAIL — `undo` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+  final _sync = SyncRepository();
+
+  Future<void> undo(BulkEditSnapshot snapshot) async {
+    if (snapshot.priorDiveRows.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final ids = snapshot.priorDiveRows.map((r) => r.id).toList();
+
+    await _db.transaction(() async {
+      // Restore scalar columns from the full prior row (nullToAbsent: false so
+      // prior NULLs are restored, not left absent), with a fresh updatedAt so
+      // the undo wins LWW; then mark each dive pending.
+      for (final row in snapshot.priorDiveRows) {
+        await (_db.update(_db.dives)..where((t) => t.id.equals(row.id)))
+            .write(row.toCompanion(false).copyWith(updatedAt: Value(now)));
+        await _sync.markRecordPending(
+            entityType: 'dives', recordId: row.id, localUpdatedAt: now);
+      }
+
+      // Restore each touched collection per dive (replace-with-prior).
+      final tags = snapshot.priorTagIds;
+      if (tags != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceTags([id], tags[id] ?? const []);
+        }
+      }
+      final equip = snapshot.priorEquipmentIds;
+      if (equip != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceEquipment([id], equip[id] ?? const []);
+        }
+      }
+      final buddies = snapshot.priorBuddies;
+      if (buddies != null) {
+        for (final id in ids) {
+          await _buddyRepo.bulkReplaceBuddies([id], buddies[id] ?? const []);
+        }
+      }
+      final tanks = snapshot.priorTanks;
+      if (tanks != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceTanks([id], _tanksFromRows(tanks[id] ?? const []));
+        }
+      }
+      final weights = snapshot.priorWeights;
+      if (weights != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceWeights([id], _weightsFromRows(weights[id] ?? const []));
+        }
+      }
+      final sightings = snapshot.priorSightings;
+      if (sightings != null) {
+        for (final id in ids) {
+          await _speciesRepo
+              .bulkReplaceSightings([id], _sightingsFromRows(sightings[id] ?? const []));
+        }
+      }
+    });
+
+    SyncEventBus.notifyLocalChange();
+  }
+
+  // Map Drift rows (unprefixed types from database.dart) back to the domain
+  // objects the bulk-replace methods consume (domain imported with prefixes
+  // `de` = dive.dart, `se` = species.dart).
+  List<de.DiveTank> _tanksFromRows(List<DiveTank> rows) => [
+        for (final r in rows)
+          de.DiveTank(
+            id: '',
+            name: r.tankName,
+            volume: r.volume,
+            workingPressure: r.workingPressure,
+            startPressure: r.startPressure,
+            endPressure: r.endPressure,
+            gasMix: de.GasMix(o2: r.o2Percent, he: r.hePercent),
+            role: de.TankRole.values.firstWhere(
+                (e) => e.name == r.tankRole, orElse: () => de.TankRole.backGas),
+            material: r.tankMaterial == null
+                ? null
+                : de.TankMaterial.values.firstWhere(
+                    (e) => e.name == r.tankMaterial, orElse: () => de.TankMaterial.aluminum),
+            presetName: r.presetName,
+          ),
+      ];
+
+  List<de.DiveWeight> _weightsFromRows(List<DiveWeight> rows) => [
+        for (final r in rows)
+          de.DiveWeight(
+            id: '',
+            weightType: de.WeightType.values.firstWhere(
+                (e) => e.name == r.weightType, orElse: () => de.WeightType.values.first),
+            amountKg: r.amountKg,
+            notes: r.notes,
+          ),
+      ];
+
+  List<se.Sighting> _sightingsFromRows(List<Sighting> rows) => [
+        for (final r in rows)
+          se.Sighting(
+            id: '',
+            diveId: '',
+            speciesId: r.speciesId,
+            speciesName: '',
+            count: r.count,
+            notes: r.notes,
+          ),
+      ];
+```
+
+Add these imports to `bulk_dive_edit_service.dart` (the `de`/`se` prefixes keep the domain entities distinct from the identically-named Drift rows; `database.dart` stays unprefixed for the rows):
+
+```dart
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart' as de;
+import 'package:submersion/features/marine_life/domain/entities/species.dart' as se;
+```
+
+`bulkReplaceTanks` recomputes `tankOrder` by index, so restored tanks need no explicit order. Confirm the domain constructor params and enum spellings (`de.TankRole.backGas`, `de.TankMaterial.aluminum`, `de.WeightType`) against `lib/features/dive_log/domain/entities/dive.dart` before running, then run `flutter analyze lib/features/dive_log/data/services/`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/services/bulk_dive_edit_service_test.dart` and `flutter analyze lib/features/dive_log/data/services/`
+Expected: PASS; analyze clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add BulkDiveEditService.undo (per-dive restore)"
+```
+
+### Task 13: `bulkDiveEditServiceProvider`
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/providers/bulk_dive_edit_provider.dart`
+- Test: none (trivial wiring; covered when the form consumes it in Plan 2)
+
+**Interfaces:**
+- Produces: `final bulkDiveEditServiceProvider = Provider<BulkDiveEditService>(...)` wiring the three repositories from their existing providers.
+
+- [ ] **Step 1: Write the implementation**
+
+```dart
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_log/data/services/bulk_dive_edit_service.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
+
+final bulkDiveEditServiceProvider = Provider<BulkDiveEditService>((ref) {
+  return BulkDiveEditService(
+    ref.watch(diveRepositoryProvider),
+    ref.watch(buddyRepositoryProvider),
+    ref.watch(speciesRepositoryProvider),
+  );
+});
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `flutter analyze lib/features/dive_log/presentation/providers/bulk_dive_edit_provider.dart`
+Expected: No issues.
+
+- [ ] **Step 3: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add bulkDiveEditServiceProvider"
+```
+
+---
+
+## Phase 4 — Selection mechanics (anchor, shift-click, date range)
+
+All Phase 4 changes are in `lib/features/dive_log/presentation/widgets/dive_list_content.dart` unless noted. Tests go in `test/features/dive_log/presentation/widgets/dive_list_selection_test.dart` (new).
+
+### Task 14: Selection anchor + shift-click range selection
+
+**Files:**
+- Modify: `dive_list_content.dart` — add `int? _anchorIndex`; update `_enterSelectionMode`, `_toggleSelection`; add `_selectRangeTo(int index, List<DiveSummary> dives)`; pass an `onSelectRange`/shift-aware tap into the list tiles.
+- Test: `dive_list_selection_test.dart`
+
+**Interfaces:**
+- Produces: `void _selectRangeTo(int index, List<DiveSummary> dives)` — selects every dive between `_anchorIndex` and `index` inclusive. Pure list math is extracted to a testable top-level function `List<String> rangeIds(List<DiveSummary> dives, int anchor, int target)`.
+
+- [ ] **Step 1: Write the failing test** (test the pure range helper — fast and deterministic)
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart'
+    show rangeIds;
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+
+DiveSummary summary(String id) => DiveSummary(id: id, dateTime: DateTime(2026, 1, 1));
+
+void main() {
+  test('rangeIds returns inclusive span regardless of direction', () {
+    final dives = ['a', 'b', 'c', 'd'].map(summary).toList();
+    expect(rangeIds(dives, 1, 3), ['b', 'c', 'd']);
+    expect(rangeIds(dives, 3, 1), ['b', 'c', 'd']); // reversed
+    expect(rangeIds(dives, 2, 2), ['c']); // single
+  });
+}
+```
+
+(Confirm `DiveSummary`'s required constructor params against `lib/features/dive_log/domain/entities/dive_summary.dart`; adjust the `summary` helper accordingly.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_list_selection_test.dart`
+Expected: FAIL — `rangeIds` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add a top-level function in `dive_list_content.dart` (above the widget class):
+
+```dart
+/// Inclusive id span between [anchor] and [target] indices in [dives].
+List<String> rangeIds(List<DiveSummary> dives, int anchor, int target) {
+  final lo = anchor < target ? anchor : target;
+  final hi = anchor < target ? target : anchor;
+  return [for (var i = lo; i <= hi; i++) dives[i].id];
+}
+```
+
+Add the anchor field and wire it:
+
+```dart
+  int? _anchorIndex;
+```
+
+In `_enterSelectionMode`, accept and store an index (overload-friendly): change call sites in the `itemBuilder` to pass the row `index`, and set `_anchorIndex = index` when entering. In `_toggleSelection`, set `_anchorIndex` to the toggled dive's index. Add:
+
+```dart
+  void _selectRangeTo(int index, List<DiveSummary> dives) {
+    final anchor = _anchorIndex ?? index;
+    setState(() {
+      _selectedIds.addAll(rangeIds(dives, anchor, index));
+      _anchorIndex = index;
+    });
+  }
+```
+
+In the detailed/compact `itemBuilder`, wrap the tile so a Shift-modified tap calls `_selectRangeTo(index, dives)` instead of `_handleItemTap`. The minimal mechanism: read `HardwareKeyboard.instance.isShiftPressed` inside the `onTap`:
+
+```dart
+    onTap: () {
+      if (_isSelectionMode &&
+          HardwareKeyboard.instance.logicalKeysPressed.any((k) =>
+              k == LogicalKeyboardKey.shiftLeft || k == LogicalKeyboardKey.shiftRight)) {
+        _selectRangeTo(index, dives);
+      } else {
+        _handleItemTap(dive);
+      }
+    },
+```
+
+Add `import 'package:flutter/services.dart';` for `HardwareKeyboard`/`LogicalKeyboardKey`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_list_selection_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): shift-click range selection with a selection anchor"
+```
+
+### Task 15: "Select by date range" action
+
+**Files:**
+- Modify: `dive_list_content.dart` — add `_selectByDateRange(List<DiveSummary> dives)` and an icon button in both `_buildSelectionAppBar` (line 1143) and `_buildSelectionBar` (line 1192).
+- l10n: add `diveLog_selection_tooltip_selectDateRange` (Task 16).
+
+**Interfaces:**
+- Produces: `Future<void> _selectByDateRange(List<DiveSummary> dives)` — shows `showDateRangePicker`, then adds every dive whose `dateTime` falls within `[start, end]` (inclusive of the end day) to `_selectedIds`. The pure predicate is extracted as `bool inDateRange(DiveSummary d, DateTimeRange r)` for testing.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+  test('inDateRange includes dives on the boundary days', () {
+    final r = DateTimeRange(start: DateTime(2026, 6, 1), end: DateTime(2026, 6, 3));
+    expect(inDateRange(summary('a', DateTime(2026, 6, 1, 8)), r), isTrue);
+    expect(inDateRange(summary('b', DateTime(2026, 6, 3, 23)), r), isTrue);
+    expect(inDateRange(summary('c', DateTime(2026, 5, 31)), r), isFalse);
+  });
+```
+
+(Extend the `summary` helper to take a `DateTime`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_list_selection_test.dart --plain-name inDateRange`
+Expected: FAIL — `inDateRange` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Top-level helper:
+
+```dart
+/// True if [d]'s date falls within [r] (inclusive of the end calendar day).
+bool inDateRange(DiveSummary d, DateTimeRange r) {
+  final day = DateTime(d.dateTime.year, d.dateTime.month, d.dateTime.day);
+  final endDay = DateTime(r.end.year, r.end.month, r.end.day);
+  return !day.isBefore(DateTime(r.start.year, r.start.month, r.start.day)) &&
+      !day.isAfter(endDay);
+}
+```
+
+Method + toolbar buttons:
+
+```dart
+  Future<void> _selectByDateRange(List<DiveSummary> dives) async {
+    final range = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(1970),
+      lastDate: DateTime(2100),
+    );
+    if (range == null) return;
+    setState(() {
+      _selectedIds.addAll(dives.where((d) => inDateRange(d, range)).map((d) => d.id));
+    });
+  }
+```
+
+Add this `IconButton` to both selection toolbars (next to select-all):
+
+```dart
+          IconButton(
+            icon: const Icon(Icons.date_range),
+            tooltip: context.l10n.diveLog_selection_tooltip_selectDateRange,
+            onPressed: () => _selectByDateRange(dives),
+          ),
+```
+
+(In `_buildSelectionBar`, the table-mode caller passes `const []`; keep the button but it will select nothing there — acceptable, matching the existing select-all limitation in table mode.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_list_selection_test.dart`
+Expected: PASS. (l10n key added in Task 16; until then use a literal string or land Task 16 first.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "feat(dive-log): add Select-by-date-range to multi-select toolbars"
+```
+
+### Task 16: Localize the new selection strings
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` (+ all 10 non-English ARB files)
+- Run: `flutter gen-l10n`
+
+**Interfaces:**
+- Produces l10n key `diveLog_selection_tooltip_selectDateRange` (and any other new selection strings) used in Task 15.
+
+- [ ] **Step 1: Add the English template key**
+
+In `lib/l10n/arb/app_en.arb`, alongside the other `diveLog_selection_tooltip_*` keys:
+
+```json
+  "diveLog_selection_tooltip_selectDateRange": "Select by date range",
+```
+
+- [ ] **Step 2: Add translations to all 10 non-English ARB files**
+
+Add the same key with a translated value to each of: `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`. (German example: `"diveLog_selection_tooltip_selectDateRange": "Nach Datumsbereich auswählen",`.)
+
+- [ ] **Step 3: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: regenerates `lib/l10n/arb/app_localizations*.dart` with the new getter; no errors.
+
+- [ ] **Step 4: Verify analyze + tests**
+
+Run: `flutter analyze lib/features/dive_log/presentation/widgets/dive_list_content.dart` then `flutter test test/features/dive_log/presentation/widgets/dive_list_selection_test.dart`
+Expected: No issues; tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add -A
+git commit -m "i18n(dive-log): localize select-by-date-range tooltip in all locales"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full new-test surface:
+  `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart test/features/buddies/data/repositories/buddy_repository_bulk_test.dart test/features/marine_life/data/repositories/species_repository_bulk_test.dart test/features/dive_log/data/services/bulk_dive_edit_service_test.dart test/features/dive_log/domain/entities/bulk_edit_request_test.dart test/features/dive_log/presentation/widgets/dive_list_selection_test.dart`
+- [ ] `flutter analyze` (whole project) — clean.
+- [ ] `dart format --set-exit-if-changed .` — clean.
+
+---
+
+## Next plan (Plan 2): DiveEditPage bulk mode
+
+The engine above is consumed by a follow-up plan that adds the user-facing bulk-edit form. That plan needs a verbatim extraction pass over the edit-form **section widgets** (`lib/features/dive_log/presentation/widgets/edit_sections/*.dart`) so the per-field gate code is real, not guessed. Its tasks:
+
+1. `DiveEditPage(bulkDiveIds:)` constructor param + `isBulk` getter + mutual-exclusion assert (mirror `SiteEditPage.mergeSiteIds`/`isMerging`, `site_edit_page.dart:32`).
+2. A `/dives/bulk-edit` route taking `state.extra as List<dynamic>?).cast<String>()` (mirror `/dives/match-sites`, `app_router.dart:267`), plus a thin `BulkDiveEditPage` wrapper (mirror `SiteMergePage`).
+3. Replace `_showBulkEditSheet` (`dive_list_content.dart:428`) with a "Bulk edit…" action that pushes the route with `_selectedIds.toList()`.
+4. A `BulkFieldGate` widget (leading toggle) and `isBulk` branches that (a) hide identity/measured sections, (b) wrap each shown field in a gate, (c) render the dive-mode rebreather cascade as gated sub-fields (decision: rebreather group stays available, collapsed, when mode is unchanged), (d) give collections the Add/Remove/Replace selector with the tank-Add `onlyIfEmpty` checkbox, (e) give notes Set/Append.
+5. A bulk `_saveDive` branch that builds a `BulkEditRequest` from the enabled gates and calls `bulkDiveEditServiceProvider`, then shows the snackbar-undo (mirror `_confirmAndDelete`, `dive_list_content.dart:228`) wired to `BulkDiveEditService.undo`.
+6. A confirm dialog summarizing the change with the contradiction guard (mode = OC + CCR fields) and the destructive replace-tanks warning (the #276 cascade).
+7. l10n for all new form strings across all 11 locales.

--- a/docs/superpowers/specs/2026-06-23-bulk-dive-editing-design.md
+++ b/docs/superpowers/specs/2026-06-23-bulk-dive-editing-design.md
@@ -1,0 +1,307 @@
+# Bulk Dive Editing — Design
+
+- **Issue:** [#150 — Batch editing: multi-select dives for bulk field updates](https://github.com/submersion-app/submersion/issues/150)
+- **Date:** 2026-06-23
+- **Status:** Approved (design); ready for implementation planning
+- **Branch:** `worktree-issue-150-bulk-dive-editing`
+
+## Summary
+
+Let a diver select multiple dives and apply edits to most fields at once. This is the
+single highest-volume community feature request (4+ ScubaBoard reporters). The driving
+workflows are post-import cleanup: stamping a dive center, buddy, gear, weight, or
+tank/gas type onto a batch of freshly imported dives that all share context.
+
+We reuse the existing dive edit form in a new **bulk mode** (the same way
+`site_merge_page.dart` reuses `SiteEditPage`), gate every field behind a per-field
+"change this" toggle so only enabled fields are written, and route the save through a
+dedicated set-based write path that never touches per-dive child rows it shouldn't.
+
+## Goals
+
+- Bulk-edit a comprehensive set of dive fields (scalars, enums, FKs, and the multi-value
+  collections), not just a curated few.
+- Cover the issue's named fields explicitly: dive center, buddy, equipment, weight, and
+  tank/gas type — plus trip, dive type, conditions, deco, dive computer, weather, and
+  rebreather settings.
+- Enhanced selection: long-press to enter (preserved), shift-click range selection, and
+  date-range / block selection.
+- Reversible: every bulk apply can be undone.
+- Correct under cloud sync: each touched record is marked pending; undo propagates too.
+
+## Non-goals
+
+- Bulk-editing measured or identity data (dive number, date/times, durations, max/avg
+  depth, profile samples, CNS/OTU, GPS, computer serial/firmware, import metadata). These
+  are never sensible to set across many dives and are hidden in bulk mode.
+- A separate "set dive center at trip level" propagation feature. Date-range selection +
+  bulk set covers it: select the trip's date span, set one field, apply.
+- A spreadsheet / inline-grid editor (considered and rejected in favor of reusing the
+  edit form).
+
+## Background — existing code this builds on
+
+Bulk editing already exists in a limited form; this is an expansion of an existing seam.
+
+- **Multi-select + current bulk sheet:**
+  `lib/features/dive_log/presentation/widgets/dive_list_content.dart`
+  - Selection state: `_isSelectionMode`, `Set<String> _selectedIds`,
+    `_enterSelectionMode` (L185), `_toggleSelection` (L203), `_selectAll` (L216),
+    `_deselectAll` (L222).
+  - Long-press is the existing entry to selection mode, wired on all tile types
+    (L1417/1461/1491) and table rows (`onDiveLongPress`, L1305): when not in selection
+    mode, `onLongPress` calls `_enterSelectionMode(dive.id)`.
+  - Current "Bulk Edit" bottom sheet (`_showBulkEditSheet`, L428) offers only Change Trip
+    / Add Tags / Remove Tags, backed by `bulkUpdateTrip` / `bulkAddTags` /
+    `bulkRemoveTags`.
+  - Selection toolbars: `_buildSelectionAppBar` (L1143, mobile), `_buildSelectionBar`
+    (L1192, desktop split-pane).
+- **Reuse-the-edit-form precedent (site merge):**
+  `lib/features/dive_sites/presentation/pages/site_merge_page.dart` is a 15-line wrapper
+  that calls `SiteEditPage(mergeSiteIds: [...])`; `site_edit_page.dart` branches on an
+  `isMerging` flag. `site_repository_impl.dart` `mergeSites` (L331) does everything in one
+  `_db.transaction`, captures a `MergeSnapshot` for undo before mutating, and
+  `undoMerge` (L476) restores it.
+- **Repository bulk template:**
+  `lib/features/dive_log/data/repositories/dive_repository_impl.dart`
+  - `bulkUpdateTrip` (L3626) is the clean model: one `UPDATE dives ... WHERE id IN`, then
+    `markRecordPending('dives', id)` per dive, then `SyncEventBus.notifyLocalChange()`.
+  - `updateDive` (L888) is the per-dive path; it delete-orphans and re-inserts all child
+    rows (tanks L1009, weights L1088, equipment L1122, custom fields L1151, tags L1185).
+    **Bulk mode must not loop this** — it would needlessly churn every child row.
+  - `bulkDeleteDives` (L1220) returns deleted dives and powers the existing 5s
+    snackbar-undo.
+
+## Approach — reuse the edit form in bulk mode (Approach B)
+
+Open the existing edit page as `DiveEditPage(bulkDiveIds: selectedIds)` with an `isBulk`
+getter, mirroring `SiteEditPage`'s merge mode. The "Bulk edit…" action in the selection
+toolbar replaces today's limited bottom sheet.
+
+**Decoupling rule (the most important correctness decision):** bulk mode shares the
+*form widget* but swaps the *save handler*. A normal save fans out per-dive child-row
+rewrites; across hundreds of dives that is catastrophic. So on save, bulk mode builds a
+request object and hands it to a new `BulkDiveEditService` that uses set-based SQL — it
+never calls `updateDive`.
+
+Trade-off accepted: weaving `isBulk` branches into the 3,473-line edit form makes that
+form carry bulk concerns and harder to restructure later. Mitigation: keep bulk-only
+logic in small helpers (`BulkFieldGate`, the request builder, the service) rather than
+smeared inline, and extract reusable leaf field-editors where practical so a future
+restyle still propagates.
+
+## Selection mechanics
+
+Range selection needs an **anchor** — the dive a range extends from. Current code only
+tracks a `Set<String>`; we add one field, `_anchorId` (or last-tapped index).
+
+- **Long-press** (not in selection mode) → enter selection mode, select that dive, set it
+  as the anchor. (Existing behavior, now also records the anchor.)
+- **Plain tap** (in selection mode) → toggle that dive; it becomes the new anchor.
+- **Shift-tap / shift-click** → select the contiguous span from anchor → tapped dive;
+  anchor unchanged. Pointer+keyboard gesture, so it applies on desktop / web / table
+  layouts.
+- **Select by date range** → new action in the selection toolbar; opens a date-range
+  picker and selects every dive whose date falls inside it. This is the cross-platform
+  (incl. mobile, which has no shift key) path to range/block selection, and it satisfies
+  the "set the dive center for a whole trip at once" use case.
+- **Select all / Deselect all** → unchanged.
+- Optional desktop bonus: in the split-pane view the `isMasterSelected` detail dive can
+  act as an implicit anchor, so a shift-click can both enter selection mode and grab the
+  range in one gesture.
+
+## The bulk form
+
+### Hidden in bulk mode (identity + measured)
+
+Dive number, entry/exit date-times, bottom time, runtime, max/avg depth, profile, CNS/OTU,
+GPS entry/exit, dive computer serial/firmware, import source/id/version.
+
+### Gated scalar fields
+
+Every shown field is wrapped in a **`BulkFieldGate`** — a leading toggle, off by default.
+Only enabled fields are written. The toggle distinguishes "leave alone" from "set to
+empty": enabling a field and clearing it clears that field on all selected dives.
+
+Fields: dive center, trip, course, dive type, rating, favorite, water type, visibility,
+current direction/strength, swell height, entry/exit method, altitude, surface pressure,
+surface interval, gradient factor low/high, deco algorithm, deco conservatism, dive
+computer model, weather (wind speed/direction, cloud cover, precipitation, humidity,
+description), dive mode, and the rebreather cluster below.
+
+### Notes — Set vs Append
+
+Notes gets a small mode selector: **Set** (overwrite) or **Append** (concatenate a line).
+Append is the common, non-destructive batch case ("add 'Cozumel 2026' to all").
+
+### Dive mode cascade
+
+`diveMode` (OC / CCR / SCR) controls a dependent rebreather cluster: setpoints (bottom /
+high / deco), scrubber type/duration/remaining, diluent gas, loop O2 min/max/avg, loop
+volume, SCR injection rate / addition ratio / orifice, assumed VO2.
+
+- Setting mode = CCR/SCR reveals the rebreather fields, each as its own optional gate.
+  Nothing is forced — you can stamp just the mode now and fill setpoints later.
+- Setting mode = OC collapses the cluster; if any rebreather gate is enabled, the confirm
+  step blocks the contradiction.
+- **Decision (settled):** when mode is *not* being changed, the rebreather cluster stays
+  available but collapsed, because the selection may already contain CCR dives whose
+  setpoints the user wants to bulk-edit without re-stamping the mode.
+
+### Collections — Add / Remove / Replace
+
+Each multi-value field shows a mode selector, then drops in the same editor the normal
+form uses. Available modes depend on whether rows are *owned* by the dive or *references*
+to shared records:
+
+| Collection  | Add | Remove | Replace | Notes |
+|-------------|-----|--------|---------|-------|
+| Tags        | yes | yes    | yes     | Add/Remove exist today; add Replace |
+| Equipment   | yes | yes    | yes     | shared gear items (junction `DiveEquipment`) |
+| Buddies     | yes | yes    | yes     | Add carries a role (`DiveBuddies.role`) |
+| Tanks       | yes | —      | yes     | owned rows — no shared identity to remove |
+| Weights     | yes | —      | yes     | owned rows |
+| Marine life | yes | —      | yes     | owned sightings (per-dive count) |
+
+- **Tank Add** reuses the existing tank editor: preset (`presetName`, e.g. `al80`),
+  volume, working pressure, material, gas mix (O2/He), role. Start/end pressure stay
+  blank — they are measured per dive; you stamp the *type*. Add honors an **"only dives
+  that don't already have a tank"** checkbox (safe to re-run after a partial import).
+- **Add** appends to each dive's existing list; fresh row UUID + `order` per dive.
+- **Replace** swaps each dive's whole list for the configured set (see warning in Edge
+  cases — destructive of tank pressure data).
+
+### Confirm step
+
+Before writing, a summary dialog: "Apply N changes to 12 dives?" listing the enabled
+fields and any warnings (contradictions, destructive replace). High blast radius warrants
+an explicit confirm.
+
+## Persistence & sync — the write path
+
+The form builds a **`BulkEditRequest`** = a partial `DivesCompanion` (scalars) + a notes
+mode + a list of collection ops. A new **`BulkDiveEditService`** applies it.
+
+### Scalars — one generic set-based method
+
+New `DiveRepository.bulkUpdateFields(List<String> diveIds, DivesCompanion partial)`:
+
+```dart
+(_db.update(_db.dives)..where((d) => d.id.isIn(diveIds)))
+    .write(partial.copyWith(updatedAt: Value(now)));   // single UPDATE
+// then markRecordPending('dives', id, now) per id; one notifyLocalChange() at the end
+```
+
+Drift companions encode the per-field gate precisely: `Value.absent()` = "don't touch
+this column"; `Value(null)` = "set NULL". So toggle-off → absent, toggle-on-empty →
+`Value(null)`, toggle-on-value → `Value(x)`. One method therefore covers all ~40 scalar
+fields; we do not write 40 field-specific methods.
+
+### Notes append
+
+A single `customUpdate`: `SET notes = COALESCE(notes,'') || ?` over the selected ids
+(only when Append is chosen; Set goes through `bulkUpdateFields`).
+
+### Collections — bulk methods, set-based, one transaction
+
+- **DiveRepository** (owned/junction rows it already manages):
+  `bulkReplaceTags`; `bulkAddEquipment` / `bulkRemoveEquipment` / `bulkReplaceEquipment`;
+  `bulkAddWeights` / `bulkReplaceWeights`; `bulkAddTank({onlyIfEmpty})` /
+  `bulkReplaceTanks`. (`bulkAddTags` / `bulkRemoveTags` already exist.)
+- **BuddyRepository** (buddies persist outside the Dive aggregate via
+  `setBuddiesForDive`, L325): `bulkAddBuddies` / `bulkRemoveBuddies` / `bulkReplaceBuddies`
+  (Add carries role).
+- **SpeciesRepository** (sightings persist outside the aggregate via `addSighting`,
+  L130): `bulkAddSightings` / `bulkReplaceSightings`.
+
+Owned-row inserts (tanks, weights, sightings) generate a fresh UUID per dive and set
+`order`. Every insert/update calls `markRecordPending(entityType, recordId)`; every delete
+calls `logDeletion(entityType, recordId)`. Junction deletion recordIds follow existing
+conventions (e.g. equipment `'diveId|equipmentId'`).
+
+### Orchestration
+
+`BulkDiveEditService` runs the whole apply inside one `_db.transaction` (mirroring
+`mergeSites`):
+
+1. Capture the undo snapshot (below).
+2. `bulkUpdateFields` for scalars (+ notes append if requested).
+3. Each collection op via the appropriate repository's bulk method.
+4. A single `SyncEventBus.notifyLocalChange()` at the end.
+
+It returns a `BulkEditSnapshot`. Because writes span repositories, the service owns the
+transaction boundary and the bulk methods must be transaction-participating (not each
+opening their own).
+
+## Undo safety
+
+Modeled on `MergeSnapshot`, but it must store **per-dive prior values**, not one "before"
+state — bulk editing collapses heterogeneous dives to one value, so undo must restore each
+dive's distinct original.
+
+`BulkEditSnapshot`:
+- `Map<diveId, priorScalars>` — prior values of only the touched columns, per dive.
+- `Map<diveId, priorCollectionRows>` — prior membership of only the touched collections,
+  per dive.
+
+Captured before mutating, scoped to touched dives × touched fields. Surfaced through the
+existing snackbar-undo pattern used by `bulkDeleteDives`. Undo is itself a write
+(re-marks pending, `notifyLocalChange()`), so sync (LWW + HLC) carries the reversal to
+peers.
+
+## Error handling & edge cases
+
+- **Atomicity:** the whole apply is one transaction; any failure rolls back entirely — no
+  half-applied batches.
+- **Contradiction guard:** mode = OC with CCR setpoints enabled is blocked at confirm.
+- **Replace-tanks is destructive:** replacing tanks cascades to delete
+  `tank_pressure_profiles` / `gas_switches` (the root of the #276 SAC-disappears bug). The
+  confirm dialog warns when any selected dive already has tank pressure data. *Add* never
+  touches existing tanks.
+- **Empty selection / nothing enabled:** Apply stays disabled.
+- **Mixed selections** (e.g. some OC, some CCR): expected and supported — gates set only
+  enabled fields; collection ops act per dive.
+- **Large batches** (hundreds): set-based SQL scales; the per-dive `markRecordPending`
+  loop is the cost. Show a progress indicator for large applies.
+- **Validation:** reuse each field's existing edit-form validators, applied only to
+  enabled fields.
+
+## Components & files
+
+**New:**
+- `BulkFieldGate` widget (toggle wrapper reporting enabled + value).
+- `BulkEditRequest` model (partial `DivesCompanion` + notes mode + collection ops).
+- `BulkDiveEditService` (orchestrator + snapshot capture) and its Riverpod provider.
+- `BulkEditSnapshot` model.
+- Bulk methods on `DiveRepository`, `BuddyRepository`, `SpeciesRepository`.
+- A bulk-edit confirm dialog.
+- l10n strings for all new UI, translated across all 11 locales.
+
+**Modified:**
+- `dive_edit_page.dart` — `bulkDiveIds` constructor param, `isBulk` getter, hidden-field
+  logic, per-field gates, collection mode selectors, notes Set/Append, save → service.
+- `dive_list_content.dart` — `_anchorId`, shift-click range, "Select by date range"
+  action, replace `_showBulkEditSheet` with the "Bulk edit…" entry.
+- `dive_repository_impl.dart` — `bulkUpdateFields`, notes append, new collection bulk
+  methods.
+
+## Testing strategy (TDD, ≥80% per repo convention)
+
+- **Repository unit tests** (in-memory Drift): `bulkUpdateFields` writes only enabled
+  columns, bumps `updatedAt`, marks each dive pending, leaves child rows untouched;
+  notes-append SQL; tank/weight Add generates fresh ids + honors `onlyIfEmpty`; each
+  collection's Add/Remove/Replace; buddy role on Add; sighting per-dive rows.
+- **Service tests:** atomic multi-field apply; rollback on simulated failure; snapshot
+  captures per-dive priors; undo restores exactly; one `notifyLocalChange`.
+- **Widget tests:** bulk mode hides measured fields, shows gates; dive-mode cascade
+  reveal/collapse; collection mode selectors; confirm-dialog summary; contradiction block;
+  replace-tanks warning.
+- **Selection tests:** long-press enters + sets anchor; shift-click range; date-range
+  select; anchor updates on tap; select-all/deselect.
+- **Sync test:** a bulk edit marks the correct records pending; undo too.
+- **l10n:** new strings present and translated in all 11 locales; regenerated.
+
+## Open questions
+
+None blocking. Trip-level dive-center propagation is intentionally folded into
+date-range selection + bulk set rather than built as separate machinery.

--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -454,6 +454,131 @@ class BuddyRepository {
     SyncEventBus.notifyLocalChange();
   }
 
+  Future<void> _bumpDive(String diveId, int now) async {
+    await (_db.update(_db.dives)..where((t) => t.id.equals(diveId))).write(
+      DivesCompanion(updatedAt: Value(now)),
+    );
+    await _syncRepository.markRecordPending(
+      entityType: 'dives',
+      recordId: diveId,
+      localUpdatedAt: now,
+    );
+  }
+
+  /// Add each buddy (with role) to every dive. Upserts role if already linked.
+  /// No notify/transaction — BulkDiveEditService owns those.
+  Future<void> bulkAddBuddies(
+    List<String> diveIds,
+    List<domain.BuddyWithRole> buddies,
+  ) async {
+    if (diveIds.isEmpty || buddies.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final bwr in buddies) {
+        final existing =
+            await (_db.select(_db.diveBuddies)..where(
+                  (t) => t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id),
+                ))
+                .getSingleOrNull();
+        if (existing != null) {
+          await (_db.update(_db.diveBuddies)..where(
+                (t) => t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id),
+              ))
+              .write(DiveBuddiesCompanion(role: Value(bwr.role.name)));
+          await _syncRepository.markRecordPending(
+            entityType: 'diveBuddies',
+            recordId: existing.id,
+            localUpdatedAt: now,
+          );
+        } else {
+          final id = _uuid.v4();
+          await _db.into(_db.diveBuddies).insert(
+            DiveBuddiesCompanion(
+              id: Value(id),
+              diveId: Value(diveId),
+              buddyId: Value(bwr.buddy.id),
+              role: Value(bwr.role.name),
+              createdAt: Value(now),
+            ),
+          );
+          await _syncRepository.markRecordPending(
+            entityType: 'diveBuddies',
+            recordId: id,
+            localUpdatedAt: now,
+          );
+        }
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+
+  /// Remove each buddy id from every dive. No notify/transaction.
+  Future<void> bulkRemoveBuddies(
+    List<String> diveIds,
+    List<String> buddyIds,
+  ) async {
+    if (diveIds.isEmpty || buddyIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(_db.diveBuddies)..where(
+          (t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds),
+        ))
+        .get();
+    await (_db.delete(_db.diveBuddies)..where(
+          (t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds),
+        ))
+        .go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(
+        entityType: 'diveBuddies',
+        recordId: row.id,
+      );
+    }
+    for (final diveId in diveIds) {
+      await _bumpDive(diveId, now);
+    }
+  }
+
+  /// Replace each dive's buddy set with exactly [buddies]. No notify/transaction.
+  Future<void> bulkReplaceBuddies(
+    List<String> diveIds,
+    List<domain.BuddyWithRole> buddies,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing = await (_db.select(
+        _db.diveBuddies,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(
+        _db.diveBuddies,
+      )..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(
+          entityType: 'diveBuddies',
+          recordId: row.id,
+        );
+      }
+      for (final bwr in buddies) {
+        final id = _uuid.v4();
+        await _db.into(_db.diveBuddies).insert(
+          DiveBuddiesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            buddyId: Value(bwr.buddy.id),
+            role: Value(bwr.role.name),
+            createdAt: Value(now),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'diveBuddies',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+
   /// Get all buddies with their dive counts in a single efficient query
   Future<List<BuddyWithDiveCount>> getAllBuddiesWithDiveCount({
     String? diverId,

--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -477,7 +477,8 @@ class BuddyRepository {
       for (final bwr in buddies) {
         final existing =
             await (_db.select(_db.diveBuddies)..where(
-                  (t) => t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id),
+                  (t) =>
+                      t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id),
                 ))
                 .getSingleOrNull();
         if (existing != null) {
@@ -492,15 +493,17 @@ class BuddyRepository {
           );
         } else {
           final id = _uuid.v4();
-          await _db.into(_db.diveBuddies).insert(
-            DiveBuddiesCompanion(
-              id: Value(id),
-              diveId: Value(diveId),
-              buddyId: Value(bwr.buddy.id),
-              role: Value(bwr.role.name),
-              createdAt: Value(now),
-            ),
-          );
+          await _db
+              .into(_db.diveBuddies)
+              .insert(
+                DiveBuddiesCompanion(
+                  id: Value(id),
+                  diveId: Value(diveId),
+                  buddyId: Value(bwr.buddy.id),
+                  role: Value(bwr.role.name),
+                  createdAt: Value(now),
+                ),
+              );
           await _syncRepository.markRecordPending(
             entityType: 'diveBuddies',
             recordId: id,
@@ -519,14 +522,12 @@ class BuddyRepository {
   ) async {
     if (diveIds.isEmpty || buddyIds.isEmpty) return;
     final now = DateTime.now().millisecondsSinceEpoch;
-    final existing = await (_db.select(_db.diveBuddies)..where(
-          (t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds),
-        ))
-        .get();
-    await (_db.delete(_db.diveBuddies)..where(
-          (t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds),
-        ))
-        .go();
+    final existing = await (_db.select(
+      _db.diveBuddies,
+    )..where((t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds))).get();
+    await (_db.delete(
+      _db.diveBuddies,
+    )..where((t) => t.diveId.isIn(diveIds) & t.buddyId.isIn(buddyIds))).go();
     for (final row in existing) {
       await _syncRepository.logDeletion(
         entityType: 'diveBuddies',
@@ -560,15 +561,17 @@ class BuddyRepository {
       }
       for (final bwr in buddies) {
         final id = _uuid.v4();
-        await _db.into(_db.diveBuddies).insert(
-          DiveBuddiesCompanion(
-            id: Value(id),
-            diveId: Value(diveId),
-            buddyId: Value(bwr.buddy.id),
-            role: Value(bwr.role.name),
-            createdAt: Value(now),
-          ),
-        );
+        await _db
+            .into(_db.diveBuddies)
+            .insert(
+              DiveBuddiesCompanion(
+                id: Value(id),
+                diveId: Value(diveId),
+                buddyId: Value(bwr.buddy.id),
+                role: Value(bwr.role.name),
+                createdAt: Value(now),
+              ),
+            );
         await _syncRepository.markRecordPending(
           entityType: 'diveBuddies',
           recordId: id,

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3673,7 +3673,10 @@ class DiveRepository {
   }
 
   /// Replace each dive's tag membership with exactly [tagIds]. No notify/txn.
-  Future<void> bulkReplaceTags(List<String> diveIds, List<String> tagIds) async {
+  Future<void> bulkReplaceTags(
+    List<String> diveIds,
+    List<String> tagIds,
+  ) async {
     if (diveIds.isEmpty) return;
     final now = DateTime.now().millisecondsSinceEpoch;
     final existing = await (_db.select(
@@ -3689,14 +3692,16 @@ class DiveRepository {
     for (final diveId in diveIds) {
       for (final tagId in tagIds) {
         final id = _uuid.v4();
-        await _db.into(_db.diveTags).insert(
-          DiveTagsCompanion(
-            id: Value(id),
-            diveId: Value(diveId),
-            tagId: Value(tagId),
-            createdAt: Value(now),
-          ),
-        );
+        await _db
+            .into(_db.diveTags)
+            .insert(
+              DiveTagsCompanion(
+                id: Value(id),
+                diveId: Value(diveId),
+                tagId: Value(tagId),
+                createdAt: Value(now),
+              ),
+            );
         await _syncRepository.markRecordPending(
           entityType: 'diveTags',
           recordId: id,
@@ -3739,12 +3744,14 @@ class DiveRepository {
     final now = DateTime.now().millisecondsSinceEpoch;
     for (final diveId in diveIds) {
       for (final equipmentId in equipmentIds) {
-        await _db.into(_db.diveEquipment).insertOnConflictUpdate(
-          DiveEquipmentCompanion(
-            diveId: Value(diveId),
-            equipmentId: Value(equipmentId),
-          ),
-        );
+        await _db
+            .into(_db.diveEquipment)
+            .insertOnConflictUpdate(
+              DiveEquipmentCompanion(
+                diveId: Value(diveId),
+                equipmentId: Value(equipmentId),
+              ),
+            );
         await _syncRepository.markRecordPending(
           entityType: 'diveEquipment',
           recordId: '$diveId|$equipmentId',
@@ -3762,10 +3769,11 @@ class DiveRepository {
   ) async {
     if (diveIds.isEmpty || equipmentIds.isEmpty) return;
     final now = DateTime.now().millisecondsSinceEpoch;
-    final existing = await (_db.select(_db.diveEquipment)..where(
-          (t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds),
-        ))
-        .get();
+    final existing =
+        await (_db.select(_db.diveEquipment)..where(
+              (t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds),
+            ))
+            .get();
     await (_db.delete(_db.diveEquipment)..where(
           (t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds),
         ))
@@ -3800,12 +3808,14 @@ class DiveRepository {
     }
     for (final diveId in diveIds) {
       for (final equipmentId in equipmentIds) {
-        await _db.into(_db.diveEquipment).insertOnConflictUpdate(
-          DiveEquipmentCompanion(
-            diveId: Value(diveId),
-            equipmentId: Value(equipmentId),
-          ),
-        );
+        await _db
+            .into(_db.diveEquipment)
+            .insertOnConflictUpdate(
+              DiveEquipmentCompanion(
+                diveId: Value(diveId),
+                equipmentId: Value(equipmentId),
+              ),
+            );
         await _syncRepository.markRecordPending(
           entityType: 'diveEquipment',
           recordId: '$diveId|$equipmentId',

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3816,6 +3816,92 @@ class DiveRepository {
     await _bumpDives(diveIds, now);
   }
 
+  DiveTanksCompanion _tankCompanion(
+    String id,
+    String diveId,
+    domain.DiveTank t,
+    int order,
+  ) => DiveTanksCompanion(
+    id: Value(id),
+    diveId: Value(diveId),
+    volume: Value(t.volume),
+    workingPressure: Value(t.workingPressure),
+    startPressure: Value(t.startPressure),
+    endPressure: Value(t.endPressure),
+    o2Percent: Value(t.gasMix.o2),
+    hePercent: Value(t.gasMix.he),
+    tankOrder: Value(order),
+    tankRole: Value(t.role.name),
+    tankMaterial: Value(t.material?.name),
+    tankName: Value(t.name),
+    presetName: Value(t.presetName),
+  );
+
+  /// Append one tank to each dive (fresh id, order = current tank count).
+  /// When [onlyIfEmpty], skips dives that already have any tank. No notify/txn.
+  Future<void> bulkAddTank(
+    List<String> diveIds,
+    domain.DiveTank tank, {
+    bool onlyIfEmpty = false,
+  }) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final changed = <String>[];
+    for (final diveId in diveIds) {
+      final existing = await (_db.select(
+        _db.diveTanks,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      if (onlyIfEmpty && existing.isNotEmpty) continue;
+      final tankId = _uuid.v4();
+      await _db
+          .into(_db.diveTanks)
+          .insert(_tankCompanion(tankId, diveId, tank, existing.length));
+      await _syncRepository.markRecordPending(
+        entityType: 'diveTanks',
+        recordId: tankId,
+        localUpdatedAt: now,
+      );
+      changed.add(diveId);
+    }
+    if (changed.isNotEmpty) await _bumpDives(changed, now);
+  }
+
+  /// Replace each dive's tank list with [tanks] (fresh ids, sequential order).
+  /// No notify/txn. Cascades to delete tank_pressure_profiles/gas_switches.
+  Future<void> bulkReplaceTanks(
+    List<String> diveIds,
+    List<domain.DiveTank> tanks,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing = await (_db.select(
+        _db.diveTanks,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(
+        _db.diveTanks,
+      )..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(
+          entityType: 'diveTanks',
+          recordId: row.id,
+        );
+      }
+      for (var i = 0; i < tanks.length; i++) {
+        final tankId = _uuid.v4();
+        await _db
+            .into(_db.diveTanks)
+            .insert(_tankCompanion(tankId, diveId, tanks[i], i));
+        await _syncRepository.markRecordPending(
+          entityType: 'diveTanks',
+          recordId: tankId,
+          localUpdatedAt: now,
+        );
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
   /// Bulk update trip for multiple dives
   Future<void> bulkUpdateTrip(List<String> diveIds, String? tripId) async {
     if (diveIds.isEmpty) return;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3716,6 +3716,106 @@ class DiveRepository {
     }
   }
 
+  /// Bump updatedAt + mark pending for a set of dives (shared by bulk ops).
+  Future<void> _bumpDives(List<String> diveIds, int now) async {
+    await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds))).write(
+      DivesCompanion(updatedAt: Value(now)),
+    );
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+
+  /// Add each equipment id to each dive (junction upsert). No notify/txn.
+  Future<void> bulkAddEquipment(
+    List<String> diveIds,
+    List<String> equipmentIds,
+  ) async {
+    if (diveIds.isEmpty || equipmentIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final equipmentId in equipmentIds) {
+        await _db.into(_db.diveEquipment).insertOnConflictUpdate(
+          DiveEquipmentCompanion(
+            diveId: Value(diveId),
+            equipmentId: Value(equipmentId),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'diveEquipment',
+          recordId: '$diveId|$equipmentId',
+          localUpdatedAt: now,
+        );
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
+  /// Remove each equipment id from each dive. No notify/txn.
+  Future<void> bulkRemoveEquipment(
+    List<String> diveIds,
+    List<String> equipmentIds,
+  ) async {
+    if (diveIds.isEmpty || equipmentIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(_db.diveEquipment)..where(
+          (t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds),
+        ))
+        .get();
+    await (_db.delete(_db.diveEquipment)..where(
+          (t) => t.diveId.isIn(diveIds) & t.equipmentId.isIn(equipmentIds),
+        ))
+        .go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(
+        entityType: 'diveEquipment',
+        recordId: '${row.diveId}|${row.equipmentId}',
+      );
+    }
+    await _bumpDives(diveIds, now);
+  }
+
+  /// Replace each dive's equipment with exactly [equipmentIds]. No notify/txn.
+  Future<void> bulkReplaceEquipment(
+    List<String> diveIds,
+    List<String> equipmentIds,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(
+      _db.diveEquipment,
+    )..where((t) => t.diveId.isIn(diveIds))).get();
+    await (_db.delete(
+      _db.diveEquipment,
+    )..where((t) => t.diveId.isIn(diveIds))).go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(
+        entityType: 'diveEquipment',
+        recordId: '${row.diveId}|${row.equipmentId}',
+      );
+    }
+    for (final diveId in diveIds) {
+      for (final equipmentId in equipmentIds) {
+        await _db.into(_db.diveEquipment).insertOnConflictUpdate(
+          DiveEquipmentCompanion(
+            diveId: Value(diveId),
+            equipmentId: Value(equipmentId),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'diveEquipment',
+          recordId: '$diveId|$equipmentId',
+          localUpdatedAt: now,
+        );
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
   /// Bulk update trip for multiple dives
   Future<void> bulkUpdateTrip(List<String> diveIds, String? tripId) async {
     if (diveIds.isEmpty) return;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3644,6 +3644,34 @@ class DiveRepository {
     }
   }
 
+  /// Append [textToAppend] to the notes of every dive in [diveIds].
+  /// Empty existing notes receive just the text. No transaction/notify.
+  Future<void> bulkAppendNotes(
+    List<String> diveIds,
+    String textToAppend,
+  ) async {
+    if (diveIds.isEmpty || textToAppend.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final placeholders = List.filled(diveIds.length, '?').join(', ');
+    await _db.customUpdate(
+      "UPDATE dives SET notes = COALESCE(notes, '') || ?, updated_at = ? "
+      'WHERE id IN ($placeholders)',
+      variables: [
+        Variable.withString(textToAppend),
+        Variable.withInt(now),
+        ...diveIds.map(Variable.withString),
+      ],
+      updates: {_db.dives},
+    );
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+
   /// Bulk update trip for multiple dives
   Future<void> bulkUpdateTrip(List<String> diveIds, String? tripId) async {
     if (diveIds.isEmpty) return;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3902,6 +3902,78 @@ class DiveRepository {
     await _bumpDives(diveIds, now);
   }
 
+  DiveWeightsCompanion _weightCompanion(
+    String id,
+    String diveId,
+    domain.DiveWeight w,
+    int now,
+  ) => DiveWeightsCompanion(
+    id: Value(id),
+    diveId: Value(diveId),
+    weightType: Value(w.weightType.name),
+    amountKg: Value(w.amountKg),
+    notes: Value(w.notes),
+    createdAt: Value(now),
+  );
+
+  /// Append each weight to every dive (fresh id per dive). No notify/txn.
+  Future<void> bulkAddWeights(
+    List<String> diveIds,
+    List<domain.DiveWeight> weights,
+  ) async {
+    if (diveIds.isEmpty || weights.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final w in weights) {
+        final id = _uuid.v4();
+        await _db
+            .into(_db.diveWeights)
+            .insert(_weightCompanion(id, diveId, w, now));
+        await _syncRepository.markRecordPending(
+          entityType: 'diveWeights',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
+  /// Replace each dive's weight list with [weights]. No notify/txn.
+  Future<void> bulkReplaceWeights(
+    List<String> diveIds,
+    List<domain.DiveWeight> weights,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing = await (_db.select(
+        _db.diveWeights,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(
+        _db.diveWeights,
+      )..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(
+          entityType: 'diveWeights',
+          recordId: row.id,
+        );
+      }
+      for (final w in weights) {
+        final id = _uuid.v4();
+        await _db
+            .into(_db.diveWeights)
+            .insert(_weightCompanion(id, diveId, w, now));
+        await _syncRepository.markRecordPending(
+          entityType: 'diveWeights',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+    }
+    await _bumpDives(diveIds, now);
+  }
+
   /// Bulk update trip for multiple dives
   Future<void> bulkUpdateTrip(List<String> diveIds, String? tripId) async {
     if (diveIds.isEmpty) return;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3622,6 +3622,28 @@ class DiveRepository {
   // Bulk Operations
   // ============================================================================
 
+  /// Bulk-set the columns present in [partial] on every dive in [diveIds].
+  /// Absent columns are left untouched (Drift writes only present columns).
+  /// Forces `updatedAt = now` and marks each dive pending. Does NOT open a
+  /// transaction or notify sync — BulkDiveEditService owns those.
+  Future<void> bulkUpdateFields(
+    List<String> diveIds,
+    DivesCompanion partial,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds))).write(
+      partial.copyWith(updatedAt: Value(now)),
+    );
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+
   /// Bulk update trip for multiple dives
   Future<void> bulkUpdateTrip(List<String> diveIds, String? tripId) async {
     if (diveIds.isEmpty) return;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3630,7 +3630,9 @@ class DiveRepository {
     List<String> diveIds,
     DivesCompanion partial,
   ) async {
-    if (diveIds.isEmpty) return;
+    // No-op when there's nothing to write; an all-absent companion must not
+    // produce a sync-visible "touch" (updatedAt bump + pending mark).
+    if (diveIds.isEmpty || partial.toColumns(false).isEmpty) return;
     final now = DateTime.now().millisecondsSinceEpoch;
     await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds))).write(
       partial.copyWith(updatedAt: Value(now)),
@@ -3847,34 +3849,48 @@ class DiveRepository {
     presetName: Value(t.presetName),
   );
 
-  /// Append one tank to each dive (fresh id, order = current tank count).
-  /// When [onlyIfEmpty], skips dives that already have any tank. No notify/txn.
-  Future<void> bulkAddTank(
+  /// Append [tanks] to each dive (fresh ids, appended after existing tanks).
+  /// When [onlyIfEmpty], a dive that already has any tank is skipped entirely.
+  /// No notify/txn.
+  Future<void> bulkAddTanks(
     List<String> diveIds,
-    domain.DiveTank tank, {
+    List<domain.DiveTank> tanks, {
     bool onlyIfEmpty = false,
   }) async {
-    if (diveIds.isEmpty) return;
+    if (diveIds.isEmpty || tanks.isEmpty) return;
     final now = DateTime.now().millisecondsSinceEpoch;
     final changed = <String>[];
     for (final diveId in diveIds) {
       final existing = await (_db.select(
         _db.diveTanks,
       )..where((t) => t.diveId.equals(diveId))).get();
+      // Evaluate emptiness once per dive (before any insert), so a multi-tank
+      // add with onlyIfEmpty adds the whole list rather than just the first.
       if (onlyIfEmpty && existing.isNotEmpty) continue;
-      final tankId = _uuid.v4();
-      await _db
-          .into(_db.diveTanks)
-          .insert(_tankCompanion(tankId, diveId, tank, existing.length));
-      await _syncRepository.markRecordPending(
-        entityType: 'diveTanks',
-        recordId: tankId,
-        localUpdatedAt: now,
-      );
+      var order = existing.length;
+      for (final tank in tanks) {
+        final tankId = _uuid.v4();
+        await _db
+            .into(_db.diveTanks)
+            .insert(_tankCompanion(tankId, diveId, tank, order));
+        order++;
+        await _syncRepository.markRecordPending(
+          entityType: 'diveTanks',
+          recordId: tankId,
+          localUpdatedAt: now,
+        );
+      }
       changed.add(diveId);
     }
     if (changed.isNotEmpty) await _bumpDives(changed, now);
   }
+
+  /// Append a single tank to each dive. Convenience wrapper over [bulkAddTanks].
+  Future<void> bulkAddTank(
+    List<String> diveIds,
+    domain.DiveTank tank, {
+    bool onlyIfEmpty = false,
+  }) => bulkAddTanks(diveIds, [tank], onlyIfEmpty: onlyIfEmpty);
 
   /// Replace each dive's tank list with [tanks] (fresh ids, sequential order).
   /// No notify/txn. Cascades to delete tank_pressure_profiles/gas_switches.

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3672,6 +3672,50 @@ class DiveRepository {
     }
   }
 
+  /// Replace each dive's tag membership with exactly [tagIds]. No notify/txn.
+  Future<void> bulkReplaceTags(List<String> diveIds, List<String> tagIds) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final existing = await (_db.select(
+      _db.diveTags,
+    )..where((t) => t.diveId.isIn(diveIds))).get();
+    await (_db.delete(_db.diveTags)..where((t) => t.diveId.isIn(diveIds))).go();
+    for (final row in existing) {
+      await _syncRepository.logDeletion(
+        entityType: 'diveTags',
+        recordId: row.id,
+      );
+    }
+    for (final diveId in diveIds) {
+      for (final tagId in tagIds) {
+        final id = _uuid.v4();
+        await _db.into(_db.diveTags).insert(
+          DiveTagsCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            tagId: Value(tagId),
+            createdAt: Value(now),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'diveTags',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+    }
+    await (_db.update(_db.dives)..where((t) => t.id.isIn(diveIds))).write(
+      DivesCompanion(updatedAt: Value(now)),
+    );
+    for (final diveId in diveIds) {
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+
   /// Bulk update trip for multiple dives
   Future<void> bulkUpdateTrip(List<String> diveIds, String? tripId) async {
     if (diveIds.isEmpty) return;

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -1,0 +1,172 @@
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_snapshot.dart';
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+
+/// Orchestrates a bulk edit across repositories in a single transaction.
+///
+/// `DiveTank`, `DiveWeight`, `Sighting` referenced here are the Drift row
+/// classes (from database.dart); `BuddyWithRole` is the domain type.
+class BulkDiveEditService {
+  BulkDiveEditService(this._diveRepo, this._buddyRepo, this._speciesRepo);
+
+  final DiveRepository _diveRepo;
+  final BuddyRepository _buddyRepo;
+  final SpeciesRepository _speciesRepo;
+
+  AppDatabase get _db => DatabaseService.instance.database;
+
+  /// Apply [req] to every dive in [req.diveIds] inside one transaction,
+  /// capturing the prior state first. Fires a single local-change notification.
+  Future<BulkEditSnapshot> apply(BulkEditRequest req) async {
+    final ids = req.diveIds;
+    if (ids.isEmpty) {
+      return const BulkEditSnapshot(priorDiveRows: []);
+    }
+
+    // Capture prior state before mutating (reads outside the transaction).
+    final priorDiveRows = await (_db.select(
+      _db.dives,
+    )..where((t) => t.id.isIn(ids))).get();
+
+    Map<String, List<String>>? priorTagIds;
+    Map<String, List<String>>? priorEquipmentIds;
+    Map<String, List<BuddyWithRole>>? priorBuddies;
+    Map<String, List<DiveTank>>? priorTanks;
+    Map<String, List<DiveWeight>>? priorWeights;
+    Map<String, List<Sighting>>? priorSightings;
+
+    for (final op in req.ops) {
+      switch (op) {
+        case TagsOp():
+          final rows = await (_db.select(
+            _db.diveTags,
+          )..where((t) => t.diveId.isIn(ids))).get();
+          priorTagIds = {for (final id in ids) id: <String>[]};
+          for (final r in rows) {
+            priorTagIds[r.diveId]!.add(r.tagId);
+          }
+        case EquipmentOp():
+          final rows = await (_db.select(
+            _db.diveEquipment,
+          )..where((t) => t.diveId.isIn(ids))).get();
+          priorEquipmentIds = {for (final id in ids) id: <String>[]};
+          for (final r in rows) {
+            priorEquipmentIds[r.diveId]!.add(r.equipmentId);
+          }
+        case BuddiesOp():
+          priorBuddies = {
+            for (final id in ids) id: await _buddyRepo.getBuddiesForDive(id),
+          };
+        case TanksOp():
+          final rows = await (_db.select(
+            _db.diveTanks,
+          )..where((t) => t.diveId.isIn(ids))).get();
+          priorTanks = {for (final id in ids) id: <DiveTank>[]};
+          for (final r in rows) {
+            priorTanks[r.diveId]!.add(r);
+          }
+        case WeightsOp():
+          final rows = await (_db.select(
+            _db.diveWeights,
+          )..where((t) => t.diveId.isIn(ids))).get();
+          priorWeights = {for (final id in ids) id: <DiveWeight>[]};
+          for (final r in rows) {
+            priorWeights[r.diveId]!.add(r);
+          }
+        case SightingsOp():
+          final rows = await (_db.select(
+            _db.sightings,
+          )..where((t) => t.diveId.isIn(ids))).get();
+          priorSightings = {for (final id in ids) id: <Sighting>[]};
+          for (final r in rows) {
+            priorSightings[r.diveId]!.add(r);
+          }
+      }
+    }
+
+    await _db.transaction(() async {
+      if (req.hasScalarChanges) {
+        await _diveRepo.bulkUpdateFields(ids, req.scalars);
+      }
+      if (req.notesAppend != null && req.notesAppend!.isNotEmpty) {
+        await _diveRepo.bulkAppendNotes(ids, req.notesAppend!);
+      }
+      for (final op in req.ops) {
+        await _applyOp(ids, op);
+      }
+    });
+
+    SyncEventBus.notifyLocalChange();
+
+    return BulkEditSnapshot(
+      priorDiveRows: priorDiveRows,
+      priorTagIds: priorTagIds,
+      priorEquipmentIds: priorEquipmentIds,
+      priorBuddies: priorBuddies,
+      priorTanks: priorTanks,
+      priorWeights: priorWeights,
+      priorSightings: priorSightings,
+    );
+  }
+
+  Future<void> _applyOp(List<String> ids, BulkCollectionOp op) async {
+    switch (op) {
+      case TagsOp(:final mode, :final tagIds):
+        switch (mode) {
+          case BulkCollectionMode.add:
+            await _diveRepo.bulkAddTags(ids, tagIds);
+          case BulkCollectionMode.remove:
+            await _diveRepo.bulkRemoveTags(ids, tagIds);
+          case BulkCollectionMode.replace:
+            await _diveRepo.bulkReplaceTags(ids, tagIds);
+        }
+      case EquipmentOp(:final mode, :final equipmentIds):
+        switch (mode) {
+          case BulkCollectionMode.add:
+            await _diveRepo.bulkAddEquipment(ids, equipmentIds);
+          case BulkCollectionMode.remove:
+            await _diveRepo.bulkRemoveEquipment(ids, equipmentIds);
+          case BulkCollectionMode.replace:
+            await _diveRepo.bulkReplaceEquipment(ids, equipmentIds);
+        }
+      case BuddiesOp(:final mode, :final buddies):
+        switch (mode) {
+          case BulkCollectionMode.add:
+            await _buddyRepo.bulkAddBuddies(ids, buddies);
+          case BulkCollectionMode.remove:
+            await _buddyRepo.bulkRemoveBuddies(
+              ids,
+              buddies.map((b) => b.buddy.id).toList(),
+            );
+          case BulkCollectionMode.replace:
+            await _buddyRepo.bulkReplaceBuddies(ids, buddies);
+        }
+      case TanksOp(:final mode, :final tanks, :final onlyIfEmpty):
+        if (mode == BulkCollectionMode.replace) {
+          await _diveRepo.bulkReplaceTanks(ids, tanks);
+        } else {
+          for (final tank in tanks) {
+            await _diveRepo.bulkAddTank(ids, tank, onlyIfEmpty: onlyIfEmpty);
+          }
+        }
+      case WeightsOp(:final mode, :final weights):
+        if (mode == BulkCollectionMode.replace) {
+          await _diveRepo.bulkReplaceWeights(ids, weights);
+        } else {
+          await _diveRepo.bulkAddWeights(ids, weights);
+        }
+      case SightingsOp(:final mode, :final sightings):
+        if (mode == BulkCollectionMode.replace) {
+          await _speciesRepo.bulkReplaceSightings(ids, sightings);
+        } else {
+          await _speciesRepo.bulkAddSightings(ids, sightings);
+        }
+    }
+  }
+}

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -232,9 +232,7 @@ class BulkDiveEditService {
           case BulkCollectionMode.replace:
             await _diveRepo.bulkReplaceTanks(ids, tanks);
           case BulkCollectionMode.add:
-            for (final tank in tanks) {
-              await _diveRepo.bulkAddTank(ids, tank, onlyIfEmpty: onlyIfEmpty);
-            }
+            await _diveRepo.bulkAddTanks(ids, tanks, onlyIfEmpty: onlyIfEmpty);
           case BulkCollectionMode.remove:
             throw UnsupportedError(
               'Tanks support only add/replace, not remove',

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -1,3 +1,6 @@
+import 'package:drift/drift.dart';
+import 'package:submersion/core/constants/enums.dart' as en;
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
@@ -6,18 +9,25 @@ import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
 import 'package:submersion/features/dive_log/domain/entities/bulk_edit_snapshot.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart' as de;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
+    as dw;
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart'
+    as se;
 
 /// Orchestrates a bulk edit across repositories in a single transaction.
 ///
-/// `DiveTank`, `DiveWeight`, `Sighting` referenced here are the Drift row
-/// classes (from database.dart); `BuddyWithRole` is the domain type.
+/// `DiveTank`, `DiveWeight`, `Sighting` referenced unprefixed here are the Drift
+/// row classes (from database.dart); the `de`/`dw`/`en`/`se` prefixes are the
+/// domain entities/enums.
 class BulkDiveEditService {
   BulkDiveEditService(this._diveRepo, this._buddyRepo, this._speciesRepo);
 
   final DiveRepository _diveRepo;
   final BuddyRepository _buddyRepo;
   final SpeciesRepository _speciesRepo;
+  final _sync = SyncRepository();
 
   AppDatabase get _db => DatabaseService.instance.database;
 
@@ -115,6 +125,77 @@ class BulkDiveEditService {
     );
   }
 
+  /// Reverse a prior [apply]: restore each dive's prior scalar columns and the
+  /// prior membership of every touched collection. One transaction, one notify.
+  Future<void> undo(BulkEditSnapshot snapshot) async {
+    if (snapshot.priorDiveRows.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final ids = snapshot.priorDiveRows.map((r) => r.id).toList();
+
+    await _db.transaction(() async {
+      // Restore scalar columns from the full prior row (nullToAbsent: false so
+      // prior NULLs are restored), with a fresh updatedAt so the undo wins LWW.
+      for (final row in snapshot.priorDiveRows) {
+        await (_db.update(_db.dives)..where((t) => t.id.equals(row.id))).write(
+          row.toCompanion(false).copyWith(updatedAt: Value(now)),
+        );
+        await _sync.markRecordPending(
+          entityType: 'dives',
+          recordId: row.id,
+          localUpdatedAt: now,
+        );
+      }
+
+      final tags = snapshot.priorTagIds;
+      if (tags != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceTags([id], tags[id] ?? const []);
+        }
+      }
+      final equip = snapshot.priorEquipmentIds;
+      if (equip != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceEquipment([id], equip[id] ?? const []);
+        }
+      }
+      final buddies = snapshot.priorBuddies;
+      if (buddies != null) {
+        for (final id in ids) {
+          await _buddyRepo.bulkReplaceBuddies([id], buddies[id] ?? const []);
+        }
+      }
+      final tanks = snapshot.priorTanks;
+      if (tanks != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceTanks(
+            [id],
+            _tanksFromRows(tanks[id] ?? const []),
+          );
+        }
+      }
+      final weights = snapshot.priorWeights;
+      if (weights != null) {
+        for (final id in ids) {
+          await _diveRepo.bulkReplaceWeights(
+            [id],
+            _weightsFromRows(weights[id] ?? const []),
+          );
+        }
+      }
+      final sightings = snapshot.priorSightings;
+      if (sightings != null) {
+        for (final id in ids) {
+          await _speciesRepo.bulkReplaceSightings(
+            [id],
+            _sightingsFromRows(sightings[id] ?? const []),
+          );
+        }
+      }
+    });
+
+    SyncEventBus.notifyLocalChange();
+  }
+
   Future<void> _applyOp(List<String> ids, BulkCollectionOp op) async {
     switch (op) {
       case TagsOp(:final mode, :final tagIds):
@@ -169,4 +250,55 @@ class BulkDiveEditService {
         }
     }
   }
+
+  // Map Drift rows back to the domain objects the bulk-replace methods consume.
+  List<de.DiveTank> _tanksFromRows(List<DiveTank> rows) => [
+    for (final r in rows)
+      de.DiveTank(
+        id: '',
+        name: r.tankName,
+        volume: r.volume,
+        workingPressure: r.workingPressure,
+        startPressure: r.startPressure,
+        endPressure: r.endPressure,
+        gasMix: de.GasMix(o2: r.o2Percent, he: r.hePercent),
+        role: en.TankRole.values.firstWhere(
+          (e) => e.name == r.tankRole,
+          orElse: () => en.TankRole.backGas,
+        ),
+        material: r.tankMaterial == null
+            ? null
+            : en.TankMaterial.values.firstWhere(
+                (e) => e.name == r.tankMaterial,
+                orElse: () => en.TankMaterial.aluminum,
+              ),
+        presetName: r.presetName,
+      ),
+  ];
+
+  List<dw.DiveWeight> _weightsFromRows(List<DiveWeight> rows) => [
+    for (final r in rows)
+      dw.DiveWeight(
+        id: '',
+        diveId: '',
+        weightType: en.WeightType.values.firstWhere(
+          (e) => e.name == r.weightType,
+          orElse: () => en.WeightType.values.first,
+        ),
+        amountKg: r.amountKg,
+        notes: r.notes,
+      ),
+  ];
+
+  List<se.Sighting> _sightingsFromRows(List<Sighting> rows) => [
+    for (final r in rows)
+      se.Sighting(
+        id: '',
+        diveId: '',
+        speciesId: r.speciesId,
+        speciesName: '',
+        count: r.count,
+        notes: r.notes,
+      ),
+  ];
 }

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -167,28 +167,25 @@ class BulkDiveEditService {
       final tanks = snapshot.priorTanks;
       if (tanks != null) {
         for (final id in ids) {
-          await _diveRepo.bulkReplaceTanks(
-            [id],
-            _tanksFromRows(tanks[id] ?? const []),
-          );
+          await _diveRepo.bulkReplaceTanks([
+            id,
+          ], _tanksFromRows(tanks[id] ?? const []));
         }
       }
       final weights = snapshot.priorWeights;
       if (weights != null) {
         for (final id in ids) {
-          await _diveRepo.bulkReplaceWeights(
-            [id],
-            _weightsFromRows(weights[id] ?? const []),
-          );
+          await _diveRepo.bulkReplaceWeights([
+            id,
+          ], _weightsFromRows(weights[id] ?? const []));
         }
       }
       final sightings = snapshot.priorSightings;
       if (sightings != null) {
         for (final id in ids) {
-          await _speciesRepo.bulkReplaceSightings(
-            [id],
-            _sightingsFromRows(sightings[id] ?? const []),
-          );
+          await _speciesRepo.bulkReplaceSightings([
+            id,
+          ], _sightingsFromRows(sightings[id] ?? const []));
         }
       }
     });

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -225,25 +225,42 @@ class BulkDiveEditService {
           case BulkCollectionMode.replace:
             await _buddyRepo.bulkReplaceBuddies(ids, buddies);
         }
+      // Owned collections support only add/replace; reject remove explicitly
+      // so a misconstructed op fails fast instead of silently doing an add.
       case TanksOp(:final mode, :final tanks, :final onlyIfEmpty):
-        if (mode == BulkCollectionMode.replace) {
-          await _diveRepo.bulkReplaceTanks(ids, tanks);
-        } else {
-          for (final tank in tanks) {
-            await _diveRepo.bulkAddTank(ids, tank, onlyIfEmpty: onlyIfEmpty);
-          }
+        switch (mode) {
+          case BulkCollectionMode.replace:
+            await _diveRepo.bulkReplaceTanks(ids, tanks);
+          case BulkCollectionMode.add:
+            for (final tank in tanks) {
+              await _diveRepo.bulkAddTank(ids, tank, onlyIfEmpty: onlyIfEmpty);
+            }
+          case BulkCollectionMode.remove:
+            throw UnsupportedError(
+              'Tanks support only add/replace, not remove',
+            );
         }
       case WeightsOp(:final mode, :final weights):
-        if (mode == BulkCollectionMode.replace) {
-          await _diveRepo.bulkReplaceWeights(ids, weights);
-        } else {
-          await _diveRepo.bulkAddWeights(ids, weights);
+        switch (mode) {
+          case BulkCollectionMode.replace:
+            await _diveRepo.bulkReplaceWeights(ids, weights);
+          case BulkCollectionMode.add:
+            await _diveRepo.bulkAddWeights(ids, weights);
+          case BulkCollectionMode.remove:
+            throw UnsupportedError(
+              'Weights support only add/replace, not remove',
+            );
         }
       case SightingsOp(:final mode, :final sightings):
-        if (mode == BulkCollectionMode.replace) {
-          await _speciesRepo.bulkReplaceSightings(ids, sightings);
-        } else {
-          await _speciesRepo.bulkAddSightings(ids, sightings);
+        switch (mode) {
+          case BulkCollectionMode.replace:
+            await _speciesRepo.bulkReplaceSightings(ids, sightings);
+          case BulkCollectionMode.add:
+            await _speciesRepo.bulkAddSightings(ids, sightings);
+          case BulkCollectionMode.remove:
+            throw UnsupportedError(
+              'Sightings support only add/replace, not remove',
+            );
         }
     }
   }

--- a/lib/features/dive_log/domain/entities/bulk_edit_request.dart
+++ b/lib/features/dive_log/domain/entities/bulk_edit_request.dart
@@ -1,0 +1,79 @@
+import 'package:submersion/core/database/database.dart' show DivesCompanion;
+import 'package:submersion/features/buddies/domain/entities/buddy.dart'
+    show BuddyWithRole;
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    show DiveTank;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
+    show DiveWeight;
+import 'package:submersion/features/marine_life/domain/entities/species.dart'
+    show Sighting;
+
+/// How a collection edit is applied across the selected dives.
+enum BulkCollectionMode { add, remove, replace }
+
+/// One collection mutation in a bulk edit. Sealed so the service can switch
+/// over every variant exhaustively.
+sealed class BulkCollectionOp {
+  const BulkCollectionOp();
+}
+
+class TagsOp extends BulkCollectionOp {
+  final BulkCollectionMode mode;
+  final List<String> tagIds;
+  const TagsOp({required this.mode, required this.tagIds});
+}
+
+class EquipmentOp extends BulkCollectionOp {
+  final BulkCollectionMode mode;
+  final List<String> equipmentIds;
+  const EquipmentOp({required this.mode, required this.equipmentIds});
+}
+
+class BuddiesOp extends BulkCollectionOp {
+  final BulkCollectionMode mode;
+  // For remove, the buddy ids are read from each entry's .buddy.id.
+  final List<BuddyWithRole> buddies;
+  const BuddiesOp({required this.mode, required this.buddies});
+}
+
+class TanksOp extends BulkCollectionOp {
+  final BulkCollectionMode mode; // add | replace
+  final List<DiveTank> tanks;
+  final bool onlyIfEmpty;
+  const TanksOp({
+    required this.mode,
+    required this.tanks,
+    this.onlyIfEmpty = false,
+  });
+}
+
+class WeightsOp extends BulkCollectionOp {
+  final BulkCollectionMode mode; // add | replace
+  final List<DiveWeight> weights;
+  const WeightsOp({required this.mode, required this.weights});
+}
+
+class SightingsOp extends BulkCollectionOp {
+  final BulkCollectionMode mode; // add | replace
+  final List<Sighting> sightings;
+  const SightingsOp({required this.mode, required this.sightings});
+}
+
+/// A single bulk edit: a partial scalar companion (only enabled columns are
+/// present), an optional notes-append, and zero or more collection ops.
+class BulkEditRequest {
+  final List<String> diveIds;
+  final DivesCompanion scalars;
+  final String? notesAppend;
+  final List<BulkCollectionOp> ops;
+
+  const BulkEditRequest({
+    required this.diveIds,
+    this.scalars = const DivesCompanion(),
+    this.notesAppend,
+    this.ops = const [],
+  });
+
+  /// True when at least one column of [scalars] is present (non-absent).
+  bool get hasScalarChanges => scalars.toColumns(false).isNotEmpty;
+}

--- a/lib/features/dive_log/domain/entities/bulk_edit_snapshot.dart
+++ b/lib/features/dive_log/domain/entities/bulk_edit_snapshot.dart
@@ -1,0 +1,29 @@
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart'
+    show BuddyWithRole;
+
+/// Captured prior state for undoing one bulk edit. All collections are keyed by
+/// diveId. A null map means that collection was not touched and must not be
+/// restored.
+///
+/// Note: `Dive`, `DiveTank`, `DiveWeight`, `Sighting` here are the Drift row
+/// classes (from database.dart), not the identically-named domain entities.
+class BulkEditSnapshot {
+  final List<Dive> priorDiveRows; // scalar + notes undo via row.toCompanion
+  final Map<String, List<String>>? priorTagIds;
+  final Map<String, List<String>>? priorEquipmentIds;
+  final Map<String, List<BuddyWithRole>>? priorBuddies;
+  final Map<String, List<DiveTank>>? priorTanks; // Drift DiveTanks rows
+  final Map<String, List<DiveWeight>>? priorWeights; // Drift DiveWeights rows
+  final Map<String, List<Sighting>>? priorSightings; // Drift Sightings rows
+
+  const BulkEditSnapshot({
+    required this.priorDiveRows,
+    this.priorTagIds,
+    this.priorEquipmentIds,
+    this.priorBuddies,
+    this.priorTanks,
+    this.priorWeights,
+    this.priorSightings,
+  });
+}

--- a/lib/features/dive_log/presentation/providers/bulk_dive_edit_provider.dart
+++ b/lib/features/dive_log/presentation/providers/bulk_dive_edit_provider.dart
@@ -1,0 +1,14 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_log/data/services/bulk_dive_edit_service.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
+
+/// Service that applies and undoes bulk edits across the selected dives.
+final bulkDiveEditServiceProvider = Provider<BulkDiveEditService>((ref) {
+  return BulkDiveEditService(
+    ref.watch(diveRepositoryProvider),
+    ref.watch(buddyRepositoryProvider),
+    ref.watch(speciesRepositoryProvider),
+  );
+});

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -1281,11 +1281,11 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               tooltip: context.l10n.diveLog_selection_tooltip_selectAll,
               onPressed: () => _selectAll(dives),
             ),
-            IconButton(
-              icon: const Icon(Icons.date_range, size: 20),
-              tooltip: context.l10n.diveLog_selection_tooltip_selectDateRange,
-              onPressed: () => _selectByDateRange(dives),
-            ),
+          IconButton(
+            icon: const Icon(Icons.date_range, size: 20),
+            tooltip: context.l10n.diveLog_selection_tooltip_selectDateRange,
+            onPressed: () => _selectByDateRange(dives),
+          ),
           if (_selectedIds.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.upload, size: 20),

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -31,6 +32,14 @@ import 'package:submersion/features/dive_log/presentation/widgets/add_dive_botto
 import 'package:submersion/features/dive_log/presentation/widgets/dive_numbering_dialog.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_table_view.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Inclusive id span between the [anchor] and [target] indices in [dives].
+/// Order-independent: a backward shift-click selects the same range.
+List<String> rangeIds(List<DiveSummary> dives, int anchor, int target) {
+  final lo = anchor < target ? anchor : target;
+  final hi = anchor < target ? target : anchor;
+  return [for (var i = lo; i <= hi; i++) dives[i].id];
+}
 
 /// Content widget for the dive list, used in master-detail layout.
 ///
@@ -90,6 +99,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   String? _lastScrolledToId;
   bool _selectionFromList =
       false; // Track if selection originated from list tap
+  String? _anchorId; // anchor dive for shift-click range selection
 
   @override
   void initState() {
@@ -187,6 +197,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     setState(() {
       _isSelectionMode = true;
       _selectedIds.clear();
+      _anchorId = initialId;
       if (initialId != null) {
         _selectedIds.add(initialId);
       }
@@ -210,6 +221,27 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
       } else {
         _selectedIds.add(id);
       }
+      _anchorId = id;
+    });
+  }
+
+  bool _isShiftPressed() {
+    final keys = HardwareKeyboard.instance.logicalKeysPressed;
+    return keys.contains(LogicalKeyboardKey.shiftLeft) ||
+        keys.contains(LogicalKeyboardKey.shiftRight);
+  }
+
+  /// Select the contiguous span from the anchor dive to [targetId].
+  void _selectRangeTo(String targetId, List<DiveSummary> dives) {
+    final targetIndex = dives.indexWhere((d) => d.id == targetId);
+    if (targetIndex < 0) return;
+    final anchorIndex = _anchorId == null
+        ? targetIndex
+        : dives.indexWhere((d) => d.id == _anchorId);
+    final from = anchorIndex < 0 ? targetIndex : anchorIndex;
+    setState(() {
+      _selectedIds.addAll(rangeIds(dives, from, targetIndex));
+      _anchorId = targetId;
     });
   }
 
@@ -1413,7 +1445,13 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                     gradientEndColor: gradientColors.end,
                     siteLatitude: dive.siteLatitude,
                     siteLongitude: dive.siteLongitude,
-                    onTap: () => _handleItemTap(dive),
+                    onTap: () {
+                      if (_isSelectionMode && _isShiftPressed()) {
+                        _selectRangeTo(dive.id, dives);
+                      } else {
+                        _handleItemTap(dive);
+                      }
+                    },
                     onLongPress: _isSelectionMode
                         ? null
                         : () => _enterSelectionMode(dive.id),
@@ -1457,7 +1495,13 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                       'stat2',
                       DiveField.bottomTime,
                     ),
-                    onTap: () => _handleItemTap(dive),
+                    onTap: () {
+                      if (_isSelectionMode && _isShiftPressed()) {
+                        _selectRangeTo(dive.id, dives);
+                      } else {
+                        _handleItemTap(dive);
+                      }
+                    },
                     onLongPress: _isSelectionMode
                         ? null
                         : () => _enterSelectionMode(dive.id),
@@ -1487,7 +1531,13 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                     gradientEndColor: gradientColors.end,
                     siteLatitude: dive.siteLatitude,
                     siteLongitude: dive.siteLongitude,
-                    onTap: () => _handleItemTap(dive),
+                    onTap: () {
+                      if (_isSelectionMode && _isShiftPressed()) {
+                        _selectRangeTo(dive.id, dives);
+                      } else {
+                        _handleItemTap(dive);
+                      }
+                    },
                     onLongPress: _isSelectionMode
                         ? null
                         : () => _enterSelectionMode(dive.id),

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -249,7 +249,10 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     final from = anchorIndex < 0 ? targetIndex : anchorIndex;
     setState(() {
       _selectedIds.addAll(rangeIds(dives, from, targetIndex));
-      _anchorId = targetId;
+      // Keep the anchor fixed across shift-clicks (only plain taps move it),
+      // so consecutive shift-clicks extend from the original anchor rather
+      // than walking it forward.
+      _anchorId ??= targetId;
     });
   }
 

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -41,6 +41,14 @@ List<String> rangeIds(List<DiveSummary> dives, int anchor, int target) {
   return [for (var i = lo; i <= hi; i++) dives[i].id];
 }
 
+/// True if [d]'s date falls within [r], inclusive of the end calendar day.
+bool inDateRange(DiveSummary d, DateTimeRange r) {
+  final day = DateTime(d.dateTime.year, d.dateTime.month, d.dateTime.day);
+  final start = DateTime(r.start.year, r.start.month, r.start.day);
+  final end = DateTime(r.end.year, r.end.month, r.end.day);
+  return !day.isBefore(start) && !day.isAfter(end);
+}
+
 /// Content widget for the dive list, used in master-detail layout.
 ///
 /// This widget contains the core list functionality extracted from DiveListPage.
@@ -242,6 +250,21 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     setState(() {
       _selectedIds.addAll(rangeIds(dives, from, targetIndex));
       _anchorId = targetId;
+    });
+  }
+
+  /// Pick a date range and select every dive whose date falls inside it.
+  Future<void> _selectByDateRange(List<DiveSummary> dives) async {
+    final range = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(1970),
+      lastDate: DateTime(2100),
+    );
+    if (range == null) return;
+    setState(() {
+      _selectedIds.addAll(
+        dives.where((d) => inDateRange(d, range)).map((d) => d.id),
+      );
     });
   }
 
@@ -1189,6 +1212,11 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
             tooltip: context.l10n.diveLog_selection_tooltip_selectAll,
             onPressed: () => _selectAll(dives),
           ),
+        IconButton(
+          icon: const Icon(Icons.date_range),
+          tooltip: context.l10n.diveLog_selection_tooltip_selectDateRange,
+          onPressed: () => _selectByDateRange(dives),
+        ),
         if (_selectedIds.isNotEmpty)
           IconButton(
             icon: const Icon(Icons.deselect),
@@ -1252,6 +1280,11 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               icon: const Icon(Icons.select_all, size: 20),
               tooltip: context.l10n.diveLog_selection_tooltip_selectAll,
               onPressed: () => _selectAll(dives),
+            ),
+            IconButton(
+              icon: const Icon(Icons.date_range, size: 20),
+              tooltip: context.l10n.diveLog_selection_tooltip_selectDateRange,
+              onPressed: () => _selectByDateRange(dives),
             ),
           if (_selectedIds.isNotEmpty)
             IconButton(

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -301,15 +301,17 @@ class SpeciesRepository {
     for (final diveId in diveIds) {
       for (final sighting in sightings) {
         final id = _uuid.v4();
-        await _db.into(_db.sightings).insert(
-          SightingsCompanion(
-            id: Value(id),
-            diveId: Value(diveId),
-            speciesId: Value(sighting.speciesId),
-            count: Value(sighting.count),
-            notes: Value(sighting.notes),
-          ),
-        );
+        await _db
+            .into(_db.sightings)
+            .insert(
+              SightingsCompanion(
+                id: Value(id),
+                diveId: Value(diveId),
+                speciesId: Value(sighting.speciesId),
+                count: Value(sighting.count),
+                notes: Value(sighting.notes),
+              ),
+            );
         await _syncRepository.markRecordPending(
           entityType: 'sightings',
           recordId: id,
@@ -342,15 +344,17 @@ class SpeciesRepository {
       }
       for (final sighting in sightings) {
         final id = _uuid.v4();
-        await _db.into(_db.sightings).insert(
-          SightingsCompanion(
-            id: Value(id),
-            diveId: Value(diveId),
-            speciesId: Value(sighting.speciesId),
-            count: Value(sighting.count),
-            notes: Value(sighting.notes),
-          ),
-        );
+        await _db
+            .into(_db.sightings)
+            .insert(
+              SightingsCompanion(
+                id: Value(id),
+                diveId: Value(diveId),
+                speciesId: Value(sighting.speciesId),
+                count: Value(sighting.count),
+                notes: Value(sighting.notes),
+              ),
+            );
         await _syncRepository.markRecordPending(
           entityType: 'sightings',
           recordId: id,

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -279,6 +279,88 @@ class SpeciesRepository {
     SyncEventBus.notifyLocalChange();
   }
 
+  Future<void> _bumpDive(String diveId, int now) async {
+    await (_db.update(_db.dives)..where((t) => t.id.equals(diveId))).write(
+      DivesCompanion(updatedAt: Value(now)),
+    );
+    await _syncRepository.markRecordPending(
+      entityType: 'dives',
+      recordId: diveId,
+      localUpdatedAt: now,
+    );
+  }
+
+  /// Add each sighting template to every dive (fresh id + diveId per dive).
+  /// No notify/transaction — BulkDiveEditService owns those.
+  Future<void> bulkAddSightings(
+    List<String> diveIds,
+    List<domain.Sighting> sightings,
+  ) async {
+    if (diveIds.isEmpty || sightings.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      for (final sighting in sightings) {
+        final id = _uuid.v4();
+        await _db.into(_db.sightings).insert(
+          SightingsCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            speciesId: Value(sighting.speciesId),
+            count: Value(sighting.count),
+            notes: Value(sighting.notes),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'sightings',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+
+  /// Replace each dive's sightings with [sightings]. No notify/transaction.
+  Future<void> bulkReplaceSightings(
+    List<String> diveIds,
+    List<domain.Sighting> sightings,
+  ) async {
+    if (diveIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final diveId in diveIds) {
+      final existing = await (_db.select(
+        _db.sightings,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      await (_db.delete(
+        _db.sightings,
+      )..where((t) => t.diveId.equals(diveId))).go();
+      for (final row in existing) {
+        await _syncRepository.logDeletion(
+          entityType: 'sightings',
+          recordId: row.id,
+        );
+      }
+      for (final sighting in sightings) {
+        final id = _uuid.v4();
+        await _db.into(_db.sightings).insert(
+          SightingsCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            speciesId: Value(sighting.speciesId),
+            count: Value(sighting.count),
+            notes: Value(sighting.notes),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'sightings',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+      await _bumpDive(diveId, now);
+    }
+  }
+
   /// Seed built-in species from the bundled JSON asset.
   ///
   /// Uses INSERT OR IGNORE keyed on stable sp_ IDs for idempotent seeding.

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1610,6 +1610,7 @@
   "diveLog_selection_tooltip_exit": "الخروج من التحديد",
   "diveLog_selection_tooltip_export": "تصدير المحدد",
   "diveLog_selection_tooltip_selectAll": "تحديد الكل",
+  "diveLog_selection_tooltip_selectDateRange": "التحديد حسب نطاق التاريخ",
   "diveLog_sighting_add": "إضافة",
   "diveLog_sighting_cancel": "إلغاء",
   "diveLog_sighting_notesHint": "مثال: الحجم، السلوك، الموقع...",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1610,6 +1610,7 @@
   "diveLog_selection_tooltip_exit": "Auswahl beenden",
   "diveLog_selection_tooltip_export": "Auswahl exportieren",
   "diveLog_selection_tooltip_selectAll": "Alle auswählen",
+  "diveLog_selection_tooltip_selectDateRange": "Nach Datumsbereich auswählen",
   "diveLog_sighting_add": "Hinzufügen",
   "diveLog_sighting_cancel": "Abbrechen",
   "diveLog_sighting_notesHint": "z. B. Größe, Verhalten, Ort...",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2353,6 +2353,7 @@
   "diveLog_selection_tooltip_exit": "Exit selection",
   "diveLog_selection_tooltip_export": "Export Selected",
   "diveLog_selection_tooltip_selectAll": "Select All",
+  "diveLog_selection_tooltip_selectDateRange": "Select by date range",
   "diveLog_sighting_add": "Add",
   "diveLog_sighting_cancel": "Cancel",
   "diveLog_sighting_notesHint": "e.g., size, behavior, location...",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1610,6 +1610,7 @@
   "diveLog_selection_tooltip_exit": "Salir de la seleccion",
   "diveLog_selection_tooltip_export": "Exportar seleccionados",
   "diveLog_selection_tooltip_selectAll": "Seleccionar todo",
+  "diveLog_selection_tooltip_selectDateRange": "Seleccionar por rango de fechas",
   "diveLog_sighting_add": "Agregar",
   "diveLog_sighting_cancel": "Cancelar",
   "diveLog_sighting_notesHint": "p. ej., tamano, comportamiento, ubicacion...",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1576,6 +1576,7 @@
   "diveLog_selection_tooltip_exit": "Quitter la selection",
   "diveLog_selection_tooltip_export": "Exporter la selection",
   "diveLog_selection_tooltip_selectAll": "Tout selectionner",
+  "diveLog_selection_tooltip_selectDateRange": "Sélectionner par plage de dates",
   "diveLog_sighting_add": "Ajouter",
   "diveLog_sighting_cancel": "Annuler",
   "diveLog_sighting_notesHint": "ex. taille, comportement, emplacement...",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1576,6 +1576,7 @@
   "diveLog_selection_tooltip_exit": "צא מבחירה",
   "diveLog_selection_tooltip_export": "ייצא נבחרים",
   "diveLog_selection_tooltip_selectAll": "בחר הכל",
+  "diveLog_selection_tooltip_selectDateRange": "בחירה לפי טווח תאריכים",
   "diveLog_sighting_add": "הוסף",
   "diveLog_sighting_cancel": "ביטול",
   "diveLog_sighting_notesHint": "לדוגמה, גודל, התנהגות, מיקום...",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1576,6 +1576,7 @@
   "diveLog_selection_tooltip_exit": "Kivalasztas bezarasa",
   "diveLog_selection_tooltip_export": "Kivalasztottak exportalasa",
   "diveLog_selection_tooltip_selectAll": "Osszes kivalasztasa",
+  "diveLog_selection_tooltip_selectDateRange": "Kijelölés dátumtartomány szerint",
   "diveLog_sighting_add": "Hozzaadas",
   "diveLog_sighting_cancel": "Megse",
   "diveLog_sighting_notesHint": "pl. meret, viselkedes, helyszin...",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1576,6 +1576,7 @@
   "diveLog_selection_tooltip_exit": "Esci dalla selezione",
   "diveLog_selection_tooltip_export": "Esporta selezionati",
   "diveLog_selection_tooltip_selectAll": "Seleziona tutto",
+  "diveLog_selection_tooltip_selectDateRange": "Seleziona per intervallo di date",
   "diveLog_sighting_add": "Aggiungi",
   "diveLog_sighting_cancel": "Annulla",
   "diveLog_sighting_notesHint": "es. dimensione, comportamento, posizione...",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -8410,6 +8410,12 @@ abstract class AppLocalizations {
   /// **'Select All'**
   String get diveLog_selection_tooltip_selectAll;
 
+  /// No description provided for @diveLog_selection_tooltip_selectDateRange.
+  ///
+  /// In en, this message translates to:
+  /// **'Select by date range'**
+  String get diveLog_selection_tooltip_selectDateRange;
+
   /// No description provided for @diveLog_sighting_add.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -4844,6 +4844,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'تحديد الكل';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'التحديد حسب نطاق التاريخ';
+
+  @override
   String get diveLog_sighting_add => 'إضافة';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -4954,6 +4954,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Alle auswählen';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Nach Datumsbereich auswählen';
+
+  @override
   String get diveLog_sighting_add => 'Hinzufügen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -4869,6 +4869,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Select All';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Select by date range';
+
+  @override
   String get diveLog_sighting_add => 'Add';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -4956,6 +4956,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Seleccionar todo';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Seleccionar por rango de fechas';
+
+  @override
   String get diveLog_sighting_add => 'Agregar';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -4984,6 +4984,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Tout selectionner';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Sélectionner par plage de dates';
+
+  @override
   String get diveLog_sighting_add => 'Ajouter';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -4823,6 +4823,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'בחר הכל';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'בחירה לפי טווח תאריכים';
+
+  @override
   String get diveLog_sighting_add => 'הוסף';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -4944,6 +4944,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Osszes kivalasztasa';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Kijelölés dátumtartomány szerint';
+
+  @override
   String get diveLog_sighting_add => 'Hozzaadas';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -4963,6 +4963,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Seleziona tutto';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Seleziona per intervallo di date';
+
+  @override
   String get diveLog_sighting_add => 'Aggiungi';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -4920,6 +4920,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Alles selecteren';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Selecteren op datumbereik';
+
+  @override
   String get diveLog_sighting_add => 'Toevoegen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -4959,6 +4959,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => 'Selecionar Todos';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange =>
+      'Selecionar por intervalo de datas';
+
+  @override
   String get diveLog_sighting_add => 'Adicionar';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -4724,6 +4724,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_selection_tooltip_selectAll => '全选';
 
   @override
+  String get diveLog_selection_tooltip_selectDateRange => '按日期范围选择';
+
+  @override
   String get diveLog_sighting_add => '添加';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1610,6 +1610,7 @@
   "diveLog_selection_tooltip_exit": "Selectie verlaten",
   "diveLog_selection_tooltip_export": "Geselecteerde exporteren",
   "diveLog_selection_tooltip_selectAll": "Alles selecteren",
+  "diveLog_selection_tooltip_selectDateRange": "Selecteren op datumbereik",
   "diveLog_sighting_add": "Toevoegen",
   "diveLog_sighting_cancel": "Annuleren",
   "diveLog_sighting_notesHint": "bijv. grootte, gedrag, locatie...",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1610,6 +1610,7 @@
   "diveLog_selection_tooltip_exit": "Sair da selecao",
   "diveLog_selection_tooltip_export": "Exportar Selecionados",
   "diveLog_selection_tooltip_selectAll": "Selecionar Todos",
+  "diveLog_selection_tooltip_selectDateRange": "Selecionar por intervalo de datas",
   "diveLog_sighting_add": "Adicionar",
   "diveLog_sighting_cancel": "Cancelar",
   "diveLog_sighting_notesHint": "ex., tamanho, comportamento, localizacao...",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1739,6 +1739,7 @@
   "diveLog_selection_tooltip_exit": "退出选择",
   "diveLog_selection_tooltip_export": "导出所选",
   "diveLog_selection_tooltip_selectAll": "全选",
+  "diveLog_selection_tooltip_selectDateRange": "按日期范围选择",
   "diveLog_sighting_add": "添加",
   "diveLog_sighting_cancel": "取消",
   "diveLog_sighting_notesHint": "例如，大小、行为、位置...",

--- a/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
+++ b/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
@@ -1,0 +1,61 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late BuddyRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    repository = BuddyRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  domain.BuddyWithRole bwr(String id) => domain.BuddyWithRole(
+    buddy: domain.Buddy(
+      id: id,
+      name: 'B$id',
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    ),
+    role: BuddyRole.buddy,
+  );
+
+  test('bulkAddBuddies links each buddy to each dive', () async {
+    await repository.bulkAddBuddies(['d1', 'd2'], [bwr('x'), bwr('y')]);
+    final d1 = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(d1.map((r) => r.buddyId).toSet(), {'x', 'y'});
+    final d2 = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.diveId.equals('d2'))).get();
+    expect(d2.length, 2);
+  });
+
+  test('bulkReplaceBuddies overwrites; bulkRemoveBuddies subtracts', () async {
+    await repository.bulkAddBuddies(['d1'], [bwr('x'), bwr('y')]);
+    await repository.bulkReplaceBuddies(['d1'], [bwr('z')]);
+    var rows = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(rows.map((r) => r.buddyId).toSet(), {'z'});
+
+    await repository.bulkRemoveBuddies(['d1'], ['z']);
+    rows = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(rows, isEmpty);
+  });
+}

--- a/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
+++ b/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
@@ -1,4 +1,3 @@
-import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
@@ -58,4 +57,25 @@ void main() {
     )..where((t) => t.diveId.equals('d1'))).get();
     expect(rows, isEmpty);
   });
+
+  test(
+    'bulkAddBuddies updates the role when the link already exists',
+    () async {
+      await repository.bulkAddBuddies(['d1'], [bwr('x')]); // role buddy
+      await repository.bulkAddBuddies(
+        ['d1'],
+        [
+          domain.BuddyWithRole(
+            buddy: bwr('x').buddy,
+            role: BuddyRole.instructor,
+          ),
+        ],
+      );
+      final rows = await (db.select(
+        db.diveBuddies,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1); // not duplicated
+      expect(rows.single.role, 'instructor'); // role updated in place
+    },
+  );
 }

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -82,7 +82,9 @@ void main() {
 
   group('bulkReplaceTags', () {
     setUp(() async {
-      await db.customStatement('PRAGMA foreign_keys = OFF'); // test-only isolation
+      await db.customStatement(
+        'PRAGMA foreign_keys = OFF',
+      ); // test-only isolation
     });
 
     test('replaces existing tag membership with the given set', () async {
@@ -140,7 +142,11 @@ void main() {
         await seed('hasTank');
         await repository.bulkAddTank(['hasTank'], al80);
 
-        await repository.bulkAddTank(['empty', 'hasTank'], al80, onlyIfEmpty: true);
+        await repository.bulkAddTank(
+          ['empty', 'hasTank'],
+          al80,
+          onlyIfEmpty: true,
+        );
 
         final emptyTanks = await (db.select(
           db.diveTanks,
@@ -158,14 +164,17 @@ void main() {
     test('bulkReplaceTanks overwrites the whole list', () async {
       await seed('d1');
       await repository.bulkAddTank(['d1'], al80);
-      await repository.bulkReplaceTanks(['d1'], const [
-        domain.DiveTank(
-          id: '',
-          name: 'D12',
-          volume: 24,
-          gasMix: domain.GasMix(o2: 32),
-        ),
-      ]);
+      await repository.bulkReplaceTanks(
+        ['d1'],
+        const [
+          domain.DiveTank(
+            id: '',
+            name: 'D12',
+            volume: 24,
+            gasMix: domain.GasMix(o2: 32),
+          ),
+        ],
+      );
       final rows = await (db.select(
         db.diveTanks,
       )..where((t) => t.diveId.equals('d1'))).get();
@@ -192,14 +201,17 @@ void main() {
       expect(rows.length, 1);
       expect(rows.single.amountKg, 4);
 
-      await repository.bulkReplaceWeights(['d1'], const [
-        domain.DiveWeight(
-          id: '',
-          diveId: '',
-          weightType: WeightType.integrated,
-          amountKg: 6,
-        ),
-      ]);
+      await repository.bulkReplaceWeights(
+        ['d1'],
+        const [
+          domain.DiveWeight(
+            id: '',
+            diveId: '',
+            weightType: WeightType.integrated,
+            amountKg: 6,
+          ),
+        ],
+      );
       rows = await (db.select(
         db.diveWeights,
       )..where((t) => t.diveId.equals('d1'))).get();

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -1,0 +1,61 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> seed(String id, {String notes = ''}) => repository.createDive(
+    domain.Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: notes),
+  );
+
+  group('bulkUpdateFields', () {
+    test(
+      'writes only the given columns, bumps updatedAt, skips other dives',
+      () async {
+        await seed('d1', notes: 'keep');
+        await seed('d2', notes: 'keep2');
+        await seed('d3', notes: 'untouched');
+
+        await repository.bulkUpdateFields([
+          'd1',
+          'd2',
+        ], const DivesCompanion(rating: Value(5), waterType: Value('salt')));
+
+        final r1 = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals('d1'))).getSingle();
+        final r3 = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals('d3'))).getSingle();
+        expect(r1.rating, 5);
+        expect(r1.waterType, 'salt');
+        expect(r1.notes, 'keep'); // untouched column preserved
+        expect(r3.rating, isNull); // dive outside the id list untouched
+        expect(r3.waterType, isNull);
+      },
+    );
+
+    test('is a no-op for an empty id list', () async {
+      await repository.bulkUpdateFields(
+        const [],
+        const DivesCompanion(rating: Value(3)),
+      );
+    });
+  });
+}

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -2,7 +2,10 @@ import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/core/constants/enums.dart' show WeightType;
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
     as domain;
 
 import '../../../../helpers/test_database.dart';
@@ -169,6 +172,39 @@ void main() {
       expect(rows.length, 1);
       expect(rows.single.tankName, 'D12');
       expect(rows.single.o2Percent, 32);
+    });
+  });
+
+  group('bulk weights', () {
+    const belt = domain.DiveWeight(
+      id: '',
+      diveId: '',
+      weightType: WeightType.belt,
+      amountKg: 4,
+    );
+
+    test('add appends; replace overwrites', () async {
+      await seed('d1');
+      await repository.bulkAddWeights(['d1'], [belt]);
+      var rows = await (db.select(
+        db.diveWeights,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1);
+      expect(rows.single.amountKg, 4);
+
+      await repository.bulkReplaceWeights(['d1'], const [
+        domain.DiveWeight(
+          id: '',
+          diveId: '',
+          weightType: WeightType.integrated,
+          amountKg: 6,
+        ),
+      ]);
+      rows = await (db.select(
+        db.diveWeights,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1);
+      expect(rows.single.amountKg, 6);
     });
   });
 }

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -60,6 +60,18 @@ void main() {
         const DivesCompanion(rating: Value(3)),
       );
     });
+
+    test('with an empty companion is a no-op (no updatedAt touch)', () async {
+      await seed('x');
+      await (db.update(db.dives)..where((t) => t.id.equals('x'))).write(
+        const DivesCompanion(updatedAt: Value(123)),
+      );
+      await repository.bulkUpdateFields(['x'], const DivesCompanion());
+      final row = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('x'))).getSingle();
+      expect(row.updatedAt, 123); // unchanged — no sync-visible touch
+    });
   });
 
   group('bulkAppendNotes', () {
@@ -182,6 +194,22 @@ void main() {
       expect(rows.single.tankName, 'D12');
       expect(rows.single.o2Percent, 32);
     });
+
+    test(
+      'bulkAddTanks with onlyIfEmpty adds ALL tanks to an empty dive',
+      () async {
+        await seed('e');
+        await repository.bulkAddTanks(
+          ['e'],
+          const [al80, al80],
+          onlyIfEmpty: true,
+        );
+        final rows = await (db.select(
+          db.diveTanks,
+        )..where((t) => t.diveId.equals('e'))).get();
+        expect(rows.length, 2); // both tanks added, not just the first
+      },
+    );
   });
 
   group('bulk weights', () {

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -94,4 +94,31 @@ void main() {
       expect(rows.map((r) => r.tagId).toSet(), {'t1', 't2'});
     });
   });
+
+  group('bulk equipment', () {
+    setUp(() async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+    });
+
+    test('add then remove adjusts membership; replace overwrites', () async {
+      await seed('d1');
+      await repository.bulkAddEquipment(['d1'], ['e1', 'e2']);
+      var rows = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.equipmentId).toSet(), {'e1', 'e2'});
+
+      await repository.bulkRemoveEquipment(['d1'], ['e1']);
+      rows = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.equipmentId).toSet(), {'e2'});
+
+      await repository.bulkReplaceEquipment(['d1'], ['e9']);
+      rows = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.equipmentId).toSet(), {'e9'});
+    });
+  });
 }

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -121,4 +121,54 @@ void main() {
       expect(rows.map((r) => r.equipmentId).toSet(), {'e9'});
     });
   });
+
+  group('bulk tanks', () {
+    const al80 = domain.DiveTank(
+      id: '',
+      name: 'AL80',
+      volume: 11.1,
+      gasMix: domain.GasMix(o2: 21, he: 0),
+    );
+
+    test(
+      'bulkAddTank appends; onlyIfEmpty skips dives that already have a tank',
+      () async {
+        await seed('empty');
+        await seed('hasTank');
+        await repository.bulkAddTank(['hasTank'], al80);
+
+        await repository.bulkAddTank(['empty', 'hasTank'], al80, onlyIfEmpty: true);
+
+        final emptyTanks = await (db.select(
+          db.diveTanks,
+        )..where((t) => t.diveId.equals('empty'))).get();
+        final hasTankTanks = await (db.select(
+          db.diveTanks,
+        )..where((t) => t.diveId.equals('hasTank'))).get();
+        expect(emptyTanks.length, 1);
+        expect(emptyTanks.single.tankName, 'AL80');
+        expect(emptyTanks.single.tankOrder, 0);
+        expect(hasTankTanks.length, 1); // skipped — still just the original
+      },
+    );
+
+    test('bulkReplaceTanks overwrites the whole list', () async {
+      await seed('d1');
+      await repository.bulkAddTank(['d1'], al80);
+      await repository.bulkReplaceTanks(['d1'], const [
+        domain.DiveTank(
+          id: '',
+          name: 'D12',
+          volume: 24,
+          gasMix: domain.GasMix(o2: 32),
+        ),
+      ]);
+      final rows = await (db.select(
+        db.diveTanks,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.length, 1);
+      expect(rows.single.tankName, 'D12');
+      expect(rows.single.o2Percent, 32);
+    });
+  });
 }

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -58,4 +58,22 @@ void main() {
       );
     });
   });
+
+  group('bulkAppendNotes', () {
+    test('appends to existing notes and to empty notes', () async {
+      await seed('a', notes: 'Cozumel');
+      await seed('b', notes: '');
+
+      await repository.bulkAppendNotes(['a', 'b'], '\nGreat viz');
+
+      final ra = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('a'))).getSingle();
+      final rb = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('b'))).getSingle();
+      expect(ra.notes, 'Cozumel\nGreat viz');
+      expect(rb.notes, '\nGreat viz');
+    });
+  });
 }

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -76,4 +76,22 @@ void main() {
       expect(rb.notes, '\nGreat viz');
     });
   });
+
+  group('bulkReplaceTags', () {
+    setUp(() async {
+      await db.customStatement('PRAGMA foreign_keys = OFF'); // test-only isolation
+    });
+
+    test('replaces existing tag membership with the given set', () async {
+      await seed('d1');
+      await repository.bulkAddTags(['d1'], ['old-tag']);
+
+      await repository.bulkReplaceTags(['d1'], ['t1', 't2']);
+
+      final rows = await (db.select(
+        db.diveTags,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(rows.map((r) => r.tagId).toSet(), {'t1', 't2'});
+    });
+  });
 }

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -257,4 +257,44 @@ void main() {
       await service.undo(snap); // must not throw
     },
   );
+
+  test('owned-collection ops reject the remove mode', () async {
+    await seed('d1');
+    await expectLater(
+      service.apply(
+        BulkEditRequest(
+          diveIds: const ['d1'],
+          ops: [
+            TanksOp(mode: BulkCollectionMode.remove, tanks: [tank('x')]),
+          ],
+        ),
+      ),
+      throwsUnsupportedError,
+    );
+    await expectLater(
+      service.apply(
+        BulkEditRequest(
+          diveIds: const ['d1'],
+          ops: [
+            WeightsOp(mode: BulkCollectionMode.remove, weights: [weight(1)]),
+          ],
+        ),
+      ),
+      throwsUnsupportedError,
+    );
+    await expectLater(
+      service.apply(
+        BulkEditRequest(
+          diveIds: const ['d1'],
+          ops: [
+            SightingsOp(
+              mode: BulkCollectionMode.remove,
+              sightings: [sighting('x')],
+            ),
+          ],
+        ),
+      ),
+      throwsUnsupportedError,
+    );
+  });
 }

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -1,0 +1,62 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/services/bulk_dive_edit_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart' as domain;
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late BulkDiveEditService service;
+  late DiveRepository diveRepo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    diveRepo = DiveRepository();
+    service = BulkDiveEditService(
+      diveRepo,
+      BuddyRepository(),
+      SpeciesRepository(),
+    );
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> seed(String id) => diveRepo.createDive(
+    domain.Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: ''),
+  );
+
+  test('apply writes scalars + notes-append + a tag op and returns a snapshot', () async {
+    await seed('d1');
+    await seed('d2');
+
+    final snap = await service.apply(
+      BulkEditRequest(
+        diveIds: const ['d1', 'd2'],
+        scalars: const DivesCompanion(rating: Value(4)),
+        notesAppend: ' trip',
+        ops: const [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['t1'])],
+      ),
+    );
+
+    final r1 = await (db.select(
+      db.dives,
+    )..where((t) => t.id.equals('d1'))).getSingle();
+    expect(r1.rating, 4);
+    expect(r1.notes, ' trip');
+    final tags = await (db.select(
+      db.diveTags,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(tags.single.tagId, 't1');
+    expect(snap.priorDiveRows.length, 2);
+    expect(snap.priorTagIds, isNotNull);
+  });
+}

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -1,12 +1,21 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart'
+    show BuddyRole, TankMaterial, WeightType;
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart'
+    as domain;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/bulk_dive_edit_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
-import 'package:submersion/features/dive_log/domain/entities/dive.dart' as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
+    as domain;
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart'
+    as domain;
 
 import '../../../../helpers/test_database.dart';
 
@@ -14,16 +23,16 @@ void main() {
   late AppDatabase db;
   late BulkDiveEditService service;
   late DiveRepository diveRepo;
+  late BuddyRepository buddyRepo;
+  late SpeciesRepository speciesRepo;
 
   setUp(() async {
     db = await setUpTestDatabase();
     await db.customStatement('PRAGMA foreign_keys = OFF');
     diveRepo = DiveRepository();
-    service = BulkDiveEditService(
-      diveRepo,
-      BuddyRepository(),
-      SpeciesRepository(),
-    );
+    buddyRepo = BuddyRepository();
+    speciesRepo = SpeciesRepository();
+    service = BulkDiveEditService(diveRepo, buddyRepo, speciesRepo);
   });
 
   tearDown(() async {
@@ -34,42 +43,103 @@ void main() {
     domain.Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: ''),
   );
 
-  test('apply writes scalars + notes-append + a tag op and returns a snapshot', () async {
-    await seed('d1');
-    await seed('d2');
+  // Buddy snapshot capture JOINs the buddies catalog, so links need a catalog
+  // row to survive a capture/restore round-trip.
+  Future<void> seedBuddy(String id) => db
+      .into(db.buddies)
+      .insert(
+        BuddiesCompanion(
+          id: Value(id),
+          name: Value(id),
+          createdAt: const Value(0),
+          updatedAt: const Value(0),
+        ),
+      );
 
-    final snap = await service.apply(
-      BulkEditRequest(
-        diveIds: const ['d1', 'd2'],
-        scalars: const DivesCompanion(rating: Value(4)),
-        notesAppend: ' trip',
-        ops: const [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['t1'])],
-      ),
-    );
+  domain.BuddyWithRole bwr(String id) => domain.BuddyWithRole(
+    buddy: domain.Buddy(
+      id: id,
+      name: id,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    ),
+    role: BuddyRole.buddy,
+  );
+  domain.DiveTank tank(String name, {TankMaterial? material}) =>
+      domain.DiveTank(id: '', name: name, material: material);
+  domain.DiveWeight weight(double kg) => domain.DiveWeight(
+    id: '',
+    diveId: '',
+    weightType: WeightType.belt,
+    amountKg: kg,
+  );
+  domain.Sighting sighting(String speciesId) => domain.Sighting(
+    id: '',
+    diveId: '',
+    speciesId: speciesId,
+    speciesName: '',
+  );
 
-    final r1 = await (db.select(
-      db.dives,
-    )..where((t) => t.id.equals('d1'))).getSingle();
-    expect(r1.rating, 4);
-    expect(r1.notes, ' trip');
-    final tags = await (db.select(
-      db.diveTags,
-    )..where((t) => t.diveId.equals('d1'))).get();
-    expect(tags.single.tagId, 't1');
-    expect(snap.priorDiveRows.length, 2);
-    expect(snap.priorTagIds, isNotNull);
-  });
+  Future<List<String>> tagsOf(String d) async => (await (db.select(
+    db.diveTags,
+  )..where((t) => t.diveId.equals(d))).get()).map((r) => r.tagId).toList();
+  Future<List<String>> equipOf(String d) async =>
+      (await (db.select(
+            db.diveEquipment,
+          )..where((t) => t.diveId.equals(d))).get())
+          .map((r) => r.equipmentId)
+          .toList();
+  Future<List<String>> buddiesOf(String d) async => (await (db.select(
+    db.diveBuddies,
+  )..where((t) => t.diveId.equals(d))).get()).map((r) => r.buddyId).toList();
+  Future<List<String?>> tanksOf(String d) async => (await (db.select(
+    db.diveTanks,
+  )..where((t) => t.diveId.equals(d))).get()).map((r) => r.tankName).toList();
+  Future<List<double>> weightsOf(String d) async => (await (db.select(
+    db.diveWeights,
+  )..where((t) => t.diveId.equals(d))).get()).map((r) => r.amountKg).toList();
+  Future<List<String>> sightingsOf(String d) async => (await (db.select(
+    db.sightings,
+  )..where((t) => t.diveId.equals(d))).get()).map((r) => r.speciesId).toList();
+
+  test(
+    'apply writes scalars + notes-append + a tag op and returns a snapshot',
+    () async {
+      await seed('d1');
+      await seed('d2');
+
+      final snap = await service.apply(
+        const BulkEditRequest(
+          diveIds: ['d1', 'd2'],
+          scalars: DivesCompanion(rating: Value(4)),
+          notesAppend: ' trip',
+          ops: [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['t1'])],
+        ),
+      );
+
+      final r1 = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('d1'))).getSingle();
+      expect(r1.rating, 4);
+      expect(r1.notes, ' trip');
+      expect((await tagsOf('d1')).single, 't1');
+      expect(snap.priorDiveRows.length, 2);
+      expect(snap.priorTagIds, isNotNull);
+    },
+  );
 
   test('undo restores prior scalar values and tag membership', () async {
     await seed('d1');
-    await diveRepo.bulkUpdateFields(['d1'], const DivesCompanion(rating: Value(2)));
+    await diveRepo.bulkUpdateFields([
+      'd1',
+    ], const DivesCompanion(rating: Value(2)));
     await diveRepo.bulkReplaceTags(['d1'], ['orig']);
 
     final snap = await service.apply(
-      BulkEditRequest(
-        diveIds: const ['d1'],
-        scalars: const DivesCompanion(rating: Value(9)),
-        ops: const [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['new'])],
+      const BulkEditRequest(
+        diveIds: ['d1'],
+        scalars: DivesCompanion(rating: Value(9)),
+        ops: [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['new'])],
       ),
     );
 
@@ -79,9 +149,108 @@ void main() {
       db.dives,
     )..where((t) => t.id.equals('d1'))).getSingle();
     expect(r.rating, 2); // restored
-    final tags = await (db.select(
-      db.diveTags,
-    )..where((t) => t.diveId.equals('d1'))).get();
-    expect(tags.single.tagId, 'orig'); // restored
+    expect((await tagsOf('d1')).single, 'orig'); // restored
   });
+
+  test('apply+undo round-trips every collection type (replace)', () async {
+    await seed('d1');
+    await diveRepo.bulkReplaceTags(['d1'], ['origTag']);
+    await diveRepo.bulkAddEquipment(['d1'], ['origEq']);
+    await seedBuddy('origBuddy');
+    await buddyRepo.bulkAddBuddies(['d1'], [bwr('origBuddy')]);
+    await diveRepo.bulkAddTank([
+      'd1',
+    ], tank('OrigTank', material: TankMaterial.steel));
+    await diveRepo.bulkAddWeights(['d1'], [weight(3)]);
+    await speciesRepo.bulkAddSightings(['d1'], [sighting('origFish')]);
+
+    final snap = await service.apply(
+      BulkEditRequest(
+        diveIds: const ['d1'],
+        ops: [
+          const TagsOp(mode: BulkCollectionMode.replace, tagIds: ['newTag']),
+          const EquipmentOp(
+            mode: BulkCollectionMode.replace,
+            equipmentIds: ['newEq'],
+          ),
+          BuddiesOp(
+            mode: BulkCollectionMode.replace,
+            buddies: [bwr('newBuddy')],
+          ),
+          TanksOp(mode: BulkCollectionMode.replace, tanks: [tank('NewTank')]),
+          WeightsOp(mode: BulkCollectionMode.replace, weights: [weight(9)]),
+          SightingsOp(
+            mode: BulkCollectionMode.replace,
+            sightings: [sighting('newFish')],
+          ),
+        ],
+      ),
+    );
+
+    expect((await tagsOf('d1')).single, 'newTag');
+    expect((await equipOf('d1')).single, 'newEq');
+    expect((await buddiesOf('d1')).single, 'newBuddy');
+    expect((await tanksOf('d1')).single, 'NewTank');
+    expect((await weightsOf('d1')).single, 9);
+    expect((await sightingsOf('d1')).single, 'newFish');
+
+    await service.undo(snap);
+
+    expect((await tagsOf('d1')).single, 'origTag');
+    expect((await equipOf('d1')).single, 'origEq');
+    expect((await buddiesOf('d1')).single, 'origBuddy');
+    expect((await tanksOf('d1')).single, 'OrigTank');
+    expect((await weightsOf('d1')).single, 3);
+    expect((await sightingsOf('d1')).single, 'origFish');
+  });
+
+  test('apply handles add and remove modes across collections', () async {
+    await seed('d1');
+    await service.apply(
+      BulkEditRequest(
+        diveIds: const ['d1'],
+        ops: [
+          const TagsOp(mode: BulkCollectionMode.add, tagIds: ['t1', 't2']),
+          const EquipmentOp(mode: BulkCollectionMode.add, equipmentIds: ['e1']),
+          BuddiesOp(mode: BulkCollectionMode.add, buddies: [bwr('b1')]),
+          TanksOp(mode: BulkCollectionMode.add, tanks: [tank('AL80')]),
+          WeightsOp(mode: BulkCollectionMode.add, weights: [weight(4)]),
+          SightingsOp(
+            mode: BulkCollectionMode.add,
+            sightings: [sighting('fish')],
+          ),
+        ],
+      ),
+    );
+    expect((await tagsOf('d1')).toSet(), {'t1', 't2'});
+    expect((await tanksOf('d1')).length, 1);
+    expect((await weightsOf('d1')).single, 4);
+    expect((await sightingsOf('d1')).single, 'fish');
+
+    await service.apply(
+      BulkEditRequest(
+        diveIds: const ['d1'],
+        ops: [
+          const TagsOp(mode: BulkCollectionMode.remove, tagIds: ['t1']),
+          const EquipmentOp(
+            mode: BulkCollectionMode.remove,
+            equipmentIds: ['e1'],
+          ),
+          BuddiesOp(mode: BulkCollectionMode.remove, buddies: [bwr('b1')]),
+        ],
+      ),
+    );
+    expect((await tagsOf('d1')).toSet(), {'t2'});
+    expect(await equipOf('d1'), isEmpty);
+    expect(await buddiesOf('d1'), isEmpty);
+  });
+
+  test(
+    'apply with no dives returns an empty snapshot; undo is a no-op',
+    () async {
+      final snap = await service.apply(const BulkEditRequest(diveIds: []));
+      expect(snap.priorDiveRows, isEmpty);
+      await service.undo(snap); // must not throw
+    },
+  );
 }

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -59,4 +59,29 @@ void main() {
     expect(snap.priorDiveRows.length, 2);
     expect(snap.priorTagIds, isNotNull);
   });
+
+  test('undo restores prior scalar values and tag membership', () async {
+    await seed('d1');
+    await diveRepo.bulkUpdateFields(['d1'], const DivesCompanion(rating: Value(2)));
+    await diveRepo.bulkReplaceTags(['d1'], ['orig']);
+
+    final snap = await service.apply(
+      BulkEditRequest(
+        diveIds: const ['d1'],
+        scalars: const DivesCompanion(rating: Value(9)),
+        ops: const [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['new'])],
+      ),
+    );
+
+    await service.undo(snap);
+
+    final r = await (db.select(
+      db.dives,
+    )..where((t) => t.id.equals('d1'))).getSingle();
+    expect(r.rating, 2); // restored
+    final tags = await (db.select(
+      db.diveTags,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(tags.single.tagId, 'orig'); // restored
+  });
 }

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -113,7 +113,9 @@ void main() {
           diveIds: ['d1', 'd2'],
           scalars: DivesCompanion(rating: Value(4)),
           notesAppend: ' trip',
-          ops: [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['t1'])],
+          ops: [
+            TagsOp(mode: BulkCollectionMode.replace, tagIds: ['t1']),
+          ],
         ),
       );
 
@@ -139,7 +141,9 @@ void main() {
       const BulkEditRequest(
         diveIds: ['d1'],
         scalars: DivesCompanion(rating: Value(9)),
-        ops: [TagsOp(mode: BulkCollectionMode.replace, tagIds: ['new'])],
+        ops: [
+          TagsOp(mode: BulkCollectionMode.replace, tagIds: ['new']),
+        ],
       ),
     );
 

--- a/test/features/dive_log/domain/entities/bulk_edit_request_test.dart
+++ b/test/features/dive_log/domain/entities/bulk_edit_request_test.dart
@@ -1,0 +1,25 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart';
+
+void main() {
+  test('hasScalarChanges is false for an all-absent companion', () {
+    const req = BulkEditRequest(diveIds: ['a'], scalars: DivesCompanion());
+    expect(req.hasScalarChanges, isFalse);
+  });
+
+  test('hasScalarChanges is true when any column is present', () {
+    const req = BulkEditRequest(
+      diveIds: ['a'],
+      scalars: DivesCompanion(rating: Value(5)),
+    );
+    expect(req.hasScalarChanges, isTrue);
+  });
+
+  test('TagsOp carries mode and ids', () {
+    const op = TagsOp(mode: BulkCollectionMode.add, tagIds: ['t1']);
+    expect(op.mode, BulkCollectionMode.add);
+    expect(op.tagIds, ['t1']);
+  });
+}

--- a/test/features/dive_log/presentation/providers/bulk_dive_edit_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/bulk_dive_edit_provider_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/bulk_dive_edit_service.dart';
+import 'package:submersion/features/dive_log/presentation/providers/bulk_dive_edit_provider.dart';
+
+void main() {
+  test('bulkDiveEditServiceProvider builds a BulkDiveEditService', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final service = container.read(bulkDiveEditServiceProvider);
+    expect(service, isA<BulkDiveEditService>());
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -1008,5 +1009,107 @@ void main() {
         expect(two.isSelected, isTrue);
       },
     );
+  });
+
+  group('phone-mode selection', () {
+    List<Dive> fourDives() => [
+      _makeDive(
+        id: 'd1',
+        diveNumber: 1,
+        site: const DiveSite(id: 's1', name: 'Aaa'),
+      ),
+      _makeDive(
+        id: 'd2',
+        diveNumber: 2,
+        site: const DiveSite(id: 's2', name: 'Bbb'),
+      ),
+      _makeDive(
+        id: 'd3',
+        diveNumber: 3,
+        site: const DiveSite(id: 's3', name: 'Ccc'),
+      ),
+      _makeDive(
+        id: 'd4',
+        diveNumber: 4,
+        site: const DiveSite(id: 's4', name: 'Ddd'),
+      ),
+    ];
+
+    testWidgets(
+      'long-press enters selection; shift-tap selects a range; tap toggles',
+      (tester) async {
+        final overrides = await _buildPhoneOverrides(
+          dives: fourDives(),
+          viewMode: ListViewMode.detailed,
+          highlightedDiveId: null,
+        );
+        await tester.pumpWidget(
+          testApp(
+            overrides: overrides,
+            child: const DiveListContent(showAppBar: false),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        DiveListTile tile(String id) => tester
+            .widgetList<DiveListTile>(find.byType(DiveListTile))
+            .firstWhere((t) => t.diveId == id);
+        Finder tileFinder(String id) =>
+            find.byWidgetPredicate((w) => w is DiveListTile && w.diveId == id);
+
+        // Long-press d1 -> enter selection mode with d1 as the anchor.
+        await tester.longPress(tileFinder('d1'));
+        await tester.pumpAndSettle();
+        expect(tile('d1').isSelectionMode, isTrue);
+        expect(tile('d1').isSelected, isTrue);
+
+        // Shift-tap d3 -> the d1..d3 span becomes selected.
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.tap(tileFinder('d3'));
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pumpAndSettle();
+        expect(tile('d1').isSelected, isTrue);
+        expect(tile('d2').isSelected, isTrue);
+        expect(tile('d3').isSelected, isTrue);
+        expect(tile('d4').isSelected, isFalse);
+
+        // Plain tap d2 -> toggles it back off.
+        await tester.tap(tileFinder('d2'));
+        await tester.pumpAndSettle();
+        expect(tile('d2').isSelected, isFalse);
+      },
+    );
+
+    testWidgets('compact view: long-press enters selection and tap toggles', (
+      tester,
+    ) async {
+      final overrides = await _buildPhoneOverrides(
+        dives: fourDives(),
+        viewMode: ListViewMode.compact,
+        highlightedDiveId: null,
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const DiveListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      CompactDiveListTile tile(String id) => tester
+          .widgetList<CompactDiveListTile>(find.byType(CompactDiveListTile))
+          .firstWhere((t) => t.diveId == id);
+      Finder tileFinder(String id) => find.byWidgetPredicate(
+        (w) => w is CompactDiveListTile && w.diveId == id,
+      );
+
+      await tester.longPress(tileFinder('d1'));
+      await tester.pumpAndSettle();
+      expect(tile('d1').isSelectionMode, isTrue);
+
+      await tester.tap(tileFinder('d2'));
+      await tester.pumpAndSettle();
+      expect(tile('d2').isSelected, isTrue);
+    });
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
@@ -3,11 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart';
 
-DiveSummary summary(String id, [DateTime? dt]) => DiveSummary(
-  id: id,
-  dateTime: dt ?? DateTime(2026, 1, 1),
-  sortTimestamp: 0,
-);
+DiveSummary summary(String id, [DateTime? dt]) =>
+    DiveSummary(id: id, dateTime: dt ?? DateTime(2026, 1, 1), sortTimestamp: 0);
 
 void main() {
   test('rangeIds returns inclusive span regardless of direction', () {

--- a/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart';
@@ -14,5 +15,15 @@ void main() {
     expect(rangeIds(dives, 1, 3), ['b', 'c', 'd']);
     expect(rangeIds(dives, 3, 1), ['b', 'c', 'd']); // reversed
     expect(rangeIds(dives, 2, 2), ['c']); // single
+  });
+
+  test('inDateRange includes dives on the boundary days', () {
+    final r = DateTimeRange(
+      start: DateTime(2026, 6, 1),
+      end: DateTime(2026, 6, 3),
+    );
+    expect(inDateRange(summary('a', DateTime(2026, 6, 1, 8)), r), isTrue);
+    expect(inDateRange(summary('b', DateTime(2026, 6, 3, 23)), r), isTrue);
+    expect(inDateRange(summary('c', DateTime(2026, 5, 31)), r), isFalse);
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart';
+
+DiveSummary summary(String id, [DateTime? dt]) => DiveSummary(
+  id: id,
+  dateTime: dt ?? DateTime(2026, 1, 1),
+  sortTimestamp: 0,
+);
+
+void main() {
+  test('rangeIds returns inclusive span regardless of direction', () {
+    final dives = ['a', 'b', 'c', 'd'].map(summary).toList();
+    expect(rangeIds(dives, 1, 3), ['b', 'c', 'd']);
+    expect(rangeIds(dives, 3, 1), ['b', 'c', 'd']); // reversed
+    expect(rangeIds(dives, 2, 2), ['c']); // single
+  });
+}

--- a/test/features/marine_life/data/repositories/species_repository_bulk_test.dart
+++ b/test/features/marine_life/data/repositories/species_repository_bulk_test.dart
@@ -1,4 +1,3 @@
-import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';

--- a/test/features/marine_life/data/repositories/species_repository_bulk_test.dart
+++ b/test/features/marine_life/data/repositories/species_repository_bulk_test.dart
@@ -1,0 +1,53 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late SpeciesRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    repository = SpeciesRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  domain.Sighting s(String speciesId, {int count = 1}) => domain.Sighting(
+    id: '',
+    diveId: '',
+    speciesId: speciesId,
+    speciesName: '',
+    count: count,
+  );
+
+  test('bulkAddSightings inserts a sighting per dive per template', () async {
+    await repository.bulkAddSightings(['d1', 'd2'], [s('turtle', count: 2)]);
+    final d1 = await (db.select(
+      db.sightings,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(d1.single.speciesId, 'turtle');
+    expect(d1.single.count, 2);
+    final d2 = await (db.select(
+      db.sightings,
+    )..where((t) => t.diveId.equals('d2'))).get();
+    expect(d2.length, 1);
+  });
+
+  test('bulkReplaceSightings overwrites per dive', () async {
+    await repository.bulkAddSightings(['d1'], [s('turtle')]);
+    await repository.bulkReplaceSightings(['d1'], [s('shark')]);
+    final rows = await (db.select(
+      db.sightings,
+    )..where((t) => t.diveId.equals('d1'))).get();
+    expect(rows.single.speciesId, 'shark');
+  });
+}


### PR DESCRIPTION
Part 1 of #150 (the #1 community-requested feature). This PR lands the **data engine + selection mechanics** for comprehensive bulk dive editing. The user-facing **bulk-edit form** — reusing `DiveEditPage` in a "bulk mode" the same way `SiteEditPage` powers site-merge — is a deliberate follow-up (its plan needs a verbatim pass over the `edit_sections/` widgets so the per-field gating isn't guessed). See the spec/plan below.

## What's included

**Bulk write engine** (fully unit-tested against an in-memory DB):
- `DiveRepository`: `bulkUpdateFields` (generic partial-`DivesCompanion` scalar update), `bulkAppendNotes`, `bulkReplaceTags`, equipment add/remove/replace, tank add (`onlyIfEmpty`) / replace, weights add/replace.
- `BuddyRepository` (buddies add/remove/replace) and `SpeciesRepository` (sightings add/replace) — these persist outside the `Dive` aggregate, so the bulk methods live with them.
- `BulkDiveEditService`: composes everything in **one transaction**, captures a **per-dive `BulkEditSnapshot`** before mutating, fires a single `notifyLocalChange()`, and provides `undo()`.
- `BulkEditRequest` / sealed `BulkCollectionOp` model + Riverpod provider.

**Selection mechanics** (`dive_list_content.dart`):
- Long-press to enter selection (preserved) now records a **shift-click anchor**.
- **Shift-click range** selection across the list tiles (desktop/pointer).
- **Select by date range** action in both selection toolbars — cross-platform, and covers the issue's "set a dive center for a whole trip at once" workflow.
- New tooltip translated across all 11 locales.

## Key design decisions
- **Never loops `updateDive`** — bulk writes are set-based (`UPDATE … WHERE id IN`); per-dive updates would churn every child row. The service owns the transaction, so the repo bulk methods don't self-notify or open their own transaction.
- **Collection semantics**: owned rows (tanks/weights/sightings) support Add/Replace; reference rows (tags/equipment/buddies) support Add/Remove/Replace.
- **Undo** stores *per-dive* prior values (heterogeneous dives collapse to one value, so undo must restore each dive's distinct original), restoring scalars via `row.toCompanion(false)` and collections via replace-with-prior.
- Sync-correct: every touched row is `markRecordPending` / `logDeletion`.

## Testing
- ~30 new tests: every repository bulk method, the orchestration service (apply + undo round-tripping **every** collection type, plus add/remove/replace modes and the empty-request guard), the provider, and a selection widget test (long-press → shift-tap range → toggle, detailed + compact).
- Local approximate **patch coverage ≈ 96%** (codecov ignores `lib/l10n/**`, generated files).

## Docs
- Spec: `docs/superpowers/specs/2026-06-23-bulk-dive-editing-design.md`
- Plan: `docs/superpowers/plans/2026-06-23-bulk-dive-editing-engine.md`

Refs #150.