### PR TITLE
fix(dc-import): document OSTC nano short-profile limitation (#394 follow-up)

### DIFF
--- a/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
+++ b/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
@@ -765,6 +765,31 @@ static void check_dive_profile_terminated(void) {
     expect(rc == DC_STATUS_TIMEOUT,
            "a profile truncated before the end marker still fails (and retries)");
   }
+
+  // Documents a KNOWN LIMITATION (issue #394 review): a notification dropped
+  // mid-profile while the final FD FD marker still arrives leaves a buffer that
+  // ends in the marker but is missing interior bytes. read_profile cannot tell
+  // this from a legitimate over-declare, so it accepts the short profile and the
+  // dive is stored corrupt -- hw_ostc3_device_foreach does not catch it (its
+  // checks compare the two declared length fields to each other, not to the
+  // received count) and the hwOS profile has no CRC. Asserted here so the
+  // behavior is explicit and the suite does not imply this case is rejected; the
+  // retry narrows the window, only a less lossy link closes it.
+  {
+    unsigned char buf[256 + 100 + 4];
+    size_t full = build_dive(buf, 100, 1, 1);  // header + 100 samples + FD FD + ready
+    // Drop 16 interior sample bytes, keeping the FD FD + ready tail intact.
+    const size_t drop = 16;
+    memmove(buf + 256 + 40, buf + 256 + 40 + drop, full - (256 + 40 + drop));
+    size_t lossy = full - drop;
+    unsigned char out[512];
+    unsigned int len = 0;
+    dc_status_t rc = run_dive(buf, lossy, 380, &len, out, sizeof(out));
+    expect(rc == DC_STATUS_SUCCESS,
+           "lost-middle-with-FD-FD-tail is accepted as complete (known limitation)");
+    expect(len == 256 + 100 + 2 - drop,
+           "the corrupt short profile is accepted at its received length");
+  }
 }
 
 int main(void) {

--- a/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
+++ b/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
@@ -778,16 +778,18 @@ static void check_dive_profile_terminated(void) {
   {
     unsigned char buf[256 + 100 + 4];
     size_t full = build_dive(buf, 100, 1, 1);  // header + 100 samples + FD FD + ready
-    // Drop 16 interior sample bytes, keeping the FD FD + ready tail intact.
-    const size_t drop = 16;
-    memmove(buf + 256 + 40, buf + 256 + 40 + drop, full - (256 + 40 + drop));
-    size_t lossy = full - drop;
+    // Drop one whole mock notification (MOCK_CHUNK bytes), aligned to a
+    // notification boundary inside the sample stream, while keeping the FD FD +
+    // ready tail intact -- the device's BLE bridge losing a single notification.
+    const size_t cut = 256 + 2 * MOCK_CHUNK;  // a notification boundary in the samples
+    memmove(buf + cut, buf + cut + MOCK_CHUNK, full - (cut + MOCK_CHUNK));
+    size_t lossy = full - MOCK_CHUNK;
     unsigned char out[512];
     unsigned int len = 0;
     dc_status_t rc = run_dive(buf, lossy, 380, &len, out, sizeof(out));
     expect(rc == DC_STATUS_SUCCESS,
            "lost-middle-with-FD-FD-tail is accepted as complete (known limitation)");
-    expect(len == 256 + 100 + 2 - drop,
+    expect(len == 256 + 100 + 2 - MOCK_CHUNK,
            "the corrupt short profile is accepted at its received length");
   }
 }


### PR DESCRIPTION
Follow-up to #416, addressing a post-merge review finding.

## The finding (verified)

#416 made the OSTC nano download stop at the device's `0xFD 0xFD` end-of-profile marker instead of the over-declared length. A reviewer flagged — and I confirmed — that the code **comments and tests claimed a guarantee the code does not provide**: a notification dropped *before* the final marker (the same BLE bridge that loses bytes, #280) still delivers the final `FD FD` notification, so the buffer ends in the marker and is accepted as a complete (short) dive.

The downstream validation in `hw_ostc3_device_foreach` does **not** catch this:
- the end-marker check (`profile[length-2..length-1] == 0xFD 0xFD`) passes — the tail is intact;
- the length check (`array_uint24_le(profile+256)` vs `profile+9`) compares the **two declared length fields to each other** — both live in the intact early bytes, never the received count;
- the hwOS profile carries **no CRC**.

So such a dive is stored corrupt, and the original comment's claim that "a notification dropped mid profile still returns the error" was wrong.

## What this PR does

- **Corrects the `hw_ostc3_read_profile` comment** to state the limitation plainly (marker, not byte count, ends the profile; a pre-marker loss is accepted; downstream cannot catch it; retry narrows but cannot close the window; a less lossy link / BLE connection priority is the real mitigation).
- **Adds a native test** asserting and documenting the accepted-corrupt behavior (`lost-middle-with-FD-FD-tail is accepted as complete (known limitation)`), so the suite no longer implies the case is rejected.

**No behavior change** — comments and coverage only. Fork: `submersion-app/libdivecomputer@2b38c6e` on `submersion-patches`.

## Why not a byte-count guard (the reviewer's optional suggestion)

A received-vs-declared length cross-check would need a tolerance constant, and the firmware's over-declare amount is not yet known across dives/firmwares (one data point: ~18–21 bytes). A too-tight tolerance would **false-reject valid over-declared dives — reintroducing the exact `-7` download failure #416 fixes** — which is a broader, louder regression than the narrow, retry-mitigated silent corruption it prevents. That guard should wait until the over-declare's real range can be measured on hardware. Left as a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)