### PR TITLE
fix: wrap long dive-type and weather rows on the dive detail page (#434)

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -48,6 +48,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/dive_locations
 import 'package:submersion/features/dive_log/presentation/widgets/surface_gps_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/data_sources_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/field_attribution_badge.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_detail_row.dart';
 import 'package:submersion/features/dive_log/domain/services/field_attribution_service.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/merge_dive_dialog.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_deco_status_card.dart';
@@ -3464,30 +3465,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     String value, {
     String? sourceName,
   }) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            label,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(value, style: Theme.of(context).textTheme.bodyMedium),
-              if (sourceName != null) ...[
-                const SizedBox(width: 6),
-                FieldAttributionBadge(sourceName: sourceName),
-              ],
-            ],
-          ),
-        ],
-      ),
-    );
+    return DiveDetailRow(label: label, value: value, sourceName: sourceName);
   }
 
   /// Build dive computer rows from profile-linked computers or string fields.

--- a/lib/features/dive_log/presentation/widgets/dive_detail_row.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_detail_row.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/field_attribution_badge.dart';
+
+/// A label/value row used throughout the dive detail page.
+///
+/// The label sits at the leading edge and the value at the trailing edge. When
+/// the value is long it wraps onto additional lines rather than crowding the
+/// label or overflowing the right edge (issue #434).
+class DiveDetailRow extends StatelessWidget {
+  const DiveDetailRow({
+    super.key,
+    required this.label,
+    required this.value,
+    this.sourceName,
+  });
+
+  /// Leading, muted field name (e.g. "Dive Type").
+  final String label;
+
+  /// Trailing value (e.g. a comma-joined list of dive types).
+  final String value;
+
+  /// When non-null, an attribution badge is shown after the value.
+  final String? sourceName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      // Top-align so a multi-line value keeps the label pinned to the first
+      // line rather than vertically centring against the wrapped block.
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          // A guaranteed gap so the label and value never touch, even when the
+          // value grows wide enough to fill the rest of the row.
+          const SizedBox(width: 16),
+          // Expanded gives the value the remaining width as a bound, so a long
+          // value wraps (right-aligned) instead of overflowing the edge.
+          Expanded(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Flexible(
+                  child: Text(
+                    value,
+                    style: theme.textTheme.bodyMedium,
+                    textAlign: TextAlign.end,
+                  ),
+                ),
+                if (sourceName != null) ...[
+                  const SizedBox(width: 6),
+                  FieldAttributionBadge(sourceName: sourceName),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/dive_log/presentation/widgets/dive_detail_row_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_detail_row_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_detail_row.dart';
+
+/// Pumps a single [DiveDetailRow] inside a deliberately narrow viewport so a
+/// long value is forced to compete with the label for horizontal space. This
+/// reproduces issue #434 (Galaxy S24 Ultra): a long "Dive Type" / weather
+/// "Description" value jammed against its label and ran off the right edge.
+Future<void> _pumpRow(
+  WidgetTester tester, {
+  required String label,
+  required String value,
+  String? sourceName,
+  double width = 250,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: width,
+            child: DiveDetailRow(
+              label: label,
+              value: value,
+              sourceName: sourceName,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('DiveDetailRow', () {
+    testWidgets('a long value wraps instead of overflowing a narrow row', (
+      tester,
+    ) async {
+      await _pumpRow(
+        tester,
+        label: 'Dive Type',
+        value: 'Recreational, Shore, Photography',
+      );
+
+      // The buggy layout (no Flexible around the value) emits a RenderFlex
+      // "overflowed" error here; the fixed layout must lay out cleanly.
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'a long value must wrap within the row, not overflow it',
+      );
+
+      // The whole value must remain on screen, not be truncated away.
+      expect(find.text('Recreational, Shore, Photography'), findsOneWidget);
+      expect(find.text('Dive Type'), findsOneWidget);
+    });
+
+    testWidgets('a long free-form description does not overflow', (
+      tester,
+    ) async {
+      await _pumpRow(
+        tester,
+        label: 'Description',
+        value: 'Overcast, 27C, moderate breeze from the east, choppy surface',
+      );
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'a long weather description must wrap, not run off the edge',
+      );
+    });
+
+    testWidgets(
+      'a short value stays at the trailing edge, clear of the label',
+      (tester) async {
+        await _pumpRow(tester, label: 'Avg Depth', value: '22.3ft', width: 300);
+
+        expect(tester.takeException(), isNull);
+
+        // Value hugs the trailing edge of the row (no horizontal padding).
+        final rowRight = tester.getTopRight(find.byType(DiveDetailRow)).dx;
+        final valueRight = tester.getTopRight(find.text('22.3ft')).dx;
+        expect((rowRight - valueRight).abs(), lessThan(1.0));
+
+        // ...and is plainly separated from the label, not jammed against it.
+        final labelRight = tester.getTopRight(find.text('Avg Depth')).dx;
+        final valueLeft = tester.getTopLeft(find.text('22.3ft')).dx;
+        expect(valueLeft - labelRight, greaterThan(16.0));
+      },
+    );
+
+    testWidgets('shows an attribution badge after the value when provided', (
+      tester,
+    ) async {
+      await _pumpRow(
+        tester,
+        label: 'Avg Depth',
+        value: '22.3ft',
+        sourceName: 'Perdix',
+        width: 300,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('22.3ft'), findsOneWidget);
+      expect(find.text('Perdix'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #434. On a Galaxy S24 Ultra, the dive detail page crowded the **Dive Type** field when multiple dive types were selected, and let the weather **Description** run off the right edge of the screen.

Both rows are built by the shared `_buildDetailRow` helper, whose value had **no `Flexible` bound**. With a long value — a comma-joined list of dive types (from #414) or a free-form weather description — the value claimed its full intrinsic width, so `MainAxisAlignment.spaceBetween` had no slack to distribute: the gap to the label collapsed to zero (the crowding) and the value painted past the right edge (a `RenderFlex overflowed` in debug builds). Short values stayed slack, which is why most rows looked fine.

## Fix

- Extract a dedicated, testable `DiveDetailRow` widget that bounds the value with `Expanded` so a long value **wraps** (right-aligned), keeps a guaranteed gap from the label, and top-aligns the label for multi-line values. This matches the `Flexible` pattern already used by the sibling trip and dive-computer rows in the same file.
- `_buildDetailRow` now delegates to the widget, so every existing call site is unchanged.
- Side benefit: the row moves out of `dive_detail_page.dart` (~5.6k lines; the project guideline is 800 max) into its own file.

## Before / after

Rendered at the Galaxy S24 Ultra logical width (411dp). BEFORE shows the label/value jamming and the right-edge overflow (Flutter's red + hazard-stripe indicators); AFTER wraps long values cleanly with a preserved gap. (Image shared in the session.)

## Tests

New `dive_detail_row_test.dart`:
- a long value wraps instead of overflowing a narrow row (the #434 repro)
- a long free-form description does not overflow
- a short value stays at the trailing edge, clear of the label
- shows an attribution badge after the value when provided

The test reproduces the real `RenderFlex overflowed by 762px` failure against the pre-fix layout, then passes after the fix.

## Verification

- [x] `test/features/dive_log/` slice green (1508 passed), whole-project `flutter analyze` clean, `dart format .` clean
- [ ] On-device visual check on a real Android phone (pending)