### PR TITLE
fix(ble): retry OSTC nano BLE downloads, unblock the notification queue (#394)

### DIFF
--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -603,11 +603,17 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         guard let value = characteristic.value else { return }
         hasSeenNotify = true
         consecutiveReadTimeouts = 0
+        // Hand the payload to the consumer before logging. Under the OSTC
+        // download fire-hose (hundreds of notifications/second) any work left on
+        // this CoreBluetooth delegate queue delays draining the next
+        // notification; if the queue falls behind, iOS drops notifications and
+        // the download loses bytes (issue #394). append() is O(1) and the log
+        // is dispatched off this queue by NativeLogger.
+        packetBuffer.append(value)
         NativeLogger.d("BleIoStream", category: "BLE",
             "notify \(characteristic.uuid.uuidString)"
                 + " bytes=\(value.count)"
                 + " data=\(Self.hexString(value, maxBytes: Self.maxLogBytes))")
-        packetBuffer.append(value)
     }
 
     func peripheral(_ peripheral: CBPeripheral,

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -100,15 +100,15 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     func connectAndDiscover() -> Bool {
         NativeLogger.d(
             "BleIoStream", category: "BLE",
-            "connectAndDiscover start for \(peripheral.identifier.uuidString)"
-                + " (peripheralState=\(peripheral.state.rawValue)"
-                + " centralState=\(centralManager.state.rawValue))"
+            "connectAndDiscover start for \(self.peripheral.identifier.uuidString)"
+                + " (peripheralState=\(self.peripheral.state.rawValue)"
+                + " centralState=\(self.centralManager.state.rawValue))"
         )
 
         guard centralManager.state == .poweredOn else {
             NativeLogger.w(
                 "BleIoStream", category: "BLE",
-                "Central not powered on (state=\(centralManager.state.rawValue))"
+                "Central not powered on (state=\(self.centralManager.state.rawValue))"
             )
             return false
         }
@@ -187,8 +187,8 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         NativeLogger.d("BleIoStream", category: "BLE",
             "Post-notify settle delay complete (\(Int(Self.notifySettleDelaySeconds * 1000)) ms)")
         NativeLogger.d("BleIoStream", category: "BLE",
-            "Discovery ready (write=\(writeCharacteristic?.uuid.uuidString ?? "nil")"
-                + " notify=\(notifyCharacteristic?.uuid.uuidString ?? "nil"))")
+            "Discovery ready (write=\(self.writeCharacteristic?.uuid.uuidString ?? "nil")"
+                + " notify=\(self.notifyCharacteristic?.uuid.uuidString ?? "nil"))")
         return true
     }
 
@@ -409,9 +409,13 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         let properties = characteristic.properties
         guard properties.contains(.write) && properties.contains(.writeWithoutResponse) else { return }
         writeWithoutResponsePreferred.toggle()
+        // Snapshot before logging: the message is built later on the logger
+        // queue, and reading this mutable flag there would race with the I/O
+        // queue that toggles it.
+        let preferWithoutResponse = writeWithoutResponsePreferred
         NativeLogger.d("BleIoStream", category: "BLE",
             "Read timed out before response; flipping preferred write mode to"
-                + " \(writeWithoutResponsePreferred ? "withoutResponse" : "withResponse")"
+                + " \(preferWithoutResponse ? "withoutResponse" : "withResponse")"
         )
     }
 
@@ -699,9 +703,10 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
                 + " notify=\(notifyChar.uuid.uuidString)"
                 + " (\(Self.propertySummary(notifyChar.properties)))"
                 + " (score=\(selection.score))")
+        let preferWithoutResponse = writeWithoutResponsePreferred
         NativeLogger.d("BleIoStream", category: "BLE",
             "Initial write mode preference:"
-                + " \(writeWithoutResponsePreferred ? "withoutResponse" : "withResponse")")
+                + " \(preferWithoutResponse ? "withoutResponse" : "withResponse")")
         if notifyChar.isNotifying {
             isReady = true
             signalDiscoveryReady()

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -872,7 +872,7 @@ private final class BlePeripheralResolver: NSObject, CBCentralManagerDelegate {
 
         switch central.state {
         case .poweredOn:
-            NativeLogger.d("DiveComputerHost", category: "BLE", "Central powered on, resolving \(targetIdentifier.uuidString)")
+            NativeLogger.d("DiveComputerHost", category: "BLE", "Central powered on, resolving \(self.targetIdentifier.uuidString)")
             attemptResolveIfReady()
         case .poweredOff, .unauthorized, .unsupported:
             NativeLogger.w("DiveComputerHost", category: "BLE", "Central unavailable (state=\(central.state.rawValue))")
@@ -899,14 +899,14 @@ private final class BlePeripheralResolver: NSObject, CBCentralManagerDelegate {
 
         if allowCachedPeripherals {
             if let cached = central.retrievePeripherals(withIdentifiers: [targetIdentifier]).first {
-                NativeLogger.d("DiveComputerHost", category: "BLE", "Found cached peripheral \(targetIdentifier.uuidString)")
+                NativeLogger.d("DiveComputerHost", category: "BLE", "Found cached peripheral \(self.targetIdentifier.uuidString)")
                 finish(peripheral: cached)
                 return
             }
         }
 
         if !isScanning {
-            NativeLogger.d("DiveComputerHost", category: "BLE", "Scanning for \(targetIdentifier.uuidString)")
+            NativeLogger.d("DiveComputerHost", category: "BLE", "Scanning for \(self.targetIdentifier.uuidString)")
             central.scanForPeripherals(
                 withServices: nil,
                 options: [CBCentralManagerScanOptionAllowDuplicatesKey: false]

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/NativeLogger.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/NativeLogger.swift
@@ -5,31 +5,46 @@ import Foundation
 class NativeLogger {
     static var flutterApi: DiveComputerFlutterApi?
 
+    // All log output is funneled through this single serial queue so a log call
+    // never blocks its caller. The CoreBluetooth delegate queue logs every GATT
+    // notification during a download -- hundreds per second under the OSTC
+    // fire-hose -- and doing the synchronous print there throttled that queue,
+    // which made iOS drop notifications and corrupt the download (issue #394).
+    // One serial queue keeps log lines in order while moving the print and the
+    // Flutter hand-off off the hot path.
+    private static let queue = DispatchQueue(label: "app.submersion.native-logger",
+                                             qos: .utility)
+
     static func d(_ tag: String, category: String, _ message: String) {
-        print("[\(tag)] \(message)")
-        sendToFlutter(category: category, level: "DEBUG", message: message)
+        log(tag: tag, category: category, level: "DEBUG", message: message)
     }
 
     static func i(_ tag: String, category: String, _ message: String) {
-        print("[\(tag)] \(message)")
-        sendToFlutter(category: category, level: "INFO", message: message)
+        log(tag: tag, category: category, level: "INFO", message: message)
     }
 
     static func w(_ tag: String, category: String, _ message: String) {
-        print("[\(tag)] WARNING: \(message)")
-        sendToFlutter(category: category, level: "WARN", message: message)
+        log(tag: tag, category: category, level: "WARN", message: message)
     }
 
     static func e(_ tag: String, category: String, _ message: String) {
-        print("[\(tag)] ERROR: \(message)")
-        sendToFlutter(category: category, level: "ERROR", message: message)
+        log(tag: tag, category: category, level: "ERROR", message: message)
     }
 
-    private static func sendToFlutter(category: String, level: String, message: String) {
-        guard let api = flutterApi else { return }
-        DispatchQueue.main.async {
-            api.onLogEvent(category: category, level: level, message: message) { _ in
-                // Ignore callback result - don't let logging failures crash the app
+    private static func log(tag: String, category: String, level: String, message: String) {
+        queue.async {
+            let prefix: String
+            switch level {
+            case "WARN": prefix = "WARNING: "
+            case "ERROR": prefix = "ERROR: "
+            default: prefix = ""
+            }
+            print("[\(tag)] \(prefix)\(message)")
+            guard let api = flutterApi else { return }
+            DispatchQueue.main.async {
+                api.onLogEvent(category: category, level: level, message: message) { _ in
+                    // Ignore callback result - don't let logging failures crash the app
+                }
             }
         }
     }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/NativeLogger.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/NativeLogger.swift
@@ -15,23 +15,29 @@ class NativeLogger {
     private static let queue = DispatchQueue(label: "app.submersion.native-logger",
                                              qos: .utility)
 
-    static func d(_ tag: String, category: String, _ message: String) {
+    // The message is an @autoclosure so its construction is deferred to the
+    // logger queue. Hot-path callers (the per-notification BLE log builds a hex
+    // dump) would otherwise format the string on the CoreBluetooth delegate
+    // queue before the call even returns, which is exactly the work we are
+    // trying to keep off that queue (issue #394).
+    static func d(_ tag: String, category: String, _ message: @autoclosure @escaping () -> String) {
         log(tag: tag, category: category, level: "DEBUG", message: message)
     }
 
-    static func i(_ tag: String, category: String, _ message: String) {
+    static func i(_ tag: String, category: String, _ message: @autoclosure @escaping () -> String) {
         log(tag: tag, category: category, level: "INFO", message: message)
     }
 
-    static func w(_ tag: String, category: String, _ message: String) {
+    static func w(_ tag: String, category: String, _ message: @autoclosure @escaping () -> String) {
         log(tag: tag, category: category, level: "WARN", message: message)
     }
 
-    static func e(_ tag: String, category: String, _ message: String) {
+    static func e(_ tag: String, category: String, _ message: @autoclosure @escaping () -> String) {
         log(tag: tag, category: category, level: "ERROR", message: message)
     }
 
-    private static func log(tag: String, category: String, level: String, message: String) {
+    private static func log(tag: String, category: String, level: String,
+                            message: @escaping () -> String) {
         queue.async {
             let prefix: String
             switch level {
@@ -39,10 +45,13 @@ class NativeLogger {
             case "ERROR": prefix = "ERROR: "
             default: prefix = ""
             }
-            print("[\(tag)] \(prefix)\(message)")
+            // Evaluate the message once, here on the logger queue, and reuse it
+            // for both the console print and the Flutter log event.
+            let text = message()
+            print("[\(tag)] \(prefix)\(text)")
             guard let api = flutterApi else { return }
             DispatchQueue.main.async {
-                api.onLogEvent(category: category, level: level, message: message) { _ in
+                api.onLogEvent(category: category, level: level, message: text) { _ in
                     // Ignore callback result - don't let logging failures crash the app
                 }
             }

--- a/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
+++ b/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
@@ -55,9 +55,12 @@ void device_event_emit(dc_device_t *device, dc_event_type_t event,
   (void)event;
   (void)data;
 }
+// Controllable so a retry test can exercise the cancellation path. Defaults to
+// 0 (not cancelled) for every other test.
+static int g_cancelled = 0;
 int device_is_cancelled(dc_device_t *device) {
   (void)device;
-  return 0;
+  return g_cancelled;
 }
 
 // One GATT notification carries up to 16 bytes in this mock, matching the
@@ -339,11 +342,225 @@ static void check_retry(void) {
   expect(attempts == 1, "an unsupported command is not retried");
 }
 
+// Opens a custom BLE iostream backed by `mock` driven by the proto_* callbacks,
+// wired into a minimal DOWNLOAD-state device. The caller runs a transfer and
+// closes via the returned context.
+static dc_iostream_t *open_proto(dc_context_t **ctx_out, proto_mock_t *mock,
+                                 hw_ostc3_device_t *dev) {
+  assert(dc_context_new(ctx_out) == DC_STATUS_SUCCESS);
+  dc_custom_cbs_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.read = proto_read;
+  cbs.write = proto_write;
+  cbs.purge = proto_purge;
+  cbs.sleep = proto_sleep;
+  cbs.close = mock_close;
+  dc_iostream_t *iostream = NULL;
+  assert(dc_custom_open(&iostream, *ctx_out, DC_TRANSPORT_BLE, &cbs, mock) ==
+         DC_STATUS_SUCCESS);
+  memset(dev, 0, sizeof(*dev));
+  dev->base.context = *ctx_out;
+  dev->iostream = iostream;
+  dev->state = DOWNLOAD;
+  return iostream;
+}
+
+// Terminal (non-retried) outcomes: a cancellation and a deterministic error
+// must both return immediately. Uses progress == NULL, which also covers the
+// wrapper's no-progress branch.
+static void check_retry_terminal(void) {
+  unsigned char payload[64], out[300];
+
+  // Cancellation: hw_ostc3_transfer sees the cancel flag and returns CANCELLED,
+  // which the wrapper propagates without retrying.
+  {
+    proto_mock_t mock;
+    memset(&mock, 0, sizeof(mock));
+    mock.payload = payload;
+    mock.size = sizeof(payload);
+    dc_context_t *ctx = NULL;
+    hw_ostc3_device_t dev;
+    dc_iostream_t *io = open_proto(&ctx, &mock, &dev);
+    g_cancelled = 1;
+    dc_status_t rc = hw_ostc3_transfer_retry(&dev, NULL, COMPACT, NULL, 0, out,
+                                             sizeof(payload), NULL, NODELAY);
+    g_cancelled = 0;
+    expect(rc == DC_STATUS_CANCELLED, "a cancelled transfer is not retried");
+    dc_iostream_close(io);
+    dc_context_free(ctx);
+  }
+
+  // Non-transient error: a DIVE transfer with osize < the full-header size is
+  // rejected as INVALIDARGS, which the wrapper must return without retrying.
+  {
+    proto_mock_t mock;
+    memset(&mock, 0, sizeof(mock));
+    mock.payload = payload;
+    mock.size = sizeof(payload);
+    dc_context_t *ctx = NULL;
+    hw_ostc3_device_t dev;
+    dc_iostream_t *io = open_proto(&ctx, &mock, &dev);
+    unsigned char number[1] = {0};
+    dc_status_t rc = hw_ostc3_transfer_retry(&dev, NULL, DIVE, number, 1, out,
+                                             100, NULL, NODELAY);
+    expect(rc == DC_STATUS_INVALIDARGS,
+           "a non-transient error is returned without retrying");
+    dc_iostream_close(io);
+    dc_context_free(ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// foreach call-site coverage: hw_ostc3_device_foreach must route its three
+// download transfers (COMPACT, the HEADER fallback, and each DIVE) through the
+// retry wrapper. This command-aware mock answers the COMPACT/HEADER handshake,
+// can report COMPACT as unsupported, and times out the DIVE read -- enough to
+// drive foreach through every call site without a full valid dive profile.
+// ---------------------------------------------------------------------------
+
+enum { FM_ECHO = 0, FM_DATA = 1, FM_READY = 2, FM_DONE = 3 };
+
+typedef struct {
+  const unsigned char *logbook;  // COMPACT/HEADER table to serve
+  size_t logbook_size;
+  int compact_unsupported;  // COMPACT echo returns READY -> DC_STATUS_UNSUPPORTED
+  int read_phase;
+  unsigned char cmd;
+  size_t offset;
+  int expect_input;  // next write is a DIVE number, not a new command
+} foreach_mock_t;
+
+static dc_status_t fm_write(void *userdata, const void *data, size_t size,
+                            size_t *actual) {
+  foreach_mock_t *m = (foreach_mock_t *)userdata;
+  if (m->expect_input) {
+    m->expect_input = 0;  // consume the DIVE number
+  } else {
+    m->cmd = ((const unsigned char *)data)[0];
+    m->read_phase = FM_ECHO;
+    m->offset = 0;
+  }
+  if (actual) *actual = size;
+  return DC_STATUS_SUCCESS;
+}
+
+static dc_status_t fm_read(void *userdata, void *data, size_t size,
+                           size_t *actual) {
+  foreach_mock_t *m = (foreach_mock_t *)userdata;
+  unsigned char *out = (unsigned char *)data;
+  switch (m->read_phase) {
+    case FM_ECHO:
+      out[0] = (m->cmd == COMPACT && m->compact_unsupported) ? READY : m->cmd;
+      if (actual) *actual = 1;
+      if (m->cmd == DIVE) m->expect_input = 1;  // a number write follows
+      m->read_phase = FM_DATA;
+      return DC_STATUS_SUCCESS;
+    case FM_DATA:
+      if (m->cmd == DIVE) {
+        if (actual) *actual = 0;  // stall the dive read; the call site is covered
+        return DC_STATUS_TIMEOUT;
+      }
+      {
+        size_t remaining = m->logbook_size - m->offset;
+        size_t n = size < MOCK_CHUNK ? size : MOCK_CHUNK;
+        if (n > remaining) n = remaining;
+        memcpy(out, m->logbook + m->offset, n);
+        m->offset += n;
+        if (actual) *actual = n;
+        if (m->offset == m->logbook_size) m->read_phase = FM_READY;
+        return DC_STATUS_SUCCESS;
+      }
+    case FM_READY:
+      out[0] = READY;
+      if (actual) *actual = 1;
+      m->read_phase = FM_DONE;
+      return DC_STATUS_SUCCESS;
+    default:
+      if (actual) *actual = 0;
+      return DC_STATUS_TIMEOUT;
+  }
+}
+
+static dc_status_t fm_purge(void *userdata, dc_direction_t direction) {
+  (void)userdata;
+  (void)direction;
+  return DC_STATUS_SUCCESS;
+}
+
+static int fm_dive_cb(const unsigned char *data, unsigned int size,
+                      const unsigned char *fingerprint, unsigned int fsize,
+                      void *userdata) {
+  (void)data;
+  (void)size;
+  (void)fingerprint;
+  (void)fsize;
+  (void)userdata;
+  return 1;
+}
+
+static dc_status_t run_foreach(const unsigned char *logbook, size_t logbook_size,
+                               int compact_unsupported) {
+  dc_context_t *ctx = NULL;
+  assert(dc_context_new(&ctx) == DC_STATUS_SUCCESS);
+  foreach_mock_t mock;
+  memset(&mock, 0, sizeof(mock));
+  mock.logbook = logbook;
+  mock.logbook_size = logbook_size;
+  mock.compact_unsupported = compact_unsupported;
+  dc_custom_cbs_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.read = fm_read;
+  cbs.write = fm_write;
+  cbs.purge = fm_purge;
+  cbs.sleep = proto_sleep;
+  cbs.close = mock_close;
+  dc_iostream_t *iostream = NULL;
+  assert(dc_custom_open(&iostream, ctx, DC_TRANSPORT_BLE, &cbs, &mock) ==
+         DC_STATUS_SUCCESS);
+  hw_ostc3_device_t dev;
+  memset(&dev, 0, sizeof(dev));
+  dev.base.context = ctx;
+  dev.iostream = iostream;
+  dev.state = DOWNLOAD;
+  dc_status_t rc = hw_ostc3_device_foreach(&dev.base, fm_dive_cb, NULL);
+  dc_iostream_close(iostream);
+  dc_context_free(ctx);
+  return rc;
+}
+
+static void check_foreach_call_sites(void) {
+  // COMPACT succeeds with one dive header -> covers the COMPACT call site and
+  // the DIVE call site. The dive read times out, so foreach reports an error.
+  unsigned char *lb = (unsigned char *)malloc(4096);
+  memset(lb, 0xFF, 4096);
+  // length field -> profile length 269 (>= the 256-byte full header); a
+  // non-zero summary so the entry does not match the all-zero fingerprint.
+  unsigned char entry[16] = {0x10, 0x00, 0x00, 1, 2, 3, 4, 5,
+                             6,    7,    8,    9, 10, 1, 0, 0x24};
+  memcpy(lb, entry, sizeof(entry));
+  dc_status_t rc1 = run_foreach(lb, 4096, 0);
+  free(lb);
+  expect(rc1 != DC_STATUS_SUCCESS,
+         "foreach drives the COMPACT and DIVE retry call sites");
+
+  // COMPACT unsupported -> HEADER fallback call site; an all-empty header
+  // table yields no dives, so foreach completes successfully.
+  size_t hb_size = 256 * 256;  // RB_LOGBOOK_SIZE_FULL * RB_LOGBOOK_COUNT
+  unsigned char *hb = (unsigned char *)malloc(hb_size);
+  memset(hb, 0xFF, hb_size);
+  dc_status_t rc2 = run_foreach(hb, hb_size, 1);
+  free(hb);
+  expect(rc2 == DC_STATUS_SUCCESS,
+         "foreach falls back to the HEADER retry call site when COMPACT is unsupported");
+}
+
 int main(void) {
   check_fill(64);    // exact multiple of the 16-byte notification size
   check_fill(40);    // non-multiple: the final read is a partial (8 bytes)
   check_fill(4096);  // the real COMPACT logbook size from issue #280
   check_retry();     // issue #394: per-transfer retry recovers from byte loss
+  check_retry_terminal();      // cancelled + non-transient: returned, not retried
+  check_foreach_call_sites();  // foreach routes COMPACT/HEADER/DIVE through retry
 
   if (failures == 0) {
     printf("All hw_ostc3_read tests passed.\n");

--- a/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
+++ b/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
@@ -141,10 +141,209 @@ static void check_fill(size_t total) {
   free(out);
 }
 
+// ---------------------------------------------------------------------------
+// Issue #394: per-transfer retry (hw_ostc3_transfer_retry).
+//
+// On iOS/macOS the OSTC nano's BLE link intermittently drops a few bytes during
+// the large logbook/profile transfers, so a read stalls short and the transfer
+// times out. The device stays idle and responsive afterwards, so re-issuing the
+// command recovers. These tests drive the real hw_ostc3_transfer through a mock
+// that speaks the OSTC command/echo/data/ready protocol and can fail the first
+// N attempts, verifying the wrapper recovers, resets progress, honors the
+// attempt cap, and does NOT retry a non-transient (UNSUPPORTED) result.
+// ---------------------------------------------------------------------------
+
+enum { PH_ECHO = 0, PH_DATA = 1, PH_READY = 2, PH_DONE = 3 };
+
+typedef struct {
+  const unsigned char *payload;
+  size_t size;
+  int phase;        // PH_* state within the current attempt
+  size_t offset;    // bytes of payload served this attempt
+  unsigned char cmd;
+  int attempt;      // command writes seen (== transfer attempts)
+  int fail_attempts;     // the first N attempts stall (lose bytes)
+  size_t fail_after;     // bytes served before the stall, on a failing attempt
+  unsigned char echo_byte;  // byte returned for the echo (cmd, or a wrong byte)
+  int purge_calls;
+} proto_mock_t;
+
+// Every write in the COMPACT flow is the 1-byte command (COMPACT has no input
+// payload), so each write begins a fresh attempt.
+static dc_status_t proto_write(void *userdata, const void *data, size_t size,
+                               size_t *actual) {
+  proto_mock_t *m = (proto_mock_t *)userdata;
+  m->cmd = ((const unsigned char *)data)[0];
+  m->phase = PH_ECHO;
+  m->offset = 0;
+  m->attempt++;
+  if (actual) *actual = size;
+  return DC_STATUS_SUCCESS;
+}
+
+static dc_status_t proto_read(void *userdata, void *data, size_t size,
+                              size_t *actual) {
+  proto_mock_t *m = (proto_mock_t *)userdata;
+  unsigned char *out = (unsigned char *)data;
+  switch (m->phase) {
+    case PH_ECHO:
+      out[0] = m->echo_byte ? m->echo_byte : m->cmd;
+      if (actual) *actual = 1;
+      m->phase = PH_DATA;
+      return DC_STATUS_SUCCESS;
+    case PH_DATA: {
+      // Simulate lost bytes: a failing attempt stalls once it has served
+      // fail_after bytes, exactly as a read does when the tail never arrives.
+      if (m->attempt <= m->fail_attempts && m->offset >= m->fail_after) {
+        if (actual) *actual = 0;
+        return DC_STATUS_TIMEOUT;
+      }
+      size_t remaining = m->size - m->offset;
+      size_t n = size < MOCK_CHUNK ? size : MOCK_CHUNK;
+      if (n > remaining) n = remaining;
+      memcpy(out, m->payload + m->offset, n);
+      m->offset += n;
+      if (actual) *actual = n;
+      if (m->offset == m->size) m->phase = PH_READY;
+      return DC_STATUS_SUCCESS;
+    }
+    case PH_READY:
+      out[0] = READY;  // 0x4D, the ready byte for state == DOWNLOAD
+      if (actual) *actual = 1;
+      m->phase = PH_DONE;
+      return DC_STATUS_SUCCESS;
+    default:
+      if (actual) *actual = 0;
+      return DC_STATUS_TIMEOUT;
+  }
+}
+
+static dc_status_t proto_purge(void *userdata, dc_direction_t direction) {
+  proto_mock_t *m = (proto_mock_t *)userdata;
+  (void)direction;
+  m->purge_calls++;
+  return DC_STATUS_SUCCESS;
+}
+
+static dc_status_t proto_sleep(void *userdata, unsigned int ms) {
+  (void)userdata;
+  (void)ms;  // no-op: keep the test fast
+  return DC_STATUS_SUCCESS;
+}
+
+// Runs one COMPACT transfer through hw_ostc3_transfer_retry against a mock that
+// fails `fail_attempts` times. Returns the transfer status and reports details
+// via the out-params so each test can assert what it cares about.
+static dc_status_t run_retry(size_t total, int fail_attempts,
+                             unsigned char echo_byte,
+                             unsigned int progress_start, int *attempts,
+                             int *purges, unsigned int *progress_end,
+                             int *data_ok) {
+  unsigned char *payload = (unsigned char *)malloc(total);
+  for (size_t i = 0; i < total; i++) payload[i] = (unsigned char)((i * 7) & 0xFF);
+
+  dc_context_t *ctx = NULL;
+  assert(dc_context_new(&ctx) == DC_STATUS_SUCCESS);
+
+  proto_mock_t mock;
+  memset(&mock, 0, sizeof(mock));
+  mock.payload = payload;
+  mock.size = total;
+  mock.fail_attempts = fail_attempts;
+  mock.fail_after = total / 2;  // stall halfway: clearly short
+  mock.echo_byte = echo_byte;
+
+  dc_custom_cbs_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.read = proto_read;
+  cbs.write = proto_write;
+  cbs.purge = proto_purge;
+  cbs.sleep = proto_sleep;
+  cbs.close = mock_close;
+
+  dc_iostream_t *iostream = NULL;
+  assert(dc_custom_open(&iostream, ctx, DC_TRANSPORT_BLE, &cbs, &mock) ==
+         DC_STATUS_SUCCESS);
+
+  hw_ostc3_device_t dev;
+  memset(&dev, 0, sizeof(dev));
+  dev.base.context = ctx;
+  dev.iostream = iostream;
+  dev.state = DOWNLOAD;  // ready byte is READY (0x4D)
+
+  dc_event_progress_t progress;
+  memset(&progress, 0, sizeof(progress));
+  progress.current = progress_start;
+  progress.maximum = progress_start + (unsigned int)total;
+
+  unsigned char *out = (unsigned char *)malloc(total);
+  memset(out, 0xEE, total);
+
+  dc_status_t rc = hw_ostc3_transfer_retry(&dev, &progress, COMPACT, NULL, 0,
+                                           out, (unsigned int)total, NULL,
+                                           NODELAY);
+
+  if (attempts) *attempts = mock.attempt;
+  if (purges) *purges = mock.purge_calls;
+  if (progress_end) *progress_end = progress.current;
+  if (data_ok) *data_ok = (rc == DC_STATUS_SUCCESS) &&
+                          (memcmp(out, payload, total) == 0);
+
+  dc_iostream_close(iostream);
+  dc_context_free(ctx);
+  free(payload);
+  free(out);
+  return rc;
+}
+
+static void expect(int cond, const char *label) {
+  if (cond) {
+    printf("PASS: %s\n", label);
+  } else {
+    printf("FAIL: %s\n", label);
+    failures++;
+  }
+}
+
+static void check_retry(void) {
+  const size_t total = 4096;  // the COMPACT logbook size from the issue
+  int attempts, purges, data_ok;
+  unsigned int progress_end;
+  dc_status_t rc;
+
+  // Recovery: one failing attempt, then success on the retry.
+  rc = run_retry(total, 1, 0, 1000, &attempts, &purges, &progress_end, &data_ok);
+  expect(rc == DC_STATUS_SUCCESS, "retry recovers a transient transfer timeout");
+  expect(data_ok, "recovered transfer fills the whole buffer correctly");
+  expect(attempts == 2, "recovery takes exactly two attempts");
+  expect(purges >= 1, "the link is purged before the retry");
+  // Progress must count only the successful attempt, not the failed partial.
+  expect(progress_end == 1000 + (unsigned int)total,
+         "progress is reset between attempts (no double counting)");
+
+  // Happy path: no failures, no retry, no purge.
+  rc = run_retry(total, 0, 0, 0, &attempts, &purges, NULL, &data_ok);
+  expect(rc == DC_STATUS_SUCCESS && data_ok && attempts == 1 && purges == 0,
+         "a clean transfer succeeds on the first attempt with no purge");
+
+  // Attempt cap: a persistently lossy link fails after the bounded attempts.
+  rc = run_retry(total, 999, 0, 0, &attempts, &purges, NULL, NULL);
+  expect(rc == DC_STATUS_TIMEOUT, "a persistent failure returns the error");
+  expect(attempts == HW_OSTC3_DOWNLOAD_ATTEMPTS,
+         "retries are capped at HW_OSTC3_DOWNLOAD_ATTEMPTS");
+
+  // Non-transient result (UNSUPPORTED via a ready-byte echo) is not retried:
+  // this preserves the COMPACT -> HEADER fallback for older firmware.
+  rc = run_retry(total, 0, READY, 0, &attempts, &purges, NULL, NULL);
+  expect(rc == DC_STATUS_UNSUPPORTED, "an unsupported command is reported");
+  expect(attempts == 1, "an unsupported command is not retried");
+}
+
 int main(void) {
   check_fill(64);    // exact multiple of the 16-byte notification size
   check_fill(40);    // non-multiple: the final read is a partial (8 bytes)
   check_fill(4096);  // the real COMPACT logbook size from issue #280
+  check_retry();     // issue #394: per-transfer retry recovers from byte loss
 
   if (failures == 0) {
     printf("All hw_ostc3_read tests passed.\n");


### PR DESCRIPTION
## Problem

The OSTC nano (Heinrichs Weikamp; whole `hw_ostc3` family) connects over BLE but the dive download intermittently fails with `result=-7`. This is the iOS-side remainder of #280: v1.5.5.107 already contains the #280 fix and it works (the reporter now sees "some progress"), but the download still aborts partway.

## Root cause

Parsed the reporter's debug log quantitatively. With #280 in place (`hw_ostc3_read` honors short reads), the remaining failures are **honest timeouts from intermittent byte loss below the app**:

| Phase | Bytes CoreBluetooth delivered | Expected | Outcome |
|------|------|------|------|
| COMPACT logbook (attempt 1) | 4090 data | 4096 | 6 bytes never arrived → 3 s timeout → `-7` |
| COMPACT logbook (attempt 2) | 4096 data | 4096 | succeeded |
| dive profile (attempt 2) | ~12344 | ~12383 | ~39 bytes short → timeout → `-7` |

The `notify bytes=N` counts are logged at raw CoreBluetooth delivery, and `PacketReadBuffer` provably preserves partial-notification remainders, so the app drops nothing — the bytes never arrive. iOS/macOS CoreBluetooth exposes no connection-interval API (the Android/Windows mitigation from #280), and the OSTC's BLE-to-UART bridge drops a few bytes during the large logbook/profile fire-hose. libdivecomputer's `hw_ostc3` `foreach` aborts the entire download on the first short read, with no retry.

## Fix

**1. Per-transfer retry — all platforms.** A new `hw_ostc3_transfer_retry` wrapper in the vendored driver re-issues a download transfer on a transient error (timeout / io / protocol), resyncing the link (sleep + purge) between attempts and restoring the progress counter so a failed partial read doesn't inflate it. The device is idle and responsive once a transfer stalls — it echoes the EXIT command right after each timeout in the log — so re-issuing on the same connection recovers. Only the `foreach` download reads (COMPACT/HEADER logbook and each DIVE) use the wrapper; init, time sync, config and firmware keep calling `hw_ostc3_transfer` directly, so a write or firmware op is never silently repeated. Submodule bump `ea56ff5..4ac9867`.

**2. Unblock the notification queue — iOS/macOS.** `NativeLogger` now routes its `print` + Flutter hand-off through a serial background queue, and `didUpdateValueFor` buffers each notification before logging. The per-notification debug logging was running synchronously on the CoreBluetooth delegate queue; under the ~330 notification/sec fire-hose that throttled the queue and made iOS drop notifications — worse in the debug mode used to capture the logs.

## Platform reach

- **Retry:** all platforms (it's in the shared C driver, compiled into every plugin build).
- **Logging change:** iOS + macOS (the `darwin` Swift transport). Android has its own Kotlin transport plus `requestConnectionPriority(HIGH)` and is far less exposed; if the symptom ever shows there, the equivalent Kotlin change is a one-liner.

## Testing

- 10 new native regression cases in `test_hw_ostc3_read.c` covering the retry wrapper: recovery from a transient stall, the attempt cap, progress reset, and that an unsupported command is reported without retry (preserving the COMPACT→HEADER fallback for older firmware). Demonstrated red → green.
- macOS app builds clean — the Swift transport changes and the C driver link together.
- **Hardware verification on the reporter's OSTC nano: pending.** The retry is verified in simulation; real-world effectiveness depends on the actual loss rate.

Addresses #394 (leaving open until hardware-confirmed by the reporter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvdinAXUouhwM86Dd7boSR
