### PR TITLE
fix: Riverpod 3 auto-pause assertion on dive detail + fl_chart tooltip crash

### DIFF
--- a/lib/core/providers/provider.dart
+++ b/lib/core/providers/provider.dart
@@ -1,3 +1,4 @@
 export 'package:flutter_riverpod/flutter_riverpod.dart';
 export 'package:flutter_riverpod/legacy.dart';
 export 'async_value_extensions.dart';
+export 'ref_invalidate_on_change.dart';

--- a/lib/core/providers/ref_invalidate_on_change.dart
+++ b/lib/core/providers/ref_invalidate_on_change.dart
@@ -39,15 +39,9 @@ extension RefInvalidateOnChange on Ref {
       refreshDue = false;
       // invalidateSelf() is rejected inside a life-cycle callback
       // (Ref._throwIfInvalidUsage), so hop to a microtask to run it once the
-      // resume has settled. Guard against disposal, and re-defer if the
-      // provider managed to pause again in between.
+      // resume has settled; guard against disposal in that window.
       Future.microtask(() {
-        if (!mounted) return;
-        if (isPaused) {
-          refreshDue = true;
-        } else {
-          invalidateSelf();
-        }
+        if (mounted) invalidateSelf();
       });
     });
     onDispose(sub.cancel);

--- a/lib/core/providers/ref_invalidate_on_change.dart
+++ b/lib/core/providers/ref_invalidate_on_change.dart
@@ -3,28 +3,53 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// Pause-aware self-invalidation for providers that refresh off a repository
 /// change-tick stream.
 extension RefInvalidateOnChange on Ref {
-  /// Rebuilds this provider whenever [changes] emits, while still participating
-  /// in Riverpod's auto-pause.
+  /// Rebuilds this provider whenever [changes] emits, while still playing nicely
+  /// with Riverpod's auto-pause.
   ///
-  /// The naive form -- `changes.listen((_) => ref.invalidateSelf())` -- opens a
-  /// raw [StreamSubscription] that Riverpod cannot see. When the provider is
-  /// paused (its widgets leave the screen and `TickerMode` disables), that
-  /// subscription keeps firing and marks the provider dirty. The deferred
-  /// rebuild then flushes during the next TickerMode *resume*, cascading a
-  /// re-entrant pause/invalidate through this provider's `ref.watch` dependents
-  /// and tripping Riverpod 3's internal `pausedActiveSubscriptionCount`
-  /// assertion (`Expected pausedActiveSubscriptionCount to be N, but was N+1`).
+  /// The naive form -- `changes.listen((_) => ref.invalidateSelf())` -- keeps
+  /// invalidating while the provider is paused (its widgets leave the screen and
+  /// `TickerMode` disables). The deferred rebuild then flushes during the next
+  /// TickerMode *resume*, cascading a re-entrant pause/invalidate through this
+  /// provider's `ref.watch` dependents and tripping Riverpod 3's internal
+  /// `pausedActiveSubscriptionCount` assertion
+  /// (`Expected pausedActiveSubscriptionCount to be N, but was N+1`).
   ///
-  /// Pausing the subscription alongside the provider -- exactly what
-  /// `StreamProvider` does for its own stream via `onCancel`/`onResume` -- keeps
-  /// the provider clean while off-screen, so the resume flush is a no-op. The
-  /// change-tick streams are single-subscription (a debounced
-  /// [StreamController]), so a tick fired while paused is buffered and delivered
-  /// on resume; the detail still refreshes after a background sync.
+  /// The fix is to defer, not to pause the subscription: while the provider is
+  /// paused a tick only records that a refresh is due ([isPaused]); the catch-up
+  /// [invalidateSelf] is scheduled on [onResume], so the provider is never dirty
+  /// across a resume and the cascade never re-enters mid-resume. Ticks that
+  /// arrive while active invalidate immediately; several ticks while paused
+  /// coalesce into one refresh on resume.
+  ///
+  /// Because the subscription is never paused, this is correct for broadcast
+  /// change streams too: Drift's `tableUpdates(...)` is broadcast, and a paused
+  /// broadcast subscription would silently drop a tick fired while off-screen
+  /// (e.g. a background sync), leaving the provider stale on return.
   void invalidateSelfWhen(Stream<void> changes) {
-    final sub = changes.listen((_) => invalidateSelf());
-    onCancel(() => sub.pause());
-    onResume(() => sub.resume());
+    var refreshDue = false;
+    final sub = changes.listen((_) {
+      if (isPaused) {
+        refreshDue = true;
+      } else {
+        invalidateSelf();
+      }
+    });
+    onResume(() {
+      if (!refreshDue) return;
+      refreshDue = false;
+      // invalidateSelf() is rejected inside a life-cycle callback
+      // (Ref._throwIfInvalidUsage), so hop to a microtask to run it once the
+      // resume has settled. Guard against disposal, and re-defer if the
+      // provider managed to pause again in between.
+      Future.microtask(() {
+        if (!mounted) return;
+        if (isPaused) {
+          refreshDue = true;
+        } else {
+          invalidateSelf();
+        }
+      });
+    });
     onDispose(sub.cancel);
   }
 }

--- a/lib/core/providers/ref_invalidate_on_change.dart
+++ b/lib/core/providers/ref_invalidate_on_change.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Pause-aware self-invalidation for providers that refresh off a repository
+/// change-tick stream.
+extension RefInvalidateOnChange on Ref {
+  /// Rebuilds this provider whenever [changes] emits, while still participating
+  /// in Riverpod's auto-pause.
+  ///
+  /// The naive form -- `changes.listen((_) => ref.invalidateSelf())` -- opens a
+  /// raw [StreamSubscription] that Riverpod cannot see. When the provider is
+  /// paused (its widgets leave the screen and `TickerMode` disables), that
+  /// subscription keeps firing and marks the provider dirty. The deferred
+  /// rebuild then flushes during the next TickerMode *resume*, cascading a
+  /// re-entrant pause/invalidate through this provider's `ref.watch` dependents
+  /// and tripping Riverpod 3's internal `pausedActiveSubscriptionCount`
+  /// assertion (`Expected pausedActiveSubscriptionCount to be N, but was N+1`).
+  ///
+  /// Pausing the subscription alongside the provider -- exactly what
+  /// `StreamProvider` does for its own stream via `onCancel`/`onResume` -- keeps
+  /// the provider clean while off-screen, so the resume flush is a no-op. The
+  /// change-tick streams are single-subscription (a debounced
+  /// [StreamController]), so a tick fired while paused is buffered and delivered
+  /// on resume; the detail still refreshes after a background sync.
+  void invalidateSelfWhen(Stream<void> changes) {
+    final sub = changes.listen((_) => invalidateSelf());
+    onCancel(() => sub.pause());
+    onResume(() => sub.resume());
+    onDispose(sub.cancel);
+  }
+}

--- a/lib/features/buddies/presentation/providers/buddy_providers.dart
+++ b/lib/features/buddies/presentation/providers/buddy_providers.dart
@@ -33,10 +33,7 @@ final allBuddiesProvider = FutureProvider<List<Buddy>>((ref) async {
     validatedCurrentDiverIdProvider.future,
   );
 
-  final sub = repository.watchBuddiesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchBuddiesChanges());
 
   return repository.getAllBuddies(diverId: validatedDiverId);
 });
@@ -56,15 +53,10 @@ final allBuddiesWithDiveCountProvider =
       final validatedDiverId = await ref.watch(
         validatedCurrentDiverIdProvider.future,
       );
-      final buddiesSub = repository.watchBuddiesChanges().listen(
-        (_) => ref.invalidateSelf(),
+      ref.invalidateSelfWhen(repository.watchBuddiesChanges());
+      ref.invalidateSelfWhen(
+        ref.read(diveRepositoryProvider).watchDivesChanges(),
       );
-      ref.onDispose(buddiesSub.cancel);
-      final divesSub = ref
-          .read(diveRepositoryProvider)
-          .watchDivesChanges()
-          .listen((_) => ref.invalidateSelf());
-      ref.onDispose(divesSub.cancel);
       return repository.getAllBuddiesWithDiveCount(diverId: validatedDiverId);
     });
 
@@ -144,11 +136,9 @@ final buddyByIdProvider = FutureProvider.family<Buddy?, String>((
 final buddiesForDiveProvider =
     FutureProvider.family<List<BuddyWithRole>, String>((ref, diveId) async {
       final repository = ref.watch(buddyRepositoryProvider);
-      final sub = ref
-          .watch(diveRepositoryProvider)
-          .watchDiveDetailChanges()
-          .listen((_) => ref.invalidateSelf());
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(
+        ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+      );
       return repository.getBuddiesForDive(diveId);
     });
 

--- a/lib/features/certifications/presentation/providers/certification_providers.dart
+++ b/lib/features/certifications/presentation/providers/certification_providers.dart
@@ -33,10 +33,7 @@ final allCertificationsProvider = FutureProvider<List<Certification>>((
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchCertificationsChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchCertificationsChanges());
   return repository.getAllCertifications(diverId: validatedDiverId);
 });
 

--- a/lib/features/courses/presentation/providers/course_providers.dart
+++ b/lib/features/courses/presentation/providers/course_providers.dart
@@ -30,10 +30,7 @@ final allCoursesProvider = FutureProvider<List<Course>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchCoursesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchCoursesChanges());
   return repository.getAllCourses(diverId: validatedDiverId);
 });
 
@@ -123,11 +120,9 @@ final courseForDiveProvider = FutureProvider.family<Course?, String>((
   diveId,
 ) async {
   final repository = ref.watch(courseRepositoryProvider);
-  final sub = ref
-      .watch(diveRepositoryProvider)
-      .watchDiveDetailChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(
+    ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+  );
   return repository.getCourseForDive(diveId);
 });
 

--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -48,10 +48,7 @@ class DashboardAlerts {
 /// site instead of relying on transitive propagation two providers away.
 final recentDivesProvider = FutureProvider<List<Dive>>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
-  final sub = repository.watchDivesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
 
   final allDives = await ref.watch(divesProvider.future);
   // Dives are already sorted by date descending in the repository

--- a/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
+++ b/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
@@ -30,10 +30,7 @@ final allDiveCentersProvider = FutureProvider<List<DiveCenter>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchDiveCentersChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDiveCentersChanges());
   return repository.getAllDiveCenters(diverId: validatedDiverId);
 });
 
@@ -140,11 +137,7 @@ final diveCenterDiveCountProvider = FutureProvider.family<int, String>((
   final repository = ref.watch(diveCenterRepositoryProvider);
   // The count reads the `dives` table, so self-invalidate whenever dives
   // change (e.g. after a sync) to keep per-row counts fresh.
-  final sub = ref
-      .read(diveRepositoryProvider)
-      .watchDivesChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(ref.read(diveRepositoryProvider).watchDivesChanges());
   return repository.getDiveCountForCenter(centerId);
 });
 

--- a/lib/features/dive_computer/presentation/providers/reparse_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/reparse_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/providers/ref_invalidate_on_change.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
@@ -28,10 +29,8 @@ final diveHasRawDataProvider = FutureProvider.family<bool, String>((
   diveId,
 ) {
   final service = ref.watch(reparseServiceProvider);
-  final sub = ref
-      .watch(diveRepositoryProvider)
-      .watchDiveDetailChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(
+    ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+  );
   return service.hasRawData(diveId);
 });

--- a/lib/features/dive_log/presentation/providers/dive_computer_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_computer_providers.dart
@@ -59,11 +59,9 @@ final favoriteDiveComputerProvider = FutureProvider<DiveComputer?>((ref) async {
 final computersForDiveProvider =
     FutureProvider.family<List<DiveComputer>, String>((ref, diveId) async {
       final repository = ref.watch(diveComputerRepositoryProvider);
-      final sub = ref
-          .watch(diveRepositoryProvider)
-          .watchDiveDetailChanges()
-          .listen((_) => ref.invalidateSelf());
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(
+        ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+      );
       return repository.getComputersForDive(diveId);
     });
 

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -120,10 +120,7 @@ final customFieldKeySuggestionsProvider =
 final divesProvider = FutureProvider<List<domain.Dive>>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
   final currentDiverId = ref.watch(currentDiverIdProvider);
-  final sub = repository.watchDivesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
   return repository.getAllDives(diverId: currentDiverId);
 });
 
@@ -142,10 +139,7 @@ final diveProvider = FutureProvider.family<domain.Dive?, String>((
   id,
 ) async {
   final repository = ref.watch(diveRepositoryProvider);
-  final sub = repository.watchDiveDetailChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
   return repository.getDiveById(id);
 });
 
@@ -156,10 +150,7 @@ final diveProfileProvider =
       diveId,
     ) async {
       final repository = ref.watch(diveRepositoryProvider);
-      final sub = repository.watchDiveDetailChanges().listen(
-        (_) => ref.invalidateSelf(),
-      );
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
       return repository.getDiveProfile(diveId);
     });
 
@@ -171,10 +162,7 @@ final profilesBySourceProvider =
       diveId,
     ) async {
       final repository = ref.watch(diveRepositoryProvider);
-      final sub = repository.watchDiveDetailChanges().listen(
-        (_) => ref.invalidateSelf(),
-      );
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
       return repository.getProfilesBySource(diveId);
     });
 
@@ -204,10 +192,7 @@ final statisticsVersionProvider = StateProvider<int>((ref) => 0);
 final diveStatisticsProvider = FutureProvider<DiveStatistics>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
   final currentDiverId = ref.watch(currentDiverIdProvider);
-  final sub = repository.watchDivesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
   return repository.getStatistics(diverId: currentDiverId);
 });
 
@@ -912,10 +897,7 @@ final surfaceIntervalProvider = FutureProvider.family<Duration?, String>((
   diveId,
 ) async {
   final repository = ref.watch(diveRepositoryProvider);
-  final sub = repository.watchDiveDetailChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
   return repository.getSurfaceInterval(diveId);
 });
 
@@ -946,11 +928,9 @@ final tankPressuresProvider =
       diveId,
     ) async {
       final repository = ref.watch(tankPressureRepositoryProvider);
-      final sub = ref
-          .watch(diveRepositoryProvider)
-          .watchDiveDetailChanges()
-          .listen((_) => ref.invalidateSelf());
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(
+        ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+      );
       return repository.getTankPressuresForDive(diveId);
     });
 
@@ -959,10 +939,7 @@ final tankPressuresProvider =
 final diveDataSourcesProvider =
     FutureProvider.family<List<DiveDataSource>, String>((ref, diveId) async {
       final repository = ref.watch(diveRepositoryProvider);
-      final sub = repository.watchDiveDetailChanges().listen(
-        (_) => ref.invalidateSelf(),
-      );
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
       return repository.getDataSources(diveId);
     });
 
@@ -972,9 +949,6 @@ final isMultiDataSourceDiveProvider = FutureProvider.family<bool, String>((
   diveId,
 ) async {
   final repository = ref.watch(diveRepositoryProvider);
-  final sub = repository.watchDiveDetailChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
   return repository.hasMultipleDataSources(diveId);
 });

--- a/lib/features/dive_log/presentation/providers/gas_switch_providers.dart
+++ b/lib/features/dive_log/presentation/providers/gas_switch_providers.dart
@@ -9,10 +9,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_reposit
 final gasSwitchesProvider =
     FutureProvider.family<List<GasSwitchWithTank>, String>((ref, diveId) async {
       final repository = ref.watch(diveRepositoryProvider);
-      final sub = repository.watchDiveDetailChanges().listen(
-        (_) => ref.invalidateSelf(),
-      );
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
       return repository.getGasSwitchesForDive(diveId);
     });
 

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1930,13 +1930,22 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   if (widget.tooltipBelow) {
                     return touchedSpots.map((_) => null).toList();
                   }
-                  // Return cached result if the same spot index is touched again
+                  // Return cached result if the same spot index is touched again.
+                  // The cache is keyed on spotIndex, but the cached list length
+                  // equals the number of touched bars when it was built. fl_chart
+                  // requires the returned list to match touchedSpots.length, so
+                  // the cache is only valid while the bar count is unchanged --
+                  // the set of rendered lines can change under a parked cursor
+                  // (a metric toggled, or a data provider refreshing), and a
+                  // stale-length cached list throws
+                  // 'tooltipItems and touchedSpots size should be same'.
                   if (touchedSpots.isNotEmpty) {
                     final firstDepthSpot = touchedSpots
                         .where((s) => s.barIndex == 0)
                         .firstOrNull;
                     if (firstDepthSpot != null &&
-                        firstDepthSpot.spotIndex == _lastTooltipSpotIndex) {
+                        firstDepthSpot.spotIndex == _lastTooltipSpotIndex &&
+                        _lastTooltipItems.length == touchedSpots.length) {
                       return _lastTooltipItems;
                     }
                   }

--- a/lib/features/dive_sites/presentation/providers/site_providers.dart
+++ b/lib/features/dive_sites/presentation/providers/site_providers.dart
@@ -182,10 +182,7 @@ final sitesProvider = FutureProvider<List<domain.DiveSite>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchSitesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchSitesChanges());
   return repository.getAllSites(diverId: validatedDiverId);
 });
 
@@ -197,15 +194,8 @@ final sitesWithCountsProvider = FutureProvider<List<SiteWithDiveCount>>((
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sitesSub = repository.watchSitesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sitesSub.cancel);
-  final divesSub = ref
-      .read(diveRepositoryProvider)
-      .watchDivesChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(divesSub.cancel);
+  ref.invalidateSelfWhen(repository.watchSitesChanges());
+  ref.invalidateSelfWhen(ref.read(diveRepositoryProvider).watchDivesChanges());
   return repository.getSitesWithDiveCounts(diverId: validatedDiverId);
 });
 

--- a/lib/features/dive_types/presentation/providers/dive_type_providers.dart
+++ b/lib/features/dive_types/presentation/providers/dive_type_providers.dart
@@ -21,10 +21,7 @@ final diveTypesProvider = FutureProvider<List<DiveTypeEntity>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchDiveTypesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDiveTypesChanges());
   return repository.getAllDiveTypes(diverId: validatedDiverId);
 });
 

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -24,10 +24,7 @@ final diverMergeRepositoryProvider = Provider<DiverMergeRepository>((ref) {
 /// `ref.read(allDiversProvider.future)` reads still resolve.
 final allDiversProvider = FutureProvider<List<Diver>>((ref) async {
   final repository = ref.watch(diverRepositoryProvider);
-  final sub = repository.watchDiversChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchDiversChanges());
   return repository.getAllDivers();
 });
 
@@ -332,11 +329,7 @@ final diverStatsProvider = FutureProvider.family<DiverStats, String>((
   final repository = ref.watch(diverRepositoryProvider);
   // The stats read the `dives` table, so self-invalidate when dives change
   // (e.g. after a sync) to keep the per-tile counts on the diver list fresh.
-  final diveSub = ref
-      .read(diveRepositoryProvider)
-      .watchDivesChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(diveSub.cancel);
+  ref.invalidateSelfWhen(ref.read(diveRepositoryProvider).watchDivesChanges());
   final diveCount = await repository.getDiveCountForDiver(diverId);
   final totalTime = await repository.getTotalBottomTimeForDiver(diverId);
   return DiverStats(diveCount: diveCount, totalBottomTimeSeconds: totalTime);

--- a/lib/features/equipment/presentation/providers/equipment_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_providers.dart
@@ -51,10 +51,7 @@ final equipmentByStatusProvider =
       final validatedDiverId = await ref.watch(
         validatedCurrentDiverIdProvider.future,
       );
-      final sub = repository.watchEquipmentChanges().listen(
-        (_) => ref.invalidateSelf(),
-      );
-      ref.onDispose(sub.cancel);
+      ref.invalidateSelfWhen(repository.watchEquipmentChanges());
       if (status == null) {
         return repository.getAllEquipment(diverId: validatedDiverId);
       }
@@ -73,10 +70,7 @@ final allEquipmentProvider = FutureProvider<List<EquipmentItem>>((ref) async {
     validatedCurrentDiverIdProvider.future,
   );
 
-  final sub = repository.watchEquipmentChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchEquipmentChanges());
 
   return repository.getAllEquipment(diverId: validatedDiverId);
 });
@@ -173,10 +167,7 @@ final serviceDueEquipmentProvider = FutureProvider<List<EquipmentItem>>((
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchEquipmentChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchEquipmentChanges());
   return repository.getEquipmentWithServiceDue(diverId: validatedDiverId);
 });
 

--- a/lib/features/marine_life/presentation/providers/species_providers.dart
+++ b/lib/features/marine_life/presentation/providers/species_providers.dart
@@ -13,10 +13,7 @@ final speciesRepositoryProvider = Provider<SpeciesRepository>((ref) {
 /// All species provider
 final allSpeciesProvider = FutureProvider<List<Species>>((ref) async {
   final repository = ref.watch(speciesRepositoryProvider);
-  final sub = repository.watchSpeciesChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchSpeciesChanges());
   return repository.getAllSpecies();
 });
 
@@ -57,11 +54,9 @@ final diveSightingsProvider = FutureProvider.family<List<Sighting>, String>((
   diveId,
 ) async {
   final repository = ref.watch(speciesRepositoryProvider);
-  final sub = ref
-      .watch(diveRepositoryProvider)
-      .watchDiveDetailChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(
+    ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+  );
   return repository.getSightingsForDive(diveId);
 });
 

--- a/lib/features/media/presentation/providers/media_providers.dart
+++ b/lib/features/media/presentation/providers/media_providers.dart
@@ -14,11 +14,9 @@ final mediaForDiveProvider = FutureProvider.family<List<MediaItem>, String>((
   diveId,
 ) async {
   final repository = ref.watch(mediaRepositoryProvider);
-  final sub = ref
-      .watch(diveRepositoryProvider)
-      .watchDiveDetailChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(
+    ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+  );
   return repository.getMediaForDive(diveId);
 });
 

--- a/lib/features/tags/presentation/providers/tag_providers.dart
+++ b/lib/features/tags/presentation/providers/tag_providers.dart
@@ -21,8 +21,7 @@ final tagsProvider = FutureProvider<List<Tag>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchTagsChanges().listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchTagsChanges());
   return repository.getAllTags(diverId: validatedDiverId);
 });
 
@@ -38,15 +37,8 @@ final tagStatisticsProvider = FutureProvider<List<TagStatistic>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final tagsSub = repository.watchTagsChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(tagsSub.cancel);
-  final divesSub = ref
-      .read(diveRepositoryProvider)
-      .watchDivesChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(divesSub.cancel);
+  ref.invalidateSelfWhen(repository.watchTagsChanges());
+  ref.invalidateSelfWhen(ref.read(diveRepositoryProvider).watchDivesChanges());
   return repository.getTagStatistics(diverId: validatedDiverId);
 });
 

--- a/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
+++ b/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
@@ -22,10 +22,7 @@ final tankPresetsProvider = FutureProvider<List<TankPresetEntity>>((ref) async {
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  final sub = repository.watchTankPresetsChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchTankPresetsChanges());
   return repository.getAllPresets(diverId: validatedDiverId);
 });
 

--- a/lib/features/tides/presentation/providers/tide_providers.dart
+++ b/lib/features/tides/presentation/providers/tide_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/providers/ref_invalidate_on_change.dart';
 import 'package:submersion/core/tide/entities/tide_extremes.dart';
 import 'package:submersion/core/tide/entities/tide_prediction.dart';
 import 'package:submersion/core/tide/tide_calculator.dart';
@@ -25,11 +26,9 @@ final tideRecordForDiveProvider = FutureProvider.family<TideRecord?, String>((
   diveId,
 ) async {
   final repository = ref.watch(tideRecordRepositoryProvider);
-  final sub = ref
-      .watch(diveRepositoryProvider)
-      .watchDiveDetailChanges()
-      .listen((_) => ref.invalidateSelf());
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(
+    ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+  );
   return repository.getTideRecordForDive(diveId);
 });
 

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -58,10 +58,7 @@ final allTripsProvider = FutureProvider<List<Trip>>((ref) async {
     validatedCurrentDiverIdProvider.future,
   );
 
-  final sub = repository.watchTripsChanges().listen(
-    (_) => ref.invalidateSelf(),
-  );
-  ref.onDispose(sub.cancel);
+  ref.invalidateSelfWhen(repository.watchTripsChanges());
 
   return repository.getAllTrips(diverId: validatedDiverId);
 });

--- a/test/core/providers/ref_invalidate_on_change_test.dart
+++ b/test/core/providers/ref_invalidate_on_change_test.dart
@@ -15,8 +15,8 @@ import 'package:submersion/core/providers/ref_invalidate_on_change.dart';
 /// a re-entrant pause/invalidate through the provider's `ref.watch` dependents
 /// and tripping Riverpod's internal pause-state accounting.
 ///
-/// The raw pattern reproduces the crash; [Ref.invalidateSelfWhen] (which pauses
-/// the subscription alongside the provider) must not.
+/// The raw pattern reproduces the crash; [Ref.invalidateSelfWhen] (which defers
+/// the catch-up invalidation past the pause) must not.
 void main() {
   /// Drives [body] in its own error-capturing zone so the assertion that
   /// Riverpod reports through `runBinaryGuarded` -> `Zone.handleUncaughtError`
@@ -110,11 +110,52 @@ void main() {
     },
   );
 
-  test('Ref.invalidateSelfWhen pauses with the provider and does not trip the '
-      'assertion on resume', () async {
+  test('Ref.invalidateSelfWhen defers invalidation past a pause and does not '
+      'trip the assertion on resume', () async {
     final errors = await runPauseResume((ref, changes) {
       ref.invalidateSelfWhen(changes);
     });
     expect(errors, isEmpty);
+  });
+
+  test('Ref.invalidateSelfWhen catches up on resume after a tick emitted while '
+      'paused (broadcast stream is not dropped)', () async {
+    // Drift's tableUpdates is a broadcast stream; a paused broadcast
+    // subscription drops events, so the helper must NOT rely on pausing it.
+    final changes = StreamController<void>.broadcast();
+    addTearDown(changes.close);
+
+    var builds = 0;
+    final provider = FutureProvider.family<int, String>((ref, id) {
+      builds++;
+      ref.invalidateSelfWhen(changes.stream);
+      return builds;
+    });
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final sub = container.listen(provider('d'), (_, _) {});
+    await container.read(provider('d').future);
+    expect(builds, 1);
+
+    // Off-screen: the only listener pauses, so the provider pauses.
+    sub.pause();
+
+    // A background sync writes the table while paused. No rebuild yet, but
+    // the tick must not be lost.
+    changes.add(null);
+    await Future<void>.delayed(Duration.zero);
+    expect(builds, 1);
+
+    // Back on-screen: the missed tick is caught up exactly once (the catch-up
+    // invalidateSelf is scheduled on a microtask from onResume).
+    sub.resume();
+    await pumpEventQueue();
+    expect(
+      builds,
+      2,
+      reason: 'a tick emitted while paused must refresh on resume',
+    );
   });
 }

--- a/test/core/providers/ref_invalidate_on_change_test.dart
+++ b/test/core/providers/ref_invalidate_on_change_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/ref_invalidate_on_change.dart';
+
+/// Reproduction + regression for the Riverpod 3 auto-pause assertion:
+///
+///   Expected pausedActiveSubscriptionCount to be 3, but was 4.
+///
+/// A `FutureProvider` that self-invalidates from a raw change-stream
+/// (`stream.listen((_) => ref.invalidateSelf())`) keeps firing while the
+/// provider is paused (its widgets are off-screen via `TickerMode`). The
+/// deferred invalidation flushes during the next TickerMode *resume*, cascading
+/// a re-entrant pause/invalidate through the provider's `ref.watch` dependents
+/// and tripping Riverpod's internal pause-state accounting.
+///
+/// The raw pattern reproduces the crash; [Ref.invalidateSelfWhen] (which pauses
+/// the subscription alongside the provider) must not.
+void main() {
+  /// Drives [body] in its own error-capturing zone so the assertion that
+  /// Riverpod reports through `runBinaryGuarded` -> `Zone.handleUncaughtError`
+  /// is observable instead of silently swallowed.
+  Future<List<Object>> captureZoneErrors(Future<void> Function() body) async {
+    final errors = <Object>[];
+    final done = Completer<void>();
+    unawaited(
+      runZonedGuarded(
+        () async {
+          await body();
+          if (!done.isCompleted) done.complete();
+        },
+        (error, _) {
+          errors.add(error);
+          if (!done.isCompleted) done.complete();
+        },
+      ),
+    );
+    await done.future;
+    return errors;
+  }
+
+  /// Builds the gas-switch-style graph: a self-invalidating base provider with
+  /// two dependents that `await ref.watch(base.future)`, subscribes to all
+  /// three like on-screen widgets, then pauses everything, fires a change while
+  /// paused, and resumes the base subscription (mirroring a TickerMode resume).
+  Future<List<Object>> runPauseResume(
+    void Function(Ref ref, Stream<void> changes) wire,
+  ) {
+    return captureZoneErrors(() async {
+      final changes = StreamController<void>.broadcast();
+      addTearDown(changes.close);
+
+      final baseProvider = FutureProvider.family<List<int>, String>((ref, id) {
+        wire(ref, changes.stream);
+        // A fresh (non-const) list each build so a rebuild actually notifies
+        // dependents, matching a DB-query-backed provider.
+        return [1, 2, 3];
+      });
+      final depBool = FutureProvider.family<bool, String>((ref, id) async {
+        final v = await ref.watch(baseProvider(id).future);
+        return v.isNotEmpty;
+      });
+      final depLen = FutureProvider.family<int, String>((ref, id) async {
+        final v = await ref.watch(baseProvider(id).future);
+        return v.length;
+      });
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final base = container.listen(baseProvider('d'), (_, _) {});
+      final a = container.listen(depBool('d'), (_, _) {});
+      final b = container.listen(depLen('d'), (_, _) {});
+
+      await container.read(baseProvider('d').future);
+      await container.read(depBool('d').future);
+      await container.read(depLen('d').future);
+
+      // Page off-screen: every subscription pauses.
+      base.pause();
+      a.pause();
+      b.pause();
+
+      // Background sync writes the DB while off-screen.
+      changes.add(null);
+      await Future<void>.delayed(Duration.zero);
+
+      // Page returns: the base widget's subscription resumes first and flushes
+      // the dirty provider while the dependents are still paused.
+      base.resume();
+      await Future<void>.delayed(Duration.zero);
+    });
+  }
+
+  test(
+    'raw stream.listen((_) => ref.invalidateSelf()) trips the pause assertion '
+    'on resume (reproduction)',
+    () async {
+      final errors = await runPauseResume((ref, changes) {
+        final sub = changes.listen((_) => ref.invalidateSelf());
+        ref.onDispose(sub.cancel);
+      });
+      // Documents the bug: the raw pattern reports the pause-state assertion.
+      expect(errors, isNotEmpty);
+      expect(
+        errors.first.toString(),
+        contains('pausedActiveSubscriptionCount'),
+      );
+    },
+  );
+
+  test('Ref.invalidateSelfWhen pauses with the provider and does not trip the '
+      'assertion on resume', () async {
+    final errors = await runPauseResume((ref, changes) {
+      ref.invalidateSelfWhen(changes);
+    });
+    expect(errors, isEmpty);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -1944,6 +1944,47 @@ void main() {
   LineChartData primaryChartData(WidgetTester tester) =>
       tester.widget<LineChart>(find.byType(LineChart).first).data;
 
+  group('tooltip cache', () {
+    testWidgets(
+      'getTooltipItems never returns a cached list whose length differs from '
+      'touchedSpots (fl_chart size-match contract)',
+      (tester) async {
+        await tester.pumpWidget(_buildChart());
+        await tester.pumpAndSettle();
+
+        final getItems = primaryChartData(
+          tester,
+        ).lineTouchData.touchTooltipData.getTooltipItems;
+        final depthBar = primaryChartData(tester).lineBarsData.first;
+        // Depth-line spotIndex stays fixed across both touches (cursor parked).
+        // Kept well inside the profile so the depth branch is exercised.
+        const spotIndex = 3;
+        final depthSpot = LineBarSpot(depthBar, 0, depthBar.spots[spotIndex]);
+
+        // First touch: the depth spot plus sibling bars under the cursor (the
+        // callback returns one entry per spot). Caches a 3-entry list keyed on
+        // this depth spotIndex.
+        final manyBars = <LineBarSpot>[
+          depthSpot,
+          LineBarSpot(depthBar, 1, depthBar.spots[spotIndex]),
+          LineBarSpot(depthBar, 2, depthBar.spots[spotIndex]),
+        ];
+        expect(getItems(manyBars).length, manyBars.length);
+
+        // Same depth spotIndex, fewer bars now touched (a sibling line toggled
+        // off or a data provider refreshed under the parked cursor). The
+        // stale-length cache must be rejected; otherwise fl_chart throws
+        // 'tooltipItems and touchedSpots size should be same'.
+        final fewerBars = <LineBarSpot>[depthSpot];
+        expect(
+          getItems(fewerBars).length,
+          fewerBars.length,
+          reason: 'cache must invalidate when the touched-bar count changes',
+        );
+      },
+    );
+  });
+
   group('zoom anchoring', () {
     testWidgets('mouse wheel up zooms in WITHOUT pinning the left edge to 0', (
       tester,


### PR DESCRIPTION
## Summary

Fixes two runtime errors on the dive detail page, both fallout from the Riverpod 3 / fl_chart 1.x upgrade (#426):

1. **`Expected pausedActiveSubscriptionCount to be N, but was N+1`** — a Riverpod 3 auto-pause assertion.
2. **`tooltipItems and touchedSpots size should be same`** — an fl_chart exception (fired repeatedly in the logs).

## 1. Riverpod 3 auto-pause assertion

Riverpod 3 added auto-pause: a `Consumer` stops listening to its providers when its widget leaves the screen (`TickerMode.of(context)`) and resumes on return.

The ~40 per-dive / cross-feature providers refresh after a background sync with a **raw** stream subscription:

```dart
final sub = repository.watchDiveDetailChanges().listen((_) => ref.invalidateSelf());
ref.onDispose(sub.cancel);
```

That raw `.listen` is invisible to Riverpod's pause machinery, so while the page is off-screen the stream keeps firing `invalidateSelf()`, marking the provider dirty. On return, the TickerMode *resume* synchronously `flush()`es the dirty provider and cascades to its `ref.watch` dependents (`gasSwitchesProvider` ← `hasGasSwitches` / `cylinderSac` / `segments`). That re-entrant pause/invalidate happens mid-resume, when Riverpod's pause counter is half-updated → the assertion trips.

**Fix:** new `Ref.invalidateSelfWhen(Stream<void>)` (`lib/core/providers/ref_invalidate_on_change.dart`). Rather than pausing the subscription, it **defers**: while the provider is paused a tick only records that a refresh is due (`isPaused`), and the catch-up `invalidateSelf` is scheduled from `onResume` (via a microtask, since `Ref` can't be used inside a life-cycle callback). The subscription is never paused, so the provider is never dirty across a resume (no assertion) **and** broadcast ticks are never dropped — important because most `watch*Changes()` are raw Drift `tableUpdates(...)`, which are broadcast (`Stream.multi(isBroadcast: true)`); only the two dive-table streams are debounced/single-subscription. Applied to all 40 raw-stream provider bodies across 19 feature files.

> An earlier revision paused/resumed the subscription (like `StreamProvider` does), but that drops events on broadcast streams while paused — see the resolved review thread. The deferral approach is broadcast-safe.

> `debug_log_providers.dart` (`LoggerService.logStream`) is deliberately left raw: it has no `ref.watch` dependents (so it can't cascade into the assertion) and its stream may be broadcast (pausing would drop log lines).

## 2. fl_chart tooltip size crash

The dive profile chart cached `_lastTooltipItems` keyed only on the depth `spotIndex`, but fl_chart requires the returned list length to equal `touchedSpots.length`. When the visible-line count changes under a parked cursor (a metric toggled, or a provider refresh adds/removes a curve), the stale-length cache threw. Fixed with a length guard on the cache hit.

## Testing

- `test/core/providers/ref_invalidate_on_change_test.dart` — reproduces the exact assertion with the raw pattern (captured via a zone error handler), proves the helper prevents it, and asserts a tick emitted on a **broadcast** stream while paused refreshes on resume (not dropped).
- `dive_profile_chart_test.dart` — new `tooltip cache` test; confirmed it fails without the guard.
- `flutter analyze` clean; `dart format` clean.
- Green locally: chart tests (103), dive_log provider tests (213), 14 converted-feature provider dirs (172), dive detail page tests (23).

Full suite runs in CI. Device check: navigate into/out of a dive's detail page during an active sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuJn8RLak3vcgXAG2mK9EN
