### PR TITLE
fix(equipment): constrain Tab traversal to the active pane while editing (#444)

### DIFF
--- a/lib/shared/widgets/master_detail/master_detail_scaffold.dart
+++ b/lib/shared/widgets/master_detail/master_detail_scaffold.dart
@@ -272,6 +272,13 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
     final selectedId = _selectedId;
     final mode = _mode;
 
+    // While editing or creating in the detail pane, keep keyboard Tab
+    // traversal confined to that pane. Without this, Tab crosses the divider
+    // into the master list on the left (issue #444). The list remains
+    // clickable and accessible; only Tab traversal is excluded.
+    final isEditingDetail =
+        mode == DetailPaneMode.edit || mode == DetailPaneMode.create;
+
     if (!isDesktop) {
       // Mobile: Just show the master pane with Scaffold
       return Scaffold(
@@ -289,11 +296,18 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
           // Master pane (list) with fixed width
           SizedBox(
             width: widget.masterWidth,
-            child: _MasterPane(
-              floatingActionButton: widget.floatingActionButton != null
-                  ? _wrapFabForCreate(widget.floatingActionButton!)
-                  : null,
-              child: widget.masterBuilder(context, _onItemSelected, selectedId),
+            child: ExcludeFocusTraversal(
+              excluding: isEditingDetail,
+              child: _MasterPane(
+                floatingActionButton: widget.floatingActionButton != null
+                    ? _wrapFabForCreate(widget.floatingActionButton!)
+                    : null,
+                child: widget.masterBuilder(
+                  context,
+                  _onItemSelected,
+                  selectedId,
+                ),
+              ),
             ),
           ),
           // Vertical divider

--- a/lib/shared/widgets/master_detail/master_detail_scaffold.dart
+++ b/lib/shared/widgets/master_detail/master_detail_scaffold.dart
@@ -272,12 +272,19 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
     final selectedId = _selectedId;
     final mode = _mode;
 
-    // While editing or creating in the detail pane, keep keyboard Tab
-    // traversal confined to that pane. Without this, Tab crosses the divider
-    // into the master list on the left (issue #444). The list remains
-    // clickable and accessible; only Tab traversal is excluded.
+    // While an edit/create form is actually shown in the detail pane, keep
+    // keyboard Tab traversal confined to that pane. Without this, Tab crosses
+    // the divider into the master list on the left (issue #444). The list
+    // remains clickable and accessible; only Tab traversal is excluded.
+    //
+    // These conditions mirror _DetailPane._buildContent so the master pane is
+    // only excluded when the edit/create builder is genuinely rendered (not,
+    // e.g., for `?mode=new` with a null createBuilder, which shows a summary).
     final isEditingDetail =
-        mode == DetailPaneMode.edit || mode == DetailPaneMode.create;
+        (mode == DetailPaneMode.create && widget.createBuilder != null) ||
+        (mode == DetailPaneMode.edit &&
+            selectedId != null &&
+            widget.editBuilder != null);
 
     if (!isDesktop) {
       // Mobile: Just show the master pane with Scaffold

--- a/test/shared/widgets/master_detail/master_detail_scaffold_focus_test.dart
+++ b/test/shared/widgets/master_detail/master_detail_scaffold_focus_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
+
+/// Builds a [MasterDetailScaffold] inside a router at [initialLocation] so
+/// query params (`?selected=1&mode=edit`) drive the detail pane mode.
+///
+/// The desktop (master-detail) layout requires width >= 800.
+Widget _buildScaffold({
+  required String initialLocation,
+  required Widget Function(
+    BuildContext context,
+    void Function(String?) onItemSelected,
+    String? selectedId,
+  )
+  masterBuilder,
+  required Widget Function(
+    BuildContext context,
+    String itemId,
+    void Function(String savedId) onSaved,
+    VoidCallback onCancel,
+  )
+  editBuilder,
+  double width = 1200,
+}) {
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        path: '/test',
+        builder: (context, state) => MediaQuery(
+          data: MediaQueryData(size: Size(width, 800)),
+          child: MasterDetailScaffold(
+            sectionId: 'test',
+            masterBuilder: masterBuilder,
+            detailBuilder: (_, id) => Text('Detail $id'),
+            summaryBuilder: (_) => const Text('Summary'),
+            editBuilder: editBuilder,
+            createBuilder: (context, onSaved, onCancel) =>
+                editBuilder(context, 'new', onSaved, onCancel),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    child: MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+/// A minimal traversable widget wrapping an explicit [FocusNode] so tests can
+/// assert exactly which pane holds focus.
+Widget _focusTarget(FocusNode node) =>
+    Focus(focusNode: node, child: const SizedBox(width: 20, height: 20));
+
+void main() {
+  group('MasterDetailScaffold focus traversal (issue #444)', () {
+    testWidgets(
+      'edit mode: Tab from the edit pane never moves focus into the master pane',
+      (tester) async {
+        final masterNode = FocusNode(debugLabel: 'master');
+        final field1 = FocusNode(debugLabel: 'edit-field-1');
+        final field2 = FocusNode(debugLabel: 'edit-field-2');
+        addTearDown(masterNode.dispose);
+        addTearDown(field1.dispose);
+        addTearDown(field2.dispose);
+
+        await tester.pumpWidget(
+          _buildScaffold(
+            initialLocation: '/test?selected=1&mode=edit',
+            masterBuilder: (context, onSelect, selectedId) =>
+                _focusTarget(masterNode),
+            editBuilder: (context, id, onSaved, onCancel) =>
+                Column(children: [_focusTarget(field1), _focusTarget(field2)]),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Start focus on the last field in the edit pane.
+        field2.requestFocus();
+        await tester.pump();
+        expect(field2.hasFocus, isTrue);
+
+        // Tabbing forward from the last edit field must wrap within the edit
+        // pane, not cross into the master list on the left.
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        expect(
+          masterNode.hasFocus,
+          isFalse,
+          reason: 'Tab must not move focus into the master (list) pane.',
+        );
+        expect(
+          field1.hasFocus || field2.hasFocus,
+          isTrue,
+          reason: 'Focus should remain within the edit pane.',
+        );
+      },
+    );
+
+    testWidgets(
+      'create mode: Tab from the create pane never moves focus into the master pane',
+      (tester) async {
+        final masterNode = FocusNode(debugLabel: 'master');
+        final field1 = FocusNode(debugLabel: 'create-field-1');
+        final field2 = FocusNode(debugLabel: 'create-field-2');
+        addTearDown(masterNode.dispose);
+        addTearDown(field1.dispose);
+        addTearDown(field2.dispose);
+
+        await tester.pumpWidget(
+          _buildScaffold(
+            initialLocation: '/test?mode=new',
+            masterBuilder: (context, onSelect, selectedId) =>
+                _focusTarget(masterNode),
+            editBuilder: (context, id, onSaved, onCancel) =>
+                Column(children: [_focusTarget(field1), _focusTarget(field2)]),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        field2.requestFocus();
+        await tester.pump();
+        expect(field2.hasFocus, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        expect(masterNode.hasFocus, isFalse);
+        expect(field1.hasFocus || field2.hasFocus, isTrue);
+      },
+    );
+  });
+}

--- a/test/shared/widgets/master_detail/master_detail_scaffold_focus_test.dart
+++ b/test/shared/widgets/master_detail/master_detail_scaffold_focus_test.dart
@@ -25,6 +25,7 @@ Widget _buildScaffold({
     VoidCallback onCancel,
   )
   editBuilder,
+  bool provideCreateBuilder = true,
   double width = 1200,
 }) {
   final router = GoRouter(
@@ -40,8 +41,10 @@ Widget _buildScaffold({
             detailBuilder: (_, id) => Text('Detail $id'),
             summaryBuilder: (_) => const Text('Summary'),
             editBuilder: editBuilder,
-            createBuilder: (context, onSaved, onCancel) =>
-                editBuilder(context, 'new', onSaved, onCancel),
+            createBuilder: provideCreateBuilder
+                ? (context, onSaved, onCancel) =>
+                      editBuilder(context, 'new', onSaved, onCancel)
+                : null,
           ),
         ),
       ),
@@ -90,8 +93,9 @@ void main() {
         await tester.pump();
         expect(field2.hasFocus, isTrue);
 
-        // Tabbing forward from the last edit field must wrap within the edit
-        // pane, not cross into the master list on the left.
+        // Tabbing forward from the last edit field must wrap to the first
+        // field within the edit pane, not cross into the master list nor
+        // silently no-op on the last field.
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.pump();
 
@@ -101,10 +105,13 @@ void main() {
           reason: 'Tab must not move focus into the master (list) pane.',
         );
         expect(
-          field1.hasFocus || field2.hasFocus,
+          field1.hasFocus,
           isTrue,
-          reason: 'Focus should remain within the edit pane.',
+          reason:
+              'Tab from the last edit field should wrap to the first edit '
+              'field, confirming traversal cycles within the edit pane.',
         );
+        expect(field2.hasFocus, isFalse);
       },
     );
 
@@ -137,7 +144,55 @@ void main() {
         await tester.pump();
 
         expect(masterNode.hasFocus, isFalse);
-        expect(field1.hasFocus || field2.hasFocus, isTrue);
+        expect(
+          field1.hasFocus,
+          isTrue,
+          reason:
+              'Tab from the last create field should wrap to the first create '
+              'field, confirming traversal cycles within the create pane.',
+        );
+        expect(field2.hasFocus, isFalse);
+      },
+    );
+
+    testWidgets(
+      'mode=new with no createBuilder does not exclude the master pane',
+      (tester) async {
+        // When createBuilder is null, `?mode=new` renders the summary, not a
+        // create form, so the master pane must stay in the Tab order.
+        final master1 = FocusNode(debugLabel: 'master-1');
+        final master2 = FocusNode(debugLabel: 'master-2');
+        addTearDown(master1.dispose);
+        addTearDown(master2.dispose);
+
+        await tester.pumpWidget(
+          _buildScaffold(
+            initialLocation: '/test?mode=new',
+            provideCreateBuilder: false,
+            masterBuilder: (context, onSelect, selectedId) => Column(
+              children: [_focusTarget(master1), _focusTarget(master2)],
+            ),
+            editBuilder: (context, id, onSaved, onCancel) =>
+                const SizedBox.shrink(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        master2.requestFocus();
+        await tester.pump();
+        expect(master2.hasFocus, isTrue);
+
+        // The master pane is traversable, so Tab wraps within it.
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        expect(
+          master1.hasFocus,
+          isTrue,
+          reason:
+              'Master pane must remain Tab-traversable when no create form is '
+              'shown.',
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary

Fixes #444. On desktop, editing or adding equipment let keyboard `Tab` cross from the edit form (right pane) into the equipment list (left pane). Tab is now constrained to the active edit form.

## Root cause

The desktop master-detail layout (`MasterDetailScaffold`) renders a two-pane `Row` — a fixed-width list pane and an `Expanded` detail/edit pane — both inside the route's single `FocusScope`. Flutter's default `ReadingOrderTraversalPolicy` walks all focusable descendants of the nearest scope and wraps around, so Tab in the edit form spilled across the `VerticalDivider` into the list.

## Fix

While the detail pane is in `edit`/`create` mode, wrap the master pane in `ExcludeFocusTraversal(excluding: true)`. This removes the list from Tab order **only** while editing; the list stays fully clickable and screen-reader accessible, and normal browsing (view mode) is unchanged.

Because `TableModeLayout` delegates to `MasterDetailScaffold` whenever a detail pane is active, this single change covers **both** the detailed/compact and table views, and **all** master-detail sections (equipment, dives, sites, buddies, trips, etc.).

## Testing

- New TDD widget test `master_detail_scaffold_focus_test.dart` reproduces the bug (failed pre-fix in both edit and create modes) and passes post-fix.
- `dart format` clean; `flutter analyze` clean (whole project).
- Ran master-detail, table-mode, and equipment-list suites: 56 tests pass, no regressions.