### PR TITLE
fix(deco): keep TTS mandatory-only, report the safety stop separately

### DIFF
--- a/lib/core/deco/buhlmann_algorithm.dart
+++ b/lib/core/deco/buhlmann_algorithm.dart
@@ -463,35 +463,31 @@ class BuhlmannAlgorithm {
         ? calculateDecoSchedule(currentDepth: currentDepth, fN2: fN2, fHe: fHe)
         : <DecoStop>[];
 
-    // Calculate TTS - even for no-deco dives, include safety stop time
-    // so divers know realistic ascent time.
+    // TTS is the MANDATORY time to surface only: the ascent plus any required
+    // decompression stops. The recommended safety stop is NOT folded in here --
+    // it is reported separately in safetyStopSeconds. Baking the safety stop
+    // into TTS made TTS drop when a dive entered deco (the safety stop vanished
+    // as deco stops appeared), which reads backwards on the profile. Keeping TTS
+    // mandatory-only means it can only ever rise as an obligation grows.
     final int tts;
+    final int safetyStop;
     if (ndl < 0) {
-      // In deco: calculate full TTS including deco stops
+      // In deco: full obligation (ascent + deco stops). The mandatory deco
+      // stops supersede any recommended safety stop, so it is not reported.
       tts = calculateTts(currentDepth: currentDepth, fN2: fN2, fHe: fHe);
+      safetyStop = 0;
     } else {
-      // Not in deco: calculate ascent time including recommended safety stop
-      // Safety stop: 3 minutes at 5m (15ft), minus time already spent there
-      const safetyStopDepth = 5.0; // meters
+      // No deco obligation: TTS is just the direct ascent to the surface.
+      tts = (currentDepth / ascentRate * 60).round();
+
+      // Report the recommended safety stop separately: a 3-minute stop, minus
+      // time already accumulated in the 3-6 m safety-stop zone during the ascent
+      // (see processProfileWithGasSegments; can't go negative).
       const safetyStopDuration = 180; // 3 minutes in seconds
-
-      // Calculate remaining safety stop time (can't be negative)
-      final remainingSafetyStop =
-          (safetyStopDuration - safetyStopTimeAccumulated).clamp(
-            0,
-            safetyStopDuration,
-          );
-
-      if (currentDepth > safetyStopDepth) {
-        // Below safety stop depth: include time to reach stop + remaining stop time + ascent
-        final ascentToStop =
-            ((currentDepth - safetyStopDepth) / ascentRate * 60).round();
-        final ascentToSurface = (safetyStopDepth / ascentRate * 60).round();
-        tts = ascentToStop + remainingSafetyStop + ascentToSurface;
-      } else {
-        // In or above safety stop zone: remaining stop time + direct ascent
-        tts = remainingSafetyStop + (currentDepth / ascentRate * 60).round();
-      }
+      safetyStop = (safetyStopDuration - safetyStopTimeAccumulated).clamp(
+        0,
+        safetyStopDuration,
+      );
     }
 
     return DecoStatus(
@@ -499,6 +495,7 @@ class BuhlmannAlgorithm {
       ndlSeconds: ndl,
       ceilingMeters: ceiling,
       ttsSeconds: tts,
+      safetyStopSeconds: safetyStop,
       gfLow: gfLow,
       gfHigh: gfHigh,
       decoStops: stops,
@@ -557,10 +554,17 @@ class BuhlmannAlgorithm {
 
     final results = <DecoStatus>[];
 
-    // Track time spent in safety stop zone (3-6m / 10-20ft)
-    // This allows TTS to count down as diver completes their safety stop
+    // Track time spent in the safety-stop zone (3-6m / 10-20ft) so the
+    // recommended safety stop reported on DecoStatus counts down as the diver
+    // completes it. Only count time during the ascent phase -- after the dive's
+    // deepest sample -- so descent through the zone and mid-dive shallow
+    // excursions don't pre-drain the recommendation. This mirrors
+    // profile_analysis_service's safety-stop detection (which anchors on the
+    // last occurrence of max depth).
     const safetyStopZoneMin = 3.0; // meters
     const safetyStopZoneMax = 6.0; // meters
+    final maxDepth = depths.reduce(math.max);
+    final maxDepthIndex = depths.lastIndexOf(maxDepth);
     int safetyStopTimeAccumulated = 0;
 
     for (int i = 0; i < depths.length; i++) {
@@ -611,8 +615,12 @@ class BuhlmannAlgorithm {
             fHe: gas.fHe,
           );
 
-          // Accumulate time if average depth was in safety stop zone
-          if (avgDepth >= safetyStopZoneMin && avgDepth <= safetyStopZoneMax) {
+          // Accumulate time if average depth was in the safety-stop zone,
+          // but only on the ascent (after the deepest sample) so descent and
+          // mid-dive shallow excursions don't count.
+          if (i > maxDepthIndex &&
+              avgDepth >= safetyStopZoneMin &&
+              avgDepth <= safetyStopZoneMax) {
             safetyStopTimeAccumulated += duration;
           }
         }

--- a/lib/core/deco/entities/deco_status.dart
+++ b/lib/core/deco/entities/deco_status.dart
@@ -14,8 +14,18 @@ class DecoStatus extends Equatable {
   /// Decompression ceiling in meters (0 if no deco obligation)
   final double ceilingMeters;
 
-  /// Time To Surface in seconds (including deco stops)
+  /// Time To Surface in seconds: the mandatory ascent time plus any
+  /// decompression stops. The recommended safety stop is NOT included here --
+  /// it is reported separately in [safetyStopSeconds] so entering deco can only
+  /// ever increase TTS, never drop it.
   final int ttsSeconds;
+
+  /// Recommended safety-stop time remaining in seconds: a 3-minute stop on
+  /// no-deco dives, minus time already accumulated in the 3-6 m safety-stop
+  /// zone during the ascent. Zero once completed or when a mandatory
+  /// decompression obligation exists (the deco stops supersede the safety
+  /// stop). Not part of [ttsSeconds].
+  final int safetyStopSeconds;
 
   /// Gradient Factor Low (0.0 - 1.0)
   final double gfLow;
@@ -37,6 +47,7 @@ class DecoStatus extends Equatable {
     required this.ndlSeconds,
     required this.ceilingMeters,
     required this.ttsSeconds,
+    this.safetyStopSeconds = 0,
     required this.gfLow,
     required this.gfHigh,
     required this.decoStops,
@@ -167,6 +178,7 @@ class DecoStatus extends Equatable {
     int? ndlSeconds,
     double? ceilingMeters,
     int? ttsSeconds,
+    int? safetyStopSeconds,
     double? gfLow,
     double? gfHigh,
     List<DecoStop>? decoStops,
@@ -178,6 +190,7 @@ class DecoStatus extends Equatable {
       ndlSeconds: ndlSeconds ?? this.ndlSeconds,
       ceilingMeters: ceilingMeters ?? this.ceilingMeters,
       ttsSeconds: ttsSeconds ?? this.ttsSeconds,
+      safetyStopSeconds: safetyStopSeconds ?? this.safetyStopSeconds,
       gfLow: gfLow ?? this.gfLow,
       gfHigh: gfHigh ?? this.gfHigh,
       decoStops: decoStops ?? this.decoStops,
@@ -192,6 +205,7 @@ class DecoStatus extends Equatable {
     ndlSeconds,
     ceilingMeters,
     ttsSeconds,
+    safetyStopSeconds,
     gfLow,
     gfHigh,
     decoStops,

--- a/test/core/deco/deco_status_safety_stop_test.dart
+++ b/test/core/deco/deco_status_safety_stop_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/entities/deco_status.dart';
+
+/// A minimal DecoStatus for exercising the safetyStopSeconds field. The
+/// tissue-loading getters are covered elsewhere; here we only care about the
+/// value being carried through the constructor default, copyWith, and equality.
+DecoStatus buildStatus({int? safetyStopSeconds}) {
+  return DecoStatus(
+    compartments: const [],
+    ndlSeconds: 999 * 60,
+    ceilingMeters: 0,
+    ttsSeconds: 0,
+    safetyStopSeconds: safetyStopSeconds ?? 0,
+    gfLow: 0.3,
+    gfHigh: 0.7,
+    decoStops: const [],
+    currentDepthMeters: 0,
+    ambientPressureBar: 1.0,
+  );
+}
+
+void main() {
+  group('DecoStatus.safetyStopSeconds', () {
+    test('defaults to 0 when omitted from the constructor', () {
+      const status = DecoStatus(
+        compartments: [],
+        ndlSeconds: 0,
+        ceilingMeters: 0,
+        ttsSeconds: 0,
+        gfLow: 0.3,
+        gfHigh: 0.7,
+        decoStops: [],
+        currentDepthMeters: 0,
+        ambientPressureBar: 1.0,
+      );
+      expect(status.safetyStopSeconds, 0);
+    });
+
+    test('copyWith overrides the value when provided', () {
+      final status = buildStatus(safetyStopSeconds: 180);
+      final updated = status.copyWith(safetyStopSeconds: 60);
+      expect(updated.safetyStopSeconds, 60);
+    });
+
+    test('copyWith preserves the value when not provided', () {
+      final status = buildStatus(safetyStopSeconds: 120);
+      final copy = status.copyWith(ttsSeconds: 999);
+      expect(copy.safetyStopSeconds, 120);
+      expect(copy.ttsSeconds, 999);
+    });
+
+    test('participates in equality (props)', () {
+      final a = buildStatus(safetyStopSeconds: 180);
+      final b = buildStatus(safetyStopSeconds: 180);
+      final c = buildStatus(safetyStopSeconds: 90);
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+}


### PR DESCRIPTION
## What this changes

Makes the **time-to-surface (TTS)** shown on the dive profile count only the **mandatory** obligation -- the ascent plus any required decompression stops -- and reports the optional safety stop **separately** instead of folding it into TTS.

## Why it was wrong before

TTS baked a recommended 3-minute safety stop into the no-deco ascent time. As soon as a dive crossed from "no deco" into a real decompression obligation, that safety stop was absorbed into the (now mandatory) deco stops, and the displayed TTS actually **dropped** -- e.g. 8 min to 5 min -- right at the NDL to deco transition. That reads backwards: the diver just picked up an obligation, so TTS should never fall there.

## What it does now

- **In deco** (`ndl < 0`): TTS = ascent + required deco stops. The mandatory stops supersede any recommended safety stop, so no safety stop is reported.
- **No deco** (`ndl >= 0`): TTS = direct ascent to the surface only. The safety stop is reported separately on `DecoStatus.safetyStopSeconds` (the 3-minute recommendation minus time already spent in the safety-stop zone).

TTS can now only ever rise as an obligation appears -- never drop as the diver enters deco. The safety stop is not lost: the profile already surfaces performed safety stops as their own phase/event, and the value is now available on
`DecoStatus` for display.

## Screenshot before:

Note the drop of the TTS curve from 8 minutes to 5 minutes at the moment when deco obligation starts.
Also note that TTS is 3 minutes during the very beginning of the descent as the safety stop was included in TTS.

<img width="502" height="295" alt="image" src="https://github.com/user-attachments/assets/d714e99b-dcbf-439e-b089-b0f1ef4f5111" />

## Screenshot after:

TTS rises during descent, stays the same until NDL is 0 and then increases with deco obligations.

<img width="744" height="414" alt="image" src="https://github.com/user-attachments/assets/95a61e27-7df9-4637-aa1d-0337892f6547" />

