### PR TITLE
Fix sync stutter & dive-detail card flicker (debounce DB change-ticks)

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -109,7 +109,7 @@ class _StartupWrapperState extends State<StartupWrapper>
   /// Forward-only; starts when _state first reaches ready.
   late final AnimationController _splashFadeController = AnimationController(
     vsync: this,
-    duration: const Duration(milliseconds: 900),
+    duration: const Duration(milliseconds: 750),
   );
 
   /// True once the fade completes, at which point the splash widget is

--- a/lib/core/utils/stream_debounce.dart
+++ b/lib/core/utils/stream_debounce.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+/// Trailing-edge debounce for [Stream]s.
+extension DebounceStream<T> on Stream<T> {
+  /// Emits an event only after the source has been silent for [duration],
+  /// dropping all but the most recent event in a burst (trailing edge).
+  ///
+  /// A pending event is flushed when the source closes, so a final event is
+  /// never lost. Errors are forwarded immediately without debouncing. The
+  /// upstream subscription and timer are cancelled when the returned stream is
+  /// cancelled, so no event fires after cancellation.
+  ///
+  /// Collapses a rapid burst of source events -- e.g. a sync committing many
+  /// per-changeset transactions, each firing a Drift table-update tick -- into
+  /// a single downstream event, so expensive listeners run once on the settled
+  /// state instead of once per intermediate write.
+  Stream<T> debounce(Duration duration) {
+    final source = this;
+    late final StreamController<T> controller;
+    StreamSubscription<T>? subscription;
+    Timer? timer;
+    // Holds at most the single most-recent un-emitted event ([] == none). A
+    // list rather than a nullable field so a legitimately-null event (e.g. the
+    // void ticks of a Drift table-update stream) is tracked by emptiness, not
+    // by a null check that cannot tell "no event" from "null event".
+    final pending = <T>[];
+
+    void flush() {
+      timer = null;
+      if (pending.isNotEmpty) {
+        controller.add(pending.removeLast());
+      }
+    }
+
+    controller = StreamController<T>(
+      onListen: () {
+        subscription = source.listen(
+          (event) {
+            pending
+              ..clear()
+              ..add(event);
+            timer?.cancel();
+            timer = Timer(duration, flush);
+          },
+          onError: controller.addError,
+          onDone: () {
+            timer?.cancel();
+            flush();
+            controller.close();
+          },
+          cancelOnError: false,
+        );
+      },
+      onCancel: () {
+        timer?.cancel();
+        timer = null;
+        pending.clear();
+        final toCancel = subscription;
+        subscription = null;
+        return toCancel?.cancel();
+      },
+    );
+
+    return controller.stream;
+  }
+}

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/performance/perf_timer.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/utils/stream_debounce.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
@@ -45,10 +46,28 @@ class DiveRepository {
   // CRUD Operations
   // ============================================================================
 
-  /// Emits whenever the `dives` table changes so list providers can
-  /// refresh after a sync or any other write.
-  Stream<void> watchDivesChanges() =>
-      _db.tableUpdates(TableUpdateQuery.onTable(_db.dives));
+  /// Trailing-debounce window applied to the table-change tick streams
+  /// ([watchDivesChanges] and [watchDiveDetailChanges]).
+  ///
+  /// A sync applies remote changes as many per-changeset transactions, each
+  /// committing separately and firing its own Drift table-update tick (see
+  /// `ChangesetReader.pull`). Un-coalesced, every tick re-invalidates every
+  /// provider listening for a change -- the list, stats, dashboard, sites,
+  /// trips, buddies, and (most expensively) the per-dive detail providers that
+  /// re-run the Buhlmann analysis in [profileAnalysisProvider]. That is 20-30s
+  /// of UI stutter and, while `dive_profiles` rows are mid-rewrite, transiently
+  /// blanks the deco/tissue/O2 cards. Debouncing collapses a write burst into a
+  /// single tick that fires only once writes go quiet, so listeners refresh once
+  /// on the SETTLED DB state instead of once per intermediate commit.
+  static const changeTickDebounce = Duration(milliseconds: 300);
+
+  /// Emits whenever the `dives` table changes so the list, stats, dashboard and
+  /// other cross-feature providers can refresh after a sync or any other write.
+  /// [changeTickDebounce]-debounced so a multi-changeset sync coalesces into a
+  /// single refresh instead of re-querying on every intermediate commit.
+  Stream<void> watchDivesChanges() => _db
+      .tableUpdates(TableUpdateQuery.onTable(_db.dives))
+      .debounce(changeTickDebounce);
 
   /// Aggregate change-tick for the dive DETAIL page: fires when ANY table that
   /// feeds a dive's detail view is written -- including a sync applying remote
@@ -57,6 +76,10 @@ class DiveRepository {
   /// provider subscribes to this (via [diveRepositoryProvider], the shared
   /// cross-feature tick source) and self-invalidates, so the whole detail page
   /// refreshes after a sync the same way the dive list already does.
+  ///
+  /// Ticks are [changeTickDebounce]-debounced so a multi-changeset sync
+  /// refreshes the detail page once on the settled state instead of flickering
+  /// and re-running the Buhlmann analysis on every intermediate commit.
   ///
   /// Broader than [watchDivesChanges] because a single `Dive` entity hydrates
   /// tanks, tank pressures, profile, and equipment (see [_mapRowToDive]) and the
@@ -67,31 +90,33 @@ class DiveRepository {
   /// + dive_computers, plus dive_sites/dive_centers/trips/courses) so a synced
   /// edit to a tag/buddy/species/equipment/site/center/trip/computer NAME also
   /// refreshes the rendered detail, not just changes to the link rows.
-  Stream<void> watchDiveDetailChanges() => _db.tableUpdates(
-    TableUpdateQuery.allOf([
-      TableUpdateQuery.onTable(_db.dives),
-      TableUpdateQuery.onTable(_db.diveProfiles),
-      TableUpdateQuery.onTable(_db.diveTanks),
-      TableUpdateQuery.onTable(_db.tankPressureProfiles),
-      TableUpdateQuery.onTable(_db.diveEquipment),
-      TableUpdateQuery.onTable(_db.equipment),
-      TableUpdateQuery.onTable(_db.gasSwitches),
-      TableUpdateQuery.onTable(_db.diveDataSources),
-      TableUpdateQuery.onTable(_db.diveComputers),
-      TableUpdateQuery.onTable(_db.diveTags),
-      TableUpdateQuery.onTable(_db.tags),
-      TableUpdateQuery.onTable(_db.diveSites),
-      TableUpdateQuery.onTable(_db.diveCenters),
-      TableUpdateQuery.onTable(_db.trips),
-      TableUpdateQuery.onTable(_db.courses),
-      TableUpdateQuery.onTable(_db.diveBuddies),
-      TableUpdateQuery.onTable(_db.buddies),
-      TableUpdateQuery.onTable(_db.sightings),
-      TableUpdateQuery.onTable(_db.species),
-      TableUpdateQuery.onTable(_db.media),
-      TableUpdateQuery.onTable(_db.tideRecords),
-    ]),
-  );
+  Stream<void> watchDiveDetailChanges() => _db
+      .tableUpdates(
+        TableUpdateQuery.allOf([
+          TableUpdateQuery.onTable(_db.dives),
+          TableUpdateQuery.onTable(_db.diveProfiles),
+          TableUpdateQuery.onTable(_db.diveTanks),
+          TableUpdateQuery.onTable(_db.tankPressureProfiles),
+          TableUpdateQuery.onTable(_db.diveEquipment),
+          TableUpdateQuery.onTable(_db.equipment),
+          TableUpdateQuery.onTable(_db.gasSwitches),
+          TableUpdateQuery.onTable(_db.diveDataSources),
+          TableUpdateQuery.onTable(_db.diveComputers),
+          TableUpdateQuery.onTable(_db.diveTags),
+          TableUpdateQuery.onTable(_db.tags),
+          TableUpdateQuery.onTable(_db.diveSites),
+          TableUpdateQuery.onTable(_db.diveCenters),
+          TableUpdateQuery.onTable(_db.trips),
+          TableUpdateQuery.onTable(_db.courses),
+          TableUpdateQuery.onTable(_db.diveBuddies),
+          TableUpdateQuery.onTable(_db.buddies),
+          TableUpdateQuery.onTable(_db.sightings),
+          TableUpdateQuery.onTable(_db.species),
+          TableUpdateQuery.onTable(_db.media),
+          TableUpdateQuery.onTable(_db.tideRecords),
+        ]),
+      )
+      .debounce(changeTickDebounce);
 
   /// Get all dives, ordered by date (newest first)
   /// This method is optimized to avoid N+1 queries by batch loading related data

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -152,6 +152,17 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   /// Empty set means "all visible" (default before sources are loaded).
   Set<String> _visibleComputers = {};
 
+  /// Last usable profile analysis rendered in the deco/tissue/O2 panel, kept
+  /// (paired with the dive id it belongs to) so a transient null from
+  /// [profileAnalysisProvider] -- e.g. a mid-sync `getDiveById` reading the dive
+  /// while its profile rows are being rewritten -- keeps the cards visible
+  /// instead of collapsing them. A dive that has genuinely never produced an
+  /// analysis never populates this, so it still shows nothing. The
+  /// `watchDiveDetailChanges` debounce makes transient nulls rare; this makes
+  /// the panel robust even to a single ill-timed tick.
+  ProfileAnalysis? _lastDecoPanelAnalysis;
+  String? _lastDecoPanelAnalysisDiveId;
+
   String get diveId => widget.diveId;
 
   @override
@@ -1439,9 +1450,25 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     Dive dive,
     int? selectedPointIndex,
   ) {
-    final analysis = ref.watch(profileAnalysisProvider(dive.id)).valueOrNull;
+    final current = ref.watch(profileAnalysisProvider(dive.id)).valueOrNull;
+    final isUsable = current != null && current.decoStatuses.isNotEmpty;
 
-    // Don't show if no analysis available
+    // Retain the last usable analysis for THIS dive and fall back to it when the
+    // provider momentarily yields null/empty (e.g. a mid-sync empty-profile
+    // read), so a single transient null doesn't blink the cards out. A dive that
+    // has genuinely never produced an analysis falls through to the
+    // SizedBox.shrink below and correctly shows nothing.
+    if (isUsable) {
+      _lastDecoPanelAnalysis = current;
+      _lastDecoPanelAnalysisDiveId = dive.id;
+    }
+    final analysis = isUsable
+        ? current
+        : (_lastDecoPanelAnalysisDiveId == dive.id
+              ? _lastDecoPanelAnalysis
+              : null);
+
+    // Don't show if no analysis is, or ever was, available for this dive.
     if (analysis == null || analysis.decoStatuses.isEmpty) {
       return const SizedBox.shrink();
     }

--- a/test/core/utils/stream_debounce_test.dart
+++ b/test/core/utils/stream_debounce_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/utils/stream_debounce.dart';
+
+void main() {
+  group('Stream.debounce', () {
+    test('emits only the most recent event of a burst, once', () {
+      fakeAsync((async) {
+        final source = StreamController<int>();
+        final emitted = <int>[];
+        final sub = source.stream
+            .debounce(const Duration(milliseconds: 300))
+            .listen(emitted.add);
+
+        source
+          ..add(1)
+          ..add(2)
+          ..add(3);
+
+        // Still inside the quiet window: nothing emitted yet.
+        async.elapse(const Duration(milliseconds: 200));
+        expect(emitted, isEmpty);
+
+        // Window elapses with no further events: one trailing emission.
+        async.elapse(const Duration(milliseconds: 200));
+        expect(emitted, [3]);
+
+        sub.cancel();
+        source.close();
+      });
+    });
+
+    test('a continuous burst collapses to a single emission', () {
+      fakeAsync((async) {
+        final source = StreamController<int>();
+        final emitted = <int>[];
+        final sub = source.stream
+            .debounce(const Duration(milliseconds: 300))
+            .listen(emitted.add);
+
+        // 20 events, each well within the window of the previous: the timer
+        // keeps resetting, so nothing fires until the stream goes quiet.
+        for (var i = 0; i < 20; i++) {
+          source.add(i);
+          async.elapse(const Duration(milliseconds: 50));
+        }
+        expect(emitted, isEmpty);
+
+        async.elapse(const Duration(milliseconds: 300));
+        expect(emitted, [19]);
+
+        sub.cancel();
+        source.close();
+      });
+    });
+
+    test('events spaced beyond the window each emit', () {
+      fakeAsync((async) {
+        final source = StreamController<int>();
+        final emitted = <int>[];
+        final sub = source.stream
+            .debounce(const Duration(milliseconds: 200))
+            .listen(emitted.add);
+
+        source.add(1);
+        async.elapse(const Duration(milliseconds: 250));
+        source.add(2);
+        async.elapse(const Duration(milliseconds: 250));
+
+        expect(emitted, [1, 2]);
+
+        sub.cancel();
+        source.close();
+      });
+    });
+
+    test('flushes a pending event when the source closes early', () {
+      fakeAsync((async) {
+        final source = StreamController<int>();
+        final emitted = <int>[];
+        final sub = source.stream
+            .debounce(const Duration(milliseconds: 300))
+            .listen(emitted.add);
+
+        source.add(42);
+        source.close(); // closes before the debounce window elapses
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(emitted, [
+          42,
+        ], reason: 'a final event must not be dropped on close');
+
+        sub.cancel();
+      });
+    });
+
+    test('cancelling the subscription suppresses a pending emit', () {
+      fakeAsync((async) {
+        final source = StreamController<int>();
+        final emitted = <int>[];
+        final sub = source.stream
+            .debounce(const Duration(milliseconds: 300))
+            .listen(emitted.add);
+
+        source.add(1);
+        sub.cancel();
+
+        async.elapse(const Duration(milliseconds: 500));
+        expect(emitted, isEmpty);
+
+        source.close();
+      });
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/entities/deco_status.dart';
+import 'package:submersion/core/deco/entities/tissue_compartment.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -12,7 +15,10 @@ import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/compact_deco_status_card.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_card.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -463,5 +469,184 @@ void main() {
         }
       },
     );
+  });
+
+  group('DiveDetailPage deco/O2 panel last-good retention', () {
+    Dive diveWithProfile() {
+      return createTestDiveWithBottomTime().copyWith(
+        profile: List.generate(
+          6,
+          (i) => DiveProfilePoint(
+            timestamp: i * 60,
+            depth: (i < 3 ? i * 8.0 : (5 - i) * 8.0),
+          ),
+        ),
+      );
+    }
+
+    // A ProfileAnalysis carrying one fully-populated DecoStatus so the
+    // deco/tissue/O2 cards actually render (the panel hides on empty
+    // decoStatuses).
+    ProfileAnalysis analysisWithDeco() {
+      final compartments = List.generate(
+        zhl16CompartmentCount,
+        (i) => TissueCompartment(
+          compartmentNumber: i + 1,
+          halfTimeN2: zhl16cN2HalfTimes[i],
+          halfTimeHe: zhl16cHeHalfTimes[i],
+          mValueAN2: zhl16cN2A[i],
+          mValueBN2: zhl16cN2B[i],
+          mValueAHe: zhl16cHeA[i],
+          mValueBHe: zhl16cHeB[i],
+          currentPN2: inspiredSurfaceN2Bar,
+          currentPHe: 0.0,
+        ),
+      );
+      final status = DecoStatus(
+        compartments: compartments,
+        ndlSeconds: 999 * 60,
+        ceilingMeters: 0,
+        ttsSeconds: 0,
+        gfLow: 0.3,
+        gfHigh: 0.7,
+        decoStops: const [],
+        currentDepthMeters: 0,
+        ambientPressureBar: 1.0,
+      );
+      return ProfileAnalysis.empty().copyWith(
+        decoStatuses: [status],
+        ppO2Curve: const [0.21],
+      );
+    }
+
+    List<Override> panelOverrides(Dive dive, Override analysisOverride) {
+      return [
+        diveProvider(dive.id).overrideWith((ref) async => dive),
+        diveDataSourcesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <DiveDataSource>[]),
+        analysisOverride,
+        gasSwitchesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+        tankPressuresProvider(
+          dive.id,
+        ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+        profilesBySourceProvider(
+          dive.id,
+        ).overrideWith((ref) async => <String?, List<DiveProfilePoint>>{}),
+        weeklyOtuProvider(dive.id).overrideWith((ref) async => 0.0),
+      ];
+    }
+
+    testWidgets('shows nothing for a dive that never produced an analysis', (
+      tester,
+    ) async {
+      final dive = diveWithProfile();
+      final base = await getBaseOverrides();
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (d) {
+        if (d.toString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...base,
+            ...panelOverrides(
+              dive,
+              profileAnalysisProvider(
+                dive.id,
+              ).overrideWith((ref) async => null),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveDetailPage(diveId: dive.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      FlutterError.onError = originalOnError;
+
+      // Genuine null: the last-good cache must not fabricate a panel for a dive
+      // that has no analysis.
+      expect(find.byType(CompactDecoStatusCard), findsNothing);
+      expect(find.byType(CompactTissueLoadingCard), findsNothing);
+      expect(find.byType(CompactO2ToxicityPanel), findsNothing);
+    });
+
+    testWidgets('keeps the cards on a transient null instead of collapsing', (
+      tester,
+    ) async {
+      final dive = diveWithProfile();
+      final analysis = analysisWithDeco();
+      // Controllable analysis: starts good, then flips to null to mimic a
+      // mid-sync empty-profile read that makes profileAnalysisProvider emit
+      // AsyncData(null).
+      final controllable = StateProvider<ProfileAnalysis?>((ref) => analysis);
+      final base = await getBaseOverrides();
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (d) {
+        if (d.toString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...base,
+            ...panelOverrides(
+              dive,
+              profileAnalysisProvider(
+                dive.id,
+              ).overrideWith((ref) async => ref.watch(controllable)),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveDetailPage(diveId: dive.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // Good analysis -> all three cards render.
+      expect(find.byType(CompactDecoStatusCard), findsOneWidget);
+      expect(find.byType(CompactTissueLoadingCard), findsOneWidget);
+      expect(find.byType(CompactO2ToxicityPanel), findsOneWidget);
+
+      // Flip to a transient null (the storm symptom, post-debounce edge case).
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveDetailPage)),
+      );
+      container.read(controllable.notifier).state = null;
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      FlutterError.onError = originalOnError;
+
+      // The provider has genuinely settled to AsyncData(null) -- so the cards
+      // below survive only because of the last-good fallback, not a loading
+      // window that still exposes the previous value via valueOrNull.
+      final settled = container.read(profileAnalysisProvider(dive.id));
+      expect(settled.isLoading, isFalse);
+      expect(settled.valueOrNull, isNull);
+
+      // Hardening: the cards must remain (last-good), not blink out.
+      expect(
+        find.byType(CompactDecoStatusCard),
+        findsOneWidget,
+        reason:
+            'a transient null analysis must not collapse the deco card; the '
+            'panel should fall back to the last usable analysis',
+      );
+      expect(find.byType(CompactTissueLoadingCard), findsOneWidget);
+      expect(find.byType(CompactO2ToxicityPanel), findsOneWidget);
+    });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -545,6 +545,9 @@ void main() {
       final dive = diveWithProfile();
       final base = await getBaseOverrides();
       final originalOnError = FlutterError.onError;
+      // Guaranteed restore even if the test throws before the end, so the
+      // global handler never leaks into later tests.
+      addTearDown(() => FlutterError.onError = originalOnError);
       FlutterError.onError = (d) {
         if (d.toString().contains('overflowed')) return;
         originalOnError?.call(d);
@@ -570,7 +573,6 @@ void main() {
       );
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
-      FlutterError.onError = originalOnError;
 
       // Genuine null: the last-good cache must not fabricate a panel for a dive
       // that has no analysis.
@@ -590,6 +592,9 @@ void main() {
       final controllable = StateProvider<ProfileAnalysis?>((ref) => analysis);
       final base = await getBaseOverrides();
       final originalOnError = FlutterError.onError;
+      // Guaranteed restore even if the test throws before the end, so the
+      // global handler never leaks into later tests.
+      addTearDown(() => FlutterError.onError = originalOnError);
       FlutterError.onError = (d) {
         if (d.toString().contains('overflowed')) return;
         originalOnError?.call(d);
@@ -628,7 +633,6 @@ void main() {
       container.read(controllable.notifier).state = null;
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
-      FlutterError.onError = originalOnError;
 
       // The provider has genuinely settled to AsyncData(null) -- so the cards
       // below survive only because of the last-good fallback, not a loading

--- a/test/features/dive_log/presentation/providers/dive_providers_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_providers_test.dart
@@ -161,4 +161,88 @@ void main() {
           'stats reflect new dives without an app restart (issue #217).',
     );
   });
+
+  test(
+    'watchDiveDetailChanges coalesces a burst of writes into a single tick',
+    () async {
+      // A sync applies remote changes as MANY per-changeset transactions, each
+      // committing separately and firing its own Drift table-update tick. Left
+      // un-coalesced, every tick re-invalidates the 15 per-dive detail
+      // providers -- re-running the expensive Buhlmann analysis and, while the
+      // dive_profiles rows are mid-rewrite, transiently blanking the deco /
+      // tissue / O2 cards. The aggregate detail-change stream must debounce a
+      // burst so listeners refresh ONCE on the settled DB state.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1, maxDepth: 20.0),
+      );
+
+      final db = DatabaseService.instance.database;
+      final repo = DiveRepository();
+
+      var ticks = 0;
+      final sub = repo.watchDiveDetailChanges().listen((_) => ticks++);
+      addTearDown(sub.cancel);
+
+      // Fire a rapid burst, like a lagging peer's changesets applied
+      // back-to-back. Each write is its own transaction -> its own commit.
+      for (var i = 0; i < 10; i++) {
+        await (db.update(db.dives)..where((t) => t.id.equals('d1'))).write(
+          DivesCompanion(maxDepth: Value(21.0 + i)),
+        );
+      }
+
+      // Let the trailing debounce window elapse.
+      await Future<void>.delayed(
+        DiveRepository.changeTickDebounce + const Duration(milliseconds: 150),
+      );
+
+      expect(
+        ticks,
+        1,
+        reason:
+            'a burst of N writes must coalesce into ONE detail-change tick so '
+            'the per-dive providers recompute once on the settled state, not '
+            'once per intermediate sync write (stutter + card flicker)',
+      );
+    },
+  );
+
+  test(
+    'watchDivesChanges coalesces a burst of writes into a single tick',
+    () async {
+      // The dives-table tick fans out to the list, stats, dashboard, sites,
+      // trips and buddy providers app-wide. The same per-changeset sync burst
+      // must coalesce here too, so those cross-feature providers re-query once
+      // on the settled state instead of once per intermediate commit.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1, maxDepth: 20.0),
+      );
+
+      final db = DatabaseService.instance.database;
+      final repo = DiveRepository();
+
+      var ticks = 0;
+      final sub = repo.watchDivesChanges().listen((_) => ticks++);
+      addTearDown(sub.cancel);
+
+      for (var i = 0; i < 10; i++) {
+        await (db.update(db.dives)..where((t) => t.id.equals('d1'))).write(
+          DivesCompanion(maxDepth: Value(21.0 + i)),
+        );
+      }
+
+      await Future<void>.delayed(
+        DiveRepository.changeTickDebounce + const Duration(milliseconds: 150),
+      );
+
+      expect(
+        ticks,
+        1,
+        reason:
+            'a burst of N dives-table writes must coalesce into ONE tick so the '
+            'list/stats/dashboard providers re-query once, not once per sync '
+            'commit',
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Fixes the 20-30s app stutter and the dive-detail **Deco Status / Tissue Loading / Oxygen Toxicity** cards repeatedly disappearing then reappearing during an iCloud **or** S3 sync. Both symptoms share one root cause, and both transports share the same provider-agnostic local-DB apply engine — which is why it reproduced on each.

Also trims the startup splash fade for a slightly snappier launch.

## Root cause

A sync applies each remote changeset as its **own** Drift transaction in a loop (no transaction spans the whole sync — deliberate, for OOM/resilience). A lagging peer can present ~200 changesets ⇒ ~200 commits ⇒ ~200 `tableUpdates` ticks. `watchDiveDetailChanges()` and `watchDivesChanges()` relayed **every** tick straight to `ref.invalidateSelf()` on their subscribers with zero coalescing:

- **Stutter** — the per-dive `profileAnalysisProvider` (full 16-compartment Bühlmann simulation) re-ran on every commit, ~200×, alongside list / stats / dashboard / sites / trips / buddies re-queries. These detail providers are non-autoDispose, so the storm runs even when you're off the detail page.
- **Flicker** — on a tick, `getDiveById` can momentarily read the dive while its `dive_profiles` rows are mid-rewrite (deleted by one changeset-transaction, not yet reinserted by a later one) ⇒ empty profile ⇒ `profileAnalysisProvider` returns `AsyncData(null)` ⇒ `_buildDecoO2Panel` collapsed all three cards to `SizedBox.shrink()`.

## Changes

1. **`fix(sync)` — debounce the change-tick streams.** New `lib/core/utils/stream_debounce.dart` (trailing-edge `Stream.debounce`; flushes a pending event on close so the post-sync refresh isn't lost; void-safe). Both `watchDiveDetailChanges()` and `watchDivesChanges()` now end in `.debounce(changeTickDebounce /* 300ms */)`, so a write burst coalesces into a single refresh on the **settled** DB state. The trailing edge is the crux: the re-read fires only after writes quiesce, eliminating both the recompute storm and the mid-rewrite empty read.

2. **`fix(dive-detail)` — last-good panel hardening (defense-in-depth).** `_buildDecoO2Panel` retains the last usable analysis per dive and falls back to it on a transient null instead of collapsing; a dive that genuinely has no profile still shows nothing (id-keyed, so a different dive never reuses it).

3. **`feat(splash)` — trim the splash fade-out dissolve 900ms → 750ms** (the 1s minimum hold is unchanged).

## Test plan

- New `test/core/utils/stream_debounce_test.dart` — 5 tests (burst coalescing, spacing, flush-on-close, cancel).
- New repro tests in `dive_providers_test.dart` — a 10-write burst coalesces to **1** tick on each stream (was 10).
- New `dive_detail_page_test.dart` tests — genuine-null hides the panel; a transient null keeps the cards (asserting the provider settled to `AsyncData(null)`, so survival is the fallback, not a loading-window value).
- Cross-feature reactivity + ~1,200 widget tests across dive_log, dashboard, sites, trips, buddies, dive-centers, tags re-run green (pending-`Timer` check for the new 300ms timer).
- `flutter analyze` clean; `dart format --set-exit-if-changed .` clean.

## Notes

- Transport-agnostic (shared apply engine), so it covers iCloud, S3, and Drive.
- The deliberate per-changeset sync transaction granularity is untouched; the fix lives at the propagation seam.
- Device verification of a live multi-device sync is still recommended.