### PR TITLE
fix(dive-types): open the picker on macOS and seed built-in types for upgraded databases

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1149,6 +1149,41 @@ const String kSeedDiveDiveTypesSql = '''
   FROM dives
 ''';
 
+/// Seeds the built-in dive types. Used by BOTH [onCreate] (fresh installs) and
+/// the v93 migration (backfill for upgraded databases). The full built-in set
+/// was historically seeded only in onCreate, so every database that reached the
+/// app via migration kept an EMPTY `dive_types` table -- harmless until the
+/// multi-select dive-type picker (#414) read it and showed no options.
+///
+/// `INSERT OR IGNORE` keyed on the stable slug ids preserves any rows already
+/// present (synced custom types, or 'cavern' added by the v88 migration) and
+/// makes re-running the seed a no-op. Keep this list in sync with the
+/// onboarding documentation; it is asserted directly in tests.
+const String kSeedBuiltInDiveTypesSql = '''
+  INSERT OR IGNORE INTO dive_types
+    (id, name, is_built_in, sort_order, created_at, updated_at)
+  SELECT id, name, 1, sort_order,
+    CAST(strftime('%s','now') AS INTEGER) * 1000,
+    CAST(strftime('%s','now') AS INTEGER) * 1000
+  FROM (
+    SELECT 'recreational' AS id, 'Recreational' AS name, 0 AS sort_order
+    UNION ALL SELECT 'technical', 'Technical', 1
+    UNION ALL SELECT 'freedive', 'Freedive', 2
+    UNION ALL SELECT 'training', 'Training', 3
+    UNION ALL SELECT 'wreck', 'Wreck', 4
+    UNION ALL SELECT 'cave', 'Cave', 5
+    UNION ALL SELECT 'ice', 'Ice', 6
+    UNION ALL SELECT 'night', 'Night', 7
+    UNION ALL SELECT 'drift', 'Drift', 8
+    UNION ALL SELECT 'deep', 'Deep', 9
+    UNION ALL SELECT 'altitude', 'Altitude', 10
+    UNION ALL SELECT 'shore', 'Shore', 11
+    UNION ALL SELECT 'boat', 'Boat', 12
+    UNION ALL SELECT 'liveaboard', 'Liveaboard', 13
+    UNION ALL SELECT 'cavern', 'Cavern', 14
+  )
+''';
+
 /// Custom tank presets (user-defined tank configurations)
 class TankPresets extends Table {
   TextColumn get id => text()();
@@ -1669,7 +1704,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 92;
+  static const int currentSchemaVersion = 93;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1765,6 +1800,7 @@ class AppDatabase extends _$AppDatabase {
     90,
     91,
     92,
+    93,
   ];
 
   /// Tables that carry a per-row Hybrid Logical Clock for cross-device conflict
@@ -1817,32 +1853,9 @@ class AppDatabase extends _$AppDatabase {
       onCreate: (Migrator m) async {
         await m.createAll();
 
-        // Seed built-in dive types
-        final now = DateTime.now().millisecondsSinceEpoch;
-        final builtInTypes = [
-          ('recreational', 'Recreational', 0),
-          ('technical', 'Technical', 1),
-          ('freedive', 'Freedive', 2),
-          ('training', 'Training', 3),
-          ('wreck', 'Wreck', 4),
-          ('cave', 'Cave', 5),
-          ('ice', 'Ice', 6),
-          ('night', 'Night', 7),
-          ('drift', 'Drift', 8),
-          ('deep', 'Deep', 9),
-          ('altitude', 'Altitude', 10),
-          ('shore', 'Shore', 11),
-          ('boat', 'Boat', 12),
-          ('liveaboard', 'Liveaboard', 13),
-          ('cavern', 'Cavern', 14),
-        ];
-
-        for (final type in builtInTypes) {
-          await customStatement('''
-            INSERT OR IGNORE INTO dive_types (id, name, is_built_in, sort_order, created_at, updated_at)
-            VALUES ('${type.$1}', '${type.$2}', 1, ${type.$3}, $now, $now)
-          ''');
-        }
+        // Seed built-in dive types (the same set the v93 migration backfills
+        // for databases created before this seed existed).
+        await customStatement(kSeedBuiltInDiveTypesSql);
       },
       onUpgrade: (Migrator m, int from, int to) async {
         int completedSteps = 0;
@@ -4285,6 +4298,23 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 92) await reportProgress();
+        if (from < 93) {
+          // Backfill built-in dive types. The full built-in set was only ever
+          // seeded in onCreate, so every database that reached the app via
+          // migration (rather than a fresh install) kept an EMPTY dive_types
+          // table -- the multi-select dive-type picker (#414) then showed no
+          // options. Guarded by a sqlite_master check so minimal-schema
+          // migration tests without dive_types are unaffected; INSERT OR IGNORE
+          // preserves rows already present (synced custom types, 'cavern' from
+          // the v88 migration).
+          final tables = await customSelect(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='dive_types'",
+          ).get();
+          if (tables.isNotEmpty) {
+            await customStatement(kSeedBuiltInDiveTypesSql);
+          }
+        }
+        if (from < 93) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1159,12 +1159,14 @@ const String kSeedDiveDiveTypesSql = '''
 /// present (synced custom types, or 'cavern' added by the v88 migration) and
 /// makes re-running the seed a no-op. Keep this list in sync with the
 /// onboarding documentation; it is asserted directly in tests.
+///
+/// The timestamp is computed once (the trailing `CROSS JOIN`) and reused for
+/// both `created_at` and `updated_at`, so the two can never diverge across a
+/// `strftime('now')` second boundary.
 const String kSeedBuiltInDiveTypesSql = '''
   INSERT OR IGNORE INTO dive_types
     (id, name, is_built_in, sort_order, created_at, updated_at)
-  SELECT id, name, 1, sort_order,
-    CAST(strftime('%s','now') AS INTEGER) * 1000,
-    CAST(strftime('%s','now') AS INTEGER) * 1000
+  SELECT t.id, t.name, 1, t.sort_order, n.now_ms, n.now_ms
   FROM (
     SELECT 'recreational' AS id, 'Recreational' AS name, 0 AS sort_order
     UNION ALL SELECT 'technical', 'Technical', 1
@@ -1181,7 +1183,8 @@ const String kSeedBuiltInDiveTypesSql = '''
     UNION ALL SELECT 'boat', 'Boat', 12
     UNION ALL SELECT 'liveaboard', 'Liveaboard', 13
     UNION ALL SELECT 'cavern', 'Cavern', 14
-  )
+  ) t
+  CROSS JOIN (SELECT CAST(strftime('%s','now') AS INTEGER) * 1000 AS now_ms) n
 ''';
 
 /// Custom tank presets (user-defined tank configurations)

--- a/lib/features/dive_log/presentation/widgets/dive_type_multi_select_field.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_type_multi_select_field.dart
@@ -2,13 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
 import 'package:submersion/features/dive_types/presentation/providers/dive_type_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Multi-select dive-type field: collapses to a row of chips for the selected
-/// types and expands (as an anchored dropdown of checkboxes) to add or remove
-/// types. Enforces the at-least-one invariant — the last selected type cannot
-/// be unchecked. Custom types are managed on the dedicated dive-types page.
+/// Multi-select dive-type field: shows the selected types as a row of chips and
+/// opens a bottom-sheet checklist (tap the field) to add or remove types.
+/// Enforces the at-least-one invariant -- the last selected type cannot be
+/// unchecked -- unless [allowEmpty] is set (bulk-edit mode). Custom types are
+/// managed on the dedicated dive-types page.
+///
+/// Uses a modal bottom sheet (mirroring [BuddyPicker]) rather than an anchored
+/// menu: Flutter 3.44's MenuAnchor regressed and would not open on macOS, so a
+/// tap on the field appeared dead. The sheet path is the one already proven in
+/// this form.
 class DiveTypeMultiSelectField extends ConsumerWidget {
   const DiveTypeMultiSelectField({
     super.key,
@@ -45,53 +52,134 @@ class DiveTypeMultiSelectField extends ConsumerWidget {
         String nameOf(String id) =>
             nameById[id] ?? Dive.diveTypeDisplayName(id);
 
-        void toggle(String id, bool selected) {
-          final next = [...selectedTypeIds];
-          if (selected) {
-            if (!next.contains(id)) next.add(id);
-          } else {
-            next.remove(id);
-            // Single-dive editor enforces >= 1; bulk mode allows clearing.
-            if (next.isEmpty && !allowEmpty) return;
-          }
-          onChanged(next);
-        }
-
-        return MenuAnchor(
-          menuChildren: [
-            for (final t in types)
-              CheckboxMenuButton(
-                value: selectedTypeIds.contains(t.id),
-                onChanged: (v) => toggle(t.id, v ?? false),
-                child: Text(t.name),
-              ),
-          ],
-          builder: (context, controller, child) {
-            return InkWell(
-              onTap: () =>
-                  controller.isOpen ? controller.close() : controller.open(),
-              child: InputDecorator(
-                decoration: InputDecoration(
-                  labelText: label,
-                  suffixIcon: const Icon(Icons.arrow_drop_down),
-                ),
-                child: Wrap(
-                  spacing: 6,
-                  runSpacing: 4,
-                  children: [
-                    for (final id in selectedTypeIds)
-                      Chip(
-                        label: Text(nameOf(id)),
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        visualDensity: VisualDensity.compact,
-                      ),
-                  ],
-                ),
-              ),
-            );
-          },
+        return InkWell(
+          onTap: () => _openPicker(context, types, label),
+          child: InputDecorator(
+            decoration: InputDecoration(
+              labelText: label,
+              suffixIcon: const Icon(Icons.arrow_drop_down),
+            ),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                for (final id in selectedTypeIds)
+                  Chip(
+                    label: Text(nameOf(id)),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
+              ],
+            ),
+          ),
         );
       },
+    );
+  }
+
+  Future<void> _openPicker(
+    BuildContext context,
+    List<DiveTypeEntity> types,
+    String title,
+  ) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => _DiveTypePickerSheet(
+        title: title,
+        types: types,
+        selectedTypeIds: selectedTypeIds,
+        allowEmpty: allowEmpty,
+        onChanged: onChanged,
+      ),
+    );
+  }
+}
+
+/// The bottom-sheet checklist. Holds its own working selection while open and
+/// reports each change live via [onChanged] (matching the original field's
+/// per-toggle semantics), so the sheet stays open for multiple selections.
+class _DiveTypePickerSheet extends StatefulWidget {
+  const _DiveTypePickerSheet({
+    required this.title,
+    required this.types,
+    required this.selectedTypeIds,
+    required this.allowEmpty,
+    required this.onChanged,
+  });
+
+  final String title;
+  final List<DiveTypeEntity> types;
+  final List<String> selectedTypeIds;
+  final bool allowEmpty;
+  final ValueChanged<List<String>> onChanged;
+
+  @override
+  State<_DiveTypePickerSheet> createState() => _DiveTypePickerSheetState();
+}
+
+class _DiveTypePickerSheetState extends State<_DiveTypePickerSheet> {
+  late List<String> _working = [...widget.selectedTypeIds];
+
+  void _toggle(String id, bool selected) {
+    final next = [..._working];
+    if (selected) {
+      if (!next.contains(id)) next.add(id);
+    } else {
+      next.remove(id);
+      // Single-dive editor enforces >= 1; bulk mode allows clearing.
+      if (next.isEmpty && !widget.allowEmpty) return;
+    }
+    setState(() => _working = next);
+    widget.onChanged(next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.6,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 12, 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.title,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(context.l10n.common_action_close),
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  for (final t in widget.types)
+                    CheckboxListTile(
+                      value: _working.contains(t.id),
+                      onChanged: (v) => _toggle(t.id, v ?? false),
+                      title: Text(t.name),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/core/database/dive_dive_types_migration_test.dart
+++ b/test/core/database/dive_dive_types_migration_test.dart
@@ -35,10 +35,10 @@ void main() {
     },
   );
 
-  test('schema version is 92 and the migration list includes it', () {
-    // Latest-version tripwire: bumping the schema must come with a matching
-    // migration block and an update here.
-    expect(AppDatabase.currentSchemaVersion, 92);
+  test('the v92 migration remains registered in the migration list', () {
+    // 92 is no longer the latest schema -- the current latest-version tripwire
+    // lives in migration_v93_dive_types_seed_test.dart -- but its migration
+    // block must stay registered so upgrade step counts stay correct.
     expect(AppDatabase.migrationVersions, contains(92));
   });
 }

--- a/test/core/database/migration_v93_dive_types_seed_test.dart
+++ b/test/core/database/migration_v93_dive_types_seed_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:submersion/core/database/database.dart'
+    show kSeedBuiltInDiveTypesSql, AppDatabase;
+
+void main() {
+  test('v93 backfill seeds all 15 built-in dive types and is idempotent', () {
+    final db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE dive_types (
+        id TEXT PRIMARY KEY,
+        diver_id TEXT,
+        name TEXT NOT NULL,
+        is_built_in INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+
+    // Rows that must survive the backfill untouched: 'cavern' (added by the v88
+    // migration) and a synced custom type.
+    db.execute(
+      "INSERT INTO dive_types (id, name, is_built_in, sort_order, created_at, updated_at) "
+      "VALUES ('cavern', 'Cavern', 1, 14, 111, 111)",
+    );
+    db.execute(
+      "INSERT INTO dive_types (id, diver_id, name, is_built_in, sort_order, created_at, updated_at) "
+      "VALUES ('reef-cleanup', 'diver-1', 'Reef Cleanup', 0, 99, 222, 222)",
+    );
+
+    // Run twice: INSERT OR IGNORE on stable slug ids must be a no-op the second
+    // time (and every app launch re-runs no migration, but defensiveness is free).
+    db.execute(kSeedBuiltInDiveTypesSql);
+    db.execute(kSeedBuiltInDiveTypesSql);
+
+    final builtIns = db.select(
+      'SELECT id, sort_order FROM dive_types WHERE is_built_in = 1 ORDER BY sort_order',
+    );
+    expect(builtIns.length, 15);
+    expect(builtIns.first['id'], 'recreational');
+    expect(builtIns[4]['id'], 'wreck');
+    expect(builtIns.last['id'], 'cavern');
+
+    // Pre-existing rows preserved, not overwritten or duplicated.
+    final cavern = db.select(
+      "SELECT created_at FROM dive_types WHERE id = 'cavern'",
+    );
+    expect(cavern.length, 1);
+    expect(cavern.first['created_at'], 111); // original kept, not re-seeded
+
+    final custom = db.select(
+      "SELECT name FROM dive_types WHERE id = 'reef-cleanup'",
+    );
+    expect(custom.length, 1);
+    expect(custom.first['name'], 'Reef Cleanup');
+
+    db.dispose();
+  });
+
+  test('schema version is 93 and the migration list includes it', () {
+    // Latest-version tripwire: bumping the schema must come with a matching
+    // migration block and an update here.
+    expect(AppDatabase.currentSchemaVersion, 93);
+    expect(AppDatabase.migrationVersions, contains(93));
+  });
+}

--- a/test/core/database/migration_v93_dive_types_seed_test.dart
+++ b/test/core/database/migration_v93_dive_types_seed_test.dart
@@ -42,6 +42,15 @@ void main() {
     expect(builtIns[4]['id'], 'wreck');
     expect(builtIns.last['id'], 'cavern');
 
+    // created_at / updated_at are seeded from a single computed value, so a
+    // freshly inserted built-in has them identical (PR #430 review).
+    final ts = db
+        .select(
+          "SELECT created_at, updated_at FROM dive_types WHERE id = 'recreational'",
+        )
+        .first;
+    expect(ts['created_at'], ts['updated_at']);
+
     // Pre-existing rows preserved, not overwritten or duplicated.
     final cavern = db.select(
       "SELECT created_at FROM dive_types WHERE id = 'cavern'",

--- a/test/features/dive_log/presentation/widgets/dive_type_multi_select_field_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_type_multi_select_field_test.dart
@@ -17,6 +17,7 @@ void main() {
   Widget harness({
     required List<String> selected,
     required ValueChanged<List<String>> onChanged,
+    bool allowEmpty = false,
   }) {
     return ProviderScope(
       overrides: [
@@ -35,6 +36,7 @@ void main() {
           body: DiveTypeMultiSelectField(
             selectedTypeIds: selected,
             onChanged: onChanged,
+            allowEmpty: allowEmpty,
           ),
         ),
       ),
@@ -47,23 +49,50 @@ void main() {
     expect(find.widgetWithText(Chip, 'Shore'), findsOneWidget);
   });
 
-  testWidgets('toggling a type in the dropdown fires onChanged', (
+  testWidgets(
+    'tapping the field opens a checklist and toggling fires onChanged',
+    (tester) async {
+      List<String>? result;
+      await tester.pumpWidget(
+        harness(selected: ['shore'], onChanged: (v) => result = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(InkWell).first); // open the checklist
+      await tester.pumpAndSettle();
+      expect(find.byType(CheckboxListTile), findsNWidgets(3));
+
+      await tester.tap(find.widgetWithText(CheckboxListTile, 'Wreck'));
+      await tester.pumpAndSettle();
+
+      expect(result, ['shore', 'wreck']);
+    },
+  );
+
+  testWidgets('checklist stays open across multiple sequential toggles', (
     tester,
   ) async {
-    List<String>? result;
+    final results = <List<String>>[];
     await tester.pumpWidget(
-      harness(selected: ['shore'], onChanged: (v) => result = v),
+      harness(selected: ['shore'], onChanged: results.add),
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(InkWell).first); // open the dropdown
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.widgetWithText(CheckboxMenuButton, 'Wreck'),
-    ); // check Wreck
+    await tester.tap(find.byType(InkWell).first);
     await tester.pumpAndSettle();
 
-    expect(result, ['shore', 'wreck']);
+    await tester.tap(find.widgetWithText(CheckboxListTile, 'Wreck'));
+    await tester.pumpAndSettle();
+
+    // The sheet stays open so a second type is reachable without reopening.
+    expect(find.widgetWithText(CheckboxListTile, 'Night'), findsOneWidget);
+    await tester.tap(find.widgetWithText(CheckboxListTile, 'Night'));
+    await tester.pumpAndSettle();
+
+    expect(results, [
+      ['shore', 'wreck'],
+      ['shore', 'wreck', 'night'],
+    ]);
   });
 
   testWidgets('cannot uncheck the last remaining type (>= 1)', (tester) async {
@@ -76,10 +105,31 @@ void main() {
     await tester.tap(find.byType(InkWell).first);
     await tester.pumpAndSettle();
     await tester.tap(
-      find.widgetWithText(CheckboxMenuButton, 'Shore'),
+      find.widgetWithText(CheckboxListTile, 'Shore'),
     ); // try to uncheck the only type
     await tester.pumpAndSettle();
 
     expect(result, isNull); // the uncheck was ignored
+  });
+
+  testWidgets('allowEmpty lets the last type be unchecked (bulk mode)', (
+    tester,
+  ) async {
+    List<String>? result;
+    await tester.pumpWidget(
+      harness(
+        selected: ['shore'],
+        onChanged: (v) => result = v,
+        allowEmpty: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(InkWell).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(CheckboxListTile, 'Shore'));
+    await tester.pumpAndSettle();
+
+    expect(result, isEmpty); // bulk mode allows clearing
   });
 }


### PR DESCRIPTION
## Summary

The "Dive Types" multi-select field in the dive editor was unusable on macOS: tapping it did nothing, and even once it could open it showed no options. This turned out to be two independent bugs (plus a minor third, filed separately), fixed here.

## What was wrong

1. **The picker wouldn't open on macOS.** Flutter 3.44 rebuilt `MenuAnchor` on `RawMenuAnchor` + `OverlayPortal` + open-animations, which regressed the anchored menu on macOS desktop -- a click produced no ripple and no menu. Synthetic widget-test taps still passed (they bypass real desktop hit-testing), so CI stayed green.

2. **The reference table was empty for upgraded users.** The 15 built-in dive types are seeded only in `onCreate` (fresh installs). No migration ever seeded them, so every database that arrived via upgrade kept an **empty `dive_types` table** -- the multi-select picker (#414) is the first UI to read it, so it had no options. Confirmed against a real upgraded database (`dive_types` had 0 rows while dives referenced slugs `recreational/wreck/training/shore/night`).

## The fixes

**1. Open via bottom sheet, not MenuAnchor** (`dive_type_multi_select_field.dart`)

Replaced the `MenuAnchor` with a `showModalBottomSheet` checklist, mirroring `BuddyPicker` (the sheet pattern already proven in this same form on macOS). The field keeps its chip display; the anchor is now a plain `InkWell`, reliably clickable like the sibling stock dropdowns. Live per-toggle `onChanged`, the >=1 invariant, and bulk `allowEmpty` are all preserved.

**2. Backfill built-in types for upgraded DBs** (`database.dart`, schema v93)

Extracted the seed into a shared `kSeedBuiltInDiveTypesSql` constant used by **both** `onCreate` and a new `from < 93` migration, so the two seed sites can't drift apart again. The migration is guarded by a `sqlite_master` check and uses `INSERT OR IGNORE`, so it is idempotent and preserves existing rows (synced custom types, `cavern` from v88).

## Testing

- 5 widget tests for the picker (open, multi-toggle stays open, >=1 invariant, bulk-clear).
- New `migration_v93_dive_types_seed_test` (seeds all 15, idempotent, preserves existing rows); the latest-version tripwire moved to v93.
- All 101 tests in `test/core/database/` and `test/features/dive_types/` pass; `flutter analyze` clean; whole-repo `dart format` clean.
- Verified the migration against a copy of a real upgraded database: `dive_types` went 0 -> 15 and every slug resolves.

## Upgrade behavior

Existing users get the built-in types automatically on next launch (the v93 migration backfills their database). Fresh installs are unchanged.

## Related

- Surfaces/fixes the picker for #414 (multiple dive types per dive).
- Filed #429 for a minor follow-up (the field briefly flashes a progress bar if `dive_types` is written mid-interaction).