### PR TITLE
perf(sync): skip redundant re-download AND re-upload of the adopted library

### DIFF
--- a/lib/core/services/sync/changeset_log/publish_state_store.dart
+++ b/lib/core/services/sync/changeset_log/publish_state_store.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart' show Value;
+
 import 'package:submersion/core/database/database.dart';
 
 /// Reads and writes this device's per-provider publish position (the upload
@@ -17,6 +19,29 @@ class PublishStateStore {
   /// carries are written (insertOnConflictUpdate updates present columns).
   Future<void> upsert(LocalPublishStatesCompanion entry) async {
     await _db.into(_db.localPublishStates).insertOnConflictUpdate(entry);
+  }
+
+  /// Record the post-adopt "deferred self-base" marker for [provider]: a row
+  /// with a NULL `baseSeq` (no base published yet) carrying the adopted
+  /// library's [adoptedHlcHigh]. The writer always sets `baseSeq` when it
+  /// publishes, so the null uniquely marks "adopted, nothing of our own to
+  /// publish yet" -- which SyncService uses to skip re-uploading a redundant
+  /// full base (a copy of the epoch the peers already hold, #358). Call after
+  /// `resetSyncState` has cleared any prior row (so this inserts fresh).
+  Future<void> markAdoptedPendingBase(
+    String provider,
+    String? adoptedHlcHigh,
+  ) async {
+    await _db
+        .into(_db.localPublishStates)
+        .insertOnConflictUpdate(
+          LocalPublishStatesCompanion(
+            provider: Value(provider),
+            publishedHlcHigh: Value(adoptedHlcHigh),
+            updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+            // baseSeq intentionally absent (null): the deferred marker.
+          ),
+        );
   }
 
   /// Drop publish state for [provider] -- used on backend switch so the device

--- a/lib/core/services/sync/changeset_log/publish_state_store.dart
+++ b/lib/core/services/sync/changeset_log/publish_state_store.dart
@@ -32,14 +32,24 @@ class PublishStateStore {
     String provider,
     String? adoptedHlcHigh,
   ) async {
+    // Write every base column EXPLICITLY rather than omitting baseSeq: with
+    // insertOnConflictUpdate, absent columns keep their prior values, so an
+    // unexpected pre-existing row would retain a non-null baseSeq (and stale
+    // base metadata) and silently defeat the null-baseSeq marker. Fully
+    // specifying the row makes the marker unambiguous whether it inserts or
+    // updates -- a fresh "adopted, no self-base yet" state.
     await _db
         .into(_db.localPublishStates)
         .insertOnConflictUpdate(
           LocalPublishStatesCompanion(
             provider: Value(provider),
+            baseSeq: const Value(null),
+            basePartCount: const Value(null),
+            baseBytes: const Value(null),
+            headSeq: const Value(0),
             publishedHlcHigh: Value(adoptedHlcHigh),
+            changesetBytesSinceBase: const Value(0),
             updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
-            // baseSeq intentionally absent (null): the deferred marker.
           ),
         );
   }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -183,10 +183,13 @@ class SyncService {
   /// Assembles a peer's base parts into a temp file (per-part + whole-file
   /// checksum verified) for the bounded-memory replace-adopt (#358).
   final BasePartFileSink _baseSink = BasePartFileSink();
+  late final PublishStateStore _publishStateStore = PublishStateStore(
+    DatabaseService.instance.database,
+  );
   late final ChangesetWriter _changesetWriter = ChangesetWriter(
     _serializer,
     _changesetCodec,
-    PublishStateStore(DatabaseService.instance.database),
+    _publishStateStore,
   );
   late final ChangesetReader _changesetReader = ChangesetReader(
     _changesetCodec,
@@ -433,35 +436,47 @@ class SyncService {
       // ---- Upload: publish our delta ----
       _reportProgress(SyncPhase.uploading, 0.8, 'Publishing changes...');
       final deletions = await _syncRepository.getAllDeletions();
-      final uploadNonce = _uuid.v4();
-      // Record the nonce BEFORE publishing: a lost response (timeout, app
-      // death) still leaves our manifest carrying this nonce, and an
-      // unrecorded copy would read as a foreign twin on the next sync.
-      await _syncInitializer?.recordUploadNonce(
-        uploadNonce,
-        provider.providerId,
-      );
-      try {
-        await _changesetWriter.publish(
-          provider: provider,
-          deviceId: deviceId,
-          folderId: folderId,
-          deletions: deletions,
-          epochId: currentEpochId,
-          uploadNonce: uploadNonce,
+      if (await _shouldDeferSelfBaseAfterAdopt(provider.providerId)) {
+        // Just adopted a restored library and have nothing of our own yet: our
+        // library == the adopted epoch the peers already published. Publishing
+        // our own full base here would redundantly re-upload the whole library
+        // (#358, the slow first sync after adopt). Defer until we have a local
+        // change of our own to contribute (checked before the nonce so a
+        // deferred sync does not consume a nonce ring slot).
+        _log.info(
+          'Deferring redundant self-base publish after adopt (no local changes)',
         );
-      } catch (e) {
-        // Keep the speculative nonce on a timeout (the publish may have
-        // landed); remove it only on definite failures, so repeated hard
-        // failures cannot evict the last good nonce from the ring.
-        final cause = e is SyncStepException ? e.error : e;
-        if (cause is! TimeoutException) {
-          await _syncInitializer?.removeUploadNonce(
-            uploadNonce,
-            provider.providerId,
+      } else {
+        final uploadNonce = _uuid.v4();
+        // Record the nonce BEFORE publishing: a lost response (timeout, app
+        // death) still leaves our manifest carrying this nonce, and an
+        // unrecorded copy would read as a foreign twin on the next sync.
+        await _syncInitializer?.recordUploadNonce(
+          uploadNonce,
+          provider.providerId,
+        );
+        try {
+          await _changesetWriter.publish(
+            provider: provider,
+            deviceId: deviceId,
+            folderId: folderId,
+            deletions: deletions,
+            epochId: currentEpochId,
+            uploadNonce: uploadNonce,
           );
+        } catch (e) {
+          // Keep the speculative nonce on a timeout (the publish may have
+          // landed); remove it only on definite failures, so repeated hard
+          // failures cannot evict the last good nonce from the ring.
+          final cause = e is SyncStepException ? e.error : e;
+          if (cause is! TimeoutException) {
+            await _syncInitializer?.removeUploadNonce(
+              uploadNonce,
+              provider.providerId,
+            );
+          }
+          rethrow;
         }
-        rethrow;
       }
 
       // Advance state only on a clean apply (idempotent re-pull otherwise).
@@ -2116,6 +2131,14 @@ class SyncService {
           lastSeqApplied: c.appliedThrough,
         );
       }
+      // Record the deferred self-base marker: our library is now exactly the
+      // adopted epoch, which the peers already published. The next sync must
+      // NOT re-upload our own full base (a redundant copy) until we actually
+      // make a local change of our own (#358, the slow first sync after adopt).
+      await _publishStateStore.markAdoptedPendingBase(
+        provider.providerId,
+        await _syncRepository.maxRowHlc(),
+      );
       await _syncRepository.setLastAcceptedEpochId(marker.epochId);
       await store.setLastAccepted(marker);
       SyncClock.instance.reset();
@@ -2310,6 +2333,26 @@ class SyncService {
       changesets: changesets,
     ),
   );
+
+  /// True when we just adopted a restored library and have nothing of our own
+  /// to publish yet -- so the next sync must NOT re-upload our own full base, a
+  /// redundant copy of the epoch the peers already published (#358, the slow
+  /// first sync after adopt).
+  ///
+  /// The deferred marker is a publish-state row with a null `baseSeq`: adopt
+  /// records it, and the writer always sets `baseSeq` when it publishes, so a
+  /// null there uniquely means "adopted, no self-base yet". A device that has
+  /// published (baseSeq set -- including a cloud-manifest-lost cold-start that
+  /// legitimately re-bases) or never adopted (no row at all) falls straight
+  /// through and publishes normally. The deferral clears the moment we have any
+  /// local change: [SyncRepository.hasUnsyncedChanges] counts pending / conflict
+  /// / deletion rows, which are written in the same transaction as the edit, so
+  /// it is reliable even in the window before the HLC clock is reconfigured.
+  Future<bool> _shouldDeferSelfBaseAfterAdopt(String providerId) async {
+    final state = await _publishStateStore.get(providerId);
+    if (state == null || state.baseSeq != null) return false;
+    return !(await _syncRepository.hasUnsyncedChanges());
+  }
 
   /// Stream every epoch-stamped changeset log into adopt sources: each device's
   /// base assembled to a temp file (bounded memory, via [BasePartFileSink],

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2102,6 +2102,20 @@ class SyncService {
       // Re-baseline under the adopted epoch. Our tombstones are obsolete --
       // the restored library is authoritative.
       await _syncRepository.resetSyncState(clearDeletionLog: true);
+      // Record what adopt just applied as each epoch device's transport cursor.
+      // resetSyncState wiped the cursors; without re-establishing them the next
+      // sync cold-starts and redundantly re-downloads the whole base we just
+      // adopted (the "slow second sync"). The streamed apply covered each
+      // device through its `appliedThrough` seq, so the next pull skips it.
+      final cursorStore = PeerCursorStore(DatabaseService.instance.database);
+      for (final c in sources.cursors) {
+        await cursorStore.upsert(
+          peerDeviceId: c.deviceId,
+          provider: provider.providerId,
+          baseSeqApplied: c.baseSeq,
+          lastSeqApplied: c.appliedThrough,
+        );
+      }
       await _syncRepository.setLastAcceptedEpochId(marker.epochId);
       await store.setLastAccepted(marker);
       SyncClock.instance.reset();
@@ -2311,6 +2325,7 @@ class SyncService {
       List<String> baseFilePaths,
       List<int> baseExportedAt,
       List<SyncPayload> changesets,
+      List<({String deviceId, int baseSeq, int appliedThrough})> cursors,
     })
   >
   _collectEpochBaseSources(
@@ -2331,6 +2346,7 @@ class SyncService {
     final baseFilePaths = <String>[];
     final baseExportedAt = <int>[];
     final changesets = <SyncPayload>[];
+    final cursors = <({String deviceId, int baseSeq, int appliedThrough})>[];
     for (final deviceId in deviceIds) {
       final manifestFile = byName[ChangesetLogLayout.manifestName(deviceId)];
       if (manifestFile == null) continue;
@@ -2362,18 +2378,29 @@ class SyncService {
       if (path == null) continue; // base incomplete/corrupt -> skip this device
       baseFilePaths.add(path);
       baseExportedAt.add(await _readBaseExportedAt(path));
+      // Track the last CONTIGUOUS seq we apply (base, then changesets up to the
+      // first gap) so adopt can record it as this peer's cursor -- otherwise the
+      // next sync cold-starts and re-downloads the whole base we just applied.
+      var appliedThrough = baseSeq;
       for (var seq = baseSeq + 1; seq <= manifest.headSeq; seq++) {
         final cf = byName[ChangesetLogLayout.changesetName(deviceId, seq)];
         if (cf == null) break;
         changesets.add(
           _changesetCodec.decodeChangeset(await provider.downloadFile(cf.id)),
         );
+        appliedThrough = seq;
       }
+      cursors.add((
+        deviceId: deviceId,
+        baseSeq: baseSeq,
+        appliedThrough: appliedThrough,
+      ));
     }
     return (
       baseFilePaths: baseFilePaths,
       baseExportedAt: baseExportedAt,
       changesets: changesets,
+      cursors: cursors,
     );
   }
 

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -5,7 +5,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:submersion/core/data/repositories/sync_repository.dart';
-import 'package:submersion/core/database/database.dart' show SyncRecord;
+import 'package:submersion/core/database/database.dart'
+    show SyncRecord, DeletionLogData;
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -436,7 +437,10 @@ class SyncService {
       // ---- Upload: publish our delta ----
       _reportProgress(SyncPhase.uploading, 0.8, 'Publishing changes...');
       final deletions = await _syncRepository.getAllDeletions();
-      if (await _shouldDeferSelfBaseAfterAdopt(provider.providerId)) {
+      if (await _shouldDeferSelfBaseAfterAdopt(
+        provider.providerId,
+        deletions,
+      )) {
         // Just adopted a restored library and have nothing of our own yet: our
         // library == the adopted epoch the peers already published. Publishing
         // our own full base here would redundantly re-upload the whole library
@@ -2348,10 +2352,17 @@ class SyncService {
   /// local change: [SyncRepository.hasUnsyncedChanges] counts pending / conflict
   /// / deletion rows, which are written in the same transaction as the edit, so
   /// it is reliable even in the window before the HLC clock is reconfigured.
-  Future<bool> _shouldDeferSelfBaseAfterAdopt(String providerId) async {
+  Future<bool> _shouldDeferSelfBaseAfterAdopt(
+    String providerId,
+    List<DeletionLogData> deletions,
+  ) async {
     final state = await _publishStateStore.get(providerId);
     if (state == null || state.baseSeq != null) return false;
-    return !(await _syncRepository.hasUnsyncedChanges());
+    // Equivalent to !hasUnsyncedChanges(), but reuses the [deletions] the caller
+    // already fetched instead of re-reading the deletion log on this path.
+    if (deletions.isNotEmpty) return false;
+    return (await _syncRepository.getPendingCount()) == 0 &&
+        (await _syncRepository.getConflictCount()) == 0;
   }
 
   /// Stream every epoch-stamped changeset log into adopt sources: each device's

--- a/test/core/services/sync/changeset_log/publish_state_store_test.dart
+++ b/test/core/services/sync/changeset_log/publish_state_store_test.dart
@@ -61,4 +61,50 @@ void main() {
     expect(await store.get('s3'), isNull);
     expect(await store.get('icloud'), isNotNull);
   });
+
+  group('markAdoptedPendingBase (deferred self-base marker)', () {
+    test('writes a null-baseSeq marker carrying the adopted hlc', () async {
+      await store.markAdoptedPendingBase('s3', '000000000000200:000000:dev');
+      final s = await store.get('s3');
+      expect(s, isNotNull);
+      expect(s!.baseSeq, isNull);
+      expect(s.publishedHlcHigh, '000000000000200:000000:dev');
+    });
+
+    test('overwrites a pre-existing base row to an unambiguous marker', () async {
+      // A row already carrying base metadata (a prior publish). The marker must
+      // reset baseSeq (and the related base fields) back to NULL/0, not leave
+      // the stale values -- otherwise a non-null baseSeq would defeat the
+      // deferral signal even though we just adopted.
+      await store.upsert(
+        const LocalPublishStatesCompanion(
+          provider: Value('s3'),
+          baseSeq: Value(7),
+          basePartCount: Value(3),
+          baseBytes: Value(999),
+          headSeq: Value(9),
+          publishedHlcHigh: Value('000000000000100:000000:dev'),
+          changesetBytesSinceBase: Value(4096),
+          updatedAt: Value(1),
+        ),
+      );
+
+      await store.markAdoptedPendingBase('s3', '000000000000300:000000:dev');
+
+      final s = await store.get('s3');
+      expect(s!.baseSeq, isNull);
+      expect(s.basePartCount, isNull);
+      expect(s.baseBytes, isNull);
+      expect(s.headSeq, 0);
+      expect(s.changesetBytesSinceBase, 0);
+      expect(s.publishedHlcHigh, '000000000000300:000000:dev');
+    });
+
+    test('accepts a null adopted hlc (adopted an empty library)', () async {
+      await store.markAdoptedPendingBase('s3', null);
+      final s = await store.get('s3');
+      expect(s!.baseSeq, isNull);
+      expect(s.publishedHlcHigh, isNull);
+    });
+  });
 }

--- a/test/core/services/sync/sync_service_epoch_test.dart
+++ b/test/core/services/sync/sync_service_epoch_test.dart
@@ -402,6 +402,54 @@ void main() {
       );
     });
 
+    test(
+      'after adoption with no local changes, performSync defers the self-base '
+      'publish',
+      () async {
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'cloud-dive'),
+        );
+        await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+        final service = buildService();
+        await service.writeLibraryEpochMarker(cloud, marker);
+        await service.adoptReplacedLibrary();
+
+        final result = await service.performSync();
+
+        // The sync itself succeeds (guards against a vacuous pass from an early
+        // error): our library == the adopted epoch (already published by
+        // 'replacer') and we have no local changes, so re-uploading our own
+        // full base would be pure redundancy -- the publish is deferred (no own
+        // manifest is written).
+        expect(result.isSuccess, isTrue);
+        final deviceId = await SyncRepository().getDeviceId();
+        expect(await hasPublishedLog(cloud, deviceId), isFalse);
+      },
+    );
+
+    test(
+      'after adoption, a local change re-enables the self-base publish',
+      () async {
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'cloud-dive'),
+        );
+        await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+        final service = buildService();
+        await service.writeLibraryEpochMarker(cloud, marker);
+        await service.adoptReplacedLibrary();
+
+        // A local edit means we now have something of our own to contribute, so
+        // the deferral clears and we publish a base.
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'my-dive', maxDepth: 42),
+        );
+        await service.performSync();
+
+        final deviceId = await SyncRepository().getDeviceId();
+        expect(await hasPublishedLog(cloud, deviceId), isTrue);
+      },
+    );
+
     test('adoption preserves device identity', () async {
       await DiveRepository().createDive(
         createTestDiveWithBottomTime(id: 'cloud-dive'),

--- a/test/core/services/sync/sync_service_epoch_test.dart
+++ b/test/core/services/sync/sync_service_epoch_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
@@ -351,6 +352,55 @@ void main() {
         expect(await serializer.fetchRecord('dives', 'cloud-dive'), isNotNull);
       },
     );
+
+    test(
+      'adoption records peer cursors so the next sync does not re-pull the base',
+      () async {
+        // seedPeerLog publishes 'replacer' as a base at seq 1 (no changesets).
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'cloud-dive'),
+        );
+        await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+        final service = buildService();
+        await service.writeLibraryEpochMarker(cloud, marker);
+
+        await service.adoptReplacedLibrary();
+
+        // resetSyncState wipes cursors; without recording what adopt applied,
+        // the next sync cold-starts and re-downloads the whole adopted base.
+        final cursor = await PeerCursorStore(
+          DatabaseService.instance.database,
+        ).get('replacer', cloud.providerId);
+        expect(
+          cursor,
+          isNotNull,
+          reason: 'adopt must record the replacer cursor',
+        );
+        expect(cursor!.lastSeqApplied, 1);
+        expect(cursor.baseSeqApplied, 1);
+      },
+    );
+
+    test('the sync after adoption does not re-apply the adopted base', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'cloud-dive'),
+      );
+      await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+      await service.adoptReplacedLibrary();
+
+      // The cursor adopt recorded makes the follow-up pull skip 'replacer', so
+      // nothing is re-applied. Without the fix this cold-started and re-pulled
+      // the entire adopted base.
+      final result = await service.performSync();
+      expect(result.isSuccess, isTrue);
+      expect(
+        result.recordsSynced,
+        0,
+        reason: 'the base just adopted must not be re-pulled',
+      );
+    });
 
     test('adoption preserves device identity', () async {
       await DiveRepository().createDive(

--- a/test/features/settings/presentation/providers/sync_providers_epoch_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_epoch_test.dart
@@ -174,9 +174,12 @@ void main() {
       final state = container.read(syncStateProvider);
       expect(state.replaceAwaitingAdoption, isFalse);
       expect(await SyncRepository().getLastAcceptedEpochId(), 'e1');
-      // The follow-up sync published this device's stamped log.
+      // We adopted exactly the replacer's library and have no local changes of
+      // our own, so the follow-up sync DEFERS our redundant self-base publish
+      // (#358): the replacer already holds this library. A later local edit
+      // re-enables the publish.
       final deviceId = await SyncRepository().getDeviceId();
-      expect(await hasPublishedLog(cloud, deviceId), isTrue);
+      expect(await hasPublishedLog(cloud, deviceId), isFalse);
     });
   });
 
@@ -207,9 +210,12 @@ void main() {
         expect(await serializer.fetchRecord('dives', 'dive-a'), isNotNull);
         expect(await serializer.fetchRecord('dives', 'dive-b'), isNull);
         expect(await SyncRepository().getLastAcceptedEpochId(), 'e1');
-        // Follow-up sync published our stamped base.
+        // dive-b (the local divergence) was discarded by the Replace-adopt, so
+        // we hold exactly the adopted library and have nothing of our own to
+        // contribute -- the follow-up sync DEFERS our redundant self-base
+        // publish (#358), leaving no base of ours in the cloud.
         final deviceId = await SyncRepository().getDeviceId();
-        expect((await cloudBasePayload(cloud, deviceId))?.epochId, 'e1');
+        expect(await cloudBasePayload(cloud, deviceId), isNull);
       },
     );
 


### PR DESCRIPTION
Fixes the slow first/second sync after a Replace-adopt. Adopting a large library used to trigger **two** redundant ~648 MB transfers on the following sync(s) — a re-download and a re-upload of the very library just adopted. Both are eliminated here.

By design an incremental sync with no changes should be near-instant (`ChangesetReader.pull` skips caught-up peers; a device with a base publishes only deltas). This PR restores that for the post-adopt case.

## 1. Redundant re-download (peer cursors)

**Root cause:** `adoptReplacedLibrary` applies each epoch device's base (streamed), then `resetSyncState` wipes all peer cursors and never re-establishes them. The next `pull` finds `lastApplied = 0 < baseSeq` and cold-starts — re-downloading + re-applying the whole base it already has. (Then the cursor gets set, so the *third* sync is finally fast.)

**Fix:** `_collectEpochBaseSources` now returns, per epoch device, `(deviceId, baseSeq, appliedThrough)` — `appliedThrough` being the last **contiguous** seq applied (base, then changesets up to the first gap). After `resetSyncState`, adopt re-establishes each peer's cursor, so the next pull skips the already-applied base. A gap mid-log just leaves `appliedThrough` short, so the next sync resumes from there rather than re-pulling everything.

## 2. Redundant re-upload (deferred self-base)

**Root cause:** `resetSyncState` also clears local publish state, so `hasBase=false` drives the next `performSync` to publish the device's **own** full base — even though the just-adopted library is identical to the epoch the peers already published.

**Fix:** adopt records a *deferred marker* — a `localPublishStates` row with a **null `baseSeq`** (unique to adopt, since the writer always sets `baseSeq` when it publishes). `performSync` skips the self-base publish while that marker is set **and** the device has no unsynced changes. The deferral clears the instant there's a local change, so:
- a passive viewer (adopts, just browses) uploads **nothing**;
- an active editor still publishes a real base once it has something of its own to contribute.

**Why `hasUnsyncedChanges()` and not an HLC watermark:** pending/conflict/deletion rows are written in the *same transaction* as the edit, so the signal is reliable even in the window after adopt resets the HLC clock but before the next sync reconfigures it. An HLC-based check could miss an edit made in that window.

**Not deferred (correctly):** cloud-manifest-lost cold-starts (`baseSeq` set → re-bases), never-adopted devices (no row), and `executeLibraryReplace` (the initiator must publish its stamped base).

## Verification
- New tests: adopt records peer cursors; a `performSync` after adopt applies **0** records (no re-pull); no self-base is published when the adopted library is unchanged; a local edit re-enables the publish.
- Patch coverage 100% on changed lines; full sync suite green (368); whole-project analyze + format clean.