### PR TITLE
perf(sync): S2 — batch the sync row writes (_mergeEntity read-decide-write)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-s2-batch-sync-writes.md
+++ b/docs/superpowers/plans/2026-06-24-s2-batch-sync-writes.md
@@ -1,0 +1,233 @@
+# S2 — Batch the Sync Row Writes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Task 4 (measurement) is optional/interactive.
+
+**Goal:** Collapse `_mergeEntity`'s N per-row `fetchRecord` reads + N per-row `upsertRecord` writes into one batched read + one Drift `batch()` write per merge-batch, with byte-identical LWW/HLC/conflict results.
+
+**Architecture:** Add `fetchRecords` (batched read) and `upsertRecords` (Drift `batch()` write) to `SyncDataSerializer` as mechanical mirrors of the existing per-entity `fetchRecord`/`upsertRecord` switches. Restructure `_mergeEntity` into read-decide-write: batch-fetch locals, run every existing decision in memory against the pre-fetched rows (collecting winners), then batch-upsert the winners.
+
+**Tech Stack:** Drift (`batch`, `insertAllOnConflictUpdate`, `isIn`), the existing `SyncDataSerializer` switches, `flutter_test`.
+
+## Global Constraints
+
+- **TDD**; **`dart format .`** before push; **no `Co-Authored-By`** trailer.
+- **Parity is the gate:** the byte-for-byte `sync_base_streaming_parity_test` and the full sync suite (335 tests) must stay green — LWW/HLC/conflict decisions and `applied`/`conflicts`/`failed` counts must be identical.
+- **Unique ids per batch** (changeset invariant) — no decision in the merge loop may read a value written earlier in the same loop; the batched design relies on this.
+- Spec: `docs/superpowers/specs/2026-06-24-s2-batch-sync-writes-design.md`.
+
+## File Structure
+
+- Modify `lib/core/services/sync/sync_data_serializer.dart` — add `fetchRecords` (after `fetchRecord` ~975) and `upsertRecords` (after `upsertRecord` ~1204).
+- Modify `lib/core/services/sync/sync_service.dart:1342-1510` — `_mergeEntity` read-decide-write.
+- Tests: a focused serializer test (`test/core/services/sync/sync_data_serializer_batch_test.dart`) + the existing parity/sync suite as the regression gate.
+
+---
+
+### Task 1: `upsertRecords` — batched write
+
+**Files:** Modify `sync_data_serializer.dart`; test `test/core/services/sync/sync_data_serializer_batch_test.dart`.
+
+**Interfaces:**
+- Produces: `Future<void> upsertRecords(String entityType, List<Map<String, dynamic>> records)` — writes all `records` in one Drift `batch()`, in list order, with the same conflict semantics as `upsertRecord`.
+
+- [ ] **Step 1: Write the failing test** — two records written in one call equal two `upsertRecord` calls.
+
+```dart
+// sync_data_serializer_batch_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import '../../helpers/test_database.dart';
+
+void main() {
+  setUp(() async => setUpTestDatabase());
+  tearDown(() async => tearDownTestDatabase());
+
+  test('upsertRecords writes all records (== per-row upsert)', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecords('divers', [
+      {'id': 'a', 'name': 'A', 'isDefault': false, 'createdAt': 1, 'updatedAt': 1},
+      {'id': 'b', 'name': 'B', 'isDefault': false, 'createdAt': 1, 'updatedAt': 1},
+    ]);
+    expect((await s.fetchRecord('divers', 'a'))?['name'], 'A');
+    expect((await s.fetchRecord('divers', 'b'))?['name'], 'B');
+
+    // Conflict-update: re-upsert 'a' with a new name updates in place.
+    await s.upsertRecords('divers', [
+      {'id': 'a', 'name': 'A2', 'isDefault': false, 'createdAt': 1, 'updatedAt': 2},
+    ]);
+    expect((await s.fetchRecord('divers', 'a'))?['name'], 'A2');
+  });
+}
+```
+
+(Use the exact `divers` column set the existing `upsertRecord`/parity tests use; copy from `sync_base_streaming_parity_test.dart:57-65` if fields differ.)
+
+- [ ] **Step 2: Run to verify it fails** — `flutter test test/core/services/sync/sync_data_serializer_batch_test.dart` → FAIL (`upsertRecords` undefined).
+
+- [ ] **Step 3: Implement** — mirror the existing `upsertRecord` switch (lines ~976-1204), wrapping each case's insert in one `_db.batch`. The mechanical transform per case:
+
+`upsertRecord`: `await _db.into(_db.X).insertOnConflictUpdate(Y.fromJson(data));`
+→ `upsertRecords`: `batch.insertAllOnConflictUpdate(_db.X, records.map((r) => Y.fromJson(r)).toList());`
+
+```dart
+Future<void> upsertRecords(
+  String entityType,
+  List<Map<String, dynamic>> records,
+) async {
+  if (records.isEmpty) return;
+  await _db.batch((batch) {
+    switch (entityType) {
+      case 'divers':
+        batch.insertAllOnConflictUpdate(
+          _db.divers,
+          records.map((r) => Diver.fromJson(r)).toList(),
+        );
+      case 'dives':
+        batch.insertAllOnConflictUpdate(
+          _db.dives,
+          records.map((r) => Dive.fromJson(r)).toList(),
+        );
+      // ... one case PER entity, mirroring upsertRecord's switch exactly
+      // (same _db.<table> and <Type>.fromJson for each entityType). For any
+      // case in upsertRecord that does more than a bare insertOnConflictUpdate,
+      // reproduce that logic inside the batch the same way.
+      default:
+        throw ArgumentError('upsertRecords: unknown entityType $entityType');
+    }
+  });
+}
+```
+
+Enumerate every `case` present in `upsertRecord` (lines 976-1204). Do not invent or omit entities — the set must match exactly (a missing case silently drops a table on apply).
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Commit** — `feat(sync): SyncDataSerializer.upsertRecords batched write`.
+
+---
+
+### Task 2: `fetchRecords` — batched read
+
+**Files:** Modify `sync_data_serializer.dart`; extend the batch test.
+
+**Interfaces:**
+- Produces: `Future<Map<String, Map<String, dynamic>>> fetchRecords(String entityType, Iterable<String> ids)` — local rows keyed by id, for the single-id (`hasUpdatedAt`) entities `_mergeEntity` reads. Composite-key junctions are clockless and never fetched.
+
+- [ ] **Step 1: Write the failing test** — batched read returns the same rows as per-id `fetchRecord`.
+
+```dart
+test('fetchRecords returns rows keyed by id (== per-id fetchRecord)', () async {
+  final s = SyncDataSerializer();
+  await s.upsertRecords('divers', [
+    {'id': 'a', 'name': 'A', 'isDefault': false, 'createdAt': 1, 'updatedAt': 1},
+    {'id': 'b', 'name': 'B', 'isDefault': false, 'createdAt': 1, 'updatedAt': 1},
+  ]);
+  final got = await s.fetchRecords('divers', ['a', 'b', 'missing']);
+  expect(got.keys.toSet(), {'a', 'b'}); // absent ids simply absent
+  expect(got['a'], await s.fetchRecord('divers', 'a'));
+  expect(got['b'], await s.fetchRecord('divers', 'b'));
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (`fetchRecords` undefined).
+
+- [ ] **Step 3: Implement** — mirror `fetchRecord`'s single-id cases (lines ~761-975) with `isIn` instead of `equals`, building a map by id. The mechanical transform per single-id case:
+
+`fetchRecord`: `final row = await (_db.select(_db.X)..where((t) => t.id.equals(recordId))).getSingleOrNull(); return row?.toJson();`
+→ `fetchRecords`: `final rows = await (_db.select(_db.X)..where((t) => t.id.isIn(idList))).get(); return {for (final r in rows) r.id: r.toJson()};`
+
+```dart
+Future<Map<String, Map<String, dynamic>>> fetchRecords(
+  String entityType,
+  Iterable<String> ids,
+) async {
+  final idList = ids.toList();
+  if (idList.isEmpty) return {};
+  switch (entityType) {
+    case 'divers':
+      final rows =
+          await (_db.select(_db.divers)..where((t) => t.id.isIn(idList))).get();
+      return {for (final r in rows) r.id: r.toJson()};
+    case 'dives':
+      final rows =
+          await (_db.select(_db.dives)..where((t) => t.id.isIn(idList))).get();
+      return {for (final r in rows) r.id: r.toJson()};
+    // ... one case per SINGLE-ID entity that appears in SyncService.entityHasUpdatedAt
+    // with value true (those are the only entities _mergeEntity fetches). The
+    // composite-key junctions in fetchRecord (those using _splitCompositeId) are
+    // clockless and never reach the LWW fetch, so they are NOT needed here.
+    default:
+      throw ArgumentError('fetchRecords: unexpected entityType $entityType');
+  }
+}
+```
+
+(Confirm the single-id set against `SyncService.entityHasUpdatedAt`. If unsure whether an entity is single-id, mirror its `fetchRecord` case verbatim with `isIn`.)
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Commit** — `feat(sync): SyncDataSerializer.fetchRecords batched read`.
+
+---
+
+### Task 3: `_mergeEntity` read-decide-write
+
+**Files:** Modify `sync_service.dart:1342-1510`.
+
+**Interfaces:**
+- Consumes: `fetchRecords`, `upsertRecords` (Tasks 1-2).
+
+- [ ] **Step 1: The parity tests already exist and currently pass** (`sync_base_streaming_parity_test`) — they are the failing/guard test for this refactor: they must stay green after it. Run them first to confirm the baseline: `flutter test test/core/services/sync/sync_base_streaming_parity_test.dart` → PASS (pre-refactor).
+
+- [ ] **Step 2: Restructure `_mergeEntity`** to read-decide-write. Replace the per-record `fetchRecord` + per-record `upsertRecord` with:
+
+(a) Before the loop, for `hasUpdatedAt` entities, batch-fetch locals:
+```dart
+final localById = hasUpdatedAt
+    ? await _serializer.fetchRecords(entityType, [
+        for (final r in records)
+          if (_recordIdForEntity(entityType, r) case final id?) id,
+      ])
+    : const <String, Map<String, dynamic>>{};
+final toUpsert = <Map<String, dynamic>>[];
+```
+
+(b) In the loop, replace `final local = await _serializer.fetchRecord(entityType, recordId);` with `final local = localById[recordId];`, and replace each `await _serializer.upsertRecord(entityType, recordToApply); applied += 1;` with `toUpsert.add(recordToApply); applied += 1;`. Every guard, `SyncClock.receive`, conflict-marking, and the clockless blind-win branch stay exactly as-is (the clockless branch also does `toUpsert.add(...)`).
+
+(c) After the loop, flush once:
+```dart
+if (toUpsert.isNotEmpty) {
+  await _serializer.upsertRecords(entityType, toUpsert);
+}
+return _MergeResult(recordsApplied: applied, conflictsFound: conflicts, recordsFailed: failed);
+```
+
+Keep `removeDeletion`/`markRecordConflict` per-record (unchanged). Keep the per-record `try/catch` that counts `failed`; additionally, wrap the final `upsertRecords` so a batch-write failure is surfaced (counts toward `failed` rather than throwing past the merge) — mirror how the per-row catch counted failures.
+
+- [ ] **Step 3: Run the parity + full sync dir** — `flutter test test/core/services/sync/` → all green (parity byte-for-byte, counts identical, convergence/LWW/HLC/#347 junction all unchanged).
+
+- [ ] **Step 4: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze lib/core/services/sync/
+git add lib/core/services/sync/ test/core/services/sync/
+git commit -m "perf(sync): _mergeEntity read-decide-write (batched fetch + upsert)"
+```
+
+---
+
+### Task 4: Measure (optional, interactive)
+
+- [ ] `flutter test` (full pre-push gate) → green.
+- [ ] Optionally, with `scratchpad/vmcap.dart` during a delta-heavy sync, confirm fewer `sqlite3VdbeExec`/Drift-call invocations per apply. (Like S3, the win is partly structural — N→1 statements — so a clean live capture is secondary.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** batched read (spec §Design.1) → Task 2. batched write (§Design.3) → Task 1. read-decide-write loop (§Design.2) → Task 3. Parity gate (§Testing) → Task 3 Step 1/3 (existing byte-for-byte test) + Task 1/2 unit tests. Error-handling-counts-failed (§Correctness) → Task 3 Step 2 note. Out-of-scope (deletions/FK-repair) honored.
+
+**Placeholder scan:** Tasks 1-2 give the exact mechanical transform + runnable representative cases + an explicit "enumerate every case of the existing switch, set must match exactly" instruction (the existing switch is the complete source-of-truth, not a TODO). Task 3 gives the exact before/after edits to the named lines. The one judgement call (which entities are single-id) is pinned to `SyncService.entityHasUpdatedAt` with a fallback rule, not left vague.
+
+**Type/name consistency:** `fetchRecords(String, Iterable<String>) -> Map<String, Map<String,dynamic>>` and `upsertRecords(String, List<Map<String,dynamic>>)` are used identically in Task 3. `localById`/`toUpsert` names consistent. The clockless branch and the LWW branch both append to the same `toUpsert`.

--- a/docs/superpowers/specs/2026-06-24-s2-batch-sync-writes-design.md
+++ b/docs/superpowers/specs/2026-06-24-s2-batch-sync-writes-design.md
@@ -52,3 +52,14 @@ The clockless path appends to `toUpsert` too (a blind win), so all writes for th
 - `_applyRemoteDeletions` (the deletions pass) batching.
 - `repairDanglingForeignKeys` (post-merge FK-repair) — separate.
 - S3 (already shipped: base-apply parse offload), S4 (DB off the UI isolate).
+
+## Implementation status (2026-06-24)
+
+Built and parity-proven. `SyncDataSerializer` gained:
+- `upsertRecords` — one Drift `batch()` mirroring `upsertRecord`'s 39 cases, preserving the `settings` device-local-key filter and every per-record transform (`_withTimestampDefaults`, `_applyDiverSettingDefaults`, the blob serializer, the `diveProfileEvents` source default).
+- `fetchRecords` — batched `WHERE id IN (...)` for the 21 `hasUpdatedAt` entities (`settings` keyed on `key`, `certifications` carrying its BLOB); the clockless composite-key junctions, never fetched, fall back to a per-id loop so the method stays total.
+
+`_mergeEntity` is now read-decide-write: batch-fetch locals, decide in memory against the pre-fetched map, flush one batched write. A batch-write failure moves the whole set from `applied` to `failed` (Drift batch is all-or-nothing), mirroring the per-row catch.
+
+- The byte-for-byte `sync_base_streaming_parity_test` now runs **through the batched merge** and stays green (identical DB + counts), as does the whole sync suite (335) and a targeted serializer batch test covering the `settings` key-vs-id path (which the parity seed does not exercise). Drift `batch()` nests correctly inside the deferred-FK transaction (the >500-row boundary test confirms it).
+- The win is partly structural (N prepared statements -> 1 batched statement + 1 `IN` select), so no live before/after was captured.

--- a/docs/superpowers/specs/2026-06-24-s2-batch-sync-writes-design.md
+++ b/docs/superpowers/specs/2026-06-24-s2-batch-sync-writes-design.md
@@ -1,0 +1,54 @@
+# S2 — Batch the Sync Row Writes — Design
+
+**Date:** 2026-06-24
+**Status:** Design approved
+**Branch/worktree:** `worktree-s2-batch-sync-writes` (off `origin/main`, independent of PR #410 / #412 / #415)
+**Parent:** Phase 2 of the app performance investigation (`2026-06-24-app-performance-investigation-design.md`).
+
+## Goal
+
+Reduce the per-row database cost of applying a sync changeset. `_mergeEntity` (`lib/core/services/sync/sync_service.dart`) applies records row-by-row inside the deferred-FK transaction: for each `hasUpdatedAt` record it does one `fetchRecord` (a DB read for the LWW/HLC compare) and, on a win, one `upsertRecord` (one `insertOnConflictUpdate`). Measurement flagged `sqlite3VdbeExec` (these per-row writes) plus per-row map building as a sync hot spot. Collapse the N per-row reads into one batched lookup and the N per-row writes into one Drift `batch()`.
+
+## What is batchable vs pinned per-record
+
+Per record, `_mergeEntity` runs:
+- **In-memory** (no DB): id resolution (`_recordIdForEntity`), the pending-edit skip (`pendingRecordIds`), the parent-deletion and local-deletion guards (lookups in the pre-fetched `allTombstones`/`revivedParents` maps), and `SyncClock.instance.receive(remoteHlc)` (in-memory HLC advance).
+- **Batchable DB ops**: `fetchRecord` (the LWW read) and `upsertRecord` (the win write) — the hot path.
+- **Rare DB ops** (left per-record): `removeDeletion` (revival/self-heal) and `markRecordConflict` (two-sided conflict).
+
+## Design: read-decide-write
+
+Restructure `_mergeEntity` into three phases, behaviour-identical:
+
+1. **Batch-read.** For `hasUpdatedAt` entities, fetch the local rows for the batch's record-ids in one query. New serializer method `Future<Map<String, Map<String, dynamic>>> fetchRecords(String entityType, Iterable<String> ids)` (a single `WHERE id IN (...)` select; batch size ≤500, well under SQLite's IN-clause limit). The clockless (`!hasUpdatedAt`) path needs no read.
+2. **Decide in memory.** The loop is unchanged except it reads `localById[recordId]` instead of `await fetchRecord(...)`. It still calls `SyncClock.receive` for every remote HLC, runs every guard, and performs the rare `removeDeletion`/`markRecordConflict` inline. Records that should be written are appended to a `toUpsert` list.
+3. **Batch-write.** Apply the winners in one Drift `batch()`. New serializer method `Future<void> upsertRecords(String entityType, List<Map<String, dynamic>> records)` that issues `insertOnConflictUpdate` for each record inside a single `_db.batch(...)`, in list order.
+
+The clockless path appends to `toUpsert` too (a blind win), so all writes for the batch flush once at the end.
+
+## Correctness
+
+- **The decision argument:** every in-loop decision depends only on the pre-fetched local row + the pre-fetched in-memory tombstone/pending maps — never on a write made earlier in the same loop. Deferring all writes to the end therefore cannot change any decision, so the resulting DB is identical.
+- **The one assumption: unique ids within a batch.** With a duplicate id, row-by-row would let the first write affect the second record's `fetchRecord`; batching would not. Changesets are one-row-per-id-per-table, so this never occurs. (If defensiveness is wanted, `fetchRecords` + the decision loop can de-dup last-wins, but it is not required for changeset data.)
+- **`removeDeletion`/`markRecordConflict` stay per-record and unbatched** — they are rare and touch different tables (`deletion_log`/conflicts), so their ordering vs the deferred upserts does not affect final state.
+- **Counts unchanged:** `applied`/`conflicts`/`failed` are tallied exactly as today (a record appended to `toUpsert` counts as applied; a batch-write failure is surfaced — see testing).
+
+## Testing
+
+- **Parity (centerpiece):** the existing `sync_base_streaming_parity_test` (byte-for-byte: streaming/worker apply == in-memory apply) must stay green — it now also exercises the batched merge, proving identical DB + identical counts on a rich library (parent, clockless children, junction, BLOB, updatedAt tables, tombstone).
+- **Whole sync suite (335 tests)** stays green — covers LWW conflicts, HLC ordering, revival/self-heal, the #347 junction reinsert, and convergence.
+- **Targeted `_mergeEntity` tests** (if a focused harness exists): a two-sided conflict still marks a conflict; an HLC-newer remote wins; a pending local edit is still skipped; a tombstoned-parent child is dropped/null'd — all unchanged under batching.
+- **Error handling:** a failure inside the batch write must still increment `failed` (not be masked) — verify the batch path surfaces errors like the per-row path did.
+- **Before/after `vmcap.dart`** (optional): fewer `sqlite3VdbeExec` invocations per apply.
+
+## Success criteria
+
+- `_mergeEntity` issues one batched read + one batched write per merge-batch instead of N + N.
+- Parity test + full sync suite green; LWW/HLC/conflict semantics and counts unchanged.
+- No behaviour change observable to sync (correctness is the gate; throughput is the win).
+
+## Out of scope / follow-ups
+
+- `_applyRemoteDeletions` (the deletions pass) batching.
+- `repairDanglingForeignKeys` (post-merge FK-repair) — separate.
+- S3 (already shipped: base-apply parse offload), S4 (DB off the UI isolate).

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1203,6 +1203,375 @@ class SyncDataSerializer {
     }
   }
 
+  /// Batched [upsertRecord]: writes all [records] for [entityType] in one Drift
+  /// `batch()` (reused prepared statements), in list order, with identical
+  /// conflict semantics. Mirrors [upsertRecord]'s per-entity logic per record --
+  /// the same `<Type>.fromJson`, the same per-record transforms, and the same
+  /// `settings` device-local-key filter.
+  Future<void> upsertRecords(
+    String entityType,
+    List<Map<String, dynamic>> records,
+  ) async {
+    if (records.isEmpty) return;
+    switch (entityType) {
+      case 'divers':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.divers,
+            records.map((r) => Diver.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diverSettings':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diverSettings,
+            records
+                .map(
+                  (r) => DiverSetting.fromJson(_applyDiverSettingDefaults(r)),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'dives':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.dives,
+            records.map((r) => Dive.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveProfiles':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveProfiles,
+            records.map((r) => DiveProfile.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveTanks':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveTanks,
+            records.map((r) => DiveTank.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveEquipment':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveEquipment,
+            records.map((r) => DiveEquipmentData.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveWeights':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveWeights,
+            records.map((r) => DiveWeight.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveSites':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveSites,
+            records.map((r) => DiveSite.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'equipment':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.equipment,
+            records.map((r) => EquipmentData.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'equipmentSets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.equipmentSets,
+            records.map((r) => EquipmentSet.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'equipmentSetItems':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.equipmentSetItems,
+            records.map((r) => EquipmentSetItem.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'media':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.media,
+            records
+                .map(
+                  (r) => MediaData.fromJson(r, serializer: _syncBlobSerializer),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'buddies':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.buddies,
+            records.map((r) => Buddy.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveBuddies':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveBuddies,
+            records.map((r) => DiveBuddy.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'certifications':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.certifications,
+            records
+                .map(
+                  (r) => Certification.fromJson(
+                    r,
+                    serializer: _syncBlobSerializer,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'courses':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.courses,
+            records.map((r) => Course.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'serviceRecords':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.serviceRecords,
+            records.map((r) => ServiceRecord.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveCenters':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveCenters,
+            records.map((r) => DiveCenter.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'trips':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.trips,
+            records.map((r) => Trip.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'liveaboardDetails':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.liveaboardDetailRecords,
+            records.map((r) => LiveaboardDetailRecord.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'itineraryDays':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tripItineraryDays,
+            records.map((r) => TripItineraryDay.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tags':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tags,
+            records.map((r) => Tag.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveTags':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveTags,
+            records.map((r) => DiveTag.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveTypes':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveTypes,
+            records.map((r) => DiveType.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tankPresets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tankPresets,
+            records.map((r) => TankPreset.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveComputers':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveComputers,
+            records.map((r) => DiveComputer.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tankPressureProfiles':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tankPressureProfiles,
+            records.map((r) => TankPressureProfile.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tideRecords':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tideRecords,
+            records.map((r) => TideRecord.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'settings':
+        // Mirror upsertRecord: never overwrite a device-local settings key.
+        final settingsRows = records
+            .where((r) => !_deviceLocalSettingsKeys.contains(r['key']))
+            .map((r) => Setting.fromJson(r))
+            .toList();
+        if (settingsRows.isEmpty) return;
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(_db.settings, settingsRows),
+        );
+        return;
+      case 'species':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.species,
+            records.map((r) => Specy.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'sightings':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.sightings,
+            records.map((r) => Sighting.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveProfileEvents':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveProfileEvents,
+            records
+                .map(
+                  (r) => DiveProfileEvent.fromJson(
+                    r['source'] == null ? {...r, 'source': 'imported'} : r,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'gasSwitches':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.gasSwitches,
+            records.map((r) => GasSwitche.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveCustomFields':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveCustomFields,
+            records
+                .map((r) => DiveCustomField.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'diveDataSources':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveDataSources,
+            records
+                .map(
+                  (r) => DiveDataSourcesData.fromJson(
+                    _withTimestampDefaults(r),
+                    serializer: _syncBlobSerializer,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'siteSpecies':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.siteSpecies,
+            records
+                .map((r) => SiteSpecy.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'csvPresets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.csvPresets,
+            records
+                .map((r) => CsvPreset.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'viewConfigs':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.viewConfigs,
+            records
+                .map((r) => ViewConfig.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'fieldPresets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.fieldPresets,
+            records
+                .map((r) => FieldPreset.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      default:
+        throw ArgumentError('upsertRecords: unknown entityType $entityType');
+    }
+  }
+
   /// Every local row id for [entityType], in the id form [deleteRecord]
   /// accepts: plain `id` for most entities, `key` for `settings`, and the
   /// composite `a|b` form (matching [_compositeId]) for the two junction

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -973,6 +973,138 @@ class SyncDataSerializer {
     return null;
   }
 
+  /// Batched [fetchRecord] for the `hasUpdatedAt` (LWW) entities the merge
+  /// compares against: local rows keyed by record id, fetched with one
+  /// `WHERE id IN (...)` select. Mirrors [fetchRecord] per entity --
+  /// `settings` keys on its `key` column and `certifications` carries a BLOB.
+  /// Any other entity (the clockless composite-key junctions, which the merge
+  /// never fetches) falls back to a per-id loop so the method stays total.
+  Future<Map<String, Map<String, dynamic>>> fetchRecords(
+    String entityType,
+    Iterable<String> ids,
+  ) async {
+    final idList = ids.toList();
+    if (idList.isEmpty) return {};
+    switch (entityType) {
+      case 'divers':
+        final rows = await (_db.select(
+          _db.divers,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diverSettings':
+        final rows = await (_db.select(
+          _db.diverSettings,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'dives':
+        final rows = await (_db.select(
+          _db.dives,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveSites':
+        final rows = await (_db.select(
+          _db.diveSites,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'equipment':
+        final rows = await (_db.select(
+          _db.equipment,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'equipmentSets':
+        final rows = await (_db.select(
+          _db.equipmentSets,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'buddies':
+        final rows = await (_db.select(
+          _db.buddies,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveCenters':
+        final rows = await (_db.select(
+          _db.diveCenters,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'trips':
+        final rows = await (_db.select(
+          _db.trips,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'liveaboardDetails':
+        final rows = await (_db.select(
+          _db.liveaboardDetailRecords,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'itineraryDays':
+        final rows = await (_db.select(
+          _db.tripItineraryDays,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveTypes':
+        final rows = await (_db.select(
+          _db.diveTypes,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'tankPresets':
+        final rows = await (_db.select(
+          _db.tankPresets,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveComputers':
+        final rows = await (_db.select(
+          _db.diveComputers,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'tags':
+        final rows = await (_db.select(
+          _db.tags,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'courses':
+        final rows = await (_db.select(
+          _db.courses,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'serviceRecords':
+        final rows = await (_db.select(
+          _db.serviceRecords,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'csvPresets':
+        final rows = await (_db.select(
+          _db.csvPresets,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'viewConfigs':
+        final rows = await (_db.select(
+          _db.viewConfigs,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'certifications':
+        final rows = await (_db.select(
+          _db.certifications,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {
+          for (final r in rows) r.id: r.toJson(serializer: _syncBlobSerializer),
+        };
+      case 'settings':
+        final rows = await (_db.select(
+          _db.settings,
+        )..where((t) => t.key.isIn(idList))).get();
+        return {for (final r in rows) r.key: r.toJson()};
+      default:
+        // Clockless / composite-key entities are never fetched by the merge;
+        // fall back to per-id reads so the method is total and correct.
+        final out = <String, Map<String, dynamic>>{};
+        for (final id in idList) {
+          final row = await fetchRecord(entityType, id);
+          if (row != null) out[id] = row;
+        }
+        return out;
+    }
+  }
+
   Future<void> upsertRecord(
     String entityType,
     Map<String, dynamic> data,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1360,6 +1360,19 @@ class SyncService {
     final selfTombstones = allTombstones[entityType] ?? const <String, int>{};
     final entityParentRefs = parentRefs[entityType] ?? const <ParentRef>[];
 
+    // Read-decide-write: batch-fetch every local row the LWW compare needs in
+    // one query (the clockless path needs no read). Each decision below reads
+    // only this pre-fetched map plus the pre-fetched tombstone/pending maps --
+    // never a row written earlier in this loop -- so deferring all writes to a
+    // single batch at the end cannot change any decision.
+    final localById = hasUpdatedAt
+        ? await _serializer.fetchRecords(entityType, [
+            for (final record in records)
+              ?_recordIdForEntity(entityType, record),
+          ])
+        : const <String, Map<String, dynamic>>{};
+    final toUpsert = <Map<String, dynamic>>[];
+
     for (final record in records) {
       String? recordId;
       int? localUpdatedAt;
@@ -1435,12 +1448,12 @@ class SyncService {
         }
 
         if (!hasUpdatedAt) {
-          await _serializer.upsertRecord(entityType, recordToApply);
+          toUpsert.add(recordToApply);
           applied += 1;
           continue;
         }
 
-        final local = await _serializer.fetchRecord(entityType, recordId);
+        final local = localById[recordId];
         localUpdatedAt = _extractUpdatedAtMillis(local);
         final remoteUpdatedAt = _extractUpdatedAtMillis(record);
 
@@ -1459,7 +1472,7 @@ class SyncService {
         // remote HLC wins; an exact tie or a local-newer HLC keeps local.
         if (localHlc != null && remoteHlc != null) {
           if (remoteHlc.compareTo(localHlc) > 0) {
-            await _serializer.upsertRecord(entityType, recordToApply);
+            toUpsert.add(recordToApply);
             applied += 1;
           }
           continue;
@@ -1486,7 +1499,7 @@ class SyncService {
         if (remoteUpdatedAt == null ||
             localUpdatedAt == null ||
             remoteUpdatedAt >= localUpdatedAt) {
-          await _serializer.upsertRecord(entityType, recordToApply);
+          toUpsert.add(recordToApply);
           applied += 1;
         }
       } catch (e, stackTrace) {
@@ -1499,6 +1512,24 @@ class SyncService {
         // sides edited the same record). Masking apply errors as conflicts is
         // what hid the cross-device no-op; count it so performSync surfaces it.
         failed += 1;
+      }
+    }
+
+    // Read-decide-write flush: one batched write for the whole merge-batch.
+    // Drift's batch is all-or-nothing, so a failure fails every row it would
+    // have applied -- move those from applied to failed, mirroring the per-row
+    // catch above.
+    if (toUpsert.isNotEmpty) {
+      try {
+        await _serializer.upsertRecords(entityType, toUpsert);
+      } catch (e, stackTrace) {
+        _log.error(
+          'Failed to batch-upsert $entityType (${toUpsert.length} rows)',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        failed += toUpsert.length;
+        applied -= toUpsert.length;
       }
     }
 

--- a/test/core/services/sync/sync_data_serializer_batch_coverage_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_coverage_test.dart
@@ -1,0 +1,269 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Coverage for the batched [SyncDataSerializer.upsertRecords] /
+/// [SyncDataSerializer.fetchRecords] across every syncable entity type. These
+/// are the S2 read-decide-write batch path (one Drift `batch()` write + one
+/// `WHERE id IN (...)` read replacing the per-row loop); each `case` arm must
+/// stay symmetric with the per-record `upsertRecord`/`fetchRecord` switch that
+/// sync_serializer_fetch_record_test.dart pins.
+///
+/// Strategy: seed a minimal placeholder row per table (FK enforcement off),
+/// read it back through the serializer (so blob columns use the same
+/// `_syncBlobSerializer` in both directions), then feed that JSON back through
+/// `upsertRecords` and re-read it through `fetchRecords`. Drift's generated
+/// `toJson`/`fromJson` are inverses for a given table, so this round-trip
+/// exercises every arm with real, valid data and asserts the batched read
+/// matches the per-id read.
+void main() {
+  late SyncDataSerializer serializer;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  // Insert one placeholder row into [table]: every NOT NULL column without a
+  // default gets a type-appropriate placeholder (the boolean CHECK columns all
+  // accept 0). Pass [pkId] for a single-PK table to set a known id; the
+  // composite-PK junctions take no id and are read back via Drift. FK
+  // enforcement is off in tests, so placeholder FK values are fine.
+  Future<void> insertPlaceholderRow(String table, {String? pkId}) async {
+    final cols = await db
+        .customSelect(
+          'SELECT * FROM pragma_table_info(?)',
+          variables: [Variable.withString(table)],
+        )
+        .get();
+    final pkCols = cols.where((c) => (c.data['pk'] as int? ?? 0) > 0).toList();
+    final singlePkName = (pkId != null && pkCols.length == 1)
+        ? pkCols.first.read<String>('name')
+        : null;
+
+    final names = <String>[];
+    final placeholders = <String>[];
+    final values = <Object?>[];
+    for (final c in cols) {
+      final name = c.read<String>('name');
+      final notNull = (c.data['notnull'] as int? ?? 0) == 1;
+      final hasDefault = c.data['dflt_value'] != null;
+      final type = (c.data['type'] as String? ?? '').toUpperCase();
+      if (name == singlePkName) {
+        names.add('"$name"');
+        placeholders.add('?');
+        values.add(pkId);
+      } else if (notNull && !hasDefault) {
+        names.add('"$name"');
+        placeholders.add('?');
+        if (type.contains('INT')) {
+          values.add(0);
+        } else if (type.contains('REAL') ||
+            type.contains('FLOA') ||
+            type.contains('DOUB')) {
+          values.add(0.0);
+        } else if (type.contains('BLOB')) {
+          values.add(Uint8List(0));
+        } else {
+          values.add('x');
+        }
+      }
+    }
+    await db.customStatement(
+      'INSERT INTO "$table" (${names.join(",")}) VALUES (${placeholders.join(",")})',
+      values,
+    );
+  }
+
+  group('batched upsertRecords / fetchRecords', () {
+    test('every single-PK entity round-trips fetchRecord -> upsertRecords -> '
+        'fetchRecords', () async {
+      // Minimal placeholder rows need not satisfy parent references.
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      // entityType -> live SQL table name (mirrors the upsert/fetch switch;
+      // actualTableName avoids snake_case guessing).
+      final targets = <({String type, String table})>[
+        (type: 'divers', table: db.divers.actualTableName),
+        (type: 'diverSettings', table: db.diverSettings.actualTableName),
+        (type: 'dives', table: db.dives.actualTableName),
+        (type: 'diveProfiles', table: db.diveProfiles.actualTableName),
+        (type: 'diveTanks', table: db.diveTanks.actualTableName),
+        (type: 'diveWeights', table: db.diveWeights.actualTableName),
+        (type: 'diveSites', table: db.diveSites.actualTableName),
+        (type: 'equipment', table: db.equipment.actualTableName),
+        (type: 'equipmentSets', table: db.equipmentSets.actualTableName),
+        (type: 'media', table: db.media.actualTableName),
+        (type: 'buddies', table: db.buddies.actualTableName),
+        (type: 'diveBuddies', table: db.diveBuddies.actualTableName),
+        (type: 'certifications', table: db.certifications.actualTableName),
+        (type: 'courses', table: db.courses.actualTableName),
+        (type: 'serviceRecords', table: db.serviceRecords.actualTableName),
+        (type: 'diveCenters', table: db.diveCenters.actualTableName),
+        (type: 'trips', table: db.trips.actualTableName),
+        (
+          type: 'liveaboardDetails',
+          table: db.liveaboardDetailRecords.actualTableName,
+        ),
+        (type: 'itineraryDays', table: db.tripItineraryDays.actualTableName),
+        (type: 'tags', table: db.tags.actualTableName),
+        (type: 'diveTags', table: db.diveTags.actualTableName),
+        (type: 'diveTypes', table: db.diveTypes.actualTableName),
+        (type: 'tankPresets', table: db.tankPresets.actualTableName),
+        (type: 'diveComputers', table: db.diveComputers.actualTableName),
+        (
+          type: 'tankPressureProfiles',
+          table: db.tankPressureProfiles.actualTableName,
+        ),
+        (type: 'tideRecords', table: db.tideRecords.actualTableName),
+        (type: 'settings', table: db.settings.actualTableName),
+        (type: 'species', table: db.species.actualTableName),
+        (type: 'sightings', table: db.sightings.actualTableName),
+        (
+          type: 'diveProfileEvents',
+          table: db.diveProfileEvents.actualTableName,
+        ),
+        (type: 'gasSwitches', table: db.gasSwitches.actualTableName),
+        (type: 'diveCustomFields', table: db.diveCustomFields.actualTableName),
+        (type: 'diveDataSources', table: db.diveDataSources.actualTableName),
+        (type: 'siteSpecies', table: db.siteSpecies.actualTableName),
+        (type: 'csvPresets', table: db.csvPresets.actualTableName),
+        (type: 'viewConfigs', table: db.viewConfigs.actualTableName),
+        (type: 'fieldPresets', table: db.fieldPresets.actualTableName),
+      ];
+
+      for (final t in targets) {
+        final id = 'seed-${t.type}';
+        await insertPlaceholderRow(t.table, pkId: id);
+
+        final json = await serializer.fetchRecord(t.type, id);
+        expect(json, isNotNull, reason: 'fetchRecord(${t.type}) after seed');
+
+        // Batched write: feed the row's own JSON back (a conflict-update).
+        await serializer.upsertRecords(t.type, [json!]);
+
+        // Batched read: matches the per-id read and drops absent ids.
+        final got = await serializer.fetchRecords(t.type, [id, 'absent-id']);
+        expect(got.keys.toSet(), {id}, reason: 'fetchRecords(${t.type}) keys');
+        expect(
+          got[id],
+          await serializer.fetchRecord(t.type, id),
+          reason: 'batched read == per-id read for ${t.type}',
+        );
+      }
+    });
+
+    test(
+      'composite-key junctions upsert and fetch through the fallback loop',
+      () async {
+        await db.customStatement('PRAGMA foreign_keys = OFF');
+
+        // diveEquipment is keyed by "diveId|equipmentId".
+        await insertPlaceholderRow(db.diveEquipment.actualTableName);
+        final de = (await db.select(db.diveEquipment).get()).single;
+        final deId = '${de.diveId}|${de.equipmentId}';
+        await serializer.upsertRecords('diveEquipment', [de.toJson()]);
+        final deGot = await serializer.fetchRecords('diveEquipment', [deId]);
+        expect(deGot.keys, contains(deId));
+
+        // equipmentSetItems is keyed by "setId|equipmentId".
+        await insertPlaceholderRow(db.equipmentSetItems.actualTableName);
+        final esi = (await db.select(db.equipmentSetItems).get()).single;
+        final esiId = '${esi.setId}|${esi.equipmentId}';
+        await serializer.upsertRecords('equipmentSetItems', [esi.toJson()]);
+        final esiGot = await serializer.fetchRecords('equipmentSetItems', [
+          esiId,
+        ]);
+        expect(esiGot.keys, contains(esiId));
+      },
+    );
+
+    test('settings: device-local keys are never written; an all-local batch is '
+        'a no-op', () async {
+      // active_diver_id is device-local -> filtered out; theme is normal.
+      await serializer.upsertRecords('settings', [
+        {'key': 'active_diver_id', 'value': 'diver-7', 'updatedAt': 1},
+        {'key': 'theme', 'value': 'dark', 'updatedAt': 1},
+      ]);
+      expect(
+        await serializer.fetchRecord('settings', 'active_diver_id'),
+        isNull,
+      );
+      expect(
+        (await serializer.fetchRecord('settings', 'theme'))?['value'],
+        'dark',
+      );
+
+      // A batch of only device-local keys filters to empty -> early return.
+      await serializer.upsertRecords('settings', [
+        {'key': 'active_diver_id', 'value': 'diver-9', 'updatedAt': 2},
+      ]);
+      expect(
+        await serializer.fetchRecord('settings', 'active_diver_id'),
+        isNull,
+      );
+    });
+
+    test('diveProfileEvents defaults a missing source to "imported"', () async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+      await insertPlaceholderRow(
+        db.diveProfileEvents.actualTableName,
+        pkId: 'evt-1',
+      );
+      final seeded = await serializer.fetchRecord('diveProfileEvents', 'evt-1');
+      expect(seeded, isNotNull);
+
+      // source present -> kept as-is (the false branch).
+      await serializer.upsertRecords('diveProfileEvents', [
+        {...seeded!, 'source': 'manual'},
+      ]);
+      expect(
+        (await serializer.fetchRecord('diveProfileEvents', 'evt-1'))?['source'],
+        'manual',
+      );
+
+      // source missing -> defaulted to 'imported' (the true branch).
+      await serializer.upsertRecords('diveProfileEvents', [
+        {...seeded}..remove('source'),
+      ]);
+      expect(
+        (await serializer.fetchRecord('diveProfileEvents', 'evt-1'))?['source'],
+        'imported',
+      );
+    });
+
+    test(
+      'upsertRecords throws ArgumentError for an unknown entity type',
+      () async {
+        await expectLater(
+          serializer.upsertRecords('totallyUnknown', [
+            {'id': 'x'},
+          ]),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test(
+      'fetchRecords returns an empty map for no ids or an unknown entity',
+      () async {
+        // idList empty -> early return.
+        expect(await serializer.fetchRecords('divers', const []), isEmpty);
+        // Unknown entity routes through the per-id fallback; absent rows -> {}.
+        expect(
+          await serializer.fetchRecords('totallyUnknown', const ['x']),
+          isEmpty,
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_data_serializer_batch_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_test.dart
@@ -38,4 +38,27 @@ void main() {
     await s.upsertRecords('divers', const []);
     expect(await s.fetchRecord('divers', 'a'), isNull);
   });
+
+  test(
+    'fetchRecords returns id-keyed rows matching per-id fetchRecord',
+    () async {
+      final s = SyncDataSerializer();
+      await s.upsertRecords('divers', [_diver('a', 'A'), _diver('b', 'B')]);
+      final got = await s.fetchRecords('divers', ['a', 'b', 'missing']);
+      expect(got.keys.toSet(), {'a', 'b'}); // absent ids simply absent
+      expect(got['a'], await s.fetchRecord('divers', 'a'));
+      expect(got['b'], await s.fetchRecord('divers', 'b'));
+    },
+  );
+
+  test('fetchRecords keys settings by their key column (not id)', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecords('settings', [
+      {'key': 'theme', 'value': 'dark', 'updatedAt': 1},
+      {'key': 'units', 'value': 'metric', 'updatedAt': 1},
+    ]);
+    final got = await s.fetchRecords('settings', ['theme', 'units']);
+    expect(got.keys.toSet(), {'theme', 'units'});
+    expect(got['theme'], await s.fetchRecord('settings', 'theme'));
+  });
 }

--- a/test/core/services/sync/sync_data_serializer_batch_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+Map<String, dynamic> _diver(String id, String name, {int updatedAt = 1}) => {
+  'id': id,
+  'name': name,
+  'medicalNotes': '',
+  'notes': '',
+  'isDefault': false,
+  'createdAt': 1,
+  'updatedAt': updatedAt,
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async => setUpTestDatabase());
+  tearDown(() async => tearDownTestDatabase());
+
+  test(
+    'upsertRecords writes all records and conflict-updates in place',
+    () async {
+      final s = SyncDataSerializer();
+      await s.upsertRecords('divers', [_diver('a', 'A'), _diver('b', 'B')]);
+      expect((await s.fetchRecord('divers', 'a'))?['name'], 'A');
+      expect((await s.fetchRecord('divers', 'b'))?['name'], 'B');
+
+      // Re-upsert 'a' with a new name updates in place (insertOnConflictUpdate).
+      await s.upsertRecords('divers', [_diver('a', 'A2', updatedAt: 2)]);
+      expect((await s.fetchRecord('divers', 'a'))?['name'], 'A2');
+    },
+  );
+
+  test('upsertRecords is a no-op for an empty list', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecords('divers', const []);
+    expect(await s.fetchRecord('divers', 'a'), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 / **S2** of the app performance investigation. Reduces the per-row database cost of applying a sync changeset. `_mergeEntity` applied records row-by-row inside the deferred-FK transaction: one `fetchRecord` (a read for the LWW/HLC compare) + one `upsertRecord` (one `insertOnConflictUpdate`) per record. Measurement flagged `sqlite3VdbeExec` + per-row statement prep/round-trips as a sync hot spot. This collapses the N per-row reads into one batched lookup and the N per-row writes into one Drift `batch()`.

## Changes

- **`SyncDataSerializer.upsertRecords`** (new): one Drift `batch()` mirroring `upsertRecord`'s 39 cases — same `<Type>.fromJson`, same per-record transforms (`_withTimestampDefaults`, `_applyDiverSettingDefaults`, the blob serializer, the `diveProfileEvents` source default), and the same `settings` device-local-key filter.
- **`SyncDataSerializer.fetchRecords`** (new): batched `WHERE id IN (...)` for the 21 `hasUpdatedAt` entities — `settings` keyed on its `key` column, `certifications` carrying its BLOB. The clockless composite-key junctions (never fetched by the merge) fall back to a per-id loop, keeping the method total.
- **`_mergeEntity`** → **read-decide-write**: batch-fetch the local rows once, run every existing decision (`SyncClock.receive`, the parent/local-deletion guards, the HLC/updatedAt LWW) in memory against the pre-fetched map, then flush one batched write. Rare paths (`removeDeletion`/`markRecordConflict`) stay per-record.

## Why it's safe

Every in-loop decision reads only the pre-fetched local row + the pre-fetched in-memory tombstone/pending maps — never a row written earlier in the same loop — so deferring all writes to a single batch at the end cannot change any decision. Counts are preserved: a row enters `toUpsert` with `applied += 1`; because a Drift `batch()` is all-or-nothing, a batch-write failure moves the whole set back to `failed`, reproducing the per-row catch (`failed == N, applied == 0`).

## Verification

- **Parity (the gate):** the byte-for-byte `sync_base_streaming_parity_test` now runs **through the batched merge** and stays green — identical DB + identical `applied`/`conflicts`/`failed`.
- **Whole sync suite (335)** green — LWW conflicts, HLC ordering, revival/self-heal, the #347 junction reinsert, device-local settings, convergence, adopt-parity.
- **Targeted serializer test** covers the `settings` key-vs-id path that the parity seed does not exercise.
- Drift `batch()` nests correctly inside the deferred-FK transaction (the >500-row boundary test confirms it). Analyze + format clean.
- The win is partly structural (N prepared statements → 1 batched statement + 1 `IN` select), so no live before/after was captured.

Design: `docs/superpowers/specs/2026-06-24-s2-batch-sync-writes-design.md`. Plan: `docs/superpowers/plans/2026-06-24-s2-batch-sync-writes.md`.