### PR TITLE
fix(o2tox): exclude later dives from weekly OTU rolling total (#407)

### DIFF
--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -970,8 +970,11 @@ final residualOtuProvider = FutureProvider.family<double, String>((
 
 /// Weekly OTU rolling total for a given dive (7-day window ending on dive date).
 ///
-/// Queries all dives in the 7 days leading up to (and including) the dive's
-/// date, sums their OTU. Used by O2ToxicityCard for REPEX compliance display.
+/// Queries dives in the 7 days leading up to the dive's date and sums the OTU
+/// of the current dive plus any dive that occurred at or before it. Dives
+/// logged LATER than the current dive (e.g. later the same day) are excluded
+/// so the displayed "Prior" never borrows OTU from the future (issue #407).
+/// Used by O2ToxicityCard for REPEX compliance display.
 final weeklyOtuProvider = FutureProvider.family<double, String>((
   ref,
   diveId,
@@ -994,6 +997,16 @@ final weeklyOtuProvider = FutureProvider.family<double, String>((
 
     double totalOtu = 0.0;
     for (final dive in weekDives) {
+      // Count the current dive and any dive that occurred at or before it, but
+      // skip dives logged LATER than the current dive. The query window spans
+      // the current dive's whole calendar day, so without this guard a later
+      // same-day dive would inflate the rolling total -- and the card derives
+      // "Prior" as (weekly - thisDive), wrongly attributing the future dive's
+      // OTU to this dive's prior exposure (issue #407). Mirrors the same-day
+      // ordering discipline in [_computeResidualOtu].
+      final diveTime = dive.entryTime ?? dive.dateTime;
+      if (dive.id != diveId && diveTime.isAfter(diveDate)) continue;
+
       // Read (not watch) to avoid cascading Riverpod invalidations.
       // Each profileAnalysisProvider independently watches settings,
       // so ref.read is sufficient for aggregation.

--- a/test/features/dive_log/presentation/providers/weekly_otu_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/weekly_otu_provider_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/deco/entities/o2_exposure.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Tests for [weeklyOtuProvider]'s rolling 7-day window.
+///
+/// Regression coverage for issue #407: the weekly OTU "Prior" for the earliest
+/// dive in the log was showing OTU borrowed from a dive logged LATER the same
+/// day. The rolling total must only include the current dive and dives that
+/// occurred at or before it -- never dives that happened afterwards.
+void main() {
+  late DiveRepository repository;
+
+  // Per-dive OTU contributions, stubbed via profileAnalysisProvider so these
+  // tests exercise only the rolling-window selection, not the Buhlmann model.
+  const earlierDiveOtu = 16.0;
+  const laterDiveOtu = 29.0;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  // Creates two dives on the SAME calendar day: the earlier at 09:19 and the
+  // later at 11:24. Built with DateTime.utc because the day-window math inside
+  // weeklyOtuProvider uses DateTime.utc and the repository round-trips
+  // timestamps as UTC -- so the fixture is timezone-independent.
+  Future<void> createTwoSameDayDives() async {
+    await repository.createDive(
+      Dive(
+        id: 'dive-earlier',
+        diveNumber: 43,
+        dateTime: DateTime.utc(2025, 9, 8, 9, 19),
+      ),
+    );
+    await repository.createDive(
+      Dive(
+        id: 'dive-later',
+        diveNumber: 44,
+        dateTime: DateTime.utc(2025, 9, 8, 11, 24),
+      ),
+    );
+  }
+
+  ProviderContainer buildContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        profileAnalysisProvider('dive-earlier').overrideWith(
+          (ref) async => ProfileAnalysis.empty().copyWith(
+            o2Exposure: const O2Exposure(otu: earlierDiveOtu),
+          ),
+        ),
+        profileAnalysisProvider('dive-later').overrideWith(
+          (ref) async => ProfileAnalysis.empty().copyWith(
+            o2Exposure: const O2Exposure(otu: laterDiveOtu),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('weeklyOtuProvider rolling 7-day window', () {
+    test('earliest dive excludes OTU from a later same-day dive', () async {
+      await createTwoSameDayDives();
+      final container = buildContainer();
+
+      final weekly = await container.read(
+        weeklyOtuProvider('dive-earlier').future,
+      );
+
+      // The earliest dive in the log has no prior exposure, so its weekly
+      // total is just its own OTU -- it must NOT be inflated by the dive that
+      // was logged later the same day (issue #407).
+      expect(weekly, equals(earlierDiveOtu));
+    });
+
+    test(
+      'later dive includes the earlier same-day dive as prior exposure',
+      () async {
+        await createTwoSameDayDives();
+        final container = buildContainer();
+
+        final weekly = await container.read(
+          weeklyOtuProvider('dive-later').future,
+        );
+
+        // Regression guard: a later dive SHOULD count an earlier dive's OTU
+        // toward its rolling total (16 + 29).
+        expect(weekly, equals(earlierDiveOtu + laterDiveOtu));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Problem

On the O2 toxicity card, the **earliest dive in the log** showed a non-zero weekly OTU **Prior** (e.g. `Prior: 29 OTU`) — exposure it could not possibly have, since nothing precedes it. The phantom value was being borrowed from a dive logged **later the same day**.

In the reporter's screenshots (same day, two dives):

| Dive | Daily | Weekly (before) |
|------|-------|-----------------|
| #43 — 9:19 AM (earliest in log) | Start **0** → +16 ✓ | Prior **29** → +16 = 45 ✗ |
| #44 — 11:24 AM (later) | Start 16 → +29 ✓ | Prior 16 → +29 = 45 ✓ |

Closes #407.

## Root cause

`weeklyOtuProvider` built a query window spanning the current dive's **entire calendar day** (`endOfDay` = midnight of the next day) and then summed the OTU of **every** dive returned, with no filter for dive time:

```dart
final weekDives = await repository.getDivesInRange(sevenDaysAgo, endOfDay);
for (final dive in weekDives) {
  totalOtu += analysis.o2Exposure.otu;   // summed ALL dives, even later ones
}
```

The card derives **"Prior" = weeklyTotal − thisDive**. For dive #43 the window also swept in dive #44, so `weeklyTotal = 16 + 29 = 45` and `Prior = 45 − 16 = 29`.

The **daily** sibling (`_computeResidualOtu`) already had the right discipline (`if (diveTime.isBefore(diveDate))`) — which is why Daily was correct while Weekly was wrong. This fix ports that same time-ordering guard to the weekly calc.

## Fix

A single guard inside the summing loop — count the current dive and any dive at/before it, skip dives logged later:

```dart
final diveTime = dive.entryTime ?? dive.dateTime;
if (dive.id != diveId && diveTime.isAfter(diveDate)) continue;
```

The query upper bound stays at end-of-day on purpose: `getDivesInRange` filters on the `diveDateTime` column while ordering uses `entryTime ?? dateTime`, so the coarse-day query + precise per-dive time filter is the same mismatch-safe pattern `_computeResidualOtu` uses.

### Result

| Dive | Weekly (after) |
|------|----------------|
| #43 (earliest) | `16/850`, **Prior 0** ✓ |
| #44 (later) | `45/850`, Prior 16 ✓ (unchanged) |

## Test plan

- **New** `test/features/dive_log/presentation/providers/weekly_otu_provider_test.dart` — written test-first, confirmed RED (`Expected: <16.0>, Actual: <45.0>`, matching the screenshot's 45) then GREEN. Runs the real repository + `getDivesInRange` against an in-memory DB while stubbing each dive's OTU via a `profileAnalysisProvider` override, so it pins the windowing logic specifically. Includes a regression-guard test proving a *later* dive still counts an earlier one.
- No regressions across the consumers: OTU / CNS / o2-toxicity panel (37), `dive_detail_page` (9), `getDivesInRange` repository (2).
- `flutter analyze`: no issues (whole project).
- `dart format`: clean (whole tree, 0 changed).