### PR TITLE
docs: app performance investigation — findings + Phase 2 plan

### DIFF
--- a/docs/superpowers/plans/2026-06-24-app-performance-phase1-measurement.md
+++ b/docs/superpowers/plans/2026-06-24-app-performance-phase1-measurement.md
@@ -1,0 +1,350 @@
+# App Performance — Phase 1 (Measurement) Implementation Plan
+
+> **For agentic workers:** This plan is **executed interactively in the main session** (profile-mode app + DevTools + visual reading of flame charts and the Frames timeline). It is **not** suitable for subagent dispatch — a subagent cannot drive the DevTools GUI or read a flame chart. Use superpowers:executing-plans (inline, with checkpoints). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure the three performance symptoms (cold-start load, first dive-details lag, background-sync stutter) on macOS in profile mode, and produce a committed findings report that confirms/refutes each Section B avenue with real numbers and ranks them for Phase 2.
+
+**Architecture:** Ad-hoc DevTools profiling — no instrumentation is added to the repo. Each scenario is run in `flutter run --profile`, captured via DevTools (Performance/CPU) or `--trace-startup`, and the numbers are recorded into a single findings document. The document's final section converts the measurements into a data-driven Phase 2 priority order.
+
+**Tech Stack:** Flutter profile-mode builds, Dart DevTools (Performance view, CPU profiler), `flutter run --trace-startup`, macOS.
+
+## Global Constraints
+
+- **Profile mode only, never debug** — debug builds are 5-10x slower and would mis-rank culprits. Every measurement uses `--profile`.
+- **Target platform: macOS** (the developer's everyday machine).
+- **Densest dive for the worst-case render:** `0822a39f-26fd-4119-bdaa-673ea4562da3` (3,644 samples).
+- **Known artificial startup floor:** ~1.9 s = 1 s hard minimum (`lib/core/presentation/pages/startup_page.dart:191`) + 900 ms fade (`:110`).
+- **Findings report path:** `docs/superpowers/specs/2026-06-24-app-performance-findings.md`.
+- **Do not commit incidental regenerated `.mocks.dart` files** (codegen side effects); stage only the findings report.
+- **No `Co-Authored-By` trailer** in commits (developer preference).
+- This phase changes **no application code** — only adds the findings document.
+
+## Execution mode
+
+Run the app from the worktree root:
+`/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/app-performance-investigation`
+
+Each scenario is a capture-and-record loop. The "test" for a measurement task is: *the report section now contains the recorded numbers and a verdict.* Commit after each scenario so partial progress is never lost.
+
+---
+
+### Task 1: Profiling environment + report scaffold
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-06-24-app-performance-findings.md`
+
+**Interfaces:**
+- Produces: the findings document with an environment section and three empty scenario sections that Tasks 2-4 fill in, and a ranking section Task 5 completes.
+
+- [ ] **Step 1: Confirm a profile build runs and record the build/device facts**
+
+Run:
+```bash
+cd "/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/app-performance-investigation"
+flutter --version
+system_profiler SPDisplaysDataType | grep -iE "resolution|refresh|display type"
+sw_vers
+```
+Record: Flutter version, macOS version, Mac model/chip, and **display refresh rate** (used to set the frame budget: 60 Hz → 16.7 ms/frame; 120 Hz ProMotion → 8.3 ms/frame).
+
+- [ ] **Step 2: Launch the app in profile mode and confirm DevTools attaches**
+
+Run:
+```bash
+flutter run --profile -d macos
+```
+In the run console, note the DevTools URL it prints (`The Flutter DevTools debugger and profiler ... available at: http://127.0.0.1:PORT?uri=...`). Open it. Confirm the **Performance** and **CPU profiler** tabs load. Leave this build running for Tasks 2-4 where possible (or relaunch per scenario as noted). Quit with `q` in the console when done.
+
+- [ ] **Step 3: Create the findings report scaffold**
+
+Create `docs/superpowers/specs/2026-06-24-app-performance-findings.md` with this content:
+
+```markdown
+# App Performance — Phase 1 Findings
+
+**Date:** 2026-06-24
+**Spec:** docs/superpowers/specs/2026-06-24-app-performance-investigation-design.md
+**Mode:** profile, macOS
+
+## Environment
+- Flutter: <fill>
+- macOS: <fill>
+- Mac model/chip: <fill>
+- Display refresh: <fill> Hz  → frame budget <fill> ms
+
+## Scenario 1 — Cold start / load time
+(filled by Task 2)
+
+## Scenario 2 — First dive-details lag
+(filled by Task 3)
+
+## Scenario 3 — Background-sync stutter
+(filled by Task 4)
+
+## Avenue verdicts & Phase 2 ranking
+(filled by Task 5)
+```
+Fill the Environment values from Steps 1-2.
+
+- [ ] **Step 4: Verify the scaffold exists and commit**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-06-24-app-performance-findings.md
+git status -s -- docs/superpowers/specs/2026-06-24-app-performance-findings.md   # expect: A  ...findings.md
+git commit -F - <<'MSG'
+docs: app performance findings scaffold + measurement environment
+
+Phase 1 measurement runbook output. Records the profiling environment
+(Flutter/macOS/chip/display refresh + frame budget) and scaffolds the
+three scenario sections.
+MSG
+```
+Expected: one file changed; no `.mocks.dart` in the commit.
+
+---
+
+### Task 2: Scenario 1 — cold-start / load time
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-24-app-performance-findings.md` (Scenario 1 section)
+
+**Interfaces:**
+- Consumes: the report scaffold from Task 1.
+- Produces: cold-start numbers + a "floor vs real init" verdict for avenues L1-L4.
+
+- [ ] **Step 1: Capture engine startup timing**
+
+Run:
+```bash
+flutter run --profile --trace-startup -d macos
+```
+Let the app reach the dashboard, then quit (`q`). Read the summary:
+```bash
+cat build/start_up_info.json
+```
+Record these fields (microseconds): `engineEnterTimestampMicros`, `timeToFrameworkInitMicros`, `timeToFirstFrameRasterizedMicros`, `timeToFirstFrameMicros`, `timeAfterFrameworkInitMicros`.
+
+- [ ] **Step 2: Capture perceived time-to-interactive (the number users feel)**
+
+`timeToFirstFrameMicros` is the *splash* frame, not the usable dashboard. Measure splash-appear → dashboard-usable separately:
+- Start a screen recording (`Cmd-Shift-5`), cold-launch the profile build, stop when the dashboard's dives/stats are populated (not skeleton).
+- Step through the recording to get the wall-clock seconds. Do this **3 times** and record min/median/max.
+
+- [ ] **Step 3: CPU-profile the init work**
+
+Relaunch `flutter run --profile -d macos`, open DevTools → CPU profiler, record across a cold start (or use the saved `--trace-startup` timeline in the Performance tab). Identify the time spent in: `NativeDatabase` open, the migration/`PRAGMA user_version` probes, and `SpeciesRepository.seedBuiltInSpecies` / the species JSON parse. Record the top 5 init hot spots with their self-times.
+
+- [ ] **Step 4: Record results + verdict in the report**
+
+Append under `## Scenario 1`:
+```markdown
+### Numbers
+| Metric | Value |
+| --- | --- |
+| timeToFirstFrameMicros | <fill> |
+| timeToFirstFrameRasterizedMicros | <fill> |
+| timeToFrameworkInitMicros | <fill> |
+| Perceived time-to-interactive (min/median/max, 3 runs) | <fill> |
+| Top init hot spots (self-time) | <fill list> |
+
+### Verdict
+- Real init work vs the ~1.9 s artificial floor: <shorter | longer> by <fill>.
+- L1 (splash floor): <confirmed dominant | not dominant> — evidence: <fill>.
+- L2 (species re-seed): species-seed self-time = <fill> ms → <worth fixing | negligible>.
+- L3 (redundant opens) / L4 (serial pre-runApp awaits): <fill from hot spots>.
+```
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-06-24-app-performance-findings.md
+git commit -m "docs: cold-start measurement findings (scenario 1)"
+```
+
+---
+
+### Task 3: Scenario 2 — first dive-details lag
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-24-app-performance-findings.md` (Scenario 2 section)
+
+**Interfaces:**
+- Consumes: the report from Task 2.
+- Produces: cold/warm open numbers, a build-vs-raster verdict, and a hot-spot list for avenues D1-D4.
+
+- [ ] **Step 1: Cold open of the densest dive**
+
+With `flutter run --profile -d macos` running and DevTools → Performance open:
+- Press **Record**.
+- From a freshly launched app (first navigation this session), tap the dive with the **longest profile** — the 3,644-sample dive (`0822a39f-26fd-4119-bdaa-673ea4562da3`; it is the longest/deepest in the list).
+- Stop recording once the details page + chart are fully painted.
+
+Read the **Frames** chart for the frame(s) spanning the navigation: record total frame time, **UI/build ms**, **raster ms**, and how many frames exceeded the budget from Task 1.
+
+- [ ] **Step 2: Warm re-open of the same dive**
+
+Navigate back to the list, **Record** again, re-open the same dive, stop. Record the same UI-build / raster / over-budget-frame numbers. The **cold − warm** delta isolates cold-cache/query cost; the warm cost isolates per-build chart + compute.
+
+- [ ] **Step 3: CPU profiler on the open**
+
+Switch to the CPU profiler, record one more open of the dive, and read **Bottom Up**. Record the top 8 functions by self-time. Note specifically the cost of: the provider fan-out queries (look for `DiveRepository` / `tankPressures` / `profileAnalysis` / `cylinderSac` / `weeklyOtu` / tide), `FlSpot` construction, and the chart's `reduce`/`sort`/`min`/`max` passes.
+
+- [ ] **Step 4: Contrast with a typical dive**
+
+Repeat Step 1 (cold open) with a typical ~1,100-sample dive. Record its UI-build/raster numbers to confirm the cost scales with sample density.
+
+- [ ] **Step 5: Record results + verdict in the report**
+
+Append under `## Scenario 2`:
+```markdown
+### Numbers
+| Dive | Open | UI/build ms | Raster ms | Over-budget frames |
+| --- | --- | --- | --- | --- |
+| densest (3,644) | cold | <fill> | <fill> | <fill> |
+| densest (3,644) | warm | <fill> | <fill> | <fill> |
+| typical (~1,100) | cold | <fill> | <fill> | <fill> |
+
+Top CPU self-time (densest open): <fill list of 8>
+
+### Verdict
+- Build-bound or raster-bound? <build | raster | mixed> — evidence: <fill>.
+- First-open-only or every-time? cold−warm delta = <fill> → <fill interpretation>.
+- D1 (chart memoize/decimate): <confirmed primary | secondary> — <build vs raster implication for the fix>.
+- D2 (lazy below-the-fold queries): provider-query share of build = <fill>.
+- D4 (media decode): <observed | not a factor>.
+```
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-06-24-app-performance-findings.md
+git commit -m "docs: dive-details lag measurement findings (scenario 2)"
+```
+
+---
+
+### Task 4: Scenario 3 — background-sync stutter
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-24-app-performance-findings.md` (Scenario 3 section)
+
+**Interfaces:**
+- Consumes: the report from Task 3.
+- Produces: frame-drop numbers during a sync/import apply and rebuild-storm evidence for avenues S1-S3.
+
+- [ ] **Step 1: Stage an inbound change to apply**
+
+Pick the available repro:
+- **Faithful (preferred if sync is configured):** on a second device/instance signed into the same backend, edit several dives, then return to the Mac.
+- **Local proxy (no second device):** prepare a UDDF or dive-computer file containing a handful of dives to import (additive, non-destructive). This exercises the same `tableUpdates` rebuild-storm + row-by-row write path that inbound sync apply triggers.
+
+- [ ] **Step 2: Record the apply**
+
+With `flutter run --profile -d macos` running and DevTools → Performance recording:
+- Faithful: trigger **Sync Now** (Settings → Cloud Sync) and let the inbound changeset apply.
+- Proxy: run the import.
+Keep the dive list (or dashboard) visible during apply so the rebuild storm hits visible widgets. Stop recording when the apply completes.
+
+- [ ] **Step 3: Read the Frames timeline for the storm**
+
+Record: number of janky (over-budget) frames during apply, the worst frame's UI-build ms, and — from the timeline events — how many times `getAllDives` / `getStatistics` re-run during the single apply (the rebuild storm signature). Note whether `divesProvider` and the list notifier both reload per tick.
+
+- [ ] **Step 4: CPU profiler on the apply (if faithful sync)**
+
+If using the faithful path, record a CPU profile during apply and note the main-isolate self-time in JSON decode (`decodeChangeset`), checksum (`sha256`), and merge (`_mergeEntity`) plus the row-by-row `upsert`. (The import proxy will show the write + rebuild cost but not the decode/merge stages.)
+
+- [ ] **Step 5: Record results + verdict in the report**
+
+Append under `## Scenario 3`:
+```markdown
+### Numbers
+| Metric | Value |
+| --- | --- |
+| Repro used | <faithful sync | import proxy> |
+| Janky frames during apply | <fill> |
+| Worst frame UI/build ms | <fill> |
+| getAllDives / getStatistics re-runs per apply | <fill> |
+| Main-isolate decode/checksum/merge self-time (faithful only) | <fill> |
+
+### Verdict
+- S1 (debounce rebuild storm): <confirmed primary cause | secondary> — re-run count = <fill>.
+- S2 (batch writes): row-by-row write share = <fill>.
+- S3 (offload sync CPU): decode/merge main-isolate time = <fill> → <worth offloading | minor>.
+```
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-06-24-app-performance-findings.md
+git commit -m "docs: sync-stutter measurement findings (scenario 3)"
+```
+
+---
+
+### Task 5: Synthesize findings and rank Phase 2
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-24-app-performance-findings.md` (ranking section)
+
+**Interfaces:**
+- Consumes: the three completed scenario sections.
+- Produces: a confirmed/refuted verdict per Section B avenue and an ordered Phase 2 backlog with the measured number that justifies each.
+
+- [ ] **Step 1: Mark each avenue confirmed / refuted / unknown**
+
+Append under `## Avenue verdicts & Phase 2 ranking`:
+```markdown
+### Avenue verdicts (from measured numbers)
+| Avenue | Status | Justifying number |
+| --- | --- | --- |
+| L1 splash floor | <confirmed/refuted> | <fill> |
+| L2 species re-seed | <confirmed/refuted> | <fill> |
+| L3 redundant opens | <confirmed/refuted> | <fill> |
+| L4 pre-runApp awaits | <confirmed/refuted> | <fill> |
+| D1 chart memoize/decimate | <confirmed/refuted> | <fill> |
+| D2 lazy sections | <confirmed/refuted> | <fill> |
+| D4 media decode | <confirmed/refuted> | <fill> |
+| S1 debounce storm | <confirmed/refuted> | <fill> |
+| S2 batch writes | <confirmed/refuted> | <fill> |
+| S3 offload sync CPU | <confirmed/refuted> | <fill> |
+| S4 DB off UI isolate | <still gated — pursue only if above fall short> | <fill> |
+```
+
+- [ ] **Step 2: Produce the ordered Phase 2 backlog**
+
+Append:
+```markdown
+### Phase 2 priority order
+1. <avenue> — expected win <fill>, risk <fill>
+2. ...
+(Each entry becomes its own writing-plans round with before/after re-measurement.)
+```
+Order by measured impact × inverse risk. Demote any avenue the data refuted.
+
+- [ ] **Step 3: Final commit**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-06-24-app-performance-findings.md
+git commit -m "docs: phase 1 findings synthesis + phase 2 ranking"
+```
+
+- [ ] **Step 4: Report completion**
+
+State the confirmed top avenues and their numbers, and recommend the first Phase 2 plan to write.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Section A's three scenarios → Tasks 2/3/4. The findings-report deliverable → Tasks 1-5. Section B's avenues → verdict rows in Tasks 2-5. Section C's "proof-by-measurement" gate → the verdict/ranking in Task 5 that every Phase 2 plan must cite. The architectural lever S4 is explicitly kept gated (Task 5, Step 1). No spec section is unaddressed for Phase 1.
+
+**Placeholder scan:** `<fill>` markers are measurement capture fields — the *deliverable* of a measurement task, not undefined behavior. Every step gives an exact command or exact DevTools action; no vague "profile it" instructions remain.
+
+**Type/name consistency:** File path `docs/superpowers/specs/2026-06-24-app-performance-findings.md` is identical across all five tasks. Section headers (`## Scenario 1/2/3`, `## Avenue verdicts & Phase 2 ranking`) created in Task 1 match those appended to in Tasks 2-5. The densest-dive id matches the spec.
+
+**Scope:** Phase 1 only, by design (the spec's measure-before-fix gate). Phase 2 fixes are deliberately out of scope and become separate writing-plans rounds grounded in this report.

--- a/docs/superpowers/specs/2026-06-24-app-performance-findings.md
+++ b/docs/superpowers/specs/2026-06-24-app-performance-findings.md
@@ -14,7 +14,20 @@
 - Library shape (from the design spec): 37 dives, 40,933 profile samples (avg 1,106, max 3,644), 40,912 tank-pressure samples, 22 MB DB
 
 ## Scenario 1 — Cold start / load time
-(filled by Task 2)
+
+### Numbers
+| Metric | Value |
+| --- | --- |
+| Time to first frame (engine -> splash) | **74 ms** (`flutter run --trace-startup`) |
+| Perceived splash -> dashboard usable (cold, observed) | **~2 s** |
+| Artificial floor (deterministic, from code) | **1.9 s** = 1 s minimum (`startup_page.dart:191`) + 0.9 s fade (`:110`) |
+
+### Verdict
+- Engine/framework init is **negligible** — 74 ms to first frame on an M5 Pro. NOT a contributor.
+- Perceived load (~2 s) ≈ the artificial floor. Service init (DB opens, species seed) runs under the 1 s minimum (`Future.wait([_initializeServices(), Future.delayed(1s)])`), so at this library size it is **masked by the floor, not additive**.
+- **L1 (shrink splash floor): CONFIRMED dominant.** ~1.5-1.8 s of perceived load is recoverable by reducing the 1 s minimum + 0.9 s fade to a minimal anti-flicker.
+- **L2 (species re-seed) / L3 (redundant opens): not separately visible** — hidden under the 1 s minimum. They matter only once L1 lowers the floor below service-init time; quantify service-init (a cold-start CPU profile) when implementing L1.
+- L4 (pre-runApp awaits): subsumed in the 74 ms first frame; negligible.
 
 ## Scenario 2 — First dive-details lag
 (filled by Task 3)

--- a/docs/superpowers/specs/2026-06-24-app-performance-findings.md
+++ b/docs/superpowers/specs/2026-06-24-app-performance-findings.md
@@ -30,10 +30,112 @@
 - L4 (pre-runApp awaits): subsumed in the 74 ms first frame; negligible.
 
 ## Scenario 2 — First dive-details lag
-(filled by Task 3)
+
+Opened Dive #41 ("Alice in Wonderland", 3,644 samples) in profile mode; exact
+Flutter.Frame build/raster timings + UI-isolate CPU samples pulled via the VM
+Service (`scratchpad/vmcap.dart`).
+
+### Numbers (Flutter frames)
+| Open | Worst build | Raster (same frame) |
+| --- | --- | --- |
+| Cold | **35.6 ms** | 2.8 ms |
+| Cold (next worst) | 27.5 / 27.1 / 26.8 / 24.0 / 23.6 ms | 2.4 / 2.2 / 18.4 / 17.7 / 0.8 ms |
+| Warm (earlier run) | ~18.6 ms | ~17.5 ms |
+
+### Verdict
+- **Build-bound.** Worst cold frames are ~35 / 27 / 27 ms of **build** with only
+  ~2-3 ms raster — the GPU is idle; the cost is Dart on the UI isolate. (Some
+  fully-drawn frames also push raster to ~18-20 ms with all curves on screen.)
+- **D1 (memoize + decimate): CONFIRMED, and it is a COMPUTE problem.** Reduce
+  Dart work — cache computed `FlSpot`/axis data; feature-preserving decimation of
+  the 3,644-sample series — which cuts build *and* the secondary raster cost. A
+  `RepaintBoundary`/raster-only fix would not touch the 35 ms build.
+- Named dive-specific hot function: `combineMultiTankPressures` (SAC/tank-pressure
+  merge over the dense profile).
+- Frame timings isolate the chart cleanly even with sync running concurrently:
+  sync work cannot inflate a frame's *build* duration; it only drops extra frames.
 
 ## Scenario 3 — Background-sync stutter
-(filled by Task 4)
+
+Caught **live and unplanned**: during the cold dive-open, the on-launch auto-sync
+was applying a base file on the main isolate. Clean UI-isolate CPU window
+(n=24,278 @ 250us, clear -> act -> read):
+
+### Numbers (top UI-isolate self-time)
+| ms | % | function | attribution |
+| --- | --- | --- | --- |
+| 415 | 6.8 | `pread` | base-file I/O (sync) |
+| 251 | 4.1 | `_Sha32BitSink.updateHash` | SHA-256 checksum (sync) |
+| 244 | 4.0 | `sqlite3VdbeExec` | row writes (sync) + dive queries |
+| 225 | 3.7 | `_GrowableList._grow` | list building |
+| 220 | 3.6 | `BaseJsonStreamReader._captureByte` | JSON byte-parse (sync) |
+| 192 | 3.2 | `read` | file I/O (sync) |
+| 102 | 1.7 | `BaseJsonStreamReader.parse` | JSON parse (sync) |
+| 59 | 1.0 | `BaseJsonStreamReader._consume` | JSON parse (sync) |
+| 56 | 0.9 | `combineMultiTankPressures` | dive SAC (chart) |
+
+### Verdict
+- **The sync apply runs entirely on the main (UI) isolate**: SHA-256
+  (`_Sha32BitSink`), streaming JSON parse (`BaseJsonStreamReader.*`), SQLite
+  writes (`sqlite3VdbeExec` + LinkedHashMap row hydration), base-file I/O
+  (`pread`/`read`). This is the #358 streaming base-apply path — memory-safe, but
+  still 100% main-isolate CPU.
+- **Sync fires on launch AND on resume / window focus** (`_maybeSyncOnResume`).
+  Every refocus can run this apply, so the stutter is an everyday occurrence — and
+  it is why a sync-free interactive capture was impossible (focusing the app to
+  interact re-triggers sync).
+- **S3 (offload sync CPU to an isolate): CONFIRMED high value.** SHA-256 + JSON
+  parse are pure CPU and directly offloadable; that alone removes most of the
+  observed main-isolate burden.
+- **S2 (batch writes): CONFIRMED** — `sqlite3VdbeExec` + per-row map building =
+  row-by-row apply.
+- **S1 (debounce rebuild storm): NOT directly measured** (needs a multi-changeset
+  sync with the dive list visible). Remains a sound but lower-confidence
+  hypothesis than S2/S3.
+- Strongest evidence yet for **S4** (move DB/sync off the UI isolate) as the
+  root-cause lever: sync I/O and the chart build are serialized on one isolate.
 
 ## Avenue verdicts & Phase 2 ranking
-(filled by Task 5)
+
+### Verdicts (from measured numbers)
+| Avenue | Status | Justifying number |
+| --- | --- | --- |
+| L1 splash floor | **CONFIRMED dominant** | 74 ms first frame vs ~1.9 s floor; ~2 s perceived |
+| L2 species re-seed | not separately visible | hidden under the 1 s minimum |
+| L3 redundant opens | not separately visible | hidden under the 1 s minimum |
+| L4 pre-runApp awaits | refuted (negligible) | subsumed in 74 ms first frame |
+| D1 chart memoize/decimate | **CONFIRMED (build-bound)** | 35 ms build / 2.8 ms raster cold |
+| D2 lazy below-fold | likely | `combineMultiTankPressures` 56 ms on open |
+| D4 media decode | refuted (not observed) | absent from samples |
+| S1 debounce storm | hypothesis (unmeasured) | not captured this run |
+| S2 batch writes | **CONFIRMED** | `sqlite3VdbeExec` + per-row maps |
+| S3 offload sync CPU | **CONFIRMED high value** | SHA-256 251 ms + JSON parse ~380 ms, main isolate |
+| S4 DB off UI isolate | strongly supported | sync I/O + chart build on one isolate |
+| (new) sync-on-resume | observed | sync fires on every window focus |
+
+### Phase 2 priority order (impact x inverse risk)
+1. **L1 — shrink the splash floor.** ~1.5-1.8 s perceived-load win, tiny low-risk
+   change. Do first.
+2. **D1 — memoize + feature-preserving decimation of the profile chart.** Kills the
+   35 ms cold build (and trims raster). Med risk (preserve max-depth/ceiling/
+   gas-switch/safety-stop features). Highest-value details fix.
+3. **S3 — offload the sync apply's pure CPU (SHA-256, JSON parse) to an isolate.**
+   Directly removes the observed main-isolate stutter on launch/resume. Med-high risk.
+4. **S2 — batch the sync row writes** (`batch()` vs row-by-row). Med risk.
+5. **S1 — debounce/coalesce the reactive rebuilds.** Sound but unmeasured; low-med
+   risk; pairs with S2/S3.
+6. **D2 — lazy-load below-the-fold sections** (defer SAC/`combineMultiTankPressures`
+   until expanded). Med.
+
+- **S4 (DB/sync off the UI isolate)** — gated root-cause lever; evidence is strong;
+  pursue with its own spec only if 1-5 leave a symptom unsolved.
+- Consider **gating/deferring sync-on-resume** so a window focus doesn't trigger a
+  main-isolate apply (largely subsumed if S3/S4 land).
+
+### Method note
+All numbers captured with `scratchpad/vmcap.dart` (VM Service over WebSocket: exact
+`Flutter.Frame` build/raster + `getCpuSamples`). Browser-based DevTools could not be
+driven (sandboxed browser cannot reach the host VM-service port); the shell could,
+so profiling was scripted. CPU capture requires `setFlag('profiler','true')` +
+`clearCpuSamples` immediately before the window, else the profiler's own JSON
+serialization dominates the samples.

--- a/docs/superpowers/specs/2026-06-24-app-performance-findings.md
+++ b/docs/superpowers/specs/2026-06-24-app-performance-findings.md
@@ -1,0 +1,26 @@
+# App Performance — Phase 1 Findings
+
+**Date:** 2026-06-24
+**Spec:** docs/superpowers/specs/2026-06-24-app-performance-investigation-design.md
+**Plan:** docs/superpowers/plans/2026-06-24-app-performance-phase1-measurement.md
+**Mode:** profile, macOS
+
+## Environment
+- Flutter: 3.41.4 stable (framework ff37bef603, engine e4b8dca3f1)
+- macOS: 26.5.1 (build 25F80)
+- Mac: MacBook Pro (Mac17,8), **Apple M5 Pro**
+- Display: Built-in Liquid Retina XDR, 3456x2234 Retina, ProMotion (up to 120 Hz)
+- Frame budget: 8.3 ms @ 120 Hz / 16.7 ms @ 60 Hz — **confirm the actual budget line from the DevTools Frames chart** (Flutter macOS desktop may render at 60 Hz even on a ProMotion panel)
+- Library shape (from the design spec): 37 dives, 40,933 profile samples (avg 1,106, max 3,644), 40,912 tank-pressure samples, 22 MB DB
+
+## Scenario 1 — Cold start / load time
+(filled by Task 2)
+
+## Scenario 2 — First dive-details lag
+(filled by Task 3)
+
+## Scenario 3 — Background-sync stutter
+(filled by Task 4)
+
+## Avenue verdicts & Phase 2 ranking
+(filled by Task 5)

--- a/docs/superpowers/specs/2026-06-24-app-performance-investigation-design.md
+++ b/docs/superpowers/specs/2026-06-24-app-performance-investigation-design.md
@@ -1,0 +1,211 @@
+# App Performance Investigation — Design
+
+**Date:** 2026-06-24
+**Status:** Design approved; measurement phase not yet started
+**Branch/worktree:** `worktree-app-performance-investigation`
+
+## Goal
+
+Investigate and improve three observed performance symptoms, measuring first so
+every fix is justified by data rather than guessed from code:
+
+1. **App load time** — cold-start time before the app is usable.
+2. **First dive-details lag** — a small delay rendering the dive-details page.
+3. **Background-sync stutter** — slight UI jank while a sync runs.
+
+Target platform for this effort: **macOS** (the developer's everyday machine,
+where the symptoms are observed and which is the easiest to profile).
+
+## Non-goals
+
+- We do **not** commit up front to the largest architectural change (moving the
+  database off the UI isolate). It is catalogued as a decision-gated avenue
+  (S4) and only pursued if targeted fixes leave a symptom unsolved, with its
+  own follow-up spec.
+- We do **not** optimize for large libraries beyond noting scale-gated avenues
+  (e.g. L7). The measured library is small (37 dives); fixes are prioritized for
+  that real shape, with large-library items flagged for the future.
+
+## The shared root cause (why one lever helps all three)
+
+The app deliberately uses Drift's **synchronous `NativeDatabase`** rather than
+`createInBackground` (`lib/core/services/database_service.dart:98-106`, with a
+comment stating this avoids "isolate communication issues during migration").
+Consequently **every** database open, migration, query, and sync write runs on
+the UI isolate. Combined with **un-debounced reactive rebuilds**
+(`watchDivesChanges` / the 22-table `watchDiveDetailChanges` have no
+`.distinct()`/debounce), this single architectural fact is the multiplier behind
+all three symptoms. It is good news for sequencing: a small number of targeted
+fixes (and, if ever needed, the one gated architectural lever) improve startup,
+details render, and sync smoothness together.
+
+## Measured data shape (ground truth, 2026-06-24)
+
+Read read-only from the live DB at
+`~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db`:
+
+| Metric | Value |
+| --- | --- |
+| Divers | 1 |
+| Dives | 37 |
+| Profile samples | 40,933 (avg 1,106/dive, **max 3,644**) |
+| Tank-pressure samples | 40,912 (≈1:1 with profile samples) |
+| Media (photos) | 434 |
+| Species (seeded) | 550 |
+| Dive sites | 19 |
+| Equipment | 31 |
+| Sightings | 17 |
+| Dive computers | 3 |
+| Pending sync records | 0 |
+| Deletion-log rows | 62 |
+| DB file size | 22 MB |
+| Schema version | 91 (current) |
+
+Timestamps confirm **1-2 second sample intervals** — dense, dive-computer
+profiles. The densest dive (`0822a39f-26fd-4119-bdaa-673ea4562da3`, 3,644
+samples) is the worst-case render target.
+
+**Key implication:** the symptoms are driven by **profile sample density and
+write volume**, not dive count. A static read of the code flagged the
+full-library `getAllDives` load as a top startup bottleneck; the data refutes
+that for this library (37 dives loads trivially). This is the measure-first
+principle paying off before any fix is written.
+
+---
+
+## Section A — Measurement protocol (ad-hoc DevTools, profile mode)
+
+No instrumentation is added to the repository. We profile `flutter run --profile
+-d macos` with DevTools attached, except startup which uses a trace file. The
+methodology's accepted trade-off: no durable re-measure harness, so each fix is
+verified by re-running the relevant repro by hand (before/after).
+
+Performance must be read in **profile mode**, never debug — debug builds are
+unoptimized and routinely 5-10x slower, which would overstate every symptom and
+mis-rank the culprits.
+
+### Scenario 1 — Cold start / load time
+
+- Capture with `flutter run --profile --trace-startup`, which writes
+  `build/start_up_info.json` (`timeToFirstFrameMicros`,
+  `timeToFirstFrameRasterizedMicros`, framework-init timings) and a saved engine
+  timeline openable in Perfetto/DevTools.
+- Decompose against the **known ~1.9 s artificial floor**
+  (`lib/core/presentation/pages/startup_page.dart:191` — a 1 s hard minimum via
+  `Future.delayed`, plus `:110` — a 900 ms fade controller).
+- Decision the numbers settle: if real init work is **shorter** than the floor,
+  the floor is the binding constraint (fix = shrink it); if **longer**, CPU-
+  profile the init to attribute time (species re-seed, double DB open, redundant
+  raw `sqlite3` opens).
+
+### Scenario 2 — First dive-details lag
+
+- Open the **densest dive** (`0822a39f-26fd-4119-bdaa-673ea4562da3`, 3,644
+  samples) for the worst case, then a typical ~1,100-sample dive for contrast.
+- Record the **CPU profiler** + the **Frames** chart. Open **cold** (first open
+  after launch), then close and reopen **warm**. The cold−warm delta isolates
+  cold-cache/query cost; the warm cost isolates the per-build chart + compute.
+- Read the flame chart for: the provider fan-out
+  (`lib/features/dive_log/presentation/pages/dive_detail_page.dart`, ~30
+  `ref.watch`/`ref.read` sites), `FlSpot` list construction, and the chart's
+  `reduce`/`sort`/`min`/`max` passes
+  (`lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`).
+- **Build-vs-raster split is the key read:** build-bound ⇒ our Dart (queries +
+  `FlSpot`/axis computation) ⇒ fixes are memoization/decimation/`compute()`;
+  raster-bound ⇒ GPU drawing too many points ⇒ fixes are `RepaintBoundary`/fewer
+  points/simpler line styles.
+
+### Scenario 3 — Background-sync stutter
+
+- Requires an inbound change to exist (currently 0 pending sync records). Two
+  repro paths:
+  - *Faithful:* a second instance/device pushes edits to the same backend, then
+    "Sync Now" on the Mac while recording.
+  - *Local proxy:* a restore or file import triggers the same mass-write +
+    reactive-rebuild path on one machine.
+- Record the **Frames** chart during apply and watch for the **rebuild storm**:
+  repeated `getAllDives` / `getStatistics` re-runs (and the `divesProvider` +
+  `DiveListNotifier` double reload) firing per changeset, plus row-by-row writes
+  of the ~80K profile/pressure rows.
+
+### Deliverable
+
+A short **findings report**: real numbers per scenario plus the attributed hot
+spots. This becomes the evidence that ranks the fix backlog in Section B.
+
+---
+
+## Section B — Avenues backlog (ranked by the real data)
+
+Each avenue: hypothesis → the measurement that confirms/refutes → candidate fix
+→ risk/effort. ⭐ = likely first wave (high value, lower risk, data already
+points here). 🔒 = decision-gated. Nothing is built until Section A confirms it.
+
+### Load / cold start
+
+| # | Avenue | Hypothesis | Candidate fix | Risk / Effort |
+| --- | --- | --- | --- | --- |
+| **L1** ⭐ | Shrink the artificial splash floor (`startup_page.dart:191`, `:110`) | The ~1.9 s floor exceeds real init at 37 dives, so it *is* the perceived load time | Reduce/remove the 1 s minimum (keep minimal anti-flicker); shorten or skip the fade when init already exceeded it | Low / Low |
+| **L2** | Seed species once, not every launch (`species_repository.dart:372`) | Parses the bundled species asset and runs an `INSERT OR IGNORE` per species on every cold start (the live DB currently holds 550 species; confirm the asset's row count during measurement) | Gate behind a "seeded@dataVersion" marker; only run when the bundled data version changes | Low / Low |
+| **L3** | Collapse redundant DB opens (`startup_page.dart:152`, `database_service.dart:178`, Drift open; second DB `local_cache_database_service.dart:44-58`) | Schema probe + compat assert + Drift each open the file; cache DB opened on the critical path | Consolidate the version probe/compat assert; open the cache DB lazily — **preserving the "DB newer than app" guard** | Med / Med |
+| **L4** | Parallelize/defer pre-`runApp` awaits (`main.dart:61-68`) | SharedPrefs + app-support dir + log-service init run serially before the first frame | `Future.wait` the independent ones; defer log-service init off the critical path | Low / Low |
+| **L6** | Migration ladder + pre-migration DB copy (`startup_page.dart:311`) | Only on version-bump launches; 22 MB copy is fast | Catalog; deprioritize | — / — |
+| **L7** | `getAllDives` full-library hydration (`dive_repository_impl.dart:99-218`) | Negligible at 37 dives | Flag for future large-library users only | — (scale-gated) |
+
+### First dive-details lag
+
+| # | Avenue | Hypothesis | Candidate fix | Risk / Effort |
+| --- | --- | --- | --- | --- |
+| **D1** ⭐ | Memoize + decimate the profile chart (`dive_profile_chart.dart`) | 3,644 samples × several curves rebuilt every interaction (tooltip/playback/range/legend); `reduce`/`sort` each build | Cache computed `FlSpot`/axis ranges per (dive, settings, visible curves); **feature-preserving** decimation for display; `RepaintBoundary`; `compute()` if build-bound | Med / Med |
+| **D2** | Lazy-load below-the-fold sections (~30-provider fan-out) | SAC/OTU/tide/segment queries hit the 40K-row tables on open | Defer each section's queries until its collapsible section expands; combine related queries; memoize | Low-Med / Med |
+| **D3** | Cold-vs-every-time attribution | Measurement branch, not a fix | If first-open-only ⇒ prewarm most-recent dive's providers post-launch; if every-time ⇒ it's D1/D2 | — |
+| **D4** | Thumbnail (not full-res) media (434 media rows) | Image decode on open | Ensure details page decodes thumbnail-sized images (cache caps already applied in `main.dart`) | Low / Low |
+
+### Background-sync stutter
+
+| # | Avenue | Hypothesis | Candidate fix | Risk / Effort |
+| --- | --- | --- | --- | --- |
+| **S1** ⭐ | Debounce/coalesce the rebuild storm (`dive_repository_impl.dart:50-94`; `dive_providers.dart:120,204,264-293`) | Per-changeset commits re-run `getAllDives` + `getStatistics` repeatedly; `divesProvider` + `DiveListNotifier` double reload | Add debounce/coalescing and/or `.distinct()`; de-dupe the double reload; consider fewer commits per apply — **must still deliver final state (no stale-after-sync regression)** | Low-Med / Low-Med |
+| **S2** | Batch the sync writes (`sync_data_serializer.dart`, merge `sync_service.dart:1342-1510`; FK repair `:704-759`) | Row-by-row `upsert` + per-row `fetchRecord` + up-to-5 FK-check passes for ~80K rows | Use `batch()` bulk upserts; reduce/condition FK-repair passes — **preserving merge/LWW correctness** | Med / Med |
+| **S3** | Offload sync CPU to an isolate (decode `changeset_codec.dart:17-18`; checksum `sync_data_serializer.dart:666-677`; merge) | JSON decode + SHA-256 + LWW run on the UI isolate | `compute()` the pure-CPU stages (DB-write stage is harder; ties to S4) | Med-High / High |
+| **S4** 🔒 | Root-cause lever: move the DB off the UI isolate (`createInBackground`) (`database_service.dart:98-106`) | Fixes load, details queries, *and* sync writes at once — but exactly what the team avoided for migration safety | Decision-gated; its own spec/spike; only if targeted fixes leave a symptom unsolved | High / High |
+
+---
+
+## Section C — Sequencing & success criteria
+
+### Phases
+
+1. **Measure.** Run the Section A protocol; produce the findings report.
+2. **First wave.** Implement the data-validated wins (likely **L1, D1, S1**),
+   each on its own branch/PR per project conventions, **re-running the relevant
+   repro before/after to prove the number moved**.
+3. **Follow-ons.** Implement further avenues as measurement justifies them.
+4. **Decision gate.** Only consider **S4** if targeted fixes leave a symptom
+   unsolved; it gets a dedicated spec/spike before any code.
+
+### Success criteria
+
+- **Proof-by-measurement:** every claimed improvement is backed by a before/after
+  DevTools number (the measure-first contract).
+- **Load:** real time-to-interactive is the binding constraint, not an artificial
+  floor.
+- **Details:** the 3,644-sample dive opens within frame budget (no dropped
+  frames); warm reopen stays smooth under interaction.
+- **Sync:** a representative inbound sync/import holds frame budget — no visible
+  stutter.
+- **No regressions:** test suite green; sync merge/LWW correctness unchanged;
+  dive-profile fidelity preserved (see constraint below).
+
+### Domain & safety constraints
+
+- **Feature-preserving decimation (D1).** A naive "every Nth point" downsampler
+  can erase exactly what divers need to see — max-depth spike, decompression
+  ceiling, gas-switch transition, safety-stop. Any decimation must be peak-aware
+  (e.g. LTTB or min/max-per-bucket) and must never drop event-flagged samples.
+  Pull in the tech-diving domain knowledge when implementing D1.
+- **Debounce must not drop state (S1).** Coalescing reactive rebuilds must still
+  deliver the final post-sync state; prior bugs in this codebase were
+  stale-after-sync, so the fix must converge on the latest data.
+- **Preserve migration safety (L3).** Consolidating DB opens must keep the
+  "database newer than app" guard that prevents opening an incompatible schema.


### PR DESCRIPTION
## Summary

Phase 1 (measure-first) of an app performance investigation across three observed symptoms: cold-start load, first dive-details lag, and background-sync stutter. **Documentation only — no application code changed.**

Adds:
- **Design spec** — `docs/superpowers/specs/2026-06-24-app-performance-investigation-design.md`
- **Measurement runbook** — `docs/superpowers/plans/2026-06-24-app-performance-phase1-measurement.md`
- **Findings** — `docs/superpowers/specs/2026-06-24-app-performance-findings.md`

## Measured findings (profile mode, Apple M5 Pro, real 37-dive / 40.9k-sample library)

| Symptom | Measured | Cause | Fix |
|---|---|---|---|
| Load (~2 s) | **74 ms** real first frame | ~1.9 s artificial splash floor (1 s min + 0.9 s fade) | **L1** — shrink the floor |
| Dive-details lag | **35 ms build / 2.8 ms raster** (cold) | chart = Dart compute over 3,644 samples (`combineMultiTankPressures` + `FlSpot`/axis work) | **D1** — memoize + decimate (compute, not raster) |
| Sync stutter | SHA-256 251 ms + JSON parse ~380 ms on the **UI isolate** | base-file apply on the main isolate, firing on launch **and** window focus | **S3** — offload CPU to isolate; **S2** — batch writes |

Two things reading the code alone would miss: the dive lag is **build-bound** (a compute fix, not `RepaintBoundary`), and the sync stutter is a **main-isolate base-apply that fires on every window focus** — routine, not occasional.

## Phase 2 priority order

L1 (floor) → D1 (chart) → S3 (offload sync CPU) → S2 (batch writes) → S1 (debounce rebuilds) → D2 (lazy sections). **S4** (DB off the UI isolate) stays gated — its own spec only if the targeted fixes fall short.

Each Phase 2 fix lands as its own PR with before/after re-measurement (the spec's proof-by-measurement gate).

## Method note

All numbers captured via a small VM Service WebSocket script (exact `Flutter.Frame` build/raster + `getCpuSamples`), since a sandboxed browser couldn't reach the host's DevTools port. No instrumentation was added to the app.