### PR TITLE
perf(sync): S3 — offload base-apply parse to a worker isolate

### DIFF
--- a/docs/superpowers/plans/2026-06-24-s3-sync-cpu-isolate.md
+++ b/docs/superpowers/plans/2026-06-24-s3-sync-cpu-isolate.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Task 5 (measurement) is interactive/main-session — it runs the app + `vmcap.dart` and cannot be done by a subagent.
 
-**Goal:** Move the base-apply's pure-CPU work (file read + SHA-256 + JSON parse) into a pull-based streaming worker isolate so background sync stops stuttering the UI; DB writes/merge stay pinned to the main isolate, with a parity test and inline fallback guaranteeing correctness.
+**Goal:** Move the base-apply's pure-CPU work (file read + JSON parse; the whole-file SHA-256 fold-in is a deferred follow-up — it still runs in `BasePartFileSink.assemble` on main) into a pull-based streaming worker isolate so background sync stops stuttering the UI; DB writes/merge stay pinned to the main isolate, with a parity test and inline fallback guaranteeing correctness.
 
 **Architecture:** A long-lived `Isolate.spawn` worker reads + parses the base file and streams decoded `Map<String,dynamic>` rows to the main isolate over `SendPort`s, backpressured (at most one batch in flight → #358 memory bound preserved). `_applyRemoteBaseFile` swaps its three inline `BaseJsonStreamReader().parse(file.openRead(), ...)` calls for `BaseParseClient` calls, keeping every `onScalar`/`onRow`/merge body unchanged; on any worker failure it falls back to the current inline path.
 
@@ -425,7 +425,7 @@ git commit -m "perf(sync): offload base-apply parse to a worker isolate with inl
 ### Task 5: Measure (interactive, main session)
 
 - [ ] **Step 1:** `flutter test` (full pre-push gate) → green.
-- [ ] **Step 2:** `flutter run --profile -d macos`; with `scratchpad/vmcap.dart` (`clear` → trigger a base-adopting sync → `read`), confirm `pread` / SHA-256 / `BaseJsonStreamReader` are **gone from the UI-isolate** CPU samples and frames stay smooth during the apply.
+- [ ] **Step 2:** `flutter run --profile -d macos`; with `scratchpad/vmcap.dart` (`clear` → trigger a base-adopting sync → `read`), confirm `pread` / `BaseJsonStreamReader` parse + per-row `jsonDecode` are **gone from the UI-isolate** CPU samples (the whole-file SHA-256 in `BasePartFileSink.assemble` stays on main until the deferred fold-in) and frames stay smooth during the apply.
 - [ ] **Step 3:** Record before/after in `docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md` under a "Measurement result" heading; commit.
 
 ---

--- a/docs/superpowers/plans/2026-06-24-s3-sync-cpu-isolate.md
+++ b/docs/superpowers/plans/2026-06-24-s3-sync-cpu-isolate.md
@@ -1,0 +1,439 @@
+# S3 — Sync Base-Apply Isolate Offload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Task 5 (measurement) is interactive/main-session — it runs the app + `vmcap.dart` and cannot be done by a subagent.
+
+**Goal:** Move the base-apply's pure-CPU work (file read + SHA-256 + JSON parse) into a pull-based streaming worker isolate so background sync stops stuttering the UI; DB writes/merge stay pinned to the main isolate, with a parity test and inline fallback guaranteeing correctness.
+
+**Architecture:** A long-lived `Isolate.spawn` worker reads + parses the base file and streams decoded `Map<String,dynamic>` rows to the main isolate over `SendPort`s, backpressured (at most one batch in flight → #358 memory bound preserved). `_applyRemoteBaseFile` swaps its three inline `BaseJsonStreamReader().parse(file.openRead(), ...)` calls for `BaseParseClient` calls, keeping every `onScalar`/`onRow`/merge body unchanged; on any worker failure it falls back to the current inline path.
+
+**Tech Stack:** Dart `dart:isolate` (`Isolate.spawn`, `ReceivePort`/`SendPort`), the existing `BaseJsonStreamReader`, Drift, `flutter_test`.
+
+## Global Constraints
+
+- **TDD** (failing test first), **`dart format .`** before push, **no `Co-Authored-By`** trailer.
+- **Parity is non-negotiable:** worker-fed apply must be **row-identical** to the inline apply. The worker must emit rows in **exact file order** so per-table batching and `mergeOrder` (parents-before-children) are preserved.
+- **The worker is a pure optimization:** any worker failure (spawn/parse/checksum/crash/timeout) falls back to the existing inline `_applyRemoteBaseFile`; sync must never fail or lose data because of the isolate.
+- **Memory bound (#358):** pull-based backpressure — at most one batch (≤500 rows) in flight.
+- Spec: `docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md`.
+
+## File Structure
+
+- Create `lib/core/services/sync/changeset_log/base_parse_worker.dart` — the isolate entrypoint (top-level worker function) + the wire-protocol message constants. One responsibility: parse a base file off-isolate and serve rows.
+- Create `lib/core/services/sync/changeset_log/base_parse_client.dart` — the main-side `BaseParseClient` (spawn/handshake/`readScalarsAndDeletions`/`dataRows`/`dispose`), hiding the ports.
+- Modify `lib/core/services/sync/sync_service.dart:966-1116` — `_applyRemoteBaseFile` to use `BaseParseClient` with inline fallback. Keep the existing inline body as `_applyRemoteBaseFileInline` (the fallback).
+- Tests: `test/core/services/sync/changeset_log/base_parse_client_test.dart` (protocol + parse-parity), and a base-apply parity/fallback test alongside the existing sync-service base tests (find with `grep -rl _applyRemoteBaseFile test/` — likely `test/core/services/sync/...base...test.dart`).
+
+---
+
+### Task 1: BaseParseClient spawn / handshake / dispose
+
+**Files:**
+- Create: `lib/core/services/sync/changeset_log/base_parse_worker.dart`
+- Create: `lib/core/services/sync/changeset_log/base_parse_client.dart`
+- Test: `test/core/services/sync/changeset_log/base_parse_client_test.dart`
+
+**Interfaces:**
+- Produces: `class BaseParseClient { static Future<BaseParseClient> spawn(String filePath); Future<void> dispose(); }`. Worker entrypoint `void baseParseWorkerMain(SendPort mainSendPort)`.
+
+- [ ] **Step 1: Write the failing test** — spawn on a tiny valid base file, then dispose cleanly.
+
+```dart
+// base_parse_client_test.dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
+
+File _writeBase(Directory dir, Map<String, dynamic> doc) {
+  final f = File(p.join(dir.path, 'base.json'));
+  f.writeAsStringSync(jsonEncode(doc));
+  return f;
+}
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('spawns and disposes without hanging', () async {
+    final f = _writeBase(tmp, {'exportedAt': 1, 'deletions': {}, 'data': {}});
+    final client = await BaseParseClient.spawn(f.path);
+    await client.dispose();
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `flutter test test/core/services/sync/changeset_log/base_parse_client_test.dart` → FAIL (`base_parse_client.dart` not found).
+
+- [ ] **Step 3: Implement the worker + client handshake**
+
+```dart
+// base_parse_worker.dart
+import 'dart:io';
+import 'dart:isolate';
+
+/// Wire protocol (all messages are plain maps / sendports — isolate-sendable).
+/// main -> worker: {'cmd': 'deletions'} | {'cmd': 'dataRows', 'tables': List<String>} |
+///                 {'cmd': 'next'} | {'cmd': 'dispose'}
+/// worker -> main: {'type': 'ready', 'port': SendPort}
+///                 {'type': 'deletions', 'exportedAt': int, 'rows': List} (table+row pairs)
+///                 {'type': 'batch', 'rows': List, 'done': bool}
+///                 {'type': 'error', 'message': String}
+void baseParseWorkerMain(List<Object> args) async {
+  final mainSendPort = args[0] as SendPort;
+  final filePath = args[1] as String;
+  final rx = ReceivePort();
+  mainSendPort.send({'type': 'ready', 'port': rx.sendPort});
+  await for (final msg in rx) {
+    final m = msg as Map;
+    if (m['cmd'] == 'dispose') break;
+    // command handlers added in Tasks 2-3
+  }
+  rx.close();
+  Isolate.exit();
+}
+```
+
+```dart
+// base_parse_client.dart
+import 'dart:async';
+import 'dart:isolate';
+import 'base_parse_worker.dart';
+
+class BaseParseClient {
+  BaseParseClient._(this._isolate, this._toWorker, this._fromWorker, this._sub);
+  final Isolate _isolate;
+  final SendPort _toWorker;
+  final ReceivePort _fromWorker;
+  final StreamSubscription _sub;
+  final _inbox = StreamController<Map>(sync: true);
+
+  static Future<BaseParseClient> spawn(String filePath) async {
+    final fromWorker = ReceivePort();
+    final ready = Completer<SendPort>();
+    late StreamSubscription sub;
+    late BaseParseClient client;
+    sub = fromWorker.listen((msg) {
+      final m = msg as Map;
+      if (m['type'] == 'ready') {
+        ready.complete(m['port'] as SendPort);
+      } else {
+        client._inbox.add(m);
+      }
+    });
+    final isolate = await Isolate.spawn(
+      baseParseWorkerMain,
+      <Object>[fromWorker.sendPort, filePath],
+      onError: fromWorker.sendPort, // uncaught worker errors arrive as a message
+    );
+    final toWorker = await ready.future;
+    client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
+    return client;
+  }
+
+  Future<void> dispose() async {
+    _toWorker.send({'cmd': 'dispose'});
+    await _sub.cancel();
+    _fromWorker.close();
+    await _inbox.close();
+    _isolate.kill(priority: Isolate.immediate);
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — same command → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/sync/changeset_log/base_parse_worker.dart \
+        lib/core/services/sync/changeset_log/base_parse_client.dart \
+        test/core/services/sync/changeset_log/base_parse_client_test.dart
+git commit -m "feat(sync): BaseParseClient isolate spawn/handshake/dispose"
+```
+
+---
+
+### Task 2: Pass 1 — scalars + deletions (`readScalarsAndDeletions`)
+
+**Files:** Modify both `base_parse_worker.dart` and `base_parse_client.dart`; add tests.
+
+**Interfaces:**
+- Produces: `Future<({int exportedAt, List<({String table, Map<String,dynamic> row})> deletions})> BaseParseClient.readScalarsAndDeletions()`.
+
+- [ ] **Step 1: Write the failing test** — worker-parsed deletions/exportedAt must equal a direct inline `BaseJsonStreamReader` parse.
+
+```dart
+test('readScalarsAndDeletions matches an inline parse', () async {
+  final doc = {
+    'exportedAt': 42,
+    'deletions': {
+      'dives': [{'id': 'd1', 'deletedAt': 100}, {'id': 'd2', 'deletedAt': 200}],
+    },
+    'data': {'dives': [{'id': 'a', 'updatedAt': 1}]},
+  };
+  final f = _writeBase(tmp, doc);
+  final client = await BaseParseClient.spawn(f.path);
+  final r = await client.readScalarsAndDeletions();
+  await client.dispose();
+
+  expect(r.exportedAt, 42);
+  expect(r.deletions.map((e) => e.table).toList(), ['dives', 'dives']);
+  expect(r.deletions.map((e) => e.row['id']).toList(), ['d1', 'd2']);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (`readScalarsAndDeletions` undefined).
+
+- [ ] **Step 3: Implement** — worker handler runs the existing reader; client sends the command and awaits one reply.
+
+Worker (inside the `await for`, handle `cmd == 'deletions'`):
+
+```dart
+import 'dart:convert';
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+// ...
+if (m['cmd'] == 'deletions') {
+  try {
+    var exportedAt = 0;
+    final rows = <Map<String, dynamic>>[];
+    await BaseJsonStreamReader().parse(
+      File(filePath).openRead(),
+      onScalar: (key, raw) async {
+        if (key == 'exportedAt') {
+          exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+        }
+      },
+      wantRows: (section, _) => section == 'deletions',
+      onRow: (section, table, rowBytes) async {
+        rows.add({'table': table, 'row': jsonDecode(utf8.decode(rowBytes))});
+      },
+    );
+    mainSendPort2.send({'type': 'deletions', 'exportedAt': exportedAt, 'rows': rows});
+  } catch (e) {
+    mainSendPort2.send({'type': 'error', 'message': e.toString()});
+  }
+  continue;
+}
+```
+
+(Use the `SendPort` the worker received back from main in the handshake — store it once; named `mainSendPort2` above for clarity; wire it from `args[0]`.)
+
+Client:
+
+```dart
+Future<({int exportedAt, List<({String table, Map<String, dynamic> row})> deletions})>
+    readScalarsAndDeletions() async {
+  _toWorker.send({'cmd': 'deletions'});
+  final m = await _nextMessage();
+  if (m['type'] == 'error') throw BaseParseException(m['message'] as String);
+  final rows = (m['rows'] as List)
+      .map((e) => (table: (e as Map)['table'] as String,
+                   row: (e['row'] as Map).cast<String, dynamic>()))
+      .toList();
+  return (exportedAt: m['exportedAt'] as int, deletions: rows);
+}
+
+Future<Map> _nextMessage() {
+  final c = Completer<Map>();
+  late StreamSubscription s;
+  s = _inbox.stream.listen((m) { s.cancel(); c.complete(m); });
+  return c.future;
+}
+```
+
+Add `class BaseParseException implements Exception { final String message; BaseParseException(this.message); @override String toString() => 'BaseParseException: $message'; }`.
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Commit** — `feat(sync): worker Pass 1 (scalars + deletions)`.
+
+---
+
+### Task 3: Pass 2/3 — streaming data rows with backpressure (`dataRows`)
+
+**Files:** Modify worker + client; add tests.
+
+**Interfaces:**
+- Produces: `Stream<({String table, Map<String,dynamic> row})> BaseParseClient.dataRows(Set<String> tables)` — emits `data`-section rows whose table is in `tables`, in file order, pull-backpressured.
+
+- [ ] **Step 1: Write the failing tests** — (a) streamed rows match an inline parse for a table filter; (b) backpressure holds (worker doesn't race ahead).
+
+```dart
+test('dataRows streams the filtered data rows in file order', () async {
+  final doc = {
+    'exportedAt': 1, 'deletions': {},
+    'data': {
+      'dives': [for (var i = 0; i < 1200; i++) {'id': 'd$i', 'updatedAt': i}],
+      'sites': [{'id': 's1', 'updatedAt': 1}],
+    },
+  };
+  final f = _writeBase(tmp, doc);
+  final client = await BaseParseClient.spawn(f.path);
+  final got = <String>[];
+  await for (final r in client.dataRows({'dives'})) {
+    got.add(r.row['id'] as String);
+  }
+  await client.dispose();
+  expect(got.length, 1200);
+  expect(got.first, 'd0');
+  expect(got.last, 'd1199'); // file order preserved across batch boundaries
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (`dataRows` undefined).
+
+- [ ] **Step 3: Implement** — the backpressure is the crux: the worker's `onRow` accumulates a batch and, when full, sends it and **awaits a Completer that the next `'next'` command completes** — which pauses `await for` (and thus the file read). The client exposes this as a paused `Stream`.
+
+Worker (`cmd == 'dataRows'`): keep a `Completer<void> nextWanted` resumed by `cmd == 'next'`.
+
+```dart
+if (m['cmd'] == 'dataRows') {
+  final tables = (m['tables'] as List).cast<String>().toSet();
+  try {
+    var batch = <Map<String, dynamic>>[];
+    Completer<void>? paused;
+    // a side-listener on rx completes `paused` when 'next' arrives:
+    // simplest: track a queue of pending 'next' tokens.
+    await BaseJsonStreamReader().parse(
+      File(filePath).openRead(),
+      wantRows: (section, table) => section == 'data' && tables.contains(table),
+      onRow: (section, table, rowBytes) async {
+        batch.add({'table': table, 'row': jsonDecode(utf8.decode(rowBytes))});
+        if (batch.length >= 500) {
+          mainSendPort2.send({'type': 'batch', 'rows': batch, 'done': false});
+          batch = <Map<String, dynamic>>[];
+          await _awaitNext();           // <- pauses await-for => pauses file read
+        }
+      },
+    );
+    mainSendPort2.send({'type': 'batch', 'rows': batch, 'done': true});
+  } catch (e) {
+    mainSendPort2.send({'type': 'error', 'message': e.toString()});
+  }
+  continue;
+}
+```
+
+`_awaitNext()` resolves on the next `{'cmd':'next'}`. Implement with a single-slot completer the command loop completes; if a `next` arrives before a pause, record it as a pending credit so no deadlock. (This single-slot credit handshake is the one piece to iterate against the test in Step 4.)
+
+Client — a `StreamController` whose `onListen`/`onResume` send `{'cmd':'next'}` and whose handler feeds rows; request the first batch on listen, request another each time the buffer drains:
+
+```dart
+Stream<({String table, Map<String, dynamic> row})> dataRows(Set<String> tables) {
+  final controller = StreamController<({String table, Map<String, dynamic> row})>();
+  var done = false;
+  StreamSubscription? sub;
+  void requestBatch() => _toWorker.send({'cmd': 'next'});
+  controller.onListen = () {
+    _toWorker.send({'cmd': 'dataRows', 'tables': tables.toList()});
+    sub = _inbox.stream.listen((m) async {
+      if (m['type'] == 'error') {
+        controller.addError(BaseParseException(m['message'] as String));
+        await controller.close();
+        return;
+      }
+      for (final e in (m['rows'] as List)) {
+        controller.add((table: (e as Map)['table'] as String,
+                        row: (e['row'] as Map).cast<String, dynamic>()));
+      }
+      done = m['done'] as bool;
+      if (done) {
+        await controller.close();
+      } else {
+        requestBatch(); // pull the next batch (backpressure: only after this one is delivered)
+      }
+    });
+  };
+  controller.onCancel = () => sub?.cancel();
+  return controller.stream;
+}
+```
+
+(Note: the first `dataRows` worker reply is a full batch; `requestBatch` after each non-final batch is the pull. The worker's `await _awaitNext()` blocks its parse until that `next` arrives — the end-to-end backpressure. Verify the at-most-one-batch invariant in Step 1's second test.)
+
+- [ ] **Step 4: Run to verify it passes** — PASS (both tests). Iterate the credit handshake until the file-order + backpressure tests are green.
+
+- [ ] **Step 5: Commit** — `feat(sync): worker Pass 2/3 streaming dataRows with backpressure`.
+
+---
+
+### Task 4: Integrate into `_applyRemoteBaseFile` with inline fallback
+
+**Files:** Modify `sync_service.dart:966-1116`; add a parity + fallback test.
+
+**Interfaces:**
+- Consumes: `BaseParseClient` (Tasks 1-3).
+
+- [ ] **Step 1: Write the failing parity + fallback tests**
+
+```dart
+// in the sync-service base-apply test file (follow its existing harness for building
+// a SyncService + an in-memory AppDatabase; mirror the existing _applyRemoteBaseFile test).
+test('worker-fed base apply is row-identical to inline', () async {
+  // Build a base file with deletions + parent/child data rows. Apply it to DB-A via
+  // the inline path (force fallback) and to DB-B via the worker path; assert the two
+  // DBs have identical rows for every synced table.
+});
+test('a worker failure falls back to inline and still applies', () async {
+  // Point the client at a path that makes the worker throw (or inject a spawn failure);
+  // assert the apply still completes with the inline result and no exception escapes.
+});
+```
+
+(Use the existing base-apply test harness; the parity assertion compares `getAllX().toJson()` lists between the two databases.)
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (no worker path yet).
+
+- [ ] **Step 3: Implement** — rename the current body to `_applyRemoteBaseFileInline` (unchanged), and add a worker path that reuses the SAME `onScalar`/`onRow`/merge logic, fed by the client:
+
+```dart
+Future<_MergeResult> _applyRemoteBaseFile(String filePath, DateTime? localLastSync) async {
+  BaseParseClient? client;
+  try {
+    client = await BaseParseClient.spawn(filePath);
+    return await _applyRemoteBaseFileViaWorker(client, filePath, localLastSync);
+  } catch (e, st) {
+    LoggerService.warning('Base apply worker failed; falling back to inline', e, st);
+    return _applyRemoteBaseFileInline(filePath, localLastSync);
+  } finally {
+    await client?.dispose();
+  }
+}
+```
+
+In `_applyRemoteBaseFileViaWorker`, replace the three `BaseJsonStreamReader().parse(file.openRead(), ...)` calls:
+- Pass 1 → `final p1 = await client.readScalarsAndDeletions();` then build `deletions`/`baseExportedAt` from `p1` using the existing `SyncDeletion.fromJson` logic (lines 985-996).
+- Pass 2 → `await for (final r in client.dataRows(pass2Tables)) { ...existing onRow body... }` where `pass2Tables = {parentTypes ∪ deletionIds.keys} ∩ entityHasUpdatedAt.keys`.
+- Pass 3 (inside the transaction) → `await for (final r in client.dataRows(entityHasUpdatedAt.keys.toSet())) { ...existing batching/flush body... }`.
+
+Keep `flush`, `_mergeEntity`, `_applyRemoteDeletions`, `repairDanglingForeignKeys`, and `applyInDeferredFkTransaction` exactly as they are.
+
+- [ ] **Step 4: Run to verify it passes** — parity + fallback tests PASS; then run the whole sync test dir: `flutter test test/core/services/sync/`.
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+dart format .
+git add lib/core/services/sync/sync_service.dart test/core/services/sync/
+git commit -m "perf(sync): offload base-apply parse to a worker isolate with inline fallback"
+```
+
+---
+
+### Task 5: Measure (interactive, main session)
+
+- [ ] **Step 1:** `flutter test` (full pre-push gate) → green.
+- [ ] **Step 2:** `flutter run --profile -d macos`; with `scratchpad/vmcap.dart` (`clear` → trigger a base-adopting sync → `read`), confirm `pread` / SHA-256 / `BaseJsonStreamReader` are **gone from the UI-isolate** CPU samples and frames stay smooth during the apply.
+- [ ] **Step 3:** Record before/after in `docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md` under a "Measurement result" heading; commit.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Worker+client (spec §Components 1-2) → Tasks 1-3. Pull/backpressure (spec §Architecture) → Task 3. Integration + inline fallback (spec §Correctness) → Task 4. Parity test (spec centerpiece) + fallback tests → Task 4. Measurement (spec §Testing) → Task 5. Checksum fold-in: deferred into the worker's read as a follow-up within Task 2/3 (note: the design's whole-file SHA validation can be added to the worker's first read; if the existing per-part `assemble` checks are deemed sufficient by review, the whole-file check stays in `assemble` — flagged, not silently dropped).
+
+**Placeholder scan:** Tasks 1-3 carry runnable code. The two genuinely iterative spots are called out explicitly, not hidden: the worker's single-slot `next` credit handshake (Task 3 Step 3) and the parity-test harness (Task 4 Step 1, which defers to the existing base-apply test file's setup rather than inventing one). Neither is a vague "handle X" — both name the exact mechanism and the test that pins it.
+
+**Type/name consistency:** `BaseParseClient.spawn`/`readScalarsAndDeletions`/`dataRows`/`dispose` and the `({String table, Map<String,dynamic> row})` record type are identical across Tasks 1-4. The wire-message `type`/`cmd` keys match between worker and client. `_applyRemoteBaseFileInline` (fallback) vs `_applyRemoteBaseFileViaWorker` (new) are distinct and both referenced from `_applyRemoteBaseFile`.

--- a/docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md
+++ b/docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md
@@ -1,0 +1,76 @@
+# S3 — Offload the Sync Base-Apply CPU to a Worker Isolate — Design
+
+**Date:** 2026-06-24
+**Status:** Design approved
+**Branch/worktree:** `worktree-s3-sync-cpu-isolate` (off `origin/main`, independent of PR #410 / #412)
+**Parent:** Phase 2 of the app performance investigation (`2026-06-24-app-performance-investigation-design.md`, findings in `2026-06-24-app-performance-findings.md`)
+
+## Goal
+
+Stop background sync from stuttering the UI. Measurement (Phase 1 + the D1a re-measure) showed the on-launch / on-resume sync runs a base-file apply **entirely on the main/UI isolate** — `pread` (file read) ~448 ms, SHA-256 ~217 ms, `BaseJsonStreamReader` parse ~324 ms, plus ~245 ms of DB writes — dominating the cold start and firing on every window focus. Move the pure-CPU work (read + checksum + parse) to a worker isolate so the main isolate is free to render; only the irreducible DB writes stay on main.
+
+## The hard constraint
+
+The DB writes cannot leave the main isolate. The merge (`_mergeEntity`, `sync_service.dart`) reads the current local row per record (`fetchRecord`) to make the LWW/HLC decision, then upserts — all on the deliberately **synchronous main-isolate `NativeDatabase`** (`database_service.dart:98`), inside one transaction. So "offload sync" means offloading the *parse/checksum/read*, never the writes or the merge.
+
+## What is offloadable vs pinned (from the pipeline map)
+
+- **Offloadable (pure CPU, no DB):** the base file `pread`, the whole-file SHA-256, the `BaseJsonStreamReader` byte-FSM, and per-row `jsonDecode`. The data crossing the boundary is plain (`Map<String,dynamic>` rows, `Map` deletions/parent-updatedAt) — fully sendable.
+- **Pinned to main (DB):** `_mergeEntity` (per-record `fetchRecord` + `upsertRecord` + `SyncClock.receive` + conflict writes), `_applyRemoteDeletions`, `repairDanglingForeignKeys`, the `applyInDeferredFkTransaction` transaction.
+
+## Scope
+
+- **In scope:** `_applyRemoteBaseFile` (`sync_service.dart`) — the base apply, the measured hot spot. Always large, so always worth the isolate.
+- **Deferred (YAGNI):** the **delta path** (`_applyRemotePayload`). Deltas are usually tiny; `compute()`'s isolate-spawn overhead would exceed the decode cost. Only rare large catch-up deltas would benefit — a future follow-up, not S3.
+- **Out of scope:** moving the DB off the main isolate (S4 root-cause lever), and the open-transaction-blocks-reads issue (S4/S1) — both separate.
+
+## Architecture: a per-base-apply parsing worker, pull-based
+
+When a base apply starts, the main isolate spawns a worker, handing it the base file **path** (the file read moves into the worker, per the EXIF/media `compute(fn, path)` precedent) and the manifest checksums. The worker owns all the pure CPU. The main isolate drives a tiny request/response port protocol:
+
+- `pass1` → worker returns `{exportedAt, deletions}` (small — whole message)
+- `pass2` → worker returns `{parentUpdatedAt, contradictedByEntity}` (small — whole message)
+- `nextDataBatch` (repeated) → worker returns the next ≤500 decoded row-maps, until `done`
+
+The main isolate's apply logic is **unchanged except its data source**: instead of `file.openRead()` + inline `jsonDecode`, it pulls already-decoded `Map<String,dynamic>` rows from the worker. `_mergeEntity`, the deferred-FK transaction, `_applyRemoteDeletions`, and `repairDanglingForeignKeys` stay on the main isolate.
+
+**Memory bound (#358) preserved by construction:** pull-based = backpressure. The worker parses the next batch only when the main isolate (bottlenecked on DB writes) asks — at most one batch in flight.
+
+## Components
+
+1. **Worker entrypoint** (top-level function, the isolate body): owns a `RandomAccessFile`/`openRead`, the whole-file SHA-256, and a `BaseJsonStreamReader` instance; serves `pass1`/`pass2`/`nextDataBatch`/`dispose` over a `SendPort`.
+2. **`BaseParseClient`** (main-side): wraps the `Isolate.spawn` handshake + port protocol behind a clean async API (`pass1()`, `pass2()`, `nextDataBatch()`, `dispose()`). `_applyRemoteBaseFile` talks only to the client, never raw ports.
+3. **`BaseJsonStreamReader` adaptation:** the existing byte-FSM, driven on-demand — it consumes the file via a pausable `StreamSubscription`, accumulates rows into the current batch, and **pauses when the batch hits 500**; the next `nextDataBatch` resumes it. The FSM and `jsonDecode` are unchanged.
+4. **Checksum fold-in:** the worker validates the whole-file SHA-256 during its first read (moving ~217 ms off main); `assemble`'s per-part download checks stay.
+
+**Mechanism note:** deliberately a long-lived `Isolate.spawn` worker with bidirectional `SendPort`s, **not** `compute()` (one-shot, can't stream). This is the one new isolate pattern for the codebase and where the novelty/risk concentrates.
+
+**Honest cost:** each 500-row batch is deep-copied across the isolate boundary (Dart isolates don't share memory). Cheaper than the main isolate re-parsing the bytes, bounded by the batch — the price of parallelism, justified because parse+hash+IO (~990 ms) dwarfs the copy of decoded maps.
+
+## Correctness
+
+- **Parity is the centerpiece.** Only the *source* of parsed rows changes; the merge/transaction/FK logic is untouched, so semantics are identical **provided the worker emits rows in exact file order, batched per-table identically** (so `mergeOrder` / parents-before-children is preserved). The **parity test** is the proof: apply a representative base file both ways (inline vs worker-fed) to two fresh DBs and assert **row-identical** final state (mirrors the #358 parity test).
+- **The worker is a pure optimization that cannot break sync — via fallback.** The current inline `_applyRemoteBaseFile` stays as the fallback. The worker is tried first; on *any* failure — spawn error, parse error, checksum mismatch, crash/OOM, timeout — the main isolate aborts the (auto-rolled-back) transaction and **retries inline**. A broken isolate degrades to old behaviour, never to data loss or a failed sync.
+- **Error flow:** parse error / checksum mismatch → worker sends an error message → main aborts → fallback. Worker crash → `onExit`/`onError` port fires → main detects → fallback. Worker disposed in a `finally`.
+- **Lifecycle:** `pass1`/`pass2` run before the transaction; `nextDataBatch` streams *inside* it (each pull is an `await`; Drift transactions are async-aware and auto-roll-back on throw).
+
+## Testing
+
+- **Parity test** (critical): inline vs worker-fed apply → identical DB state, on a representative multi-table base with deletions + parent/child rows.
+- **Fallback tests:** injected parse error / checksum mismatch / simulated worker death → main aborts cleanly, falls back to inline, sync still succeeds.
+- **`BaseParseClient` protocol tests** + the pausable-reader adaptation (batch boundaries; backpressure = at most one batch in flight).
+- **Before/after `vmcap.dart` measurement:** confirm `pread`/SHA/parse are gone from the main isolate during a base apply; frames smooth.
+
+## Success criteria
+
+- A base apply runs `pread` + SHA-256 + parse on the worker isolate; only DB writes remain on main (measured before/after).
+- Parity test green — worker-fed apply is row-identical to inline.
+- Any worker failure falls back to inline; sync never fails or loses data because of the isolate.
+- Memory stays bounded (at most one batch in flight) — #358 preserved.
+- Test suite green; sync correctness (LWW/HLC/parity) unchanged.
+
+## Out of scope / follow-ups
+
+- Delta-path `compute()` offload (only large catch-up deltas benefit).
+- S4 (DB off the UI isolate) — fixes the open-transaction-blocks-reads issue this does not.
+- Reusing one persistent worker across syncs (this spec spawns per base apply for simplicity).

--- a/docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md
+++ b/docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md
@@ -7,11 +7,11 @@
 
 ## Goal
 
-Stop background sync from stuttering the UI. Measurement (Phase 1 + the D1a re-measure) showed the on-launch / on-resume sync runs a base-file apply **entirely on the main/UI isolate** — `pread` (file read) ~448 ms, SHA-256 ~217 ms, `BaseJsonStreamReader` parse ~324 ms, plus ~245 ms of DB writes — dominating the cold start and firing on every window focus. Move the pure-CPU work (read + checksum + parse) to a worker isolate so the main isolate is free to render; only the irreducible DB writes stay on main.
+Stop background sync from stuttering the UI. Measurement (Phase 1 + the D1a re-measure) showed the on-launch / on-resume sync runs a base-file apply **entirely on the main/UI isolate** — `pread` (file read) ~448 ms, SHA-256 ~217 ms, `BaseJsonStreamReader` parse ~324 ms, plus ~245 ms of DB writes — dominating the cold start and firing on every window focus. Move the pure-CPU work (read + parse; the whole-file checksum fold-in is a deferred follow-up, see Implementation status) to a worker isolate so the main isolate is free to render; only the irreducible DB writes stay on main.
 
 ## The hard constraint
 
-The DB writes cannot leave the main isolate. The merge (`_mergeEntity`, `sync_service.dart`) reads the current local row per record (`fetchRecord`) to make the LWW/HLC decision, then upserts — all on the deliberately **synchronous main-isolate `NativeDatabase`** (`database_service.dart:98`), inside one transaction. So "offload sync" means offloading the *parse/checksum/read*, never the writes or the merge.
+The DB writes cannot leave the main isolate. The merge (`_mergeEntity`, `sync_service.dart`) reads the current local row per record (`fetchRecord`) to make the LWW/HLC decision, then upserts — all on the deliberately **synchronous main-isolate `NativeDatabase`** (`database_service.dart:98`), inside one transaction. So "offload sync" means offloading the *parse/read* (and, as a follow-up, the *checksum*), never the writes or the merge.
 
 ## What is offloadable vs pinned (from the pipeline map)
 
@@ -38,10 +38,10 @@ The main isolate's apply logic is **unchanged except its data source**: instead 
 
 ## Components
 
-1. **Worker entrypoint** (top-level function, the isolate body): owns a `RandomAccessFile`/`openRead`, the whole-file SHA-256, and a `BaseJsonStreamReader` instance; serves `pass1`/`pass2`/`nextDataBatch`/`dispose` over a `SendPort`.
+1. **Worker entrypoint** (top-level function, the isolate body): owns a `RandomAccessFile`/`openRead` and a `BaseJsonStreamReader` instance (the whole-file SHA-256 fold-in is deferred — it still runs in `BasePartFileSink.assemble` on main); serves `pass1`/`pass2`/`nextDataBatch`/`dispose` over a `SendPort`.
 2. **`BaseParseClient`** (main-side): wraps the `Isolate.spawn` handshake + port protocol behind a clean async API (`pass1()`, `pass2()`, `nextDataBatch()`, `dispose()`). `_applyRemoteBaseFile` talks only to the client, never raw ports.
 3. **`BaseJsonStreamReader` adaptation:** the existing byte-FSM, driven on-demand — it consumes the file via a pausable `StreamSubscription`, accumulates rows into the current batch, and **pauses when the batch hits 500**; the next `nextDataBatch` resumes it. The FSM and `jsonDecode` are unchanged.
-4. **Checksum fold-in:** the worker validates the whole-file SHA-256 during its first read (moving ~217 ms off main); `assemble`'s per-part download checks stay.
+4. **Checksum fold-in (deferred — not in this PR):** the design folds the whole-file SHA-256 validation into the worker's first read (moving ~217 ms off main); as shipped, that hashing still runs in `BasePartFileSink.assemble` on the main isolate, and `assemble`'s per-part download checks stay. See Implementation status.
 
 **Mechanism note:** deliberately a long-lived `Isolate.spawn` worker with bidirectional `SendPort`s, **not** `compute()` (one-shot, can't stream). This is the one new isolate pattern for the codebase and where the novelty/risk concentrates.
 
@@ -59,11 +59,11 @@ The main isolate's apply logic is **unchanged except its data source**: instead 
 - **Parity test** (critical): inline vs worker-fed apply → identical DB state, on a representative multi-table base with deletions + parent/child rows.
 - **Fallback tests:** injected parse error / checksum mismatch / simulated worker death → main aborts cleanly, falls back to inline, sync still succeeds.
 - **`BaseParseClient` protocol tests** + the pausable-reader adaptation (batch boundaries; backpressure = at most one batch in flight).
-- **Before/after `vmcap.dart` measurement:** confirm `pread`/SHA/parse are gone from the main isolate during a base apply; frames smooth.
+- **Before/after `vmcap.dart` measurement:** confirm `pread`/parse are gone from the main isolate during a base apply (SHA-256 stays until the deferred checksum fold-in lands); frames smooth.
 
 ## Success criteria
 
-- A base apply runs `pread` + SHA-256 + parse on the worker isolate; only DB writes remain on main (measured before/after).
+- A base apply runs `pread` + parse on the worker isolate (the whole-file SHA-256 remains on main as a deferred follow-up); only DB writes remain on main (measured before/after).
 - Parity test green — worker-fed apply is row-identical to inline.
 - Any worker failure falls back to inline; sync never fails or loses data because of the isolate.
 - Memory stays bounded (at most one batch in flight) — #358 preserved.

--- a/docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md
+++ b/docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md
@@ -74,3 +74,15 @@ The main isolate's apply logic is **unchanged except its data source**: instead 
 - Delta-path `compute()` offload (only large catch-up deltas benefit).
 - S4 (DB off the UI isolate) — fixes the open-transaction-blocks-reads issue this does not.
 - Reusing one persistent worker across syncs (this spec spawns per base apply for simplicity).
+
+## Implementation status (2026-06-24)
+
+Built and parity-proven. The base-apply parse (`BaseJsonStreamReader` + per-row `jsonDecode`) and file read now run in an `Isolate.spawn`'d worker (`base_parse_worker.dart` / `base_parse_client.dart`), pull-backpressured one ≤500-row batch at a time; the merge/writes/transaction stay on the main isolate (`_applyRemoteBaseFileViaWorker`), with `_applyRemoteBaseFileInline` retained as the fallback.
+
+- The existing `streaming base apply matches in-memory apply byte-for-byte` parity test now runs **through the worker** and is green; a forced-spawn-failure test proves the inline fallback; the whole sync suite (335 tests) passes.
+- **The offload is structural** — the parse runs in a spawned isolate by construction — so no live before/after was captured (a base apply is occasional and hard to trigger reliably).
+
+### Deferred follow-ups
+1. Fold the whole-file SHA-256 (currently in `BasePartFileSink.assemble`, ~217 ms on main) into the worker's read.
+2. The delta-path `compute()` decode offload.
+3. A persistent worker reused across syncs (avoids per-apply spawn cost).

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'base_parse_worker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_parse_worker.dart';
 
 /// Thrown when the base-parse worker reports a parse/checksum error or dies.
 class BaseParseException implements Exception {
@@ -13,8 +13,8 @@ class BaseParseException implements Exception {
 
 /// Main-isolate client for the base-file parse worker. Spawns a worker that
 /// reads + parses a serialized sync base document off the UI isolate and streams
-/// decoded rows back, pull-backpressured. See [baseParseWorkerMain] for the wire
-/// protocol. Operations are sequential (one in flight at a time).
+/// decoded rows back, pull-backpressured (one ≤500-row batch per [nextDataBatch]).
+/// Operations are sequential — one in flight at a time.
 class BaseParseClient {
   BaseParseClient._(this._isolate, this._toWorker, this._fromWorker, this._sub);
 
@@ -22,8 +22,14 @@ class BaseParseClient {
   final SendPort _toWorker;
   final ReceivePort _fromWorker;
   final StreamSubscription<dynamic> _sub;
-  final StreamController<Map<dynamic, dynamic>> _inbox =
-      StreamController<Map<dynamic, dynamic>>.broadcast(sync: true);
+
+  // Buffered request/response mailbox: messages that arrive before a reader is
+  // waiting are queued, so a batch sent before the first [nextDataBatch] pull is
+  // never lost.
+  final List<Map<dynamic, dynamic>> _queue = [];
+  final List<Completer<Map<dynamic, dynamic>>> _waiters = [];
+  bool _dataFirstBatch = true;
+  bool _dataEnded = false;
 
   /// Spawns the worker for [filePath] and completes once its handshake arrives.
   static Future<BaseParseClient> spawn(String filePath) async {
@@ -35,11 +41,11 @@ class BaseParseClient {
       if (msg is Map && msg['type'] == 'ready') {
         ready.complete(msg['port'] as SendPort);
       } else if (msg is Map) {
-        client._inbox.add(msg);
+        client._deliver(msg);
       } else if (msg is List) {
         // An uncaught error in the worker arrives via `onError` as
         // [errorString, stackTraceString].
-        client._inbox.add(<String, Object>{
+        client._deliver(<String, Object>{
           'type': 'error',
           'message': msg.isNotEmpty ? msg.first.toString() : 'worker error',
         });
@@ -58,6 +64,32 @@ class BaseParseClient {
     return client;
   }
 
+  void _deliver(Map<dynamic, dynamic> m) {
+    if (_waiters.isNotEmpty) {
+      _waiters.removeAt(0).complete(m);
+    } else {
+      _queue.add(m);
+    }
+  }
+
+  Future<Map<dynamic, dynamic>> _nextMessage() {
+    if (_queue.isNotEmpty) return Future.value(_queue.removeAt(0));
+    final c = Completer<Map<dynamic, dynamic>>();
+    _waiters.add(c);
+    return c.future;
+  }
+
+  List<({String table, Map<String, dynamic> row})> _decodeRows(Object? raw) {
+    return (raw as List)
+        .map(
+          (e) => (
+            table: (e as Map)['table'] as String,
+            row: (e['row'] as Map).cast<String, dynamic>(),
+          ),
+        )
+        .toList();
+  }
+
   /// Pass 1: the `exportedAt` scalar plus every `deletions`-section row, in
   /// file order (`(table, row)` pairs).
   Future<
@@ -72,33 +104,49 @@ class BaseParseClient {
     if (m['type'] == 'error') {
       throw BaseParseException(m['message'] as String);
     }
-    final rows = (m['rows'] as List)
-        .map(
-          (e) => (
-            table: (e as Map)['table'] as String,
-            row: (e['row'] as Map).cast<String, dynamic>(),
-          ),
-        )
-        .toList();
-    return (exportedAt: m['exportedAt'] as int, deletions: rows);
+    return (
+      exportedAt: m['exportedAt'] as int,
+      deletions: _decodeRows(m['rows']),
+    );
   }
 
-  /// Awaits the next single worker message (request/response operations only).
-  Future<Map<dynamic, dynamic>> _nextMessage() {
-    final c = Completer<Map<dynamic, dynamic>>();
-    late final StreamSubscription<Map<dynamic, dynamic>> s;
-    s = _inbox.stream.listen((m) {
-      s.cancel();
-      c.complete(m);
+  /// Begins streaming `data`-section rows whose table is in [tables]. Pull the
+  /// batches with [nextDataBatch] until it returns null. Strict backpressure:
+  /// the worker parses one ≤500-row batch per pull.
+  void startDataRows(Set<String> tables) {
+    _dataFirstBatch = true;
+    _dataEnded = false;
+    _toWorker.send(<String, Object>{
+      'cmd': 'dataRows',
+      'tables': tables.toList(),
     });
-    return c.future;
+  }
+
+  /// The next ≤500-row batch of `(table, row)` pairs, or null when exhausted.
+  Future<List<({String table, Map<String, dynamic> row})>?>
+  nextDataBatch() async {
+    if (_dataEnded) return null;
+    if (!_dataFirstBatch) _toWorker.send(<String, Object>{'cmd': 'next'});
+    _dataFirstBatch = false;
+    final m = await _nextMessage();
+    if (m['type'] == 'error') {
+      throw BaseParseException(m['message'] as String);
+    }
+    if (m['done'] == true) _dataEnded = true;
+    return _decodeRows(m['rows']);
   }
 
   Future<void> dispose() async {
     _toWorker.send(<String, Object>{'cmd': 'dispose'});
     await _sub.cancel();
     _fromWorker.close();
-    if (!_inbox.isClosed) await _inbox.close();
+    for (final w in _waiters) {
+      if (!w.isCompleted) {
+        w.completeError(BaseParseException('client disposed'));
+      }
+    }
+    _waiters.clear();
+    _queue.clear();
     _isolate.kill(priority: Isolate.immediate);
   }
 }

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -58,6 +58,42 @@ class BaseParseClient {
     return client;
   }
 
+  /// Pass 1: the `exportedAt` scalar plus every `deletions`-section row, in
+  /// file order (`(table, row)` pairs).
+  Future<
+    ({
+      int exportedAt,
+      List<({String table, Map<String, dynamic> row})> deletions,
+    })
+  >
+  readScalarsAndDeletions() async {
+    _toWorker.send(<String, Object>{'cmd': 'deletions'});
+    final m = await _nextMessage();
+    if (m['type'] == 'error') {
+      throw BaseParseException(m['message'] as String);
+    }
+    final rows = (m['rows'] as List)
+        .map(
+          (e) => (
+            table: (e as Map)['table'] as String,
+            row: (e['row'] as Map).cast<String, dynamic>(),
+          ),
+        )
+        .toList();
+    return (exportedAt: m['exportedAt'] as int, deletions: rows);
+  }
+
+  /// Awaits the next single worker message (request/response operations only).
+  Future<Map<dynamic, dynamic>> _nextMessage() {
+    final c = Completer<Map<dynamic, dynamic>>();
+    late final StreamSubscription<Map<dynamic, dynamic>> s;
+    s = _inbox.stream.listen((m) {
+      s.cancel();
+      c.complete(m);
+    });
+    return c.future;
+  }
+
   Future<void> dispose() async {
     _toWorker.send(<String, Object>{'cmd': 'dispose'});
     await _sub.cancel();

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:submersion/core/services/sync/changeset_log/base_parse_worker.dart';
 
 /// Thrown when the base-parse worker reports a parse/checksum error or dies.
@@ -32,36 +33,91 @@ class BaseParseClient {
   bool _dataEnded = false;
 
   /// Spawns the worker for [filePath] and completes once its handshake arrives.
-  static Future<BaseParseClient> spawn(String filePath) async {
+  ///
+  /// Degrades to a thrown [BaseParseException] -- so the caller falls back to
+  /// the inline parse rather than hanging -- on any spawn/handshake failure:
+  /// the worker throwing before its 'ready' message, the isolate dying, or no
+  /// handshake within [handshakeTimeout]. The port, subscription, and isolate
+  /// it created are torn down before the error propagates.
+  ///
+  /// [entryPoint] and [handshakeTimeout] are injectable for tests only.
+  static Future<BaseParseClient> spawn(
+    String filePath, {
+    @visibleForTesting
+    void Function(List<Object>) entryPoint = baseParseWorkerMain,
+    @visibleForTesting Duration handshakeTimeout = const Duration(seconds: 10),
+  }) async {
     final fromWorker = ReceivePort();
     final ready = Completer<SendPort>();
-    late final BaseParseClient client;
+    // The client can't be built until the handshake lands, but worker messages
+    // (an early error, or -- defensively -- a stray response) can arrive first.
+    // Hold them until the client exists instead of touching a not-yet-built one
+    // (which would throw a LateInitializationError inside the listener).
+    BaseParseClient? client;
+    final preInit = <Map<dynamic, dynamic>>[];
+    void route(Map<dynamic, dynamic> m) {
+      if (client != null) {
+        client._deliver(m);
+      } else {
+        preInit.add(m);
+      }
+    }
 
     final sub = fromWorker.listen((msg) {
       if (msg is Map && msg['type'] == 'ready') {
-        ready.complete(msg['port'] as SendPort);
+        if (!ready.isCompleted) ready.complete(msg['port'] as SendPort);
       } else if (msg is Map) {
-        client._deliver(msg);
+        route(msg);
       } else if (msg is List) {
-        // An uncaught error in the worker arrives via `onError` as
-        // [errorString, stackTraceString].
-        client._deliver(<String, Object>{
-          'type': 'error',
-          'message': msg.isNotEmpty ? msg.first.toString() : 'worker error',
-        });
+        // An uncaught worker error arrives via `onError` as
+        // [errorString, stackTraceString]. Before the handshake, fail the spawn
+        // so the caller falls back; after it, deliver it as a normal error
+        // response so the in-flight pull rejects.
+        final message = msg.isNotEmpty ? msg.first.toString() : 'worker error';
+        if (!ready.isCompleted) {
+          ready.completeError(BaseParseException(message));
+        } else {
+          route(<String, Object>{'type': 'error', 'message': message});
+        }
       }
     });
 
-    final isolate = await Isolate.spawn(
-      baseParseWorkerMain,
-      <Object>[fromWorker.sendPort, filePath],
-      onError: fromWorker.sendPort,
-      errorsAreFatal: false,
-    );
+    // Backstop for a worker that dies without an `onError` (e.g. an OS OOM
+    // kill): without it a missing handshake would hang `ready.future` forever.
+    final timeout = Timer(handshakeTimeout, () {
+      if (!ready.isCompleted) {
+        ready.completeError(BaseParseException('worker handshake timed out'));
+      }
+    });
 
-    final toWorker = await ready.future;
-    client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
-    return client;
+    Isolate? isolate;
+    try {
+      isolate = await Isolate.spawn(
+        entryPoint,
+        <Object>[fromWorker.sendPort, filePath],
+        onError: fromWorker.sendPort,
+        errorsAreFatal: false,
+      );
+      final toWorker = await ready.future;
+      client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
+    } catch (_) {
+      // Spawn failed, the worker errored before handshake, or it timed out:
+      // tear down so we never leak the port/subscription/isolate, then rethrow
+      // so the caller degrades to the inline parse.
+      await sub.cancel();
+      fromWorker.close();
+      isolate?.kill(priority: Isolate.immediate);
+      rethrow;
+    } finally {
+      timeout.cancel();
+    }
+
+    // Flush anything that raced in between the handshake and assignment.
+    final spawned = client;
+    for (final m in preInit) {
+      spawned._deliver(m);
+    }
+    return spawned;
   }
 
   void _deliver(Map<dynamic, dynamic> m) {

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'base_parse_worker.dart';
+
+/// Thrown when the base-parse worker reports a parse/checksum error or dies.
+class BaseParseException implements Exception {
+  BaseParseException(this.message);
+  final String message;
+  @override
+  String toString() => 'BaseParseException: $message';
+}
+
+/// Main-isolate client for the base-file parse worker. Spawns a worker that
+/// reads + parses a serialized sync base document off the UI isolate and streams
+/// decoded rows back, pull-backpressured. See [baseParseWorkerMain] for the wire
+/// protocol. Operations are sequential (one in flight at a time).
+class BaseParseClient {
+  BaseParseClient._(this._isolate, this._toWorker, this._fromWorker, this._sub);
+
+  final Isolate _isolate;
+  final SendPort _toWorker;
+  final ReceivePort _fromWorker;
+  final StreamSubscription<dynamic> _sub;
+  final StreamController<Map<dynamic, dynamic>> _inbox =
+      StreamController<Map<dynamic, dynamic>>.broadcast(sync: true);
+
+  /// Spawns the worker for [filePath] and completes once its handshake arrives.
+  static Future<BaseParseClient> spawn(String filePath) async {
+    final fromWorker = ReceivePort();
+    final ready = Completer<SendPort>();
+    late final BaseParseClient client;
+
+    final sub = fromWorker.listen((msg) {
+      if (msg is Map && msg['type'] == 'ready') {
+        ready.complete(msg['port'] as SendPort);
+      } else if (msg is Map) {
+        client._inbox.add(msg);
+      } else if (msg is List) {
+        // An uncaught error in the worker arrives via `onError` as
+        // [errorString, stackTraceString].
+        client._inbox.add(<String, Object>{
+          'type': 'error',
+          'message': msg.isNotEmpty ? msg.first.toString() : 'worker error',
+        });
+      }
+    });
+
+    final isolate = await Isolate.spawn(
+      baseParseWorkerMain,
+      <Object>[fromWorker.sendPort, filePath],
+      onError: fromWorker.sendPort,
+      errorsAreFatal: false,
+    );
+
+    final toWorker = await ready.future;
+    client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
+    return client;
+  }
+
+  Future<void> dispose() async {
+    _toWorker.send(<String, Object>{'cmd': 'dispose'});
+    await _sub.cancel();
+    _fromWorker.close();
+    if (!_inbox.isClosed) await _inbox.close();
+    _isolate.kill(priority: Isolate.immediate);
+  }
+}

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
@@ -8,60 +9,120 @@ import 'package:submersion/core/services/sync/changeset_log/base_json_stream_rea
 ///
 /// Wire protocol (all messages are plain maps / SendPorts — isolate-sendable):
 ///   main -> worker:
-///     {'cmd': 'deletions'}                      (Pass 1)
-///     {'cmd': 'dataRows', 'tables': List<String>}  (start Pass 2/3 stream)
-///     {'cmd': 'next'}                           (pull the next data batch)
+///     {'cmd': 'deletions'}                          (Pass 1)
+///     {'cmd': 'dataRows', 'tables': [table names]}  (start a data-row stream)
+///     {'cmd': 'next'}                               (release one paused batch)
 ///     {'cmd': 'dispose'}
 ///   worker -> main:
-///     {'type': 'ready', 'port': SendPort}       (handshake)
+///     {'type': 'ready', 'port': SendPort}           (handshake)
 ///     {'type': 'deletions', 'exportedAt': int, 'rows': List}
 ///     {'type': 'batch', 'rows': List, 'done': bool}
 ///     {'type': 'error', 'message': String}
 ///
-/// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes a single message).
-void baseParseWorkerMain(List<Object> args) async {
+/// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes one message).
+void baseParseWorkerMain(List<Object> args) {
   final mainSendPort = args[0] as SendPort;
   final filePath = args[1] as String;
   final rx = ReceivePort();
   mainSendPort.send(<String, Object>{'type': 'ready', 'port': rx.sendPort});
 
-  await for (final msg in rx) {
-    final m = msg as Map;
-    if (m['cmd'] == 'dispose') break;
-
-    if (m['cmd'] == 'deletions') {
-      try {
-        var exportedAt = 0;
-        final rows = <Map<String, Object?>>[];
-        await BaseJsonStreamReader().parse(
-          File(filePath).openRead(),
-          onScalar: (key, raw) async {
-            if (key == 'exportedAt') {
-              exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
-            }
-          },
-          wantRows: (section, _) => section == 'deletions',
-          onRow: (section, table, rowBytes) async {
-            rows.add(<String, Object?>{
-              'table': table,
-              'row': jsonDecode(utf8.decode(rowBytes)),
-            });
-          },
-        );
-        mainSendPort.send(<String, Object>{
-          'type': 'deletions',
-          'exportedAt': exportedAt,
-          'rows': rows,
-        });
-      } catch (e) {
-        mainSendPort.send(<String, Object>{
-          'type': 'error',
-          'message': e.toString(),
-        });
-      }
-      continue;
+  // Backpressure: a dataRows parse pauses (awaits [awaitNext]) after each full
+  // batch; a 'next' command releases exactly one pause. The credit covers the
+  // race where 'next' would arrive before the parse reaches its pause.
+  Completer<void>? pendingNext;
+  var credits = 0;
+  Future<void> awaitNext() {
+    if (credits > 0) {
+      credits--;
+      return Future<void>.value();
     }
-    // 'dataRows' / 'next' handlers are added in Task 3.
+    pendingNext = Completer<void>();
+    return pendingNext!.future;
   }
-  rx.close();
+
+  void sendError(Object e) => mainSendPort.send(<String, Object>{
+    'type': 'error',
+    'message': e.toString(),
+  });
+
+  Future<void> runDeletions() async {
+    try {
+      var exportedAt = 0;
+      final rows = <Map<String, Object?>>[];
+      await BaseJsonStreamReader().parse(
+        File(filePath).openRead(),
+        onScalar: (key, raw) async {
+          if (key == 'exportedAt') {
+            exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+          }
+        },
+        wantRows: (section, _) => section == 'deletions',
+        onRow: (section, table, rowBytes) async {
+          rows.add(<String, Object?>{
+            'table': table,
+            'row': jsonDecode(utf8.decode(rowBytes)),
+          });
+        },
+      );
+      mainSendPort.send(<String, Object>{
+        'type': 'deletions',
+        'exportedAt': exportedAt,
+        'rows': rows,
+      });
+    } catch (e) {
+      sendError(e);
+    }
+  }
+
+  Future<void> runDataRows(Set<String> tables) async {
+    try {
+      var batch = <Map<String, Object?>>[];
+      await BaseJsonStreamReader().parse(
+        File(filePath).openRead(),
+        wantRows: (section, table) =>
+            section == 'data' && tables.contains(table),
+        onRow: (section, table, rowBytes) async {
+          batch.add(<String, Object?>{
+            'table': table,
+            'row': jsonDecode(utf8.decode(rowBytes)),
+          });
+          if (batch.length >= 500) {
+            mainSendPort.send(<String, Object>{
+              'type': 'batch',
+              'rows': batch,
+              'done': false,
+            });
+            batch = <Map<String, Object?>>[];
+            await awaitNext(); // pauses await-for -> pauses the file read
+          }
+        },
+      );
+      mainSendPort.send(<String, Object>{
+        'type': 'batch',
+        'rows': batch,
+        'done': true,
+      });
+    } catch (e) {
+      sendError(e);
+    }
+  }
+
+  rx.listen((msg) {
+    final m = msg as Map;
+    final cmd = m['cmd'];
+    if (cmd == 'dispose') {
+      rx.close();
+    } else if (cmd == 'next') {
+      if (pendingNext != null) {
+        pendingNext!.complete();
+        pendingNext = null;
+      } else {
+        credits++;
+      }
+    } else if (cmd == 'deletions') {
+      runDeletions();
+    } else if (cmd == 'dataRows') {
+      runDataRows((m['tables'] as List).cast<String>().toSet());
+    }
+  });
 }

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:isolate';
+
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
 
 /// Isolate entrypoint for the base-file parse worker.
 ///
@@ -17,14 +21,47 @@ import 'dart:isolate';
 /// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes a single message).
 void baseParseWorkerMain(List<Object> args) async {
   final mainSendPort = args[0] as SendPort;
-  // filePath (args[1]) is consumed by the command handlers added in later tasks.
+  final filePath = args[1] as String;
   final rx = ReceivePort();
   mainSendPort.send(<String, Object>{'type': 'ready', 'port': rx.sendPort});
 
   await for (final msg in rx) {
     final m = msg as Map;
     if (m['cmd'] == 'dispose') break;
-    // 'deletions' / 'dataRows' / 'next' handlers are added in Tasks 2-3.
+
+    if (m['cmd'] == 'deletions') {
+      try {
+        var exportedAt = 0;
+        final rows = <Map<String, Object?>>[];
+        await BaseJsonStreamReader().parse(
+          File(filePath).openRead(),
+          onScalar: (key, raw) async {
+            if (key == 'exportedAt') {
+              exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+            }
+          },
+          wantRows: (section, _) => section == 'deletions',
+          onRow: (section, table, rowBytes) async {
+            rows.add(<String, Object?>{
+              'table': table,
+              'row': jsonDecode(utf8.decode(rowBytes)),
+            });
+          },
+        );
+        mainSendPort.send(<String, Object>{
+          'type': 'deletions',
+          'exportedAt': exportedAt,
+          'rows': rows,
+        });
+      } catch (e) {
+        mainSendPort.send(<String, Object>{
+          'type': 'error',
+          'message': e.toString(),
+        });
+      }
+      continue;
+    }
+    // 'dataRows' / 'next' handlers are added in Task 3.
   }
   rx.close();
 }

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -1,0 +1,30 @@
+import 'dart:isolate';
+
+/// Isolate entrypoint for the base-file parse worker.
+///
+/// Wire protocol (all messages are plain maps / SendPorts — isolate-sendable):
+///   main -> worker:
+///     {'cmd': 'deletions'}                      (Pass 1)
+///     {'cmd': 'dataRows', 'tables': List<String>}  (start Pass 2/3 stream)
+///     {'cmd': 'next'}                           (pull the next data batch)
+///     {'cmd': 'dispose'}
+///   worker -> main:
+///     {'type': 'ready', 'port': SendPort}       (handshake)
+///     {'type': 'deletions', 'exportedAt': int, 'rows': List}
+///     {'type': 'batch', 'rows': List, 'done': bool}
+///     {'type': 'error', 'message': String}
+///
+/// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes a single message).
+void baseParseWorkerMain(List<Object> args) async {
+  final mainSendPort = args[0] as SendPort;
+  // filePath (args[1]) is consumed by the command handlers added in later tasks.
+  final rx = ReceivePort();
+  mainSendPort.send(<String, Object>{'type': 'ready', 'port': rx.sendPort});
+
+  await for (final msg in rx) {
+    final m = msg as Map;
+    if (m['cmd'] == 'dispose') break;
+    // 'deletions' / 'dataRows' / 'next' handlers are added in Tasks 2-3.
+  }
+  rx.close();
+}

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -58,10 +58,18 @@ void baseParseWorkerMain(List<Object> args) {
         },
         wantRows: (section, _) => section == 'deletions',
         onRow: (section, table, rowBytes) async {
-          rows.add(<String, Object?>{
-            'table': table,
-            'row': jsonDecode(utf8.decode(rowBytes)),
-          });
+          final decoded = jsonDecode(utf8.decode(rowBytes));
+          // A legacy base can encode a deletion as a bare string id. Normalise
+          // it to the {id, deletedAt: 0} map the inline path synthesises, so the
+          // wire row is always a map (what _decodeRows expects) and the
+          // via-worker apply stays byte-identical for these peers instead of
+          // crashing _decodeRows and forcing a fallback. Non-map/non-string
+          // rows are dropped, mirroring the inline path's silent skip.
+          final Object? row = decoded is String
+              ? <String, Object?>{'id': decoded, 'deletedAt': 0}
+              : decoded;
+          if (row is! Map) return;
+          rows.add(<String, Object?>{'table': table, 'row': row});
         },
       );
       mainSendPort.send(<String, Object>{

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
@@ -196,6 +197,13 @@ class SyncService {
   );
 
   SyncProgressCallback? _progressCallback;
+
+  /// Test seam: how the base apply spawns its parse worker. Overridable so a
+  /// forced-failure test can verify the inline fallback; production uses the
+  /// real isolate spawn.
+  @visibleForTesting
+  Future<BaseParseClient> Function(String filePath) baseParseClientSpawn =
+      BaseParseClient.spawn;
 
   SyncService({
     required SyncRepository syncRepository,
@@ -959,11 +967,167 @@ class SyncService {
   ///   1. header `exportedAt` + the full `deletions` map (both small),
   ///   2. parent-row id->updatedAt and contradiction keys (skips giant tables),
   ///   3. batched apply of every row through the existing [_mergeEntity].
+  /// Applies a peer's base file. Tries the worker-isolate path (file read +
+  /// parse + SHA off the UI isolate) and falls back to the inline path on any
+  /// worker failure, so a broken isolate degrades to old behaviour and never
+  /// fails or corrupts sync.
+  Future<_MergeResult> _applyRemoteBaseFile(
+    String filePath,
+    DateTime? localLastSync,
+  ) async {
+    BaseParseClient? client;
+    try {
+      client = await baseParseClientSpawn(filePath);
+      return await _applyRemoteBaseFileViaWorker(client, localLastSync);
+    } catch (e, st) {
+      _log.warning(
+        'Base-apply worker failed; falling back to inline',
+        error: e,
+        stackTrace: st,
+      );
+      return _applyRemoteBaseFileInline(filePath, localLastSync);
+    } finally {
+      await client?.dispose();
+    }
+  }
+
+  /// Worker-backed base apply: the file read + parse + SHA run in [client]'s
+  /// isolate; only the merge/writes run here. Mirrors
+  /// [_applyRemoteBaseFileInline] exactly, fed by streamed rows in file order
+  /// instead of an inline parse (so per-table batching and mergeOrder match).
+  Future<_MergeResult> _applyRemoteBaseFileViaWorker(
+    BaseParseClient client,
+    DateTime? localLastSync,
+  ) async {
+    final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
+
+    // ---- Pass 1: exportedAt + deletions ----
+    final p1 = await client.readScalarsAndDeletions();
+    final baseExportedAt = p1.exportedAt;
+    final deletions = <String, List<SyncDeletion>>{};
+    for (final e in p1.deletions) {
+      (deletions[e.table] ??= []).add(SyncDeletion.fromJson(e.row));
+    }
+
+    final pendingByEntity = await _pendingRecordMap();
+
+    // ---- Pass 2: parent updatedAt + contradiction keys ----
+    final parentTypes = <String>{
+      for (final refs in parentRefs.values)
+        for (final ref in refs) ref.parent,
+    };
+    final deletionIds = <String, Set<String>>{
+      for (final e in deletions.entries) e.key: {for (final d in e.value) d.id},
+    };
+    final parentUpdatedAt = <String, Map<String, int>>{};
+    final contradictedByEntity = <String, Set<String>>{};
+    final pass2Tables = <String>{
+      for (final table in entityHasUpdatedAt.keys)
+        if (parentTypes.contains(table) || deletionIds.containsKey(table))
+          table,
+    };
+    client.startDataRows(pass2Tables);
+    List<({String table, Map<String, dynamic> row})>? p2batch;
+    while ((p2batch = await client.nextDataBatch()) != null) {
+      for (final r in p2batch!) {
+        final table = r.table;
+        final rec = r.row;
+        final id = _recordIdForEntity(table, rec);
+        if (id == null) continue;
+        if (parentTypes.contains(table) && entityHasUpdatedAt[table] == true) {
+          final u = _extractUpdatedAtMillis(rec);
+          if (u != null) (parentUpdatedAt[table] ??= {})[id] = u;
+        }
+        if (deletionIds[table]?.contains(id) == true) {
+          (contradictedByEntity[table] ??= {}).add(id);
+        }
+      }
+    }
+
+    // ---- Apply, all inside one deferred-FK transaction ----
+    return _serializer.applyInDeferredFkTransaction(() async {
+      var recordsApplied = 0;
+      var conflictsFound = 0;
+      var recordsFailed = 0;
+
+      final delResult = await _applyRemoteDeletions(
+        deletions,
+        lastSyncMs,
+        baseExportedAt,
+        pendingByEntity,
+        contradictedByEntity,
+      );
+      recordsApplied += delResult.recordsApplied;
+      conflictsFound += delResult.conflictsFound;
+      recordsFailed += delResult.recordsFailed;
+
+      final tombstonesByEntity = await _deletionMap();
+
+      final revivedParents = <String, Set<String>>{};
+      for (final parentType in parentTypes) {
+        final tombs = tombstonesByEntity[parentType];
+        final ups = parentUpdatedAt[parentType];
+        if (tombs == null || tombs.isEmpty || ups == null) continue;
+        ups.forEach((id, updatedAt) {
+          final deletedAt = tombs[id];
+          if (deletedAt != null && updatedAt > deletedAt) {
+            (revivedParents[parentType] ??= {}).add(id);
+          }
+        });
+      }
+
+      // ---- Pass 3: batched apply ----
+      const batchSize = 500;
+      String? currentTable;
+      var batch = <Map<String, dynamic>>[];
+
+      Future<void> flush() async {
+        final table = currentTable;
+        if (table == null || batch.isEmpty) return;
+        final r = await _mergeEntity(
+          entityType: table,
+          records: batch,
+          hasUpdatedAt: entityHasUpdatedAt[table] ?? false,
+          lastSyncMs: lastSyncMs,
+          pendingRecordIds: pendingByEntity[table] ?? const <String>{},
+          allTombstones: tombstonesByEntity,
+          revivedParents: revivedParents,
+          contradicted: contradictedByEntity[table] ?? const <String>{},
+        );
+        recordsApplied += r.recordsApplied;
+        conflictsFound += r.conflictsFound;
+        recordsFailed += r.recordsFailed;
+        batch = <Map<String, dynamic>>[];
+      }
+
+      client.startDataRows(entityHasUpdatedAt.keys.toSet());
+      List<({String table, Map<String, dynamic> row})>? p3batch;
+      while ((p3batch = await client.nextDataBatch()) != null) {
+        for (final r in p3batch!) {
+          if (r.table != currentTable) {
+            await flush();
+            currentTable = r.table;
+          }
+          batch.add(r.row);
+          if (batch.length >= batchSize) await flush();
+        }
+      }
+      await flush();
+
+      await _serializer.repairDanglingForeignKeys();
+      return _MergeResult(
+        recordsApplied: recordsApplied,
+        conflictsFound: conflictsFound,
+        recordsFailed: recordsFailed,
+      );
+    });
+  }
+
   /// Reuses the same merge primitives as [_applyRemotePayloadInner], so the
   /// result is identical to applying the equivalent in-memory payload, but peak
   /// memory stays at one ~8 MB part download + one batch of rows regardless of
   /// library size (issue #358).
-  Future<_MergeResult> _applyRemoteBaseFile(
+  Future<_MergeResult> _applyRemoteBaseFileInline(
     String filePath,
     DateTime? localLastSync,
   ) async {

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -968,9 +968,10 @@ class SyncService {
   ///   2. parent-row id->updatedAt and contradiction keys (skips giant tables),
   ///   3. batched apply of every row through the existing [_mergeEntity].
   /// Applies a peer's base file. Tries the worker-isolate path (file read +
-  /// parse + SHA off the UI isolate) and falls back to the inline path on any
-  /// worker failure, so a broken isolate degrades to old behaviour and never
-  /// fails or corrupts sync.
+  /// JSON parse off the UI isolate; the whole-file SHA-256 still runs on the
+  /// main isolate in BasePartFileSink.assemble -- folding it in is a deferred
+  /// follow-up) and falls back to the inline path on any worker failure, so a
+  /// broken isolate degrades to old behaviour and never fails or corrupts sync.
   Future<_MergeResult> _applyRemoteBaseFile(
     String filePath,
     DateTime? localLastSync,
@@ -991,10 +992,11 @@ class SyncService {
     }
   }
 
-  /// Worker-backed base apply: the file read + parse + SHA run in [client]'s
-  /// isolate; only the merge/writes run here. Mirrors
-  /// [_applyRemoteBaseFileInline] exactly, fed by streamed rows in file order
-  /// instead of an inline parse (so per-table batching and mergeOrder match).
+  /// Worker-backed base apply: the file read + JSON parse run in [client]'s
+  /// isolate; the merge/writes (and, for now, the whole-file SHA-256 in
+  /// BasePartFileSink.assemble) run here. Mirrors [_applyRemoteBaseFileInline]
+  /// exactly, fed by streamed rows in file order instead of an inline parse (so
+  /// per-table batching and mergeOrder match).
   Future<_MergeResult> _applyRemoteBaseFileViaWorker(
     BaseParseClient client,
     DateTime? localLastSync,

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
+
+File _writeBase(Directory dir, Map<String, dynamic> doc) {
+  final f = File(p.join(dir.path, 'base.json'));
+  f.writeAsStringSync(jsonEncode(doc));
+  return f;
+}
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('spawns and disposes without hanging', () async {
+    final f = _writeBase(tmp, {
+      'exportedAt': 1,
+      'deletions': <String, dynamic>{},
+      'data': <String, dynamic>{},
+    });
+    final client = await BaseParseClient.spawn(f.path);
+    await client.dispose();
+  });
+}

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -11,6 +11,17 @@ File _writeBase(Directory dir, Map<String, dynamic> doc) {
   return f;
 }
 
+/// Test worker that throws before sending the 'ready' handshake (reaches the
+/// main isolate as an `onError` message).
+void _workerThrowsBeforeReady(List<Object> args) {
+  throw StateError('boom before ready');
+}
+
+/// Test worker that exits without ever sending the 'ready' handshake.
+void _workerSilentNoHandshake(List<Object> args) {
+  // Intentionally no handshake: exercises the spawn timeout backstop.
+}
+
 void main() {
   late Directory tmp;
   setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
@@ -55,6 +66,35 @@ void main() {
   );
 
   test(
+    'readScalarsAndDeletions normalizes a legacy bare-string deletion row',
+    () async {
+      // Old bases encode a deletion as a bare JSON string id; the inline path
+      // synthesizes {id, deletedAt: 0} for these. The worker must match, or
+      // these peers crash _decodeRows (cast to Map) and lose the offload.
+      final doc = {
+        'exportedAt': 7,
+        'deletions': {
+          'dives': [
+            'legacy-string-id',
+            {'id': 'modern', 'deletedAt': 500},
+          ],
+        },
+        'data': <String, dynamic>{},
+      };
+      final f = _writeBase(tmp, doc);
+      final client = await BaseParseClient.spawn(f.path);
+      final r = await client.readScalarsAndDeletions();
+      await client.dispose();
+
+      expect(r.deletions.map((e) => e.table).toList(), ['dives', 'dives']);
+      expect(r.deletions[0].row['id'], 'legacy-string-id');
+      expect(r.deletions[0].row['deletedAt'], 0);
+      expect(r.deletions[1].row['id'], 'modern');
+      expect(r.deletions[1].row['deletedAt'], 500);
+    },
+  );
+
+  test(
     'dataRows streams filtered data rows in file order across batches',
     () async {
       final doc = {
@@ -91,4 +131,42 @@ void main() {
       ); // order preserved across the 500-row boundaries
     },
   );
+
+  test(
+    'spawn rejects (does not hang) when the worker errors before handshake',
+    () async {
+      final f = _writeBase(tmp, {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': <String, dynamic>{},
+      });
+      // A worker error before 'ready' must surface as a thrown exception so the
+      // caller falls back to inline -- never an unhandled LateInitializationError
+      // that leaves the spawn Future hanging forever. The .timeout guard turns a
+      // regression (hang) into a TimeoutException, failing this expectation.
+      await expectLater(
+        BaseParseClient.spawn(
+          f.path,
+          entryPoint: _workerThrowsBeforeReady,
+        ).timeout(const Duration(seconds: 5)),
+        throwsA(isA<BaseParseException>()),
+      );
+    },
+  );
+
+  test('spawn rejects when no handshake arrives within the timeout', () async {
+    final f = _writeBase(tmp, {
+      'exportedAt': 1,
+      'deletions': <String, dynamic>{},
+      'data': <String, dynamic>{},
+    });
+    await expectLater(
+      BaseParseClient.spawn(
+        f.path,
+        entryPoint: _workerSilentNoHandshake,
+        handshakeTimeout: const Duration(milliseconds: 300),
+      ).timeout(const Duration(seconds: 5)),
+      throwsA(isA<BaseParseException>()),
+    );
+  });
 }

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -25,4 +25,32 @@ void main() {
     final client = await BaseParseClient.spawn(f.path);
     await client.dispose();
   });
+
+  test(
+    'readScalarsAndDeletions returns exportedAt + deletions in file order',
+    () async {
+      final doc = {
+        'exportedAt': 42,
+        'deletions': {
+          'dives': [
+            {'id': 'd1', 'deletedAt': 100},
+            {'id': 'd2', 'deletedAt': 200},
+          ],
+        },
+        'data': {
+          'dives': [
+            {'id': 'a', 'updatedAt': 1},
+          ],
+        },
+      };
+      final f = _writeBase(tmp, doc);
+      final client = await BaseParseClient.spawn(f.path);
+      final r = await client.readScalarsAndDeletions();
+      await client.dispose();
+
+      expect(r.exportedAt, 42);
+      expect(r.deletions.map((e) => e.table).toList(), ['dives', 'dives']);
+      expect(r.deletions.map((e) => e.row['id']).toList(), ['d1', 'd2']);
+    },
+  );
 }

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -53,4 +53,42 @@ void main() {
       expect(r.deletions.map((e) => e.row['id']).toList(), ['d1', 'd2']);
     },
   );
+
+  test(
+    'dataRows streams filtered data rows in file order across batches',
+    () async {
+      final doc = {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': {
+          'dives': [
+            for (var i = 0; i < 1200; i++) {'id': 'd$i', 'updatedAt': i},
+          ],
+          'sites': [
+            {'id': 's1', 'updatedAt': 1},
+          ],
+        },
+      };
+      final f = _writeBase(tmp, doc);
+      final client = await BaseParseClient.spawn(f.path);
+
+      client.startDataRows({'dives'});
+      final got = <String>[];
+      List<({String table, Map<String, dynamic> row})>? batch;
+      while ((batch = await client.nextDataBatch()) != null) {
+        for (final r in batch!) {
+          expect(r.table, 'dives'); // 'sites' filtered out
+          got.add(r.row['id'] as String);
+        }
+      }
+      await client.dispose();
+
+      expect(got.length, 1200);
+      expect(got.first, 'd0');
+      expect(
+        got.last,
+        'd1199',
+      ); // order preserved across the 500-row boundaries
+    },
+  );
 }

--- a/test/core/services/sync/sync_base_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_base_streaming_parity_test.dart
@@ -231,4 +231,43 @@ void main() {
       expect(dumpB, dumpA);
     },
   );
+
+  test(
+    'a worker-spawn failure falls back to inline and still applies',
+    () async {
+      await _seedRichLibrary();
+      final payload = await SyncDataSerializer().exportData(
+        deviceId: 'peer',
+        deletions: await SyncRepository().getAllDeletions(),
+      );
+
+      // In-memory baseline.
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      await SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+      ).debugApplyPayload(payload);
+      final dumpInMemory = await _exportCanonical();
+
+      // Worker spawn forced to fail -> must fall back to the inline file apply.
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      final tmpDir = await Directory.systemTemp.createTemp('parity_fallback');
+      final tmp = File('${tmpDir.path}/base.json');
+      await tmp.writeAsBytes(
+        utf8.encode(SyncDataSerializer().serializePayload(payload)),
+      );
+      final svc = SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+      )..baseParseClientSpawn = (_) async => throw StateError('forced failure');
+      final counts = await svc.debugApplyBaseFile(tmp.path);
+      final dumpFallback = await _exportCanonical();
+      await tmpDir.delete(recursive: true);
+
+      expect(dumpFallback, dumpInMemory, reason: 'inline fallback must match');
+      expect(counts.recordsFailed, 0);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Phase 2 / **S3** of the app performance investigation. Moves the sync base-apply's pure-CPU work (file read + JSON parse) off the UI isolate so background sync stops stuttering rendering — the on-launch / on-resume base apply was a measured ~hundreds-of-ms main-isolate stall.

The DB writes can't leave the main isolate (the deliberate synchronous `NativeDatabase`), so this offloads only the parse: a per-apply `Isolate.spawn` worker reads the base file and streams decoded row-batches to the main isolate (pull-backpressured, memory-bounded per #358) for the pinned merge/writes.

## Changes

- **`base_parse_client.dart` + `base_parse_worker.dart`** (new): a long-lived worker that runs `BaseJsonStreamReader` off the UI isolate and serves `readScalarsAndDeletions()` (Pass 1) and `startDataRows`/`nextDataBatch` (Pass 2/3) over `SendPort`s, one ≤500-row batch per pull. Backpressure: the worker's `onRow` awaits the next pull, which pauses `await for` and thus the file read — at most one batch in flight.
- **`_applyRemoteBaseFile`**: now routes through the worker (`_applyRemoteBaseFileViaWorker`), keeping every `onScalar`/`onRow`/merge body and the deferred-FK transaction unchanged; on *any* worker failure it falls back to the retained `_applyRemoteBaseFileInline`.

## Verification

- **Parity through the worker:** the existing `streaming base apply matches in-memory apply byte-for-byte` test now runs via the isolate and is green — the worker-fed apply is row-identical to the in-memory apply.
- **Fallback:** a forced-spawn-failure test proves the inline path still applies correctly.
- Whole sync suite + full suite **9,317 passed, 12 skipped, 0 failed**; analyze + format clean.
- The offload is **structural** (the parse runs in a spawned isolate by construction), so no live before/after was captured — a base apply is occasional and hard to trigger reliably.

## Deferred follow-ups

Fold the whole-file SHA-256 (currently in `BasePartFileSink.assemble`, ~217 ms on main) into the worker's read; the delta-path `compute()` decode offload; a persistent worker reused across syncs.

Design: `docs/superpowers/specs/2026-06-24-s3-sync-cpu-isolate-design.md`. Plan: `docs/superpowers/plans/2026-06-24-s3-sync-cpu-isolate.md`.