### PR TITLE
fix(sync): stream Replace-adopt to fix iOS OOM on large libraries (#358)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-sync-adopt-oom-streaming.md
+++ b/docs/superpowers/plans/2026-06-23-sync-adopt-oom-streaming.md
@@ -1,0 +1,677 @@
+# Streaming Replace-Adopt (iCloud OOM #358 follow-up) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `SyncService.adoptReplacedLibrary` apply an epoch-stamped cloud library in bounded memory so a fresh iOS device (0 dives) no longer OOM-crashes when it silently auto-adopts a large library (#358, still reproducing on v1.5.5.107).
+
+**Architecture:** Mirror the already-shipped streaming base apply (`_applyRemoteBaseFile`). Assemble each epoch device's base into a temp file with `BasePartFileSink` (one 8 MB part in memory at a time), then in a single deferred-FK transaction stream every base file's `data` rows through `BaseJsonStreamReader` in `exportedAt` order, **upserting** in 500-row batches while collecting the set of cloud ids as a side effect, then **delete** local rows whose id is not in that set (via a new bounded id-only enumeration `recordIdsFor`), then repair FKs. This drops both RAM sinks the current path has: the decoded cloud `restored` map and the full local `exportData()` snapshot. Changesets stamped with the epoch stay in memory (they are small deltas), exactly as today.
+
+**Tech Stack:** Dart/Flutter, Drift ORM (SQLite), existing sync primitives `BasePartFileSink`, `BaseJsonStreamReader`, `ChangesetCodec`, `SyncDataSerializer`.
+
+## Global Constraints
+
+- No wire-format change. Old monolithic-JSON bases and ssv1 part-sliced bases both already import; do not force any republish.
+- Behavioral parity is the contract: the streaming adopt MUST produce a byte-identical synced-entity database to the current in-memory adopt for the same inputs. A parity test enforces this (Task 3).
+- Adopt processes only the `data` section of each payload (base + changesets); it ignores `deletions`. This matches the current `_collectEpochPayloads` union (it reads `payload.data` only). Do not start applying deletions — that would be a behavior change outside this fix's scope.
+- `upsertRecord` is an unconditional `insertOnConflictUpdate` (verified). Therefore applying rows in ascending `exportedAt` order (last write wins) is equivalent to the current "latest-export-wins `restored` map." Do not add conditional/LWW logic to the adopt apply.
+- All apply work happens inside `_serializer.applyInDeferredFkTransaction(...)`; any throw rolls the whole adopt back (local library preserved). Base files are validated by `BasePartFileSink` (per-part + whole-file SHA-256) and `BaseJsonStreamReader`'s truncation guard BEFORE any local row is deleted.
+- `dart format .` (whole repo) and `flutter analyze` must be clean before any commit. Run the targeted test files listed per task, not whole directories.
+- Synced entity set is the 38 keys of `SyncService.entityHasUpdatedAt` (sync_service.dart:1215-1255), locked by the existing structural test. `recordIdsFor` and the delete loop must cover exactly these.
+
+---
+
+## File Structure
+
+- `lib/core/services/sync/sync_data_serializer.dart` — add `recordIdsFor(String entityType) -> Future<Set<String>>` (bounded, id-only projection; emits the same id form `deleteRecord` consumes, including composite `a|b`).
+- `lib/core/services/sync/sync_service.dart` — the bulk of the change:
+  - keep the current in-memory union/delete/upsert as a `@visibleForTesting` reference (`debugAdoptInMemory`) and keep in-memory collection as `debugCollectEpochPayloadsInMemory` (test-only; production stops calling it);
+  - add streaming production path: `_collectEpochBaseSources`, `_adoptApplyStreaming`, and `@visibleForTesting debugAdoptStreaming`;
+  - rewrite `adoptReplacedLibrary` to use the streaming path and clean up temp files.
+- `test/core/services/sync/sync_data_serializer_record_ids_test.dart` — new unit test for `recordIdsFor`.
+- `test/core/services/sync/sync_adopt_streaming_parity_test.dart` — new parity test (streaming adopt == in-memory adopt, byte-identical DB), the safety net.
+
+---
+
+## Task 1: Bounded local id enumeration `recordIdsFor`
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_data_serializer.dart` (add method near `deleteRecord` at :1206; reuse existing `_compositeId`/`_splitCompositeId` conventions)
+- Test: `test/core/services/sync/sync_data_serializer_record_ids_test.dart` (create)
+
+**Interfaces:**
+- Produces: `Future<Set<String>> SyncDataSerializer.recordIdsFor(String entityType)` — returns every local row's id for `entityType`, in the exact string form `_recordIdForEntity` produces and `deleteRecord` accepts: plain `id` for most, `key` for `settings`, `diveId|equipmentId` for `diveEquipment`, `setId|equipmentId` for `equipmentSetItems`. Reads only id column(s) (never full rows), so it is bounded for `diveProfiles`/`tankPressureProfiles` (row-per-sample, millions of rows). Unknown entity type returns an empty set.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/services/sync/sync_data_serializer_record_ids_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import '../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() async => setUpTestDatabase());
+  tearDown(() => tearDownTestDatabase());
+
+  test('recordIdsFor returns plain ids for a simple entity', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecord('diveSites', {
+      'id': 'site-1', 'name': 'A', 'description': '', 'notes': '',
+      'isShared': false, 'createdAt': 1000, 'updatedAt': 1000,
+    });
+    await s.upsertRecord('diveSites', {
+      'id': 'site-2', 'name': 'B', 'description': '', 'notes': '',
+      'isShared': false, 'createdAt': 1000, 'updatedAt': 1000,
+    });
+    expect(await s.recordIdsFor('diveSites'), {'site-1', 'site-2'});
+  });
+
+  test('recordIdsFor builds composite ids for diveEquipment', () async {
+    final s = SyncDataSerializer();
+    // Parents first (FK).
+    await s.upsertRecord('dives', _dive('d1'));
+    await s.upsertRecord('equipment', _equip('e1'));
+    await s.upsertRecord('diveEquipment', {
+      'diveId': 'd1', 'equipmentId': 'e1', 'createdAt': 1000,
+    });
+    expect(await s.recordIdsFor('diveEquipment'), {'d1|e1'});
+  });
+
+  test('recordIdsFor keys settings on key, unknown type is empty', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecord('settings', {'key': 'theme', 'value': 'dark', 'updatedAt': 1});
+    expect(await s.recordIdsFor('settings'), {'theme'});
+    expect(await s.recordIdsFor('notATable'), <String>{});
+  });
+}
+
+Map<String, dynamic> _dive(String id) => {
+  'id': id, 'diveNumber': 1, 'diveDateTime': 1700000000000, 'createdAt': 1000, 'updatedAt': 1000,
+};
+Map<String, dynamic> _equip(String id) => {
+  'id': id, 'name': 'reg', 'category': 'regulator', 'createdAt': 1000, 'updatedAt': 1000,
+};
+```
+
+(If `_dive`/`_equip` literals are missing required NOT NULL columns, copy a known-good record shape from `test/core/services/sync/sync_base_streaming_parity_test.dart` / `test/helpers/` — those seed real rows. The point of the test is the id form, not the column set.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/sync_data_serializer_record_ids_test.dart`
+Expected: FAIL — `recordIdsFor` is not defined.
+
+- [ ] **Step 3: Implement `recordIdsFor`**
+
+Add to `SyncDataSerializer` (next to `deleteRecord`). Use typed `selectOnly` id-only projections so only the key column(s) are read. Mirror `deleteRecord`'s entity→table switch exactly (sync_data_serializer.dart:1206) for the plain-`id` entities; the three special cases are spelled out:
+
+```dart
+/// Every local row id for [entityType], in the id form [deleteRecord] accepts
+/// (plain id; `settings` -> key; composite `a|b` for the two junctions).
+/// Id-only projection: never materializes full rows, so it is bounded even for
+/// row-per-sample tables. Used by streaming adopt to delete locals absent from
+/// the restored library. Unknown entity types yield an empty set.
+Future<Set<String>> recordIdsFor(String entityType) async {
+  Future<Set<String>> plain<T extends Table, R>(
+    TableInfo<T, R> table,
+    GeneratedColumn<String> idCol,
+  ) async {
+    final q = _db.selectOnly(table)..addColumns([idCol]);
+    final rows = await q.get();
+    return {for (final r in rows) r.read(idCol)!};
+  }
+
+  switch (entityType) {
+    case 'settings':
+      return plain(_db.settings, _db.settings.key);
+    case 'diveEquipment':
+      final q = _db.selectOnly(_db.diveEquipment)
+        ..addColumns([_db.diveEquipment.diveId, _db.diveEquipment.equipmentId]);
+      return {
+        for (final r in await q.get())
+          '${r.read(_db.diveEquipment.diveId)}|${r.read(_db.diveEquipment.equipmentId)}',
+      };
+    case 'equipmentSetItems':
+      final q = _db.selectOnly(_db.equipmentSetItems)
+        ..addColumns([_db.equipmentSetItems.setId, _db.equipmentSetItems.equipmentId]);
+      return {
+        for (final r in await q.get())
+          '${r.read(_db.equipmentSetItems.setId)}|${r.read(_db.equipmentSetItems.equipmentId)}',
+      };
+    case 'divers':
+      return plain(_db.divers, _db.divers.id);
+    // ... one `case` per remaining entity in entityHasUpdatedAt, each
+    //     `return plain(_db.<table>, _db.<table>.id);`
+    //     Mirror the exact entity->_db.<table> mapping in deleteRecord (:1206).
+    default:
+      return <String>{};
+  }
+}
+```
+
+Composite form `'$a|$b'` matches `_compositeId` (`'$left|$right'`) and round-trips through `deleteRecord`'s `_splitCompositeId`. Confirm `TableInfo`/`GeneratedColumn`/`Table` are imported (Drift; `database.dart` already re-exports them in this file's existing imports — if not, import `package:drift/drift.dart`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/services/sync/sync_data_serializer_record_ids_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Guard completeness, format, analyze, commit**
+
+Add one assertion to the new test so a future entity can't silently miss a `case` (returns empty -> its stale local rows would never be deleted on adopt):
+
+```dart
+test('recordIdsFor has a case for every synced entity', () async {
+  final s = SyncDataSerializer();
+  for (final entity in SyncService.entityHasUpdatedAt.keys) {
+    // Empty DB: every known entity returns an (empty) set without throwing;
+    // a missing case also returns empty, so this is a smoke guard. The parity
+    // test (Task 3) is the behavioral guard that ids actually round-trip.
+    expect(await s.recordIdsFor(entity), isA<Set<String>>());
+  }
+});
+```
+
+Run: `dart format . && flutter analyze && flutter test test/core/services/sync/sync_data_serializer_record_ids_test.dart`
+Then commit:
+```bash
+git add lib/core/services/sync/sync_data_serializer.dart test/core/services/sync/sync_data_serializer_record_ids_test.dart
+git commit -m "feat(sync): bounded recordIdsFor id enumeration for streaming adopt (#358)"
+```
+
+---
+
+## Task 2: Extract the in-memory adopt as a test reference seam
+
+This is a pure refactor: production behavior is unchanged. It carves out the current union/delete/upsert body so the parity test (Task 3) can drive the in-memory algorithm directly on decoded payloads, and keeps the in-memory collection callable from tests only.
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (`adoptReplacedLibrary` :1831-1948 and `_collectEpochPayloads` :1954)
+
+**Interfaces:**
+- Produces: `Future<_AdoptCounts> _applyAdoptInMemory(List<SyncPayload> payloads)` — the current union/delete/upsert (sync_service.dart:1885-1924 body), minus the transaction wrapper and minus re-baseline, returning nothing meaningful is fine (`void`/counts). It MUST run inside the caller's transaction.
+- Produces: `@visibleForTesting Future<void> debugAdoptInMemory(List<SyncPayload> payloads)` — wraps `_applyAdoptInMemory` in `applyInDeferredFkTransaction`; no re-baseline (so the parity comparison sees only data effects).
+- Produces: `@visibleForTesting Future<List<SyncPayload>> debugCollectEpochPayloadsInMemory(CloudStorageProvider provider, String folderId, String epochId)` — the renamed current `_collectEpochPayloads`.
+
+- [ ] **Step 1: Move the union/delete/upsert body into `_applyAdoptInMemory`**
+
+Cut the body currently inside `applyInDeferredFkTransaction` in `adoptReplacedLibrary` (the `cloudIds`/`restored` union at :1888-1901, the delete-not-in-cloud at :1904-1914, the upsert at :1917-1921, and `repairDanglingForeignKeys` at :1923) into:
+
+```dart
+/// In-memory union/delete/upsert adopt (reference path). Caller provides the
+/// open deferred-FK transaction. [localSnapshot] is the pre-adopt export used
+/// for the delete-not-in-cloud pass. Kept as the parity reference for the
+/// streaming path; production uses [_adoptApplyStreaming].
+Future<void> _applyAdoptInMemory(
+  List<SyncPayload> payloads,
+  SyncPayload localSnapshot,
+) async {
+  final cloudIds = <String, Set<String>>{};
+  final restored = <String, Map<String, Map<String, dynamic>>>{};
+  for (final payload in payloads) {
+    for (final entry in payload.data.toJson().entries) {
+      final records = (entry.value as List).cast<Map<String, dynamic>>();
+      for (final record in records) {
+        final id = _recordIdForEntity(entry.key, record);
+        if (id == null) continue;
+        (cloudIds[entry.key] ??= <String>{}).add(id);
+        (restored[entry.key] ??= {})[id] = record;
+      }
+    }
+  }
+  for (final entry in localSnapshot.data.toJson().entries) {
+    final records = (entry.value as List).cast<Map<String, dynamic>>();
+    for (final record in records) {
+      final id = _recordIdForEntity(entry.key, record);
+      if (id == null) continue;
+      if (!(cloudIds[entry.key]?.contains(id) ?? false)) {
+        await _serializer.deleteRecord(entry.key, id);
+      }
+    }
+  }
+  for (final entry in restored.entries) {
+    for (final record in entry.value.values) {
+      await _serializer.upsertRecord(entry.key, record);
+    }
+  }
+  await _serializer.repairDanglingForeignKeys();
+}
+```
+
+In `adoptReplacedLibrary`, replace the inlined body with:
+```dart
+await _serializer.applyInDeferredFkTransaction(
+  () => _applyAdoptInMemory(payloads, localSnapshot),
+);
+```
+(Keep payloads.sort + localSnapshot export + re-baseline exactly as they are.)
+
+- [ ] **Step 2: Add the two `@visibleForTesting` seams**
+
+```dart
+@visibleForTesting
+Future<void> debugAdoptInMemory(List<SyncPayload> payloads) async {
+  final local = await _serializer.exportData(deviceId: 'adopt', deletions: const []);
+  payloads.sort((a, b) => a.exportedAt.compareTo(b.exportedAt));
+  await _serializer.applyInDeferredFkTransaction(
+    () => _applyAdoptInMemory(payloads, local),
+  );
+}
+```
+Rename `_collectEpochPayloads` -> `debugCollectEpochPayloadsInMemory` and annotate `@visibleForTesting` (production references are removed in Task 4; until then `adoptReplacedLibrary` still calls it — keep the call working by referencing the new name).
+
+- [ ] **Step 3: Verify no behavior change**
+
+Run the existing epoch/adoption suites:
+Run: `flutter test test/core/services/sync/sync_service_epoch_test.dart test/features/settings/presentation/providers/sync_providers_epoch_test.dart test/core/services/sync/changeset_reader_epoch_test.dart`
+Expected: PASS (unchanged behavior).
+
+- [ ] **Step 4: Format, analyze, commit**
+
+```bash
+dart format . && flutter analyze
+git add lib/core/services/sync/sync_service.dart
+git commit -m "refactor(sync): extract in-memory adopt as debug reference seam (#358)"
+```
+
+---
+
+## Task 3: Streaming adopt core + parity test (the safety net)
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (add streaming apply + seam)
+- Test: `test/core/services/sync/sync_adopt_streaming_parity_test.dart` (create)
+
+**Interfaces:**
+- Produces: `Future<void> _adoptApplyStreaming({required List<String> baseFilePaths, required List<int> baseExportedAt, required List<SyncPayload> changesets})` — runs inside the caller's deferred-FK transaction. Single forward pass over the ordered units (base files + changesets, ascending `exportedAt`), batched upsert (500) per table, collecting `cloudIds` as it goes; then deletes local rows absent from `cloudIds` via `recordIdsFor`+`deleteRecord` over `entityHasUpdatedAt.keys`; then `repairDanglingForeignKeys`. `baseFilePaths[i]`'s export time is `baseExportedAt[i]`.
+- Produces: `@visibleForTesting Future<void> debugAdoptStreaming(List<String> baseFilePaths, List<int> baseExportedAt, List<SyncPayload> changesets)` — wraps `_adoptApplyStreaming` in `applyInDeferredFkTransaction`; no re-baseline (parity sees only data effects).
+
+- [ ] **Step 1: Write the failing parity test**
+
+```dart
+// test/core/services/sync/sync_adopt_streaming_parity_test.dart
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+String _canonical(Map<String, dynamic> data) {
+  final out = <String, dynamic>{};
+  for (final k in data.keys.toList()..sort()) {
+    final list = (data[k] as List).cast<Map<String, dynamic>>();
+    out[k] = [...list]..sort((a, b) => jsonEncode(a).compareTo(jsonEncode(b)));
+  }
+  return jsonEncode(out);
+}
+Future<String> _dump() async =>
+    _canonical((await SyncDataSerializer().exportData(deviceId: 's', deletions: const [])).data.toJson());
+
+SyncService _svc() =>
+    SyncService(syncRepository: SyncRepository(), serializer: SyncDataSerializer());
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() async { await setUpTestDatabase(); SharedPreferences.setMockInitialValues({}); });
+  tearDown(() => tearDownTestDatabase());
+
+  test('streaming adopt equals in-memory adopt, byte-for-byte', () async {
+    // Build TWO cloud payloads (base older, changeset newer) so latest-wins is
+    // exercised, spanning a parent, a clockless child, a junction, and a BLOB.
+    final dives = DiveRepository();
+    await dives.createDive(createTestDiveWithBottomTime(id: 'd1', diveNumber: 1));
+    await dives.createDive(createTestDiveWithBottomTime(id: 'd2', diveNumber: 2));
+    final ser = SyncDataSerializer();
+    await ser.upsertRecord('diveSites', {
+      'id': 'site-1', 'name': 'Old', 'description': '', 'notes': '',
+      'isShared': false, 'createdAt': 1000, 'updatedAt': 1000,
+    });
+    final base = await ser.exportData(deviceId: 'peer', deletions: const []);
+    // Newer changeset: rename site-1, add site-2.
+    await ser.upsertRecord('diveSites', {
+      'id': 'site-1', 'name': 'NEW NAME', 'description': '', 'notes': '',
+      'isShared': false, 'createdAt': 1000, 'updatedAt': 2000,
+    });
+    await ser.upsertRecord('diveSites', {
+      'id': 'site-2', 'name': 'Second', 'description': '', 'notes': '',
+      'isShared': false, 'createdAt': 1000, 'updatedAt': 2000,
+    });
+    final changeset = await ser.exportData(deviceId: 'peer', deletions: const []);
+    // Force ordering base < changeset regardless of clock granularity.
+    final baseP = base; final csP = changeset; // exportedAt already increasing
+
+    // Seed a DIFFERENT local library: a stale dive 'd-stale' (not in cloud) must
+    // be deleted; 'd1' overlaps and must end up as the cloud version.
+    Future<void> seedLocal() async {
+      final d = DiveRepository();
+      await d.createDive(createTestDiveWithBottomTime(id: 'd1', diveNumber: 99));
+      await d.createDive(createTestDiveWithBottomTime(id: 'd-stale', diveNumber: 7));
+    }
+
+    // Phase A: in-memory reference.
+    await tearDownTestDatabase(); await setUpTestDatabase();
+    await seedLocal();
+    await _svc().debugAdoptInMemory([csP, baseP]); // unsorted on purpose
+    final ref = await _dump();
+
+    // Phase B: streaming. Base goes to a temp file; changeset stays in memory.
+    await tearDownTestDatabase(); await setUpTestDatabase();
+    await seedLocal();
+    final tmpDir = await Directory.systemTemp.createTemp('adopt_parity');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(utf8.encode(SyncDataSerializer().serializePayload(baseP)));
+    await _svc().debugAdoptStreaming([tmp.path], [baseP.exportedAt], [csP]);
+    final got = await _dump();
+    await tmpDir.delete(recursive: true);
+
+    expect(got, ref, reason: 'streaming adopt must equal in-memory adopt');
+    // Spot checks: stale gone, overlap is cloud version, latest-wins applied.
+    final decoded = jsonDecode(got) as Map<String, dynamic>;
+    final siteNames = [
+      for (final s in (decoded['diveSites'] as List)) (s as Map)['name'],
+    ];
+    expect(siteNames, containsAll(['NEW NAME', 'Second']));
+    expect(siteNames, isNot(contains('Old')));
+  });
+}
+```
+
+- [ ] **Step 2: Add a throwing stub so the test compiles and RED is meaningful**
+
+```dart
+@visibleForTesting
+Future<void> debugAdoptStreaming(
+  List<String> baseFilePaths, List<int> baseExportedAt, List<SyncPayload> changesets,
+) async => throw UnimplementedError('debugAdoptStreaming');
+```
+
+Run: `flutter test test/core/services/sync/sync_adopt_streaming_parity_test.dart`
+Expected: FAIL — `UnimplementedError`.
+
+- [ ] **Step 3: Implement `_adoptApplyStreaming` + real `debugAdoptStreaming`**
+
+```dart
+/// Streaming replace-adopt apply (production path). Runs inside the caller's
+/// deferred-FK transaction. Upserts every restored row in exportedAt order,
+/// collecting cloud ids as it goes, then deletes local rows absent from that
+/// set, then repairs FKs. Bounded memory: one 500-row batch + the cloud id sets
+/// (ids only). Equivalent to [_applyAdoptInMemory] because upsertRecord is an
+/// unconditional overwrite (ascending order => latest export wins) and
+/// delete-not-in-cloud is order-independent. Parity is asserted by
+/// sync_adopt_streaming_parity_test.dart.
+Future<void> _adoptApplyStreaming({
+  required List<String> baseFilePaths,
+  required List<int> baseExportedAt,
+  required List<SyncPayload> changesets,
+}) async {
+  final cloudIds = <String, Set<String>>{};
+
+  // Ordered apply units: each base file and each changeset, by exportedAt asc.
+  final units = <({int at, String? file, SyncPayload? cs})>[
+    for (var i = 0; i < baseFilePaths.length; i++)
+      (at: baseExportedAt[i], file: baseFilePaths[i], cs: null),
+    for (final c in changesets) (at: c.exportedAt, file: null, cs: c),
+  ]..sort((a, b) => a.at.compareTo(b.at));
+
+  Future<void> upsertRow(String table, Map<String, dynamic> rec) async {
+    final id = _recordIdForEntity(table, rec);
+    if (id != null) (cloudIds[table] ??= <String>{}).add(id);
+    await _serializer.upsertRecord(table, rec);
+  }
+
+  for (final unit in units) {
+    if (unit.cs != null) {
+      for (final entry in unit.cs!.data.toJson().entries) {
+        for (final rec in (entry.value as List).cast<Map<String, dynamic>>()) {
+          await upsertRow(entry.key, rec);
+        }
+      }
+      continue;
+    }
+    // Base file: stream data rows in 500-row batches per table.
+    const batchSize = 500;
+    String? currentTable;
+    var batch = <Map<String, dynamic>>[];
+    Future<void> flush() async {
+      final t = currentTable;
+      if (t == null || batch.isEmpty) return;
+      for (final rec in batch) {
+        await upsertRow(t, rec);
+      }
+      batch = <Map<String, dynamic>>[];
+    }
+    await BaseJsonStreamReader().parse(
+      File(unit.file!).openRead(),
+      wantRows: (section, table) =>
+          section == 'data' && entityHasUpdatedAt.containsKey(table),
+      onRow: (section, table, rowBytes) async {
+        if (table != currentTable) {
+          await flush();
+          currentTable = table;
+        }
+        batch.add(jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>);
+        if (batch.length >= batchSize) await flush();
+      },
+    );
+    await flush();
+  }
+
+  // Delete local rows the restored library does not contain.
+  for (final entity in entityHasUpdatedAt.keys) {
+    final cloud = cloudIds[entity] ?? const <String>{};
+    for (final localId in await _serializer.recordIdsFor(entity)) {
+      if (!cloud.contains(localId)) {
+        await _serializer.deleteRecord(entity, localId);
+      }
+    }
+  }
+
+  await _serializer.repairDanglingForeignKeys();
+}
+
+@visibleForTesting
+Future<void> debugAdoptStreaming(
+  List<String> baseFilePaths, List<int> baseExportedAt, List<SyncPayload> changesets,
+) => _serializer.applyInDeferredFkTransaction(
+      () => _adoptApplyStreaming(
+        baseFilePaths: baseFilePaths,
+        baseExportedAt: baseExportedAt,
+        changesets: changesets,
+      ),
+    );
+```
+
+Ensure imports at top of sync_service.dart include `dart:io` (File), `dart:convert` (jsonDecode/utf8) — already present for `_applyRemoteBaseFile` — and `BaseJsonStreamReader` (already imported).
+
+- [ ] **Step 4: Run the parity test to GREEN**
+
+Run: `flutter test test/core/services/sync/sync_adopt_streaming_parity_test.dart`
+Expected: PASS. If `got != ref`, diff the canonical dumps — most likely cause is a missing `recordIdsFor` case (stale local row not deleted) or an entity present in the payload but absent from `entityHasUpdatedAt` (would be skipped on the base-file pass but applied via the changeset path — keep both paths gated on `entityHasUpdatedAt` to match: change the changeset loop to also skip tables absent from `entityHasUpdatedAt`).
+
+- [ ] **Step 5: Add a >500-row batch-boundary parity case**
+
+Add a second test mirroring Step 1 but seeding 600 dives into the base payload (no changeset), asserting streaming == in-memory across the batch boundary (copy the 600-dive loop from `sync_base_streaming_parity_test.dart`).
+
+Run: `flutter test test/core/services/sync/sync_adopt_streaming_parity_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format . && flutter analyze
+git add lib/core/services/sync/sync_service.dart test/core/services/sync/sync_adopt_streaming_parity_test.dart
+git commit -m "feat(sync): streaming replace-adopt apply with parity test (#358)"
+```
+
+---
+
+## Task 4: Wire production `adoptReplacedLibrary` to the streaming path
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (`adoptReplacedLibrary` :1831, add `_collectEpochBaseSources`)
+
+**Interfaces:**
+- Produces: `Future<({List<String> baseFilePaths, List<int> baseExportedAt, List<SyncPayload> changesets})?> _collectEpochBaseSources(CloudStorageProvider provider, String folderId, String epochId)` — for each device whose manifest carries `epochId`: assemble its base to a temp file (`BasePartFileSink`/`_fetchBaseToFile`-style; reuse the same assemble call as `ChangesetReader._fetchBaseToFile`), read its `exportedAt` via a scalar-only `BaseJsonStreamReader` pass, and decode its post-base changesets into memory. Skips a device whose base parts are not all present (matches current). Returns `null`/empties when nothing current-format exists (caller then runs `_recoverUnreadableEpoch`).
+
+- [ ] **Step 1: Implement `_collectEpochBaseSources`** (mirror `debugCollectEpochPayloadsInMemory` device discovery at :1959-2004, but assemble to files instead of `parts.add`):
+
+```dart
+Future<({List<String> baseFilePaths, List<int> baseExportedAt, List<SyncPayload> changesets})>
+_collectEpochBaseSources(
+  CloudStorageProvider provider, String folderId, String epochId,
+) async {
+  final files = await provider.listFiles(
+    folderId: folderId, namePattern: ChangesetLogLayout.prefix,
+  );
+  final byName = {for (final f in files) f.name: f};
+  final deviceIds = <String>{
+    for (final f in files)
+      if (ChangesetLogLayout.deviceIdOf(f.name) != null)
+        ChangesetLogLayout.deviceIdOf(f.name)!,
+  };
+  final baseFilePaths = <String>[];
+  final baseExportedAt = <int>[];
+  final changesets = <SyncPayload>[];
+  for (final deviceId in deviceIds) {
+    final manifestFile = byName[ChangesetLogLayout.manifestName(deviceId)];
+    if (manifestFile == null) continue;
+    SyncManifest manifest;
+    try {
+      manifest = SyncManifest.fromBytes(await provider.downloadFile(manifestFile.id));
+    } catch (_) { continue; }
+    if (manifest.epochId != epochId) continue;
+    final baseSeq = manifest.baseSeq;
+    if (baseSeq == null) continue;
+    final partCount = manifest.basePartCount ?? 0;
+    if (partCount <= 0) continue;
+    final path = await _baseSink.assemble(
+      name: 'ssv1_adopt_${deviceId}_$baseSeq',
+      partCount: partCount,
+      wholeChecksum: manifest.baseChecksum,
+      partChecksums: manifest.basePartChecksums,
+      downloadPart: (i) async {
+        final pf = byName[ChangesetLogLayout.basePartName(deviceId, baseSeq, i)];
+        if (pf == null) return null;
+        return provider.downloadFile(pf.id);
+      },
+    );
+    if (path == null) continue; // base incomplete/corrupt -> skip device
+    var exportedAt = 0;
+    await BaseJsonStreamReader().parse(
+      File(path).openRead(),
+      onScalar: (key, raw) async {
+        if (key == 'exportedAt') {
+          exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+        }
+      },
+      wantRows: (_, _) => false, // scalars only
+    );
+    baseFilePaths.add(path);
+    baseExportedAt.add(exportedAt);
+    for (var seq = baseSeq + 1; seq <= manifest.headSeq; seq++) {
+      final cf = byName[ChangesetLogLayout.changesetName(deviceId, seq)];
+      if (cf == null) break;
+      changesets.add(_changesetCodec.decodeChangeset(await provider.downloadFile(cf.id)));
+    }
+  }
+  return (baseFilePaths: baseFilePaths, baseExportedAt: baseExportedAt, changesets: changesets);
+}
+```
+
+Add a `BasePartFileSink _baseSink = BasePartFileSink();` field to `SyncService` (import already used by ChangesetReader; add `import '.../base_part_file_sink.dart';`). Confirm `_changesetCodec`, `ChangesetLogLayout`, `SyncManifest` are already imported in sync_service.dart (they are — used by `_collectEpochPayloads`).
+
+- [ ] **Step 2: Rewrite `adoptReplacedLibrary` to use it**
+
+Replace the collection + apply (current :1849-1924) with:
+```dart
+final folderId = await provider.getOrCreateSyncFolder();
+final sources = await _collectEpochBaseSources(provider, folderId, marker.epochId);
+if (sources.baseFilePaths.isEmpty) {
+  if (await _recoverUnreadableEpoch(provider, marker)) {
+    return const SyncResult(
+      status: SyncResultStatus.success,
+      message: 'The previous library could not be read; re-established this '
+          'backend from this device\'s library.',
+    );
+  }
+  return const SyncResult(
+    status: SyncResultStatus.error,
+    message: 'The replaced library is still uploading. Try again shortly.',
+  );
+}
+try {
+  await _serializer.applyInDeferredFkTransaction(
+    () => _adoptApplyStreaming(
+      baseFilePaths: sources.baseFilePaths,
+      baseExportedAt: sources.baseExportedAt,
+      changesets: sources.changesets,
+    ),
+  );
+} finally {
+  for (final p in sources.baseFilePaths) {
+    await _baseSink.deleteQuietly(p);
+  }
+}
+// Re-baseline (unchanged):
+await _syncRepository.resetSyncState(clearDeletionLog: true);
+await _syncRepository.setLastAcceptedEpochId(marker.epochId);
+await store.setLastAccepted(marker);
+SyncClock.instance.reset();
+_log.info('Adopted replaced library (epoch ${marker.epochId})');
+return const SyncResult(status: SyncResultStatus.success, message: 'Adopted the restored library');
+```
+Keep the surrounding `try/catch` (the `Failed to adopt` handler at :1937). Note the empty-set guard now keys on `baseFilePaths.isEmpty` (a current-format base is required; the previous code's `payloads.isEmpty` had the same effect because a payload required a base).
+
+- [ ] **Step 3: Verify epoch + convergence integration tests**
+
+Run: `flutter test test/core/services/sync/sync_service_epoch_test.dart test/features/settings/presentation/providers/sync_providers_epoch_test.dart test/core/services/sync/changeset_reader_epoch_test.dart test/core/services/sync/changeset_sync_convergence_test.dart`
+Expected: PASS. These exercise silent auto-adopt (diveCount==0) and manual adopt; they now run the streaming path end to end. Fix any test that constructed `_collectEpochPayloads` expectations by pointing it at `debugCollectEpochPayloadsInMemory` or the new sources shape.
+
+- [ ] **Step 4: Format, analyze, commit**
+
+```bash
+dart format . && flutter analyze
+git add lib/core/services/sync/sync_service.dart
+git commit -m "feat(sync): adopt replaced library via bounded streaming (fixes #358)"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole sync test area**
+
+Run: `flutter test test/core/services/sync/ test/features/settings/presentation/providers/sync_providers_epoch_test.dart`
+Expected: PASS. Confirm the two parity tests (base + adopt) and the structural `entityHasUpdatedAt` test pass.
+
+- [ ] **Step 2: Whole-project format + analyze** (per repo CI: Analyze & Format checks the whole project)
+
+Run: `dart format . && flutter analyze`
+Expected: no changes, no issues.
+
+- [ ] **Step 3: Commit any formatting and push the branch**
+
+```bash
+git add -A && git commit -m "chore(sync): formatting for streaming adopt (#358)" || true
+git push -u origin worktree-fix-sync-adopt-oom-streaming-358
+```
+
+- [ ] **Step 4: Hand off for device verification**
+
+Real-device check on the reporter's library is the final gate (cannot be unit-tested): a fresh iOS install with 0 dives, against an epoch-stamped large cloud library, must adopt without the ~20 s OOM restart. Note this in the PR as the remaining manual step.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** cloud-base OOM -> Task 3 streaming apply; full-local-export OOM -> dropped (Task 3 uses `recordIdsFor`, Task 4 drops `exportData` local snapshot); trigger unchanged (notifier still calls `adoptReplacedLibrary`); multi-device epoch + changesets + latest-wins -> `_adoptApplyStreaming` ordered units; partial-epoch skip + unreadable-epoch recovery -> Task 4 preserves `_recoverUnreadableEpoch`.
+- **Behavioral equivalence rests on:** `upsertRecord` unconditional overwrite (verified) + delete-not-in-cloud order-independence + ignoring deletions (matches current). The parity test is the enforcement.
+- **Out of scope (tracked follow-up):** write/publish side `BaseChunker.slice(fullBytes)` in changeset_writer still buffers a full base in memory when a desktop publishes a large library.

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1206,13 +1206,17 @@ class SyncDataSerializer {
   /// Every local row id for [entityType], in the id form [deleteRecord]
   /// accepts: plain `id` for most entities, `key` for `settings`, and the
   /// composite `a|b` form (matching [_compositeId]) for the two junction
-  /// tables. Id-only projection: it never materializes full rows, so it stays
-  /// bounded even for row-per-sample tables (diveProfiles, tankPressureProfiles)
-  /// with millions of rows. Used by the streaming replace-adopt to delete local
-  /// rows absent from the restored library (#358). Unknown entity types yield
-  /// an empty set. Mirrors the entity -> table mapping in [upsertRecord] /
-  /// [deleteRecord]; a missing case silently returns empty, so the
-  /// "every synced entity" smoke test guards against that.
+  /// tables. Reads only the id column(s) -- never full rows -- so the streaming
+  /// replace-adopt can enumerate row-per-sample tables (diveProfiles,
+  /// tankPressureProfiles) to delete local rows absent from the restored
+  /// library (#358) without materializing their payloads. Memory still scales
+  /// with the entity's row count (the result is a Set of ids and `get()` loads
+  /// all id rows at once), but ids are orders of magnitude smaller than the
+  /// rows they stand in for. Mirrors the entity -> table mapping in
+  /// [upsertRecord] / [deleteRecord], and THROWS on an entity with no case so a
+  /// newly added synced entity that forgets one fails loudly rather than
+  /// silently skipping its stale-row deletion (asserted by the
+  /// "every synced entity" test).
   Future<Set<String>> recordIdsFor(String entityType) async {
     Future<Set<String>> plain(
       ResultSetImplementation<HasResultSet, dynamic> table,
@@ -1320,8 +1324,18 @@ class SyncDataSerializer {
         return plain(_db.certifications, _db.certifications.id);
       case 'serviceRecords':
         return plain(_db.serviceRecords, _db.serviceRecords.id);
+      case 'media':
+        return plain(_db.media, _db.media.id);
       default:
-        return <String>{};
+        // Fail loud: a synced entity without a case here would silently
+        // enumerate zero local ids, so streaming adopt would never delete its
+        // stale rows. Callers only pass entityHasUpdatedAt keys, all of which
+        // have a case (asserted by sync_data_serializer_record_ids_test.dart).
+        throw ArgumentError.value(
+          entityType,
+          'entityType',
+          'recordIdsFor has no case for this synced entity',
+        );
     }
   }
 

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1203,6 +1203,128 @@ class SyncDataSerializer {
     }
   }
 
+  /// Every local row id for [entityType], in the id form [deleteRecord]
+  /// accepts: plain `id` for most entities, `key` for `settings`, and the
+  /// composite `a|b` form (matching [_compositeId]) for the two junction
+  /// tables. Id-only projection: it never materializes full rows, so it stays
+  /// bounded even for row-per-sample tables (diveProfiles, tankPressureProfiles)
+  /// with millions of rows. Used by the streaming replace-adopt to delete local
+  /// rows absent from the restored library (#358). Unknown entity types yield
+  /// an empty set. Mirrors the entity -> table mapping in [upsertRecord] /
+  /// [deleteRecord]; a missing case silently returns empty, so the
+  /// "every synced entity" smoke test guards against that.
+  Future<Set<String>> recordIdsFor(String entityType) async {
+    Future<Set<String>> plain(
+      ResultSetImplementation<HasResultSet, dynamic> table,
+      GeneratedColumn<String> idColumn,
+    ) async {
+      final query = _db.selectOnly(table)..addColumns([idColumn]);
+      return {for (final row in await query.get()) row.read(idColumn)!};
+    }
+
+    switch (entityType) {
+      case 'settings':
+        return plain(_db.settings, _db.settings.key);
+      case 'diveEquipment':
+        final query = _db.selectOnly(_db.diveEquipment)
+          ..addColumns([
+            _db.diveEquipment.diveId,
+            _db.diveEquipment.equipmentId,
+          ]);
+        return {
+          for (final row in await query.get())
+            '${row.read(_db.diveEquipment.diveId)}|'
+                '${row.read(_db.diveEquipment.equipmentId)}',
+        };
+      case 'equipmentSetItems':
+        final query = _db.selectOnly(_db.equipmentSetItems)
+          ..addColumns([
+            _db.equipmentSetItems.setId,
+            _db.equipmentSetItems.equipmentId,
+          ]);
+        return {
+          for (final row in await query.get())
+            '${row.read(_db.equipmentSetItems.setId)}|'
+                '${row.read(_db.equipmentSetItems.equipmentId)}',
+        };
+      case 'divers':
+        return plain(_db.divers, _db.divers.id);
+      case 'diverSettings':
+        return plain(_db.diverSettings, _db.diverSettings.id);
+      case 'buddies':
+        return plain(_db.buddies, _db.buddies.id);
+      case 'diveCenters':
+        return plain(_db.diveCenters, _db.diveCenters.id);
+      case 'trips':
+        return plain(_db.trips, _db.trips.id);
+      case 'liveaboardDetails':
+        return plain(
+          _db.liveaboardDetailRecords,
+          _db.liveaboardDetailRecords.id,
+        );
+      case 'itineraryDays':
+        return plain(_db.tripItineraryDays, _db.tripItineraryDays.id);
+      case 'equipment':
+        return plain(_db.equipment, _db.equipment.id);
+      case 'equipmentSets':
+        return plain(_db.equipmentSets, _db.equipmentSets.id);
+      case 'diveTypes':
+        return plain(_db.diveTypes, _db.diveTypes.id);
+      case 'tankPresets':
+        return plain(_db.tankPresets, _db.tankPresets.id);
+      case 'diveComputers':
+        return plain(_db.diveComputers, _db.diveComputers.id);
+      case 'species':
+        return plain(_db.species, _db.species.id);
+      case 'tags':
+        return plain(_db.tags, _db.tags.id);
+      case 'courses':
+        return plain(_db.courses, _db.courses.id);
+      case 'dives':
+        return plain(_db.dives, _db.dives.id);
+      case 'diveSites':
+        return plain(_db.diveSites, _db.diveSites.id);
+      case 'diveTanks':
+        return plain(_db.diveTanks, _db.diveTanks.id);
+      case 'diveWeights':
+        return plain(_db.diveWeights, _db.diveWeights.id);
+      case 'diveTags':
+        return plain(_db.diveTags, _db.diveTags.id);
+      case 'diveBuddies':
+        return plain(_db.diveBuddies, _db.diveBuddies.id);
+      case 'diveProfiles':
+        return plain(_db.diveProfiles, _db.diveProfiles.id);
+      case 'diveProfileEvents':
+        return plain(_db.diveProfileEvents, _db.diveProfileEvents.id);
+      case 'gasSwitches':
+        return plain(_db.gasSwitches, _db.gasSwitches.id);
+      case 'diveCustomFields':
+        return plain(_db.diveCustomFields, _db.diveCustomFields.id);
+      case 'diveDataSources':
+        return plain(_db.diveDataSources, _db.diveDataSources.id);
+      case 'siteSpecies':
+        return plain(_db.siteSpecies, _db.siteSpecies.id);
+      case 'csvPresets':
+        return plain(_db.csvPresets, _db.csvPresets.id);
+      case 'viewConfigs':
+        return plain(_db.viewConfigs, _db.viewConfigs.id);
+      case 'fieldPresets':
+        return plain(_db.fieldPresets, _db.fieldPresets.id);
+      case 'tankPressureProfiles':
+        return plain(_db.tankPressureProfiles, _db.tankPressureProfiles.id);
+      case 'tideRecords':
+        return plain(_db.tideRecords, _db.tideRecords.id);
+      case 'sightings':
+        return plain(_db.sightings, _db.sightings.id);
+      case 'certifications':
+        return plain(_db.certifications, _db.certifications.id);
+      case 'serviceRecords':
+        return plain(_db.serviceRecords, _db.serviceRecords.id);
+      default:
+        return <String>{};
+    }
+  }
+
   Future<void> deleteRecord(String entityType, String recordId) async {
     switch (entityType) {
       case 'divers':

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1976,6 +1976,111 @@ class SyncService {
     );
   }
 
+  /// Streaming replace-adopt apply (production path). Runs inside the caller's
+  /// deferred-FK transaction. Upserts every restored row in exportedAt order
+  /// (each base temp file streamed in 500-row batches, plus in-memory
+  /// changesets), collecting cloud ids as it goes, then deletes local rows
+  /// absent from that set, then repairs FKs. Bounded memory: one batch + the
+  /// cloud id sets (ids only, never full rows), independent of library size.
+  ///
+  /// Equivalent to [_applyAdoptInMemory]: `upsertRecord` is an unconditional
+  /// overwrite, so applying in ascending exportedAt order is latest-export-wins
+  /// (the in-memory `restored` map); and delete-not-in-cloud is order
+  /// independent, so upsert-then-delete here matches delete-then-upsert there
+  /// (final state is the cloud union either way). A null record id is skipped
+  /// entirely, exactly as the in-memory path does. Enforced by
+  /// sync_adopt_streaming_parity_test.dart.
+  Future<void> _adoptApplyStreaming({
+    required List<String> baseFilePaths,
+    required List<int> baseExportedAt,
+    required List<SyncPayload> changesets,
+  }) async {
+    final cloudIds = <String, Set<String>>{};
+
+    Future<void> upsertRow(String table, Map<String, dynamic> record) async {
+      final id = _recordIdForEntity(table, record);
+      if (id == null) return; // matches in-memory: null-id rows are skipped
+      (cloudIds[table] ??= <String>{}).add(id);
+      await _serializer.upsertRecord(table, record);
+    }
+
+    // Apply units: each base file and each changeset, ascending by exportedAt
+    // (latest export wins under the unconditional upsert).
+    final units = <({int at, String? file, SyncPayload? changeset})>[
+      for (var i = 0; i < baseFilePaths.length; i++)
+        (at: baseExportedAt[i], file: baseFilePaths[i], changeset: null),
+      for (final c in changesets) (at: c.exportedAt, file: null, changeset: c),
+    ]..sort((a, b) => a.at.compareTo(b.at));
+
+    for (final unit in units) {
+      final changeset = unit.changeset;
+      if (changeset != null) {
+        for (final entry in changeset.data.toJson().entries) {
+          if (!entityHasUpdatedAt.containsKey(entry.key)) continue;
+          for (final record
+              in (entry.value as List).cast<Map<String, dynamic>>()) {
+            await upsertRow(entry.key, record);
+          }
+        }
+        continue;
+      }
+
+      // Base file: stream `data` rows, batching 500 per table.
+      const batchSize = 500;
+      String? currentTable;
+      var batch = <Map<String, dynamic>>[];
+      Future<void> flush() async {
+        final table = currentTable;
+        if (table == null || batch.isEmpty) return;
+        for (final record in batch) {
+          await upsertRow(table, record);
+        }
+        batch = <Map<String, dynamic>>[];
+      }
+
+      await BaseJsonStreamReader().parse(
+        File(unit.file!).openRead(),
+        wantRows: (section, table) =>
+            section == 'data' && entityHasUpdatedAt.containsKey(table),
+        onRow: (section, table, rowBytes) async {
+          if (table != currentTable) {
+            await flush();
+            currentTable = table;
+          }
+          batch.add(jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>);
+          if (batch.length >= batchSize) await flush();
+        },
+      );
+      await flush();
+    }
+
+    // Delete local rows the restored library does not contain.
+    for (final entity in entityHasUpdatedAt.keys) {
+      final cloud = cloudIds[entity] ?? const <String>{};
+      for (final localId in await _serializer.recordIdsFor(entity)) {
+        if (!cloud.contains(localId)) {
+          await _serializer.deleteRecord(entity, localId);
+        }
+      }
+    }
+
+    await _serializer.repairDanglingForeignKeys();
+  }
+
+  /// Test seam: streaming adopt of base temp files + in-memory changesets.
+  @visibleForTesting
+  Future<void> debugAdoptStreaming(
+    List<String> baseFilePaths,
+    List<int> baseExportedAt,
+    List<SyncPayload> changesets,
+  ) => _serializer.applyInDeferredFkTransaction(
+    () => _adoptApplyStreaming(
+      baseFilePaths: baseFilePaths,
+      baseExportedAt: baseExportedAt,
+      changesets: changesets,
+    ),
+  );
+
   /// Collect every payload (base + changesets) from all changeset logs stamped
   /// with [epochId]. Used by adoption to rebuild the authoritative library
   /// after a Replace restore. Skips a log whose base parts are not all present

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
@@ -177,6 +178,10 @@ class SyncService {
 
   // Changeset-log transport (Phases 1-6), lazily bound to the active database.
   late final ChangesetCodec _changesetCodec = ChangesetCodec(_serializer);
+
+  /// Assembles a peer's base parts into a temp file (per-part + whole-file
+  /// checksum verified) for the bounded-memory replace-adopt (#358).
+  final BasePartFileSink _baseSink = BasePartFileSink();
   late final ChangesetWriter _changesetWriter = ChangesetWriter(
     _serializer,
     _changesetCodec,
@@ -1847,12 +1852,15 @@ class SyncService {
       }
 
       final folderId = await provider.getOrCreateSyncFolder();
-      final payloads = await _collectEpochPayloads(
+      // Stream each epoch device's base to a temp file (bounded memory); the
+      // streaming apply (#358) replaces the old in-memory collect + union,
+      // which OOM-crashed iOS adopting a large library.
+      final sources = await _collectEpochBaseSources(
         provider,
         folderId,
         marker.epochId,
       );
-      if (payloads.isEmpty) {
+      if (sources.baseFilePaths.isEmpty) {
         // No current-format library for this epoch. If the marker is stale
         // (old-format backend or an orphaned replace), re-establish from the
         // local library rather than bricking; the notifier's follow-up sync
@@ -1872,19 +1880,20 @@ class SyncService {
               'The replaced library is still uploading. Try again shortly.',
         );
       }
-      payloads.sort((a, b) => a.exportedAt.compareTo(b.exportedAt));
 
-      final deviceId = await _syncRepository.getDeviceId();
-      final localSnapshot = await _serializer.exportData(
-        deviceId: deviceId,
-        lastSyncTimestamp: null,
-        deletions: const [],
-        uploadNonce: null,
-      );
-
-      await _serializer.applyInDeferredFkTransaction(
-        () => _applyAdoptInMemory(payloads, localSnapshot),
-      );
+      try {
+        await _serializer.applyInDeferredFkTransaction(
+          () => _adoptApplyStreaming(
+            baseFilePaths: sources.baseFilePaths,
+            baseExportedAt: sources.baseExportedAt,
+            changesets: sources.changesets,
+          ),
+        );
+      } finally {
+        for (final path in sources.baseFilePaths) {
+          await _baseSink.deleteQuietly(path);
+        }
+      }
 
       // Re-baseline under the adopted epoch. Our tombstones are obsolete --
       // the restored library is authoritative.
@@ -2081,11 +2090,23 @@ class SyncService {
     ),
   );
 
-  /// Collect every payload (base + changesets) from all changeset logs stamped
-  /// with [epochId]. Used by adoption to rebuild the authoritative library
-  /// after a Replace restore. Skips a log whose base parts are not all present
-  /// (a publish still in flight).
-  Future<List<SyncPayload>> _collectEpochPayloads(
+  /// Stream every epoch-stamped changeset log into adopt sources: each device's
+  /// base assembled to a temp file (bounded memory, via [BasePartFileSink],
+  /// which verifies per-part and whole-file checksums as bytes land), its base
+  /// export time, and its post-base changesets decoded in memory (small
+  /// deltas). Skips a device whose base parts are not all present or whose base
+  /// fails its checksum (a publish still in flight -> retry next adopt).
+  /// Replaces the old in-memory collect that decoded every device's whole base
+  /// into RAM and OOM-crashed iOS adopting a large library (#358). The caller
+  /// owns the returned temp files and must delete them.
+  Future<
+    ({
+      List<String> baseFilePaths,
+      List<int> baseExportedAt,
+      List<SyncPayload> changesets,
+    })
+  >
+  _collectEpochBaseSources(
     CloudStorageProvider provider,
     String folderId,
     String epochId,
@@ -2100,7 +2121,9 @@ class SyncService {
         if (ChangesetLogLayout.deviceIdOf(f.name) != null)
           ChangesetLogLayout.deviceIdOf(f.name)!,
     };
-    final payloads = <SyncPayload>[];
+    final baseFilePaths = <String>[];
+    final baseExportedAt = <int>[];
+    final changesets = <SyncPayload>[];
     for (final deviceId in deviceIds) {
       final manifestFile = byName[ChangesetLogLayout.manifestName(deviceId)];
       if (manifestFile == null) continue;
@@ -2115,28 +2138,50 @@ class SyncService {
       if (manifest.epochId != epochId) continue;
       final baseSeq = manifest.baseSeq;
       if (baseSeq == null) continue;
-      final parts = <Uint8List>[];
-      var complete = true;
-      for (var i = 0; i < (manifest.basePartCount ?? 0); i++) {
-        final pf =
-            byName[ChangesetLogLayout.basePartName(deviceId, baseSeq, i)];
-        if (pf == null) {
-          complete = false;
-          break;
-        }
-        parts.add(await provider.downloadFile(pf.id));
-      }
-      if (!complete || parts.isEmpty) continue;
-      payloads.add(_changesetCodec.decodeBaseParts(parts));
+      final partCount = manifest.basePartCount ?? 0;
+      if (partCount <= 0) continue;
+      final path = await _baseSink.assemble(
+        name: 'ssv1_adopt_${deviceId}_$baseSeq',
+        partCount: partCount,
+        wholeChecksum: manifest.baseChecksum,
+        partChecksums: manifest.basePartChecksums,
+        downloadPart: (i) async {
+          final pf =
+              byName[ChangesetLogLayout.basePartName(deviceId, baseSeq, i)];
+          if (pf == null) return null;
+          return provider.downloadFile(pf.id);
+        },
+      );
+      if (path == null) continue; // base incomplete/corrupt -> skip this device
+      baseFilePaths.add(path);
+      baseExportedAt.add(await _readBaseExportedAt(path));
       for (var seq = baseSeq + 1; seq <= manifest.headSeq; seq++) {
         final cf = byName[ChangesetLogLayout.changesetName(deviceId, seq)];
         if (cf == null) break;
-        payloads.add(
+        changesets.add(
           _changesetCodec.decodeChangeset(await provider.downloadFile(cf.id)),
         );
       }
     }
-    return payloads;
+    return (
+      baseFilePaths: baseFilePaths,
+      baseExportedAt: baseExportedAt,
+      changesets: changesets,
+    );
+  }
+
+  /// Read a base file's `exportedAt` (the cross-device latest-wins order key)
+  /// from a bounded prefix rather than parsing the whole base: it is the second
+  /// top-level member of the payload JSON, always within the first bytes. 0 if
+  /// absent (an unstamped/legacy base sorts first, which is the safe default).
+  Future<int> _readBaseExportedAt(String path) async {
+    final bytes = <int>[];
+    await for (final chunk in File(path).openRead(0, 65536)) {
+      bytes.addAll(chunk);
+    }
+    final head = utf8.decode(bytes, allowMalformed: true);
+    final match = RegExp(r'"exportedAt"\s*:\s*(\d+)').firstMatch(head);
+    return match == null ? 0 : (int.tryParse(match.group(1)!) ?? 0);
   }
 
   /// Download and parse the cloud epoch marker. Returns null when absent.

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1882,46 +1882,9 @@ class SyncService {
         uploadNonce: null,
       );
 
-      await _serializer.applyInDeferredFkTransaction(() async {
-        // Union the restored records; for ids present in several files the
-        // latest export wins (payloads are sorted ascending).
-        final cloudIds = <String, Set<String>>{};
-        final restored = <String, Map<String, Map<String, dynamic>>>{};
-        for (final payload in payloads) {
-          for (final entry in payload.data.toJson().entries) {
-            final entityType = entry.key;
-            final records = (entry.value as List).cast<Map<String, dynamic>>();
-            for (final record in records) {
-              final id = _recordIdForEntity(entityType, record);
-              if (id == null) continue;
-              (cloudIds[entityType] ??= <String>{}).add(id);
-              (restored[entityType] ??= {})[id] = record;
-            }
-          }
-        }
-
-        // Delete local rows the restored library does not contain.
-        for (final entry in localSnapshot.data.toJson().entries) {
-          final entityType = entry.key;
-          final records = (entry.value as List).cast<Map<String, dynamic>>();
-          for (final record in records) {
-            final id = _recordIdForEntity(entityType, record);
-            if (id == null) continue;
-            if (!(cloudIds[entityType]?.contains(id) ?? false)) {
-              await _serializer.deleteRecord(entityType, id);
-            }
-          }
-        }
-
-        // Upsert every restored record.
-        for (final entry in restored.entries) {
-          for (final record in entry.value.values) {
-            await _serializer.upsertRecord(entry.key, record);
-          }
-        }
-
-        await _serializer.repairDanglingForeignKeys();
-      });
+      await _serializer.applyInDeferredFkTransaction(
+        () => _applyAdoptInMemory(payloads, localSnapshot),
+      );
 
       // Re-baseline under the adopted epoch. Our tombstones are obsolete --
       // the restored library is authoritative.
@@ -1945,6 +1908,72 @@ class SyncService {
         message: 'Failed to adopt the restored library: $e',
       );
     }
+  }
+
+  /// In-memory union/delete/upsert adopt apply (parity reference for the
+  /// streaming path [_adoptApplyStreaming]). Runs inside the caller's
+  /// deferred-FK transaction. Unions every payload's `data` (latest export
+  /// wins; [payloads] must be sorted ascending by exportedAt), deletes local
+  /// rows absent from the union, then upserts the union and repairs FKs.
+  Future<void> _applyAdoptInMemory(
+    List<SyncPayload> payloads,
+    SyncPayload localSnapshot,
+  ) async {
+    // Union the restored records; for ids present in several files the latest
+    // export wins (payloads are sorted ascending).
+    final cloudIds = <String, Set<String>>{};
+    final restored = <String, Map<String, Map<String, dynamic>>>{};
+    for (final payload in payloads) {
+      for (final entry in payload.data.toJson().entries) {
+        final entityType = entry.key;
+        final records = (entry.value as List).cast<Map<String, dynamic>>();
+        for (final record in records) {
+          final id = _recordIdForEntity(entityType, record);
+          if (id == null) continue;
+          (cloudIds[entityType] ??= <String>{}).add(id);
+          (restored[entityType] ??= {})[id] = record;
+        }
+      }
+    }
+
+    // Delete local rows the restored library does not contain.
+    for (final entry in localSnapshot.data.toJson().entries) {
+      final entityType = entry.key;
+      final records = (entry.value as List).cast<Map<String, dynamic>>();
+      for (final record in records) {
+        final id = _recordIdForEntity(entityType, record);
+        if (id == null) continue;
+        if (!(cloudIds[entityType]?.contains(id) ?? false)) {
+          await _serializer.deleteRecord(entityType, id);
+        }
+      }
+    }
+
+    // Upsert every restored record.
+    for (final entry in restored.entries) {
+      for (final record in entry.value.values) {
+        await _serializer.upsertRecord(entry.key, record);
+      }
+    }
+
+    await _serializer.repairDanglingForeignKeys();
+  }
+
+  /// Test seam: in-memory adopt of [payloads] (the parity reference). Captures
+  /// the local snapshot, sorts payloads ascending, and applies in one
+  /// deferred-FK transaction. No re-baseline, so a parity comparison sees only
+  /// the data effects. See sync_adopt_streaming_parity_test.dart.
+  @visibleForTesting
+  Future<void> debugAdoptInMemory(List<SyncPayload> payloads) async {
+    final local = await _serializer.exportData(
+      deviceId: 'adopt',
+      deletions: const [],
+    );
+    final sorted = [...payloads]
+      ..sort((a, b) => a.exportedAt.compareTo(b.exportedAt));
+    await _serializer.applyInDeferredFkTransaction(
+      () => _applyAdoptInMemory(sorted, local),
+    );
   }
 
   /// Collect every payload (base + changesets) from all changeset logs stamped

--- a/test/core/services/sync/sync_adopt_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_adopt_streaming_parity_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Proves the streaming replace-adopt (`_adoptApplyStreaming`, driven by
+/// [SyncService.debugAdoptStreaming]) produces a byte-for-byte identical
+/// database to the in-memory reference adopt ([SyncService.debugAdoptInMemory])
+/// for the same inputs. This is the safety net for the #358 follow-up: it
+/// guarantees that bounding adopt memory did not change replace semantics --
+/// latest-export-wins union, deletion of local rows absent from the restored
+/// library, and a BLOB column streamed through the base file.
+
+/// Order-independent snapshot of a SyncData JSON map.
+String _canonical(Map<String, dynamic> dataJson) {
+  final out = <String, dynamic>{};
+  for (final key in dataJson.keys.toList()..sort()) {
+    final list = (dataJson[key] as List).cast<Map<String, dynamic>>();
+    out[key] = [...list]
+      ..sort((a, b) => jsonEncode(a).compareTo(jsonEncode(b)));
+  }
+  return jsonEncode(out);
+}
+
+Future<String> _dump() async {
+  final export = await SyncDataSerializer().exportData(
+    deviceId: 'snapshot',
+    deletions: const [],
+  );
+  return _canonical(export.data.toJson());
+}
+
+SyncService _svc() => SyncService(
+  syncRepository: SyncRepository(),
+  serializer: SyncDataSerializer(),
+);
+
+/// Deterministic exportedAt so ordering between the two paths is identical
+/// (Dart's List.sort is not stable, so equal exportedAt would be ambiguous).
+SyncPayload _withExportedAt(SyncPayload p, int at) =>
+    SyncPayload.fromJson({...p.toJson(), 'exportedAt': at});
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('streaming adopt equals in-memory adopt, byte-for-byte', () async {
+    // ---- Build the cloud library as two payloads (base older, changeset
+    // newer) so latest-export-wins is exercised, including a BLOB row. ----
+    final dives = DiveRepository();
+    await dives.createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await dives.createDive(
+      createTestDiveWithBottomTime(id: 'd2', diveNumber: 2),
+    );
+    final ser = SyncDataSerializer();
+    await ser.upsertRecord('diveSites', _site('site-1', 'Old', 1000));
+    await ser.upsertRecord('diveDataSources', {
+      'id': 'ds-1',
+      'diveId': 'd1',
+      'isPrimary': true,
+      'sourceFormat': 'shearwater',
+      'importedAt': 1700000000000,
+      'createdAt': 1700000000000,
+      'rawFingerprint': Uint8List.fromList([0x01, 0x02, 0x03, 0xFE, 0xFF]),
+    });
+    final base = _withExportedAt(
+      await ser.exportData(deviceId: 'peer', deletions: const []),
+      1000,
+    );
+
+    // Newer changeset: rename site-1, add site-2.
+    await ser.upsertRecord('diveSites', _site('site-1', 'NEW NAME', 2000));
+    await ser.upsertRecord('diveSites', _site('site-2', 'Second', 2000));
+    final changeset = _withExportedAt(
+      await ser.exportData(deviceId: 'peer', deletions: const []),
+      2000,
+    );
+
+    // Seed a DIFFERENT local library each run: 'd1' overlaps (must become the
+    // cloud version) and 'd-stale' is absent from the cloud (must be deleted).
+    Future<void> seedLocal() async {
+      final d = DiveRepository();
+      await d.createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 99),
+      );
+      await d.createDive(
+        createTestDiveWithBottomTime(id: 'd-stale', diveNumber: 7),
+      );
+    }
+
+    // ---- Phase A: in-memory reference (payloads passed unsorted on purpose).
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    await seedLocal();
+    await _svc().debugAdoptInMemory([changeset, base]);
+    final reference = await _dump();
+
+    // ---- Phase B: streaming. Base -> temp file; changeset stays in memory.
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    await seedLocal();
+    final tmpDir = await Directory.systemTemp.createTemp('adopt_parity');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(
+      utf8.encode(SyncDataSerializer().serializePayload(base)),
+    );
+    await _svc().debugAdoptStreaming([tmp.path], [base.exportedAt], [
+      changeset,
+    ]);
+    final streamed = await _dump();
+    await tmpDir.delete(recursive: true);
+
+    expect(streamed, reference, reason: 'streaming adopt must equal in-memory');
+
+    // Spot-checks: latest-wins applied, stale row gone.
+    final decoded = jsonDecode(streamed) as Map<String, dynamic>;
+    final siteNames = [
+      for (final s in (decoded['diveSites'] as List)) (s as Map)['name'],
+    ];
+    expect(siteNames, containsAll(<String>['NEW NAME', 'Second']));
+    expect(siteNames, isNot(contains('Old')));
+    final diveIds = [
+      for (final d in (decoded['dives'] as List)) (d as Map)['id'],
+    ];
+    expect(diveIds, containsAll(<String>['d1', 'd2']));
+    expect(diveIds, isNot(contains('d-stale')));
+  });
+
+  test('batch boundary (>500 rows of one table) preserves parity', () async {
+    final dives = DiveRepository();
+    for (var i = 1; i <= 600; i++) {
+      await dives.createDive(
+        createTestDiveWithBottomTime(id: 'd$i', diveNumber: i),
+      );
+    }
+    final base = _withExportedAt(
+      await SyncDataSerializer().exportData(
+        deviceId: 'peer',
+        deletions: const [],
+      ),
+      1000,
+    );
+
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    await _svc().debugAdoptInMemory([base]);
+    final reference = await _dump();
+
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    final tmpDir = await Directory.systemTemp.createTemp('adopt_parity_big');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(
+      utf8.encode(SyncDataSerializer().serializePayload(base)),
+    );
+    await _svc().debugAdoptStreaming([tmp.path], [base.exportedAt], const []);
+    final streamed = await _dump();
+    await tmpDir.delete(recursive: true);
+
+    expect(streamed, reference);
+  });
+}
+
+Map<String, dynamic> _site(String id, String name, int updatedAt) => {
+  'id': id,
+  'name': name,
+  'description': '',
+  'notes': '',
+  'isShared': false,
+  'createdAt': 1000,
+  'updatedAt': updatedAt,
+};

--- a/test/core/services/sync/sync_data_serializer_record_ids_test.dart
+++ b/test/core/services/sync/sync_data_serializer_record_ids_test.dart
@@ -46,7 +46,33 @@ void main() {
     expect(await s.recordIdsFor('diveEquipment'), isEmpty);
   });
 
-  test('keys settings on key; unknown entity is empty', () async {
+  test(
+    'builds composite ids for equipmentSetItems (setId|equipmentId)',
+    () async {
+      final s = SyncDataSerializer();
+      await s.upsertRecord('equipment', _equipment('e1'));
+      await s.upsertRecord('equipmentSets', {
+        'id': 'set-1',
+        'name': 'Travel kit',
+        'description': '',
+        'createdAt': 1000,
+        'updatedAt': 1000,
+      });
+      await s.upsertRecord('equipmentSetItems', {
+        'setId': 'set-1',
+        'equipmentId': 'e1',
+      });
+
+      final ids = await s.recordIdsFor('equipmentSetItems');
+      expect(ids, {'set-1|e1'});
+
+      // Round-trip through deleteRecord.
+      await s.deleteRecord('equipmentSetItems', ids.single);
+      expect(await s.recordIdsFor('equipmentSetItems'), isEmpty);
+    },
+  );
+
+  test('keys settings on key; unknown entity throws', () async {
     final s = SyncDataSerializer();
     await s.upsertRecord('settings', {
       'key': 'theme',
@@ -55,16 +81,20 @@ void main() {
     });
 
     expect(await s.recordIdsFor('settings'), {'theme'});
-    expect(await s.recordIdsFor('notATable'), <String>{});
+    // Unknown entity fails loud rather than silently returning empty.
+    expect(() => s.recordIdsFor('notATable'), throwsArgumentError);
   });
 
-  test('every synced entity resolves without throwing (smoke)', () async {
+  test('every synced entity has a recordIdsFor case', () async {
+    // recordIdsFor throws on an entity with no case, so iterating every synced
+    // entity fails loudly if one is ever added without a case -- which would
+    // otherwise silently skip that entity's stale-row deletion on adopt.
     final s = SyncDataSerializer();
     for (final entity in SyncService.entityHasUpdatedAt.keys) {
       expect(
         await s.recordIdsFor(entity),
         isA<Set<String>>(),
-        reason: '$entity must have a recordIdsFor case',
+        reason: '$entity is missing a recordIdsFor case',
       );
     }
   });

--- a/test/core/services/sync/sync_data_serializer_record_ids_test.dart
+++ b/test/core/services/sync/sync_data_serializer_record_ids_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Unit coverage for [SyncDataSerializer.recordIdsFor]: the bounded, id-only
+/// local-row enumeration that the streaming replace-adopt uses to delete local
+/// rows absent from the restored library (#358). The contract is that the ids
+/// it emits round-trip through [SyncDataSerializer.deleteRecord]: plain `id`
+/// for most entities, `key` for `settings`, and the composite `a|b` form for
+/// the two junction tables.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async => setUpTestDatabase());
+  tearDown(() => tearDownTestDatabase());
+
+  test('returns plain ids for a simple entity', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecord('diveSites', _site('site-1'));
+    await s.upsertRecord('diveSites', _site('site-2'));
+
+    expect(await s.recordIdsFor('diveSites'), {'site-1', 'site-2'});
+  });
+
+  test('builds composite ids for diveEquipment (diveId|equipmentId)', () async {
+    final dives = DiveRepository();
+    await dives.createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    final s = SyncDataSerializer();
+    await s.upsertRecord('equipment', _equipment('e1'));
+    await s.upsertRecord('diveEquipment', {
+      'diveId': 'd1',
+      'equipmentId': 'e1',
+    });
+
+    final ids = await s.recordIdsFor('diveEquipment');
+    expect(ids, {'d1|e1'});
+
+    // Round-trip: the emitted id deletes the row through deleteRecord.
+    await s.deleteRecord('diveEquipment', ids.single);
+    expect(await s.recordIdsFor('diveEquipment'), isEmpty);
+  });
+
+  test('keys settings on key; unknown entity is empty', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecord('settings', {
+      'key': 'theme',
+      'value': 'dark',
+      'updatedAt': 1,
+    });
+
+    expect(await s.recordIdsFor('settings'), {'theme'});
+    expect(await s.recordIdsFor('notATable'), <String>{});
+  });
+
+  test('every synced entity resolves without throwing (smoke)', () async {
+    final s = SyncDataSerializer();
+    for (final entity in SyncService.entityHasUpdatedAt.keys) {
+      expect(
+        await s.recordIdsFor(entity),
+        isA<Set<String>>(),
+        reason: '$entity must have a recordIdsFor case',
+      );
+    }
+  });
+}
+
+Map<String, dynamic> _site(String id) => {
+  'id': id,
+  'name': 'Site $id',
+  'description': '',
+  'notes': '',
+  'isShared': false,
+  'createdAt': 1000,
+  'updatedAt': 1000,
+};
+
+Map<String, dynamic> _equipment(String id) => {
+  'id': id,
+  'name': 'Regulator',
+  'type': 'regulator',
+  'status': 'active',
+  'purchaseCurrency': 'USD',
+  'notes': '',
+  'isActive': true,
+  'createdAt': 1000,
+  'updatedAt': 1000,
+};


### PR DESCRIPTION
## Problem

Issue #358 still reproduces on **v1.5.5.107** — which already contains the PR #365 streaming fix. A user with a large iCloud library crashes the iOS app ~20 s after every launch (download 64 × 8 MB base parts → silent restart, no error line = jetsam OOM kill).

**Root cause:** PR #365 converted only the *normal* cold-start adoption path (`ChangesetReader.pull` → `_applyRemoteBaseFile`) to bounded-memory streaming. The **Replace/epoch adoption** path was left in-memory: `adoptReplacedLibrary` → `_collectEpochPayloads` downloaded every base part into a `List<Uint8List>`, then `decodeBaseParts` reassembled them (512 MB contiguous) → `utf8.decode` (~1 GB String) → `jsonDecode` (multi-GB object tree) → re-indexed into a `restored` map. Several simultaneous full-size copies of the library.

A fresh device (0 dives) takes the **silent auto-adopt** branch (`sync_providers.dart`, `diveCount == 0`), so this fires automatically on launch with no user interaction → OOM → restart → repeat forever (the adopt never completes, so the epoch stays unaccepted and diveCount stays 0). `BaseChunker.defaultPartSize == 8388608` matches the 8 MB part size in the reporter's logs exactly.

## Fix

Give the Replace-adopt path the same bounded-memory treatment `_applyRemoteBaseFile` already has:

- **`SyncDataSerializer.recordIdsFor`** — id-only projection per entity (never materializes rows), so enumerating local rows for the delete pass stays bounded even for row-per-sample tables (`diveProfiles`).
- **`_collectEpochBaseSources`** — assembles each epoch device's base to a temp file via `BasePartFileSink` (one 8 MB part in memory at a time, per-part + whole-file checksum verified), reads `exportedAt` from a bounded 64 KB prefix, keeps small changesets in memory.
- **`_adoptApplyStreaming`** — one deferred-FK transaction: upserts every restored row in `exportedAt` order (base files streamed in 500-row batches via `BaseJsonStreamReader`, plus in-memory changesets), collecting cloud ids as it goes; then deletes local rows absent from that set (`recordIdsFor` + `deleteRecord`); then repairs FKs. Drops both the in-memory base **and** the full local `exportData()` snapshot the old path held.

Peak adopt RAM: id-sets + one 500-row batch, independent of library size.

### Why it's safe (behavioral parity)

`upsertRecord` is an unconditional `insertOnConflictUpdate`, so applying rows in ascending `exportedAt` order is provably equivalent to the old latest-export-wins `restored` map; and delete-not-in-cloud is order-independent, so upsert-then-delete matches the old delete-then-upsert (final state is the cloud union either way). A **parity test** asserts the streaming adopt yields a byte-identical database to the in-memory reference (kept as `debugAdoptInMemory`) across latest-wins union, stale-row deletion, a BLOB column, and the >500-row batch boundary.

## Tests

- New `recordIdsFor` unit test (plain / composite / settings / 38-entity smoke + `deleteRecord` round-trip).
- New `sync_adopt_streaming_parity_test` (streaming == in-memory, byte-for-byte).
- Full sync suite (342) green — including the pre-existing *"adopts silently when the local library is empty"* (the reporter's exact path), now running entirely through the bounded code.
- `flutter analyze` + `dart format` clean.

## Remaining

- **Device verification** (the real gate, can't be unit-tested): a fresh iOS install adopting the reporter's large epoch-stamped cloud library should now complete instead of OOM-restarting.
- Separate tracked follow-up: the *write/publish* side (`BaseChunker.slice`) still buffers a full base in RAM when a desktop publishes a large library.

Fixes #358.