### PR TITLE
Import Garmin FIT tank cylinder volume (#403)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-garmin-fit-tank-volume.md
+++ b/docs/superpowers/plans/2026-06-24-garmin-fit-tank-volume.md
@@ -1,0 +1,402 @@
+# Garmin FIT Tank Cylinder Volume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Import each air-integration tank's configured cylinder volume (liters) from Garmin FIT dives, derived from `volume_used` and the start/end pressures, so users stop entering tank volume manually (#403).
+
+**Architecture:** Reuse the merged "make FIT speak UDDF" pipeline. Derive the volume in the pure `FitTankExtractor`, carry it on `FitTank` → `ImportedTank` → the UDDF-shaped `diveData['tanks'][i]['volume']`, where the existing `UddfEntityImporter` already maps it to `DiveTank.volume`. No new persistence code.
+
+**Tech Stack:** Dart/Flutter, `fit_tool` 1.0.5 (FIT parsing), `flutter_test`, Drift (persistence, unchanged here).
+
+## Global Constraints
+
+- Derivation: `cylinderVolumeLiters = round0.1( volumeUsedLiters / (startBar − endBar) )`.
+- Null-guards (return null → tank imports without volume, never a wrong number): `volumeUsed` null or ≤ 0; `startBar`/`endBar` null; drop `< FitConstants.minDeriveDropBar` (5.0); result ≤ 0 or `> FitConstants.maxPlausibleVolumeLiters` (60.0).
+- Store metric internally (liters). Round derived value to 0.1 L.
+- No emojis in code/comments.
+- Lint `always_use_package_imports`: import siblings via `package:submersion/...`, never relative paths.
+- `dart format .` (WHOLE project) must be clean before any commit; `flutter analyze` must be clean (whole project).
+- Commit messages: Conventional Commits, scope `dive-import`. Do NOT add `Co-Authored-By` lines.
+
+---
+
+### Task 1: Derive cylinder volume in `FitTankExtractor`
+
+**Files:**
+- Modify: `lib/features/dive_import/data/services/fit/fit_constants.dart`
+- Modify: `lib/features/dive_import/data/services/fit/fit_tank_extractor.dart`
+- Test: `test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`
+
+**Interfaces:**
+- Consumes: existing `FitConstants.tsStartPressure/tsEndPressure/tsVolumeUsed`, `FitConstants.pressureScaleBar/volumeScaleLiters`.
+- Produces: `FitTank.cylinderVolumeLiters` (`double?`) — the derived configured cylinder volume in liters, or null when not reliably derivable. Used by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`, inside `void main() { ... }`:
+
+```dart
+  test('derives cylinder volume from volume_used and pressure drop', () {
+    // Bouchot 72: 1993.5 L used over (221.25 - 88.11)=133.14 bar -> 14.97 -> 15.0 L.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 22125, endRaw: 8811, volRaw: 199350),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, closeTo(15.0, 1e-9));
+  });
+
+  test('cylinder volume is null when volume_used is zero (overheard tx)', () {
+    // Real pressures but zero gas used -> cannot derive; pressures still present.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 21200, endRaw: 7400, volRaw: 0),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, isNull);
+    expect(data.tanks.single.startPressureBar, closeTo(212.0, 1e-6));
+  });
+
+  test('cylinder volume is null when the pressure drop is below the floor', () {
+    // 200.00 - 197.00 = 3 bar drop (< 5 bar floor) -> unreliable -> null.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 20000, endRaw: 19700, volRaw: 4500),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, isNull);
+  });
+
+  test('cylinder volume is null when the result is implausibly large', () {
+    // 500 L used over a 6 bar drop -> 83.3 L (> 60 L clamp) -> null.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 20000, endRaw: 19400, volRaw: 50000),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, isNull);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`
+Expected: FAIL — compile error, `cylinderVolumeLiters` is not defined on `FitTank`.
+
+- [ ] **Step 3: Add the derivation constants**
+
+In `lib/features/dive_import/data/services/fit/fit_constants.dart`, add after the `semicircleToDegrees` line (before the `fitEpochToUnixSeconds` doc block):
+
+```dart
+  /// Cylinder-volume derivation (`size = volume_used / pressure_drop`). Garmin
+  /// does not transmit cylinder size; it stores volume_used computed from the
+  /// user's configured size, so the size is recovered by reversing that.
+  /// Below this pressure drop the quotient is noise; reject it.
+  static const double minDeriveDropBar = 5.0;
+
+  /// Reject an implausibly large derived cylinder volume (liters) as garbage.
+  static const double maxPlausibleVolumeLiters = 60.0;
+```
+
+- [ ] **Step 4: Add the field and derivation to `FitTank`/`extract()`**
+
+In `lib/features/dive_import/data/services/fit/fit_tank_extractor.dart`:
+
+(a) Add the field to `FitTank` — replace the constructor + fields block:
+
+```dart
+class FitTank {
+  const FitTank({
+    required this.sensorId,
+    required this.order,
+    this.startPressureBar,
+    this.endPressureBar,
+    this.volumeUsedLiters,
+    this.cylinderVolumeLiters,
+  });
+
+  final int sensorId;
+  final int order;
+  final double? startPressureBar;
+  final double? endPressureBar;
+  final double? volumeUsedLiters;
+
+  /// Configured cylinder volume in liters, DERIVED from gas consumption (Garmin
+  /// does not transmit size). Null when not reliably derivable, in which case
+  /// the tank still imports with pressure/gas but no volume.
+  final double? cylinderVolumeLiters;
+}
+```
+
+(b) In `extract()`, replace the `tanks.add(FitTank(...))` call (the one inside the
+summaries loop) with locals + derivation:
+
+```dart
+      final startBar = _scaled(
+        m,
+        FitConstants.tsStartPressure,
+        FitConstants.pressureScaleBar,
+      );
+      final endBar = _scaled(
+        m,
+        FitConstants.tsEndPressure,
+        FitConstants.pressureScaleBar,
+      );
+      final usedLiters = _scaled(
+        m,
+        FitConstants.tsVolumeUsed,
+        FitConstants.volumeScaleLiters,
+      );
+      tanks.add(
+        FitTank(
+          sensorId: sensor,
+          order: order,
+          startPressureBar: startBar,
+          endPressureBar: endBar,
+          volumeUsedLiters: usedLiters,
+          cylinderVolumeLiters: _deriveCylinderVolumeLiters(
+            startBar,
+            endBar,
+            usedLiters,
+          ),
+        ),
+      );
+```
+
+(c) Add the pure helper next to `_scaled` (inside `class FitTankExtractor`):
+
+```dart
+  /// Derives the configured cylinder volume (liters) by reversing Garmin's
+  /// gas-consumption computation: `size = volumeUsed / (startBar - endBar)`.
+  /// Returns null (no volume) when inputs are missing or the result is
+  /// unreliable: see [FitConstants.minDeriveDropBar] /
+  /// [FitConstants.maxPlausibleVolumeLiters]. Rounded to 0.1 L because the value
+  /// is reconstructed, not measured.
+  static double? _deriveCylinderVolumeLiters(
+    double? startBar,
+    double? endBar,
+    double? usedLiters,
+  ) {
+    if (usedLiters == null || usedLiters <= 0) return null;
+    if (startBar == null || endBar == null) return null;
+    final drop = startBar - endBar;
+    if (drop < FitConstants.minDeriveDropBar) return null;
+    final size = usedLiters / drop;
+    if (size <= 0 || size > FitConstants.maxPlausibleVolumeLiters) return null;
+    return double.parse(size.toStringAsFixed(1));
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `flutter test test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart`
+Expected: PASS (all existing + 4 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/features/dive_import/data/services/fit/fit_constants.dart lib/features/dive_import/data/services/fit/fit_tank_extractor.dart test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
+git add lib/features/dive_import/data/services/fit/fit_constants.dart lib/features/dive_import/data/services/fit/fit_tank_extractor.dart test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
+git commit -m "feat(dive-import): derive Garmin cylinder volume from gas consumption"
+```
+
+---
+
+### Task 2: Carry cylinder volume on `ImportedTank` and populate it from the orchestrator
+
+**Files:**
+- Modify: `lib/features/dive_import/domain/entities/imported_dive.dart`
+- Modify: `lib/features/dive_import/data/services/fit_parser_service.dart`
+- Test: `test/features/dive_import/data/services/fit_parser_service_test.dart`
+
+**Interfaces:**
+- Consumes: `FitTank.cylinderVolumeLiters` (Task 1).
+- Produces: `ImportedTank.volumeLiters` (`double?`) — the configured cylinder volume in liters. Used by Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/features/dive_import/data/services/fit_parser_service_test.dart`, extend the existing test `'air-integration: tank pressure from msgs 319/323 merges to samples'` — add this assertion right after the `expect(tank.volumeUsedLiters, closeTo(1993.5, 1e-6));` line:
+
+```dart
+        // Cylinder volume derived from volume_used / pressure_drop:
+        // 1993.5 / (221.25 - 88.11) = 14.97 -> rounded to 15.0 L.
+        expect(tank.volumeLiters, closeTo(15.0, 1e-9));
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_import/data/services/fit_parser_service_test.dart --plain-name 'air-integration: tank pressure from msgs 319/323 merges to samples'`
+Expected: FAIL — `volumeLiters` is not defined on `ImportedTank`.
+
+- [ ] **Step 3: Add `volumeLiters` to `ImportedTank`**
+
+In `lib/features/dive_import/domain/entities/imported_dive.dart`, replace the `ImportedTank` constructor, fields, and `props` so the new field is threaded through all three:
+
+```dart
+class ImportedTank extends Equatable {
+  const ImportedTank({
+    required this.order,
+    this.startPressureBar,
+    this.endPressureBar,
+    this.volumeUsedLiters,
+    this.volumeLiters,
+    this.o2Percent,
+    this.hePercent,
+  });
+
+  final int order;
+  final double? startPressureBar;
+  final double? endPressureBar;
+  final double? volumeUsedLiters;
+
+  /// Configured cylinder volume in liters (water volume). Derived for Garmin
+  /// air-integration tanks; null when unknown.
+  final double? volumeLiters;
+  final double? o2Percent;
+  final double? hePercent;
+
+  @override
+  List<Object?> get props => [
+    order,
+    startPressureBar,
+    endPressureBar,
+    volumeUsedLiters,
+    volumeLiters,
+    o2Percent,
+    hePercent,
+  ];
+}
+```
+
+- [ ] **Step 4: Populate it in the orchestrator**
+
+In `lib/features/dive_import/data/services/fit_parser_service.dart`, inside
+`_buildImportedTanks`, add the `volumeLiters` line to the `ImportedTank(...)`
+constructor (right after `volumeUsedLiters:`):
+
+```dart
+          volumeUsedLiters: i < realTanks.length
+              ? realTanks[i].volumeUsedLiters
+              : null,
+          volumeLiters: i < realTanks.length
+              ? realTanks[i].cylinderVolumeLiters
+              : null,
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_import/data/services/fit_parser_service_test.dart`
+Expected: PASS (all existing + the new assertion).
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/features/dive_import/domain/entities/imported_dive.dart lib/features/dive_import/data/services/fit_parser_service.dart test/features/dive_import/data/services/fit_parser_service_test.dart
+git add lib/features/dive_import/domain/entities/imported_dive.dart lib/features/dive_import/data/services/fit_parser_service.dart test/features/dive_import/data/services/fit_parser_service_test.dart
+git commit -m "feat(dive-import): carry derived cylinder volume on ImportedTank"
+```
+
+---
+
+### Task 3: Emit `volume` in the FIT import payload
+
+**Files:**
+- Modify: `lib/features/universal_import/data/parsers/fit_import_parser.dart`
+- Test: `test/features/universal_import/data/parsers/fit_import_parser_test.dart`
+
+**Interfaces:**
+- Consumes: `ImportedTank.volumeLiters` (Task 2).
+- Produces: `diveData['tanks'][i]['volume']` (`double`), consumed by the existing
+  `UddfEntityImporter` (maps `t['volume']` → `DiveTank.volume`; no change there).
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/features/universal_import/data/parsers/fit_import_parser_test.dart`, extend
+the existing test `'emits tank pressure, allTankPressures, exit GPS, and heart rate'`
+— add right after the `expect(tanks.single['endPressure'], closeTo(88.11, 1e-6));` line:
+
+```dart
+      // Cylinder volume derived from volume_used: 1993.5 / 133.14 -> 15.0 L.
+      expect(tanks.single['volume'], closeTo(15.0, 1e-9));
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/universal_import/data/parsers/fit_import_parser_test.dart --plain-name 'emits tank pressure, allTankPressures, exit GPS, and heart rate'`
+Expected: FAIL — `tanks.single['volume']` is null (key not emitted).
+
+- [ ] **Step 3: Emit the volume key**
+
+In `lib/features/universal_import/data/parsers/fit_import_parser.dart`, inside the
+`dive.tanks.map((t) { ... })` builder, add the `volume` line after the `endPressure`
+line:
+
+```dart
+        if (t.endPressureBar != null) tank['endPressure'] = t.endPressureBar;
+        if (t.volumeLiters != null) tank['volume'] = t.volumeLiters;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/universal_import/data/parsers/fit_import_parser_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format lib/features/universal_import/data/parsers/fit_import_parser.dart test/features/universal_import/data/parsers/fit_import_parser_test.dart
+git add lib/features/universal_import/data/parsers/fit_import_parser.dart test/features/universal_import/data/parsers/fit_import_parser_test.dart
+git commit -m "feat(dive-import): import Garmin tank cylinder volume into dives"
+```
+
+---
+
+### Task 4: Verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Whole-project format check**
+
+Run: `dart format .`
+Expected: "0 changed" (or it formats then shows changes — if so, re-run the relevant
+commits' `git add`/`commit --amend` is NOT needed; instead `git add -A && git commit -m "style: dart format"`). The whole-project format must be clean (CI Analyze & Format checks the whole repo).
+
+- [ ] **Step 2: Whole-project analyze**
+
+Run: `flutter analyze`
+Expected: "No issues found!"
+
+- [ ] **Step 3: Run the full FIT test surface**
+
+Run: `flutter test test/features/dive_import/data/services/fit test/features/dive_import/data/services/fit_parser_service_test.dart test/features/universal_import/data/parsers/fit_import_parser_test.dart test/features/dive_import/data/services/uddf_entity_importer_test.dart`
+Expected: all PASS.
+
+- [ ] **Step 4: Real-file backstop (manual dev check, not CI)**
+
+Re-derive cylinder volumes from the reporter's real files and confirm they match the
+spec's validated table (Bouchot 15.0 L; Verdugo 43 mm ~9.4 L; 51 mm / X50i ~11.0 L).
+Run (sample dir is outside the repo, on the dev's Desktop):
+
+```bash
+python3 - "$HOME/Desktop/Garmin_files" <<'PY'
+import glob, os, sys
+from fitparse import FitFile
+for path in sorted(glob.glob(os.path.join(sys.argv[1], '**', '*.fit'), recursive=True)):
+    ff = FitFile(path); ff.parse()
+    for msg in ff.get_messages('unknown_323'):
+        d = {f.def_num: f.raw_value for f in msg.fields}
+        drop = (d.get(1) or 0)/100 - (d.get(2) or 0)/100
+        used = (d.get(3) or 0)/100
+        size = round(used/drop, 1) if drop > 5 and used > 0 else None
+        print(f"{os.path.basename(path):40s} sensor={d.get(0)} size={size}")
+PY
+```
+
+Expected: derived sizes round to 15.0 (Bouchot), ~9.4 (Verdugo 43 mm), ~11.0 (51 mm / X50i); zero-`volume_used` transmitters print `size=None`.
+
+- [ ] **Step 5: (No commit)** — verification only. If Steps 1–3 surfaced fixes, they were committed within their own task.
+
+---
+
+## Out of scope (tracked, not built here)
+
+- Dive notes from the file (absent from the binary) — handled by a reply to the reporter (see spec §9) asking what "notes" they mean. Posting requires product-owner approval.
+- Notes/title from the Connect-export filename; tank nicknames (`unknown_147`) → `DiveTank.name`.
+
+## Self-review (completed)
+
+- **Spec coverage:** §4 derivation+guards → Task 1; §5/§6 plumbing → Tasks 2–3; §8 tests → Tasks 1–4; §8 real-file backstop → Task 4 Step 4; UddfEntityImporter mapping (§6.6) → pre-existing, exercised by `uddf_entity_importer_test.dart` lines 997/1057. Notes deferral (§2/§9) → Out of scope + reporter reply.
+- **Placeholder scan:** none — every step has concrete code/commands.
+- **Type consistency:** `cylinderVolumeLiters` (FitTank, Task 1) → read in Task 2; `volumeLiters` (ImportedTank, Task 2) → read in Task 3; payload key `'volume'` (Task 3) ↔ `UddfEntityImporter` `t['volume']`. Consistent throughout.

--- a/docs/superpowers/specs/2026-06-24-garmin-fit-tank-volume-design.md
+++ b/docs/superpowers/specs/2026-06-24-garmin-fit-tank-volume-design.md
@@ -1,0 +1,217 @@
+# Garmin FIT — Import Tank Cylinder Volume (and defer Notes) — Design Spec
+
+Issue: [#403 "Garmin .fit issues"](https://github.com/submersion-app/submersion/issues/403)
+(reporter: Floris Bouchot, who supplied the sample files used to validate PR #391).
+Builds on the merged FIT-import enrichment (PR #391, "make FIT speak UDDF").
+
+## 1. Background & problem
+
+The reporter asks for two enrichments to Garmin `.fit` import:
+
+1. **Tank details such as cylinder size from T2 transmitters**, so the user does not
+   set tank volume manually.
+2. **Dive notes** imported from the file.
+
+Empirical investigation of all 21 reporter-supplied sample files (Bouchot Mk3i+T2,
+Verdugo X50i + 2×Mk3i recorded simultaneously) using `python fitparse` established:
+
+- **Tank/cylinder size is NOT transmitted** by the T2, and is NOT a stored field
+  anywhere in the FIT stream. But Garmin's `tank_summary` (msg 323) stores
+  `volume_used` (surface gas consumed), which Garmin computes *from* the user's
+  configured cylinder size. The size is therefore recoverable by reversing that
+  computation. **Feasible.**
+- **Dive notes are NOT in the FIT binary at all.** Across every sample (both raw
+  device files and Garmin Connect exports) the only strings are the activity-profile
+  name (`"Single-Gas"`/`"Multi-Gas"`), the diver's name, transmitter nicknames, and
+  enum labels. Garmin keeps user dive notes in the **Connect cloud**; they do not
+  travel into the exported `.fit`. The dive *site* in the reporter's filenames
+  ("Qrendi") exists only in the **filename** (Connect names exports after the Connect
+  activity title), never in the bytes — and raw device files are timestamp-named
+  (`2026-06-07-09-17-09.fit`). **Not feasible from the file.**
+
+## 2. Goals / non-goals
+
+**Goals**
+- Import the configured cylinder volume (liters) for each air-integration tank in a
+  Garmin FIT dive, derived from `volume_used` and the start/end pressures.
+- Persist it to `DiveTank.volume` via the existing FIT→UDDF→importer path with no new
+  persistence code.
+- Degrade safely to "no volume" (tank still imports with pressure/gas) whenever the
+  derivation is unreliable.
+
+**Non-goals (this PR)**
+- Importing dive notes from the file (impossible — see §1). Handled by a reply to the
+  reporter asking what "notes" they mean (§9).
+- Importing notes/title from the export *filename* (product owner deferred this; would
+  require threading the filename through `ImportParser` and a fragile, Connect-export-only
+  heuristic).
+- Tank *nicknames* (the user labels "A2", "z Backup" found in `unknown_147`) → possible
+  future enhancement, out of scope here.
+- Deriving size for non-Garmin sources (see §4.4 — the required input does not exist there).
+
+## 3. Decisions (settled with product owner)
+
+- **Scope:** tank volume now; notes deferred to a reporter clarification reply.
+- **Source:** derive from `volume_used / (startBar − endBar)`. There is no direct size
+  field. (A single-file look would have mis-identified `unknown_147.field77`=`150` as
+  "15.0 L"; the multi-tank Verdugo files disprove it — field77 is a constant `800`
+  behind both 9.4 L and 11 L tanks; it is a pressure-alarm threshold in the user's
+  pressure unit, not size.)
+- **Rounding:** round the derived liters to **0.1 L**. The value is reconstructed, not
+  measured; 0.1 L communicates "≈15 L" without implying false precision (`14.97`).
+- **Scoping of the helper:** implement the math as a **pure, reusable** function, but
+  wire it only into the Garmin FIT extractor. No generic "any dive with pressure" path
+  (YAGNI — and the input is unavailable elsewhere).
+
+## 4. The derivation
+
+### 4.1 Formula
+
+```
+cylinderVolumeLiters = round0.1( volumeUsedLiters / (startPressureBar − endPressureBar) )
+```
+
+Units resolve to liters: surface gas consumed (L) = cylinder size (L) × pressure drop
+(bar), since 1 L of cylinder at 1 bar over ambient ≈ 1 L of surface gas. Reversing
+yields size in liters, matching `DiveTank.volume` (water volume, liters).
+
+### 4.2 Guards — return `null` (no volume) when
+
+- `volumeUsedLiters` is null or ≤ 0 — catches the dive-92 phantom summary and the
+  X50i "overheard" transmitter (pressure present, `volume_used = 0`).
+- `startPressureBar` or `endPressureBar` is null.
+- pressure drop `< 5 bar` (`FitConstants.minDeriveDropBar`) — avoids divide-by-near-zero
+  and noise from an essentially unused tank.
+- result ≤ 0 or > 60 L (`FitConstants.maxPlausibleVolumeLiters`) — plausibility clamp
+  against garbage. A single cylinder or manifolded twinset realistically falls well
+  inside this range.
+
+`null` means the tank still imports (pressure, gas mix) but without a volume — never a
+wrong number.
+
+### 4.3 Accuracy & confidence
+
+Validated against the reporter's files:
+
+| Tank | Derived size across dives | Spread |
+|---|---|---|
+| Bouchot Mk3i+T2 | 14.97, 14.98 → **15.0 L** | 0.01 L |
+| Verdugo 43 mm (×2) | 9.37–9.39 → **9.4 L** | 0.02 L |
+| Verdugo 51 mm | 10.94–10.95 → **11.0 L** | 0.01 L |
+| Verdugo X50i | 10.93–10.95 → **11.0 L** | 0.02 L |
+
+- **Precision (reproducibility): ≤0.2%.** The size is near-constant per physical tank
+  across dives whose pressure drops range ~100–180 bar. A pressure-dependent real-gas
+  (Z-factor) correction in Garmin's `volume_used` would make the derived size drift
+  across those dives; it does not, so Garmin uses the same linear model we invert and we
+  recover its value. Residual error is integer rounding (inputs stored ×100) ≈ <0.01%.
+- **Fidelity to configured size: effectively exact** (to 0.1 L). Proof it recovers
+  *config*, not a guess: the same physical transmitter (sensor 2504425580) derives
+  9.4 L on the 43 mm computer but 11.0 L on the X50i — one tank, two computers, two
+  configs. This is the desired behavior ("instead of setting tank volume manually").
+- **Fidelity to true physical cylinder: bounded by the user's own config.** We cannot
+  beat their input. One residual unknown: a *constant* (pressure-independent) Z-factor
+  in `volume_used` would add a small (~1–2%) systematic offset invisible to the
+  cross-dive check; the clean landings (15.0, 11.0) argue against it, and the reporter
+  can confirm against the device. Worst case is far better than manual entry.
+
+### 4.4 Why this does not generalize to "any dive with pressure"
+
+The formula needs **absolute gas consumed** (surface liters), not just pressure.
+Pressure drop alone is size-independent — a 100 bar drop is identical in a 7 L pony and
+a 15 L steel. Garmin is unusual in storing `volume_used` directly; that is the only
+reason derivation is possible.
+
+- Other dive computers (Shearwater/Suunto/Perdix via libdivecomputer): pressure
+  time-series only, no absolute gas-used → circular, cannot derive.
+- UDDF/Subsurface/MacDive: tank volume is typically a direct field → read it, no derivation.
+- Apple Watch/HealthKit: no air integration.
+
+So the derivation lives in the Garmin path. The pure helper is reusable if a future
+source ever reports absolute gas-used.
+
+## 5. Architecture & data flow
+
+Reuses the merged "make FIT speak UDDF" pipeline unchanged; the volume rides existing
+plumbing:
+
+```
+tank_summary (323)        FitTankExtractor            ImportedTank      FitImportParser         UddfEntityImporter
+ field1 startP ─┐         derive (§4):                .volumeLiters ──► tank['volume'] = …  ──►  DiveTank.volume
+ field2 endP   ─┼─►FitTank used/(start−end) ────────► (NEW field)       (NEW line)               (EXISTING map; no change)
+ field3 used   ─┘         →FitTank.cylinderVolumeLiters (NEW)
+```
+
+## 6. Components / affected files
+
+1. `lib/features/dive_import/data/services/fit/fit_tank_extractor.dart`
+   - Add `cylinderVolumeLiters` to `FitTank`.
+   - Compute it in `extract()` from a pure helper applying §4.1–§4.2. The helper is a
+     private static for now, but takes only `(usedLiters, startBar, endBar)` with no
+     Garmin coupling, so it can be promoted to a shared util if a second consumer
+     (a source that reports absolute gas-used) ever appears.
+2. `lib/features/dive_import/data/services/fit/fit_constants.dart`
+   - Add `minDeriveDropBar = 5.0` and `maxPlausibleVolumeLiters = 60.0`.
+3. `lib/features/dive_import/domain/entities/imported_dive.dart`
+   - Add `volumeLiters` to `ImportedTank` (ctor + `props`).
+4. `lib/features/dive_import/data/services/fit_parser_service.dart`
+   - In `_buildImportedTanks`, set `volumeLiters: realTanks[i].cylinderVolumeLiters`.
+5. `lib/features/universal_import/data/parsers/fit_import_parser.dart`
+   - In the tank map, emit `tank['volume'] = t.volumeLiters` when non-null.
+6. `UddfEntityImporter` — **no change** (already maps `t['volume']` → `DiveTank.volume`,
+   line ~1591); locked in by a test.
+
+## 7. Edge cases
+
+- Phantom zero-pressure `tank_summary` (dive 92) — already dropped by the orchestrator's
+  `realTanks` pressure>0 filter; never reaches derivation.
+- "Overheard" transmitter (X50i 3rd sensor): pressure present, `volume_used = 0` →
+  guard returns null; tank imports with pressure, no volume.
+- Gas-only padded tanks (more gases than transmitters): no real tank → `volumeLiters` null.
+- Multiple tanks (X50i, 2–3): each derives independently by sensor/order.
+
+## 8. Testing (TDD)
+
+- `fit_tank_extractor_test.dart` (extend; synthetic `GenericMessage` builder already present):
+  Bouchot-72 raw values → `cylinderVolumeLiters ≈ 15.0`; `volume_used=0` → null;
+  drop < 5 bar → null; absurd (huge used / tiny drop) → null.
+- `fit_import_parser_test.dart`: synthetic file with a `tank_summary` → emitted
+  `diveData['tanks'][i]['volume']` present and ≈ derived; not-derivable → key absent.
+- Importer/converter test: `t['volume']` → `DiveTank.volume` persisted.
+- Backstop: re-run the Python derivation over all 21 real sample files (the FIT lesson:
+  real-file bugs do not reproduce against `FitFileBuilder` round-trips).
+
+## 9. Reporter reply (deferred notes)
+
+Post after the PR (product owner to approve wording first):
+
+> Tank size: recoverable and being added — the T2 does not transmit cylinder size, but
+> your Descent computes gas consumption from the size you configured, so we reverse it
+> (your 15 L came through exactly). Notes: we checked all the files you sent — Garmin
+> stores dive notes in Garmin Connect (the cloud), not in the exported `.fit`, so there
+> is no notes field to read. Could you clarify which you mean: the dive **title** you set
+> in Connect (it survives in the export *filename*, e.g. "72 Qrendi Single-Gas Dive"),
+> or free-text **notes** typed in Connect? That tells us what is actually achievable.
+
+## 10. Out of scope / future
+
+- Notes from the Connect-export filename (needs `ImportParser` filename threading;
+  Connect-export-only; revisit after reporter clarifies).
+- Tank nicknames from `unknown_147` → `DiveTank.name`.
+- Direct Garmin USB/MTP download.
+
+## Appendix A — verified ground truth (preserve; expensive to re-derive)
+
+- `tank_summary` (msg 323) fields: 0=sensor, 1=startPressure (×0.01 bar),
+  2=endPressure (×0.01 bar), 3=`volume_used` (×0.01 L, surface gas consumed — NOT size).
+- `volume_used` varies with the dive's consumption (e.g. Verdugo 43 mm: 926→1622 L over
+  6 dives) while `used / drop` stays ~9.38 L → confirms field 3 is gas-used and the
+  quotient is the configured size.
+- `unknown_147` = per-transmitter registration: field0=sensor (matches `tank_summary`),
+  field52=O2%, field2/91=user nickname, fields 75/76/77 = pressure-alarm thresholds in
+  the user's pressure unit (Bouchot metric 232/50/150 bar; Verdugo imperial
+  3500/700/800 psi). **field77 is NOT tank size** (constant 800 across 9.4 L and 11 L).
+- No free-text notes field exists in any sample. Dive site name appears only in
+  Connect-export filenames, not the binary; entry/exit GPS (already imported by #391)
+  drives site matching instead.
+- Garmin product codes (from #391): 4223=Descent Mk3i, 4518=Descent X50i, 3865=T2.

--- a/lib/features/dive_import/data/services/fit/fit_constants.dart
+++ b/lib/features/dive_import/data/services/fit/fit_constants.dart
@@ -27,6 +27,15 @@ class FitConstants {
   static const double volumeScaleLiters = 100.0; // raw / 100 = liters
   static const double semicircleToDegrees = 180.0 / 2147483648.0;
 
+  /// Cylinder-volume derivation (`size = volume_used / pressure_drop`). Garmin
+  /// does not transmit cylinder size; it stores volume_used computed from the
+  /// user's configured size, so the size is recovered by reversing that. Below
+  /// this pressure drop the quotient is noise; reject it.
+  static const double minDeriveDropBar = 5.0;
+
+  /// Reject an implausibly large derived cylinder volume (liters) as garbage.
+  static const double maxPlausibleVolumeLiters = 60.0;
+
   /// Seconds between the Unix epoch (1970-01-01) and the FIT epoch
   /// (1989-12-31). A GenericMessage timestamp field is raw FIT-epoch seconds;
   /// add this and multiply by 1000 to get Unix milliseconds.

--- a/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
@@ -10,6 +10,7 @@ class FitTank {
     this.startPressureBar,
     this.endPressureBar,
     this.volumeUsedLiters,
+    this.cylinderVolumeLiters,
   });
 
   final int sensorId;
@@ -17,6 +18,11 @@ class FitTank {
   final double? startPressureBar;
   final double? endPressureBar;
   final double? volumeUsedLiters;
+
+  /// Configured cylinder volume in liters, DERIVED from gas consumption (Garmin
+  /// does not transmit size). Null when not reliably derivable, in which case
+  /// the tank still imports with pressure/gas but no volume.
+  final double? cylinderVolumeLiters;
 }
 
 /// A single tank-pressure reading, from a FIT `tank_update` message.
@@ -75,24 +81,32 @@ class FitTankExtractor {
       if (sensor == null || orderBySensor.containsKey(sensor)) continue;
       final order = orderBySensor.length;
       orderBySensor[sensor] = order;
+      final startBar = _scaled(
+        m,
+        FitConstants.tsStartPressure,
+        FitConstants.pressureScaleBar,
+      );
+      final endBar = _scaled(
+        m,
+        FitConstants.tsEndPressure,
+        FitConstants.pressureScaleBar,
+      );
+      final usedLiters = _scaled(
+        m,
+        FitConstants.tsVolumeUsed,
+        FitConstants.volumeScaleLiters,
+      );
       tanks.add(
         FitTank(
           sensorId: sensor,
           order: order,
-          startPressureBar: _scaled(
-            m,
-            FitConstants.tsStartPressure,
-            FitConstants.pressureScaleBar,
-          ),
-          endPressureBar: _scaled(
-            m,
-            FitConstants.tsEndPressure,
-            FitConstants.pressureScaleBar,
-          ),
-          volumeUsedLiters: _scaled(
-            m,
-            FitConstants.tsVolumeUsed,
-            FitConstants.volumeScaleLiters,
+          startPressureBar: startBar,
+          endPressureBar: endBar,
+          volumeUsedLiters: usedLiters,
+          cylinderVolumeLiters: _deriveCylinderVolumeLiters(
+            startBar,
+            endBar,
+            usedLiters,
           ),
         ),
       );
@@ -126,5 +140,25 @@ class FitTankExtractor {
   static double? _scaled(DataMessage m, int fieldId, double scale) {
     final raw = FitMessageAccess.rawNum(m, fieldId);
     return raw == null ? null : raw.toDouble() / scale;
+  }
+
+  /// Derives the configured cylinder volume (liters) by reversing Garmin's
+  /// gas-consumption computation: `size = volumeUsed / (startBar - endBar)`.
+  /// Returns null (no volume) when inputs are missing or the result is
+  /// unreliable: see [FitConstants.minDeriveDropBar] /
+  /// [FitConstants.maxPlausibleVolumeLiters]. Rounded to 0.1 L because the value
+  /// is reconstructed, not measured.
+  static double? _deriveCylinderVolumeLiters(
+    double? startBar,
+    double? endBar,
+    double? usedLiters,
+  ) {
+    if (usedLiters == null || usedLiters <= 0) return null;
+    if (startBar == null || endBar == null) return null;
+    final drop = startBar - endBar;
+    if (drop < FitConstants.minDeriveDropBar) return null;
+    final size = usedLiters / drop;
+    if (size <= 0 || size > FitConstants.maxPlausibleVolumeLiters) return null;
+    return double.parse(size.toStringAsFixed(1));
   }
 }

--- a/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
+++ b/lib/features/dive_import/data/services/fit/fit_tank_extractor.dart
@@ -158,7 +158,14 @@ class FitTankExtractor {
     final drop = startBar - endBar;
     if (drop < FitConstants.minDeriveDropBar) return null;
     final size = usedLiters / drop;
-    if (size <= 0 || size > FitConstants.maxPlausibleVolumeLiters) return null;
-    return double.parse(size.toStringAsFixed(1));
+    if (!size.isFinite ||
+        size <= 0 ||
+        size > FitConstants.maxPlausibleVolumeLiters) {
+      return null;
+    }
+    // Round to 0.1 L numerically (the value is reconstructed, not measured).
+    // Numeric rounding avoids a string round-trip; the isFinite guard above
+    // keeps round() from receiving NaN/Infinity.
+    return (size * 10).round() / 10;
   }
 }

--- a/lib/features/dive_import/data/services/fit_parser_service.dart
+++ b/lib/features/dive_import/data/services/fit_parser_service.dart
@@ -279,6 +279,9 @@ class FitParserService {
           volumeUsedLiters: i < realTanks.length
               ? realTanks[i].volumeUsedLiters
               : null,
+          volumeLiters: i < realTanks.length
+              ? realTanks[i].cylinderVolumeLiters
+              : null,
           o2Percent: i < gases.length ? gases[i].o2Percent : null,
           hePercent: i < gases.length ? gases[i].hePercent : null,
         ),

--- a/lib/features/dive_import/domain/entities/imported_dive.dart
+++ b/lib/features/dive_import/domain/entities/imported_dive.dart
@@ -26,6 +26,7 @@ class ImportedTank extends Equatable {
     this.startPressureBar,
     this.endPressureBar,
     this.volumeUsedLiters,
+    this.volumeLiters,
     this.o2Percent,
     this.hePercent,
   });
@@ -34,6 +35,10 @@ class ImportedTank extends Equatable {
   final double? startPressureBar;
   final double? endPressureBar;
   final double? volumeUsedLiters;
+
+  /// Configured cylinder volume in liters (water volume). Derived for Garmin
+  /// air-integration tanks; null when unknown.
+  final double? volumeLiters;
   final double? o2Percent;
   final double? hePercent;
 
@@ -43,6 +48,7 @@ class ImportedTank extends Equatable {
     startPressureBar,
     endPressureBar,
     volumeUsedLiters,
+    volumeLiters,
     o2Percent,
     hePercent,
   ];

--- a/lib/features/universal_import/data/parsers/fit_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/fit_import_parser.dart
@@ -99,6 +99,7 @@ class FitImportParser implements ImportParser {
           tank['startPressure'] = t.startPressureBar;
         }
         if (t.endPressureBar != null) tank['endPressure'] = t.endPressureBar;
+        if (t.volumeLiters != null) tank['volume'] = t.volumeLiters;
         if (t.o2Percent != null || t.hePercent != null) {
           tank['gasMix'] = GasMix(
             o2: t.o2Percent ?? 21.0,

--- a/test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
+++ b/test/features/dive_import/data/services/fit/fit_tank_extractor_test.dart
@@ -84,4 +84,37 @@ void main() {
     expect(data.tanks, hasLength(1));
     expect(data.orderForSensor(100), 0);
   });
+
+  test('derives cylinder volume from volume_used and pressure drop', () {
+    // Bouchot 72: 1993.5 L used over (221.25 - 88.11)=133.14 bar -> 14.97 -> 15.0 L.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 22125, endRaw: 8811, volRaw: 199350),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, closeTo(15.0, 1e-9));
+  });
+
+  test('cylinder volume is null when volume_used is zero (overheard tx)', () {
+    // Real pressures but zero gas used -> cannot derive; pressures still present.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 21200, endRaw: 7400, volRaw: 0),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, isNull);
+    expect(data.tanks.single.startPressureBar, closeTo(212.0, 1e-6));
+  });
+
+  test('cylinder volume is null when the pressure drop is below the floor', () {
+    // 200.00 - 197.00 = 3 bar drop (< 5 bar floor) -> unreliable -> null.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 20000, endRaw: 19700, volRaw: 4500),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, isNull);
+  });
+
+  test('cylinder volume is null when the result is implausibly large', () {
+    // 500 L used over a 6 bar drop -> 83.3 L (> 60 L clamp) -> null.
+    final data = FitTankExtractor.extract([
+      tankSummary(sensor: 1, startRaw: 20000, endRaw: 19400, volRaw: 50000),
+    ]);
+    expect(data.tanks.single.cylinderVolumeLiters, isNull);
+  });
 }

--- a/test/features/dive_import/data/services/fit_parser_service_test.dart
+++ b/test/features/dive_import/data/services/fit_parser_service_test.dart
@@ -573,6 +573,9 @@ void main() {
         expect(tank.startPressureBar, closeTo(221.25, 1e-6));
         expect(tank.endPressureBar, closeTo(88.11, 1e-6));
         expect(tank.volumeUsedLiters, closeTo(1993.5, 1e-6));
+        // Cylinder volume derived from volume_used / pressure_drop:
+        // 1993.5 / (221.25 - 88.11) = 14.97 -> rounded to 15.0 L.
+        expect(tank.volumeLiters, closeTo(15.0, 1e-9));
 
         // The pressure series is merged onto the contemporaneous depth samples.
         final withPressure = dive.profile

--- a/test/features/universal_import/data/parsers/fit_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/fit_import_parser_test.dart
@@ -203,6 +203,8 @@ void main() {
       final tanks = d['tanks'] as List<Map<String, dynamic>>;
       expect(tanks.single['startPressure'], closeTo(221.25, 1e-6));
       expect(tanks.single['endPressure'], closeTo(88.11, 1e-6));
+      // Cylinder volume derived from volume_used: 1993.5 / 133.14 -> 15.0 L.
+      expect(tanks.single['volume'], closeTo(15.0, 1e-9));
       expect(d['avgHeartRate'], isNotNull);
       expect(d['exitLatitude'], closeTo(19.691, 1e-3));
 


### PR DESCRIPTION
## Summary

Addresses [#403](https://github.com/submersion-app/submersion/issues/403) — imports each air-integration tank's **configured cylinder volume** from Garmin FIT dives, so users no longer set tank volume manually after a Garmin import.

The Garmin T2 / Mk3i does **not** transmit cylinder size. But `tank_summary` (msg 323) stores `volume_used` (surface gas consumed), which Garmin computes *from* the user's configured size. We reverse that:

```
cylinderVolume (L) = volume_used / (startBar − endBar)    [rounded to 0.1 L]
```

returning `null` (the tank still imports with pressure/gas — never a wrong number) when the result is unreliable: `volume_used ≤ 0`, pressure drop `< 5 bar`, or result `> 60 L`.

## Why derivation, not a direct field

There is no cylinder-size field anywhere in the FIT stream. A single file makes `unknown_147.field77 = 150` look like "15.0 L", but the multi-tank Verdugo files disprove it — field77 is a constant `800` behind both 9.4 L and 11 L tanks (it is a pressure-alarm threshold in the user's pressure unit). Derivation is the only reliable path, and it self-validates: the same physical tank lands on the same size across 6+ dives with very different consumption (≤0.2% spread).

## Validation (all 21 reporter sample files)

| Diver / computer | Derived size |
|---|---|
| Bouchot Mk3i + T2 | 15.0 L |
| Verdugo Mk3i 43 mm (×2 tanks) | 9.4 L |
| Verdugo Mk3i 51 mm | ~11 L |
| Verdugo X50i | ~11 L (2 real tanks; 3rd "overheard" transmitter → null) |
| Bouchot multi-gas (no transmitter) | null |

## Architecture

Reuses the merged "make FIT speak UDDF" pipeline (#391): derive in the pure `FitTankExtractor` → carry on `FitTank` / `ImportedTank` → emit `diveData['tanks'][i]['volume']`, which the existing `UddfEntityImporter` already maps to `DiveTank.volume`. No new persistence code.

## Notes (the other half of #403) — deferred

Dive notes are **not in the FIT binary** (confirmed across all 21 files); Garmin keeps them in Connect's cloud, not the exported `.fit`, so there is nothing to import from the file. A reply is queued asking the reporter to clarify what "notes" they mean — the Connect activity title that survives only in the export *filename* (e.g. "72 Qrendi Single-Gas Dive"), vs free-text Connect notes — before building anything fragile. #403 stays open for that half.

## Test plan

- 4 new derivation unit tests (15.0 L; null for zero-used / sub-5-bar drop / >60 L).
- Extended orchestrator + parser tests assert the volume flows into the payload.
- Full FIT test surface (113) + import blast radius (2167) green; `flutter analyze` clean; whole-project `dart format` clean.
- Real-file Python backstop over all 21 files matches the table above.

Design + plan: `docs/superpowers/specs/2026-06-24-garmin-fit-tank-volume-design.md`, `docs/superpowers/plans/2026-06-24-garmin-fit-tank-volume.md`.