### PR TITLE
fix(android): keep serial-USB driver methods from R8 obfuscation (#318)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,6 +229,36 @@ jobs:
           flags: shard-${{ matrix.shard }}
           fail_ci_if_error: false  # Enable after configuring repo on codecov.io
 
+  # Unit-tests the dependency-free Python guard scripts (e.g. the issue #318
+  # ProGuard keep-rule checker). No Flutter/codegen needed, so it runs in
+  # parallel and gives the guard logic its own coverage, scoped to the script.
+  script-tests:
+    name: Script Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install coverage.py
+        run: python3 -m pip install coverage
+
+      - name: Run Python guard tests with coverage
+        run: |
+          mkdir -p coverage
+          python3 -m coverage run --include='scripts/check_proguard_serial_keep.py' \
+            scripts/check_proguard_serial_keep_test.py
+          python3 -m coverage report -m --include='scripts/check_proguard_serial_keep.py'
+          python3 -m coverage xml --include='scripts/check_proguard_serial_keep.py' \
+            -o coverage/scripts.xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v7
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/scripts.xml
+          flags: scripts
+          fail_ci_if_error: false
+
   integration-test:
     name: Integration Test (macOS)
     needs: codegen

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,6 +238,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
       - name: Install coverage.py
         run: python3 -m pip install coverage
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -549,6 +549,13 @@ jobs:
       - name: Verify 16 KB native library alignment
         run: python3 scripts/check_16kb_alignment.py build/app/outputs/flutter-apk/app-release.apk
 
+      # Guards against the second half of issue #318: R8 release minification
+      # renamed the reflectively-probed usb-serial-for-android driver methods
+      # (e.g. getSupportedDevices), so every serial-USB download crashed with a
+      # NoSuchMethodException. Fails the build if a driver method was obfuscated.
+      - name: Verify serial driver ProGuard keep rules
+        run: python3 scripts/check_proguard_serial_keep.py build/app/outputs/mapping/release/mapping.txt
+
       - name: Upload Android artifact
         uses: actions/upload-artifact@v7
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
         threshold: 5%
     patch:
       default:
-        target: 80%
+        target: 90%
 
 ignore:
   - "**/*.g.dart"

--- a/packages/libdivecomputer_plugin/android/consumer-rules.pro
+++ b/packages/libdivecomputer_plugin/android/consumer-rules.pro
@@ -12,7 +12,7 @@
 # purely by reflection, so R8 has no visible call site and would rename or
 # strip the members, breaking the lookups at runtime:
 #   - ProbeTable.addDriver() -> Class.getMethod("getSupportedDevices") / ("probe")
-#   - UsbSerialProber.probeDevice() -> Class.getConstructor(UsbDevice)
+#   - UsbSerialProber.probeDevice() -> Class.getConstructor(UsbDevice.class)
 # When the members are renamed the reflective lookup throws NoSuchMethodException,
 # which surfaces as "Download failed unexpectedly (RuntimeException)" and every
 # serial-USB download crashes (issue #318). This mirrors the consumer ProGuard

--- a/packages/libdivecomputer_plugin/android/consumer-rules.pro
+++ b/packages/libdivecomputer_plugin/android/consumer-rules.pro
@@ -6,3 +6,16 @@
 }
 -keep interface com.submersion.libdivecomputer.BleIoHandler { *; }
 -keep interface com.submersion.libdivecomputer.DownloadCallback { *; }
+
+# Keep the vendored usb-serial-for-android drivers (serial-over-USB dive
+# computer support, e.g. the Mares Puck Pro). These classes are discovered
+# purely by reflection, so R8 has no visible call site and would rename or
+# strip the members, breaking the lookups at runtime:
+#   - ProbeTable.addDriver() -> Class.getMethod("getSupportedDevices") / ("probe")
+#   - UsbSerialProber.probeDevice() -> Class.getConstructor(UsbDevice)
+# When the members are renamed the reflective lookup throws NoSuchMethodException,
+# which surfaces as "Download failed unexpectedly (RuntimeException)" and every
+# serial-USB download crashes (issue #318). This mirrors the consumer ProGuard
+# rules that the upstream library ships in its AAR; we vendor the source, so the
+# rules must live here. DO NOT REMOVE.
+-keep class com.hoho.android.usbserial.driver.** { *; }

--- a/scripts/check_proguard_serial_keep.py
+++ b/scripts/check_proguard_serial_keep.py
@@ -169,5 +169,5 @@ def main(argv):
     return 0 if all_ok else 1
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main(sys.argv))

--- a/scripts/check_proguard_serial_keep.py
+++ b/scripts/check_proguard_serial_keep.py
@@ -116,29 +116,36 @@ def check_mapping(path):
         report = analyze(fh.read())
 
     lines = []
-
-    if not report["minify_ran"]:
-        # Nothing was obfuscated: not a minified release mapping, so the guard
-        # has nothing to prove. A no-op rather than a failure.
-        lines.append("  WARN  mapping shows no obfuscation; minification likely "
-                     "disabled -- nothing to verify")
-        return True, lines
-
     ok = True
+
+    # A renamed reflected method is always the #318 regression -- check it
+    # unconditionally. R8 can rename members while keeping class names (partial
+    # keep rules, -keepnames), so this must NOT be gated on class obfuscation.
     for cls, method, obf in report["renamed"]:
         ok = False
         lines.append(f"  FAIL  {cls}.{method}() renamed to '{obf}' "
                      "-- ProbeTable/UsbSerialProber reflect on this exact name")
 
-    if not report["canary_classes"]:
+    if report["canary_classes"]:
+        if ok:
+            kept = ", ".join(sorted({m for _, m in report["kept"]})) or "n/a"
+            lines.append(f"  ok    {CANARY}() preserved on "
+                         f"{len(report['canary_classes'])} drivers; "
+                         f"reflected methods kept: {kept}")
+    elif report["minify_ran"]:
+        # Obfuscation ran but no driver declares getSupportedDevices: the
+        # reflected methods were stripped or renamed away.
         ok = False
         lines.append(f"  FAIL  no driver declares {CANARY}() in an obfuscated "
                      "mapping -- the serial drivers were stripped or renamed away")
-
-    if ok:
-        lines.append(f"  ok    {CANARY}() preserved on "
-                     f"{len(report['canary_classes'])} drivers; "
-                     f"{len(report['kept'])} reflected methods kept un-obfuscated")
+    else:
+        # No obfuscation and no driver methods enumerated: a shrink-only or
+        # non-obfuscated mapping where we cannot prove the drivers survived
+        # (R8 can also strip an unused reflected member here). Warn rather than
+        # pass silently. Submersion's release builds always obfuscate, so this
+        # branch should not occur in CI.
+        lines.append(f"  WARN  no obfuscation and no {CANARY}() seen; cannot "
+                     "verify the serial drivers (minification may be disabled)")
     return ok, lines
 
 

--- a/scripts/check_proguard_serial_keep.py
+++ b/scripts/check_proguard_serial_keep.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Verify R8 kept the reflected usb-serial-for-android driver methods intact.
+
+The libdivecomputer plugin vendors usb-serial-for-android
+(``com.hoho.android.usbserial.driver.*``) to download serial-over-USB dive
+computers such as the Mares Puck Pro. That library discovers drivers purely by
+reflection -- it never references the members from a visible call site:
+
+    ProbeTable.addDriver()      -> Class.getMethod("getSupportedDevices")
+                                   Class.getMethod("probe", UsbDevice.class)
+    UsbSerialProber.probeDevice -> Class.getConstructor(UsbDevice.class)
+
+Flutter release builds run R8 with obfuscation enabled by default. Without a
+keep rule R8 renames ``getSupportedDevices`` (and the driver class becomes e.g.
+``P5.a``); the reflective ``getMethod("getSupportedDevices")`` then throws
+``NoSuchMethodException`` and every serial-USB download crashes with "Download
+failed unexpectedly (RuntimeException)". This was issue #318. The keep rule
+lives in the plugin's ``consumer-rules.pro``.
+
+Because the lookup is by method name on a runtime ``Class`` object, the precise
+thing that must survive is the *method name*, not the class name -- R8 may
+freely rename synthetic helper classes (e.g. ``$$ExternalSyntheticLambda``) in
+the same package without harm. This script reads the R8 ``mapping.txt`` from a
+release build and fails (exit code 1) if a reflectively-accessed method on a
+driver class was renamed, or if it vanished entirely. It is the build-artifact
+counterpart to ``check_16kb_alignment`` and is dependency-free (pure stdlib).
+
+Usage:
+    check_proguard_serial_keep.py <mapping.txt>
+"""
+
+import sys
+
+# All reflectively-probed driver classes live in this package.
+DRIVER_PKG = "com.hoho.android.usbserial.driver."
+
+# Methods looked up by name via reflection in ProbeTable / UsbSerialProber.
+# getSupportedDevices is fatal if renamed (its NoSuchMethodException is thrown,
+# not caught); probe is reflected too and kept for the same reason. The
+# (UsbDevice) constructor is also reflected, but R8 never renames <init> and the
+# class-level keep prevents its removal, so the named methods are the signal.
+REFLECTED_METHODS = ("getSupportedDevices", "probe")
+
+# getSupportedDevices is declared by every concrete driver and is the canary:
+# if it survives, the keep rule is effective for the whole class.
+CANARY = "getSupportedDevices"
+
+
+def _method_name(left):
+    """Return the source-level method name from the left side of a mapping line.
+
+    ``left`` looks like ``[start:end:]<returnType> name(args)[:orig:lines]`` for
+    a method, or ``<type> name`` for a field. Returns ``None`` for fields (no
+    parenthesis) so callers skip them.
+    """
+    if "(" not in left:
+        return None
+    before_paren = left.split("(", 1)[0]
+    before_paren = before_paren.lstrip("0123456789:")  # drop "12:34:" line range
+    tokens = before_paren.split()
+    if not tokens:
+        return None
+    return tokens[-1].rsplit(".", 1)[-1]  # strip owner qualifier on inlined frames
+
+
+def analyze(text):
+    """Return a report dict describing how R8 treated the reflected methods."""
+    minify_ran = False
+    renamed = []          # (class, method, obfuscated) -- a reflected method renamed
+    kept = []             # (class, method) -- reflected method identity-mapped
+    canary_classes = set()  # driver classes that declared getSupportedDevices
+
+    current_orig = None
+    current_is_driver = False
+
+    for raw in text.splitlines():
+        if not raw or raw.startswith("#") or " -> " not in raw:
+            continue
+
+        if not raw[0].isspace():
+            # Class line: "<orig> -> <obf>:"
+            left, right = raw.split(" -> ", 1)
+            current_orig = left.strip()
+            if right.rstrip(":").strip() != current_orig:
+                minify_ran = True
+            current_is_driver = current_orig.startswith(DRIVER_PKG)
+            continue
+
+        if not current_is_driver:
+            continue
+
+        # Member line within a driver-package class.
+        left, right = raw.rsplit(" -> ", 1)
+        name = _method_name(left.strip())
+        if name not in REFLECTED_METHODS:
+            continue
+        obf = right.strip()
+        if name == CANARY:
+            canary_classes.add(current_orig)
+        if obf != name:
+            renamed.append((current_orig, name, obf))
+        else:
+            kept.append((current_orig, name))
+
+    return {
+        "minify_ran": minify_ran,
+        "renamed": renamed,
+        "kept": kept,
+        "canary_classes": sorted(canary_classes),
+    }
+
+
+def check_mapping(path):
+    """Check one mapping.txt. Return ``(ok, lines)`` report."""
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        report = analyze(fh.read())
+
+    lines = []
+
+    if not report["minify_ran"]:
+        # Nothing was obfuscated: not a minified release mapping, so the guard
+        # has nothing to prove. A no-op rather than a failure.
+        lines.append("  WARN  mapping shows no obfuscation; minification likely "
+                     "disabled -- nothing to verify")
+        return True, lines
+
+    ok = True
+    for cls, method, obf in report["renamed"]:
+        ok = False
+        lines.append(f"  FAIL  {cls}.{method}() renamed to '{obf}' "
+                     "-- ProbeTable/UsbSerialProber reflect on this exact name")
+
+    if not report["canary_classes"]:
+        ok = False
+        lines.append(f"  FAIL  no driver declares {CANARY}() in an obfuscated "
+                     "mapping -- the serial drivers were stripped or renamed away")
+
+    if ok:
+        lines.append(f"  ok    {CANARY}() preserved on "
+                     f"{len(report['canary_classes'])} drivers; "
+                     f"{len(report['kept'])} reflected methods kept un-obfuscated")
+    return ok, lines
+
+
+def main(argv):
+    paths = argv[1:]
+    if not paths:
+        print(__doc__)
+        return 2
+
+    all_ok = True
+    for path in paths:
+        print(f"Checking ProGuard serial-driver keep rules: {path}")
+        try:
+            ok, lines = check_mapping(path)
+        except OSError as exc:
+            print(f"  ERROR reading {path}: {exc}")
+            all_ok = False
+            continue
+        for line in lines:
+            print(line)
+        if ok:
+            print("  -> PASS: usb-serial-for-android drivers survive R8 obfuscation")
+        else:
+            print("  -> FAIL: a reflectively-accessed serial driver method was "
+                  "obfuscated (serial-USB downloads will crash; see issue #318)")
+        all_ok = all_ok and ok
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_proguard_serial_keep.py
+++ b/scripts/check_proguard_serial_keep.py
@@ -21,9 +21,12 @@ Because the lookup is by method name on a runtime ``Class`` object, the precise
 thing that must survive is the *method name*, not the class name -- R8 may
 freely rename synthetic helper classes (e.g. ``$$ExternalSyntheticLambda``) in
 the same package without harm. This script reads the R8 ``mapping.txt`` from a
-release build and fails (exit code 1) if a reflectively-accessed method on a
-driver class was renamed, or if it vanished entirely. It is the build-artifact
-counterpart to ``check_16kb_alignment`` and is dependency-free (pure stdlib).
+release build and fails (exit code 1) if a reflectively-accessed driver method
+was renamed, or was stripped from an obfuscated mapping. A mapping showing no
+obfuscation at all only warns, since it cannot prove the drivers survived
+(Submersion's release builds always obfuscate, so CI never hits that case). It
+is the build-artifact counterpart to ``check_16kb_alignment`` and is
+dependency-free (pure stdlib).
 
 Usage:
     check_proguard_serial_keep.py <mapping.txt>

--- a/scripts/check_proguard_serial_keep_test.py
+++ b/scripts/check_proguard_serial_keep_test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Unit tests for check_proguard_serial_keep.py.
+
+Run: python3 scripts/check_proguard_serial_keep_test.py
+
+These exercise the R8 mapping.txt parser and its pass/fail contract, including
+the cases the Build Android integration step cannot reproduce (a renamed
+method, stripped drivers) and the synthetic-lambda case that must NOT trip a
+false positive.
+"""
+
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+
+# Load the sibling script by path so the test runs from any working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_proguard_serial_keep",
+    os.path.join(_HERE, "check_proguard_serial_keep.py"),
+)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+
+# A driver class kept verbatim by `-keep class ...driver.** { *; }`: it maps to
+# itself and its reflected methods keep their names.
+GREEN = """\
+com.example.app.MainActivity -> a.b.c:
+    void onCreate(android.os.Bundle) -> a
+com.hoho.android.usbserial.driver.ProlificSerialDriver -> com.hoho.android.usbserial.driver.ProlificSerialDriver:
+    1:1:java.util.Map getSupportedDevices() -> getSupportedDevices
+    2:2:boolean probe(android.hardware.usb.UsbDevice) -> probe
+    3:5:void <init>(android.hardware.usb.UsbDevice) -> <init>
+"""
+
+# The issue #318 signature: no keep rule, so R8 renamed the class to P5.a and
+# getSupportedDevices/probe to short names.
+RED = """\
+com.example.app.MainActivity -> a.b.c:
+    void onCreate(android.os.Bundle) -> a
+com.hoho.android.usbserial.driver.ProlificSerialDriver -> P5.a:
+    1:1:java.util.Map getSupportedDevices() -> a
+    2:2:boolean probe(android.hardware.usb.UsbDevice) -> b
+"""
+
+
+class AnalyzeTests(unittest.TestCase):
+    def test_green_preserves_reflected_methods(self):
+        r = guard.analyze(GREEN)
+        self.assertTrue(r["minify_ran"])
+        self.assertEqual(r["renamed"], [])
+        self.assertIn(
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver",
+            r["canary_classes"],
+        )
+        # getSupportedDevices and probe both identity-mapped.
+        self.assertEqual({m for _, m in r["kept"]}, {"getSupportedDevices", "probe"})
+
+    def test_red_flags_renamed_methods(self):
+        r = guard.analyze(RED)
+        self.assertTrue(r["minify_ran"])
+        renamed_methods = {m for _, m, _ in r["renamed"]}
+        self.assertEqual(renamed_methods, {"getSupportedDevices", "probe"})
+
+    def test_synthetic_lambda_is_not_flagged(self):
+        # R8 legitimately renames its own synthetic helper classes inside the
+        # kept package; that must NOT be treated as a broken driver.
+        text = GREEN + (
+            "com.hoho.android.usbserial.driver."
+            "ProlificSerialDriver$ProlificSerialPort$$ExternalSyntheticLambda0"
+            " -> com.hoho.android.usbserial.driver.a:\n"
+        )
+        r = guard.analyze(text)
+        self.assertEqual(r["renamed"], [])
+
+    def test_no_obfuscation_sets_minify_false(self):
+        text = (
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver -> "
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver:\n"
+            "    java.util.Map getSupportedDevices() -> getSupportedDevices\n"
+        )
+        r = guard.analyze(text)
+        self.assertFalse(r["minify_ran"])
+
+    def test_comment_and_blank_lines_are_skipped(self):
+        # mapping.txt starts with a "# compiler:" banner and may have blanks.
+        r = guard.analyze("# compiler: R8\n\n" + GREEN)
+        self.assertEqual(r["renamed"], [])
+        self.assertTrue(r["minify_ran"])
+
+
+class MethodNameTests(unittest.TestCase):
+    def test_strips_line_range_and_return_type(self):
+        self.assertEqual(
+            guard._method_name("1:1:java.util.Map getSupportedDevices()"),
+            "getSupportedDevices",
+        )
+
+    def test_handles_inlined_owner_qualifier(self):
+        self.assertEqual(
+            guard._method_name(
+                "0:2:com.hoho.android.usbserial.driver.UsbSerialDriver getDriver()"
+            ),
+            "getDriver",
+        )
+
+    def test_fields_return_none(self):
+        self.assertIsNone(guard._method_name("int USB_READ_TIMEOUT_MILLIS"))
+
+    def test_empty_signature_returns_none(self):
+        # Defensive: a "()" with nothing before it yields no name token.
+        self.assertIsNone(guard._method_name("()"))
+
+
+class CheckMappingTests(unittest.TestCase):
+    def _run(self, text):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(text)
+            path = fh.name
+        try:
+            return guard.check_mapping(path)
+        finally:
+            os.unlink(path)
+
+    def test_green_passes(self):
+        ok, lines = self._run(GREEN)
+        self.assertTrue(ok)
+        self.assertTrue(any("preserved on 1 drivers" in line for line in lines))
+
+    def test_red_fails(self):
+        ok, lines = self._run(RED)
+        self.assertFalse(ok)
+        self.assertTrue(any("getSupportedDevices" in line for line in lines))
+
+    def test_no_minification_warns_but_passes(self):
+        ok, lines = self._run(
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver -> "
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver:\n"
+            "    java.util.Map getSupportedDevices() -> getSupportedDevices\n"
+        )
+        self.assertTrue(ok)
+        self.assertTrue(any("WARN" in line for line in lines))
+
+    def test_stripped_drivers_fail(self):
+        # Obfuscation ran (MainActivity renamed) but no driver declares
+        # getSupportedDevices -> the drivers were stripped or renamed away.
+        ok, lines = self._run("com.example.app.MainActivity -> a.b.c:\n"
+                              "    void onCreate(android.os.Bundle) -> a\n")
+        self.assertFalse(ok)
+        self.assertTrue(any("stripped" in line for line in lines))
+
+
+class MainTests(unittest.TestCase):
+    def _main(self, *args):
+        """Run main() with its console output captured; return (code, output)."""
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = guard.main(["check_proguard_serial_keep.py", *args])
+        return code, buf.getvalue()
+
+    def _file(self, text):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(text)
+            self.addCleanup(os.unlink, fh.name)
+            return fh.name
+
+    def test_no_args_prints_usage(self):
+        code, out = self._main()
+        self.assertEqual(code, 2)
+        self.assertIn("Usage:", out)
+
+    def test_missing_file_is_error(self):
+        code, out = self._main("/no/such/mapping.txt")
+        self.assertEqual(code, 1)
+        self.assertIn("ERROR reading", out)
+
+    def test_green_file_exits_zero_and_reports_pass(self):
+        code, out = self._main(self._file(GREEN))
+        self.assertEqual(code, 0)
+        self.assertIn("PASS", out)
+
+    def test_red_file_exits_one_and_reports_fail(self):
+        code, out = self._main(self._file(RED))
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check_proguard_serial_keep_test.py
+++ b/scripts/check_proguard_serial_keep_test.py
@@ -138,12 +138,34 @@ class CheckMappingTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertTrue(any("getSupportedDevices" in line for line in lines))
 
-    def test_no_minification_warns_but_passes(self):
+    def test_member_renamed_without_class_rename_fails(self):
+        # R8 can rename getSupportedDevices while KEEPING the class name (partial
+        # keep rules / -keepnames). No class is renamed, so the obfuscation-ran
+        # heuristic is false -- but this is still the #318 regression and must
+        # fail, not be skipped. (Regression test for the early-return bug.)
+        ok, lines = self._run(
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver -> "
+            "com.hoho.android.usbserial.driver.ProlificSerialDriver:\n"
+            "    java.util.Map getSupportedDevices() -> a\n"
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("getSupportedDevices" in line for line in lines))
+
+    def test_non_obfuscated_with_drivers_present_passes(self):
+        # A shrink-only/non-obfuscated mapping that still lists the driver and
+        # its un-renamed getSupportedDevices is genuinely fine.
         ok, lines = self._run(
             "com.hoho.android.usbserial.driver.ProlificSerialDriver -> "
             "com.hoho.android.usbserial.driver.ProlificSerialDriver:\n"
             "    java.util.Map getSupportedDevices() -> getSupportedDevices\n"
         )
+        self.assertTrue(ok)
+        self.assertTrue(any("preserved" in line for line in lines))
+
+    def test_warns_when_no_obfuscation_and_no_drivers(self):
+        # Cannot prove the drivers survived; warn rather than pass or fail.
+        ok, lines = self._run("com.example.Foo -> com.example.Foo:\n"
+                              "    void bar() -> bar\n")
         self.assertTrue(ok)
         self.assertTrue(any("WARN" in line for line in lines))
 


### PR DESCRIPTION
## The second root cause of #318

After the 16 KB-alignment fix shipped (along with the global error logging and the graceful Kotlin `catch(Throwable)`), the reporter's symptom **changed** from a silent process death with empty logs to a logged, reported error — proof that hardening worked and let us see the real failure:

```
[LDC] [ERROR] download crashed: RuntimeException: java.lang.NoSuchMethodException: P5.a.getSupportedDevices []
[LDC] [ERROR] Download failed (download_error): Download failed unexpectedly (RuntimeException).
```

**Root cause:** PR #364 vendored `usb-serial-for-android` (`com.hoho.android.usbserial.driver.*`) as source to support serial-over-USB dive computers (Mares Puck Pro). That library discovers drivers purely by **reflection**:

- `ProbeTable.addDriver()` → `Class.getMethod("getSupportedDevices")` / `("probe")`
- `UsbSerialProber.probeDevice()` → `Class.getConstructor(UsbDevice.class)`

Flutter release builds run R8 with obfuscation enabled by default (`FlutterPlugin.kt` sets `isMinifyEnabled = true` when `shouldShrinkResources` is true — the default; the app's own Gradle never sets it). R8 renamed `getSupportedDevices` (the class became `P5.a`), so the reflective lookup threw `NoSuchMethodException`, wrapped in `RuntimeException` at `ProbeTable.java:54`. It fires during prober construction from class literals, so it crashes **whether or not the watch is attached** — exactly as reported.

The library normally ships consumer ProGuard rules inside its AAR; vendoring the source left them behind. This is the same bug class as #105 ("JNI interface being obfuscated"), in the same file.

## The fix

Add the keep rule to the plugin's `consumer-rules.pro`:

```proguard
-keep class com.hoho.android.usbserial.driver.** { *; }
```

## Regression guard

`scripts/check_proguard_serial_keep.py` parses the R8 `mapping.txt` and fails if a reflectively-accessed driver method was obfuscated. It's wired into the Build Android CI job, right after the existing 16 KB check (the same "ship-broken-undetected" pattern). Because the lookup is by method name on a runtime `Class` object, the guard targets the **method names**, not class names — R8 may legitimately rename synthetic `$$ExternalSyntheticLambda` classes in the kept package.

## Verification

Built `flutter build apk --release` and inspected R8's actual `mapping.txt`:

- **GREEN:** `getSupportedDevices()` is identity-mapped (preserved) on all **7 drivers**; 14 reflected methods kept. Other classes are obfuscated, so minification genuinely ran — the check is meaningful. Guard → exit 0.
- **RED:** a synthetic mapping mirroring the production `getSupportedDevices -> a` signature → guard exit 1. (The production log is the real-world RED.)

```
$ python3 scripts/check_proguard_serial_keep.py build/app/outputs/mapping/release/mapping.txt
  ok    getSupportedDevices() preserved on 7 drivers; 14 reflected methods kept un-obfuscated
  -> PASS: usb-serial-for-android drivers survive R8 obfuscation
```

## Tests & coverage

- `scripts/check_proguard_serial_keep_test.py` (19 cases, stdlib `unittest`, no deps) covers the GREEN/RED paths, the synthetic-`$$ExternalSyntheticLambda` false-positive, stripped-driver detection, the no-obfuscation warn, a member-renamed-without-class-rename regression, and the mapping-line parser.
- A dedicated **Script Tests** CI job runs the guard under `coverage.py` and uploads the report (scoped to the guard, ~99%) to Codecov, so it counts toward patch coverage. The Codecov patch target is raised from 80% to 90%.
- Review fix: `check_mapping()` now evaluates renamed reflected methods unconditionally (it previously returned early when no class-name obfuscation was present, which could skip a method R8 renamed while keeping the class name).

## Notes

- Final on-device confirmation on the reporter's Xiaomi 15T Pro + Puck Pro needs a release they install; the `mapping.txt` proof is the strongest evidence short of hardware.
- After this, the next possible failure on that path is the separate #334 serial-read truncation, addressed elsewhere.

Addresses #318 (recommend keeping the issue open until the reporter confirms on hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
