### PR TITLE
perf(sync): restore orphaned S2 batched-writes + S3 isolate parse (large-library sync speed)

### DIFF
--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'base_parse_worker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_parse_worker.dart';
 
 /// Thrown when the base-parse worker reports a parse/checksum error or dies.
 class BaseParseException implements Exception {
@@ -13,8 +13,8 @@ class BaseParseException implements Exception {
 
 /// Main-isolate client for the base-file parse worker. Spawns a worker that
 /// reads + parses a serialized sync base document off the UI isolate and streams
-/// decoded rows back, pull-backpressured. See [baseParseWorkerMain] for the wire
-/// protocol. Operations are sequential (one in flight at a time).
+/// decoded rows back, pull-backpressured (one ≤500-row batch per [nextDataBatch]).
+/// Operations are sequential — one in flight at a time.
 class BaseParseClient {
   BaseParseClient._(this._isolate, this._toWorker, this._fromWorker, this._sub);
 
@@ -22,8 +22,14 @@ class BaseParseClient {
   final SendPort _toWorker;
   final ReceivePort _fromWorker;
   final StreamSubscription<dynamic> _sub;
-  final StreamController<Map<dynamic, dynamic>> _inbox =
-      StreamController<Map<dynamic, dynamic>>.broadcast(sync: true);
+
+  // Buffered request/response mailbox: messages that arrive before a reader is
+  // waiting are queued, so a batch sent before the first [nextDataBatch] pull is
+  // never lost.
+  final List<Map<dynamic, dynamic>> _queue = [];
+  final List<Completer<Map<dynamic, dynamic>>> _waiters = [];
+  bool _dataFirstBatch = true;
+  bool _dataEnded = false;
 
   /// Spawns the worker for [filePath] and completes once its handshake arrives.
   static Future<BaseParseClient> spawn(String filePath) async {
@@ -35,11 +41,11 @@ class BaseParseClient {
       if (msg is Map && msg['type'] == 'ready') {
         ready.complete(msg['port'] as SendPort);
       } else if (msg is Map) {
-        client._inbox.add(msg);
+        client._deliver(msg);
       } else if (msg is List) {
         // An uncaught error in the worker arrives via `onError` as
         // [errorString, stackTraceString].
-        client._inbox.add(<String, Object>{
+        client._deliver(<String, Object>{
           'type': 'error',
           'message': msg.isNotEmpty ? msg.first.toString() : 'worker error',
         });
@@ -58,6 +64,32 @@ class BaseParseClient {
     return client;
   }
 
+  void _deliver(Map<dynamic, dynamic> m) {
+    if (_waiters.isNotEmpty) {
+      _waiters.removeAt(0).complete(m);
+    } else {
+      _queue.add(m);
+    }
+  }
+
+  Future<Map<dynamic, dynamic>> _nextMessage() {
+    if (_queue.isNotEmpty) return Future.value(_queue.removeAt(0));
+    final c = Completer<Map<dynamic, dynamic>>();
+    _waiters.add(c);
+    return c.future;
+  }
+
+  List<({String table, Map<String, dynamic> row})> _decodeRows(Object? raw) {
+    return (raw as List)
+        .map(
+          (e) => (
+            table: (e as Map)['table'] as String,
+            row: (e['row'] as Map).cast<String, dynamic>(),
+          ),
+        )
+        .toList();
+  }
+
   /// Pass 1: the `exportedAt` scalar plus every `deletions`-section row, in
   /// file order (`(table, row)` pairs).
   Future<
@@ -72,33 +104,49 @@ class BaseParseClient {
     if (m['type'] == 'error') {
       throw BaseParseException(m['message'] as String);
     }
-    final rows = (m['rows'] as List)
-        .map(
-          (e) => (
-            table: (e as Map)['table'] as String,
-            row: (e['row'] as Map).cast<String, dynamic>(),
-          ),
-        )
-        .toList();
-    return (exportedAt: m['exportedAt'] as int, deletions: rows);
+    return (
+      exportedAt: m['exportedAt'] as int,
+      deletions: _decodeRows(m['rows']),
+    );
   }
 
-  /// Awaits the next single worker message (request/response operations only).
-  Future<Map<dynamic, dynamic>> _nextMessage() {
-    final c = Completer<Map<dynamic, dynamic>>();
-    late final StreamSubscription<Map<dynamic, dynamic>> s;
-    s = _inbox.stream.listen((m) {
-      s.cancel();
-      c.complete(m);
+  /// Begins streaming `data`-section rows whose table is in [tables]. Pull the
+  /// batches with [nextDataBatch] until it returns null. Strict backpressure:
+  /// the worker parses one ≤500-row batch per pull.
+  void startDataRows(Set<String> tables) {
+    _dataFirstBatch = true;
+    _dataEnded = false;
+    _toWorker.send(<String, Object>{
+      'cmd': 'dataRows',
+      'tables': tables.toList(),
     });
-    return c.future;
+  }
+
+  /// The next ≤500-row batch of `(table, row)` pairs, or null when exhausted.
+  Future<List<({String table, Map<String, dynamic> row})>?>
+  nextDataBatch() async {
+    if (_dataEnded) return null;
+    if (!_dataFirstBatch) _toWorker.send(<String, Object>{'cmd': 'next'});
+    _dataFirstBatch = false;
+    final m = await _nextMessage();
+    if (m['type'] == 'error') {
+      throw BaseParseException(m['message'] as String);
+    }
+    if (m['done'] == true) _dataEnded = true;
+    return _decodeRows(m['rows']);
   }
 
   Future<void> dispose() async {
     _toWorker.send(<String, Object>{'cmd': 'dispose'});
     await _sub.cancel();
     _fromWorker.close();
-    if (!_inbox.isClosed) await _inbox.close();
+    for (final w in _waiters) {
+      if (!w.isCompleted) {
+        w.completeError(BaseParseException('client disposed'));
+      }
+    }
+    _waiters.clear();
+    _queue.clear();
     _isolate.kill(priority: Isolate.immediate);
   }
 }

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -58,6 +58,42 @@ class BaseParseClient {
     return client;
   }
 
+  /// Pass 1: the `exportedAt` scalar plus every `deletions`-section row, in
+  /// file order (`(table, row)` pairs).
+  Future<
+    ({
+      int exportedAt,
+      List<({String table, Map<String, dynamic> row})> deletions,
+    })
+  >
+  readScalarsAndDeletions() async {
+    _toWorker.send(<String, Object>{'cmd': 'deletions'});
+    final m = await _nextMessage();
+    if (m['type'] == 'error') {
+      throw BaseParseException(m['message'] as String);
+    }
+    final rows = (m['rows'] as List)
+        .map(
+          (e) => (
+            table: (e as Map)['table'] as String,
+            row: (e['row'] as Map).cast<String, dynamic>(),
+          ),
+        )
+        .toList();
+    return (exportedAt: m['exportedAt'] as int, deletions: rows);
+  }
+
+  /// Awaits the next single worker message (request/response operations only).
+  Future<Map<dynamic, dynamic>> _nextMessage() {
+    final c = Completer<Map<dynamic, dynamic>>();
+    late final StreamSubscription<Map<dynamic, dynamic>> s;
+    s = _inbox.stream.listen((m) {
+      s.cancel();
+      c.complete(m);
+    });
+    return c.future;
+  }
+
   Future<void> dispose() async {
     _toWorker.send(<String, Object>{'cmd': 'dispose'});
     await _sub.cancel();

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:submersion/core/services/sync/changeset_log/base_parse_worker.dart';
 
 /// Thrown when the base-parse worker reports a parse/checksum error or dies.
@@ -32,36 +33,91 @@ class BaseParseClient {
   bool _dataEnded = false;
 
   /// Spawns the worker for [filePath] and completes once its handshake arrives.
-  static Future<BaseParseClient> spawn(String filePath) async {
+  ///
+  /// Degrades to a thrown [BaseParseException] -- so the caller falls back to
+  /// the inline parse rather than hanging -- on any spawn/handshake failure:
+  /// the worker throwing before its 'ready' message, the isolate dying, or no
+  /// handshake within [handshakeTimeout]. The port, subscription, and isolate
+  /// it created are torn down before the error propagates.
+  ///
+  /// [entryPoint] and [handshakeTimeout] are injectable for tests only.
+  static Future<BaseParseClient> spawn(
+    String filePath, {
+    @visibleForTesting
+    void Function(List<Object>) entryPoint = baseParseWorkerMain,
+    @visibleForTesting Duration handshakeTimeout = const Duration(seconds: 10),
+  }) async {
     final fromWorker = ReceivePort();
     final ready = Completer<SendPort>();
-    late final BaseParseClient client;
+    // The client can't be built until the handshake lands, but worker messages
+    // (an early error, or -- defensively -- a stray response) can arrive first.
+    // Hold them until the client exists instead of touching a not-yet-built one
+    // (which would throw a LateInitializationError inside the listener).
+    BaseParseClient? client;
+    final preInit = <Map<dynamic, dynamic>>[];
+    void route(Map<dynamic, dynamic> m) {
+      if (client != null) {
+        client._deliver(m);
+      } else {
+        preInit.add(m);
+      }
+    }
 
     final sub = fromWorker.listen((msg) {
       if (msg is Map && msg['type'] == 'ready') {
-        ready.complete(msg['port'] as SendPort);
+        if (!ready.isCompleted) ready.complete(msg['port'] as SendPort);
       } else if (msg is Map) {
-        client._deliver(msg);
+        route(msg);
       } else if (msg is List) {
-        // An uncaught error in the worker arrives via `onError` as
-        // [errorString, stackTraceString].
-        client._deliver(<String, Object>{
-          'type': 'error',
-          'message': msg.isNotEmpty ? msg.first.toString() : 'worker error',
-        });
+        // An uncaught worker error arrives via `onError` as
+        // [errorString, stackTraceString]. Before the handshake, fail the spawn
+        // so the caller falls back; after it, deliver it as a normal error
+        // response so the in-flight pull rejects.
+        final message = msg.isNotEmpty ? msg.first.toString() : 'worker error';
+        if (!ready.isCompleted) {
+          ready.completeError(BaseParseException(message));
+        } else {
+          route(<String, Object>{'type': 'error', 'message': message});
+        }
       }
     });
 
-    final isolate = await Isolate.spawn(
-      baseParseWorkerMain,
-      <Object>[fromWorker.sendPort, filePath],
-      onError: fromWorker.sendPort,
-      errorsAreFatal: false,
-    );
+    // Backstop for a worker that dies without an `onError` (e.g. an OS OOM
+    // kill): without it a missing handshake would hang `ready.future` forever.
+    final timeout = Timer(handshakeTimeout, () {
+      if (!ready.isCompleted) {
+        ready.completeError(BaseParseException('worker handshake timed out'));
+      }
+    });
 
-    final toWorker = await ready.future;
-    client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
-    return client;
+    Isolate? isolate;
+    try {
+      isolate = await Isolate.spawn(
+        entryPoint,
+        <Object>[fromWorker.sendPort, filePath],
+        onError: fromWorker.sendPort,
+        errorsAreFatal: false,
+      );
+      final toWorker = await ready.future;
+      client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
+    } catch (_) {
+      // Spawn failed, the worker errored before handshake, or it timed out:
+      // tear down so we never leak the port/subscription/isolate, then rethrow
+      // so the caller degrades to the inline parse.
+      await sub.cancel();
+      fromWorker.close();
+      isolate?.kill(priority: Isolate.immediate);
+      rethrow;
+    } finally {
+      timeout.cancel();
+    }
+
+    // Flush anything that raced in between the handshake and assignment.
+    final spawned = client;
+    for (final m in preInit) {
+      spawned._deliver(m);
+    }
+    return spawned;
   }
 
   void _deliver(Map<dynamic, dynamic> m) {

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'base_parse_worker.dart';
+
+/// Thrown when the base-parse worker reports a parse/checksum error or dies.
+class BaseParseException implements Exception {
+  BaseParseException(this.message);
+  final String message;
+  @override
+  String toString() => 'BaseParseException: $message';
+}
+
+/// Main-isolate client for the base-file parse worker. Spawns a worker that
+/// reads + parses a serialized sync base document off the UI isolate and streams
+/// decoded rows back, pull-backpressured. See [baseParseWorkerMain] for the wire
+/// protocol. Operations are sequential (one in flight at a time).
+class BaseParseClient {
+  BaseParseClient._(this._isolate, this._toWorker, this._fromWorker, this._sub);
+
+  final Isolate _isolate;
+  final SendPort _toWorker;
+  final ReceivePort _fromWorker;
+  final StreamSubscription<dynamic> _sub;
+  final StreamController<Map<dynamic, dynamic>> _inbox =
+      StreamController<Map<dynamic, dynamic>>.broadcast(sync: true);
+
+  /// Spawns the worker for [filePath] and completes once its handshake arrives.
+  static Future<BaseParseClient> spawn(String filePath) async {
+    final fromWorker = ReceivePort();
+    final ready = Completer<SendPort>();
+    late final BaseParseClient client;
+
+    final sub = fromWorker.listen((msg) {
+      if (msg is Map && msg['type'] == 'ready') {
+        ready.complete(msg['port'] as SendPort);
+      } else if (msg is Map) {
+        client._inbox.add(msg);
+      } else if (msg is List) {
+        // An uncaught error in the worker arrives via `onError` as
+        // [errorString, stackTraceString].
+        client._inbox.add(<String, Object>{
+          'type': 'error',
+          'message': msg.isNotEmpty ? msg.first.toString() : 'worker error',
+        });
+      }
+    });
+
+    final isolate = await Isolate.spawn(
+      baseParseWorkerMain,
+      <Object>[fromWorker.sendPort, filePath],
+      onError: fromWorker.sendPort,
+      errorsAreFatal: false,
+    );
+
+    final toWorker = await ready.future;
+    client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
+    return client;
+  }
+
+  Future<void> dispose() async {
+    _toWorker.send(<String, Object>{'cmd': 'dispose'});
+    await _sub.cancel();
+    _fromWorker.close();
+    if (!_inbox.isClosed) await _inbox.close();
+    _isolate.kill(priority: Isolate.immediate);
+  }
+}

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -128,11 +128,25 @@ class BaseParseClient {
     }
   }
 
+  /// Per-message backstop: after the handshake, a worker can still die or hang
+  /// without delivering an `onError` (e.g. an OS OOM kill), which would leave a
+  /// waiting pull blocked forever and hang the whole sync. Time out and surface
+  /// a [BaseParseException] so the caller (readScalarsAndDeletions /
+  /// nextDataBatch) falls back to the inline parser. Injectable for tests.
+  @visibleForTesting
+  static Duration messageTimeout = const Duration(seconds: 60);
+
   Future<Map<dynamic, dynamic>> _nextMessage() {
     if (_queue.isNotEmpty) return Future.value(_queue.removeAt(0));
     final c = Completer<Map<dynamic, dynamic>>();
     _waiters.add(c);
-    return c.future;
+    return c.future.timeout(
+      messageTimeout,
+      onTimeout: () {
+        _waiters.remove(c);
+        throw BaseParseException('worker message timed out');
+      },
+    );
   }
 
   List<({String table, Map<String, dynamic> row})> _decodeRows(Object? raw) {

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
@@ -8,60 +9,120 @@ import 'package:submersion/core/services/sync/changeset_log/base_json_stream_rea
 ///
 /// Wire protocol (all messages are plain maps / SendPorts — isolate-sendable):
 ///   main -> worker:
-///     {'cmd': 'deletions'}                      (Pass 1)
-///     {'cmd': 'dataRows', 'tables': List<String>}  (start Pass 2/3 stream)
-///     {'cmd': 'next'}                           (pull the next data batch)
+///     {'cmd': 'deletions'}                          (Pass 1)
+///     {'cmd': 'dataRows', 'tables': [table names]}  (start a data-row stream)
+///     {'cmd': 'next'}                               (release one paused batch)
 ///     {'cmd': 'dispose'}
 ///   worker -> main:
-///     {'type': 'ready', 'port': SendPort}       (handshake)
+///     {'type': 'ready', 'port': SendPort}           (handshake)
 ///     {'type': 'deletions', 'exportedAt': int, 'rows': List}
 ///     {'type': 'batch', 'rows': List, 'done': bool}
 ///     {'type': 'error', 'message': String}
 ///
-/// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes a single message).
-void baseParseWorkerMain(List<Object> args) async {
+/// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes one message).
+void baseParseWorkerMain(List<Object> args) {
   final mainSendPort = args[0] as SendPort;
   final filePath = args[1] as String;
   final rx = ReceivePort();
   mainSendPort.send(<String, Object>{'type': 'ready', 'port': rx.sendPort});
 
-  await for (final msg in rx) {
-    final m = msg as Map;
-    if (m['cmd'] == 'dispose') break;
-
-    if (m['cmd'] == 'deletions') {
-      try {
-        var exportedAt = 0;
-        final rows = <Map<String, Object?>>[];
-        await BaseJsonStreamReader().parse(
-          File(filePath).openRead(),
-          onScalar: (key, raw) async {
-            if (key == 'exportedAt') {
-              exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
-            }
-          },
-          wantRows: (section, _) => section == 'deletions',
-          onRow: (section, table, rowBytes) async {
-            rows.add(<String, Object?>{
-              'table': table,
-              'row': jsonDecode(utf8.decode(rowBytes)),
-            });
-          },
-        );
-        mainSendPort.send(<String, Object>{
-          'type': 'deletions',
-          'exportedAt': exportedAt,
-          'rows': rows,
-        });
-      } catch (e) {
-        mainSendPort.send(<String, Object>{
-          'type': 'error',
-          'message': e.toString(),
-        });
-      }
-      continue;
+  // Backpressure: a dataRows parse pauses (awaits [awaitNext]) after each full
+  // batch; a 'next' command releases exactly one pause. The credit covers the
+  // race where 'next' would arrive before the parse reaches its pause.
+  Completer<void>? pendingNext;
+  var credits = 0;
+  Future<void> awaitNext() {
+    if (credits > 0) {
+      credits--;
+      return Future<void>.value();
     }
-    // 'dataRows' / 'next' handlers are added in Task 3.
+    pendingNext = Completer<void>();
+    return pendingNext!.future;
   }
-  rx.close();
+
+  void sendError(Object e) => mainSendPort.send(<String, Object>{
+    'type': 'error',
+    'message': e.toString(),
+  });
+
+  Future<void> runDeletions() async {
+    try {
+      var exportedAt = 0;
+      final rows = <Map<String, Object?>>[];
+      await BaseJsonStreamReader().parse(
+        File(filePath).openRead(),
+        onScalar: (key, raw) async {
+          if (key == 'exportedAt') {
+            exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+          }
+        },
+        wantRows: (section, _) => section == 'deletions',
+        onRow: (section, table, rowBytes) async {
+          rows.add(<String, Object?>{
+            'table': table,
+            'row': jsonDecode(utf8.decode(rowBytes)),
+          });
+        },
+      );
+      mainSendPort.send(<String, Object>{
+        'type': 'deletions',
+        'exportedAt': exportedAt,
+        'rows': rows,
+      });
+    } catch (e) {
+      sendError(e);
+    }
+  }
+
+  Future<void> runDataRows(Set<String> tables) async {
+    try {
+      var batch = <Map<String, Object?>>[];
+      await BaseJsonStreamReader().parse(
+        File(filePath).openRead(),
+        wantRows: (section, table) =>
+            section == 'data' && tables.contains(table),
+        onRow: (section, table, rowBytes) async {
+          batch.add(<String, Object?>{
+            'table': table,
+            'row': jsonDecode(utf8.decode(rowBytes)),
+          });
+          if (batch.length >= 500) {
+            mainSendPort.send(<String, Object>{
+              'type': 'batch',
+              'rows': batch,
+              'done': false,
+            });
+            batch = <Map<String, Object?>>[];
+            await awaitNext(); // pauses await-for -> pauses the file read
+          }
+        },
+      );
+      mainSendPort.send(<String, Object>{
+        'type': 'batch',
+        'rows': batch,
+        'done': true,
+      });
+    } catch (e) {
+      sendError(e);
+    }
+  }
+
+  rx.listen((msg) {
+    final m = msg as Map;
+    final cmd = m['cmd'];
+    if (cmd == 'dispose') {
+      rx.close();
+    } else if (cmd == 'next') {
+      if (pendingNext != null) {
+        pendingNext!.complete();
+        pendingNext = null;
+      } else {
+        credits++;
+      }
+    } else if (cmd == 'deletions') {
+      runDeletions();
+    } else if (cmd == 'dataRows') {
+      runDataRows((m['tables'] as List).cast<String>().toSet());
+    }
+  });
 }

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:isolate';
+
+import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
 
 /// Isolate entrypoint for the base-file parse worker.
 ///
@@ -17,14 +21,47 @@ import 'dart:isolate';
 /// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes a single message).
 void baseParseWorkerMain(List<Object> args) async {
   final mainSendPort = args[0] as SendPort;
-  // filePath (args[1]) is consumed by the command handlers added in later tasks.
+  final filePath = args[1] as String;
   final rx = ReceivePort();
   mainSendPort.send(<String, Object>{'type': 'ready', 'port': rx.sendPort});
 
   await for (final msg in rx) {
     final m = msg as Map;
     if (m['cmd'] == 'dispose') break;
-    // 'deletions' / 'dataRows' / 'next' handlers are added in Tasks 2-3.
+
+    if (m['cmd'] == 'deletions') {
+      try {
+        var exportedAt = 0;
+        final rows = <Map<String, Object?>>[];
+        await BaseJsonStreamReader().parse(
+          File(filePath).openRead(),
+          onScalar: (key, raw) async {
+            if (key == 'exportedAt') {
+              exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
+            }
+          },
+          wantRows: (section, _) => section == 'deletions',
+          onRow: (section, table, rowBytes) async {
+            rows.add(<String, Object?>{
+              'table': table,
+              'row': jsonDecode(utf8.decode(rowBytes)),
+            });
+          },
+        );
+        mainSendPort.send(<String, Object>{
+          'type': 'deletions',
+          'exportedAt': exportedAt,
+          'rows': rows,
+        });
+      } catch (e) {
+        mainSendPort.send(<String, Object>{
+          'type': 'error',
+          'message': e.toString(),
+        });
+      }
+      continue;
+    }
+    // 'dataRows' / 'next' handlers are added in Task 3.
   }
   rx.close();
 }

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -1,0 +1,30 @@
+import 'dart:isolate';
+
+/// Isolate entrypoint for the base-file parse worker.
+///
+/// Wire protocol (all messages are plain maps / SendPorts — isolate-sendable):
+///   main -> worker:
+///     {'cmd': 'deletions'}                      (Pass 1)
+///     {'cmd': 'dataRows', 'tables': List<String>}  (start Pass 2/3 stream)
+///     {'cmd': 'next'}                           (pull the next data batch)
+///     {'cmd': 'dispose'}
+///   worker -> main:
+///     {'type': 'ready', 'port': SendPort}       (handshake)
+///     {'type': 'deletions', 'exportedAt': int, 'rows': List}
+///     {'type': 'batch', 'rows': List, 'done': bool}
+///     {'type': 'error', 'message': String}
+///
+/// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes a single message).
+void baseParseWorkerMain(List<Object> args) async {
+  final mainSendPort = args[0] as SendPort;
+  // filePath (args[1]) is consumed by the command handlers added in later tasks.
+  final rx = ReceivePort();
+  mainSendPort.send(<String, Object>{'type': 'ready', 'port': rx.sendPort});
+
+  await for (final msg in rx) {
+    final m = msg as Map;
+    if (m['cmd'] == 'dispose') break;
+    // 'deletions' / 'dataRows' / 'next' handlers are added in Tasks 2-3.
+  }
+  rx.close();
+}

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -58,10 +58,18 @@ void baseParseWorkerMain(List<Object> args) {
         },
         wantRows: (section, _) => section == 'deletions',
         onRow: (section, table, rowBytes) async {
-          rows.add(<String, Object?>{
-            'table': table,
-            'row': jsonDecode(utf8.decode(rowBytes)),
-          });
+          final decoded = jsonDecode(utf8.decode(rowBytes));
+          // A legacy base can encode a deletion as a bare string id. Normalise
+          // it to the {id, deletedAt: 0} map the inline path synthesises, so the
+          // wire row is always a map (what _decodeRows expects) and the
+          // via-worker apply stays byte-identical for these peers instead of
+          // crashing _decodeRows and forcing a fallback. Non-map/non-string
+          // rows are dropped, mirroring the inline path's silent skip.
+          final Object? row = decoded is String
+              ? <String, Object?>{'id': decoded, 'deletedAt': 0}
+              : decoded;
+          if (row is! Map) return;
+          rows.add(<String, Object?>{'table': table, 'row': row});
         },
       );
       mainSendPort.send(<String, Object>{

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1297,6 +1297,138 @@ class SyncDataSerializer {
     return null;
   }
 
+  /// Batched [fetchRecord] for the `hasUpdatedAt` (LWW) entities the merge
+  /// compares against: local rows keyed by record id, fetched with one
+  /// `WHERE id IN (...)` select. Mirrors [fetchRecord] per entity --
+  /// `settings` keys on its `key` column and `certifications` carries a BLOB.
+  /// Any other entity (the clockless composite-key junctions, which the merge
+  /// never fetches) falls back to a per-id loop so the method stays total.
+  Future<Map<String, Map<String, dynamic>>> fetchRecords(
+    String entityType,
+    Iterable<String> ids,
+  ) async {
+    final idList = ids.toList();
+    if (idList.isEmpty) return {};
+    switch (entityType) {
+      case 'divers':
+        final rows = await (_db.select(
+          _db.divers,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diverSettings':
+        final rows = await (_db.select(
+          _db.diverSettings,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'dives':
+        final rows = await (_db.select(
+          _db.dives,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveSites':
+        final rows = await (_db.select(
+          _db.diveSites,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'equipment':
+        final rows = await (_db.select(
+          _db.equipment,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'equipmentSets':
+        final rows = await (_db.select(
+          _db.equipmentSets,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'buddies':
+        final rows = await (_db.select(
+          _db.buddies,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveCenters':
+        final rows = await (_db.select(
+          _db.diveCenters,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'trips':
+        final rows = await (_db.select(
+          _db.trips,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'liveaboardDetails':
+        final rows = await (_db.select(
+          _db.liveaboardDetailRecords,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'itineraryDays':
+        final rows = await (_db.select(
+          _db.tripItineraryDays,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveTypes':
+        final rows = await (_db.select(
+          _db.diveTypes,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'tankPresets':
+        final rows = await (_db.select(
+          _db.tankPresets,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'diveComputers':
+        final rows = await (_db.select(
+          _db.diveComputers,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'tags':
+        final rows = await (_db.select(
+          _db.tags,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'courses':
+        final rows = await (_db.select(
+          _db.courses,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'serviceRecords':
+        final rows = await (_db.select(
+          _db.serviceRecords,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'csvPresets':
+        final rows = await (_db.select(
+          _db.csvPresets,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'viewConfigs':
+        final rows = await (_db.select(
+          _db.viewConfigs,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
+      case 'certifications':
+        final rows = await (_db.select(
+          _db.certifications,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {
+          for (final r in rows) r.id: r.toJson(serializer: _syncBlobSerializer),
+        };
+      case 'settings':
+        final rows = await (_db.select(
+          _db.settings,
+        )..where((t) => t.key.isIn(idList))).get();
+        return {for (final r in rows) r.key: r.toJson()};
+      default:
+        // Clockless / composite-key entities are never fetched by the merge;
+        // fall back to per-id reads so the method is total and correct.
+        final out = <String, Map<String, dynamic>>{};
+        for (final id in idList) {
+          final row = await fetchRecord(entityType, id);
+          if (row != null) out[id] = row;
+        }
+        return out;
+    }
+  }
+
   Future<void> upsertRecord(
     String entityType,
     Map<String, dynamic> data,

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1309,6 +1309,19 @@ class SyncDataSerializer {
   ) async {
     final idList = ids.toList();
     if (idList.isEmpty) return {};
+    // Chunk to stay under SQLite's bound-variable limit (~999): a large
+    // changeset apply can pass thousands of ids, which would overflow a single
+    // `WHERE id IN (...)` with "too many SQL variables". Each chunk recurses to
+    // the per-entity switch below (a slice <= idChunk skips this branch).
+    const idChunk = 900;
+    if (idList.length > idChunk) {
+      final merged = <String, Map<String, dynamic>>{};
+      for (var i = 0; i < idList.length; i += idChunk) {
+        final end = (i + idChunk < idList.length) ? i + idChunk : idList.length;
+        merged.addAll(await fetchRecords(entityType, idList.sublist(i, end)));
+      }
+      return merged;
+    }
     switch (entityType) {
       case 'divers':
         final rows = await (_db.select(

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -973,9 +973,10 @@ class SyncService {
   ///   2. parent-row id->updatedAt and contradiction keys (skips giant tables),
   ///   3. batched apply of every row through the existing [_mergeEntity].
   /// Applies a peer's base file. Tries the worker-isolate path (file read +
-  /// parse + SHA off the UI isolate) and falls back to the inline path on any
-  /// worker failure, so a broken isolate degrades to old behaviour and never
-  /// fails or corrupts sync.
+  /// JSON parse off the UI isolate; the whole-file SHA-256 still runs on the
+  /// main isolate in BasePartFileSink.assemble -- folding it in is a deferred
+  /// follow-up) and falls back to the inline path on any worker failure, so a
+  /// broken isolate degrades to old behaviour and never fails or corrupts sync.
   Future<_MergeResult> _applyRemoteBaseFile(
     String filePath,
     DateTime? localLastSync,
@@ -996,10 +997,11 @@ class SyncService {
     }
   }
 
-  /// Worker-backed base apply: the file read + parse + SHA run in [client]'s
-  /// isolate; only the merge/writes run here. Mirrors
-  /// [_applyRemoteBaseFileInline] exactly, fed by streamed rows in file order
-  /// instead of an inline parse (so per-table batching and mergeOrder match).
+  /// Worker-backed base apply: the file read + JSON parse run in [client]'s
+  /// isolate; the merge/writes (and, for now, the whole-file SHA-256 in
+  /// BasePartFileSink.assemble) run here. Mirrors [_applyRemoteBaseFileInline]
+  /// exactly, fed by streamed rows in file order instead of an inline parse (so
+  /// per-table batching and mergeOrder match).
   Future<_MergeResult> _applyRemoteBaseFileViaWorker(
     BaseParseClient client,
     DateTime? localLastSync,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1533,6 +1533,19 @@ class SyncService {
     final selfTombstones = allTombstones[entityType] ?? const <String, int>{};
     final entityParentRefs = parentRefs[entityType] ?? const <ParentRef>[];
 
+    // Read-decide-write: batch-fetch every local row the LWW compare needs in
+    // one query (the clockless path needs no read). Each decision below reads
+    // only this pre-fetched map plus the pre-fetched tombstone/pending maps --
+    // never a row written earlier in this loop -- so deferring all writes to a
+    // single batch at the end cannot change any decision.
+    final localById = hasUpdatedAt
+        ? await _serializer.fetchRecords(entityType, [
+            for (final record in records)
+              ?_recordIdForEntity(entityType, record),
+          ])
+        : const <String, Map<String, dynamic>>{};
+    final toUpsert = <Map<String, dynamic>>[];
+
     for (final record in records) {
       String? recordId;
       int? localUpdatedAt;
@@ -1608,12 +1621,12 @@ class SyncService {
         }
 
         if (!hasUpdatedAt) {
-          await _serializer.upsertRecord(entityType, recordToApply);
+          toUpsert.add(recordToApply);
           applied += 1;
           continue;
         }
 
-        final local = await _serializer.fetchRecord(entityType, recordId);
+        final local = localById[recordId];
         localUpdatedAt = _extractUpdatedAtMillis(local);
         final remoteUpdatedAt = _extractUpdatedAtMillis(record);
 
@@ -1632,7 +1645,7 @@ class SyncService {
         // remote HLC wins; an exact tie or a local-newer HLC keeps local.
         if (localHlc != null && remoteHlc != null) {
           if (remoteHlc.compareTo(localHlc) > 0) {
-            await _serializer.upsertRecord(entityType, recordToApply);
+            toUpsert.add(recordToApply);
             applied += 1;
           }
           continue;
@@ -1659,7 +1672,7 @@ class SyncService {
         if (remoteUpdatedAt == null ||
             localUpdatedAt == null ||
             remoteUpdatedAt >= localUpdatedAt) {
-          await _serializer.upsertRecord(entityType, recordToApply);
+          toUpsert.add(recordToApply);
           applied += 1;
         }
       } catch (e, stackTrace) {
@@ -1672,6 +1685,24 @@ class SyncService {
         // sides edited the same record). Masking apply errors as conflicts is
         // what hid the cross-device no-op; count it so performSync surfaces it.
         failed += 1;
+      }
+    }
+
+    // Read-decide-write flush: one batched write for the whole merge-batch.
+    // Drift's batch is all-or-nothing, so a failure fails every row it would
+    // have applied -- move those from applied to failed, mirroring the per-row
+    // catch above.
+    if (toUpsert.isNotEmpty) {
+      try {
+        await _serializer.upsertRecords(entityType, toUpsert);
+      } catch (e, stackTrace) {
+        _log.error(
+          'Failed to batch-upsert $entityType (${toUpsert.length} rows)',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        failed += toUpsert.length;
+        applied -= toUpsert.length;
       }
     }
 

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
@@ -196,6 +197,13 @@ class SyncService {
   );
 
   SyncProgressCallback? _progressCallback;
+
+  /// Test seam: how the base apply spawns its parse worker. Overridable so a
+  /// forced-failure test can verify the inline fallback; production uses the
+  /// real isolate spawn.
+  @visibleForTesting
+  Future<BaseParseClient> Function(String filePath) baseParseClientSpawn =
+      BaseParseClient.spawn;
 
   SyncService({
     required SyncRepository syncRepository,
@@ -964,11 +972,167 @@ class SyncService {
   ///   1. header `exportedAt` + the full `deletions` map (both small),
   ///   2. parent-row id->updatedAt and contradiction keys (skips giant tables),
   ///   3. batched apply of every row through the existing [_mergeEntity].
+  /// Applies a peer's base file. Tries the worker-isolate path (file read +
+  /// parse + SHA off the UI isolate) and falls back to the inline path on any
+  /// worker failure, so a broken isolate degrades to old behaviour and never
+  /// fails or corrupts sync.
+  Future<_MergeResult> _applyRemoteBaseFile(
+    String filePath,
+    DateTime? localLastSync,
+  ) async {
+    BaseParseClient? client;
+    try {
+      client = await baseParseClientSpawn(filePath);
+      return await _applyRemoteBaseFileViaWorker(client, localLastSync);
+    } catch (e, st) {
+      _log.warning(
+        'Base-apply worker failed; falling back to inline',
+        error: e,
+        stackTrace: st,
+      );
+      return _applyRemoteBaseFileInline(filePath, localLastSync);
+    } finally {
+      await client?.dispose();
+    }
+  }
+
+  /// Worker-backed base apply: the file read + parse + SHA run in [client]'s
+  /// isolate; only the merge/writes run here. Mirrors
+  /// [_applyRemoteBaseFileInline] exactly, fed by streamed rows in file order
+  /// instead of an inline parse (so per-table batching and mergeOrder match).
+  Future<_MergeResult> _applyRemoteBaseFileViaWorker(
+    BaseParseClient client,
+    DateTime? localLastSync,
+  ) async {
+    final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
+
+    // ---- Pass 1: exportedAt + deletions ----
+    final p1 = await client.readScalarsAndDeletions();
+    final baseExportedAt = p1.exportedAt;
+    final deletions = <String, List<SyncDeletion>>{};
+    for (final e in p1.deletions) {
+      (deletions[e.table] ??= []).add(SyncDeletion.fromJson(e.row));
+    }
+
+    final pendingByEntity = await _pendingRecordMap();
+
+    // ---- Pass 2: parent updatedAt + contradiction keys ----
+    final parentTypes = <String>{
+      for (final refs in parentRefs.values)
+        for (final ref in refs) ref.parent,
+    };
+    final deletionIds = <String, Set<String>>{
+      for (final e in deletions.entries) e.key: {for (final d in e.value) d.id},
+    };
+    final parentUpdatedAt = <String, Map<String, int>>{};
+    final contradictedByEntity = <String, Set<String>>{};
+    final pass2Tables = <String>{
+      for (final table in entityHasUpdatedAt.keys)
+        if (parentTypes.contains(table) || deletionIds.containsKey(table))
+          table,
+    };
+    client.startDataRows(pass2Tables);
+    List<({String table, Map<String, dynamic> row})>? p2batch;
+    while ((p2batch = await client.nextDataBatch()) != null) {
+      for (final r in p2batch!) {
+        final table = r.table;
+        final rec = r.row;
+        final id = _recordIdForEntity(table, rec);
+        if (id == null) continue;
+        if (parentTypes.contains(table) && entityHasUpdatedAt[table] == true) {
+          final u = _extractUpdatedAtMillis(rec);
+          if (u != null) (parentUpdatedAt[table] ??= {})[id] = u;
+        }
+        if (deletionIds[table]?.contains(id) == true) {
+          (contradictedByEntity[table] ??= {}).add(id);
+        }
+      }
+    }
+
+    // ---- Apply, all inside one deferred-FK transaction ----
+    return _serializer.applyInDeferredFkTransaction(() async {
+      var recordsApplied = 0;
+      var conflictsFound = 0;
+      var recordsFailed = 0;
+
+      final delResult = await _applyRemoteDeletions(
+        deletions,
+        lastSyncMs,
+        baseExportedAt,
+        pendingByEntity,
+        contradictedByEntity,
+      );
+      recordsApplied += delResult.recordsApplied;
+      conflictsFound += delResult.conflictsFound;
+      recordsFailed += delResult.recordsFailed;
+
+      final tombstonesByEntity = await _deletionMap();
+
+      final revivedParents = <String, Set<String>>{};
+      for (final parentType in parentTypes) {
+        final tombs = tombstonesByEntity[parentType];
+        final ups = parentUpdatedAt[parentType];
+        if (tombs == null || tombs.isEmpty || ups == null) continue;
+        ups.forEach((id, updatedAt) {
+          final deletedAt = tombs[id];
+          if (deletedAt != null && updatedAt > deletedAt) {
+            (revivedParents[parentType] ??= {}).add(id);
+          }
+        });
+      }
+
+      // ---- Pass 3: batched apply ----
+      const batchSize = 500;
+      String? currentTable;
+      var batch = <Map<String, dynamic>>[];
+
+      Future<void> flush() async {
+        final table = currentTable;
+        if (table == null || batch.isEmpty) return;
+        final r = await _mergeEntity(
+          entityType: table,
+          records: batch,
+          hasUpdatedAt: entityHasUpdatedAt[table] ?? false,
+          lastSyncMs: lastSyncMs,
+          pendingRecordIds: pendingByEntity[table] ?? const <String>{},
+          allTombstones: tombstonesByEntity,
+          revivedParents: revivedParents,
+          contradicted: contradictedByEntity[table] ?? const <String>{},
+        );
+        recordsApplied += r.recordsApplied;
+        conflictsFound += r.conflictsFound;
+        recordsFailed += r.recordsFailed;
+        batch = <Map<String, dynamic>>[];
+      }
+
+      client.startDataRows(entityHasUpdatedAt.keys.toSet());
+      List<({String table, Map<String, dynamic> row})>? p3batch;
+      while ((p3batch = await client.nextDataBatch()) != null) {
+        for (final r in p3batch!) {
+          if (r.table != currentTable) {
+            await flush();
+            currentTable = r.table;
+          }
+          batch.add(r.row);
+          if (batch.length >= batchSize) await flush();
+        }
+      }
+      await flush();
+
+      await _serializer.repairDanglingForeignKeys();
+      return _MergeResult(
+        recordsApplied: recordsApplied,
+        conflictsFound: conflictsFound,
+        recordsFailed: recordsFailed,
+      );
+    });
+  }
+
   /// Reuses the same merge primitives as [_applyRemotePayloadInner], so the
   /// result is identical to applying the equivalent in-memory payload, but peak
   /// memory stays at one ~8 MB part download + one batch of rows regardless of
   /// library size (issue #358).
-  Future<_MergeResult> _applyRemoteBaseFile(
+  Future<_MergeResult> _applyRemoteBaseFileInline(
     String filePath,
     DateTime? localLastSync,
   ) async {

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
+
+File _writeBase(Directory dir, Map<String, dynamic> doc) {
+  final f = File(p.join(dir.path, 'base.json'));
+  f.writeAsStringSync(jsonEncode(doc));
+  return f;
+}
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('spawns and disposes without hanging', () async {
+    final f = _writeBase(tmp, {
+      'exportedAt': 1,
+      'deletions': <String, dynamic>{},
+      'data': <String, dynamic>{},
+    });
+    final client = await BaseParseClient.spawn(f.path);
+    await client.dispose();
+  });
+}

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -11,6 +11,17 @@ File _writeBase(Directory dir, Map<String, dynamic> doc) {
   return f;
 }
 
+/// Test worker that throws before sending the 'ready' handshake (reaches the
+/// main isolate as an `onError` message).
+void _workerThrowsBeforeReady(List<Object> args) {
+  throw StateError('boom before ready');
+}
+
+/// Test worker that exits without ever sending the 'ready' handshake.
+void _workerSilentNoHandshake(List<Object> args) {
+  // Intentionally no handshake: exercises the spawn timeout backstop.
+}
+
 void main() {
   late Directory tmp;
   setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
@@ -55,6 +66,35 @@ void main() {
   );
 
   test(
+    'readScalarsAndDeletions normalizes a legacy bare-string deletion row',
+    () async {
+      // Old bases encode a deletion as a bare JSON string id; the inline path
+      // synthesizes {id, deletedAt: 0} for these. The worker must match, or
+      // these peers crash _decodeRows (cast to Map) and lose the offload.
+      final doc = {
+        'exportedAt': 7,
+        'deletions': {
+          'dives': [
+            'legacy-string-id',
+            {'id': 'modern', 'deletedAt': 500},
+          ],
+        },
+        'data': <String, dynamic>{},
+      };
+      final f = _writeBase(tmp, doc);
+      final client = await BaseParseClient.spawn(f.path);
+      final r = await client.readScalarsAndDeletions();
+      await client.dispose();
+
+      expect(r.deletions.map((e) => e.table).toList(), ['dives', 'dives']);
+      expect(r.deletions[0].row['id'], 'legacy-string-id');
+      expect(r.deletions[0].row['deletedAt'], 0);
+      expect(r.deletions[1].row['id'], 'modern');
+      expect(r.deletions[1].row['deletedAt'], 500);
+    },
+  );
+
+  test(
     'dataRows streams filtered data rows in file order across batches',
     () async {
       final doc = {
@@ -91,4 +131,42 @@ void main() {
       ); // order preserved across the 500-row boundaries
     },
   );
+
+  test(
+    'spawn rejects (does not hang) when the worker errors before handshake',
+    () async {
+      final f = _writeBase(tmp, {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': <String, dynamic>{},
+      });
+      // A worker error before 'ready' must surface as a thrown exception so the
+      // caller falls back to inline -- never an unhandled LateInitializationError
+      // that leaves the spawn Future hanging forever. The .timeout guard turns a
+      // regression (hang) into a TimeoutException, failing this expectation.
+      await expectLater(
+        BaseParseClient.spawn(
+          f.path,
+          entryPoint: _workerThrowsBeforeReady,
+        ).timeout(const Duration(seconds: 5)),
+        throwsA(isA<BaseParseException>()),
+      );
+    },
+  );
+
+  test('spawn rejects when no handshake arrives within the timeout', () async {
+    final f = _writeBase(tmp, {
+      'exportedAt': 1,
+      'deletions': <String, dynamic>{},
+      'data': <String, dynamic>{},
+    });
+    await expectLater(
+      BaseParseClient.spawn(
+        f.path,
+        entryPoint: _workerSilentNoHandshake,
+        handshakeTimeout: const Duration(milliseconds: 300),
+      ).timeout(const Duration(seconds: 5)),
+      throwsA(isA<BaseParseException>()),
+    );
+  });
 }

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -25,4 +25,32 @@ void main() {
     final client = await BaseParseClient.spawn(f.path);
     await client.dispose();
   });
+
+  test(
+    'readScalarsAndDeletions returns exportedAt + deletions in file order',
+    () async {
+      final doc = {
+        'exportedAt': 42,
+        'deletions': {
+          'dives': [
+            {'id': 'd1', 'deletedAt': 100},
+            {'id': 'd2', 'deletedAt': 200},
+          ],
+        },
+        'data': {
+          'dives': [
+            {'id': 'a', 'updatedAt': 1},
+          ],
+        },
+      };
+      final f = _writeBase(tmp, doc);
+      final client = await BaseParseClient.spawn(f.path);
+      final r = await client.readScalarsAndDeletions();
+      await client.dispose();
+
+      expect(r.exportedAt, 42);
+      expect(r.deletions.map((e) => e.table).toList(), ['dives', 'dives']);
+      expect(r.deletions.map((e) => e.row['id']).toList(), ['d1', 'd2']);
+    },
+  );
 }

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -53,4 +53,42 @@ void main() {
       expect(r.deletions.map((e) => e.row['id']).toList(), ['d1', 'd2']);
     },
   );
+
+  test(
+    'dataRows streams filtered data rows in file order across batches',
+    () async {
+      final doc = {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': {
+          'dives': [
+            for (var i = 0; i < 1200; i++) {'id': 'd$i', 'updatedAt': i},
+          ],
+          'sites': [
+            {'id': 's1', 'updatedAt': 1},
+          ],
+        },
+      };
+      final f = _writeBase(tmp, doc);
+      final client = await BaseParseClient.spawn(f.path);
+
+      client.startDataRows({'dives'});
+      final got = <String>[];
+      List<({String table, Map<String, dynamic> row})>? batch;
+      while ((batch = await client.nextDataBatch()) != null) {
+        for (final r in batch!) {
+          expect(r.table, 'dives'); // 'sites' filtered out
+          got.add(r.row['id'] as String);
+        }
+      }
+      await client.dispose();
+
+      expect(got.length, 1200);
+      expect(got.first, 'd0');
+      expect(
+        got.last,
+        'd1199',
+      ); // order preserved across the 500-row boundaries
+    },
+  );
 }

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -22,6 +23,16 @@ void _workerSilentNoHandshake(List<Object> args) {
   // Intentionally no handshake: exercises the spawn timeout backstop.
 }
 
+/// Test worker that completes the handshake, then never answers a command --
+/// exercises the per-message timeout backstop in _nextMessage (a worker that
+/// dies/hangs after the handshake without an onError).
+void _workerReadyThenSilent(List<Object> args) {
+  final toMain = args[0] as SendPort;
+  final cmdPort = ReceivePort();
+  toMain.send(<String, Object>{'type': 'ready', 'port': cmdPort.sendPort});
+  cmdPort.listen((_) {}); // stay alive, but never reply
+}
+
 void main() {
   late Directory tmp;
   setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
@@ -36,6 +47,34 @@ void main() {
     final client = await BaseParseClient.spawn(f.path);
     await client.dispose();
   });
+
+  test(
+    'times out (not hang) when the worker goes silent after handshake',
+    () async {
+      final f = _writeBase(tmp, {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': <String, dynamic>{},
+      });
+      final original = BaseParseClient.messageTimeout;
+      BaseParseClient.messageTimeout = const Duration(milliseconds: 300);
+      try {
+        final client = await BaseParseClient.spawn(
+          f.path,
+          entryPoint: _workerReadyThenSilent,
+        );
+        // A pull against a silent worker must surface a BaseParseException (so the
+        // SyncService caller falls back to the inline parser) rather than hang.
+        await expectLater(
+          client.readScalarsAndDeletions(),
+          throwsA(isA<BaseParseException>()),
+        );
+        await client.dispose();
+      } finally {
+        BaseParseClient.messageTimeout = original;
+      }
+    },
+  );
 
   test(
     'readScalarsAndDeletions returns exportedAt + deletions in file order',

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -76,6 +76,36 @@ void main() {
     },
   );
 
+  test('surfaces a worker parse error as BaseParseException', () async {
+    // A corrupt base file: the real worker fails to read/parse and reports an
+    // error, which the client raises so the caller falls back to inline.
+    final f = File(p.join(tmp.path, 'base.json'))
+      ..writeAsStringSync('{ not valid json');
+    await expectLater(() async {
+      final client = await BaseParseClient.spawn(f.path);
+      try {
+        await client.readScalarsAndDeletions();
+      } finally {
+        await client.dispose();
+      }
+    }(), throwsA(isA<BaseParseException>()));
+  });
+
+  test('dispose completes a pending pull with an error (no hang)', () async {
+    final f = _writeBase(tmp, {
+      'exportedAt': 1,
+      'deletions': <String, dynamic>{},
+      'data': <String, dynamic>{},
+    });
+    final client = await BaseParseClient.spawn(
+      f.path,
+      entryPoint: _workerReadyThenSilent,
+    );
+    final pending = client.readScalarsAndDeletions();
+    await client.dispose();
+    await expectLater(pending, throwsA(isA<BaseParseException>()));
+  });
+
   test(
     'readScalarsAndDeletions returns exportedAt + deletions in file order',
     () async {

--- a/test/core/services/sync/sync_base_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_base_streaming_parity_test.dart
@@ -231,4 +231,43 @@ void main() {
       expect(dumpB, dumpA);
     },
   );
+
+  test(
+    'a worker-spawn failure falls back to inline and still applies',
+    () async {
+      await _seedRichLibrary();
+      final payload = await SyncDataSerializer().exportData(
+        deviceId: 'peer',
+        deletions: await SyncRepository().getAllDeletions(),
+      );
+
+      // In-memory baseline.
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      await SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+      ).debugApplyPayload(payload);
+      final dumpInMemory = await _exportCanonical();
+
+      // Worker spawn forced to fail -> must fall back to the inline file apply.
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      final tmpDir = await Directory.systemTemp.createTemp('parity_fallback');
+      final tmp = File('${tmpDir.path}/base.json');
+      await tmp.writeAsBytes(
+        utf8.encode(SyncDataSerializer().serializePayload(payload)),
+      );
+      final svc = SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+      )..baseParseClientSpawn = (_) async => throw StateError('forced failure');
+      final counts = await svc.debugApplyBaseFile(tmp.path);
+      final dumpFallback = await _exportCanonical();
+      await tmpDir.delete(recursive: true);
+
+      expect(dumpFallback, dumpInMemory, reason: 'inline fallback must match');
+      expect(counts.recordsFailed, 0);
+    },
+  );
 }

--- a/test/core/services/sync/sync_data_serializer_batch_coverage_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_coverage_test.dart
@@ -84,7 +84,7 @@ void main() {
 
   group('batched upsertRecords', () {
     test(
-      'every single-PK entity round-trips fetchRecord -> upsertRecords',
+      'every single-PK entity round-trips fetchRecord -> upsertRecords -> fetchRecords',
       () async {
         // Minimal placeholder rows need not satisfy parent references.
         await db.customStatement('PRAGMA foreign_keys = OFF');
@@ -153,11 +153,16 @@ void main() {
           // Batched write: feed the row's own JSON back (a conflict-update).
           await serializer.upsertRecords(t.type, [json!]);
 
-          // The row still reads back after the batched upsert.
+          // Batched read: every entity arm, matching the per-id read and
+          // dropping absent ids.
+          final got = await serializer.fetchRecords(t.type, [id, 'absent-id']);
+          expect(got.keys.toSet(), {
+            id,
+          }, reason: 'fetchRecords(${t.type}) keys');
           expect(
+            got[id],
             await serializer.fetchRecord(t.type, id),
-            isNotNull,
-            reason: '${t.type} survives its own batched upsert',
+            reason: 'batched read == per-id read for ${t.type}',
           );
         }
       },

--- a/test/core/services/sync/sync_data_serializer_batch_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+Map<String, dynamic> _diver(String id, String name, {int updatedAt = 1}) => {
+  'id': id,
+  'name': name,
+  'medicalNotes': '',
+  'notes': '',
+  'isDefault': false,
+  'createdAt': 1,
+  'updatedAt': updatedAt,
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async => setUpTestDatabase());
+  tearDown(() async => tearDownTestDatabase());
+
+  test(
+    'upsertRecords writes all records and conflict-updates in place',
+    () async {
+      final s = SyncDataSerializer();
+      await s.upsertRecords('divers', [_diver('a', 'A'), _diver('b', 'B')]);
+      expect((await s.fetchRecord('divers', 'a'))?['name'], 'A');
+      expect((await s.fetchRecord('divers', 'b'))?['name'], 'B');
+
+      // Re-upsert 'a' with a new name updates in place (insertOnConflictUpdate).
+      await s.upsertRecords('divers', [_diver('a', 'A2', updatedAt: 2)]);
+      expect((await s.fetchRecord('divers', 'a'))?['name'], 'A2');
+    },
+  );
+
+  test('upsertRecords is a no-op for an empty list', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecords('divers', const []);
+    expect(await s.fetchRecord('divers', 'a'), isNull);
+  });
+
+  test(
+    'fetchRecords returns id-keyed rows matching per-id fetchRecord',
+    () async {
+      final s = SyncDataSerializer();
+      await s.upsertRecords('divers', [_diver('a', 'A'), _diver('b', 'B')]);
+      final got = await s.fetchRecords('divers', ['a', 'b', 'missing']);
+      expect(got.keys.toSet(), {'a', 'b'}); // absent ids simply absent
+      expect(got['a'], await s.fetchRecord('divers', 'a'));
+      expect(got['b'], await s.fetchRecord('divers', 'b'));
+    },
+  );
+
+  test('fetchRecords keys settings by their key column (not id)', () async {
+    final s = SyncDataSerializer();
+    await s.upsertRecords('settings', [
+      {'key': 'theme', 'value': 'dark', 'updatedAt': 1},
+      {'key': 'units', 'value': 'metric', 'updatedAt': 1},
+    ]);
+    final got = await s.fetchRecords('settings', ['theme', 'units']);
+    expect(got.keys.toSet(), {'theme', 'units'});
+    expect(got['theme'], await s.fetchRecord('settings', 'theme'));
+  });
+}

--- a/test/core/services/sync/sync_data_serializer_batch_test.dart
+++ b/test/core/services/sync/sync_data_serializer_batch_test.dart
@@ -61,4 +61,24 @@ void main() {
     expect(got.keys.toSet(), {'theme', 'units'});
     expect(got['theme'], await s.fetchRecord('settings', 'theme'));
   });
+
+  test(
+    'fetchRecords chunks past the SQLite variable limit (>900 ids)',
+    () async {
+      // A single `WHERE id IN (...)` with >999 ids overflows SQLite's
+      // bound-variable limit ("too many SQL variables"); a large changeset apply
+      // hits this, so fetchRecords must chunk the id list (#448 review).
+      final s = SyncDataSerializer();
+      const n = 1500;
+      await s.upsertRecords('divers', [
+        for (var i = 0; i < n; i++) _diver('d$i', 'N$i'),
+      ]);
+      final got = await s.fetchRecords('divers', [
+        for (var i = 0; i < n; i++) 'd$i',
+      ]);
+      expect(got.length, n);
+      expect(got['d0'], isNotNull);
+      expect(got['d${n - 1}'], isNotNull);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Restores the sync **performance** work (S2 batched writes + S3 isolate parse) that was **merged but orphaned from `main`**, and re-applies it cleanly on top of #447.

**Stacked on #447** (base = `worktree-issue-358-publish-base-oom-streaming`) — this PR's diff is only the S2/S3 commits. Merge #447 first, then rebase this onto `main`.

### Why this is needed
PRs **#417 (S2)** and **#415 (S3)** merged 2026-06-25 but are **not in the current `main`** (`708425c0cc8`): the history diverged at #412 into a perf lineage and a feature lineage, and `main` is the feature lineage. Current `main` has **0 `upsertRecords`**, no isolate, and still row-by-row `_mergeEntity` — which is why syncing a large library is slow (~10-20 min) and the progress spinner freezes.

### What this restores
- **S2 — batched pull writes:** `_mergeEntity` read-decide-write (`fetchRecords` + `upsertRecords`) instead of a per-row upsert loop. Fixes the **slow sync**. (`upsertRecords` itself already lives in #447, which ported it for the adopt path; this reuses it — no duplication.)
- **S3 — isolate base-parse:** `BaseParseClient`/`base_parse_worker` offload the base-file parse+apply to a worker isolate, with an **inline fallback** if the isolate can't spawn. Fixes the **UI-thread freeze** (spinner stalls).

Together with #447's batched *adopt* path, all three large-library sync paths (pull, adopt, publish) are now batched and off the main isolate.

### Verification
- Full suite: **9,492 passed / 12 skipped / 0 failed**; whole-project analyze + format clean.
- Cherry-picked S2/S3 commits (history preserved) with their tests, incl. `base_parse_client_test` and the batched-serializer tests; the isolate's inline-fallback path is tested.
- Adopt + base-streaming parity tests stay byte-for-byte green.

### Notes
- S1 (stream-coalescing / UI-rebuild debounce) from the orphaned lineage is **not** included here — separate, non-blocking.
- Redundant coverage: `sync_data_serializer_batch_test.dart` (from S2) and `sync_data_serializer_batch_coverage_test.dart` (from #447) overlap on `upsertRecords`; harmless, left as-is.