### PR TITLE
fix(sync): fix both iOS OOM paths on large-library sync (#358)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-sync-publish-base-oom-streaming.md
+++ b/docs/superpowers/plans/2026-06-30-sync-publish-base-oom-streaming.md
@@ -1,0 +1,894 @@
+# Streaming Base Publish (write-side OOM #358) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish (and compact) a device's own sync base of any size without ever materializing the whole library in RAM, fixing the remaining iOS OOM crash in #358.
+
+**Architecture:** Mirror the already-shipped read-side streaming in reverse. A new `SyncDataSerializer.exportBaseToTempFile` streams all rows (keyset-paged by `id`) to a temp file as exactly `jsonEncode(SyncPayload.toJson())`; a new `BasePartFileSource` reads that file back in 8 MB parts (checksumming incrementally) for upload. `ChangesetWriter` uses these at its two base-writing sites instead of `exportChangeset` → `encodeChangeset` → `BaseChunker.slice`.
+
+**Tech Stack:** Dart/Flutter, Drift ORM (SQLite), `package:crypto` (SHA-256), `dart:io` `RandomAccessFile`.
+
+## Global Constraints
+
+- `dart format .` clean and `flutter analyze` clean before every commit (project pre-push hook enforces this).
+- No emojis in code/comments/docs.
+- Wire format unchanged: output is a valid `SyncPayload.toJson()` JSON object with the same keys/structure; existing readers and old bases must keep working (no forced re-publish).
+- Peak memory bounded to one keyset page of rows + one 8 MB part buffer, independent of library size.
+- Only the two **base**-writing paths change (`ChangesetWriter.publish` `!hasBase` branch and `_compact`). The incremental **changeset** path (`hasBase`) stays on `exportChangeset` + `encodeChangeset` (small deltas) — do not touch it.
+- Correctness anchor is **semantic/round-trip parity**, not byte-identity: rows stream in `id` order (reorders arrays vs. today's rowid order), which is safe because each base is verified only against its own manifest checksums.
+- `syncFormatVersion == 2`. BLOB serializer (`_syncBlobSerializer`, base64) is used for exactly `media`, `certifications`, `diveDataSources`.
+
+---
+
+### Task 1: `BasePartFileSource` (read temp file back out as checksummed parts)
+
+**Files:**
+- Create: `lib/core/services/sync/changeset_log/base_part_file_source.dart`
+- Test: `test/core/services/sync/changeset_log/base_part_file_source_test.dart`
+
+**Interfaces:**
+- Produces: `BasePartFileSource(String path, {int partSize})` with
+  `Future<BasePartUploadResult> uploadAll(Future<void> Function(int index, Uint8List bytes) upload)`
+  where `BasePartUploadResult = ({int partCount, String wholeChecksum, List<String> partChecksums, int byteLength})`. `wholeChecksum`/part checksums use the `sha256:<hex>` convention of `BaseChunker.checksum`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/services/sync/changeset_log/base_part_file_source_test.dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_source.dart';
+
+void main() {
+  test('yields parts + checksums matching BaseChunker over a multi-part file', () async {
+    final dir = await Directory.systemTemp.createTemp('src');
+    final path = '${dir.path}/base.json';
+    // 2.5 parts of the 8 MB default so we cross part boundaries with a remainder.
+    final data = Uint8List.fromList(
+      List.generate(2 * BaseChunker.defaultPartSize + 12345, (i) => i % 256),
+    );
+    await File(path).writeAsBytes(data);
+    final expected = BaseChunker.slice(data);
+
+    final uploaded = <int, Uint8List>{};
+    final res = await BasePartFileSource(path).uploadAll((i, bytes) async {
+      uploaded[i] = Uint8List.fromList(bytes);
+    });
+
+    expect(res.partCount, expected.length);
+    expect(res.byteLength, data.length);
+    expect(res.wholeChecksum, BaseChunker.checksum(data));
+    for (var i = 0; i < expected.length; i++) {
+      expect(uploaded[i], expected[i], reason: 'part $i bytes');
+      expect(res.partChecksums[i], BaseChunker.checksum(expected[i]));
+    }
+    await dir.delete(recursive: true);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_part_file_source_test.dart`
+Expected: FAIL — `base_part_file_source.dart` / `BasePartFileSource` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/services/sync/changeset_log/base_part_file_source.dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+
+typedef BasePartUploadResult = ({
+  int partCount,
+  String wholeChecksum,
+  List<String> partChecksums,
+  int byteLength,
+});
+
+/// Reads an assembled base temp file back out in fixed-size parts, checksumming
+/// each part and the whole file incrementally so the full base is never held in
+/// memory. Write-side mirror of [BasePartFileSink] (which does the reverse on
+/// download). Each part is handed to [upload] in order; the returned checksums
+/// use the same `sha256:<hex>` convention as the manifest fields.
+class BasePartFileSource {
+  BasePartFileSource(this.path, {this.partSize = BaseChunker.defaultPartSize});
+
+  final String path;
+  final int partSize;
+
+  Future<BasePartUploadResult> uploadAll(
+    Future<void> Function(int index, Uint8List bytes) upload,
+  ) async {
+    final raf = await File(path).open();
+    final digestSink = _DigestSink();
+    final whole = sha256.startChunkedConversion(digestSink);
+    final partChecksums = <String>[];
+    try {
+      final length = await raf.length();
+      var index = 0;
+      if (length == 0) {
+        // Mirror BaseChunker.slice(empty) == [Uint8List(0)].
+        final empty = Uint8List(0);
+        whole.add(empty);
+        partChecksums.add(BaseChunker.checksum(empty));
+        await upload(0, empty);
+        index = 1;
+      } else {
+        for (var off = 0; off < length; off += partSize) {
+          final n = (off + partSize < length) ? partSize : length - off;
+          final buf = await raf.read(n);
+          whole.add(buf);
+          partChecksums.add(BaseChunker.checksum(buf));
+          await upload(index, buf);
+          index++;
+        }
+      }
+      whole.close();
+      return (
+        partCount: index,
+        wholeChecksum: 'sha256:${digestSink.value}',
+        partChecksums: partChecksums,
+        byteLength: length,
+      );
+    } finally {
+      await raf.close();
+    }
+  }
+}
+
+/// Minimal `Sink<Digest>` capturing the digest emitted at close (mirrors the
+/// one in base_part_file_sink.dart; crypto does not export AccumulatorSink).
+class _DigestSink implements Sink<Digest> {
+  Digest? value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_part_file_source_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format lib/core/services/sync/changeset_log/base_part_file_source.dart test/core/services/sync/changeset_log/base_part_file_source_test.dart
+git add lib/core/services/sync/changeset_log/base_part_file_source.dart test/core/services/sync/changeset_log/base_part_file_source_test.dart
+git commit -m "feat(sync): BasePartFileSource streams a base temp file into checksummed parts (#358)"
+```
+
+---
+
+### Task 2: `SyncDataSerializer.exportBaseToTempFile` (stream DB → base JSON temp file)
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_data_serializer.dart` (add imports, `StreamedBase` typedef, `_baseTables`, `_pageBaseTableById`, `exportBaseToTempFile`, `_Sha256DigestSink`)
+- Test: `test/core/services/sync/base_publish_streaming_parity_test.dart`
+
+**Interfaces:**
+- Consumes: existing `_db`, `_groupDeletions`, `_maxHlc`, `_computeChecksum`, `_syncBlobSerializer`, `syncFormatVersion`, and the composite-table exporters `_exportDiveEquipment`, `_exportEquipmentSetItems`, `_exportSettings`.
+- Produces: `Future<StreamedBase> exportBaseToTempFile({required String deviceId, required List<DeletionLogData> deletions, String? epochId, String? uploadNonce, int? seq, int pageSize, DateTime Function() now, Future<Directory> Function()? tempDir})` where `StreamedBase = ({String path, int byteLength, int exportedAt, String? toHlc, int rowCount})`. Writes exactly `jsonEncode(SyncPayload.toJson())` for a full base (all rows, `hlcWatermark == null` semantics). Caller owns and must delete the temp file.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/core/services/sync/base_publish_streaming_parity_test.dart
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Order-independent snapshot: each table's rows sorted by their JSON so an
+/// array-order difference (id order here vs. list order in exportChangeset) is
+/// not a mismatch -- only data differences are.
+String _canonical(Map<String, dynamic> dataJson) {
+  final out = <String, dynamic>{};
+  for (final key in dataJson.keys.toList()..sort()) {
+    final list = (dataJson[key] as List).cast<Map<String, dynamic>>();
+    final sorted = [...list]..sort((a, b) => jsonEncode(a).compareTo(jsonEncode(b)));
+    out[key] = sorted;
+  }
+  return jsonEncode(out);
+}
+
+Future<void> _seedRich() async {
+  final serializer = SyncDataSerializer();
+  final dives = DiveRepository();
+  await dives.createDive(createTestDiveWithBottomTime(id: 'd1', diveNumber: 1));
+  await dives.createDive(createTestDiveWithBottomTime(id: 'd2', diveNumber: 2));
+  await serializer.upsertRecord('diveSites', {
+    'id': 'site-1', 'name': 'Test Site', 'description': '', 'notes': '',
+    'isShared': false, 'createdAt': 1000, 'updatedAt': 1000,
+  });
+  // BLOB-bearing table (diveDataSources uses the base64 serializer).
+  await serializer.upsertRecord('diveDataSources', {
+    'id': 'ds-1', 'diveId': 'd1', 'isPrimary': true, 'sourceFormat': 'shearwater',
+    'importedAt': 1700000000000, 'createdAt': 1700000000000,
+    'rawFingerprint': Uint8List.fromList([0x01, 0x02, 0x03, 0xFE, 0xFF]),
+  });
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('_baseTables lists exactly the SyncData entities in order', () {
+    // A missing/extra/misordered entity would silently drop or misplace rows.
+    expect(
+      SyncDataSerializer.debugBaseTableKeys,
+      const SyncData().toJson().keys.toList(),
+    );
+  });
+
+  test('streamed base equals exportChangeset(null) per table + valid checksum', () async {
+    await _seedRich();
+    final deletions = await SyncRepository().getAllDeletions();
+    final expected = await SyncDataSerializer().exportChangeset(
+      deviceId: 'peer', hlcWatermark: null, deletions: deletions,
+    );
+
+    final base = await SyncDataSerializer().exportBaseToTempFile(
+      deviceId: 'peer', deletions: deletions, now: () => DateTime.fromMillisecondsSinceEpoch(123),
+    );
+    final decoded = jsonDecode(await File(base.path).readAsString()) as Map<String, dynamic>;
+    await File(base.path).delete();
+
+    expect(decoded['version'], syncFormatVersion);
+    expect(decoded['exportedAt'], 123);
+    expect(base.exportedAt, 123);
+    expect(_canonical(decoded['data'] as Map<String, dynamic>),
+        _canonical(expected.data.toJson()));
+    expect(base.toHlc, expected.toHlc);
+    // Internal checksum is valid over the streamed data bytes.
+    final dataJson = jsonEncode(decoded['data']);
+    expect(decoded['checksum'], sha256.convert(utf8.encode(dataJson)).toString());
+  });
+
+  test('keyset paging across >1 page is complete', () async {
+    final dives = DiveRepository();
+    for (var i = 1; i <= 250; i++) {
+      await dives.createDive(createTestDiveWithBottomTime(id: 'd$i', diveNumber: i));
+    }
+    final expected = await SyncDataSerializer().exportChangeset(
+      deviceId: 'peer', hlcWatermark: null, deletions: const [],
+    );
+    final base = await SyncDataSerializer().exportBaseToTempFile(
+      deviceId: 'peer', deletions: const [], pageSize: 100, // forces 3 pages of dives
+    );
+    final decoded = jsonDecode(await File(base.path).readAsString()) as Map<String, dynamic>;
+    await File(base.path).delete();
+    expect((decoded['data']['dives'] as List).length, 250);
+    expect(_canonical(decoded['data'] as Map<String, dynamic>),
+        _canonical(expected.data.toJson()));
+  });
+}
+```
+
+Add `import 'package:crypto/crypto.dart';` to the test file (used for the checksum assertion).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/base_publish_streaming_parity_test.dart`
+Expected: FAIL — `exportBaseToTempFile` / `debugBaseTableKeys` not defined.
+
+- [ ] **Step 3: Add imports + `_Sha256DigestSink` at the top of `sync_data_serializer.dart`**
+
+Add to the imports (after `import 'dart:convert';`):
+
+```dart
+import 'dart:io';
+
+import 'package:uuid/uuid.dart';
+```
+
+Add a file-level uuid (near `const int syncFormatVersion = 2;`):
+
+```dart
+const _baseTempUuid = Uuid();
+```
+
+Add near the bottom of the file (outside the class):
+
+```dart
+/// Captures the single digest a chunked SHA-256 conversion emits at close.
+class _Sha256DigestSink implements Sink<Digest> {
+  Digest? value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
+}
+```
+
+- [ ] **Step 4: Add the streaming export to `SyncDataSerializer`**
+
+Add the return typedef above the class:
+
+```dart
+/// Result of streaming a base to a temp file. The caller owns [path] and must
+/// delete it. [byteLength] is the on-disk base size (== manifest `baseBytes`);
+/// [rowCount] is the total rows written (0 => an empty library).
+typedef StreamedBase = ({
+  String path,
+  int byteLength,
+  int exportedAt,
+  String? toHlc,
+  int rowCount,
+});
+```
+
+Inside `class SyncDataSerializer`, add:
+
+```dart
+/// Ordered table descriptors for a base snapshot, matching SyncData.toJson.
+/// `table != null` => keyset-page by `id`; otherwise `full` loads the whole
+/// (small, composite-key) table. `blob` selects the base64 BLOB serializer.
+List<({String key, TableInfo<Table, dynamic>? table, bool blob,
+       Future<List<Map<String, dynamic>>> Function()? full})>
+    get _baseTables => [
+  (key: 'divers', table: _db.divers, blob: false, full: null),
+  (key: 'diverSettings', table: _db.diverSettings, blob: false, full: null),
+  (key: 'dives', table: _db.dives, blob: false, full: null),
+  (key: 'diveProfiles', table: _db.diveProfiles, blob: false, full: null),
+  (key: 'diveTanks', table: _db.diveTanks, blob: false, full: null),
+  (key: 'diveEquipment', table: null, blob: false, full: () => _exportDiveEquipment(null)),
+  (key: 'diveWeights', table: _db.diveWeights, blob: false, full: null),
+  (key: 'diveSites', table: _db.diveSites, blob: false, full: null),
+  (key: 'equipment', table: _db.equipment, blob: false, full: null),
+  (key: 'equipmentSets', table: _db.equipmentSets, blob: false, full: null),
+  (key: 'equipmentSetItems', table: null, blob: false, full: () => _exportEquipmentSetItems(null)),
+  (key: 'media', table: _db.media, blob: true, full: null),
+  (key: 'buddies', table: _db.buddies, blob: false, full: null),
+  (key: 'diveBuddies', table: _db.diveBuddies, blob: false, full: null),
+  (key: 'certifications', table: _db.certifications, blob: true, full: null),
+  (key: 'courses', table: _db.courses, blob: false, full: null),
+  (key: 'serviceRecords', table: _db.serviceRecords, blob: false, full: null),
+  (key: 'diveCenters', table: _db.diveCenters, blob: false, full: null),
+  (key: 'trips', table: _db.trips, blob: false, full: null),
+  (key: 'liveaboardDetails', table: _db.liveaboardDetails, blob: false, full: null),
+  (key: 'itineraryDays', table: _db.itineraryDays, blob: false, full: null),
+  (key: 'tags', table: _db.tags, blob: false, full: null),
+  (key: 'diveTags', table: _db.diveTags, blob: false, full: null),
+  (key: 'diveDiveTypes', table: _db.diveDiveTypes, blob: false, full: null),
+  (key: 'diveTypes', table: _db.diveTypes, blob: false, full: null),
+  (key: 'tankPresets', table: _db.tankPresets, blob: false, full: null),
+  (key: 'diveComputers', table: _db.diveComputers, blob: false, full: null),
+  (key: 'tankPressureProfiles', table: _db.tankPressureProfiles, blob: false, full: null),
+  (key: 'tideRecords', table: _db.tideRecords, blob: false, full: null),
+  (key: 'settings', table: null, blob: false, full: () => _exportSettings(null)),
+  (key: 'species', table: _db.species, blob: false, full: null),
+  (key: 'sightings', table: _db.sightings, blob: false, full: null),
+  (key: 'diveProfileEvents', table: _db.diveProfileEvents, blob: false, full: null),
+  (key: 'gasSwitches', table: _db.gasSwitches, blob: false, full: null),
+  (key: 'diveCustomFields', table: _db.diveCustomFields, blob: false, full: null),
+  (key: 'diveDataSources', table: _db.diveDataSources, blob: true, full: null),
+  (key: 'siteSpecies', table: _db.siteSpecies, blob: false, full: null),
+  (key: 'csvPresets', table: _db.csvPresets, blob: false, full: null),
+  (key: 'viewConfigs', table: _db.viewConfigs, blob: false, full: null),
+  (key: 'fieldPresets', table: _db.fieldPresets, blob: false, full: null),
+];
+
+/// Test seam: the base table order, asserted equal to SyncData.toJson keys.
+@visibleForTesting
+static List<String> get debugBaseTableKeys =>
+    SyncDataSerializer()._baseTables.map((t) => t.key).toList();
+
+/// One keyset page (`id > cursor`, ascending, up to [limit]) of an id-PK table,
+/// as JSON rows identical to the table's own `toJson` (blob serializer applied
+/// for BLOB tables). O(n) total across pages; never loads the whole table.
+Future<List<Map<String, dynamic>>> _pageBaseTableById(
+  TableInfo<Table, dynamic> table, {
+  required String? cursor,
+  required int limit,
+  required bool blob,
+}) async {
+  final name = table.actualTableName;
+  final rows = cursor == null
+      ? await _db.customSelect(
+          'SELECT * FROM "$name" ORDER BY id LIMIT ?',
+          variables: [Variable.withInt(limit)],
+        ).get()
+      : await _db.customSelect(
+          'SELECT * FROM "$name" WHERE id > ? ORDER BY id LIMIT ?',
+          variables: [Variable.withString(cursor), Variable.withInt(limit)],
+        ).get();
+  return rows.map((r) {
+    final data = table.map(r.data) as dynamic;
+    return (blob
+        ? data.toJson(serializer: _syncBlobSerializer)
+        : data.toJson()) as Map<String, dynamic>;
+  }).toList();
+}
+
+/// Streams a full base snapshot to a temp file as exactly
+/// `jsonEncode(SyncPayload.toJson())`, in bounded memory (one keyset page + one
+/// write). Replaces `exportChangeset(null)` + `encodeChangeset` on the
+/// publish/compact path, whose full-graph materialization OOM-crashed iOS on
+/// large libraries (#358, write side). Rows stream in `id` order.
+Future<StreamedBase> exportBaseToTempFile({
+  required String deviceId,
+  required List<DeletionLogData> deletions,
+  String? epochId,
+  String? uploadNonce,
+  int? seq,
+  int pageSize = 2000,
+  DateTime Function() now = DateTime.now,
+  Future<Directory> Function()? tempDir,
+}) async {
+  final dir = await (tempDir?.call() ?? Future.value(Directory.systemTemp));
+  final path = '${dir.path}/ssv1_base_${deviceId}_${seq ?? 0}.${_baseTempUuid.v4()}.json';
+  final raf = await File(path).open(mode: FileMode.write);
+  final digestSink = _Sha256DigestSink();
+  final dataHash = sha256.startChunkedConversion(digestSink);
+  final exportedAt = now().millisecondsSinceEpoch;
+  String? maxRowHlc;
+  var rowCount = 0;
+
+  // Writes + hashes only the `data` object bytes (matches _computeChecksum,
+  // which hashes jsonEncode(data.toJson())).
+  Future<void> writeData(String s) async {
+    final bytes = utf8.encode(s);
+    dataHash.add(bytes);
+    await raf.writeFrom(bytes);
+  }
+
+  try {
+    // Header up to (but not including) the checksum value.
+    await raf.writeString(
+      '{"version":$syncFormatVersion,"exportedAt":$exportedAt,'
+      '"deviceId":${jsonEncode(deviceId)},"lastSyncTimestamp":null,"checksum":"',
+    );
+    final checksumOffset = await raf.position();
+    await raf.writeFrom(List.filled(64, 0x30)); // 64 '0' placeholder, patched below
+    await raf.writeString('","data":');
+
+    // ---- data object (hashed) ----
+    await writeData('{');
+    for (var t = 0; t < _baseTables.length; t++) {
+      final spec = _baseTables[t];
+      if (t > 0) await writeData(',');
+      await writeData('${jsonEncode(spec.key)}:[');
+      var firstRow = true;
+
+      Future<void> emit(Map<String, dynamic> row) async {
+        if (!firstRow) await writeData(',');
+        firstRow = false;
+        rowCount++;
+        final hlc = row['hlc'];
+        if (hlc is String && (maxRowHlc == null || hlc.compareTo(maxRowHlc!) > 0)) {
+          maxRowHlc = hlc;
+        }
+        await writeData(jsonEncode(row));
+      }
+
+      if (spec.table != null) {
+        String? cursor;
+        while (true) {
+          final rows = await _pageBaseTableById(
+            spec.table!, cursor: cursor, limit: pageSize, blob: spec.blob,
+          );
+          for (final row in rows) {
+            await emit(row);
+          }
+          if (rows.length < pageSize) break;
+          cursor = rows.last['id'] as String;
+        }
+      } else {
+        for (final row in await spec.full!()) {
+          await emit(row);
+        }
+      }
+      await writeData(']');
+    }
+    await writeData('}');
+
+    // ---- trailer (not part of the data checksum) ----
+    final toHlc = _maxHlc([maxRowHlc, ...deletions.map((d) => d.hlc)]);
+    final tail = <String, dynamic>{
+      'deletions': _groupDeletions(deletions)
+          .map((k, v) => MapEntry(k, v.map((d) => d.toJson()).toList())),
+      'uploadNonce': uploadNonce,
+      'epochId': epochId,
+      'seq': seq,
+      'baseSeq': null,
+      'sinceHlc': null,
+      'toHlc': toHlc,
+    };
+    final tailBuf = StringBuffer();
+    tail.forEach((k, v) => tailBuf.write(',${jsonEncode(k)}:${jsonEncode(v)}'));
+    tailBuf.write('}');
+    await raf.writeString(tailBuf.toString());
+
+    // ---- patch the checksum placeholder with the real data digest ----
+    dataHash.close();
+    final endPos = await raf.position();
+    await raf.setPosition(checksumOffset);
+    await raf.writeFrom(utf8.encode(digestSink.value.toString()));
+    await raf.setPosition(endPos);
+    await raf.flush();
+    await raf.close();
+
+    final byteLength = await File(path).length();
+    return (
+      path: path,
+      byteLength: byteLength,
+      exportedAt: exportedAt,
+      toHlc: toHlc,
+      rowCount: rowCount,
+    );
+  } catch (e) {
+    await raf.close();
+    try {
+      await File(path).delete();
+    } catch (_) {}
+    rethrow;
+  }
+}
+```
+
+Note: `@visibleForTesting` requires `import 'package:meta/meta.dart';` — add it if not already imported (drift re-exports it, so it is usually already available via `package:drift/drift.dart`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/base_publish_streaming_parity_test.dart`
+Expected: PASS (all three tests). If `table.actualTableName` does not resolve, use `table.entityName`; if `table.map(r.data)` typing complains, the row map is `r.data` (a `Map<String, dynamic>`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format lib/core/services/sync/sync_data_serializer.dart test/core/services/sync/base_publish_streaming_parity_test.dart
+flutter analyze lib/core/services/sync/sync_data_serializer.dart
+git add lib/core/services/sync/sync_data_serializer.dart test/core/services/sync/base_publish_streaming_parity_test.dart
+git commit -m "feat(sync): stream a base snapshot to a temp file in bounded memory (#358)"
+```
+
+---
+
+### Task 3: Wire `ChangesetWriter.publish` `!hasBase` branch to the streaming path
+
+**Files:**
+- Modify: `lib/core/services/sync/changeset_log/changeset_writer.dart` (imports, restructure `publish`)
+- Test: `test/core/services/sync/changeset_log/changeset_writer_test.dart` (add a round-trip test; the existing "first publish" test is a regression guard)
+
+**Interfaces:**
+- Consumes: `SyncDataSerializer.exportBaseToTempFile` (Task 2), `BasePartFileSource` (Task 1).
+- Produces: unchanged `publish(...) -> Future<ChangesetWriteResult>`; the `ChangesetWriteKind.base` result and manifest fields are identical in meaning to today.
+
+- [ ] **Step 1: Write the failing test** (append inside `main()` of `changeset_writer_test.dart`)
+
+```dart
+  test('first base publish streams parts that reassemble to the library', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd2', diveNumber: 2),
+    );
+    final result = await publish();
+    expect(result.kind, ChangesetWriteKind.base);
+
+    final deviceId = await SyncRepository().getDeviceId();
+    final manifest = SyncManifest.fromBytes(
+      await provider.downloadFile(
+        '$folder/${ChangesetLogLayout.manifestName(deviceId)}',
+      ),
+    );
+
+    // Reassemble the uploaded parts and verify checksum + parsed content.
+    final parts = <int, List<int>>{};
+    for (final f in await provider.listFiles(
+        folderId: folder, namePattern: ChangesetLogLayout.prefix)) {
+      final bp = ChangesetLogLayout.basePartOf(f.name);
+      if (bp != null && bp.baseSeq == manifest.baseSeq) {
+        parts[bp.partIndex] = await provider.downloadFile(f.id);
+      }
+    }
+    final ordered = (parts.keys.toList()..sort()).expand((i) => parts[i]!).toList();
+    expect(ordered.length, manifest.baseBytes);
+    expect('sha256:${sha256.convert(ordered)}', manifest.baseChecksum);
+
+    final payload = jsonDecode(utf8.decode(ordered)) as Map<String, dynamic>;
+    final diveIds = ((payload['data'] as Map)['dives'] as List)
+        .map((d) => (d as Map)['id'])
+        .toSet();
+    expect(diveIds, {'d1', 'd2'});
+  });
+```
+
+Add imports at the top of `changeset_writer_test.dart` if missing: `import 'dart:convert';`, `import 'package:crypto/crypto.dart';`, and ensure `basePartOf(...)` exposes `partIndex`/`baseSeq` (it already returns a record used in `changeset_writer.dart`).
+
+- [ ] **Step 2: Run the new test as a refactor-guard baseline**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_writer_test.dart -n "reassemble"`
+Expected: PASS on the current (in-memory) base path. This is a characterization/guard test for a refactor: it pins the observable publish behavior (parts reassemble to the library, checksum matches the manifest) so the streaming rewrite in Step 3 must keep it green. Memory bounding itself is validated by the parity/paging tests in Task 2 and the device run in Task 5, not here.
+
+- [ ] **Step 3: Restructure `publish` to stream the base**
+
+Add imports to `changeset_writer.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_source.dart';
+```
+
+First fix the pre-branch setup: keep `final newSeq = knownHeadSeq + 1;` and `final now = DateTime.now().millisecondsSinceEpoch;` **before** the `if (!hasBase)` (both branches use them), and **delete** the pre-branch `final payload = await _serializer.exportChangeset(...)` (lines ~64-71) and `if (_isEmpty(payload)) return ...noop;` (lines ~73-75) — they move into the changeset branch. Then replace the `if (!hasBase) { ... }` base branch with:
+
+```dart
+    if (!hasBase) {
+      // Stream the base to a temp file and slice-upload it, so a large library
+      // is never materialized in RAM (#358 write side). Do NOT call
+      // exportChangeset(null) here -- that is the OOM path.
+      final base = await _serializer.exportBaseToTempFile(
+        deviceId: deviceId,
+        deletions: deletions,
+        epochId: epochId,
+        uploadNonce: uploadNonce,
+        seq: newSeq,
+      );
+      try {
+        if (base.rowCount == 0 && deletions.isEmpty) {
+          return const ChangesetWriteResult(ChangesetWriteKind.noop);
+        }
+        final upload = await BasePartFileSource(base.path).uploadAll(
+          (i, bytes) => provider.uploadFile(
+            bytes,
+            ChangesetLogLayout.basePartName(deviceId, newSeq, i),
+            folderId: folderId,
+          ),
+        );
+        final manifest = SyncManifest(
+          deviceId: deviceId,
+          provider: providerId,
+          baseSeq: newSeq,
+          basePartCount: upload.partCount,
+          baseBytes: base.byteLength,
+          baseChecksum: upload.wholeChecksum,
+          basePartChecksums: upload.partChecksums,
+          headSeq: newSeq,
+          publishedHlcHigh: base.toHlc,
+          epochId: epochId,
+          uploadNonce: uploadNonce,
+          updatedAt: now,
+        );
+        await _writeManifest(provider, folderId, deviceId, manifest);
+        await _publishState.upsert(
+          LocalPublishStatesCompanion(
+            provider: Value(providerId),
+            baseSeq: Value(newSeq),
+            basePartCount: Value(upload.partCount),
+            baseBytes: Value(base.byteLength),
+            headSeq: Value(newSeq),
+            publishedHlcHigh: Value(base.toHlc),
+            changesetBytesSinceBase: const Value(0),
+            updatedAt: Value(now),
+          ),
+        );
+        return ChangesetWriteResult(ChangesetWriteKind.base, newSeq);
+      } finally {
+        try {
+          await File(base.path).delete();
+        } catch (_) {}
+      }
+    }
+```
+
+Then, at the start of the changeset branch (the existing `// Changeset:` comment, just before `final bytes = _codec.encodeChangeset(payload);`), insert the payload computation that used to run before the branch:
+
+```dart
+    // Changeset: reuse the base fields from the (authoritative) own manifest;
+    // only headSeq / publishedHlcHigh advance. The incremental delta stays in
+    // memory (small); only the base path above is streamed (#358).
+    final payload = await _serializer.exportChangeset(
+      deviceId: deviceId,
+      hlcWatermark: watermark,
+      deletions: deletions,
+      seq: newSeq,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+    );
+    if (_isEmpty(payload)) {
+      return const ChangesetWriteResult(ChangesetWriteKind.noop);
+    }
+    final bytes = _codec.encodeChangeset(payload);
+```
+
+Everything after `final bytes = _codec.encodeChangeset(payload);` (the changeset upload, manifest, publish-state upsert, and compaction trip check) is unchanged. Note `watermark` (not `hasBase ? watermark : null`) is correct here because this branch only runs when `hasBase` is true.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_writer_test.dart`
+Expected: PASS (existing "first publish with data writes a base + manifest", the new reassemble test, and the noop/changeset tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format lib/core/services/sync/changeset_log/changeset_writer.dart test/core/services/sync/changeset_log/changeset_writer_test.dart
+flutter analyze lib/core/services/sync/changeset_log/changeset_writer.dart
+git add lib/core/services/sync/changeset_log/changeset_writer.dart test/core/services/sync/changeset_log/changeset_writer_test.dart
+git commit -m "fix(sync): stream base publish to fix iOS OOM on large libraries (#358)"
+```
+
+---
+
+### Task 4: Wire `ChangesetWriter._compact` to the streaming path
+
+**Files:**
+- Modify: `lib/core/services/sync/changeset_log/changeset_writer.dart` (`_compact`)
+- Test: `test/core/services/sync/changeset_log/changeset_writer_compaction_test.dart` (existing tests are the regression guard)
+
+**Interfaces:**
+- Consumes: `exportBaseToTempFile`, `BasePartFileSource`.
+- Produces: unchanged `_compact(...) -> Future<int>` (the new base seq), same manifest/publish-state effects and pruning.
+
+- [ ] **Step 1: Run the existing compaction tests to confirm the baseline**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_writer_compaction_test.dart`
+Expected: PASS (before the change). These assert a compaction rewrites a fresh base + prunes; they will re-run after the change as the guard.
+
+- [ ] **Step 2: Replace the base build in `_compact`**
+
+In `_compact`, replace:
+
+```dart
+    final full = await _serializer.exportChangeset(
+      deviceId: deviceId,
+      hlcWatermark: null,
+      deletions: deletions,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+    );
+    final fullBytes = _codec.encodeChangeset(full);
+    // Slice the same bytes we checksum (serialize once) -- see publish().
+    final parts = BaseChunker.slice(fullBytes);
+    final compSeq = afterSeq + 1;
+    for (var i = 0; i < parts.length; i++) {
+      await provider.uploadFile(
+        parts[i],
+        ChangesetLogLayout.basePartName(deviceId, compSeq, i),
+        folderId: folderId,
+      );
+    }
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final manifest = SyncManifest(
+      deviceId: deviceId,
+      provider: providerId,
+      baseSeq: compSeq,
+      basePartCount: parts.length,
+      baseBytes: fullBytes.length,
+      baseChecksum: BaseChunker.checksum(fullBytes),
+      basePartChecksums: parts.map(BaseChunker.checksum).toList(),
+      headSeq: compSeq,
+      publishedHlcHigh: full.toHlc,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+      updatedAt: now,
+    );
+```
+
+with:
+
+```dart
+    final compSeq = afterSeq + 1;
+    final base = await _serializer.exportBaseToTempFile(
+      deviceId: deviceId,
+      deletions: deletions,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+      seq: compSeq,
+    );
+    final BasePartUploadResult upload;
+    try {
+      upload = await BasePartFileSource(base.path).uploadAll(
+        (i, bytes) => provider.uploadFile(
+          bytes,
+          ChangesetLogLayout.basePartName(deviceId, compSeq, i),
+          folderId: folderId,
+        ),
+      );
+    } finally {
+      try {
+        await File(base.path).delete();
+      } catch (_) {}
+    }
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final manifest = SyncManifest(
+      deviceId: deviceId,
+      provider: providerId,
+      baseSeq: compSeq,
+      basePartCount: upload.partCount,
+      baseBytes: base.byteLength,
+      baseChecksum: upload.wholeChecksum,
+      basePartChecksums: upload.partChecksums,
+      headSeq: compSeq,
+      publishedHlcHigh: base.toHlc,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+      updatedAt: now,
+    );
+```
+
+Then update the `_publishState.upsert` in `_compact` to use `upload.partCount` / `base.byteLength` / `base.toHlc` in place of `parts.length` / `fullBytes.length` / `full.toHlc`. If `BaseChunker` is now unused in `changeset_writer.dart`, remove its import.
+
+- [ ] **Step 3: Run the compaction tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_writer_compaction_test.dart`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+dart format lib/core/services/sync/changeset_log/changeset_writer.dart
+flutter analyze lib/core/services/sync/changeset_log/changeset_writer.dart
+git add lib/core/services/sync/changeset_log/changeset_writer.dart
+git commit -m "fix(sync): stream base compaction to bound memory (#358)"
+```
+
+---
+
+### Task 5: Full verification (suite + format/analyze + device)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Whole-project format + analyze**
+
+Run: `dart format . && flutter analyze`
+Expected: "0 issues found" and no formatting changes. (Format the whole project, not a subdir — the Analyze & Format CI check covers everything.)
+
+- [ ] **Step 2: Run the full sync suite**
+
+Run: `flutter test test/core/services/sync/`
+Expected: all green (new parity/round-trip tests + all pre-existing sync tests, including the read-side `sync_base_streaming_parity_test.dart` and adopt parity).
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `flutter test`
+Expected: all green.
+
+- [ ] **Step 4: Device verification on the iOS simulator**
+
+The macOS dev instance already published the reporter's ~648 MB library (`base_bytes=648190516`, 78 parts) to S3. On the booted simulator (`B3558678-E6A7-4366-B806-FB1035E5511C`):
+
+```bash
+flutter run -d B3558678-E6A7-4366-B806-FB1035E5511C
+```
+
+Configure S3 sync (same bucket) and trigger a sync. Expected: the pull completes (streamed), then **publish completes without the crash/hang** (progress reaches "Sync complete"). Confirm the device's own manifest was written and its `base_part_count`/`base_bytes` match the macOS publisher (a full base was published in bounded memory). Watch memory in Xcode/Instruments or `flutter run` DevTools: peak stays bounded (no multi-GB spike during "Publishing changes...").
+
+- [ ] **Step 5: Update memory + open PR** (after device verification)
+
+Record the outcome (write-side #358 fixed, device-verified) and open a PR referencing #358, noting this completes the write half of the three OOM paths (read pull #365, read adopt #398, write publish this PR).
+
+## Self-Review notes
+
+- **Spec coverage:** `BasePartFileSource` (Task 1) ↔ read-side mirror; `exportBaseToTempFile` + keyset paging + seek-back checksum + composite-table handling (Task 2) ↔ mechanics section; both `ChangesetWriter` base sites (Tasks 3–4) ↔ "affected files"; semantic parity + round-trip + paging + device (Tasks 2–5) ↔ testing section. The `_baseTables` structural test enforces the 40-table order automatically.
+- **Type consistency:** `StreamedBase`/`BasePartUploadResult` record fields are used identically across tasks (`byteLength`, `wholeChecksum`, `partChecksums`, `partCount`, `toHlc`, `rowCount`).
+- **Known API risks to verify during Task 2 (analyzer/tests will catch):** `TableInfo.actualTableName` (fallback `entityName`) and `table.map(r.data)` dynamic `toJson`. These are the only non-obvious Drift touchpoints.

--- a/docs/superpowers/specs/2026-06-30-sync-publish-base-oom-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-30-sync-publish-base-oom-streaming-design.md
@@ -1,0 +1,190 @@
+# Streaming base *publish* — write-side OOM fix (#358)
+
+Date: 2026-06-30
+Branch: `worktree-issue-358-publish-base-oom-streaming`
+Status: Design approved (scope: memory-safe publish only)
+
+## Problem
+
+Enabling cloud sync on iOS still crashes the app on a large library, even after
+the two read-side streaming fixes shipped (PR #365 pull-base, PR #398
+Replace-adopt, both in v1.5.8). The reporter's iPhone gets *past* the download
+now, then dies during the **upload/publish** phase.
+
+### Root cause
+
+`ChangesetWriter.publish()` publishes this device's own per-device base whenever
+it has never published to the current backend (`hasBase == false`). That is
+exactly the state of a **fresh device that just cold-pulled a large library**:
+after the streamed pull, its local DB holds the whole library, and on the next
+`performSync` it takes the `!hasBase` branch and re-materializes the entire
+library in RAM to publish its base:
+
+1. `_serializer.exportChangeset(hlcWatermark: null)` → `_buildSyncData(null)`
+   builds the full 39-table object graph in memory, then `jsonEncode` produces
+   the full `dataJson` string.
+2. `_codec.encodeChangeset(payload)` re-encodes the whole thing to one
+   `Uint8List fullBytes`.
+3. `BaseChunker.slice(fullBytes)` copies it again into 8 MB parts.
+4. `parts.map(BaseChunker.checksum)` hashes each.
+
+All held simultaneously → object graph + full JSON string + `fullBytes` + parts
+≈ 3–4× the base size. `_compact()` has the identical shape.
+
+This write side was **explicitly deferred** in the 2026-06-20 read-side design
+("Write side | Out of scope (tracked follow-up) | Publisher also holds the whole
+serialized DB, but has desktop headroom and is not the reported crash"). The
+missed case: the publisher is not always a roomy desktop — a phone that ingests
+a big library becomes a publisher too.
+
+### Evidence
+
+The macOS publisher's `local_publish_states` row for the reporter's library:
+
+```
+provider=s3  base_seq=1  base_part_count=78  base_bytes=648190516  head_seq=1
+```
+
+`base_bytes = 648,190,516` is literal proof `exportChangeset(null)` yields one
+~648 MB base (78 × 8 MB parts). Library is ~1.86 M time-series rows
+(1,077,216 `dive_profiles` + 784,752 `tank_pressure_profiles`) across 1,032
+dives. A 648 MB base materialized 3–4× exceeds iOS's per-process jetsam limit;
+the macOS publisher survived only on desktop RAM headroom.
+
+## Goal / non-goals
+
+- **Goal:** publish (and compact) a base of any size with peak memory bounded to
+  one page of rows + one 8 MB part buffer, independent of library size.
+- **Non-goal (this PR):** avoiding the redundant self-base upload (a freshly
+  cold-pulled device still uploads its own full base — just without crashing).
+- **Non-goal:** binary/`VACUUM INTO` base format; apply-path CPU work already in
+  flight on the `s2`/`s3` worktrees.
+
+## Approach — mirror the read side, in reverse
+
+The read side streams cloud → file → DB via two components. This adds their
+write-side mirrors so the pipeline is symmetric:
+
+| Read side (exists) | Write side (new) | Boundary |
+| --- | --- | --- |
+| `BasePartFileSink` — download parts → temp file, verify per-part + whole checksums | **`BasePartFileSource`** — read temp file in 8 MB slices → yield each part + its `sha256:` checksum + the whole-file checksum, for upload | transport ↔ file |
+| `BaseJsonStreamReader` — stream file → rows | **`SyncDataSerializer.exportBaseToTempFile(...)`** — stream DB rows → payload-JSON temp file | file ↔ DB |
+
+`ChangesetWriter` stops calling `exportChangeset` → `encodeChangeset` →
+`BaseChunker.slice` at its two base sites and instead calls
+`exportBaseToTempFile` then streams parts from `BasePartFileSource`.
+
+### Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Wire format | Unchanged JSON | Hard constraint carried from the read-side fix: old bases must import without a forced re-publish, and existing readers must not change. Same `SyncPayload.toJson` structure, keys, and per-row encoding. |
+| Correctness anchor | **Semantic / round-trip parity** (not byte-identity) | Rows are streamed in `id` order (keyset), which reorders each table's array vs. today's rowid-order `.get()`. That is safe: each base is verified only against **its own** manifest checksums — no reader compares one device's base bytes to another's — so reordering rows within a base has zero fleet impact, and `baseBytes` is even numerically identical (same rows, same separators). Parity is proven by (a) parse-and-compare per table as id-keyed sets, and (b) publish→pull→compare-DBs round trip. |
+| DB passes | **One** | The payload's internal `checksum` field precedes `data` but is a fixed-width 64-char hex digest, so its byte span is reserved as a placeholder, `data` is streamed+hashed once, then the placeholder is patched via `RandomAccessFile.setPosition`. The base read path does not verify this field (`validateChecksum` covers changesets only), but keeping it valid over the actual `data` bytes is cheap and well-formed for any consumer. |
+| Row streaming | **Keyset pagination by `id`** for the 36 `id`-PK tables (page ~1–2k rows); full-load via existing `_exportX(null)` for the 3 composite/keyed tables | Keyset is O(n) (offset would be O(n²) on million-row tables). A base exports *all* rows (`hlcSince == null`), so no per-table HLC-filter logic is needed. The 3 non-`id` tables (`diveEquipment` `{diveId,equipmentId}`, `equipmentSetItems` `{setId,equipmentId}`, `settings` `{key}`) are junction/settings tables that are inherently small, so full-loading them keeps peak memory bounded. |
+| BLOB tables | `media`, `certifications`, `diveDataSources` use `_syncBlobSerializer` (base64) as today; all three have `id` PKs so they are keyset-paged (BLOBs can be large) | These are the only `_exportX` methods that pass the blob serializer; the streaming path must pass it for exactly these three so per-row bytes are unchanged. |
+| Snapshot consistency | Match existing semantics (no long-held read txn) | Today's `_buildSyncData` runs each table's `.get()` as an independent query, so cross-table consistency is already best-effort; keyset paging preserves the same characteristics without holding a multi-minute WAL read open on a phone. |
+| Temp file | `Directory.systemTemp`, unique per `deviceId+seq`, deleted in `finally` | Same policy as the read-side sink: not backed up, survives a killed prior run via overwrite. |
+| Internal `checksum` field | Kept valid (byte-identical) though the base read path does not verify it | Base reads verify integrity via the manifest `BaseChunker` checksums, not `SyncPayload.checksum` (`validateChecksum` at `changeset_reader.dart:117` covers changesets only). Keeping it valid is belt-and-suspenders for any legacy monolithic reader. |
+
+## `exportBaseToTempFile` mechanics
+
+Produces exactly `jsonEncode(SyncPayload.toJson())` for the base payload, in one
+bounded pass:
+
+1. Open a `RandomAccessFile` at a unique temp path.
+2. Write the header prefix in `SyncPayload.toJson` key order:
+   `{"version":1,"exportedAt":<ts>,"deviceId":"<id>","lastSyncTimestamp":<n|null>,`
+   then `"checksum":"<64 placeholder chars>"` (record the byte offset).
+3. Write `,"data":{`. For each of the 39 tables **in `SyncData.toJson` order**:
+   emit `"<jsonKey>":[`, then stream the table's rows, emitting comma-joined
+   `jsonEncode(row)`; emit `]`. Row sourcing:
+   - 36 `id`-PK tables: keyset page by `id` —
+     `SELECT * FROM "<actualTableName>" WHERE id > ? ORDER BY id LIMIT ?`
+     via `customSelect`, mapping each `QueryRow` back through the table's own
+     `map(row.data).toJson(serializer: …)` (blob serializer for `media`,
+     `certifications`, `diveDataSources`; plain otherwise). Cursor = last row's
+     `id`; stop when a page returns < the limit.
+   - 3 composite/keyed tables (`diveEquipment`, `equipmentSetItems`,
+     `settings`): reuse the existing `_exportX(null)` once (small tables).
+   A running SHA-256 hashes the `data` object's bytes as written; a running max
+   tracks `toHlc` from any row's `hlc` string.
+4. Write `},"deletions":<jsonEncode(groupedDeletions)>,"uploadNonce":<…>,`
+   `"epochId":<…>,"seq":<…>,"baseSeq":null,"sinceHlc":null,"toHlc":<…>}`.
+5. `setPosition(checksumOffset)` and overwrite the placeholder with the real
+   64-char digest of the `data` bytes. Close.
+
+Returns the temp path plus the metadata `ChangesetWriter` needs for the manifest
+(`exportedAt`, `toHlc`, `byteLength`). `exportedAt` stays in the leading bytes so
+the adopt path's 64 KB-prefix `_readBaseExportedAt` still finds it.
+
+Peak memory: one page of rows + JSON for that page. Independent of library size.
+
+## `BasePartFileSource` + `ChangesetWriter` wiring
+
+`BasePartFileSource` opens the temp file and yields successive 8 MB slices; for
+each it computes the `sha256:` part checksum, and it maintains the whole-file
+`sha256:` checksum across all slices — the same values `BaseChunker.checksum`
+would produce for the equivalent in-memory parts. `ChangesetWriter.publish()`
+(`!hasBase` branch) and `_compact()`:
+
+1. `path, meta = await _serializer.exportBaseToTempFile(...)` (in `finally`,
+   delete the temp file).
+2. For each part from `BasePartFileSource(path)`: `provider.uploadFile(partBytes,
+   basePartName(deviceId, seq, i))`, collecting per-part checksums.
+3. Build `SyncManifest` with `basePartCount`, `baseBytes = meta.byteLength`,
+   `baseChecksum = source.wholeChecksum`, `basePartChecksums`,
+   `publishedHlcHigh = meta.toHlc` — identical fields to today.
+4. Upsert `local_publish_states` and (compact only) prune superseded files.
+
+The empty-payload `noop` short-circuit is preserved: if the export would be
+empty, publish nothing (checked before writing the temp file).
+
+## Testing
+
+Mirrors the parity-test culture of the two read-side fixes.
+
+- **Semantic parity unit test:** parse `exportBaseToTempFile`'s output and the
+  old `exportChangeset(deviceId, hlcWatermark: null, …)` payload, and assert
+  equality **per table as id-keyed sets** (order-independent) plus equal header
+  fields (with `exportedAt` fixed via an injected `now`), for a library
+  exercising: parent/child/junction rows, all three BLOB tables, empty tables,
+  and **more than one page** (> the page size, e.g. 2.5k rows in a time-series
+  table) to cross a keyset boundary. Also assert the internal `checksum` equals
+  `_computeChecksum` over the streamed `data` bytes.
+- **Checksum/manifest self-consistency:** `BasePartFileSource` over the temp
+  file yields a whole-file `sha256:` checksum equal to `BaseChunker.checksum` of
+  the reassembled parts, per-part checksums matching each 8 MB slice, and
+  `baseBytes` == the temp file length — the exact fields the manifest carries.
+- **Round-trip test:** publish a library through the streaming path into a fake
+  provider, then read it back through the existing `pull` / `_applyRemoteBaseFile`
+  into a second DB and assert the two DBs are identical.
+- **Bounded-memory / structural proof:** assert the streaming path never calls
+  `_buildSyncData` (no full-graph build) and that a large synthetic library
+  pages (multiple keyset windows) rather than one `.get()`.
+- **Compaction:** a base rewritten by `_compact()` via the streaming path equals
+  the in-memory-equivalent base.
+- **Device verification:** on the booted simulator (B3558678-…) against the S3
+  library — pull completes, then publish completes without crash/hang; the
+  published `base_bytes` / `base_part_count` match the macOS publisher's.
+
+## Out of scope / follow-ups
+
+- **Skip redundant self-base publish:** a device that just cold-pulled with no
+  local-only changes still uploads its own full (now memory-safe) base. Avoiding
+  that upload is a separate sync-semantics change (deferred by scope choice).
+- **Binary base format** (`VACUUM INTO`): smaller and fixes read+write, but
+  breaks the "old JSON bases stay importable" constraint. Rejected here.
+- **Apply-path CPU/throughput** (batched merge writes, isolate parse): already
+  in flight on the `s2`/`s3` worktrees; untouched by this PR.
+
+## Affected files
+
+- New: `lib/core/services/sync/changeset_log/base_part_file_source.dart`
+- New: streaming export on `SyncDataSerializer` (method + keyset row source;
+  possibly a small `base_source_file_writer.dart` helper to keep the serializer
+  focused).
+- Edit: `lib/core/services/sync/changeset_log/changeset_writer.dart` (both base
+  sites).
+- Tests: parity + round-trip + compaction, alongside the existing
+  `sync_*_parity_test.dart` suite.

--- a/lib/core/services/sync/changeset_log/base_part_file_source.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_source.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+
+typedef BasePartUploadResult = ({
+  int partCount,
+  String wholeChecksum,
+  List<String> partChecksums,
+  int byteLength,
+});
+
+/// Reads an assembled base temp file back out in fixed-size parts, checksumming
+/// each part and the whole file incrementally so the full base is never held in
+/// memory. Write-side mirror of [BasePartFileSink] (which does the reverse on
+/// download). Each part is handed to [uploadAll]'s callback in order; the
+/// returned checksums use the same `sha256:<hex>` convention as the manifest
+/// fields, so a reader's verification against the manifest can only fail on real
+/// transport corruption.
+class BasePartFileSource {
+  BasePartFileSource(this.path, {this.partSize = BaseChunker.defaultPartSize});
+
+  final String path;
+  final int partSize;
+
+  /// Streams the file in [partSize] slices, invoking [upload] for each in order,
+  /// and returns the part count plus the `sha256:` whole-file and per-part
+  /// checksums (and the total byte length) for the manifest.
+  Future<BasePartUploadResult> uploadAll(
+    Future<void> Function(int index, Uint8List bytes) upload,
+  ) async {
+    final raf = await File(path).open();
+    final digestSink = _DigestSink();
+    final whole = sha256.startChunkedConversion(digestSink);
+    final partChecksums = <String>[];
+    try {
+      final length = await raf.length();
+      var index = 0;
+      if (length == 0) {
+        // Mirror BaseChunker.slice(empty) == [Uint8List(0)]: one empty part.
+        final empty = Uint8List(0);
+        whole.add(empty);
+        partChecksums.add(BaseChunker.checksum(empty));
+        await upload(0, empty);
+        index = 1;
+      } else {
+        for (var off = 0; off < length; off += partSize) {
+          final n = (off + partSize < length) ? partSize : length - off;
+          final buf = await raf.read(n);
+          whole.add(buf);
+          partChecksums.add(BaseChunker.checksum(buf));
+          await upload(index, buf);
+          index++;
+        }
+      }
+      whole.close();
+      return (
+        partCount: index,
+        wholeChecksum: 'sha256:${digestSink.value}',
+        partChecksums: partChecksums,
+        byteLength: length,
+      );
+    } finally {
+      await raf.close();
+    }
+  }
+}
+
+/// Minimal `Sink<Digest>` capturing the digest emitted at close (mirrors the one
+/// in base_part_file_sink.dart; crypto does not export AccumulatorSink).
+class _DigestSink implements Sink<Digest> {
+  Digest? value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
+}

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -5,7 +5,6 @@ import 'package:drift/drift.dart' show Value;
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
-import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_source.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
@@ -261,35 +260,42 @@ class ChangesetWriter {
     // a since-deleted record and cold-starts from this base (its prior
     // changesets pruned) would otherwise never see the tombstone and resurrect
     // the row. Mirrors the first base, which also exports with deletions.
-    final full = await _serializer.exportChangeset(
+    // Stream the fresh base to a temp file and slice-upload it (bounded memory,
+    // #358), mirroring publish()'s base path. The base still carries the full
+    // deletion log (see above).
+    final compSeq = afterSeq + 1;
+    final base = await _serializer.exportBaseToTempFile(
       deviceId: deviceId,
-      hlcWatermark: null,
       deletions: deletions,
       epochId: epochId,
       uploadNonce: uploadNonce,
+      seq: compSeq,
     );
-    final fullBytes = _codec.encodeChangeset(full);
-    // Slice the same bytes we checksum (serialize once) -- see publish().
-    final parts = BaseChunker.slice(fullBytes);
-    final compSeq = afterSeq + 1;
-    for (var i = 0; i < parts.length; i++) {
-      await provider.uploadFile(
-        parts[i],
-        ChangesetLogLayout.basePartName(deviceId, compSeq, i),
-        folderId: folderId,
+    final BasePartUploadResult upload;
+    try {
+      upload = await BasePartFileSource(base.path).uploadAll(
+        (i, bytes) => provider.uploadFile(
+          bytes,
+          ChangesetLogLayout.basePartName(deviceId, compSeq, i),
+          folderId: folderId,
+        ),
       );
+    } finally {
+      try {
+        await File(base.path).delete();
+      } catch (_) {}
     }
     final now = DateTime.now().millisecondsSinceEpoch;
     final manifest = SyncManifest(
       deviceId: deviceId,
       provider: providerId,
       baseSeq: compSeq,
-      basePartCount: parts.length,
-      baseBytes: fullBytes.length,
-      baseChecksum: BaseChunker.checksum(fullBytes),
-      basePartChecksums: parts.map(BaseChunker.checksum).toList(),
+      basePartCount: upload.partCount,
+      baseBytes: base.byteLength,
+      baseChecksum: upload.wholeChecksum,
+      basePartChecksums: upload.partChecksums,
       headSeq: compSeq,
-      publishedHlcHigh: full.toHlc,
+      publishedHlcHigh: base.toHlc,
       epochId: epochId,
       uploadNonce: uploadNonce,
       updatedAt: now,
@@ -299,10 +305,10 @@ class ChangesetWriter {
       LocalPublishStatesCompanion(
         provider: Value(providerId),
         baseSeq: Value(compSeq),
-        basePartCount: Value(parts.length),
-        baseBytes: Value(fullBytes.length),
+        basePartCount: Value(upload.partCount),
+        baseBytes: Value(base.byteLength),
         headSeq: Value(compSeq),
-        publishedHlcHigh: Value(full.toHlc),
+        publishedHlcHigh: Value(base.toHlc),
         changesetBytesSinceBase: const Value(0),
         updatedAt: Value(now),
       ),

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:drift/drift.dart' show Value;
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_source.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
@@ -61,68 +64,80 @@ class ChangesetWriter {
     final hasBase = ownManifest?.baseSeq != null;
     final watermark = ownManifest?.publishedHlcHigh ?? state?.publishedHlcHigh;
 
-    final payload = await _serializer.exportChangeset(
-      deviceId: deviceId,
-      hlcWatermark: hasBase ? watermark : null,
-      deletions: deletions,
-      seq: knownHeadSeq + 1,
-      epochId: epochId,
-      uploadNonce: uploadNonce,
-    );
-
-    if (_isEmpty(payload)) {
-      return const ChangesetWriteResult(ChangesetWriteKind.noop);
-    }
-
     final newSeq = knownHeadSeq + 1;
     final now = DateTime.now().millisecondsSinceEpoch;
 
     if (!hasBase) {
-      final fullBytes = _codec.encodeChangeset(payload);
-      // Slice the SAME bytes we checksum (serialize once): the base parts and
-      // baseChecksum are then guaranteed consistent, so a reader's whole-base
-      // checksum can only fail on real transport corruption, never on a
-      // re-serialization divergence.
-      final parts = BaseChunker.slice(fullBytes);
-      for (var i = 0; i < parts.length; i++) {
-        await provider.uploadFile(
-          parts[i],
-          ChangesetLogLayout.basePartName(deviceId, newSeq, i),
-          folderId: folderId,
-        );
-      }
-      final manifest = SyncManifest(
+      // Stream the base to a temp file and slice-upload it, so a large library
+      // is never materialized in RAM (#358 write side). Do NOT call
+      // exportChangeset(null) here -- that is the OOM path.
+      final base = await _serializer.exportBaseToTempFile(
         deviceId: deviceId,
-        provider: providerId,
-        baseSeq: newSeq,
-        basePartCount: parts.length,
-        baseBytes: fullBytes.length,
-        baseChecksum: BaseChunker.checksum(fullBytes),
-        basePartChecksums: parts.map(BaseChunker.checksum).toList(),
-        headSeq: newSeq,
-        publishedHlcHigh: payload.toHlc,
+        deletions: deletions,
         epochId: epochId,
         uploadNonce: uploadNonce,
-        updatedAt: now,
+        seq: newSeq,
       );
-      await _writeManifest(provider, folderId, deviceId, manifest);
-      await _publishState.upsert(
-        LocalPublishStatesCompanion(
-          provider: Value(providerId),
-          baseSeq: Value(newSeq),
-          basePartCount: Value(parts.length),
-          baseBytes: Value(fullBytes.length),
-          headSeq: Value(newSeq),
-          publishedHlcHigh: Value(payload.toHlc),
-          changesetBytesSinceBase: const Value(0),
-          updatedAt: Value(now),
-        ),
-      );
-      return ChangesetWriteResult(ChangesetWriteKind.base, newSeq);
+      try {
+        if (base.rowCount == 0 && deletions.isEmpty) {
+          return const ChangesetWriteResult(ChangesetWriteKind.noop);
+        }
+        final upload = await BasePartFileSource(base.path).uploadAll(
+          (i, bytes) => provider.uploadFile(
+            bytes,
+            ChangesetLogLayout.basePartName(deviceId, newSeq, i),
+            folderId: folderId,
+          ),
+        );
+        final manifest = SyncManifest(
+          deviceId: deviceId,
+          provider: providerId,
+          baseSeq: newSeq,
+          basePartCount: upload.partCount,
+          baseBytes: base.byteLength,
+          baseChecksum: upload.wholeChecksum,
+          basePartChecksums: upload.partChecksums,
+          headSeq: newSeq,
+          publishedHlcHigh: base.toHlc,
+          epochId: epochId,
+          uploadNonce: uploadNonce,
+          updatedAt: now,
+        );
+        await _writeManifest(provider, folderId, deviceId, manifest);
+        await _publishState.upsert(
+          LocalPublishStatesCompanion(
+            provider: Value(providerId),
+            baseSeq: Value(newSeq),
+            basePartCount: Value(upload.partCount),
+            baseBytes: Value(base.byteLength),
+            headSeq: Value(newSeq),
+            publishedHlcHigh: Value(base.toHlc),
+            changesetBytesSinceBase: const Value(0),
+            updatedAt: Value(now),
+          ),
+        );
+        return ChangesetWriteResult(ChangesetWriteKind.base, newSeq);
+      } finally {
+        try {
+          await File(base.path).delete();
+        } catch (_) {}
+      }
     }
 
     // Changeset: reuse the base fields from the (authoritative) own manifest;
-    // only headSeq / publishedHlcHigh advance.
+    // only headSeq / publishedHlcHigh advance. The incremental delta stays in
+    // memory (small); only the base path above is streamed (#358).
+    final payload = await _serializer.exportChangeset(
+      deviceId: deviceId,
+      hlcWatermark: watermark,
+      deletions: deletions,
+      seq: newSeq,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+    );
+    if (_isEmpty(payload)) {
+      return const ChangesetWriteResult(ChangesetWriteKind.noop);
+    }
     final bytes = _codec.encodeChangeset(payload);
     await provider.uploadFile(
       bytes,

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1532,6 +1532,383 @@ class SyncDataSerializer {
     }
   }
 
+  /// Batched [upsertRecord]: writes all [records] for [entityType] in one Drift
+  /// `batch()` (reused prepared statements), in list order, with identical
+  /// conflict semantics. Mirrors [upsertRecord]'s per-entity logic per record --
+  /// the same `<Type>.fromJson`, the same per-record transforms, and the same
+  /// `settings` device-local-key filter.
+  Future<void> upsertRecords(
+    String entityType,
+    List<Map<String, dynamic>> records,
+  ) async {
+    if (records.isEmpty) return;
+    switch (entityType) {
+      case 'divers':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.divers,
+            records.map((r) => Diver.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diverSettings':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diverSettings,
+            records
+                .map(
+                  (r) => DiverSetting.fromJson(_applyDiverSettingDefaults(r)),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'dives':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.dives,
+            records.map((r) => Dive.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveProfiles':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveProfiles,
+            records.map((r) => DiveProfile.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveTanks':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveTanks,
+            records.map((r) => DiveTank.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveEquipment':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveEquipment,
+            records.map((r) => DiveEquipmentData.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveWeights':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveWeights,
+            records.map((r) => DiveWeight.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveSites':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveSites,
+            records.map((r) => DiveSite.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'equipment':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.equipment,
+            records.map((r) => EquipmentData.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'equipmentSets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.equipmentSets,
+            records.map((r) => EquipmentSet.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'equipmentSetItems':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.equipmentSetItems,
+            records.map((r) => EquipmentSetItem.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'media':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.media,
+            records
+                .map(
+                  (r) => MediaData.fromJson(r, serializer: _syncBlobSerializer),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'buddies':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.buddies,
+            records.map((r) => Buddy.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveBuddies':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveBuddies,
+            records.map((r) => DiveBuddy.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'certifications':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.certifications,
+            records
+                .map(
+                  (r) => Certification.fromJson(
+                    r,
+                    serializer: _syncBlobSerializer,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'courses':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.courses,
+            records.map((r) => Course.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'serviceRecords':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.serviceRecords,
+            records.map((r) => ServiceRecord.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveCenters':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveCenters,
+            records.map((r) => DiveCenter.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'trips':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.trips,
+            records.map((r) => Trip.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'liveaboardDetails':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.liveaboardDetailRecords,
+            records.map((r) => LiveaboardDetailRecord.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'itineraryDays':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tripItineraryDays,
+            records.map((r) => TripItineraryDay.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tags':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tags,
+            records.map((r) => Tag.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveTags':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveTags,
+            records.map((r) => DiveTag.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveDiveTypes':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveDiveTypes,
+            records.map((r) => DiveDiveType.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveTypes':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveTypes,
+            records.map((r) => DiveType.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tankPresets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tankPresets,
+            records.map((r) => TankPreset.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveComputers':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveComputers,
+            records.map((r) => DiveComputer.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tankPressureProfiles':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tankPressureProfiles,
+            records.map((r) => TankPressureProfile.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'tideRecords':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.tideRecords,
+            records.map((r) => TideRecord.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'settings':
+        // Mirror upsertRecord: never overwrite a device-local settings key.
+        final settingsRows = records
+            .where((r) => !_deviceLocalSettingsKeys.contains(r['key']))
+            .map((r) => Setting.fromJson(r))
+            .toList();
+        if (settingsRows.isEmpty) return;
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(_db.settings, settingsRows),
+        );
+        return;
+      case 'species':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.species,
+            records.map((r) => Specy.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'sightings':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.sightings,
+            records.map((r) => Sighting.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveProfileEvents':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveProfileEvents,
+            records
+                .map(
+                  (r) => DiveProfileEvent.fromJson(
+                    r['source'] == null ? {...r, 'source': 'imported'} : r,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'gasSwitches':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.gasSwitches,
+            records.map((r) => GasSwitche.fromJson(r)).toList(),
+          ),
+        );
+        return;
+      case 'diveCustomFields':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveCustomFields,
+            records
+                .map((r) => DiveCustomField.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'diveDataSources':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.diveDataSources,
+            records
+                .map(
+                  (r) => DiveDataSourcesData.fromJson(
+                    _withTimestampDefaults(r),
+                    serializer: _syncBlobSerializer,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return;
+      case 'siteSpecies':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.siteSpecies,
+            records
+                .map((r) => SiteSpecy.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'csvPresets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.csvPresets,
+            records
+                .map((r) => CsvPreset.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'viewConfigs':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.viewConfigs,
+            records
+                .map((r) => ViewConfig.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      case 'fieldPresets':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.fieldPresets,
+            records
+                .map((r) => FieldPreset.fromJson(_withTimestampDefaults(r)))
+                .toList(),
+          ),
+        );
+        return;
+      default:
+        throw ArgumentError('upsertRecords: unknown entityType $entityType');
+    }
+  }
+
   /// Every local row id for [entityType], in the id form [deleteRecord]
   /// accepts: plain `id` for most entities, `key` for `settings`, and the
   /// composite `a|b` form (matching [_compositeId]) for the two junction

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2051,8 +2051,20 @@ class SyncDataSerializer {
   /// Replace-adopt (#358): clearing each table then re-inserting the cloud
   /// union is equivalent to upsert-then-delete-not-in-cloud but needs no in-RAM
   /// id set to diff against, so adopt memory stays bounded regardless of size.
-  Future<void> deleteAllRecords(String entityType) =>
-      _db.delete(_syncTableFor(entityType)).go();
+  ///
+  /// Device-local settings keys ([_deviceLocalSettingsKeys], e.g.
+  /// `active_diver_id`) are preserved: they are never part of a synced or
+  /// replaced library, so an adopt must not wipe them (they are also excluded
+  /// from the base by [_exportSettings], so re-insert would not restore them).
+  Future<void> deleteAllRecords(String entityType) async {
+    if (entityType == 'settings') {
+      await (_db.delete(
+        _db.settings,
+      )..where((t) => t.key.isNotIn(_deviceLocalSettingsKeys.toList()))).go();
+      return;
+    }
+    await _db.delete(_syncTableFor(entityType)).go();
+  }
 
   /// The Drift table backing a synced [entityType] (mirrors recordIdsFor).
   TableInfo<Table, dynamic> _syncTableFor(String entityType) {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1670,6 +1670,105 @@ class SyncDataSerializer {
     }
   }
 
+  /// Delete every row of the table backing [entityType]. Used by streaming
+  /// Replace-adopt (#358): clearing each table then re-inserting the cloud
+  /// union is equivalent to upsert-then-delete-not-in-cloud but needs no in-RAM
+  /// id set to diff against, so adopt memory stays bounded regardless of size.
+  Future<void> deleteAllRecords(String entityType) =>
+      _db.delete(_syncTableFor(entityType)).go();
+
+  /// The Drift table backing a synced [entityType] (mirrors recordIdsFor).
+  TableInfo<Table, dynamic> _syncTableFor(String entityType) {
+    switch (entityType) {
+      case 'settings':
+        return _db.settings;
+      case 'diveEquipment':
+        return _db.diveEquipment;
+      case 'equipmentSetItems':
+        return _db.equipmentSetItems;
+      case 'divers':
+        return _db.divers;
+      case 'diverSettings':
+        return _db.diverSettings;
+      case 'buddies':
+        return _db.buddies;
+      case 'diveCenters':
+        return _db.diveCenters;
+      case 'trips':
+        return _db.trips;
+      case 'liveaboardDetails':
+        return _db.liveaboardDetailRecords;
+      case 'itineraryDays':
+        return _db.tripItineraryDays;
+      case 'equipment':
+        return _db.equipment;
+      case 'equipmentSets':
+        return _db.equipmentSets;
+      case 'diveTypes':
+        return _db.diveTypes;
+      case 'tankPresets':
+        return _db.tankPresets;
+      case 'diveComputers':
+        return _db.diveComputers;
+      case 'species':
+        return _db.species;
+      case 'tags':
+        return _db.tags;
+      case 'courses':
+        return _db.courses;
+      case 'dives':
+        return _db.dives;
+      case 'diveSites':
+        return _db.diveSites;
+      case 'diveTanks':
+        return _db.diveTanks;
+      case 'diveWeights':
+        return _db.diveWeights;
+      case 'diveTags':
+        return _db.diveTags;
+      case 'diveDiveTypes':
+        return _db.diveDiveTypes;
+      case 'diveBuddies':
+        return _db.diveBuddies;
+      case 'diveProfiles':
+        return _db.diveProfiles;
+      case 'diveProfileEvents':
+        return _db.diveProfileEvents;
+      case 'gasSwitches':
+        return _db.gasSwitches;
+      case 'diveCustomFields':
+        return _db.diveCustomFields;
+      case 'diveDataSources':
+        return _db.diveDataSources;
+      case 'siteSpecies':
+        return _db.siteSpecies;
+      case 'csvPresets':
+        return _db.csvPresets;
+      case 'viewConfigs':
+        return _db.viewConfigs;
+      case 'fieldPresets':
+        return _db.fieldPresets;
+      case 'tankPressureProfiles':
+        return _db.tankPressureProfiles;
+      case 'tideRecords':
+        return _db.tideRecords;
+      case 'sightings':
+        return _db.sightings;
+      case 'certifications':
+        return _db.certifications;
+      case 'serviceRecords':
+        return _db.serviceRecords;
+      case 'media':
+        return _db.media;
+      default:
+        throw ArgumentError.value(
+          entityType,
+          'entityType',
+          '_syncTableFor has no case for this synced entity',
+        );
+    }
+  }
+
   Future<void> deleteRecord(String entityType, String recordId) async {
     switch (entityType) {
       case 'divers':

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -9,6 +11,20 @@ import 'package:submersion/core/services/logger_service.dart';
 
 /// Sync data format version for compatibility checking
 const int syncFormatVersion = 2;
+
+/// Unique-ish suffix for base temp files (deviceId + seq already scope them).
+const _baseTempUuid = Uuid();
+
+/// Result of streaming a base snapshot to a temp file. The caller owns [path]
+/// and must delete it. [byteLength] is the on-disk base size (== manifest
+/// `baseBytes`); [rowCount] is the total rows written (0 => an empty library).
+typedef StreamedBase = ({
+  String path,
+  int byteLength,
+  int exportedAt,
+  String? toHlc,
+  int rowCount,
+});
 
 /// Value serializer used only for sync export/import of BLOB-bearing entities.
 ///
@@ -474,6 +490,301 @@ class SyncDataSerializer {
       uploadNonce: uploadNonce,
       epochId: epochId,
     );
+  }
+
+  /// Ordered table descriptors for a base snapshot, matching SyncData.toJson.
+  /// `table != null` => keyset-page by `id`; otherwise `full` loads the whole
+  /// (small, composite-key) table once. `blob` selects the base64 BLOB
+  /// serializer (media / certifications / diveDataSources).
+  List<
+    ({
+      String key,
+      TableInfo<Table, dynamic>? table,
+      bool blob,
+      Future<List<Map<String, dynamic>>> Function()? full,
+    })
+  >
+  get _baseTables => [
+    (key: 'divers', table: _db.divers, blob: false, full: null),
+    (key: 'diverSettings', table: _db.diverSettings, blob: false, full: null),
+    (key: 'dives', table: _db.dives, blob: false, full: null),
+    (key: 'diveProfiles', table: _db.diveProfiles, blob: false, full: null),
+    (key: 'diveTanks', table: _db.diveTanks, blob: false, full: null),
+    (
+      key: 'diveEquipment',
+      table: null,
+      blob: false,
+      full: () => _exportDiveEquipment(null),
+    ),
+    (key: 'diveWeights', table: _db.diveWeights, blob: false, full: null),
+    (key: 'diveSites', table: _db.diveSites, blob: false, full: null),
+    (key: 'equipment', table: _db.equipment, blob: false, full: null),
+    (key: 'equipmentSets', table: _db.equipmentSets, blob: false, full: null),
+    (
+      key: 'equipmentSetItems',
+      table: null,
+      blob: false,
+      full: () => _exportEquipmentSetItems(null),
+    ),
+    (key: 'media', table: _db.media, blob: true, full: null),
+    (key: 'buddies', table: _db.buddies, blob: false, full: null),
+    (key: 'diveBuddies', table: _db.diveBuddies, blob: false, full: null),
+    (key: 'certifications', table: _db.certifications, blob: true, full: null),
+    (key: 'courses', table: _db.courses, blob: false, full: null),
+    (key: 'serviceRecords', table: _db.serviceRecords, blob: false, full: null),
+    (key: 'diveCenters', table: _db.diveCenters, blob: false, full: null),
+    (key: 'trips', table: _db.trips, blob: false, full: null),
+    (
+      key: 'liveaboardDetails',
+      table: _db.liveaboardDetailRecords,
+      blob: false,
+      full: null,
+    ),
+    (
+      key: 'itineraryDays',
+      table: _db.tripItineraryDays,
+      blob: false,
+      full: null,
+    ),
+    (key: 'tags', table: _db.tags, blob: false, full: null),
+    (key: 'diveTags', table: _db.diveTags, blob: false, full: null),
+    (key: 'diveDiveTypes', table: _db.diveDiveTypes, blob: false, full: null),
+    // diveTypes/species/fieldPresets exclude built-in reference data
+    // (isBuiltIn=false), so reuse their exporters rather than paging all rows.
+    (
+      key: 'diveTypes',
+      table: null,
+      blob: false,
+      full: () => _exportDiveTypes(null),
+    ),
+    (key: 'tankPresets', table: _db.tankPresets, blob: false, full: null),
+    (key: 'diveComputers', table: _db.diveComputers, blob: false, full: null),
+    (
+      key: 'tankPressureProfiles',
+      table: _db.tankPressureProfiles,
+      blob: false,
+      full: null,
+    ),
+    (key: 'tideRecords', table: _db.tideRecords, blob: false, full: null),
+    (
+      key: 'settings',
+      table: null,
+      blob: false,
+      full: () => _exportSettings(null),
+    ),
+    (
+      key: 'species',
+      table: null,
+      blob: false,
+      full: () => _exportSpecies(null),
+    ),
+    (key: 'sightings', table: _db.sightings, blob: false, full: null),
+    (
+      key: 'diveProfileEvents',
+      table: _db.diveProfileEvents,
+      blob: false,
+      full: null,
+    ),
+    (key: 'gasSwitches', table: _db.gasSwitches, blob: false, full: null),
+    (
+      key: 'diveCustomFields',
+      table: _db.diveCustomFields,
+      blob: false,
+      full: null,
+    ),
+    (
+      key: 'diveDataSources',
+      table: _db.diveDataSources,
+      blob: true,
+      full: null,
+    ),
+    (key: 'siteSpecies', table: _db.siteSpecies, blob: false, full: null),
+    (key: 'csvPresets', table: _db.csvPresets, blob: false, full: null),
+    (key: 'viewConfigs', table: _db.viewConfigs, blob: false, full: null),
+    (
+      key: 'fieldPresets',
+      table: null,
+      blob: false,
+      full: () => _exportFieldPresets(null),
+    ),
+  ];
+
+  /// Test seam: the base table order, asserted equal to SyncData.toJson keys so
+  /// a dropped/added/misordered entity is caught at build time.
+  static List<String> get debugBaseTableKeys =>
+      SyncDataSerializer()._baseTables.map((t) => t.key).toList();
+
+  /// One keyset page (`id > cursor`, ascending, up to [limit]) of an id-PK
+  /// table, as JSON rows identical to the table's own `toJson` (BLOB serializer
+  /// applied for BLOB tables). O(n) total across pages; never loads the whole
+  /// table into memory.
+  Future<List<Map<String, dynamic>>> _pageBaseTableById(
+    TableInfo<Table, dynamic> table, {
+    required String? cursor,
+    required int limit,
+    required bool blob,
+  }) async {
+    final name = table.actualTableName;
+    final rows = cursor == null
+        ? await _db
+              .customSelect(
+                'SELECT * FROM "$name" ORDER BY id LIMIT ?',
+                variables: [Variable.withInt(limit)],
+              )
+              .get()
+        : await _db
+              .customSelect(
+                'SELECT * FROM "$name" WHERE id > ? ORDER BY id LIMIT ?',
+                variables: [
+                  Variable.withString(cursor),
+                  Variable.withInt(limit),
+                ],
+              )
+              .get();
+    return rows.map((r) {
+      final data = table.map(r.data) as dynamic;
+      return (blob
+              ? data.toJson(serializer: _syncBlobSerializer)
+              : data.toJson())
+          as Map<String, dynamic>;
+    }).toList();
+  }
+
+  /// Streams a full base snapshot to a temp file as exactly
+  /// `jsonEncode(SyncPayload.toJson())`, in bounded memory (one keyset page +
+  /// one write). Replaces `exportChangeset(null)` + `encodeChangeset` on the
+  /// publish/compact path, whose full-graph materialization OOM-crashed iOS on
+  /// large libraries (#358, write side). Rows stream in `id` order; the internal
+  /// `checksum` is patched in over the streamed `data` bytes via a single
+  /// seek-back so there is no second DB scan. Caller owns and must delete [path].
+  Future<StreamedBase> exportBaseToTempFile({
+    required String deviceId,
+    required List<DeletionLogData> deletions,
+    String? epochId,
+    String? uploadNonce,
+    int? seq,
+    int pageSize = 2000,
+    DateTime Function() now = DateTime.now,
+    Future<Directory> Function()? tempDir,
+  }) async {
+    final dir = await (tempDir?.call() ?? Future.value(Directory.systemTemp));
+    final path =
+        '${dir.path}/ssv1_base_${deviceId}_${seq ?? 0}.${_baseTempUuid.v4()}.json';
+    final raf = await File(path).open(mode: FileMode.write);
+    final digestSink = _Sha256DigestSink();
+    final dataHash = sha256.startChunkedConversion(digestSink);
+    final exportedAt = now().millisecondsSinceEpoch;
+    String? maxRowHlc;
+    var rowCount = 0;
+
+    // Writes + hashes only the `data` object bytes (matches _computeChecksum,
+    // which hashes jsonEncode(data.toJson())).
+    Future<void> writeData(String s) async {
+      final bytes = utf8.encode(s);
+      dataHash.add(bytes);
+      await raf.writeFrom(bytes);
+    }
+
+    try {
+      // Header up to (but not including) the checksum value.
+      await raf.writeString(
+        '{"version":$syncFormatVersion,"exportedAt":$exportedAt,'
+        '"deviceId":${jsonEncode(deviceId)},"lastSyncTimestamp":null,'
+        '"checksum":"',
+      );
+      final checksumOffset = await raf.position();
+      await raf.writeFrom(List.filled(64, 0x30)); // '0'*64 placeholder
+      await raf.writeString('","data":');
+
+      // ---- data object (hashed) ----
+      await writeData('{');
+      final tables = _baseTables;
+      for (var t = 0; t < tables.length; t++) {
+        final spec = tables[t];
+        if (t > 0) await writeData(',');
+        await writeData('${jsonEncode(spec.key)}:[');
+        var firstRow = true;
+
+        Future<void> emit(Map<String, dynamic> row) async {
+          if (!firstRow) await writeData(',');
+          firstRow = false;
+          rowCount++;
+          final hlc = row['hlc'];
+          if (hlc is String &&
+              (maxRowHlc == null || hlc.compareTo(maxRowHlc!) > 0)) {
+            maxRowHlc = hlc;
+          }
+          await writeData(jsonEncode(row));
+        }
+
+        if (spec.table != null) {
+          String? cursor;
+          while (true) {
+            final rows = await _pageBaseTableById(
+              spec.table!,
+              cursor: cursor,
+              limit: pageSize,
+              blob: spec.blob,
+            );
+            for (final row in rows) {
+              await emit(row);
+            }
+            if (rows.length < pageSize) break;
+            cursor = rows.last['id'] as String;
+          }
+        } else {
+          for (final row in await spec.full!()) {
+            await emit(row);
+          }
+        }
+        await writeData(']');
+      }
+      await writeData('}');
+
+      // ---- trailer (not part of the data checksum) ----
+      final toHlc = _maxHlc([maxRowHlc, ...deletions.map((d) => d.hlc)]);
+      final tail = <String, dynamic>{
+        'deletions': _groupDeletions(
+          deletions,
+        ).map((k, v) => MapEntry(k, v.map((d) => d.toJson()).toList())),
+        'uploadNonce': uploadNonce,
+        'epochId': epochId,
+        'seq': seq,
+        'baseSeq': null,
+        'sinceHlc': null,
+        'toHlc': toHlc,
+      };
+      final tailBuf = StringBuffer();
+      tail.forEach(
+        (k, v) => tailBuf.write(',${jsonEncode(k)}:${jsonEncode(v)}'),
+      );
+      tailBuf.write('}');
+      await raf.writeString(tailBuf.toString());
+
+      // ---- patch the checksum placeholder with the real data digest ----
+      dataHash.close();
+      final endPos = await raf.position();
+      await raf.setPosition(checksumOffset);
+      await raf.writeFrom(utf8.encode(digestSink.value.toString()));
+      await raf.setPosition(endPos);
+      await raf.flush();
+      await raf.close();
+
+      final byteLength = await File(path).length();
+      return (
+        path: path,
+        byteLength: byteLength,
+        exportedAt: exportedAt,
+        toHlc: toHlc,
+        rowCount: rowCount,
+      );
+    } catch (_) {
+      await raf.close();
+      try {
+        await File(path).delete();
+      } catch (_) {}
+      rethrow;
+    }
   }
 
   /// Group a flat deletion list into the payload's entityType -> deletions map.
@@ -2232,4 +2543,17 @@ class SyncDataSerializer {
     }
     return merged;
   }
+}
+
+/// Captures the single digest a chunked SHA-256 conversion emits at close.
+/// Mirrors the sink in base_part_file_sink.dart (crypto does not export
+/// AccumulatorSink).
+class _Sha256DigestSink implements Sink<Digest> {
+  Digest? value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
 }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2020,10 +2020,19 @@ class SyncService {
       await _serializer.deleteAllRecords(entity);
     }
 
-    Future<void> upsertRow(String table, Map<String, dynamic> record) async {
-      final id = _recordIdForEntity(table, record);
-      if (id == null) return; // matches in-memory: null-id rows are skipped
-      await _serializer.upsertRecord(table, record);
+    // Batched upsert of a table's rows (skipping null-id rows, matching the
+    // in-memory path). Batching is the throughput lever: a large adopt is
+    // millions of rows, and row-by-row upserts froze the UI (#358 adopt).
+    Future<void> applyBatch(
+      String table,
+      List<Map<String, dynamic>> records,
+    ) async {
+      final valid = [
+        for (final r in records)
+          if (_recordIdForEntity(table, r) != null) r,
+      ];
+      if (valid.isEmpty) return;
+      await _serializer.upsertRecords(table, valid);
     }
 
     // Apply units: each base file and each changeset, ascending by exportedAt
@@ -2039,10 +2048,10 @@ class SyncService {
       if (changeset != null) {
         for (final entry in changeset.data.toJson().entries) {
           if (!entityHasUpdatedAt.containsKey(entry.key)) continue;
-          for (final record
-              in (entry.value as List).cast<Map<String, dynamic>>()) {
-            await upsertRow(entry.key, record);
-          }
+          await applyBatch(
+            entry.key,
+            (entry.value as List).cast<Map<String, dynamic>>(),
+          );
         }
         continue;
       }
@@ -2054,9 +2063,7 @@ class SyncService {
       Future<void> flush() async {
         final table = currentTable;
         if (table == null || batch.isEmpty) return;
-        for (final record in batch) {
-          await upsertRow(table, record);
-        }
+        await applyBatch(table, batch);
         batch = <Map<String, dynamic>>[];
       }
 

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1993,30 +1993,36 @@ class SyncService {
   }
 
   /// Streaming replace-adopt apply (production path). Runs inside the caller's
-  /// deferred-FK transaction. Upserts every restored row in exportedAt order
-  /// (each base temp file streamed in 500-row batches, plus in-memory
-  /// changesets), collecting cloud ids as it goes, then deletes local rows
-  /// absent from that set, then repairs FKs. Bounded memory: one batch + the
-  /// cloud id sets (ids only, never full rows), independent of library size.
+  /// deferred-FK transaction. Clears every synced table, then upserts every
+  /// restored row in exportedAt order (each base temp file streamed in 500-row
+  /// batches, plus in-memory changesets), then repairs FKs. Bounded memory: one
+  /// batch of rows at a time, independent of library size -- unlike the old
+  /// path it holds NO id set (#358 adopt OOM: a full-library cloud-id set plus
+  /// per-entity local-id sets pushed a large library past the iOS jetsam
+  /// limit).
   ///
-  /// Equivalent to [_applyAdoptInMemory]: `upsertRecord` is an unconditional
-  /// overwrite, so applying in ascending exportedAt order is latest-export-wins
-  /// (the in-memory `restored` map); and delete-not-in-cloud is order
-  /// independent, so upsert-then-delete here matches delete-then-upsert there
-  /// (final state is the cloud union either way). A null record id is skipped
-  /// entirely, exactly as the in-memory path does. Enforced by
+  /// Equivalent to [_applyAdoptInMemory]: clearing then re-inserting the cloud
+  /// union yields the same final rows as upsert-then-delete-not-in-cloud (both
+  /// converge the DB to the cloud union), `upsertRecord` is an unconditional
+  /// overwrite so ascending exportedAt order is latest-export-wins, and a null
+  /// record id is skipped exactly as the in-memory path does. Enforced by
   /// sync_adopt_streaming_parity_test.dart.
   Future<void> _adoptApplyStreaming({
     required List<String> baseFilePaths,
     required List<int> baseExportedAt,
     required List<SyncPayload> changesets,
   }) async {
-    final cloudIds = <String, Set<String>>{};
+    // Replace semantics: clear every synced table, then insert the cloud union
+    // (latest export wins). Equivalent to the old upsert-then-delete-not-in-
+    // cloud, but needs no in-RAM id set to diff against, so adopt memory stays
+    // bounded regardless of library size (#358 adopt OOM).
+    for (final entity in entityHasUpdatedAt.keys) {
+      await _serializer.deleteAllRecords(entity);
+    }
 
     Future<void> upsertRow(String table, Map<String, dynamic> record) async {
       final id = _recordIdForEntity(table, record);
       if (id == null) return; // matches in-memory: null-id rows are skipped
-      (cloudIds[table] ??= <String>{}).add(id);
       await _serializer.upsertRecord(table, record);
     }
 
@@ -2068,16 +2074,6 @@ class SyncService {
         },
       );
       await flush();
-    }
-
-    // Delete local rows the restored library does not contain.
-    for (final entity in entityHasUpdatedAt.keys) {
-      final cloud = cloudIds[entity] ?? const <String>{};
-      for (final localId in await _serializer.recordIdsFor(entity)) {
-        if (!cloud.contains(localId)) {
-          await _serializer.deleteRecord(entity, localId);
-        }
-      }
     }
 
     await _serializer.repairDanglingForeignKeys();

--- a/test/core/services/sync/base_publish_streaming_parity_test.dart
+++ b/test/core/services/sync/base_publish_streaming_parity_test.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Order-independent snapshot: each table's rows sorted by their JSON so an
+/// array-order difference (id order in the streamed base vs. list order in
+/// exportChangeset) is not a mismatch -- only data differences are.
+String _canonical(Map<String, dynamic> dataJson) {
+  final out = <String, dynamic>{};
+  for (final key in dataJson.keys.toList()..sort()) {
+    final list = (dataJson[key] as List).cast<Map<String, dynamic>>();
+    final sorted = [...list]
+      ..sort((a, b) => jsonEncode(a).compareTo(jsonEncode(b)));
+    out[key] = sorted;
+  }
+  return jsonEncode(out);
+}
+
+Future<void> _seedRich() async {
+  final serializer = SyncDataSerializer();
+  final dives = DiveRepository();
+  await dives.createDive(createTestDiveWithBottomTime(id: 'd1', diveNumber: 1));
+  await dives.createDive(createTestDiveWithBottomTime(id: 'd2', diveNumber: 2));
+  await serializer.upsertRecord('diveSites', {
+    'id': 'site-1',
+    'name': 'Test Site',
+    'description': '',
+    'notes': '',
+    'isShared': false,
+    'createdAt': 1000,
+    'updatedAt': 1000,
+  });
+  // BLOB-bearing table (diveDataSources uses the base64 serializer).
+  await serializer.upsertRecord('diveDataSources', {
+    'id': 'ds-1',
+    'diveId': 'd1',
+    'isPrimary': true,
+    'sourceFormat': 'shearwater',
+    'importedAt': 1700000000000,
+    'createdAt': 1700000000000,
+    'rawFingerprint': Uint8List.fromList([0x01, 0x02, 0x03, 0xFE, 0xFF]),
+  });
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('_baseTables lists exactly the SyncData entities in order', () {
+    // A missing/extra/misordered entity would silently drop or misplace rows.
+    expect(
+      SyncDataSerializer.debugBaseTableKeys,
+      const SyncData().toJson().keys.toList(),
+    );
+  });
+
+  test(
+    'streamed base equals exportChangeset(null) per table + valid checksum',
+    () async {
+      await _seedRich();
+      final deletions = await SyncRepository().getAllDeletions();
+      final expected = await SyncDataSerializer().exportChangeset(
+        deviceId: 'peer',
+        hlcWatermark: null,
+        deletions: deletions,
+      );
+
+      final base = await SyncDataSerializer().exportBaseToTempFile(
+        deviceId: 'peer',
+        deletions: deletions,
+        now: () => DateTime.fromMillisecondsSinceEpoch(123),
+      );
+      final decoded =
+          jsonDecode(await File(base.path).readAsString())
+              as Map<String, dynamic>;
+      await File(base.path).delete();
+
+      expect(decoded['version'], syncFormatVersion);
+      expect(decoded['exportedAt'], 123);
+      expect(base.exportedAt, 123);
+      expect(
+        _canonical(decoded['data'] as Map<String, dynamic>),
+        _canonical(expected.data.toJson()),
+      );
+      expect(base.toHlc, expected.toHlc);
+      // Internal checksum is valid over the streamed data bytes.
+      final dataJson = jsonEncode(decoded['data']);
+      expect(
+        decoded['checksum'],
+        sha256.convert(utf8.encode(dataJson)).toString(),
+      );
+    },
+  );
+
+  test('keyset paging across >1 page is complete', () async {
+    final dives = DiveRepository();
+    for (var i = 1; i <= 250; i++) {
+      await dives.createDive(
+        createTestDiveWithBottomTime(id: 'd$i', diveNumber: i),
+      );
+    }
+    final expected = await SyncDataSerializer().exportChangeset(
+      deviceId: 'peer',
+      hlcWatermark: null,
+      deletions: const [],
+    );
+    final base = await SyncDataSerializer().exportBaseToTempFile(
+      deviceId: 'peer',
+      deletions: const [],
+      pageSize: 100, // forces 3 pages of dives
+    );
+    final decoded =
+        jsonDecode(await File(base.path).readAsString())
+            as Map<String, dynamic>;
+    await File(base.path).delete();
+    expect((decoded['data']['dives'] as List).length, 250);
+    expect(
+      _canonical(decoded['data'] as Map<String, dynamic>),
+      _canonical(expected.data.toJson()),
+    );
+  });
+
+  test('rowCount equals the total rows written to the base', () async {
+    await _seedRich();
+    final base = await SyncDataSerializer().exportBaseToTempFile(
+      deviceId: 'peer',
+      deletions: const [],
+    );
+    final decoded =
+        jsonDecode(await File(base.path).readAsString())
+            as Map<String, dynamic>;
+    await File(base.path).delete();
+    final total = (decoded['data'] as Map<String, dynamic>).values.fold<int>(
+      0,
+      (n, v) => n + (v as List).length,
+    );
+    expect(base.rowCount, total);
+    expect(base.rowCount, greaterThan(0));
+  });
+}

--- a/test/core/services/sync/changeset_log/base_part_file_source_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_source_test.dart
@@ -56,4 +56,25 @@ void main() {
     expect(res.wholeChecksum, BaseChunker.checksum(data));
     await dir.delete(recursive: true);
   });
+
+  test(
+    'empty file yields one empty part (mirrors BaseChunker.slice)',
+    () async {
+      final dir = await Directory.systemTemp.createTemp('src_empty');
+      final path = '${dir.path}/base.json';
+      await File(path).writeAsBytes(Uint8List(0));
+
+      final uploaded = <int, Uint8List>{};
+      final res = await BasePartFileSource(path).uploadAll((i, bytes) async {
+        uploaded[i] = Uint8List.fromList(bytes);
+      });
+
+      expect(res.partCount, 1);
+      expect(res.byteLength, 0);
+      expect(uploaded[0], isEmpty);
+      expect(res.wholeChecksum, BaseChunker.checksum(Uint8List(0)));
+      expect(res.partChecksums.single, BaseChunker.checksum(Uint8List(0)));
+      await dir.delete(recursive: true);
+    },
+  );
 }

--- a/test/core/services/sync/changeset_log/base_part_file_source_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_source_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_source.dart';
+
+void main() {
+  test(
+    'yields parts + checksums matching BaseChunker over a multi-part file',
+    () async {
+      final dir = await Directory.systemTemp.createTemp('src');
+      final path = '${dir.path}/base.json';
+      // 2.5 parts of the 8 MB default so we cross part boundaries with a remainder.
+      final data = Uint8List.fromList(
+        List.generate(2 * BaseChunker.defaultPartSize + 12345, (i) => i % 256),
+      );
+      await File(path).writeAsBytes(data);
+      final expected = BaseChunker.slice(data);
+
+      final uploaded = <int, Uint8List>{};
+      final res = await BasePartFileSource(path).uploadAll((i, bytes) async {
+        uploaded[i] = Uint8List.fromList(bytes);
+      });
+
+      expect(res.partCount, expected.length);
+      expect(res.byteLength, data.length);
+      expect(res.wholeChecksum, BaseChunker.checksum(data));
+      for (var i = 0; i < expected.length; i++) {
+        expect(uploaded[i], expected[i], reason: 'part $i bytes');
+        expect(res.partChecksums[i], BaseChunker.checksum(expected[i]));
+      }
+      await dir.delete(recursive: true);
+    },
+  );
+
+  test('small partSize slices a file into many parts', () async {
+    final dir = await Directory.systemTemp.createTemp('src_small');
+    final path = '${dir.path}/base.json';
+    final data = Uint8List.fromList(List.generate(1000, (i) => i % 256));
+    await File(path).writeAsBytes(data);
+
+    final uploaded = <int, Uint8List>{};
+    final res = await BasePartFileSource(path, partSize: 256).uploadAll((
+      i,
+      bytes,
+    ) async {
+      uploaded[i] = Uint8List.fromList(bytes);
+    });
+
+    expect(res.partCount, 4); // 256 + 256 + 256 + 232
+    final reassembled = <int>[
+      for (final i in uploaded.keys.toList()..sort()) ...uploaded[i]!,
+    ];
+    expect(reassembled, data);
+    expect(res.wholeChecksum, BaseChunker.checksum(data));
+    await dir.delete(recursive: true);
+  });
+}

--- a/test/core/services/sync/changeset_log/changeset_writer_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_writer_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -238,6 +241,51 @@ void main() {
         before,
         reason: 'a no-op writes no new file',
       );
+    },
+  );
+
+  test(
+    'first base publish streams parts that reassemble to the library',
+    () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+      );
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd2', diveNumber: 2),
+      );
+      final result = await publish();
+      expect(result.kind, ChangesetWriteKind.base);
+
+      final deviceId = await SyncRepository().getDeviceId();
+      final manifest = SyncManifest.fromBytes(
+        await provider.downloadFile(
+          '$folder/${ChangesetLogLayout.manifestName(deviceId)}',
+        ),
+      );
+
+      // Reassemble the streamed parts and verify checksum + parsed content.
+      final parts = <int, List<int>>{};
+      for (final f in await provider.listFiles(
+        folderId: folder,
+        namePattern: ChangesetLogLayout.prefix,
+      )) {
+        final bp = ChangesetLogLayout.basePartOf(f.name);
+        if (bp != null && bp.baseSeq == manifest.baseSeq) {
+          parts[bp.part] = await provider.downloadFile(f.id);
+        }
+      }
+      final ordered = [
+        for (final i in parts.keys.toList()..sort()) ...parts[i]!,
+      ];
+      expect(parts.length, manifest.basePartCount);
+      expect(ordered.length, manifest.baseBytes);
+      expect('sha256:${sha256.convert(ordered)}', manifest.baseChecksum);
+
+      final payload = jsonDecode(utf8.decode(ordered)) as Map<String, dynamic>;
+      final diveIds = ((payload['data'] as Map)['dives'] as List)
+          .map((d) => (d as Map)['id'])
+          .toSet();
+      expect(diveIds, {'d1', 'd2'});
     },
   );
 }

--- a/test/core/services/sync/sync_data_serializer_batch_coverage_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_coverage_test.dart
@@ -1,0 +1,254 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Coverage for the batched [SyncDataSerializer.upsertRecords] across every
+/// syncable entity type. This is the throughput path the streaming
+/// Replace-adopt uses (one Drift `batch()` write per table instead of a per-row
+/// loop, #358); each `case` arm must stay symmetric with the per-record
+/// `upsertRecord` switch.
+///
+/// Strategy: seed a minimal placeholder row per table (FK enforcement off),
+/// read it back through the serializer (so blob columns use the same
+/// `_syncBlobSerializer` in both directions), feed that JSON through
+/// `upsertRecords` (a conflict-update on the row it came from), and assert the
+/// row still reads back. Drift's generated `toJson`/`fromJson` are inverses for
+/// a given table, so this exercises every arm with real, valid data.
+void main() {
+  late SyncDataSerializer serializer;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  // Insert one placeholder row into [table]: every NOT NULL column without a
+  // default gets a type-appropriate placeholder (the boolean CHECK columns all
+  // accept 0). Pass [pkId] for a single-PK table to set a known id; the
+  // composite-PK junctions take no id and are read back via Drift. FK
+  // enforcement is off in tests, so placeholder FK values are fine.
+  Future<void> insertPlaceholderRow(String table, {String? pkId}) async {
+    final cols = await db
+        .customSelect(
+          'SELECT * FROM pragma_table_info(?)',
+          variables: [Variable.withString(table)],
+        )
+        .get();
+    final pkCols = cols.where((c) => (c.data['pk'] as int? ?? 0) > 0).toList();
+    final singlePkName = (pkId != null && pkCols.length == 1)
+        ? pkCols.first.read<String>('name')
+        : null;
+
+    final names = <String>[];
+    final placeholders = <String>[];
+    final values = <Object?>[];
+    for (final c in cols) {
+      final name = c.read<String>('name');
+      final notNull = (c.data['notnull'] as int? ?? 0) == 1;
+      final hasDefault = c.data['dflt_value'] != null;
+      final type = (c.data['type'] as String? ?? '').toUpperCase();
+      if (name == singlePkName) {
+        names.add('"$name"');
+        placeholders.add('?');
+        values.add(pkId);
+      } else if (notNull && !hasDefault) {
+        names.add('"$name"');
+        placeholders.add('?');
+        if (type.contains('INT')) {
+          values.add(0);
+        } else if (type.contains('REAL') ||
+            type.contains('FLOA') ||
+            type.contains('DOUB')) {
+          values.add(0.0);
+        } else if (type.contains('BLOB')) {
+          values.add(Uint8List(0));
+        } else {
+          values.add('x');
+        }
+      }
+    }
+    await db.customStatement(
+      'INSERT INTO "$table" (${names.join(",")}) VALUES (${placeholders.join(",")})',
+      values,
+    );
+  }
+
+  group('batched upsertRecords', () {
+    test(
+      'every single-PK entity round-trips fetchRecord -> upsertRecords',
+      () async {
+        // Minimal placeholder rows need not satisfy parent references.
+        await db.customStatement('PRAGMA foreign_keys = OFF');
+
+        // entityType -> live SQL table name (mirrors the upsert switch;
+        // actualTableName avoids snake_case guessing).
+        final targets = <({String type, String table})>[
+          (type: 'divers', table: db.divers.actualTableName),
+          (type: 'diverSettings', table: db.diverSettings.actualTableName),
+          (type: 'dives', table: db.dives.actualTableName),
+          (type: 'diveProfiles', table: db.diveProfiles.actualTableName),
+          (type: 'diveTanks', table: db.diveTanks.actualTableName),
+          (type: 'diveWeights', table: db.diveWeights.actualTableName),
+          (type: 'diveSites', table: db.diveSites.actualTableName),
+          (type: 'equipment', table: db.equipment.actualTableName),
+          (type: 'equipmentSets', table: db.equipmentSets.actualTableName),
+          (type: 'media', table: db.media.actualTableName),
+          (type: 'buddies', table: db.buddies.actualTableName),
+          (type: 'diveBuddies', table: db.diveBuddies.actualTableName),
+          (type: 'certifications', table: db.certifications.actualTableName),
+          (type: 'courses', table: db.courses.actualTableName),
+          (type: 'serviceRecords', table: db.serviceRecords.actualTableName),
+          (type: 'diveCenters', table: db.diveCenters.actualTableName),
+          (type: 'trips', table: db.trips.actualTableName),
+          (
+            type: 'liveaboardDetails',
+            table: db.liveaboardDetailRecords.actualTableName,
+          ),
+          (type: 'itineraryDays', table: db.tripItineraryDays.actualTableName),
+          (type: 'tags', table: db.tags.actualTableName),
+          (type: 'diveTags', table: db.diveTags.actualTableName),
+          (type: 'diveDiveTypes', table: db.diveDiveTypes.actualTableName),
+          (type: 'diveTypes', table: db.diveTypes.actualTableName),
+          (type: 'tankPresets', table: db.tankPresets.actualTableName),
+          (type: 'diveComputers', table: db.diveComputers.actualTableName),
+          (
+            type: 'tankPressureProfiles',
+            table: db.tankPressureProfiles.actualTableName,
+          ),
+          (type: 'tideRecords', table: db.tideRecords.actualTableName),
+          (type: 'species', table: db.species.actualTableName),
+          (type: 'sightings', table: db.sightings.actualTableName),
+          (
+            type: 'diveProfileEvents',
+            table: db.diveProfileEvents.actualTableName,
+          ),
+          (type: 'gasSwitches', table: db.gasSwitches.actualTableName),
+          (
+            type: 'diveCustomFields',
+            table: db.diveCustomFields.actualTableName,
+          ),
+          (type: 'diveDataSources', table: db.diveDataSources.actualTableName),
+          (type: 'siteSpecies', table: db.siteSpecies.actualTableName),
+          (type: 'csvPresets', table: db.csvPresets.actualTableName),
+          (type: 'viewConfigs', table: db.viewConfigs.actualTableName),
+          (type: 'fieldPresets', table: db.fieldPresets.actualTableName),
+        ];
+
+        for (final t in targets) {
+          final id = 'seed-${t.type}';
+          await insertPlaceholderRow(t.table, pkId: id);
+
+          final json = await serializer.fetchRecord(t.type, id);
+          expect(json, isNotNull, reason: 'fetchRecord(${t.type}) after seed');
+
+          // Batched write: feed the row's own JSON back (a conflict-update).
+          await serializer.upsertRecords(t.type, [json!]);
+
+          // The row still reads back after the batched upsert.
+          expect(
+            await serializer.fetchRecord(t.type, id),
+            isNotNull,
+            reason: '${t.type} survives its own batched upsert',
+          );
+        }
+      },
+    );
+
+    test('composite-key junctions upsert through their batch arms', () async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      // diveEquipment is keyed by "diveId|equipmentId".
+      await insertPlaceholderRow(db.diveEquipment.actualTableName);
+      final de = (await db.select(db.diveEquipment).get()).single;
+      await serializer.upsertRecords('diveEquipment', [de.toJson()]);
+      expect(await serializer.recordIdsFor('diveEquipment'), isNotEmpty);
+
+      // equipmentSetItems is keyed by "setId|equipmentId".
+      await insertPlaceholderRow(db.equipmentSetItems.actualTableName);
+      final esi = (await db.select(db.equipmentSetItems).get()).single;
+      await serializer.upsertRecords('equipmentSetItems', [esi.toJson()]);
+      expect(await serializer.recordIdsFor('equipmentSetItems'), isNotEmpty);
+    });
+
+    test('settings: device-local keys are never written; an all-local batch is '
+        'a no-op', () async {
+      // active_diver_id is device-local -> filtered out; theme is normal.
+      await serializer.upsertRecords('settings', [
+        {'key': 'active_diver_id', 'value': 'diver-7', 'updatedAt': 1},
+        {'key': 'theme', 'value': 'dark', 'updatedAt': 1},
+      ]);
+      expect(
+        await serializer.fetchRecord('settings', 'active_diver_id'),
+        isNull,
+      );
+      expect(
+        (await serializer.fetchRecord('settings', 'theme'))?['value'],
+        'dark',
+      );
+
+      // A batch of only device-local keys filters to empty -> early return.
+      await serializer.upsertRecords('settings', [
+        {'key': 'active_diver_id', 'value': 'diver-9', 'updatedAt': 2},
+      ]);
+      expect(
+        await serializer.fetchRecord('settings', 'active_diver_id'),
+        isNull,
+      );
+    });
+
+    test('diveProfileEvents defaults a missing source to "imported"', () async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+      await insertPlaceholderRow(
+        db.diveProfileEvents.actualTableName,
+        pkId: 'evt-1',
+      );
+      final seeded = await serializer.fetchRecord('diveProfileEvents', 'evt-1');
+      expect(seeded, isNotNull);
+
+      // source present -> kept as-is (the false branch).
+      await serializer.upsertRecords('diveProfileEvents', [
+        {...seeded!, 'source': 'manual'},
+      ]);
+      expect(
+        (await serializer.fetchRecord('diveProfileEvents', 'evt-1'))?['source'],
+        'manual',
+      );
+
+      // source missing -> defaulted to 'imported' (the true branch).
+      await serializer.upsertRecords('diveProfileEvents', [
+        {...seeded}..remove('source'),
+      ]);
+      expect(
+        (await serializer.fetchRecord('diveProfileEvents', 'evt-1'))?['source'],
+        'imported',
+      );
+    });
+
+    test('upsertRecords is a no-op for an empty list', () async {
+      // Early return before the switch.
+      await serializer.upsertRecords('divers', const []);
+      expect(await serializer.recordIdsFor('divers'), isEmpty);
+    });
+
+    test(
+      'upsertRecords throws ArgumentError for an unknown entity type',
+      () async {
+        await expectLater(
+          serializer.upsertRecords('totallyUnknown', [
+            {'id': 'x'},
+          ]),
+          throwsArgumentError,
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_data_serializer_record_ids_test.dart
+++ b/test/core/services/sync/sync_data_serializer_record_ids_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
@@ -107,6 +108,31 @@ void main() {
     for (final entity in SyncService.entityHasUpdatedAt.keys) {
       await s.deleteAllRecords(entity); // must not throw on an empty table
     }
+  });
+
+  test('deleteAllRecords(settings) preserves device-local keys', () async {
+    // Replace-adopt clears each synced table before re-inserting the cloud
+    // union. A device-local key (active_diver_id) is excluded from every base
+    // (_exportSettings) AND from the re-insert (upsertRecords filter), so
+    // clearing it would permanently lose it. It must survive the clear (#447).
+    final db = DatabaseService.instance.database;
+    // Device-local key: upsertRecord filters it, so insert it directly.
+    await db.customStatement(
+      "INSERT INTO settings (key, value, updated_at) "
+      "VALUES ('active_diver_id', 'diver-1', 1)",
+    );
+    await SyncDataSerializer().upsertRecord('settings', {
+      'key': 'theme',
+      'value': 'dark',
+      'updatedAt': 1,
+    });
+
+    await SyncDataSerializer().deleteAllRecords('settings');
+
+    final keys = {for (final r in await db.select(db.settings).get()) r.key};
+    expect(keys, {
+      'active_diver_id',
+    }, reason: 'device-local key survives; the synced key is cleared');
   });
 }
 

--- a/test/core/services/sync/sync_data_serializer_record_ids_test.dart
+++ b/test/core/services/sync/sync_data_serializer_record_ids_test.dart
@@ -98,6 +98,16 @@ void main() {
       );
     }
   });
+
+  test('every synced entity has a deleteAllRecords case', () async {
+    // deleteAllRecords -> _syncTableFor throws on an entity with no case, so
+    // iterating every synced entity fails loudly if one is ever added without a
+    // case -- streaming Replace-adopt clears each synced table by entity (#358).
+    final s = SyncDataSerializer();
+    for (final entity in SyncService.entityHasUpdatedAt.keys) {
+      await s.deleteAllRecords(entity); // must not throw on an empty table
+    }
+  });
 }
 
 Map<String, dynamic> _site(String id) => {


### PR DESCRIPTION
## Summary

Closes the two remaining iOS OOM paths in #358. The earlier read-side fixes (#365 pull-base, #398 replace-adopt) got large-library sync *past the download*, but the reporter still crashed on v1.5.8. Device reproduction in this session showed there are **two distinct OOM paths left**, and this PR fixes both.

### 1. Write/publish side (Merge-mode)
A fresh device that cold-pulls a large library becomes a *publisher* on its next sync: with `hasBase == false` it re-serialized the **entire library** to publish its own base (`exportChangeset(null)` object graph + full `Uint8List` + `BaseChunker.slice` copy, held simultaneously ~3–4x). This was the documented deferred "write-side" follow-up from the 2026-06-20 design.

- New `BasePartFileSource` — reads a base temp file back out in 8 MB checksummed parts (mirror of `BasePartFileSink`).
- New `SyncDataSerializer.exportBaseToTempFile` — streams every row (keyset-paged by `id`, blob serializer for the 3 BLOB tables) to a temp file as `SyncPayload.toJson`, with a single-pass seek-back checksum.
- `ChangesetWriter.publish` (`!hasBase`) and `_compact` now stream + slice-upload instead of materializing the whole base. Peak memory: one page + one 8 MB buffer, independent of library size.

### 2. Replace-adopt side (the reporter's actual crash)
Device testing revealed the reporter's backend has a **library-epoch marker**, so an empty device takes the **Replace-adopt** path, not pull+publish. `_adoptApplyStreaming` still OOM'd because it built an in-RAM `cloudIds` set of every applied id **plus** per-entity `recordIdsFor` sets to compute delete-not-in-cloud — O(library size) Dart heap (~1.86 M ids for the reporter) — and applied rows **one-by-one**, freezing the UI for minutes.

- **Memory:** `delete-all-then-insert` (`deleteAllRecords`/`_syncTableFor`). Clearing each synced table then inserting the cloud union is equivalent to upsert-then-delete-not-in-cloud but needs **no id set** — adopt Dart heap is now O(batch).
- **Throughput:** batched `upsertRecords` (per-entity `insertAllOnConflictUpdate`), applying the base stream in 500-row batches. Measured: **600 k rows adopt in ~8 s** (was timing out at 30 s row-by-row).

## Verification
- Full suite: **9,473 passed / 12 skipped / 0 failed**; whole-project `dart format` + `flutter analyze` clean.
- **Adopt parity test stays byte-for-byte green** — delete-all-first + batching preserve the exact applied DB vs. the in-memory reference.
- New parity/round-trip tests for the streaming publish; coverage guards lock `upsertRecords`/`deleteAllRecords`/`recordIdsFor` to the identical 40-entity set (this caught a real gap — a missing `diveDiveTypes` case).

## Device verification: pending
On-device runtime confirmation (RSS stays bounded on the actual large library) is still to do — same status the earlier halves of #358 (#365/#398) merged with. Best confirmed via a TestFlight build to the reporter. Spec/plan for the write-side in `docs/superpowers/{specs,plans}/2026-06-30-sync-publish-base-oom-streaming*`; the adopt rework was driven by device reproduction in-session.