### PR TITLE
fix(profile): show hover tooltips on the Ascent Rate depth line

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -291,6 +291,15 @@ class DiveProfileChart extends ConsumerStatefulWidget {
   @visibleForTesting
   static List<({int start, int end, AscentRateCategory category})>
   velocityBandRuns(int profileLength, List<AscentRatePoint> ascentRates) {
+    // The loop indexes ascentRates up to profileLength - 1, so it needs at
+    // least one rate sample per profile point. All internal callers validate
+    // this; the assert turns a would-be RangeError into a clear message if the
+    // exposed helper is ever mis-called.
+    assert(
+      ascentRates.length >= profileLength,
+      'velocityBandRuns needs one ascent-rate sample per profile point '
+      '(got ${ascentRates.length} for $profileLength points)',
+    );
     final runs = <({int start, int end, AscentRateCategory category})>[];
     var segStart = 1; // first drawable segment connects points 0 and 1
     while (segStart < profileLength) {

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -275,6 +275,40 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     return (min: -span, max: span);
   }
 
+  /// Contiguous velocity-band runs over the depth profile, in draw order.
+  ///
+  /// Adjacent samples in the same band merge into one run covering profile
+  /// points `[start, end)` (end exclusive). The ascent-rate at index i describes
+  /// the segment that *ends* at i (index 0 is a zero placeholder), so the first
+  /// drawable run starts at sample 1 and reaches back to point 0. Neighbouring
+  /// runs share their boundary sample, so a run's `start` is the previous run's
+  /// last point.
+  ///
+  /// This is the single source of truth for both velocity colouring
+  /// ([_DiveProfileChartState._buildVelocityColoredDepthLines]) and mapping a
+  /// touched depth spot back to its global profile index: a spot on bar `b` at
+  /// local `spotIndex` addresses profile point `runs[b].start + spotIndex`.
+  @visibleForTesting
+  static List<({int start, int end, AscentRateCategory category})>
+  velocityBandRuns(int profileLength, List<AscentRatePoint> ascentRates) {
+    final runs = <({int start, int end, AscentRateCategory category})>[];
+    var segStart = 1; // first drawable segment connects points 0 and 1
+    while (segStart < profileLength) {
+      var segEnd = segStart;
+      while (segEnd + 1 < profileLength &&
+          ascentRates[segEnd + 1].category == ascentRates[segStart].category) {
+        segEnd++;
+      }
+      runs.add((
+        start: segStart - 1,
+        end: segEnd + 1,
+        category: ascentRates[segStart].category,
+      ));
+      segStart = segEnd + 1;
+    }
+    return runs;
+  }
+
   const DiveProfileChart({
     super.key,
     required this.profile,
@@ -410,6 +444,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         return Colors.red;
     }
   }
+
+  /// Colour for a velocity-coloured depth-line band. The safe/baseline band
+  /// keeps the normal depth blue so the line looks unchanged where the ascent
+  /// is within limits; only the elevated warning/danger bands are recoloured.
+  Color _velocityDepthColor(AscentRateCategory category) =>
+      category == AscentRateCategory.safe
+      ? AppColors.chartDepth
+      : _getAscentRateColor(category);
 
   /// Interpolate tank pressure at a given timestamp
   double? _interpolateTankPressure(
@@ -614,11 +656,22 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   ) {
     if (widget.onTooltipData == null) return;
 
-    final spot = touchedSpots.where((s) => s.barIndex == 0).firstOrNull;
-    if (spot == null || spot.spotIndex >= widget.profile.length) {
+    // The depth line may be split into per-band bars (velocity colouring), so a
+    // touched spot's spotIndex is local to its segment. Resolve it to the global
+    // profile index, then shadow `spot` with that index so every row below reads
+    // the right sample without further changes.
+    final starts = _depthBarStartIndices();
+    final touched = touchedSpots
+        .where((s) => s.barIndex < starts.length)
+        .firstOrNull;
+    final index = touched == null
+        ? -1
+        : starts[touched.barIndex] + touched.spotIndex;
+    if (touched == null || index < 0 || index >= widget.profile.length) {
       widget.onTooltipData!(null);
       return;
     }
+    final spot = (spotIndex: index);
 
     final point = widget.profile[spot.spotIndex];
     final rows = <TooltipRow>[];
@@ -1895,10 +1948,20 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     }
                   } else if (response?.lineBarSpots != null &&
                       response!.lineBarSpots!.isNotEmpty) {
-                    final spot = response.lineBarSpots!.first;
-                    if (spot.barIndex == 0 &&
-                        spot.spotIndex < widget.profile.length) {
-                      widget.onPointSelected?.call(spot.spotIndex);
+                    // Velocity colouring splits the depth line into per-band
+                    // bars; find the touched depth spot on any of them and map
+                    // it back to the global profile index.
+                    final starts = _depthBarStartIndices();
+                    final depthSpot = response.lineBarSpots!
+                        .where((s) => s.barIndex < starts.length)
+                        .firstOrNull;
+                    final index = depthSpot == null
+                        ? -1
+                        : starts[depthSpot.barIndex] + depthSpot.spotIndex;
+                    if (depthSpot != null &&
+                        index >= 0 &&
+                        index < widget.profile.length) {
+                      widget.onPointSelected?.call(index);
                       if (widget.tooltipBelow) {
                         final settings = ref.read(settingsProvider);
                         final units = UnitFormatter(settings);
@@ -1930,33 +1993,48 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   if (widget.tooltipBelow) {
                     return touchedSpots.map((_) => null).toList();
                   }
-                  // Return cached result if the same spot index is touched again.
-                  // The cache is keyed on spotIndex, but the cached list length
-                  // equals the number of touched bars when it was built. fl_chart
-                  // requires the returned list to match touchedSpots.length, so
-                  // the cache is only valid while the bar count is unchanged --
-                  // the set of rendered lines can change under a parked cursor
-                  // (a metric toggled, or a data provider refreshing), and a
-                  // stale-length cached list throws
+                  // Resolve the touched depth spot to a global profile index.
+                  // Velocity colouring splits the depth line into per-band bars,
+                  // so the depth spot can land on any bar in [0, starts.length)
+                  // and its spotIndex is local to that bar.
+                  final depthBarStarts = _depthBarStartIndices();
+                  final depthSpot = touchedSpots
+                      .where((s) => s.barIndex < depthBarStarts.length)
+                      .firstOrNull;
+                  final depthIndex = depthSpot == null
+                      ? -1
+                      : depthBarStarts[depthSpot.barIndex] +
+                            depthSpot.spotIndex;
+                  final hasDepth =
+                      depthSpot != null &&
+                      depthIndex >= 0 &&
+                      depthIndex < widget.profile.length;
+
+                  // Return cached result if the same sample is touched again.
+                  // The cache is keyed on the resolved depth index, but the
+                  // cached list length equals the number of touched bars when it
+                  // was built. fl_chart requires the returned list to match
+                  // touchedSpots.length, so the cache is only valid while the bar
+                  // count is unchanged -- the set of rendered lines can change
+                  // under a parked cursor (a metric toggled, or a data provider
+                  // refreshing), and a stale-length cached list throws
                   // 'tooltipItems and touchedSpots size should be same'.
-                  if (touchedSpots.isNotEmpty) {
-                    final firstDepthSpot = touchedSpots
-                        .where((s) => s.barIndex == 0)
-                        .firstOrNull;
-                    if (firstDepthSpot != null &&
-                        firstDepthSpot.spotIndex == _lastTooltipSpotIndex &&
-                        _lastTooltipItems.length == touchedSpots.length) {
-                      return _lastTooltipItems;
-                    }
+                  if (hasDepth &&
+                      depthIndex == _lastTooltipSpotIndex &&
+                      _lastTooltipItems.length == touchedSpots.length) {
+                    return _lastTooltipItems;
                   }
 
-                  // Build tooltip showing all enabled metrics for the touched point
-                  // Only process the depth line (barIndex 0) and build combined tooltip
-                  final result = touchedSpots.map((spot) {
-                    final isDepth = spot.barIndex == 0;
-                    if (!isDepth) {
+                  // Build the combined tooltip from the resolved depth spot; all
+                  // other touched bars contribute a null entry so the returned
+                  // list still matches touchedSpots.length. `spot` is shadowed
+                  // with the global index so every metric row reads the right
+                  // sample.
+                  final result = touchedSpots.map((touched) {
+                    if (!hasDepth || !identical(touched, depthSpot)) {
                       return null;
                     }
+                    final spot = (spotIndex: depthIndex);
 
                     final point = widget.profile[spot.spotIndex];
                     final minutes = point.timestamp ~/ 60;
@@ -2458,12 +2536,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     );
                   }).toList();
 
-                  // Cache the result for next frame
-                  final depthSpot = touchedSpots
-                      .where((s) => s.barIndex == 0)
-                      .firstOrNull;
-                  if (depthSpot != null) {
-                    _lastTooltipSpotIndex = depthSpot.spotIndex;
+                  // Cache the result for next frame, keyed on the resolved
+                  // global depth index (see the resolution above).
+                  if (hasDepth) {
+                    _lastTooltipSpotIndex = depthIndex;
                     _lastTooltipItems = result;
                   }
 
@@ -2775,30 +2851,45 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     UnitFormatter units,
     List<AscentRatePoint> ascentRates,
   ) {
-    final n = widget.profile.length;
-    final lines = <LineChartBarData>[];
-    var segStart = 1; // first drawable segment connects points 0 and 1
-    while (segStart < n) {
-      var segEnd = segStart;
-      while (segEnd + 1 < n &&
-          ascentRates[segEnd + 1].category == ascentRates[segStart].category) {
-        segEnd++;
-      }
-      // Segments [segStart..segEnd] cover points [segStart-1 .. segEnd]; the
-      // sublist end is exclusive, so segEnd + 1 includes point segEnd. Adjacent
-      // runs share their boundary sample, so the coloured pieces join cleanly.
-      lines.add(
-        _buildSingleDepthSegment(
-          _getAscentRateColor(ascentRates[segStart].category),
-          units,
-          segStart - 1,
-          segEnd + 1,
-          showFill: true,
-        ),
-      );
-      segStart = segEnd + 1;
+    // One coloured bar per band. [DiveProfileChart.velocityBandRuns] is the
+    // shared source of truth so the tooltip's spot-to-sample mapping and this
+    // rendering never disagree on where a segment starts.
+    return DiveProfileChart.velocityBandRuns(widget.profile.length, ascentRates)
+        .map(
+          (run) => _buildSingleDepthSegment(
+            _velocityDepthColor(run.category),
+            units,
+            run.start,
+            run.end,
+            showFill: true,
+          ),
+        )
+        .toList();
+  }
+
+  /// Global profile start index of each depth-line bar, in bar order.
+  ///
+  /// Depth bars always occupy `barIndex` `[0, length)`. A touched spot on bar
+  /// `b` at local `spotIndex` addresses profile point `result[b] + spotIndex`.
+  /// The depth line is a single full-span bar in the common case (and for
+  /// multi-computer rendering, where only the primary line maps to
+  /// [widget.profile]); velocity colouring splits it into one bar per band.
+  /// Mirrors the branching in [_buildGasColoredDepthLines].
+  List<int> _depthBarStartIndices() {
+    final cpProfiles = widget.computerProfiles;
+    final multiComputer = cpProfiles != null && cpProfiles.length >= 2;
+    final ascentRates = widget.ascentRates;
+    if (!multiComputer &&
+        _showAscentRateColors &&
+        ascentRates != null &&
+        ascentRates.length == widget.profile.length &&
+        widget.profile.length >= 2) {
+      return DiveProfileChart.velocityBandRuns(
+        widget.profile.length,
+        ascentRates,
+      ).map((run) => run.start).toList();
     }
-    return lines;
+    return const [0];
   }
 
   /// Build one depth line per computer for multi-computer rendering.

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2295,6 +2295,7 @@ void main() {
       required List<DiveProfilePoint> profile,
       required List<AscentRatePoint> ascentRates,
       void Function(ProfileLegend notifier)? configure,
+      void Function(int? index)? onPointSelected,
     }) {
       final container = ProviderContainer(
         overrides: [
@@ -2317,6 +2318,7 @@ void main() {
               child: DiveProfileChart(
                 profile: profile,
                 ascentRates: ascentRates,
+                onPointSelected: onPointSelected,
               ),
             ),
           ),
@@ -2371,10 +2373,102 @@ void main() {
       final colors = primaryChartData(
         tester,
       ).lineBarsData.map((b) => b.color).toSet();
-      expect(colors, contains(Colors.green));
+      // The safe/baseline band keeps the normal depth blue -- only the elevated
+      // warning/danger bands are recoloured.
+      expect(colors, contains(AppColors.chartDepth));
       expect(colors, contains(Colors.orange));
       expect(colors, contains(Colors.red));
+      expect(colors, isNot(contains(Colors.green)));
     });
+
+    test('velocityBandRuns splits bands sharing their boundary sample', () {
+      final profile = _makeProfile(points: 12);
+      final runs = DiveProfileChart.velocityBandRuns(
+        profile.length,
+        ratesSpanningBands(profile),
+      );
+      // Three bands; adjacent runs share the boundary sample (each run's start
+      // is the previous run's last point) so the coloured pieces join cleanly.
+      expect(runs.map((r) => r.start).toList(), [0, 3, 7]);
+      expect(runs.map((r) => r.end).toList(), [4, 8, 12]);
+      expect(runs.map((r) => r.category).toList(), [
+        AscentRateCategory.safe,
+        AscentRateCategory.warning,
+        AscentRateCategory.danger,
+      ]);
+    });
+
+    testWidgets('tooltip builds when hovering a non-first velocity segment', (
+      tester,
+    ) async {
+      // Regression: with velocity colouring on, the depth line is drawn as
+      // one bar per band. The tooltip builder only recognised barIndex 0, so
+      // hovering any later segment produced no tooltip at all.
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        buildWithLegend(
+          profile: profile,
+          ascentRates: ratesSpanningBands(profile),
+          configure: (n) => n.toggleAscentRateColors(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final data = primaryChartData(tester);
+      final bars = data.lineBarsData;
+      expect(
+        bars.length,
+        greaterThan(1),
+        reason: 'velocity colouring should split the depth line into bands',
+      );
+
+      final getItems = data.lineTouchData.touchTooltipData.getTooltipItems;
+      // Hover the second band (barIndex 1) at its first sample.
+      final secondBar = bars[1];
+      final spot = LineBarSpot(secondBar, 1, secondBar.spots.first);
+      final items = getItems(<LineBarSpot>[spot]);
+
+      expect(items.length, 1);
+      expect(
+        items.first,
+        isNotNull,
+        reason: 'a hover on a non-first velocity band must show a tooltip',
+      );
+    });
+
+    testWidgets(
+      'hover on a non-first velocity segment selects the right sample',
+      (tester) async {
+        // The onPointSelected / external-tooltip path shares the same
+        // barIndex==0 assumption; a hover landing on a later band must still
+        // resolve to a global profile index, not the band-local spot index.
+        final profile = _makeProfile(points: 12);
+        int? selected;
+        await tester.pumpWidget(
+          buildWithLegend(
+            profile: profile,
+            ascentRates: ratesSpanningBands(profile),
+            configure: (n) => n.toggleAscentRateColors(),
+            onPointSelected: (i) => selected = i,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final chart = find.byType(LineChart).first;
+        final topLeft = tester.getTopLeft(chart);
+        final size = tester.getSize(chart);
+        // Hover in the right third of the plot -- that x lands on the danger
+        // band (a non-first segment).
+        final pointer = TestPointer(1, PointerDeviceKind.mouse);
+        await tester.sendEventToBinding(
+          pointer.hover(topLeft + Offset(size.width * 0.8, size.height * 0.5)),
+        );
+        await tester.pump();
+
+        expect(selected, isNotNull);
+        expect(selected, inInclusiveRange(0, profile.length - 1));
+      },
+    );
 
     testWidgets('a band change at the final sample still draws a line', (
       tester,

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -2457,16 +2457,25 @@ void main() {
         final chart = find.byType(LineChart).first;
         final topLeft = tester.getTopLeft(chart);
         final size = tester.getSize(chart);
-        // Hover in the right third of the plot -- that x lands on the danger
-        // band (a non-first segment).
+        // Hover well into the right of the plot -- that x lands in the danger
+        // band (the last, non-first segment).
         final pointer = TestPointer(1, PointerDeviceKind.mouse);
         await tester.sendEventToBinding(
-          pointer.hover(topLeft + Offset(size.width * 0.8, size.height * 0.5)),
+          pointer.hover(topLeft + Offset(size.width * 0.85, size.height * 0.5)),
         );
         await tester.pump();
 
+        // Every band-local spotIndex in this fixture is <= 4 (each bar holds at
+        // most 5 points), and the danger band starts at global index 7. A hover
+        // here must resolve to a global index >= 7, which a band-local emission
+        // could never produce -- that is what proves the mapping, not merely
+        // "some in-range index".
         expect(selected, isNotNull);
-        expect(selected, inInclusiveRange(0, profile.length - 1));
+        expect(
+          selected,
+          allOf(greaterThanOrEqualTo(7), lessThan(profile.length)),
+          reason: 'must be the global danger-band index, not a band-local one',
+        );
       },
     );
 


### PR DESCRIPTION
## Problem

When **Ascent Rate** (velocity colouring) is selected in the dive profile chart options, hover-over tooltips do not show.

## Root cause

Enabling velocity colouring draws the depth curve as **one `LineChartBarData` per velocity band** (`barIndex` 0, 1, 2…). Every touch/tooltip path assumed the depth curve was a single bar at `barIndex == 0`:

- `getTooltipItems` built a tooltip only for `spot.barIndex == 0` → hovering any later band returned all-null → **no tooltip bubble**.
- `touchCallback` (external tooltip + `onPointSelected`) gated on `spot.barIndex == 0` → **no selection/emit** on later bands.

A second latent bug: fl_chart's `spot.spotIndex` is **local to each bar's spot list**, so even reaching a non-first band would have indexed the wrong sample.

## Fix

- Add `DiveProfileChart.velocityBandRuns()` as the single source of truth for band segmentation, shared by the renderer (`_buildVelocityColoredDepthLines`) and a new `_depthBarStartIndices()` mapping.
- A touched spot on bar `b` at local `spotIndex` now resolves to the global profile index `starts[b] + spotIndex` across all three touch paths (`getTooltipItems`, `touchCallback`/`onPointSelected`, `_emitExternalTooltip`). A tiny record shadow (`final spot = (spotIndex: globalIndex)`) keeps the large tooltip closure otherwise unchanged.
- Multi-computer rendering and the separate "Ascent Rate Line" overlay are unaffected (they fall through to the single-depth-bar `[0]` mapping).

Also (per follow-up feedback): keep the **safe/baseline band the normal depth blue** instead of green — only the elevated warning/danger bands are recoloured, so a within-limits ascent renders identically whether or not the toggle is on.

## Tests

- `velocityBandRuns` unit test (band boundaries/categories).
- Deterministic reproduction via `getTooltipItems`: a hover on a non-first velocity band now returns a non-null tooltip. Verified it **fails** with the old `barIndex == 0` gate.
- Hover integration test: `onPointSelected` fires with a valid global index when hovering a later band.
- Updated the depth-line colour test to assert the safe band is `AppColors.chartDepth` and no green appears.
- Full chart suite: **104/104 pass**; `dart format` and whole-project `flutter analyze` clean.