### PR TITLE
Default ascent-rate toggles off and unify their naming

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -897,8 +897,14 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(true))();
   BoolColumn get defaultShowGasTimeline =>
       boolean().withDefault(const Constant(false))();
+  // Drift column declarations are codegen inputs shadowed by the generated
+  // table at runtime, so this line is never executed (every sibling column
+  // getter is likewise uncovered). The default is verified via the migration
+  // and settings tests, not by exercising this declaration.
+  // coverage:ignore-start
   BoolColumn get defaultShowAscentRateLine =>
       boolean().withDefault(const Constant(false))();
+  // coverage:ignore-end
   // Notification settings (v26)
   BoolColumn get notificationsEnabled =>
       boolean().withDefault(const Constant(true))();

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -802,7 +802,7 @@ class DiverSettings extends Table {
   BoolColumn get showCeilingOnProfile =>
       boolean().withDefault(const Constant(true))();
   BoolColumn get showAscentRateColors =>
-      boolean().withDefault(const Constant(true))();
+      boolean().withDefault(const Constant(false))();
   BoolColumn get showNdlOnProfile =>
       boolean().withDefault(const Constant(true))();
   RealColumn get lastStopDepth => real().withDefault(const Constant(3.0))();
@@ -896,6 +896,8 @@ class DiverSettings extends Table {
   BoolColumn get defaultShowGasSwitchMarkers =>
       boolean().withDefault(const Constant(true))();
   BoolColumn get defaultShowGasTimeline =>
+      boolean().withDefault(const Constant(false))();
+  BoolColumn get defaultShowAscentRateLine =>
       boolean().withDefault(const Constant(false))();
   // Notification settings (v26)
   BoolColumn get notificationsEnabled =>
@@ -1632,7 +1634,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 90;
+  static const int currentSchemaVersion = 91;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1726,6 +1728,7 @@ class AppDatabase extends _$AppDatabase {
     88,
     89,
     90,
+    91,
   ];
 
   /// Tables that carry a per-row Hybrid Logical Clock for cross-device conflict
@@ -4209,6 +4212,27 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 90) await reportProgress();
+        if (from < 91) {
+          // Persisted default for the "Ascent Rate Line" profile overlay
+          // (issue: ascent-rate toggles default-off). Previously the line was a
+          // session-only toggle with no setting; it now joins the Default
+          // Visible Metrics list. PRAGMA-guarded so a healthy database no-ops
+          // and an interrupted upgrade does not fail on a duplicate ALTER.
+          final cols = await customSelect(
+            "PRAGMA table_info('diver_settings')",
+          ).get();
+          if (cols.isNotEmpty) {
+            final existing = cols.map((c) => c.read<String>('name')).toSet();
+            if (!existing.contains('default_show_ascent_rate_line')) {
+              await customStatement(
+                'ALTER TABLE diver_settings '
+                'ADD COLUMN default_show_ascent_rate_line '
+                'INTEGER NOT NULL DEFAULT 0',
+              );
+            }
+          }
+        }
+        if (from < 91) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2171,6 +2171,10 @@ class SyncDataSerializer {
       // Dive profile markers
       'showMaxDepthMarker': true,
       'showPressureThresholdMarkers': false,
+      // Dive profile default-visible metrics. Non-nullable bool added in v91;
+      // seed it so payloads predating the column hydrate instead of throwing in
+      // DiverSetting.fromJson.
+      'defaultShowAscentRateLine': false,
       // Override with actual data (existing values take precedence)
       ...data,
     };

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2156,7 +2156,7 @@ class SyncDataSerializer {
       'ascentRateWarning': 9.0,
       'ascentRateCritical': 12.0,
       'showCeilingOnProfile': true,
-      'showAscentRateColors': true,
+      'showAscentRateColors': false,
       'showNdlOnProfile': true,
       'lastStopDepth': 3.0,
       'decoStopIncrement': 3.0,

--- a/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
@@ -28,9 +28,9 @@ class ProfileLegendState {
   final bool showSac;
   final bool showAscentRateColors;
 
-  /// Separate ascent-rate magnitude line (m/min). Session-only, no persisted
-  /// setting (mirrors [showMod]); distinct from [showAscentRateColors], which
-  /// tints the depth line by velocity band.
+  /// Separate ascent-rate magnitude line (m/min). Its session state seeds from
+  /// the persisted [AppSettings.defaultShowAscentRateLine] default; distinct
+  /// from [showAscentRateColors], which tints the depth line by velocity band.
   final bool showAscentRateLine;
   final bool showEvents;
   final bool showMaxDepthMarker;
@@ -74,7 +74,7 @@ class ProfileLegendState {
     this.showCeiling = true,
     this.showHeartRate = false,
     this.showSac = false,
-    this.showAscentRateColors = true,
+    this.showAscentRateColors = false,
     this.showAscentRateLine = false,
     this.showEvents = true,
     this.showMaxDepthMarker = true,
@@ -309,6 +309,7 @@ class ProfileLegend extends _$ProfileLegend {
       showHeartRate: settings.defaultShowHeartRate,
       showSac: settings.defaultShowSac,
       showAscentRateColors: settings.showAscentRateColors,
+      showAscentRateLine: settings.defaultShowAscentRateLine,
       showEvents: settings.defaultShowEvents,
       showMaxDepthMarker: settings.showMaxDepthMarker,
       showPressureMarkers: settings.showPressureThresholdMarkers,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -290,7 +290,7 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     this.tankVolume,
     this.sacNormalizationFactor = 1.0,
     this.showCeiling = true,
-    this.showAscentRateColors = true,
+    this.showAscentRateColors = false,
     this.showEvents = true,
     this.showSac = false,
     this.markers,
@@ -341,7 +341,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
   // Decompression visualization toggles
   bool _showCeiling = true;
-  bool _showAscentRateColors = true;
+  bool _showAscentRateColors = false;
   bool _showAscentRateLine = false;
   bool _showEvents = true;
 

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -135,6 +135,7 @@ class DiverSettingsRepository {
               defaultShowOtu: Value(s.defaultShowOtu),
               defaultShowGasSwitchMarkers: Value(s.defaultShowGasSwitchMarkers),
               defaultShowGasTimeline: Value(s.defaultShowGasTimeline),
+              defaultShowAscentRateLine: Value(s.defaultShowAscentRateLine),
               notificationsEnabled: Value(s.notificationsEnabled),
               serviceReminderDays: Value(
                 _formatReminderDays(s.serviceReminderDays),
@@ -271,6 +272,7 @@ class DiverSettingsRepository {
             settings.defaultShowGasSwitchMarkers,
           ),
           defaultShowGasTimeline: Value(settings.defaultShowGasTimeline),
+          defaultShowAscentRateLine: Value(settings.defaultShowAscentRateLine),
           notificationsEnabled: Value(settings.notificationsEnabled),
           serviceReminderDays: Value(
             _formatReminderDays(settings.serviceReminderDays),
@@ -438,6 +440,7 @@ class DiverSettingsRepository {
       defaultShowOtu: row.defaultShowOtu,
       defaultShowGasSwitchMarkers: row.defaultShowGasSwitchMarkers,
       defaultShowGasTimeline: row.defaultShowGasTimeline,
+      defaultShowAscentRateLine: row.defaultShowAscentRateLine,
       notificationsEnabled: row.notificationsEnabled,
       serviceReminderDays: _parseReminderDays(row.serviceReminderDays),
       reminderTime: _parseReminderTime(row.reminderTime),

--- a/lib/features/settings/presentation/pages/default_visible_metrics_page.dart
+++ b/lib/features/settings/presentation/pages/default_visible_metrics_page.dart
@@ -64,11 +64,14 @@ class DefaultVisibleMetricsPage extends ConsumerWidget {
             onChanged: notifier.setShowCeilingOnProfile,
           ),
           SwitchListTile(
-            title: Text(
-              context.l10n.settings_appearance_metric_ascentRateColors,
-            ),
+            title: Text(context.l10n.diveLog_legend_label_ascentRate),
             value: settings.showAscentRateColors,
             onChanged: notifier.setShowAscentRateColors,
+          ),
+          SwitchListTile(
+            title: Text(context.l10n.diveLog_legend_label_ascentRateLine),
+            value: settings.defaultShowAscentRateLine,
+            onChanged: notifier.setDefaultShowAscentRateLine,
           ),
           SwitchListTile(
             title: Text(context.l10n.settings_appearance_metric_ndl),

--- a/lib/features/settings/presentation/pages/section_appearance_page.dart
+++ b/lib/features/settings/presentation/pages/section_appearance_page.dart
@@ -611,6 +611,7 @@ class SectionAppearancePage extends ConsumerWidget {
       settings.defaultShowEvents,
       settings.showCeilingOnProfile,
       settings.showAscentRateColors,
+      settings.defaultShowAscentRateLine,
       settings.showNdlOnProfile,
       settings.defaultShowTts,
       settings.defaultShowCns,

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -251,6 +251,11 @@ class AppSettings {
   /// Default visibility for the gas-usage timeline strip on the dive profile
   final bool defaultShowGasTimeline;
 
+  /// Default visibility for the separate ascent-rate magnitude line on the
+  /// dive profile (distinct from [showAscentRateColors], which tints the depth
+  /// line by velocity band).
+  final bool defaultShowAscentRateLine;
+
   // Notification settings
   final bool notificationsEnabled;
   final List<int> serviceReminderDays;
@@ -302,7 +307,7 @@ class AppSettings {
     this.ascentRateWarning = 9.0,
     this.ascentRateCritical = 12.0,
     this.showCeilingOnProfile = true,
-    this.showAscentRateColors = true,
+    this.showAscentRateColors = false,
     this.showNdlOnProfile = true,
     this.lastStopDepth = 3.0,
     this.decoStopIncrement = 3.0,
@@ -351,6 +356,7 @@ class AppSettings {
     this.defaultShowOtu = false,
     this.defaultShowGasSwitchMarkers = true,
     this.defaultShowGasTimeline = false,
+    this.defaultShowAscentRateLine = false,
     // Notification defaults
     this.notificationsEnabled = true,
     this.serviceReminderDays = const [7, 14, 30],
@@ -476,6 +482,7 @@ class AppSettings {
     bool? defaultShowOtu,
     bool? defaultShowGasSwitchMarkers,
     bool? defaultShowGasTimeline,
+    bool? defaultShowAscentRateLine,
     bool? notificationsEnabled,
     List<int>? serviceReminderDays,
     TimeOfDay? reminderTime,
@@ -582,6 +589,8 @@ class AppSettings {
           defaultShowGasSwitchMarkers ?? this.defaultShowGasSwitchMarkers,
       defaultShowGasTimeline:
           defaultShowGasTimeline ?? this.defaultShowGasTimeline,
+      defaultShowAscentRateLine:
+          defaultShowAscentRateLine ?? this.defaultShowAscentRateLine,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
       serviceReminderDays: serviceReminderDays ?? this.serviceReminderDays,
       reminderTime: reminderTime ?? this.reminderTime,
@@ -1118,6 +1127,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   Future<void> setDefaultShowGasTimeline(bool value) async {
     state = state.copyWith(defaultShowGasTimeline: value);
+    await _saveSettings();
+  }
+
+  Future<void> setDefaultShowAscentRateLine(bool value) async {
+    state = state.copyWith(defaultShowAscentRateLine: value);
     await _saveSettings();
   }
 

--- a/test/core/database/migration_v90_site_location_test.dart
+++ b/test/core/database/migration_v90_site_location_test.dart
@@ -54,10 +54,11 @@ void main() {
     },
   );
 
-  test('schema version is 90 and the migration list includes it', () {
-    // Latest-version tripwire: bumping the schema must come with a matching
-    // migration block and an update here.
-    expect(AppDatabase.currentSchemaVersion, 90);
+  test('schema version is at least 90 and the migration list includes it', () {
+    // Bumping the schema must come with a matching migration block. Uses
+    // greaterThanOrEqualTo so a later bump does not break this version's test;
+    // the exact-latest tripwire lives in the newest migration test.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(90));
     expect(AppDatabase.migrationVersions, contains(90));
   });
 

--- a/test/core/database/migration_v91_ascent_rate_line_test.dart
+++ b/test/core/database/migration_v91_ascent_rate_line_test.dart
@@ -1,0 +1,101 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+void main() {
+  test(
+    'v91 adds default_show_ascent_rate_line to diver_settings, default 0',
+    () async {
+      final nativeDb = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA user_version = 90');
+          // Minimal pre-v91 diver_settings shape: just enough columns to insert
+          // a row. The v91 migration adds default_show_ascent_rate_line.
+          rawDb.execute('''
+          CREATE TABLE diver_settings (
+            id TEXT NOT NULL PRIMARY KEY,
+            diver_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+          rawDb.execute(
+            "INSERT INTO diver_settings (id, diver_id, created_at, updated_at) "
+            "VALUES ('s1', 'd1', 1, 1)",
+          );
+        },
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(() => db.close());
+
+      // Touch the DB so the migration runs.
+      final cols = await db
+          .customSelect("PRAGMA table_info('diver_settings')")
+          .get();
+      final names = cols.map((c) => c.read<String>('name')).toSet();
+      expect(names, contains('default_show_ascent_rate_line'));
+
+      // Existing rows read the new column as the SQL default (0 / false).
+      final row = await db
+          .customSelect(
+            "SELECT default_show_ascent_rate_line FROM diver_settings "
+            "WHERE id = 's1'",
+          )
+          .getSingle();
+      expect(row.data['default_show_ascent_rate_line'], 0);
+    },
+  );
+
+  test('schema version is 91 and the migration list includes it', () {
+    // Latest-version tripwire: bumping the schema must come with a matching
+    // migration block and an update here.
+    expect(AppDatabase.currentSchemaVersion, 91);
+    expect(AppDatabase.migrationVersions, contains(91));
+  });
+
+  test('v91 migration is idempotent when the column already exists', () async {
+    // Exercises the PRAGMA guard branch: a database where the v91 column is
+    // already present (e.g. an interrupted upgrade) must not fail on a
+    // duplicate ALTER.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 90');
+        rawDb.execute('''
+          CREATE TABLE diver_settings (
+            id TEXT NOT NULL PRIMARY KEY,
+            diver_id TEXT NOT NULL,
+            default_show_ascent_rate_line INTEGER NOT NULL DEFAULT 1,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+        rawDb.execute(
+          "INSERT INTO diver_settings "
+          "(id, diver_id, default_show_ascent_rate_line, created_at, updated_at) "
+          "VALUES ('s1', 'd1', 1, 1, 1)",
+        );
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('diver_settings')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toList();
+
+    // Column present exactly once (no duplicate ALTER).
+    expect(names.where((n) => n == 'default_show_ascent_rate_line').length, 1);
+
+    // The pre-existing value is preserved, not reset to the new default.
+    final row = await db
+        .customSelect(
+          "SELECT default_show_ascent_rate_line FROM diver_settings "
+          "WHERE id = 's1'",
+        )
+        .getSingle();
+    expect(row.data['default_show_ascent_rate_line'], 1);
+  });
+}

--- a/test/core/services/sync/sync_diver_settings_fallback_test.dart
+++ b/test/core/services/sync/sync_diver_settings_fallback_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// A receiving device on an older schema sends a diver_settings payload that
+/// predates v91, so it lacks `defaultShowAscentRateLine` (a NOT NULL column).
+/// The fallback map in [SyncDataSerializer] must seed it, otherwise
+/// `DiverSetting.fromJson` throws on the missing non-nullable bool.
+void main() {
+  late SyncDataSerializer serializer;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  test(
+    'applies a pre-v91 diver_settings payload missing the new field',
+    () async {
+      // FK enforcement off so a placeholder diver_id needn't reference a real
+      // diver -- this row only exercises the settings serialization path.
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      // Seed a real settings row, then read it back in the export wire format.
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.diverSettings)
+          .insert(
+            DiverSettingsCompanion.insert(
+              id: 'ds1',
+              diverId: 'diver-1',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      final exported = await serializer.fetchRecord('diverSettings', 'ds1');
+      expect(exported, isNotNull);
+
+      // Simulate the older sender: strip the v91-era keys from the payload.
+      final legacy = Map<String, dynamic>.from(exported!)
+        ..remove('defaultShowAscentRateLine')
+        ..remove('showAscentRateColors');
+
+      // Remove the local row so the upsert is a fresh insert.
+      await (db.delete(
+        db.diverSettings,
+      )..where((t) => t.id.equals('ds1'))).go();
+
+      // Must not throw on the missing non-nullable column.
+      await serializer.upsertRecord('diverSettings', legacy);
+
+      final row = await (db.select(
+        db.diverSettings,
+      )..where((t) => t.id.equals('ds1'))).getSingle();
+      // Both fields hydrate to the v91 defaults rather than throwing.
+      expect(row.defaultShowAscentRateLine, isFalse);
+      expect(row.showAscentRateColors, isFalse);
+    },
+  );
+}

--- a/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
@@ -173,10 +173,13 @@ void main() {
   });
 
   group('showAscentRateLine', () {
-    test('defaults to false (session-only, no setting)', () {
-      const state = ProfileLegendState();
-      expect(state.showAscentRateLine, isFalse);
-    });
+    test(
+      'defaults to false (seeds from defaultShowAscentRateLine setting)',
+      () {
+        const state = ProfileLegendState();
+        expect(state.showAscentRateLine, isFalse);
+      },
+    );
 
     test('copyWith sets showAscentRateLine to true', () {
       const state = ProfileLegendState();
@@ -278,6 +281,51 @@ void main() {
       );
       addTearDown(container.dispose);
       expect(container.read(profileLegendProvider).showGas, isFalse);
+    });
+  });
+
+  group('ProfileLegend.build ascent rate hydration', () {
+    test('both ascent-rate toggles start off with default settings', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _StubSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+      final state = container.read(profileLegendProvider);
+      expect(state.showAscentRateColors, isFalse);
+      expect(state.showAscentRateLine, isFalse);
+    });
+
+    test('showAscentRateColors starts true when the setting is on', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => _StubSettingsNotifier(
+              const AppSettings(showAscentRateColors: true),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(
+        container.read(profileLegendProvider).showAscentRateColors,
+        isTrue,
+      );
+    });
+
+    test('showAscentRateLine seeds from defaultShowAscentRateLine', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => _StubSettingsNotifier(
+              const AppSettings(defaultShowAscentRateLine: true),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(profileLegendProvider).showAscentRateLine, isTrue);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2319,7 +2319,11 @@ void main() {
     ) async {
       final profile = _makeProfile(points: 12);
       await tester.pumpWidget(
-        _buildChart(profile: profile, ascentRates: ratesSpanningBands(profile)),
+        buildWithLegend(
+          profile: profile,
+          ascentRates: ratesSpanningBands(profile),
+          configure: (n) => n.toggleAscentRateColors(), // default off -> on
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2351,7 +2355,11 @@ void main() {
       });
 
       await tester.pumpWidget(
-        _buildChart(profile: profile, ascentRates: rates),
+        buildWithLegend(
+          profile: profile,
+          ascentRates: rates,
+          configure: (n) => n.toggleAscentRateColors(), // default off -> on
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -2370,7 +2378,7 @@ void main() {
         buildWithLegend(
           profile: profile,
           ascentRates: ratesSpanningBands(profile),
-          configure: (n) => n.toggleAscentRateColors(), // default on -> off
+          // Coloring now defaults off, so no toggle needed to disable it.
         ),
       );
       await tester.pumpAndSettle();

--- a/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
@@ -308,9 +308,9 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      // Default state: showCeiling=true, showAscentRateColors=true
-      // Badge should show 2
-      expect(find.text('2'), findsOneWidget);
+      // Default state: showCeiling=true, showAscentRateColors=false (both ascent
+      // rate toggles now default off). Only Ceiling counts -> badge shows 1.
+      expect(find.text('1'), findsOneWidget);
     });
 
     testWidgets('badge includes gas strip when hasGasData is true', (

--- a/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
+++ b/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/pages/default_visible_metrics_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Minimal SettingsNotifier stub that mutates in-memory state without touching
+/// the database. Only the setters tapped by this test are implemented; every
+/// other [SettingsNotifier] member falls through to [noSuchMethod] (never
+/// invoked, since the page only takes tear-offs of the untapped setters).
+class _StubSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _StubSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setShowAscentRateColors(bool value) async =>
+      state = state.copyWith(showAscentRateColors: value);
+
+  @override
+  Future<void> setDefaultShowAscentRateLine(bool value) async =>
+      state = state.copyWith(defaultShowAscentRateLine: value);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  Widget buildPage(_StubSettingsNotifier notifier) {
+    return ProviderScope(
+      overrides: [settingsProvider.overrideWith((ref) => notifier)],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: DefaultVisibleMetricsPage(),
+      ),
+    );
+  }
+
+  testWidgets('shows the renamed Ascent Rate toggle plus the new line toggle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildPage(_StubSettingsNotifier()));
+    await tester.pumpAndSettle();
+
+    // The chart-matching labels are present; the old "Ascent Rate Colors"
+    // wording is gone.
+    expect(find.text('Ascent Rate'), findsOneWidget);
+    expect(find.text('Ascent Rate Line'), findsOneWidget);
+    expect(find.text('Ascent Rate Colors'), findsNothing);
+  });
+
+  testWidgets('both ascent-rate toggles start off', (tester) async {
+    await tester.pumpWidget(buildPage(_StubSettingsNotifier()));
+    await tester.pumpAndSettle();
+
+    final switches = tester
+        .widgetList<SwitchListTile>(find.byType(SwitchListTile))
+        .toList();
+    SwitchListTile tileFor(String label) =>
+        switches.firstWhere((s) => (s.title as Text).data == label);
+
+    expect(tileFor('Ascent Rate').value, isFalse);
+    expect(tileFor('Ascent Rate Line').value, isFalse);
+  });
+
+  testWidgets('tapping Ascent Rate Line enables the persisted default', (
+    tester,
+  ) async {
+    final notifier = _StubSettingsNotifier();
+    await tester.pumpWidget(buildPage(notifier));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Ascent Rate Line'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.state.defaultShowAscentRateLine, isTrue);
+  });
+
+  testWidgets('tapping Ascent Rate enables velocity coloring', (tester) async {
+    final notifier = _StubSettingsNotifier();
+    await tester.pumpWidget(buildPage(notifier));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Ascent Rate'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.state.showAscentRateColors, isTrue);
+  });
+}

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -114,6 +114,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override
+  Future<void> setDefaultShowAscentRateLine(bool value) async =>
+      state = state.copyWith(defaultShowAscentRateLine: value);
+  @override
   Future<void> setDepthUnit(DepthUnit unit) async =>
       state = state.copyWith(depthUnit: unit);
   @override

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -38,6 +38,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override
+  Future<void> setDefaultShowAscentRateLine(bool value) async =>
+      state = state.copyWith(defaultShowAscentRateLine: value);
+  @override
   Future<void> setDepthUnit(DepthUnit unit) async =>
       state = state.copyWith(depthUnit: unit);
   @override

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -292,6 +292,39 @@ void main() {
           .setShowDataSourceBadges(false);
       expect(container.read(settingsProvider).showDataSourceBadges, isFalse);
     });
+
+    test('setDefaultShowAscentRateLine persists the new default', () async {
+      container.read(settingsProvider.notifier);
+      await waitForInit();
+
+      // Promoted from session-only to a persisted default in v91; starts off.
+      expect(
+        container.read(settingsProvider).defaultShowAscentRateLine,
+        isFalse,
+      );
+      await container
+          .read(settingsProvider.notifier)
+          .setDefaultShowAscentRateLine(true);
+      expect(
+        container.read(settingsProvider).defaultShowAscentRateLine,
+        isTrue,
+      );
+    });
+
+    test(
+      'setShowAscentRateColors toggles the velocity-coloring default',
+      () async {
+        container.read(settingsProvider.notifier);
+        await waitForInit();
+
+        // Coloring now defaults off as of this change.
+        expect(container.read(settingsProvider).showAscentRateColors, isFalse);
+        await container
+            .read(settingsProvider.notifier)
+            .setShowAscentRateColors(true);
+        expect(container.read(settingsProvider).showAscentRateColors, isTrue);
+      },
+    );
   });
 }
 

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -30,6 +30,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override
+  Future<void> setDefaultShowAscentRateLine(bool value) async =>
+      state = state.copyWith(defaultShowAscentRateLine: value);
+  @override
   Future<void> setDepthUnit(DepthUnit unit) async =>
       state = state.copyWith(depthUnit: unit);
   @override

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -243,6 +243,9 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override
+  Future<void> setDefaultShowAscentRateLine(bool value) async =>
+      state = state.copyWith(defaultShowAscentRateLine: value);
+  @override
   Future<void> setDefaultShowPpO2(bool value) async =>
       state = state.copyWith(defaultShowPpO2: value);
   @override


### PR DESCRIPTION
## Summary

The dive profile had two confusingly-named ascent-rate controls. The chart legend's **"Ascent Rate"** toggle and Settings' **"Ascent Rate Colors"** toggle were the *same* setting (`showAscentRateColors` — depth-line velocity coloring), while **"Ascent Rate Line"** (the separate m/min magnitude line) was session-only and absent from Settings entirely.

This PR makes both ascent-rate overlays **default off**, gives them matching names in the chart and Settings, and promotes "Ascent Rate Line" to a real persisted default.

## Changes

- **Defaults off:** `showAscentRateColors` ("Ascent Rate" coloring) now defaults `false` across the DB column, `AppSettings`, the legend state, the chart widget, and the sync import fallback.
- **New persisted setting:** "Ascent Rate Line" promoted from session-only to `defaultShowAscentRateLine` (default `false`) via **schema migration v90 → v91** (PRAGMA-guarded, idempotent), wired through `DiverSettingsRepository` and Drift codegen.
- **Settings UI** (`Default Visible Metrics`): the old "Ascent Rate Colors" row is relabeled **"Ascent Rate"** and a new **"Ascent Rate Line"** toggle is added. Both reuse the already-translated `diveLog_legend_label_ascentRate*` strings, so the chart legend and Settings render identical text in all 11 locales — no new ARB entries.
- **Metric count:** the appearance subtitle now counts the new line toggle.

## Why reuse the legend l10n keys

`diveLog_legend_label_ascentRate` / `…Line` are already translated everywhere. Pointing Settings at them keeps chart and Settings labels in lockstep by construction. The old `settings_appearance_metric_ascentRateColors` key is now orphaned (harmless unused getter) — a candidate for a future ARB cleanup.

## Tests

- New `migration_v91_ascent_rate_line_test.dart`: add-column, default-0, and idempotency (interrupted-upgrade) cases.
- Hardened the v90 tripwire to `greaterThanOrEqualTo` so future bumps don't break it; the exact-latest tripwire now lives in the v91 test.
- Added provider hydration coverage (colors default-off, line seeds from the setting).
- Fixed the chart coloring + legend badge tests that had silently depended on the old default, plus the 4 `SettingsNotifier` test mocks for the new setter.

## Verification

- Whole-project `flutter analyze`: clean
- `dart format`: clean
- Full test suite green (passed via the pre-push hook)

Device verification on a real dive profile still pending.