### PR TITLE
fix: keep dive-type chips visible during background reloads (#429)

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_type_multi_select_field.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_type_multi_select_field.dart
@@ -43,37 +43,47 @@ class DiveTypeMultiSelectField extends ConsumerWidget {
     final typesAsync = ref.watch(diveTypesProvider);
     final label = labelText ?? context.l10n.diveLog_edit_label_diveTypes;
 
-    return typesAsync.when(
-      loading: () => const LinearProgressIndicator(),
-      error: (e, _) =>
-          Text(context.l10n.diveLog_edit_errorLoadingDiveTypes(e.toString())),
-      data: (types) {
-        final nameById = {for (final t in types) t.id: t.name};
-        String nameOf(String id) =>
-            nameById[id] ?? Dive.diveTypeDisplayName(id);
-
-        return InkWell(
-          onTap: () => _openPicker(context, types, label),
-          child: InputDecorator(
-            decoration: InputDecoration(
-              labelText: label,
-              suffixIcon: const Icon(Icons.arrow_drop_down),
-            ),
-            child: Wrap(
-              spacing: 6,
-              runSpacing: 4,
-              children: [
-                for (final id in selectedTypeIds)
-                  Chip(
-                    label: Text(nameOf(id)),
-                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    visualDensity: VisualDensity.compact,
-                  ),
-              ],
-            ),
+    // diveTypesProvider self-invalidates on every dive_types write (e.g. an
+    // incoming sync), which drops it back into a loading state while Riverpod
+    // keeps the previous value. Render from that retained value so a background
+    // reload never flashes a bare progress bar over the chips; the spinner is
+    // shown only on the very first load, before any data has arrived. This
+    // mirrors the notifier's silent-reload behaviour. See #429.
+    final types = typesAsync.value;
+    if (types == null) {
+      if (typesAsync.hasError) {
+        return Text(
+          context.l10n.diveLog_edit_errorLoadingDiveTypes(
+            typesAsync.error.toString(),
           ),
         );
-      },
+      }
+      return const LinearProgressIndicator();
+    }
+
+    final nameById = {for (final t in types) t.id: t.name};
+    String nameOf(String id) => nameById[id] ?? Dive.diveTypeDisplayName(id);
+
+    return InkWell(
+      onTap: () => _openPicker(context, types, label),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          suffixIcon: const Icon(Icons.arrow_drop_down),
+        ),
+        child: Wrap(
+          spacing: 6,
+          runSpacing: 4,
+          children: [
+            for (final id in selectedTypeIds)
+              Chip(
+                label: Text(nameOf(id)),
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                visualDensity: VisualDensity.compact,
+              ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/test/features/dive_log/presentation/widgets/dive_type_multi_select_field_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_type_multi_select_field_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_type_multi_select_field.dart';
 import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
@@ -131,5 +134,106 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(result, isEmpty); // bulk mode allows clearing
+  });
+
+  // Regression: #429 -- diveTypesProvider self-invalidates on every dive_types
+  // table write (e.g. an incoming sync). On reload it drops back into a loading
+  // state while Riverpod keeps the previous value (hasValue stays true). The
+  // field must keep showing its chips across that background reload instead of
+  // flashing a bare LinearProgressIndicator.
+  //
+  // The reload is driven through a watched dependency: that is the state where
+  // AsyncValue.when() surfaces the loading branch despite retaining a value
+  // (skipLoadingOnReload defaults to false), which is the exact flicker users
+  // see when a sync ticks the table.
+  testWidgets('keeps the selected chips visible while the provider reloads', (
+    tester,
+  ) async {
+    final reloadKey = StateProvider<int>((ref) => 0);
+    final loads = <Completer<List<DiveTypeEntity>>>[];
+    Future<List<DiveTypeEntity>> nextLoad() {
+      final completer = Completer<List<DiveTypeEntity>>();
+      loads.add(completer);
+      return completer.future;
+    }
+
+    final types = [type('shore', 'Shore'), type('wreck', 'Wreck')];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          diveTypesProvider.overrideWith((ref) {
+            ref.watch(reloadKey);
+            return nextLoad();
+          }),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveTypeMultiSelectField(
+              selectedTypeIds: const ['shore'],
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // First load resolves -> the populated field is on screen.
+    loads.last.complete(types);
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(Chip, 'Shore'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+
+    // A dive_types write lands: the provider rebuilds and is briefly pending
+    // again while retaining its previous value.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DiveTypeMultiSelectField)),
+      listen: false,
+    );
+    container.read(reloadKey.notifier).state++;
+    await tester.pump();
+
+    expect(
+      find.byType(LinearProgressIndicator),
+      findsNothing,
+      reason: 'a background reload must not replace the field with a spinner',
+    );
+    expect(find.widgetWithText(Chip, 'Shore'), findsOneWidget);
+
+    // Let the reload settle so the test ends cleanly.
+    loads.last.complete(types);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('shows a progress indicator on the very first load', (
+    tester,
+  ) async {
+    final completer = Completer<List<DiveTypeEntity>>();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [diveTypesProvider.overrideWith((ref) => completer.future)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveTypeMultiSelectField(
+              selectedTypeIds: const ['shore'],
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // No value has ever arrived, so the spinner is the correct placeholder.
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.byType(Chip), findsNothing);
+
+    completer.complete([type('shore', 'Shore')]);
+    await tester.pumpAndSettle();
   });
 }


### PR DESCRIPTION
## Summary

Closes #429.

`DiveTypeMultiSelectField` (Conditions section of the dive edit form, and the
bulk editor) briefly replaced its selected-type chips with a bare
`LinearProgressIndicator` whenever the `dive_types` table was written while the
field was on screen — most visibly when an incoming iCloud/S3 sync applies remote
`dive_types` rows.

## Root cause

`diveTypesProvider` self-invalidates on every `dive_types` change
(`ref.invalidateSelfWhen(repository.watchDiveTypesChanges())`). The widget routed
through `typesAsync.when(loading: () => const LinearProgressIndicator(), …)`,
whose `loading:` branch fires on **every** reload, not just the first — so each
background refresh swapped the whole populated field for a spinner for a frame.

Riverpod keeps the previous value across a reload (`hasValue` stays true), so the
data was there the whole time; the widget just wasn't reading it.

## Fix

Render the field from the retained value and show the spinner only on the very
first load:

```dart
final types = typesAsync.value;          // retained across a reload
if (types == null) {                     // nothing loaded yet
  if (typesAsync.hasError) return Text(…errorLoadingDiveTypes…);
  return const LinearProgressIndicator();
}
// …InputDecorator + chips from `types`…
```

This mirrors the silent-reload behaviour the notifier already uses
(`DiveTypeListNotifier._silentReloadDiveTypes`).

Two Riverpod-3 subtleties worth flagging for reviewers:

- `AsyncValue.when` defaults to `skipLoadingOnReload: false` (but
  `skipLoadingOnRefresh: true`), so a self-`invalidate` reload surfaces the
  loading branch even though a value is retained. That is the flicker.
- This repo's custom `AsyncValue.valueOrNull` extension is
  `when(…, loading: () => null)`, so it goes **null during a reload** and cannot
  carry data across one. The fix uses the built-in nullable `AsyncValue.value`
  (value retained across reload) instead.

## Tests

- Regression test: drives the provider through a reload and asserts the chips
  stay while no `LinearProgressIndicator` appears. Verified it **fails before**
  the fix (spinner shown) and passes after.
- Guard: the first-load spinner still shows before any data arrives.

The reload is driven via a watched dependency — the deterministic way to reach
the `isReloading` state in `flutter_test`, since the real `invalidateSelfWhen`
stream tick stalls in Riverpod's auto-pause branch (the test harness never fires
`onResume`).

## Verification

- `flutter test test/features/dive_log test/features/dive_types` — 1510 pass, 0 fail
- `flutter analyze` — No issues found
- `dart format --set-exit-if-changed .` — clean

Logic-level fix, all platforms, no data loss. Live-sync visual verification on a
device is the only thing the automated tests can't cover.