### PR TITLE
fix(deco): match Subsurface's gradient-factor ascent (deep GF-low anchor + clear-to-next-stop)

### DIFF
--- a/lib/core/deco/buhlmann_algorithm.dart
+++ b/lib/core/deco/buhlmann_algorithm.dart
@@ -33,6 +33,13 @@ class BuhlmannAlgorithm {
   /// Current tissue compartments state
   List<TissueCompartment> _compartments;
 
+  /// Deepest GF-low ceiling (metres) reached so far this dive -- the fixed
+  /// anchor for gradient-factor interpolation, mirroring Subsurface's
+  /// `gf_low_pressure_this_dive`. It is a running maximum, never re-derived from
+  /// the current (off-gassing) tissue state, so shallow stops interpolate toward
+  /// GF-high instead of collapsing to GF-low.
+  double _gfLowCeilingAnchor = 0.0;
+
   BuhlmannAlgorithm({
     this.gfLow = 0.30,
     this.gfHigh = 0.70,
@@ -73,12 +80,15 @@ class BuhlmannAlgorithm {
   /// Reset compartments to surface-saturated state.
   void reset() {
     _compartments = _createSurfaceSaturatedCompartments();
+    _gfLowCeilingAnchor = 0.0;
   }
 
   /// Set compartments to a specific state (for loading from saved data).
   void setCompartments(List<TissueCompartment> compartments) {
     if (compartments.length == zhl16CompartmentCount) {
       _compartments = List.from(compartments);
+      _gfLowCeilingAnchor = 0.0;
+      _updateGfAnchor();
     }
   }
 
@@ -123,6 +133,20 @@ class BuhlmannAlgorithm {
     }
 
     _compartments = newCompartments;
+    _updateGfAnchor();
+  }
+
+  /// Grow the GF-low anchor to the current deepest GF-low ceiling. Runs after
+  /// every loading step so it records the dive's deepest stop; it only ever
+  /// increases. Simulated look-ahead (NDL, deco schedule) saves/restores it so
+  /// their transient loading cannot pollute it.
+  void _updateGfAnchor() {
+    double ceiling = 0;
+    for (final comp in _compartments) {
+      final c = comp.ceiling(gf: gfLow);
+      if (c > ceiling) ceiling = c;
+    }
+    if (ceiling > _gfLowCeilingAnchor) _gfLowCeilingAnchor = ceiling;
   }
 
   /// Schreiner equation for gas loading/unloading.
@@ -168,30 +192,16 @@ class BuhlmannAlgorithm {
   double _interpolateGf(double currentDepth) {
     if (currentDepth <= 0) return gfHigh;
 
-    final firstStopDepth = _findFirstStopDepth();
-    if (firstStopDepth <= 0) return gfHigh;
+    // Anchor GF-low at the dive's deepest ceiling, fixed for the whole ascent
+    // (Subsurface's gf_low_pressure_this_dive), not the current stop.
+    final anchorDepth = _gfLowCeilingAnchor;
+    if (anchorDepth <= 0) return gfHigh;
 
-    if (currentDepth >= firstStopDepth) return gfLow;
+    if (currentDepth >= anchorDepth) return gfLow;
 
-    // Linear interpolation
-    final ratio = currentDepth / firstStopDepth;
+    // Linear interpolation from GF-low at the anchor to GF-high at the surface.
+    final ratio = currentDepth / anchorDepth;
     return gfHigh - (gfHigh - gfLow) * ratio;
-  }
-
-  /// Find the depth of the first required stop.
-  double _findFirstStopDepth() {
-    double maxCeiling = 0;
-
-    for (final comp in _compartments) {
-      final ceiling = comp.ceiling(gf: gfLow);
-      if (ceiling > maxCeiling) {
-        maxCeiling = ceiling;
-      }
-    }
-
-    // Round up to next stop depth
-    if (maxCeiling <= 0) return 0;
-    return (maxCeiling / stopIncrement).ceil() * stopIncrement;
   }
 
   /// Calculate ceiling using GF High only (for NDL/deco obligation checks).
@@ -239,6 +249,7 @@ class BuhlmannAlgorithm {
 
     // Create a copy of current compartments for simulation
     final savedCompartments = List<TissueCompartment>.from(_compartments);
+    final savedAnchor = _gfLowCeilingAnchor;
 
     while (high - low > 1) {
       final mid = (low + high) ~/ 2;
@@ -262,8 +273,9 @@ class BuhlmannAlgorithm {
       }
     }
 
-    // Restore original compartments
+    // Restore original compartments and anchor.
     _compartments = savedCompartments;
+    _gfLowCeilingAnchor = savedAnchor;
 
     return low;
   }
@@ -283,11 +295,13 @@ class BuhlmannAlgorithm {
 
     // Create working copy of compartments
     final savedCompartments = List<TissueCompartment>.from(_compartments);
+    final savedAnchor = _gfLowCeilingAnchor;
 
     // Find first stop depth
     final double ceiling = calculateCeiling(currentDepth: currentDepth);
     if (ceiling <= 0) {
       _compartments = savedCompartments;
+      _gfLowCeilingAnchor = savedAnchor;
       return stops; // No deco required
     }
 
@@ -326,8 +340,9 @@ class BuhlmannAlgorithm {
       currentStopDepth = nextStop;
     }
 
-    // Restore original compartments
+    // Restore original compartments and anchor.
     _compartments = savedCompartments;
+    _gfLowCeilingAnchor = savedAnchor;
 
     return stops;
   }
@@ -344,6 +359,7 @@ class BuhlmannAlgorithm {
     while (stopTime < maxStopTime) {
       // Calculate ceiling after 1 minute at stop
       final testCompartments = List<TissueCompartment>.from(_compartments);
+      final testAnchor = _gfLowCeilingAnchor;
 
       calculateSegment(
         depthMeters: stopDepth,
@@ -352,10 +368,20 @@ class BuhlmannAlgorithm {
         fHe: fHe,
       );
 
-      final ceiling = calculateCeiling(currentDepth: stopDepth);
+      // Leave the stop once the diver may ascend to the NEXT (shallower) stop:
+      // evaluate the ceiling at the gradient factor for that shallower depth,
+      // matching Subsurface's trial_ascent (tissue tolerance at the target
+      // stoplevel), with GF-low anchored at the dive's deepest ceiling. At the
+      // last stop the next level is the surface, where the GF is GF-high -- the
+      // same criterion the deco-cleared check uses -- so TTS counts down to
+      // surfacing instead of collapsing in one sample.
+      final ceiling = calculateCeiling(currentDepth: nextStopDepth);
 
-      // Restore for next iteration
+      // Restore for next iteration. The trial minute must not leak into
+      // persistent state: restore the anchor too, otherwise a trial minute that
+      // is never taken (the break below) could permanently grow the anchor.
       _compartments = testCompartments;
+      _gfLowCeilingAnchor = testAnchor;
 
       if (ceiling <= nextStopDepth) {
         break;

--- a/test/core/deco/tts_last_stop_countdown_test.dart
+++ b/test/core/deco/tts_last_stop_countdown_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/entities/deco_status.dart';
+import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/parsers/subsurface_xml_parser.dart';
+
+// These tests pin the gradient-factor ascent against Subsurface's model:
+//
+//  * GF-low is anchored at the dive's DEEPEST ceiling and held fixed for the
+//    whole ascent (Subsurface's gf_low_pressure_this_dive), so shallow stops
+//    interpolate toward GF-high instead of collapsing to GF-low.
+//  * A stop is left when the diver may ascend to the NEXT shallower stop,
+//    evaluated at that shallower depth's GF (Subsurface's trial_ascent). At the
+//    last stop that depth is the surface (GF-high) -- the same criterion the
+//    deco-cleared check uses -- so TTS counts down smoothly instead of sitting
+//    pinned at the GF-low value and then collapsing in a single sample.
+Future<(List<double>, List<int>, List<ProfileGasSegment>)> _loadOc(
+  String fixture,
+) async {
+  final bytes = Uint8List.fromList(
+    utf8.encode(File('test/dives/$fixture').readAsStringSync()),
+  );
+  final dive = (await SubsurfaceXmlParser().parse(
+    bytes,
+  )).entitiesOf(ImportEntityType.dives).first;
+  final profile = (dive['profile'] as List).cast<Map<String, dynamic>>();
+  final mixes = (dive['tanks'] as List)
+      .map((t) => (t as Map)['gasMix'] as GasMix)
+      .toList();
+  final segs = <ProfileGasSegment>[
+    ProfileGasSegment(
+      startTimestamp: 0,
+      fN2: (100 - mixes[0].o2 - mixes[0].he) / 100,
+      fHe: mixes[0].he / 100,
+    ),
+  ];
+  for (final s in (dive['gasSwitches'] as List)) {
+    final t = (s as Map)['timestamp'] as int;
+    final idx = int.parse((s['tankRef'] as String).split(':').first);
+    final m = mixes[idx];
+    segs.add(
+      ProfileGasSegment(
+        startTimestamp: t,
+        fN2: (100 - m.o2 - m.he) / 100,
+        fHe: m.he / 100,
+      ),
+    );
+  }
+  return (
+    profile.map((p) => p['depth'] as double).toList(),
+    profile.map((p) => p['timestamp'] as int).toList(),
+    segs,
+  );
+}
+
+void main() {
+  test('fixture 001: calculated TTS at the 3 m stop does not cliff', () async {
+    final (depths, ts, segs) = await _loadOc(
+      '001_short_deco_single_gas_switch.ssrf.xml',
+    );
+    final tts = (BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.75)..reset())
+        .processProfileWithGasSegments(
+          depths: depths,
+          timestamps: ts,
+          gasSegments: segs,
+        )
+        .map((s) => s.ttsSeconds)
+        .toList();
+
+    // Inspect the final shallow (3 m) phase, isolating the last-stop clearance
+    // from the separate recorded-gas-switch drop earlier in the dive. A smooth
+    // count-down drops at most ~1 stop-minute per sample; the bug collapsed TTS
+    // by ~12 min (~720 s) in a single 10 s sample.
+    var maxDrop = 0;
+    for (var i = 1; i < ts.length; i++) {
+      if (depths[i] <= 3.5 && ts[i] > 45 * 60) {
+        final drop = tts[i - 1] - tts[i];
+        if (drop > maxDrop) maxDrop = drop;
+      }
+    }
+    expect(
+      maxDrop,
+      lessThanOrEqualTo(120),
+      reason: 'TTS collapsed by ${maxDrop}s at the 3 m stop (flat-then-cliff)',
+    );
+  });
+
+  test(
+    'fixture 004 @ 9 m: ceiling matches Subsurface (deep GF-low anchor)',
+    () async {
+      // Subsurface (GF 50/75) reports a 7.4 m calculated ceiling at min 30 (9 m).
+      // Before the fixed deep anchor the app collapsed to GF-low at the 9 m stop
+      // and reported ~8.8 m (too conservative).
+      final (depths, ts, segs) = await _loadOc(
+        '004_short_deco_single_gas_switch.ssrf.xml',
+      );
+      final statuses = (BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.75)..reset())
+          .processProfileWithGasSegments(
+            depths: depths,
+            timestamps: ts,
+            gasSegments: segs,
+          );
+      final DecoStatus atMin30 = statuses[ts.indexWhere((t) => t == 30 * 60)];
+      expect(atMin30.ceilingMeters, closeTo(7.4, 0.6));
+    },
+  );
+}

--- a/test/dives/004_short_deco_single_gas_switch.ssrf.xml
+++ b/test/dives/004_short_deco_single_gas_switch.ssrf.xml
@@ -1,0 +1,269 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+<site uuid='a1b2c3d4' name='Test Wall / Ideal Deco' gps='0.000000 0.000000'>
+</site>
+</divesites>
+<dives>
+<dive number='1' rating='5' divesiteid='a1b2c3d4' date='2026-06-02' time='10:00:00' duration='40:50 min'>
+  <cylinder size='24.0 l' workpressure='232.0 bar' description='Back gas (air)' />
+  <cylinder size='11.0 l' workpressure='232.0 bar' description='Deco EAN50' o2='50.0%' />
+  <divecomputer model='Submersion Test' deviceid='00000001' diveid='0a1b2c3d'>
+  <depth max='45.0 m' mean='30.0 m' />
+  <temperature water='20.0 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1030 g/l' />
+  <extradata key='Deco model' value='GF 50/75' />
+  <extradata key='Divemode' value='OC Technical' />
+  <event time='0:10 min' type='25' flags='2' name='gaschange' cylinder='0' />
+  <event time='24:30 min' type='25' flags='1' name='gaschange' cylinder='1' o2='50.0%' />
+  <sample time='0:10 min' depth='0.0 m' ndl='45:00 min' tts='2:00 min' />
+  <sample time='0:20 min' depth='3.2 m' ndl='40:00 min' tts='3:00 min' />
+  <sample time='0:30 min' depth='6.4 m' ndl='35:00 min' tts='3:00 min' />
+  <sample time='0:40 min' depth='9.6 m' ndl='31:00 min' tts='4:00 min' />
+  <sample time='0:50 min' depth='12.9 m' ndl='26:00 min' tts='5:00 min' />
+  <sample time='1:00 min' depth='16.1 m' ndl='21:00 min' tts='6:00 min' />
+  <sample time='1:10 min' depth='19.3 m' ndl='16:00 min' tts='6:00 min' />
+  <sample time='1:20 min' depth='22.5 m' ndl='11:00 min' tts='7:00 min' />
+  <sample time='1:30 min' depth='25.7 m' ndl='6:00 min' tts='8:00 min' />
+  <sample time='1:40 min' depth='28.9 m' ndl='2:00 min' tts='8:00 min' />
+  <sample time='1:50 min' depth='32.1 m' in_deco='1' tts='9:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='2:00 min' depth='35.4 m' in_deco='1' tts='10:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='2:10 min' depth='38.6 m' in_deco='1' tts='11:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='2:20 min' depth='41.8 m' in_deco='1' tts='11:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='2:30 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='2:40 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='2:50 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='3:00 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='3:10 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='3:20 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='3:30 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='3:40 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='3:50 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='4:00 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='4:10 min' depth='45.0 m' in_deco='1' tts='12:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='4:20 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='4:30 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='4:40 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='4:50 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='5:00 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='5:10 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='5:20 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='5:30 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='5:40 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='5:50 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='6:00 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='6:10 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='6:20 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='6:30 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='6:40 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='6:50 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='7:00 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='7:10 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='7:20 min' depth='45.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='7:30 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='7:40 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='7:50 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='8:00 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='8:10 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='8:20 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='8:30 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='8:40 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='8:50 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='9:00 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='9:10 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='9:20 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='9:30 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='9:40 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='9:50 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='10:00 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='10:10 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='10:20 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='10:30 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='10:40 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='10:50 min' depth='45.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='11:00 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='11:10 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='11:20 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='11:30 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='11:40 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='11:50 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='12:00 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='12:10 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='12:20 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='12:30 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='12:40 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='12:50 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='13:00 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='13:10 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='13:20 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='13:30 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='13:40 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='13:50 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='14:00 min' depth='45.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='14:10 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='14:20 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='14:30 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='14:40 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='14:50 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='15:00 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='15:10 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='15:20 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='15:30 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='15:40 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='15:50 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='16:00 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='16:10 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='16:20 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='16:30 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='16:40 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='16:50 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='17:00 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='17:10 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='17:20 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='17:30 min' depth='45.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='17:40 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='17:50 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='18:00 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='18:10 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='18:20 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='18:30 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='18:40 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='18:50 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='19:00 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='19:10 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='19:20 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='19:30 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='19:40 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='19:50 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='20:00 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='20:10 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='20:20 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='20:30 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='20:40 min' depth='45.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='20:50 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='21:00 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='21:10 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='21:20 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='21:30 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='21:40 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='21:50 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='22:00 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='22:10 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='22:20 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='22:30 min' depth='45.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='22:40 min' depth='43.0 m' in_deco='1' tts='18:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='22:50 min' depth='41.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='23:00 min' depth='39.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='23:10 min' depth='37.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='23:20 min' depth='35.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='23:30 min' depth='33.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='23:40 min' depth='31.0 m' in_deco='1' tts='17:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='23:50 min' depth='29.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='24:00 min' depth='27.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='24:10 min' depth='25.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='24:20 min' depth='23.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='24:30 min' depth='21.0 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='24:40 min' depth='19.5 m' in_deco='1' tts='16:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='24:50 min' depth='18.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='25:00 min' depth='18.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='25:10 min' depth='18.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='25:20 min' depth='18.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='25:30 min' depth='18.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='25:40 min' depth='18.0 m' in_deco='1' tts='15:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='25:50 min' depth='18.0 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='26:00 min' depth='16.5 m' in_deco='1' tts='14:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='26:10 min' depth='15.0 m' in_deco='1' tts='14:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='26:20 min' depth='15.0 m' in_deco='1' tts='14:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='26:30 min' depth='15.0 m' in_deco='1' tts='14:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='26:40 min' depth='15.0 m' in_deco='1' tts='14:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='26:50 min' depth='15.0 m' in_deco='1' tts='13:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='27:00 min' depth='15.0 m' in_deco='1' tts='13:00 min' stopdepth='15.0 m' stoptime='1:00 min' />
+  <sample time='27:10 min' depth='15.0 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='27:20 min' depth='13.5 m' in_deco='1' tts='13:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='27:30 min' depth='12.0 m' in_deco='1' tts='13:00 min' stopdepth='12.0 m' stoptime='2:00 min' />
+  <sample time='27:40 min' depth='12.0 m' in_deco='1' tts='13:00 min' stopdepth='12.0 m' stoptime='2:00 min' />
+  <sample time='27:50 min' depth='12.0 m' in_deco='1' tts='12:00 min' stopdepth='12.0 m' stoptime='2:00 min' />
+  <sample time='28:00 min' depth='12.0 m' in_deco='1' tts='12:00 min' stopdepth='12.0 m' stoptime='2:00 min' />
+  <sample time='28:10 min' depth='12.0 m' in_deco='1' tts='12:00 min' stopdepth='12.0 m' stoptime='2:00 min' />
+  <sample time='28:20 min' depth='12.0 m' in_deco='1' tts='12:00 min' stopdepth='12.0 m' stoptime='2:00 min' />
+  <sample time='28:30 min' depth='12.0 m' in_deco='1' tts='12:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='28:40 min' depth='12.0 m' in_deco='1' tts='12:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='28:50 min' depth='12.0 m' in_deco='1' tts='11:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='29:00 min' depth='12.0 m' in_deco='1' tts='11:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='29:10 min' depth='12.0 m' in_deco='1' tts='11:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='29:20 min' depth='12.0 m' in_deco='1' tts='11:00 min' stopdepth='12.0 m' stoptime='1:00 min' />
+  <sample time='29:30 min' depth='12.0 m' in_deco='1' tts='11:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='29:40 min' depth='10.5 m' in_deco='1' tts='11:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='29:50 min' depth='9.0 m' in_deco='1' tts='10:00 min' stopdepth='9.0 m' stoptime='3:00 min' />
+  <sample time='30:00 min' depth='9.0 m' in_deco='1' tts='10:00 min' stopdepth='9.0 m' stoptime='3:00 min' />
+  <sample time='30:10 min' depth='9.0 m' in_deco='1' tts='10:00 min' stopdepth='9.0 m' stoptime='3:00 min' />
+  <sample time='30:20 min' depth='9.0 m' in_deco='1' tts='10:00 min' stopdepth='9.0 m' stoptime='3:00 min' />
+  <sample time='30:30 min' depth='9.0 m' in_deco='1' tts='10:00 min' stopdepth='9.0 m' stoptime='3:00 min' />
+  <sample time='30:40 min' depth='9.0 m' in_deco='1' tts='10:00 min' stopdepth='9.0 m' stoptime='3:00 min' />
+  <sample time='30:50 min' depth='9.0 m' in_deco='1' tts='9:00 min' stopdepth='9.0 m' stoptime='2:00 min' />
+  <sample time='31:00 min' depth='9.0 m' in_deco='1' tts='9:00 min' stopdepth='9.0 m' stoptime='2:00 min' />
+  <sample time='31:10 min' depth='9.0 m' in_deco='1' tts='9:00 min' stopdepth='9.0 m' stoptime='2:00 min' />
+  <sample time='31:20 min' depth='9.0 m' in_deco='1' tts='9:00 min' stopdepth='9.0 m' stoptime='2:00 min' />
+  <sample time='31:30 min' depth='9.0 m' in_deco='1' tts='9:00 min' stopdepth='9.0 m' stoptime='2:00 min' />
+  <sample time='31:40 min' depth='9.0 m' in_deco='1' tts='9:00 min' stopdepth='9.0 m' stoptime='2:00 min' />
+  <sample time='31:50 min' depth='9.0 m' in_deco='1' tts='8:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='32:00 min' depth='9.0 m' in_deco='1' tts='8:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='32:10 min' depth='9.0 m' in_deco='1' tts='8:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='32:20 min' depth='9.0 m' in_deco='1' tts='8:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='32:30 min' depth='9.0 m' in_deco='1' tts='8:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='32:40 min' depth='9.0 m' in_deco='1' tts='8:00 min' stopdepth='9.0 m' stoptime='1:00 min' />
+  <sample time='32:50 min' depth='9.0 m' in_deco='1' tts='7:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='33:00 min' depth='7.5 m' in_deco='1' tts='7:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='33:10 min' depth='6.0 m' in_deco='1' tts='7:00 min' stopdepth='6.0 m' stoptime='6:00 min' />
+  <sample time='33:20 min' depth='6.0 m' in_deco='1' tts='7:00 min' stopdepth='6.0 m' stoptime='6:00 min' />
+  <sample time='33:30 min' depth='6.0 m' in_deco='1' tts='7:00 min' stopdepth='6.0 m' stoptime='6:00 min' />
+  <sample time='33:40 min' depth='6.0 m' in_deco='1' tts='7:00 min' stopdepth='6.0 m' stoptime='6:00 min' />
+  <sample time='33:50 min' depth='6.0 m' in_deco='1' tts='6:00 min' stopdepth='6.0 m' stoptime='6:00 min' />
+  <sample time='34:00 min' depth='6.0 m' in_deco='1' tts='6:00 min' stopdepth='6.0 m' stoptime='6:00 min' />
+  <sample time='34:10 min' depth='6.0 m' in_deco='1' tts='6:00 min' stopdepth='6.0 m' stoptime='5:00 min' />
+  <sample time='34:20 min' depth='6.0 m' in_deco='1' tts='6:00 min' stopdepth='6.0 m' stoptime='5:00 min' />
+  <sample time='34:30 min' depth='6.0 m' in_deco='1' tts='6:00 min' stopdepth='6.0 m' stoptime='5:00 min' />
+  <sample time='34:40 min' depth='6.0 m' in_deco='1' tts='6:00 min' stopdepth='6.0 m' stoptime='5:00 min' />
+  <sample time='34:50 min' depth='6.0 m' in_deco='1' tts='5:00 min' stopdepth='6.0 m' stoptime='5:00 min' />
+  <sample time='35:00 min' depth='6.0 m' in_deco='1' tts='5:00 min' stopdepth='6.0 m' stoptime='5:00 min' />
+  <sample time='35:10 min' depth='6.0 m' in_deco='1' tts='5:00 min' stopdepth='6.0 m' stoptime='4:00 min' />
+  <sample time='35:20 min' depth='6.0 m' in_deco='1' tts='5:00 min' stopdepth='6.0 m' stoptime='4:00 min' />
+  <sample time='35:30 min' depth='6.0 m' in_deco='1' tts='5:00 min' stopdepth='6.0 m' stoptime='4:00 min' />
+  <sample time='35:40 min' depth='6.0 m' in_deco='1' tts='5:00 min' stopdepth='6.0 m' stoptime='4:00 min' />
+  <sample time='35:50 min' depth='6.0 m' in_deco='1' tts='4:00 min' stopdepth='6.0 m' stoptime='4:00 min' />
+  <sample time='36:00 min' depth='6.0 m' in_deco='1' tts='4:00 min' stopdepth='6.0 m' stoptime='4:00 min' />
+  <sample time='36:10 min' depth='6.0 m' in_deco='1' tts='4:00 min' stopdepth='6.0 m' stoptime='3:00 min' />
+  <sample time='36:20 min' depth='6.0 m' in_deco='1' tts='4:00 min' stopdepth='6.0 m' stoptime='3:00 min' />
+  <sample time='36:30 min' depth='6.0 m' in_deco='1' tts='4:00 min' stopdepth='6.0 m' stoptime='3:00 min' />
+  <sample time='36:40 min' depth='6.0 m' in_deco='1' tts='4:00 min' stopdepth='6.0 m' stoptime='3:00 min' />
+  <sample time='36:50 min' depth='6.0 m' in_deco='1' tts='3:00 min' stopdepth='6.0 m' stoptime='3:00 min' />
+  <sample time='37:00 min' depth='6.0 m' in_deco='1' tts='3:00 min' stopdepth='6.0 m' stoptime='3:00 min' />
+  <sample time='37:10 min' depth='6.0 m' in_deco='1' tts='3:00 min' stopdepth='6.0 m' stoptime='2:00 min' />
+  <sample time='37:20 min' depth='6.0 m' in_deco='1' tts='3:00 min' stopdepth='6.0 m' stoptime='2:00 min' />
+  <sample time='37:30 min' depth='6.0 m' in_deco='1' tts='3:00 min' stopdepth='6.0 m' stoptime='2:00 min' />
+  <sample time='37:40 min' depth='6.0 m' in_deco='1' tts='3:00 min' stopdepth='6.0 m' stoptime='2:00 min' />
+  <sample time='37:50 min' depth='6.0 m' in_deco='1' tts='2:00 min' stopdepth='6.0 m' stoptime='2:00 min' />
+  <sample time='38:00 min' depth='6.0 m' in_deco='1' tts='2:00 min' stopdepth='6.0 m' stoptime='2:00 min' />
+  <sample time='38:10 min' depth='6.0 m' in_deco='1' tts='2:00 min' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='38:20 min' depth='6.0 m' in_deco='1' tts='2:00 min' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='38:30 min' depth='6.0 m' in_deco='1' tts='2:00 min' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='38:40 min' depth='6.0 m' in_deco='1' tts='2:00 min' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='38:50 min' depth='6.0 m' in_deco='1' tts='1:00 min' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='39:00 min' depth='6.0 m' in_deco='1' tts='1:00 min' stopdepth='6.0 m' stoptime='1:00 min' />
+  <sample time='39:10 min' depth='6.0 m' in_deco='1' tts='1:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='39:20 min' depth='4.5 m' in_deco='1' tts='1:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='39:30 min' depth='3.0 m' in_deco='1' tts='1:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='39:40 min' depth='1.5 m' in_deco='1' tts='1:00 min' stopdepth='18.0 m' stoptime='1:00 min' />
+  <sample time='39:50 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  <sample time='40:00 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  <sample time='40:10 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  <sample time='40:20 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  <sample time='40:30 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  <sample time='40:40 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  <sample time='40:50 min' depth='0.0 m' tts='0:00 min' in_deco='0' stopdepth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>


### PR DESCRIPTION
## What this changes

This aligns how the app **plans the ascent** — the deco **stops** and the **time‑to‑surface (TTS)** shown on the dive profile — with **Subsurface's** gradient‑factor model. The tissue loading was already correct; this fixes two gradient‑factor bugs in the ascent planning.

## Why it was wrong before

The app uses **gradient factors** (GF‑low / GF‑high): a stricter limit deep, a looser one near the surface. You're meant to ride from GF‑low at the deepest stop up to GF‑high at the surface. Two bugs broke that:

1. **The GF‑low anchor kept moving.** The depth where "GF‑low" applies should be the dive's **deepest stop**, fixed for the whole ascent. The app re‑computed it on every step from the current tissues — so whenever the diver was sitting on a stop, the anchor shrank to that stop and the gradient factor **collapsed back to GF‑low** (the strictest setting). Every shallow stop ended up far more conservative than it should be.

2. **Each stop was judged at the wrong depth's GF.** You leave a stop when you can safely move up to the **next, shallower** stop. The app instead checked "can I stay at *this* depth?" using the current (deeper) stop's GF. At the **last** stop this was worst: it held the stop against the strict GF‑low ceiling, while a *separate* "are you out of deco?" check used GF‑high. The two disagreed — so TTS sat pinned at an inflated value (~12 min) and then dropped to ~0 in a **single 10‑second sample**: the "cliff" you could see on the TTS curve.

## What it fixes

- **Ceiling matches Subsurface at the validated checkpoints.** Example: dive 004 at 9 m reads **7.4 m** (was 8.8 m).
- **TTS counts down smoothly** to the surface instead of hanging flat and then falling off a cliff.
- Shallow stops are **no longer over‑conservative**.

## How it works now (Subsurface's model)

- Anchor GF‑low at the dive's **deepest ceiling** and hold it fixed as a running maximum — Subsurface's `gf_low_pressure_this_dive`. Shallow stops interpolate toward GF‑high.
- Leave each stop when the diver may reach the **next shallower** stop, evaluated at *that* depth's GF — Subsurface's `trial_ascent`. At the last stop the next level is the surface (GF‑high), so the cliff is gone **structurally**, with no special case.

## Scope / known limitations

This PR targets the **two gradient‑factor bugs above**. It does **not** touch the per‑stop *duration* logic, which has two separate, **pre‑existing** issues in `_calculateStopTime` / `calculateDecoSchedule` (surfaced during review): the deeper stop's tissue loading is applied twice before the next stop is computed, and the stop‑time loop reports one minute short of its own clearance criterion. Those compound on **long, multi‑stop technical dives**, so the "matches Subsurface" claim here should be read as **holding at the checkpoints these tests validate**, not as bit‑for‑bit agreement across every profile. They're tracked as a follow‑up (their own PR, since fixing them shifts every deco schedule and needs full‑suite re‑validation).

## Testing

- New regression tests: dive 001's last‑stop TTS has **no cliff**; dive 004's ceiling **matches Subsurface (7.4 m)**. Both committed with the dive‑004 fixture.
- **Full test suite green.**

Screenshot before:
<img width="3178" height="1397" alt="before" src="https://github.com/user-attachments/assets/ef583c63-c56b-46af-a062-1f6f3f1791a3" />


Screenshot after: 
<img width="3196" height="1420" alt="after" src="https://github.com/user-attachments/assets/5905b5cb-1005-49bf-9f9a-07ecefa22cf0" />


Still not correct as the gas switch is not taken into consideration
