### PR TITLE
fix(android): release JNI local refs in libdc callbacks (#318)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,14 +254,23 @@ jobs:
       - name: Install coverage.py
         run: python3 -m pip install coverage
 
+      - name: Check JNI local-reference hygiene (source)
+        # Source-level guard: no build artifact needed (unlike the APK/mapping
+        # guards), so it runs here. Fails if a libdivecomputer JNI callback
+        # leaks a local ref -> local reference table overflow on a long download
+        # (Mares Puck Pro) -> silent SIGABRT. See issue #318.
+        run: python3 scripts/check_jni_local_refs.py
+
       - name: Run Python guard tests with coverage
         run: |
           mkdir -p coverage
-          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py'
+          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py,scripts/check_jni_local_refs.py'
           python3 -m coverage run --include="$guards" \
             scripts/check_proguard_serial_keep_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/check_native_libs_present_test.py
+          python3 -m coverage run --append --include="$guards" \
+            scripts/check_jni_local_refs_test.py
           python3 -m coverage report -m --include="$guards"
           python3 -m coverage xml --include="$guards" \
             -o coverage/scripts.xml

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -228,6 +228,7 @@ static void jni_on_progress(unsigned int current, unsigned int maximum, void *us
 
     jclass cls = env->GetObjectClass(ctx->callback);
     jmethodID method = env->GetMethodID(cls, "onProgress", "(II)V");
+    env->DeleteLocalRef(cls);
     if (method) {
         env->CallVoidMethod(ctx->callback, method,
             static_cast<jint>(current), static_cast<jint>(maximum));
@@ -247,6 +248,7 @@ static void jni_on_dive(const libdc_parsed_dive_t *dive, void *userdata) {
 
     jclass cls = env->GetObjectClass(ctx->callback);
     jmethodID method = env->GetMethodID(cls, "onDive", "(J)V");
+    env->DeleteLocalRef(cls);
     if (method) {
         // Pass the dive pointer so Kotlin can read fields via additional JNI calls.
         env->CallVoidMethod(ctx->callback, method,
@@ -281,6 +283,7 @@ static int jni_io_read(void *userdata, void *data, size_t size, size_t *actual) 
 
     jclass cls = env->GetObjectClass(ctx->ioHandler);
     jmethodID method = env->GetMethodID(cls, "read", "(II)[B");
+    env->DeleteLocalRef(cls);
     if (!method) {
         if (attached) ctx->jvm->DetachCurrentThread();
         return LIBDC_STATUS_IO;
@@ -313,6 +316,7 @@ static int jni_io_read(void *userdata, void *data, size_t size, size_t *actual) 
 
     jsize len = env->GetArrayLength(result);
     env->GetByteArrayRegion(result, 0, len, static_cast<jbyte *>(data));
+    env->DeleteLocalRef(result);
     *actual = static_cast<size_t>(len);
 
     if (attached) ctx->jvm->DetachCurrentThread();
@@ -330,6 +334,7 @@ static int jni_io_write(void *userdata, const void *data, size_t size, size_t *a
 
     jclass cls = env->GetObjectClass(ctx->ioHandler);
     jmethodID method = env->GetMethodID(cls, "write", "([BI)I");
+    env->DeleteLocalRef(cls);
     if (!method) {
         if (attached) ctx->jvm->DetachCurrentThread();
         return LIBDC_STATUS_IO;
@@ -341,6 +346,7 @@ static int jni_io_write(void *userdata, const void *data, size_t size, size_t *a
 
     jint result = env->CallIntMethod(ctx->ioHandler, method, arr,
         static_cast<jint>(ctx->timeout_ms));
+    env->DeleteLocalRef(arr);
 
     if (result < 0) {
         *actual = 0;
@@ -370,6 +376,7 @@ static int jni_io_configure(void *userdata, unsigned int baudrate,
 
     jclass cls = env->GetObjectClass(ctx->ioHandler);
     jmethodID method = env->GetMethodID(cls, "configure", "(IIIII)I");
+    env->DeleteLocalRef(cls);
     int status = LIBDC_STATUS_UNSUPPORTED;
     if (method != nullptr) {
         jint r = env->CallIntMethod(ctx->ioHandler, method,
@@ -396,6 +403,7 @@ static int jni_io_set_modem_line(JniIoContext *ctx, const char *methodName,
 
     jclass cls = env->GetObjectClass(ctx->ioHandler);
     jmethodID method = env->GetMethodID(cls, methodName, "(I)I");
+    env->DeleteLocalRef(cls);
     int status = LIBDC_STATUS_UNSUPPORTED;
     if (method != nullptr) {
         jint r = env->CallIntMethod(ctx->ioHandler, method, static_cast<jint>(value));
@@ -488,6 +496,7 @@ static int jni_io_ioctl(void *userdata, unsigned int request,
         }
 
         if (jPin != nullptr) env->DeleteLocalRef(jPin);
+        env->DeleteLocalRef(cls);
         if (attached) ctx->jvm->DetachCurrentThread();
         return status;
     }
@@ -548,6 +557,7 @@ static int jni_io_ioctl(void *userdata, unsigned int request,
         }
 
         env->DeleteLocalRef(jAddress);
+        env->DeleteLocalRef(cls);
         if (attached) ctx->jvm->DetachCurrentThread();
         return status;
     }
@@ -566,6 +576,7 @@ static int jni_io_purge(void *userdata, unsigned int direction) {
 
     jclass cls = env->GetObjectClass(ctx->ioHandler);
     jmethodID method = env->GetMethodID(cls, "purge", "(I)V");
+    env->DeleteLocalRef(cls);
     if (method) {
         env->CallVoidMethod(ctx->ioHandler, method, static_cast<jint>(direction));
     }
@@ -585,6 +596,7 @@ static int jni_io_close(void *userdata) {
 
     jclass cls = env->GetObjectClass(ctx->ioHandler);
     jmethodID method = env->GetMethodID(cls, "close", "()V");
+    env->DeleteLocalRef(cls);
     if (method) {
         env->CallVoidMethod(ctx->ioHandler, method);
     }

--- a/scripts/check_jni_local_refs.py
+++ b/scripts/check_jni_local_refs.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Verify the libdivecomputer JNI callbacks free every local reference.
+
+The Android backend bridges libdivecomputer's synchronous I/O to Kotlin through
+the JNI callbacks in ``libdc_jni.cpp`` (``jni_io_read``, ``jni_io_write``,
+``jni_io_configure`` ... and the ``jni_on_progress`` / ``jni_on_dive`` download
+callbacks). libdivecomputer calls these *repeatedly* from
+``Java_..._nativeDownloadRun``, which runs the whole download synchronously on
+the Kotlin thread that invoked it.
+
+That thread is already attached to the JVM, so in every callback
+``GetEnv()`` returns ``JNI_OK`` -> ``attached = false`` -> ``DetachCurrentThread``
+is never called. JNI local references are reclaimed only when the native method
+returns to Java *or* when the thread detaches -- neither happens until the whole
+download finishes. So every undeleted local ref (the ``jclass`` from
+``GetObjectClass``, the byte array from ``CallObjectMethod`` / ``NewByteArray``)
+accumulates for the entire session.
+
+A full Mares Puck Pro dump reads 0x40000 bytes in 256-byte packets -- roughly
+5,000 read/write callbacks, each leaking ~2 local refs. That overflows ART's
+local reference table (``JNI ERROR (app bug): local reference table overflow``),
+which aborts the process with SIGABRT: the app "just closes" with no Dart/Java
+exception. This is the v1.5.8 face of issue #318. (The earlier #334 serial-read
+fix is what let the download run long enough to reach the overflow -- it did not
+introduce the leak, it un-masked it.)
+
+This guard is a source-level static check (no build artifact, no NDK). For each
+download-thread callback it confirms every local-reference-creating JNI call has
+either a matching ``DeleteLocalRef`` or a ``PushLocalFrame`` bracket. It is the
+source-level counterpart to ``check_proguard_serial_keep`` /
+``check_16kb_alignment`` and is dependency-free (pure stdlib).
+
+Usage:
+    check_jni_local_refs.py [libdc_jni.cpp]   # defaults to the Android source
+"""
+
+import re
+import sys
+
+DEFAULT_SOURCE = (
+    "packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp"
+)
+
+# JNI calls that return a *local reference* the caller owns and must release
+# with DeleteLocalRef. GetMethodID/GetFieldID return IDs (not refs);
+# Call{Int,Void,Boolean}Method return primitives (not refs) -- excluded on
+# purpose. NewGlobalRef makes a global ref (freed by DeleteGlobalRef) and is
+# handled by nativeDownloadRun, not these per-call callbacks.
+REF_CREATING = (
+    "GetObjectClass",
+    "CallObjectMethod",
+    "NewByteArray",
+    "NewStringUTF",
+    "NewString",
+    "NewObject",
+    "NewObjectArray",
+    "GetObjectArrayElement",
+)
+
+# Callbacks libdivecomputer invokes on the (already-attached) download thread.
+# These names must exist; a rename should fail the guard loudly rather than let
+# it silently scan nothing.
+EXPECTED_CALLBACKS = ("jni_io_read", "jni_io_write")
+
+# A body that brackets its work in a JNI local frame frees every local ref in
+# bulk on pop, so accept that as a complete fix without per-variable accounting.
+FRAME_MARKER = "PushLocalFrame"
+
+# Only the per-call libdivecomputer callbacks are audited (see _functions, which
+# anchors on these names). nativeDownloadRun manages its refs differently
+# (global refs, a single invocation that returns to Java) and is out of scope.
+
+
+def _strip_comments(text):
+    """Remove C/C++ comments while preserving string and char literals.
+
+    Comment removal matters twice: a ``//`` comment with an unbalanced ``(`` (the
+    ``DC_IOCTL('b', 0)`` note above ``jni_io_ioctl``) would otherwise let the
+    signature scan run past it into the next function, and a comment that merely
+    *mentions* ``DeleteLocalRef(cls)`` must never be mistaken for a real release.
+    Literals are kept verbatim because JNI signatures such as
+    ``"(Ljava/lang/String;)..."`` carry ``;`` and ``(`` that the parser relies on.
+    """
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        two = text[i:i + 2]
+        if two == "//":
+            nl = text.find("\n", i)
+            i = n if nl < 0 else nl  # leave the newline for the next iteration
+        elif two == "/*":
+            end = text.find("*/", i + 2)
+            out.append(" ")  # keep tokens on either side separated
+            i = n if end < 0 else end + 2
+        elif text[i] in "\"'":
+            quote = text[i]
+            out.append(text[i])
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    i += 1
+                    break
+                i += 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def _functions(text):
+    """Yield ``(name, body)`` for each ``jni_io_*`` / ``jni_on_*`` definition.
+
+    Anchored to the callback names so an upstream ``(`` cannot start a spurious
+    match, and brace-matched so nested blocks do not end a body early. Operates
+    on comment-stripped source.
+    """
+    text = _strip_comments(text)
+    for m in re.finditer(r"\b(jni_(?:io|on)_\w*)\s*\([^;{}]*\)\s*\{", text):
+        name = m.group(1)
+        brace = text.index("{", m.end() - 1)
+        depth = 0
+        for i in range(brace, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    yield name, text[brace + 1:i]
+                    break
+
+
+def _assign_target(statement):
+    """Return the variable a statement assigns to, or ``None``.
+
+    The first plain ``=`` (not ``==`` / ``<=`` / ``>=`` / ``!=``) marks the
+    assignment; the identifier to its left is the target. ``jclass cls = ...``
+    -> ``cls``; ``auto result = static_cast<jbyteArray>(...)`` -> ``result``.
+    """
+    m = re.search(r"(\b[A-Za-z_]\w*)\s*=(?!=)", statement)
+    return m.group(1) if m else None
+
+
+def _ref_creating_calls(body):
+    """Return ``[(call, var), ...]`` for ref-creating calls in ``body``.
+
+    Split on ``;`` so a statement whose call spills across lines stays intact.
+    ``var`` is the assignment target, or ``None`` when the ref is not bound to a
+    variable (and so cannot be proven released).
+    """
+    found = []
+    for statement in body.split(";"):
+        for call in REF_CREATING:
+            # \s*\( so NewString does not match inside NewStringUTF.
+            if re.search(r"\b" + call + r"\s*\(", statement):
+                found.append((call, _assign_target(statement)))
+    return found
+
+
+def find_leaks(text):
+    """Return ``(leaks, seen)``.
+
+    ``leaks`` is a list of ``(function, call, var)`` for every local ref that is
+    created but never released. ``seen`` is the set of callback function names
+    audited.
+    """
+    leaks = []
+    seen = set()
+    for name, body in _functions(text):
+        seen.add(name)
+        if FRAME_MARKER in body:
+            continue  # bulk-freed on PopLocalFrame
+        for call, var in _ref_creating_calls(body):
+            if var is None:
+                leaks.append((name, call, None))
+                continue
+            released = re.search(
+                r"DeleteLocalRef\s*\(\s*" + re.escape(var) + r"\s*\)", body
+            )
+            if not released:
+                leaks.append((name, call, var))
+    return leaks, seen
+
+
+def check_file(path):
+    """Check one libdc_jni.cpp. Return ``(ok, lines)`` report."""
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        leaks, seen = find_leaks(fh.read())
+
+    lines = []
+    ok = True
+
+    missing = [c for c in EXPECTED_CALLBACKS if c not in seen]
+    if missing:
+        ok = False
+        lines.append(
+            "  FAIL  expected callback(s) not found: "
+            f"{', '.join(missing)} -- did the JNI bridge move/rename? "
+            "update this guard"
+        )
+
+    for name, call, var in leaks:
+        ok = False
+        target = var if var is not None else "(unbound)"
+        lines.append(
+            f"  FAIL  {name}: {call} local ref '{target}' is never released "
+            "(needs DeleteLocalRef or a PushLocalFrame bracket)"
+        )
+
+    if ok:
+        lines.append(
+            f"  ok    {len(seen)} download-thread JNI callbacks free every "
+            "local ref"
+        )
+    return ok, lines
+
+
+def main(argv):
+    paths = argv[1:] or [DEFAULT_SOURCE]
+    all_ok = True
+    for path in paths:
+        print(f"Checking JNI local-reference hygiene: {path}")
+        try:
+            ok, lines = check_file(path)
+        except OSError as exc:
+            print(f"  ERROR reading {path}: {exc}")
+            all_ok = False
+            continue
+        for line in lines:
+            print(line)
+        if ok:
+            print(
+                "  -> PASS: download-thread JNI callbacks release their "
+                "local refs"
+            )
+        else:
+            print(
+                "  -> FAIL: a JNI callback leaks local refs; a long download "
+                "(e.g. Mares Puck Pro) overflows the local reference table and "
+                "crashes with a silent SIGABRT (see issue #318)"
+            )
+        all_ok = all_ok and ok
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv))

--- a/scripts/check_jni_local_refs_test.py
+++ b/scripts/check_jni_local_refs_test.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Unit tests for check_jni_local_refs.py.
+
+Run: python3 scripts/check_jni_local_refs_test.py
+
+These exercise the JNI local-reference accounting the Build Android step cannot
+reproduce without an emulator: a callback that leaks a ``jclass`` (the issue
+#318 crash), the ``DeleteLocalRef`` / ``PushLocalFrame`` exemptions, and the
+comment/literal hazards that previously hid ``jni_io_ioctl`` from the scanner.
+A smoke test runs the guard against the real libdc_jni.cpp so the shipped fix
+stays green.
+"""
+
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+
+# Load the sibling script by path so the test runs from any working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_HERE)
+_spec = importlib.util.spec_from_file_location(
+    "check_jni_local_refs",
+    os.path.join(_HERE, "check_jni_local_refs.py"),
+)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+REAL_SOURCE = os.path.join(
+    _REPO_ROOT,
+    "packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp",
+)
+
+
+# A callback that releases every local ref it makes: cls right after the method
+# lookup, the returned array after its last use.
+GREEN = """\
+static int jni_io_read(void *userdata, void *data, size_t size, size_t *actual) {
+    auto *ctx = static_cast<JniIoContext *>(userdata);
+    JNIEnv *env = ctx->env;
+    jclass cls = env->GetObjectClass(ctx->ioHandler);
+    jmethodID method = env->GetMethodID(cls, "read", "(II)[B");
+    env->DeleteLocalRef(cls);
+    auto result = static_cast<jbyteArray>(env->CallObjectMethod(ctx->ioHandler, method));
+    jsize len = env->GetArrayLength(result);
+    env->DeleteLocalRef(result);
+    *actual = len;
+    return 0;
+}
+
+static int jni_io_write(void *userdata, const void *data, size_t size, size_t *actual) {
+    auto *ctx = static_cast<JniIoContext *>(userdata);
+    JNIEnv *env = ctx->env;
+    jclass cls = env->GetObjectClass(ctx->ioHandler);
+    jmethodID method = env->GetMethodID(cls, "write", "([BI)I");
+    env->DeleteLocalRef(cls);
+    jbyteArray arr = env->NewByteArray((jint)size);
+    env->CallIntMethod(ctx->ioHandler, method, arr);
+    env->DeleteLocalRef(arr);
+    return 0;
+}
+"""
+
+# The issue #318 signature: cls and the returned array are never released, so
+# every call leaks two local refs.
+RED = """\
+static int jni_io_read(void *userdata, void *data, size_t size, size_t *actual) {
+    auto *ctx = static_cast<JniIoContext *>(userdata);
+    JNIEnv *env = ctx->env;
+    jclass cls = env->GetObjectClass(ctx->ioHandler);
+    jmethodID method = env->GetMethodID(cls, "read", "(II)[B");
+    auto result = static_cast<jbyteArray>(env->CallObjectMethod(ctx->ioHandler, method));
+    jsize len = env->GetArrayLength(result);
+    *actual = len;
+    return 0;
+}
+
+static int jni_io_write(void *userdata, const void *data, size_t size, size_t *actual) {
+    jclass cls = env->GetObjectClass(ctx->ioHandler);
+    env->CallIntMethod(ctx->ioHandler, env->GetMethodID(cls, "write", "([BI)I"));
+    return 0;
+}
+"""
+
+
+class FindLeaksTests(unittest.TestCase):
+    def test_green_has_no_leaks(self):
+        leaks, seen = guard.find_leaks(GREEN)
+        self.assertEqual(leaks, [])
+        self.assertEqual(seen, {"jni_io_read", "jni_io_write"})
+
+    def test_red_flags_every_undeleted_ref(self):
+        leaks, _ = guard.find_leaks(RED)
+        flagged = {(name, var) for name, _, var in leaks}
+        self.assertIn(("jni_io_read", "cls"), flagged)
+        self.assertIn(("jni_io_read", "result"), flagged)
+        self.assertIn(("jni_io_write", "cls"), flagged)
+
+    def test_push_local_frame_exempts_the_body(self):
+        # A PushLocalFrame bracket frees every ref in bulk on pop, so the
+        # per-variable DeleteLocalRef requirement is waived.
+        framed = """\
+static void jni_on_progress(unsigned int c, unsigned int m, void *userdata) {
+    auto *ctx = static_cast<JniDownloadContext *>(userdata);
+    JNIEnv *env = ctx->env;
+    env->PushLocalFrame(8);
+    jclass cls = env->GetObjectClass(ctx->callback);
+    jmethodID method = env->GetMethodID(cls, "onProgress", "(II)V");
+    env->CallVoidMethod(ctx->callback, method, (jint)c, (jint)m);
+    env->PopLocalFrame(nullptr);
+}
+static int jni_io_read(void *u) { return 0; }
+static int jni_io_write(void *u) { return 0; }
+"""
+        leaks, seen = guard.find_leaks(framed)
+        self.assertEqual(leaks, [])
+        self.assertIn("jni_on_progress", seen)
+
+    def test_unbound_ref_is_flagged(self):
+        # A ref-creating call whose result is not bound to a variable cannot be
+        # proven released -- treat it as a leak.
+        body = """\
+static int jni_io_read(void *u) {
+    env->CallVoidMethod(o, m, env->NewStringUTF("x"));
+    return 0;
+}
+static int jni_io_write(void *u) { return 0; }
+"""
+        leaks, _ = guard.find_leaks(body)
+        self.assertTrue(any(var is None for _, _, var in leaks))
+
+
+class CommentAndLiteralHazardTests(unittest.TestCase):
+    def test_comment_with_unbalanced_paren_does_not_hide_next_function(self):
+        # Regression: a `//` comment with a stray '(' directly above a function
+        # whose preamble has no ';{}' (the real DC_IOCTL note + #defines) used to
+        # let the signature scan run past jni_io_ioctl entirely.
+        src = """\
+// DC_IOCTL('b', 0) = (0x62 << 8) | 0 = 0x6200
+#define BLE_IOCTL_GET_NAME 0x6200
+#define BLE_IOCTL_ACCESSCODE_NR 2
+static int jni_io_ioctl(void *userdata, unsigned int request,
+                         void *data, size_t size) {
+    jclass cls = env->GetObjectClass(ctx->ioHandler);
+    return 0;
+}
+static int jni_io_read(void *u) { return 0; }
+static int jni_io_write(void *u) { return 0; }
+"""
+        leaks, seen = guard.find_leaks(src)
+        self.assertIn("jni_io_ioctl", seen)
+        self.assertIn(("jni_io_ioctl", "GetObjectClass", "cls"), leaks)
+
+    def test_deletelocalref_in_a_comment_is_not_a_real_release(self):
+        src = """\
+static int jni_io_read(void *u) {
+    jclass cls = env->GetObjectClass(o);
+    // we intentionally do NOT call env->DeleteLocalRef(cls) yet
+    return 0;
+}
+static int jni_io_write(void *u) { return 0; }
+"""
+        leaks, _ = guard.find_leaks(src)
+        self.assertIn(("jni_io_read", "GetObjectClass", "cls"), leaks)
+
+    def test_semicolon_inside_a_string_literal_is_preserved(self):
+        # A JNI signature carries ';'; stripping must keep it so the method
+        # lookup statement is not mis-split and the real leak is still seen.
+        src = """\
+static int jni_io_ioctl(void *u) {
+    jclass cls = env->GetObjectClass(o);
+    jmethodID m = env->GetMethodID(cls, "onPinCodeRequired",
+        "(Ljava/lang/String;)Ljava/lang/String;");
+    return 0;
+}
+static int jni_io_read(void *u) { return 0; }
+static int jni_io_write(void *u) { return 0; }
+"""
+        leaks, seen = guard.find_leaks(src)
+        self.assertIn("jni_io_ioctl", seen)
+        self.assertIn(("jni_io_ioctl", "GetObjectClass", "cls"), leaks)
+
+    def test_block_comment_is_stripped(self):
+        stripped = guard._strip_comments("a /* b ; { } */ c")
+        self.assertNotIn("b", stripped)
+        self.assertIn("a", stripped)
+        self.assertIn("c", stripped)
+
+
+class AssignTargetTests(unittest.TestCase):
+    def test_simple_and_auto_targets(self):
+        self.assertEqual(guard._assign_target("jclass cls = env->Foo()"), "cls")
+        self.assertEqual(
+            guard._assign_target("auto result = static_cast<jbyteArray>(x)"),
+            "result",
+        )
+
+    def test_comparison_is_not_an_assignment(self):
+        self.assertIsNone(guard._assign_target("if (r == 0)"))
+        self.assertIsNone(guard._assign_target("while (n >= size)"))
+
+
+class CheckFileTests(unittest.TestCase):
+    def _write(self, text):
+        fd, path = tempfile.mkstemp(suffix=".cpp")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_green_file_passes(self):
+        ok, lines = guard.check_file(self._write(GREEN))
+        self.assertTrue(ok)
+        self.assertTrue(any("free every local ref" in ln for ln in lines))
+
+    def test_red_file_fails(self):
+        ok, lines = guard.check_file(self._write(RED))
+        self.assertFalse(ok)
+        self.assertTrue(any("never released" in ln for ln in lines))
+
+    def test_missing_expected_callback_fails(self):
+        # No jni_io_read/jni_io_write at all -- the bridge moved or the guard is
+        # pointed at the wrong file; fail loudly rather than scan nothing.
+        ok, lines = guard.check_file(self._write("static int jni_on_dive(void *u) { return 0; }"))
+        self.assertFalse(ok)
+        self.assertTrue(any("expected callback" in ln for ln in lines))
+
+    def test_real_source_is_clean(self):
+        # The shipped libdc_jni.cpp must satisfy the guard (the #318 fix).
+        if not os.path.exists(REAL_SOURCE):
+            self.skipTest("libdc_jni.cpp not present")
+        ok, lines = guard.check_file(REAL_SOURCE)
+        self.assertTrue(ok, msg="\n".join(lines))
+
+
+class MainTests(unittest.TestCase):
+    def _write(self, text):
+        fd, path = tempfile.mkstemp(suffix=".cpp")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = guard.main(argv)
+        return rc, buf.getvalue()
+
+    def test_main_passes_on_clean_file(self):
+        rc, out = self._run(["prog", self._write(GREEN)])
+        self.assertEqual(rc, 0)
+        self.assertIn("PASS", out)
+
+    def test_main_fails_on_leaky_file(self):
+        rc, out = self._run(["prog", self._write(RED)])
+        self.assertEqual(rc, 1)
+        self.assertIn("FAIL", out)
+
+    def test_main_reports_unreadable_path(self):
+        rc, out = self._run(["prog", os.path.join(_HERE, "does_not_exist.cpp")])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR", out)
+
+    def test_main_default_path_resolves_from_repo_root(self):
+        cwd = os.getcwd()
+        os.chdir(_REPO_ROOT)
+        try:
+            rc, out = self._run(["prog"])
+        finally:
+            os.chdir(cwd)
+        self.assertEqual(rc, 0)
+        self.assertIn("PASS", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third sequential root cause for #318 (Mares Puck Pro "shuts down app" on Android). After the 16 KB-alignment fix, the R8 keep-rule fix, and the #334 serial-read-accumulation fix all shipped in **v1.5.8**, the reporter's symptom regressed from a logged "Download failed (RuntimeException)" back to a **silent hard crash** ("the app asks to connect, then as soon as the connection is made the app closes," no error).

## Root cause

The per-call JNI I/O callbacks in `libdc_jni.cpp` (`jni_io_read/write/configure/set_modem_line/purge/close/ioctl`, `jni_on_progress/jni_on_dive`) create JNI **local references** (`jclass` from `GetObjectClass`; the byte array from `CallObjectMethod`/`NewByteArray`) and never call `DeleteLocalRef`.

`libdc_download_run` runs the entire download **synchronously on the already-attached Kotlin thread**, so:

- `GetEnv` returns `JNI_OK` → `attached = false` → `DetachCurrentThread` never runs, and
- the native `nativeDownloadRun` frame doesn't return to Java until the whole download finishes,

so the local refs are never reclaimed and **accumulate for the entire session**. A Mares Puck Pro (`mares_iconhd`, model `0x18`) dumps a fixed **262 KB** in 256-byte packets ≈ **5,125 I/O callbacks × ~2 refs ≈ 10,000 local refs**, overflowing ART's 512-entry local reference table → `JniAbort` → **SIGABRT** (the process dies with no Dart/Java exception — hence "the app just closes").

This is **Android-only** (desktop serial bypasses JNI) and was **un-masked, not caused, by #334**: before #334 the serial reads truncated and the download failed fast (`rc=-8`) after a few ops, never reaching the overflow.

Log evidence ([issue comment, 2026-06-29](https://github.com/submersion-app/submersion/issues/318#issuecomment-4830247929)): `[SER] Opened USB serial port` → `[SER] nativeDownloadRun (serial)` → ~3-12 s gap → `[APP] Initializing notification service` (a cold app restart), repeated 3×.

## Fix

12 surgical `env->DeleteLocalRef(...)` calls — `cls` right after the `GetMethodID` that uses it (a `jmethodID` stays valid after the `jclass` local ref is freed, so one line covers every return path), `result`/`arr` after last use, one per `ioctl` branch. Peak local refs per callback drops from unbounded to ≤3.

## Regression guard

`scripts/check_jni_local_refs.py` + `_test.py` (18 tests, 100% coverage), wired into the `script-tests` CI job. A **source-level** static check (no NDK/emulator) that fails if any `jni_io_*`/`jni_on_*` callback creates a local ref without a matching `DeleteLocalRef` (or a `PushLocalFrame` bracket). Goes red on the pre-fix source, green after. (Writing it surfaced a static-analysis trap where a comment's stray `(` hid `jni_io_ioctl` from the scanner — fixed with comment-stripping + name-anchoring.)

## Verification

- ✅ Root cause confirmed from three independent angles (callback ref audit, synchronous-execution model, Mares read-count).
- ✅ Leak eliminated — guard green, all 12 sites inspected, 100% test coverage.
- ⏳ C++ compile — not run locally (no Android NDK); CI's Android build covers it.
- ⏳ Hardware — needs the reporter's Xiaomi 15T Pro + Mares Puck Pro after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FQefjvDvaY8GfDrtYVKey
