### PR TITLE
fix(dive-detail): keep SAC-by-segment card on a transient null analysis

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -163,6 +163,17 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   ProfileAnalysis? _lastDecoPanelAnalysis;
   String? _lastDecoPanelAnalysisDiveId;
 
+  /// Last usable profile analysis rendered in the "SAC Rate by Segment" card,
+  /// kept (paired with its dive id) so a transient null from
+  /// [profileAnalysisProvider] -- the same mid-sync empty-profile read that
+  /// blinks the deco/O2 panel -- keeps the segment card visible instead of
+  /// collapsing it to [SizedBox.shrink]. A dive that has genuinely never
+  /// produced segments never populates this, so it still shows nothing.
+  /// Sibling defense-in-depth to [_lastDecoPanelAnalysis] alongside the
+  /// `watchDiveDetailChanges` change-tick debounce.
+  ProfileAnalysis? _lastSacSegmentsAnalysis;
+  String? _lastSacSegmentsAnalysisDiveId;
+
   String get diveId => widget.diveId;
 
   @override
@@ -1578,7 +1589,27 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     Dive dive,
     int? selectedPointIndex,
   ) {
-    final analysis = ref.watch(profileAnalysisProvider(dive.id)).valueOrNull;
+    final current = ref.watch(profileAnalysisProvider(dive.id)).valueOrNull;
+    final isUsable =
+        current != null &&
+        current.sacSegments != null &&
+        current.sacSegments!.isNotEmpty;
+
+    // Retain the last usable analysis for THIS dive and fall back to it when the
+    // provider momentarily yields null/empty (e.g. a mid-sync empty-profile
+    // read), so a single transient null doesn't blink the card out. A dive that
+    // has genuinely never produced segments falls through to the
+    // SizedBox.shrink below and correctly shows nothing.
+    if (isUsable) {
+      _lastSacSegmentsAnalysis = current;
+      _lastSacSegmentsAnalysisDiveId = dive.id;
+    }
+    final analysis = isUsable
+        ? current
+        : (_lastSacSegmentsAnalysisDiveId == dive.id
+              ? _lastSacSegmentsAnalysis
+              : null);
+
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
     final sacUnit = ref.watch(sacUnitProvider);
@@ -1598,7 +1629,8 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // Get cylinder SAC data for multi-tank dives
     final cylinderSacAsync = ref.watch(cylinderSacProvider(dive.id));
 
-    // Don't show if no segments available at all
+    // Don't show if no segments are, or ever were, available for this dive
+    // (the last-good fallback above keeps a transient null from collapsing it).
     if (analysis == null ||
         (analysis.sacSegments == null || analysis.sacSegments!.isEmpty)) {
       // Still show cylinder SAC if available

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1650,8 +1650,15 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // Get collapsed state from provider
     final isExpanded = ref.watch(sacSegmentsSectionExpandedProvider);
 
-    // Use current segments or fall back to time-based
-    final displaySegments = segments ?? analysis.sacSegments!;
+    // Use the selected mode's segments, falling back to the (last-good)
+    // analysis time segments when that mode yields nothing usable. Treat an
+    // empty list like null: activeSegmentsForDiveProvider watches the LIVE
+    // profileAnalysisProvider, so a transient non-null/empty-sacSegments
+    // emission would otherwise leave `segments` empty and render an empty card
+    // even though `analysis` holds a usable last-good list.
+    final displaySegments = (segments == null || segments.isEmpty)
+        ? analysis.sacSegments!
+        : segments;
 
     // Get tank volume for L/min conversion (use first tank with volume)
     final tankVolume = dive.tanks

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -13,8 +13,10 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_analysis_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/collapsible_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_deco_status_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
@@ -651,6 +653,189 @@ void main() {
       );
       expect(find.byType(CompactTissueLoadingCard), findsOneWidget);
       expect(find.byType(CompactO2ToxicityPanel), findsOneWidget);
+    });
+  });
+
+  group('DiveDetailPage SAC-by-segment last-good retention', () {
+    Dive diveWithProfile() {
+      return createTestDiveWithBottomTime().copyWith(
+        profile: List.generate(
+          6,
+          (i) => DiveProfilePoint(
+            timestamp: i * 60,
+            depth: (i < 3 ? i * 8.0 : (5 - i) * 8.0),
+          ),
+        ),
+      );
+    }
+
+    // A ProfileAnalysis carrying one time-interval SAC segment so the
+    // "SAC Rate by Segment" card actually renders (the section hides on a
+    // null/empty sacSegments). decoStatuses stays empty so the sibling
+    // deco/O2 panel renders nothing and this stays scoped to the SAC card.
+    ProfileAnalysis analysisWithSacSegments() {
+      return ProfileAnalysis.empty().copyWith(
+        sacSegments: const [
+          SacSegment(
+            startTimestamp: 0,
+            endTimestamp: 300,
+            avgDepth: 18.0,
+            minDepth: 0.0,
+            maxDepth: 24.0,
+            sacRate: 0.8,
+            gasConsumed: 4.0,
+            segmentationType: SacSegmentationType.timeInterval,
+          ),
+        ],
+      );
+    }
+
+    // timeInterval segmentation makes activeSegmentsForDiveProvider read the
+    // segments straight off profileAnalysisProvider, so the whole card is
+    // driven by the single controllable analysis (no phase/gas-switch
+    // providers in play).
+    List<Override> sacOverrides(Dive dive, Override analysisOverride) {
+      return [
+        diveProvider(dive.id).overrideWith((ref) async => dive),
+        diveDataSourcesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <DiveDataSource>[]),
+        analysisOverride,
+        selectedSegmentationProvider.overrideWith(
+          (ref) => SacSegmentationType.timeInterval,
+        ),
+        gasSwitchesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+        tankPressuresProvider(
+          dive.id,
+        ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+        profilesBySourceProvider(
+          dive.id,
+        ).overrideWith((ref) async => <String?, List<DiveProfilePoint>>{}),
+        weeklyOtuProvider(dive.id).overrideWith((ref) async => 0.0),
+      ];
+    }
+
+    // The SAC-by-segment card is a CollapsibleCardSection titled with the
+    // localized "SAC Rate by Segment" string; matching that title scopes the
+    // finder precisely to this card.
+    Finder sacCardFinder(WidgetTester tester) {
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(DiveDetailPage)),
+      );
+      return find.widgetWithText(
+        CollapsibleCardSection,
+        l10n.diveLog_detail_section_sacRateBySegment,
+      );
+    }
+
+    testWidgets('shows nothing for a dive that never produced segments', (
+      tester,
+    ) async {
+      final dive = diveWithProfile();
+      final base = await getBaseOverrides();
+      final originalOnError = FlutterError.onError;
+      // Guaranteed restore even if the test throws before the end, so the
+      // global handler never leaks into later tests.
+      addTearDown(() => FlutterError.onError = originalOnError);
+      FlutterError.onError = (d) {
+        if (d.toString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...base,
+            ...sacOverrides(
+              dive,
+              profileAnalysisProvider(
+                dive.id,
+              ).overrideWith((ref) async => null),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveDetailPage(diveId: dive.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // Genuine null: the last-good cache must not fabricate a card for a dive
+      // that has no segment analysis.
+      expect(sacCardFinder(tester), findsNothing);
+    });
+
+    testWidgets('keeps the card on a transient null instead of collapsing', (
+      tester,
+    ) async {
+      final dive = diveWithProfile();
+      final analysis = analysisWithSacSegments();
+      // Controllable analysis: starts good, then flips to null to mimic a
+      // mid-sync empty-profile read that makes profileAnalysisProvider emit
+      // AsyncData(null).
+      final controllable = StateProvider<ProfileAnalysis?>((ref) => analysis);
+      final base = await getBaseOverrides();
+      final originalOnError = FlutterError.onError;
+      // Guaranteed restore even if the test throws before the end, so the
+      // global handler never leaks into later tests.
+      addTearDown(() => FlutterError.onError = originalOnError);
+      FlutterError.onError = (d) {
+        if (d.toString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...base,
+            ...sacOverrides(
+              dive,
+              profileAnalysisProvider(
+                dive.id,
+              ).overrideWith((ref) async => ref.watch(controllable)),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveDetailPage(diveId: dive.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // Good analysis -> the SAC-by-segment card renders.
+      expect(sacCardFinder(tester), findsOneWidget);
+
+      // Flip to a transient null (the storm symptom, post-debounce edge case).
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveDetailPage)),
+      );
+      container.read(controllable.notifier).state = null;
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // The provider has genuinely settled to AsyncData(null) -- so the card
+      // below survives only because of the last-good fallback, not a loading
+      // window that still exposes the previous value via valueOrNull.
+      final settled = container.read(profileAnalysisProvider(dive.id));
+      expect(settled.isLoading, isFalse);
+      expect(settled.valueOrNull, isNull);
+
+      // Hardening: the card must remain (last-good), not blink out.
+      expect(
+        sacCardFinder(tester),
+        findsOneWidget,
+        reason:
+            'a transient null analysis must not collapse the SAC-by-segment '
+            'card; the section should fall back to the last usable analysis',
+      );
     });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -837,5 +837,77 @@ void main() {
             'card; the section should fall back to the last usable analysis',
       );
     });
+
+    testWidgets(
+      'keeps cached segments when analysis flips to non-null empty sacSegments',
+      (tester) async {
+        final dive = diveWithProfile();
+        final analysis = analysisWithSacSegments();
+        // Flip from a good analysis to a NON-NULL analysis whose sacSegments is
+        // an empty (not null) list -- the case where
+        // activeSegmentsForDiveProvider yields [] for time/depth modes. The
+        // null-coalescing displaySegments fallback (`segments ?? ...`) does not
+        // catch an empty list, so without an empty-aware fallback the card
+        // would render zero rows even though the cached analysis still has a
+        // usable segment.
+        final controllable = StateProvider<ProfileAnalysis?>((ref) => analysis);
+        final base = await getBaseOverrides();
+        final originalOnError = FlutterError.onError;
+        addTearDown(() => FlutterError.onError = originalOnError);
+        FlutterError.onError = (d) {
+          if (d.toString().contains('overflowed')) return;
+          originalOnError?.call(d);
+        };
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              ...base,
+              ...sacOverrides(
+                dive,
+                profileAnalysisProvider(
+                  dive.id,
+                ).overrideWith((ref) async => ref.watch(controllable)),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: DiveDetailPage(diveId: dive.id, embedded: true),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        // Good analysis -> the single time segment row renders (label '0-5min').
+        expect(find.text('0-5min'), findsOneWidget);
+
+        // Flip to a non-null analysis carrying an EMPTY segment list.
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(DiveDetailPage)),
+        );
+        container.read(controllable.notifier).state = ProfileAnalysis.empty()
+            .copyWith(sacSegments: const <SacSegment>[]);
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        // The live analysis is non-null with empty sacSegments, so
+        // activeSegmentsForDiveProvider yields []. The card must still render
+        // the cached segment rather than an empty list.
+        expect(
+          sacCardFinder(tester),
+          findsOneWidget,
+          reason: 'card stays visible on a non-null empty-segments analysis',
+        );
+        expect(
+          find.text('0-5min'),
+          findsOneWidget,
+          reason:
+              'an empty (non-null) segment list must fall back to the cached '
+              'analysis segments, not render an empty card',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

The "SAC Rate by Segment" card on the dive detail page blinked out and back during sync — the same defect PR #427 fixed for the deco/tissue/O2 panel, on the same provider, but this sibling section never received the fix.

`_buildSacSegmentsSection` watches `profileAnalysisProvider(dive.id).valueOrNull`. During a sync the provider momentarily settles to `AsyncData(null)` (it observes `diveProvider` mid-refresh / reads an empty profile at `profile_analysis_provider.dart:598`), and the guard collapsed the card to `SizedBox.shrink()`. #427 added a shared change-tick debounce (which already helps here) **plus** per-card last-good retention — but the retention was only applied to `_buildDecoO2Panel`.

## Fix

Apply the same id-keyed last-good retention to the SAC section:

- New `_lastSacSegmentsAnalysis` + `_lastSacSegmentsAnalysisDiveId` state fields.
- Cache the analysis when it is *usable* (non-null, non-empty `sacSegments`); on a transient null/empty, fall back to the cached value only when the dive id matches.
- A dive that genuinely never produced segments is never cached, so it still correctly shows nothing.

The section-level `dive.profile.isEmpty` gate is not a second blink path: Riverpod's `.when()` defaults to `skipLoadingOnRefresh: true`, so the top-level `dive` keeps its populated profile during a sync refresh — only the analysis transiently goes null.

## Tests

New `DiveDetailPage SAC-by-segment last-good retention` group in `dive_detail_page_test.dart` (mirrors the #427 deco-panel tests):

- `shows nothing for a dive that never produced segments` — a genuine null must not fabricate a card.
- `keeps the card on a transient null instead of collapsing` — fails without the fix (card collapses), passes with it; asserts the provider settled to `AsyncData(null)` so survival is the last-good fallback, not a loading-window value.

## Verification

- New tests: red→green (failed before the fix existed, pass after).
- Full `dive_detail_page_test.dart`: 13 passing (deco-panel tests unaffected).
- Related SAC/analysis suites: 55 passing.
- `dart format`: clean. `flutter analyze`: no issues found.

Device verification pending — like #427, the on-device sync flicker can't be exercised in `flutter_test`; the widget test reproduces the transient-null mechanism deterministically.