### PR TITLE
feat(deco): gas-aware optimal ascent for imported-dive decompression (OC)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-gas-aware-ascent.md
+++ b/docs/superpowers/plans/2026-06-28-gas-aware-ascent.md
@@ -1,0 +1,1329 @@
+# Gas-Aware Ascent for Imported-Dive Decompression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every forward-looking decompression projection (TTS, ceiling, stop schedule) simulate the ascent on the best breathable gas the diver carries at each simulated depth, eliminating the discontinuous TTS step at recorded gas switches — for open-circuit dives only.
+
+**Architecture:** Introduce a pluggable `AscentGasPlan` strategy that answers "what inert fractions do I breathe at this ascent depth?". Thread it through the existing Bühlmann ascent primitives (`calculateDecoSchedule` / `calculateTts` / `_calculateStopTime` / `_simulateAscent` / `getDecoStatus` / `processProfileWithGasSegments`), splitting each ascent leg at any gas-switch (MOD) depth it crosses. The bottom-phase tissue-loading path delivered by the 2026-03-31 spec is untouched; only the per-sample projection changes. CCR/SCR are out of scope and keep today's behavior.
+
+**Tech Stack:** Flutter / Dart, Drift ORM (SQLite), Riverpod, Bühlmann ZH-L16C with gradient factors.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Open-circuit only.** Gas-aware ascent must never engage off the OC path. The existing `useOcGasSegments` guard (`diveMode == DiveMode.oc && gasSegments != null`, `profile_analysis_service.dart:573`) is the single gate. No `CcrLoopAscentGas`, no bailout modeling.
+- **Single-gas dives must be byte-identical to `main`.** When only one gas is in play the plan must reduce to today's fixed-gas ascent exactly.
+- **Eligibility ceiling reuses the existing `ppO2MaxDeco` diver setting (default 1.6 bar).** Do not add a parallel ppO2 setting. Eligibility uses `O2ToxicityCalculator.calculateMod(fO2, maxPpO2: ppO2MaxDeco)`, never an inline ppO2 re-derivation.
+- **No invented gases.** Only cylinders actually recorded on `dive.tanks`. A cylinder's presence is proof it was carried and breathable.
+- **Bühlmann math stays shared, not forked.** Thread the plan through the existing methods; do not copy the algorithm.
+- **The recorded computer TTS overlay (`overlayComputerDecoData`) stays authoritative per-metric where present.** This plan changes only the *calculated* values it falls back to.
+- **No schema/stored-data migration for dive deco data.** Curves recompute on next open. (The new *setting* below does add one Drift column + migration — that is the only migration in this plan.)
+- **`fO2 = 1 - fN2 - fHe`** everywhere; `ProfileGasSegment` and `AscentGas` carry only `fN2`/`fHe`.
+- **The "Plan ascent with" setting is a single persisted enum** `AscentGasSet { allCarried, decoStageOnly }`, default `allCarried`. `allCarried` = every recorded cylinder. `decoStageOnly` = cylinders with role `deco`/`stage`/`bailout` plus the current back gas (the gas actually being breathed at the sample, always included as the ascent floor). There is no separate feature kill-switch.
+- **Run `dart format .` after each task.** All Dart must pass `dart format` with no changes (pre-push hook enforces it).
+- **TDD.** Write the failing test first, watch it fail, implement minimally, watch it pass, commit.
+- **Fixtures:** use only the committed files in `test/dives/`. OC: `001_short_deco_single_gas_switch.ssrf.xml`. CCR (used only to assert no-change): `002_ccr_only_low_sp_no_calculated_po2.ssrf.xml`, `003_ccr_with_setpoint_switch_and_calculated_po2.ssrf.xml`. Any other recording under `test/dives/` (e.g. `sanfran.ssrf`) is a private local file and must not be referenced.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `lib/core/deco/ascent/ascent_gas_plan.dart` | **New.** `AscentGas`, `AscentGasPlan`, `FixedAscentGas`, `AvailableGas`, `OptimalOcAscentGas`. Pure logic, no Flutter/Drift imports. |
+| `lib/core/deco/buhlmann_algorithm.dart` | Thread `AscentGasPlan` through the ascent primitives; MOD-split in `_simulateAscent`; keep `fN2/fHe` optional-param overloads. |
+| `lib/features/settings/presentation/providers/settings_providers.dart` | `AscentGasSet` enum, `AppSettings.ascentGasSet` field + copyWith, `ascentGasSetProvider`. |
+| `lib/core/database/database.dart` | `DiverSettings.ascentGasSet` Drift column (v94), `currentSchemaVersion = 94`, migration step. |
+| `lib/features/settings/data/repositories/diver_settings_repository.dart` | Persist/read `ascentGasSet`. |
+| `lib/core/services/sync/sync_data_serializer.dart` | Serialize/deserialize `ascentGasSet`. |
+| `lib/features/dive_log/presentation/providers/profile_analysis_provider.dart` | `buildAvailableGases(dive)`; pass available gases + ppO2MaxDeco + gas-set into the isolate input; build `OptimalOcAscentGas` in the isolate (OC path only). |
+| `lib/features/dive_log/data/services/profile_analysis_service.dart` | `analyze()` gains `ascentGasPlan`; plumb into `processProfileWithGasSegments` for the OC path. |
+| `lib/features/dive_planner/data/services/plan_calculator_service.dart` | Select `OptimalOcAscentGas` (ideal) vs `FixedAscentGas` per the existing gas model. |
+| `lib/features/settings/presentation/pages/<deco settings page>.dart` | "Plan ascent with" selector (all vs deco-only). |
+| `test/core/deco/ascent_gas_plan_test.dart` | **New.** Strategy selection, MOD eligibility, tie-breaking, switch-depth enumeration. |
+| `test/core/deco/buhlmann_algorithm_test.dart` | MOD-split / on-the-fly-switch / overload-delegation tests (append). |
+| `test/core/deco/tts_gas_switch_regression_test.dart` | **New.** Step-free TTS across a switch; single-gas equivalence; CCR path unchanged. |
+| `test/core/deco/tts_cleanroom_cross_check_test.dart` | **New.** Independent ZHL-16C/GF per-sample TTS cross-check pinning absolute numbers. |
+| `test/features/settings/ascent_gas_set_setting_test.dart` | **New.** Default + round-trip persistence of the setting. |
+| `test/features/dive_log/build_available_gases_test.dart` | **New.** `buildAvailableGases` mapping + gas-set filtering + no invented gases. |
+
+---
+
+### Task 1: `AscentGasPlan` strategy and implementations
+
+**Files:**
+- Create: `lib/core/deco/ascent/ascent_gas_plan.dart`
+- Test: `test/core/deco/ascent_gas_plan_test.dart`
+
+**Interfaces:**
+- Consumes: `O2ToxicityCalculator.calculateMod(double o2Fraction, {double maxPpO2})` from `lib/core/deco/o2_toxicity_calculator.dart` (returns MOD in meters); `airN2Fraction` from `lib/core/deco/constants/buhlmann_coefficients.dart`.
+- Produces:
+  - `class AscentGas { final double fN2; final double fHe; const AscentGas({required this.fN2, required this.fHe}); }`
+  - `abstract class AscentGasPlan { AscentGas gasForDepth(double depthMeters); List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth); }`
+  - `class FixedAscentGas extends AscentGasPlan { FixedAscentGas({required double fN2, double fHe}); }`
+  - `class AvailableGas { final double fN2; final double fHe; final double maxPpO2Mod; double get fO2; const AvailableGas({required this.fN2, required this.fHe, required this.maxPpO2Mod}); }`
+  - `class OptimalOcAscentGas extends AscentGasPlan { OptimalOcAscentGas({required List<AvailableGas> gases, required double maxPpO2}); }`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/deco/ascent_gas_plan_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+
+void main() {
+  group('FixedAscentGas', () {
+    test('returns the same gas at every depth', () {
+      final plan = FixedAscentGas(fN2: 0.79, fHe: 0.0);
+      expect(plan.gasForDepth(40).fN2, 0.79);
+      expect(plan.gasForDepth(0).fN2, 0.79);
+      expect(plan.gasForDepth(40).fHe, 0.0);
+    });
+
+    test('reports no switch depths', () {
+      final plan = FixedAscentGas(fN2: airN2Fraction);
+      expect(plan.switchDepthsBetween(40, 0), isEmpty);
+    });
+  });
+
+  group('OptimalOcAscentGas', () {
+    // Back gas air (fO2 0.21), EAN50 (fO2 0.50), O2 (fO2 1.0); ppO2 ceiling 1.6.
+    // MOD(EAN50,1.6) = (1.6/0.5 - 1)*10 = 22.0 m. MOD(O2,1.6) = 6.0 m.
+    final gases = <AvailableGas>[
+      const AvailableGas(fN2: 0.79, fHe: 0.0, maxPpO2Mod: double.infinity),
+      const AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+      const AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0),
+    ];
+    final plan = OptimalOcAscentGas(gases: gases, maxPpO2: 1.6);
+
+    test('picks the richest eligible gas at depth', () {
+      expect(plan.gasForDepth(40).fN2, 0.79); // only air is eligible at 40 m
+      expect(plan.gasForDepth(21).fN2, 0.50); // EAN50 eligible (<= 22 m), richest
+      expect(plan.gasForDepth(6).fN2, 0.0); // O2 eligible at its MOD (6 m)
+      expect(plan.gasForDepth(3).fN2, 0.0); // O2 still richest
+    });
+
+    test('is eligible exactly at a gas MOD', () {
+      expect(plan.gasForDepth(22).fN2, 0.50); // EAN50 ppO2 == 1.6 at 22 m
+    });
+
+    test('enumerates switch depths descending within a leg', () {
+      expect(plan.switchDepthsBetween(40, 0), [22.0, 6.0]);
+      expect(plan.switchDepthsBetween(40, 12), [22.0]); // 6 m is outside (40,12)
+      expect(plan.switchDepthsBetween(9, 6), isEmpty); // no MOD strictly inside
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/ascent_gas_plan_test.dart`
+Expected: FAIL — `ascent_gas_plan.dart` does not exist / `OptimalOcAscentGas` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/deco/ascent/ascent_gas_plan.dart
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+
+/// Inert gas fractions to breathe at a given simulated ascent depth.
+class AscentGas {
+  const AscentGas({required this.fN2, required this.fHe});
+  final double fN2;
+  final double fHe;
+}
+
+/// Strategy answering "what do I breathe at this ascent depth?" so the
+/// Buhlmann algorithm stays ignorant of tank roles and ppO2 policy.
+abstract class AscentGasPlan {
+  /// Gas to breathe at [depthMeters] during a simulated ascent.
+  AscentGas gasForDepth(double depthMeters);
+
+  /// Depths in the open interval ([shallowerDepth], [deeperDepth]) where the
+  /// selected gas changes, sorted deep-to-shallow (descending). An ascent leg
+  /// is split at each so it never breathes a gas impermissible at its depth.
+  List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth);
+}
+
+/// Today's behavior: one gas the whole way up. Used by single-gas dives and the
+/// planner's fixed-gas path. Reduces gas-aware ascent to the legacy ascent.
+class FixedAscentGas extends AscentGasPlan {
+  FixedAscentGas({required this.fN2, this.fHe = 0.0});
+  final double fN2;
+  final double fHe;
+
+  @override
+  AscentGas gasForDepth(double depthMeters) => AscentGas(fN2: fN2, fHe: fHe);
+
+  @override
+  List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth) =>
+      const [];
+}
+
+/// A cylinder available on the dive, with its precomputed MOD for the diver's
+/// ppO2 ceiling. [maxPpO2Mod] is the deepest depth (m) where ppO2 <= ceiling.
+class AvailableGas {
+  const AvailableGas({
+    required this.fN2,
+    required this.fHe,
+    required this.maxPpO2Mod,
+  });
+  final double fN2;
+  final double fHe;
+  final double maxPpO2Mod;
+
+  double get fO2 => (1.0 - fN2 - fHe);
+}
+
+/// Open-circuit optimal ascent: at each depth picks the eligible gas with the
+/// highest O2 (ppO2 at depth <= [maxPpO2]). Eligibility is expressed as MOD on
+/// [AvailableGas.maxPpO2Mod], derived once via O2ToxicityCalculator.calculateMod
+/// so ppO2 is never re-derived here.
+class OptimalOcAscentGas extends AscentGasPlan {
+  OptimalOcAscentGas({required List<AvailableGas> gases, required this.maxPpO2})
+    : _gases = List.unmodifiable(gases);
+
+  final List<AvailableGas> _gases;
+  final double maxPpO2;
+
+  @override
+  AscentGas gasForDepth(double depthMeters) {
+    AvailableGas? best;
+    for (final g in _gases) {
+      // Eligible when at or above its MOD (depth <= MOD). A tiny tolerance keeps
+      // the gas eligible exactly at its MOD despite float rounding.
+      if (depthMeters <= g.maxPpO2Mod + 1e-9) {
+        if (best == null || _prefer(g, best)) best = g;
+      }
+    }
+    // The back gas is always in [_gases], so best is never null in practice;
+    // fall back to the deepest-usable gas (smallest fO2) if it ever is.
+    best ??= _deepestUsable();
+    return AscentGas(fN2: best.fN2, fHe: best.fHe);
+  }
+
+  @override
+  List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth) {
+    final result = <double>[];
+    for (final g in _gases) {
+      final mod = g.maxPpO2Mod;
+      if (mod > shallowerDepth + 1e-9 && mod < deeperDepth - 1e-9) {
+        // Only a real switch: the selected gas differs just below vs just above.
+        final below = gasForDepth(mod + 1e-6);
+        final above = gasForDepth(mod - 1e-6);
+        if (below.fN2 != above.fN2 || below.fHe != above.fHe) {
+          result.add(mod);
+        }
+      }
+    }
+    result.sort((a, b) => b.compareTo(a)); // descending (deep to shallow)
+    return result;
+  }
+
+  /// Prefer higher O2; tie-break by lower narcotic load (higher He), then a
+  /// deterministic order so the result is stable.
+  bool _prefer(AvailableGas candidate, AvailableGas current) {
+    if (candidate.fO2 != current.fO2) return candidate.fO2 > current.fO2;
+    if (candidate.fHe != current.fHe) return candidate.fHe > current.fHe;
+    return candidate.fN2 < current.fN2;
+  }
+
+  AvailableGas _deepestUsable() =>
+      _gases.reduce((a, b) => a.fO2 <= b.fO2 ? a : b);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/deco/ascent_gas_plan_test.dart`
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/core/deco/ascent/ascent_gas_plan.dart test/core/deco/ascent_gas_plan_test.dart
+git commit -m "feat(deco): add AscentGasPlan strategy for gas-aware ascent"
+```
+
+---
+
+### Task 2: Thread `AscentGasPlan` through the Bühlmann ascent primitives
+
+**Files:**
+- Modify: `lib/core/deco/buhlmann_algorithm.dart` (`calculateDecoSchedule` `:277`, `_calculateStopTime` `:336`, `_simulateAscent` `:378`, `calculateTts` `:408`)
+- Test: `test/core/deco/buhlmann_algorithm_test.dart` (append)
+
+**Interfaces:**
+- Consumes: `AscentGasPlan`, `FixedAscentGas`, `AscentGas` from Task 1.
+- Produces (signatures later tasks rely on):
+  - `List<DecoStop> calculateDecoSchedule({required double currentDepth, double fN2, double fHe, AscentGasPlan? ascentGas})`
+  - `int calculateTts({required double currentDepth, double fN2, double fHe, AscentGasPlan? ascentGas})`
+  - `_simulateAscent(double fromDepth, double toDepth, AscentGasPlan ascentGas)` and `_calculateStopTime(double stopDepth, AscentGasPlan ascentGas)` (private).
+  - Invariant: when `ascentGas` is null/`FixedAscentGas`, output is byte-identical to the pre-change single-gas path.
+
+- [ ] **Step 1: Write the failing test (append to `test/core/deco/buhlmann_algorithm_test.dart`)**
+
+```dart
+  group('gas-aware ascent (AscentGasPlan)', () {
+    // A deco dive: 40 m for 25 min on air, then project ascent.
+    BuhlmannAlgorithm loadedAt40() {
+      final algo = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80);
+      algo.reset();
+      algo.calculateSegment(
+        depthMeters: 40,
+        durationSeconds: 25 * 60,
+        fN2: airN2Fraction,
+        fHe: 0.0,
+      );
+      return algo;
+    }
+
+    test('FixedAscentGas TTS equals the fN2/fHe overload (equivalence)', () {
+      final a = loadedAt40();
+      final viaFraction = a.calculateTts(currentDepth: 40, fN2: airN2Fraction);
+      final b = loadedAt40();
+      final viaPlan = b.calculateTts(
+        currentDepth: 40,
+        ascentGas: FixedAscentGas(fN2: airN2Fraction),
+      );
+      expect(viaPlan, viaFraction);
+    });
+
+    test('richer ascent gas yields lower-or-equal TTS than all-air', () {
+      final allAir = loadedAt40().calculateTts(
+        currentDepth: 40,
+        fN2: airN2Fraction,
+      );
+      // Air back gas + EAN50 (MOD 22 m @1.6) + O2 (MOD 6 m @1.6).
+      final plan = OptimalOcAscentGas(
+        gases: const [
+          AvailableGas(fN2: 0.79, fHe: 0.0, maxPpO2Mod: double.infinity),
+          AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+          AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0),
+        ],
+        maxPpO2: 1.6,
+      );
+      final gasAware = loadedAt40().calculateTts(
+        currentDepth: 40,
+        ascentGas: plan,
+      );
+      expect(gasAware, lessThanOrEqualTo(allAir));
+    });
+
+    test('MOD split: gas at the deeper end of each sub-leg is correct', () {
+      // Spy plan records the depths gasForDepth() is queried at during a leg.
+      final spy = _RecordingPlan(
+        OptimalOcAscentGas(
+          gases: const [
+            AvailableGas(fN2: 0.79, fHe: 0.0, maxPpO2Mod: double.infinity),
+            AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+          ],
+          maxPpO2: 1.6,
+        ),
+      );
+      final a = loadedAt40();
+      // Drive a full schedule so _simulateAscent walks 40 -> first stop.
+      a.calculateDecoSchedule(currentDepth: 40, ascentGas: spy);
+      // The travel leg from 40 m must have been split at 22 m: back gas was
+      // queried at a depth > 22 and EAN50 at exactly 22 (sub-leg deeper end).
+      expect(spy.queriedDepths.any((d) => d >= 22.0), isTrue);
+    });
+  });
+```
+
+Add this private spy near the bottom of the test file:
+
+```dart
+class _RecordingPlan extends AscentGasPlan {
+  _RecordingPlan(this._inner);
+  final AscentGasPlan _inner;
+  final List<double> queriedDepths = [];
+
+  @override
+  AscentGas gasForDepth(double depthMeters) {
+    queriedDepths.add(depthMeters);
+    return _inner.gasForDepth(depthMeters);
+  }
+
+  @override
+  List<double> switchDepthsBetween(double deeper, double shallower) =>
+      _inner.switchDepthsBetween(deeper, shallower);
+}
+```
+
+Ensure the test file imports:
+```dart
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/buhlmann_algorithm_test.dart --plain-name "gas-aware ascent"`
+Expected: FAIL — `calculateTts`/`calculateDecoSchedule` have no `ascentGas` parameter.
+
+- [ ] **Step 3: Implement — replace the four primitives**
+
+In `lib/core/deco/buhlmann_algorithm.dart`, add the import at the top:
+```dart
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+```
+
+Replace `calculateDecoSchedule` (`:277-333`) with:
+```dart
+  List<DecoStop> calculateDecoSchedule({
+    required double currentDepth,
+    double fN2 = airN2Fraction,
+    double fHe = 0.0,
+    AscentGasPlan? ascentGas,
+  }) {
+    final plan = ascentGas ?? FixedAscentGas(fN2: fN2, fHe: fHe);
+    final stops = <DecoStop>[];
+
+    final savedCompartments = List<TissueCompartment>.from(_compartments);
+
+    final double ceiling = calculateCeiling(currentDepth: currentDepth);
+    if (ceiling <= 0) {
+      _compartments = savedCompartments;
+      return stops; // No deco required
+    }
+
+    double currentStopDepth = (ceiling / stopIncrement).ceil() * stopIncrement;
+
+    // Travel to first stop may cross a gas MOD: _simulateAscent splits it.
+    _simulateAscent(currentDepth, currentStopDepth, plan);
+
+    while (currentStopDepth >= lastStopDepth) {
+      final int stopTime = _calculateStopTime(currentStopDepth, plan);
+
+      if (stopTime > 0) {
+        stops.add(
+          DecoStop(
+            depthMeters: currentStopDepth,
+            durationSeconds: stopTime,
+            isDeepStop: currentStopDepth > 9,
+          ),
+        );
+
+        final stopGas = plan.gasForDepth(currentStopDepth);
+        calculateSegment(
+          depthMeters: currentStopDepth,
+          durationSeconds: stopTime,
+          fN2: stopGas.fN2,
+          fHe: stopGas.fHe,
+        );
+      }
+
+      final nextStop = currentStopDepth - stopIncrement;
+      if (nextStop >= lastStopDepth) {
+        _simulateAscent(currentStopDepth, nextStop, plan);
+      }
+      currentStopDepth = nextStop;
+    }
+
+    _compartments = savedCompartments;
+    return stops;
+  }
+```
+
+Replace `_calculateStopTime` (`:336-376`) with:
+```dart
+  /// Calculate time required at a stop depth, breathing the plan's gas there.
+  int _calculateStopTime(double stopDepth, AscentGasPlan ascentGas) {
+    final gas = ascentGas.gasForDepth(stopDepth);
+    final nextStopDepth = stopDepth <= lastStopDepth
+        ? 0.0
+        : stopDepth - stopIncrement;
+    int stopTime = 0;
+    const maxStopTime = 120 * 60;
+
+    while (stopTime < maxStopTime) {
+      final testCompartments = List<TissueCompartment>.from(_compartments);
+
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: 60,
+        fN2: gas.fN2,
+        fHe: gas.fHe,
+      );
+
+      final ceiling = calculateCeiling(currentDepth: stopDepth);
+
+      _compartments = testCompartments;
+
+      if (ceiling <= nextStopDepth) {
+        break;
+      }
+
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: 60,
+        fN2: gas.fN2,
+        fHe: gas.fHe,
+      );
+      stopTime += 60;
+    }
+
+    return ((stopTime + 59) ~/ 60) * 60;
+  }
+```
+
+Replace `_simulateAscent` (`:378-400`) with the split-aware version plus a single-leg helper:
+```dart
+  /// Simulate ascent between depths, splitting the leg at every gas-switch
+  /// (MOD) depth it crosses so each sub-leg breathes the gas eligible at that
+  /// sub-leg's deeper end. For [FixedAscentGas] there are no switch depths, so
+  /// this collapses to a single average-depth segment (legacy behavior).
+  void _simulateAscent(
+    double fromDepth,
+    double toDepth,
+    AscentGasPlan ascentGas,
+  ) {
+    if (fromDepth <= toDepth) return;
+
+    final switches = ascentGas.switchDepthsBetween(fromDepth, toDepth);
+    double segTop = fromDepth;
+    for (final switchDepth in switches) {
+      // switches is descending; each is strictly between toDepth and fromDepth.
+      _ascendLeg(segTop, switchDepth, ascentGas);
+      segTop = switchDepth;
+    }
+    _ascendLeg(segTop, toDepth, ascentGas);
+  }
+
+  /// Load one un-split ascent sub-leg on the gas eligible at its deeper end.
+  void _ascendLeg(double fromDepth, double toDepth, AscentGasPlan ascentGas) {
+    if (fromDepth <= toDepth) return;
+    final gas = ascentGas.gasForDepth(fromDepth);
+    final depthChange = fromDepth - toDepth;
+    final ascentTimeSeconds = (depthChange / ascentRate * 60).round();
+    final avgDepth = (fromDepth + toDepth) / 2.0;
+
+    calculateSegment(
+      depthMeters: avgDepth,
+      durationSeconds: ascentTimeSeconds,
+      fN2: gas.fN2,
+      fHe: gas.fHe,
+    );
+  }
+```
+
+Replace `calculateTts` (`:408-440`) signature/body head to accept the plan and delegate the schedule (the ascent-time accounting is gas-independent — depth/rate only — so the rest is unchanged):
+```dart
+  int calculateTts({
+    required double currentDepth,
+    double fN2 = airN2Fraction,
+    double fHe = 0.0,
+    AscentGasPlan? ascentGas,
+  }) {
+    final plan = ascentGas ?? FixedAscentGas(fN2: fN2, fHe: fHe);
+    final stops = calculateDecoSchedule(
+      currentDepth: currentDepth,
+      ascentGas: plan,
+    );
+
+    int tts = 0;
+    for (final stop in stops) {
+      tts += stop.durationSeconds;
+    }
+
+    double depth = currentDepth;
+    for (final stop in stops) {
+      final ascentTime = ((depth - stop.depthMeters) / ascentRate * 60).round();
+      tts += ascentTime;
+      depth = stop.depthMeters;
+    }
+
+    if (depth > 0) {
+      tts += (depth / ascentRate * 60).round();
+    }
+
+    return tts;
+  }
+```
+
+- [ ] **Step 4: Run the new tests and the full deco suite to verify pass + no regression**
+
+Run: `flutter test test/core/deco/buhlmann_algorithm_test.dart`
+Expected: PASS, including the existing single-gas tests (equivalence invariant holds).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/core/deco/buhlmann_algorithm.dart test/core/deco/buhlmann_algorithm_test.dart
+git commit -m "feat(deco): thread AscentGasPlan through ascent primitives with MOD split"
+```
+
+---
+
+### Task 3: `getDecoStatus` and `processProfileWithGasSegments` accept a plan
+
+**Files:**
+- Modify: `lib/core/deco/buhlmann_algorithm.dart` (`getDecoStatus` `:448`, `processProfileWithGasSegments` `:535`)
+- Test: `test/core/deco/tts_gas_switch_regression_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `calculateTts`/`calculateDecoSchedule` with `ascentGas` (Task 2).
+- Produces:
+  - `DecoStatus getDecoStatus({required double currentDepth, double fN2, double fHe, int safetyStopTimeAccumulated, AscentGasPlan? ascentGas})`
+  - `List<DecoStatus> processProfileWithGasSegments({required List<double> depths, required List<int> timestamps, required List<ProfileGasSegment> gasSegments, AscentGasPlan? ascentGasPlan})`
+  - Invariant: `ascentGasPlan == null` reproduces today's per-sample `FixedAscentGas(active gas)` behavior exactly.
+
+- [ ] **Step 1: Write the failing regression test**
+
+```dart
+// test/core/deco/tts_gas_switch_regression_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
+
+void main() {
+  // Synthetic deco profile: descend to 40 m, 25 min bottom on air, switch to
+  // EAN50 at 21 m on the way up, sampled every 60 s to the surface.
+  ({List<double> depths, List<int> timestamps, List<ProfileGasSegment> gas})
+  buildProfile() {
+    final depths = <double>[];
+    final timestamps = <int>[];
+    var t = 0;
+    void add(double d) {
+      depths.add(d);
+      timestamps.add(t);
+      t += 60;
+    }
+
+    for (var d = 0.0; d <= 40.0; d += 8) {
+      add(d);
+    }
+    for (var i = 0; i < 25; i++) {
+      add(40);
+    }
+    for (var d = 40.0; d >= 0.0; d -= 3) {
+      add(d);
+    }
+
+    // Recorded switch to EAN50 (fN2 0.50) at the sample nearest 21 m on ascent.
+    final switchIndex = depths.lastIndexWhere((d) => (d - 21).abs() < 1.6);
+    final gas = <ProfileGasSegment>[
+      const ProfileGasSegment(startTimestamp: 0, fN2: airN2Fraction),
+      ProfileGasSegment(
+        startTimestamp: timestamps[switchIndex],
+        fN2: 0.50,
+      ),
+    ];
+    return (depths: depths, timestamps: timestamps, gas: gas);
+  }
+
+  test('gas-aware TTS is monotone non-increasing across the recorded switch '
+      'and reads 0 at the surface', () {
+    final p = buildProfile();
+    final algo = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80);
+    algo.reset();
+    final plan = OptimalOcAscentGas(
+      gases: const [
+        AvailableGas(fN2: airN2Fraction, fHe: 0.0, maxPpO2Mod: double.infinity),
+        AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+      ],
+      maxPpO2: 1.6,
+    );
+    final statuses = algo.processProfileWithGasSegments(
+      depths: p.depths,
+      timestamps: p.timestamps,
+      gasSegments: p.gas,
+      ascentGasPlan: plan,
+    );
+
+    // Surface sample TTS is 0.
+    expect(statuses.last.ttsSeconds, 0);
+
+    // No upward step in TTS at the recorded switch: from the bottom phase
+    // through the ascent the TTS must never jump UP at the switch sample.
+    final tts = statuses.map((s) => s.ttsSeconds).toList();
+    final switchIndex = p.depths.lastIndexWhere((d) => (d - 21).abs() < 1.6);
+    expect(
+      tts[switchIndex] <= tts[switchIndex - 1] + 1,
+      isTrue,
+      reason: 'TTS stepped up at the recorded gas switch',
+    );
+  });
+
+  test('null ascentGasPlan reproduces the single-gas-per-sample legacy path', () {
+    final p = buildProfile();
+    final a = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80)..reset();
+    final legacy = a.processProfileWithGasSegments(
+      depths: p.depths,
+      timestamps: p.timestamps,
+      gasSegments: p.gas,
+    );
+    final b = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80)..reset();
+    final explicitNull = b.processProfileWithGasSegments(
+      depths: p.depths,
+      timestamps: p.timestamps,
+      gasSegments: p.gas,
+      ascentGasPlan: null,
+    );
+    expect(
+      explicitNull.map((s) => s.ttsSeconds),
+      legacy.map((s) => s.ttsSeconds),
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/core/deco/tts_gas_switch_regression_test.dart`
+Expected: FAIL — `processProfileWithGasSegments` has no `ascentGasPlan` parameter.
+
+- [ ] **Step 3: Implement**
+
+In `getDecoStatus` (`:448`), add the parameter and thread it into the in-deco branches:
+```dart
+  DecoStatus getDecoStatus({
+    required double currentDepth,
+    double fN2 = airN2Fraction,
+    double fHe = 0.0,
+    int safetyStopTimeAccumulated = 0,
+    AscentGasPlan? ascentGas,
+  }) {
+    final plan = ascentGas ?? FixedAscentGas(fN2: fN2, fHe: fHe);
+    final ndl = calculateNdl(depthMeters: currentDepth, fN2: fN2, fHe: fHe);
+```
+Then change the two in-deco computations to pass the plan:
+```dart
+    final stops = ndl < 0
+        ? calculateDecoSchedule(currentDepth: currentDepth, ascentGas: plan)
+        : <DecoStop>[];
+```
+and
+```dart
+    if (ndl < 0) {
+      tts = calculateTts(currentDepth: currentDepth, ascentGas: plan);
+    } else {
+      // ... unchanged safety-stop branch ...
+    }
+```
+Leave `calculateNdl` on `fN2`/`fHe` (NDL stays on the current breathing gas per the spec — it is intentionally not ascent-plan-aware) and the `ceiling`/no-deco branches unchanged.
+
+In `processProfileWithGasSegments` (`:535`), add the parameter and pass it to each per-sample `getDecoStatus`. The bottom-phase loading loop (using `_activeGasAtTimestamp`) is unchanged.
+```dart
+  List<DecoStatus> processProfileWithGasSegments({
+    required List<double> depths,
+    required List<int> timestamps,
+    required List<ProfileGasSegment> gasSegments,
+    AscentGasPlan? ascentGasPlan,
+  }) {
+```
+At the `results.add(getDecoStatus(...))` call (`:621`), pass `ascentGas: ascentGasPlan`. When `ascentGasPlan` is null, `getDecoStatus` falls back to `FixedAscentGas(active gas)` (today's behavior) because `fN2`/`fHe` are still the active-sample gas.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `flutter test test/core/deco/tts_gas_switch_regression_test.dart test/core/deco/buhlmann_algorithm_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/core/deco/buhlmann_algorithm.dart test/core/deco/tts_gas_switch_regression_test.dart
+git commit -m "feat(deco): plumb ascent gas plan into getDecoStatus and profile processing"
+```
+
+---
+
+### Task 4: `AscentGasSet` setting — enum, model, Drift column + migration, persistence, sync
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/settings_providers.dart` (`AppSettings` `:65`, copyWith `:410`, providers tail)
+- Modify: `lib/core/database/database.dart` (`DiverSettings` table `:757`, `currentSchemaVersion` `:1710`, migration block near `:1845`)
+- Modify: `lib/features/settings/data/repositories/diver_settings_repository.dart`
+- Modify: `lib/core/services/sync/sync_data_serializer.dart`
+- Test: `test/features/settings/ascent_gas_set_setting_test.dart` (new)
+
+**Interfaces:**
+- Produces:
+  - `enum AscentGasSet { allCarried, decoStageOnly }` (exported from `settings_providers.dart`).
+  - `AppSettings.ascentGasSet` (default `AscentGasSet.allCarried`) + `copyWith({AscentGasSet? ascentGasSet})`.
+  - `final ascentGasSetProvider = Provider<AscentGasSet>(...)`.
+  - Drift `DiverSettings.ascentGasSet` int column, default `0` (= `allCarried.index`). `currentSchemaVersion == 94`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/settings/ascent_gas_set_setting_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  test('AppSettings defaults ascentGasSet to allCarried', () {
+    const settings = AppSettings();
+    expect(settings.ascentGasSet, AscentGasSet.allCarried);
+  });
+
+  test('copyWith overrides ascentGasSet and preserves it otherwise', () {
+    const settings = AppSettings();
+    final updated = settings.copyWith(ascentGasSet: AscentGasSet.decoStageOnly);
+    expect(updated.ascentGasSet, AscentGasSet.decoStageOnly);
+    expect(updated.copyWith(gfLow: 40).ascentGasSet, AscentGasSet.decoStageOnly);
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/features/settings/ascent_gas_set_setting_test.dart`
+Expected: FAIL — `AscentGasSet` / `ascentGasSet` undefined.
+
+- [ ] **Step 3: Implement the model + provider**
+
+In `settings_providers.dart`, near the top-level enums, add:
+```dart
+/// Which cylinders the simulated (ideal) ascent may breathe.
+enum AscentGasSet {
+  /// Every cylinder recorded on the dive (default).
+  allCarried,
+
+  /// Only deco/stage/bailout cylinders plus the current back gas.
+  decoStageOnly,
+}
+```
+Add the field to `AppSettings` (next to `lastStopDepth`):
+```dart
+  /// Which carried gases feed the ideal (best-gas) ascent projection.
+  final AscentGasSet ascentGasSet;
+```
+Add to the constructor defaults:
+```dart
+    this.ascentGasSet = AscentGasSet.allCarried,
+```
+Add to `copyWith` params and body:
+```dart
+    AscentGasSet? ascentGasSet,
+    // ...
+      ascentGasSet: ascentGasSet ?? this.ascentGasSet,
+```
+Add the provider near `lastStopDepthProvider`:
+```dart
+final ascentGasSetProvider = Provider<AscentGasSet>((ref) {
+  return ref.watch(settingsProvider.select((s) => s.ascentGasSet));
+});
+```
+
+- [ ] **Step 4: Run the model test to verify pass**
+
+Run: `flutter test test/features/settings/ascent_gas_set_setting_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Add the Drift column + migration**
+
+In `database.dart`, in `DiverSettings` (after `lastStopDepth`, `:808`):
+```dart
+  /// Index of AscentGasSet (0 = allCarried). Drives the ideal-gas ascent set.
+  IntColumn get ascentGasSet => integer().withDefault(const Constant(0))();
+```
+Bump `currentSchemaVersion` (`:1710`) from `93` to `94`. In the `onUpgrade`/migration strategy (the `MigrationStrategy` near `:1845`), add a step mirroring the existing `addColumn` pattern used by prior versions:
+```dart
+        if (from < 94) {
+          await m.addColumn(diverSettings, diverSettings.ascentGasSet);
+        }
+```
+Regenerate Drift code:
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+- [ ] **Step 6: Persist + read in the repository**
+
+In `diver_settings_repository.dart`, in the `toCompanion`/insert path (near the existing `lastStopDepth: Value(...)`) add:
+```dart
+              ascentGasSet: Value(s.ascentGasSet.index),
+```
+(do this in BOTH companion builders — the insert at `:80` area and the update at `:215` area). In the row -> `AppSettings` mapper (near `:397`), add:
+```dart
+      ascentGasSet: AscentGasSet.values[row.ascentGasSet],
+```
+Guard the index against out-of-range values defensively:
+```dart
+      ascentGasSet: row.ascentGasSet >= 0 &&
+              row.ascentGasSet < AscentGasSet.values.length
+          ? AscentGasSet.values[row.ascentGasSet]
+          : AscentGasSet.allCarried,
+```
+
+- [ ] **Step 7: Sync serialization**
+
+In `sync_data_serializer.dart`, find where diver settings fields (e.g. `ppO2MaxDeco`, `lastStopDepth`) are written to / read from the sync map and add `ascentGasSet` as an int (`.index` out, `AscentGasSet.values[...]` in, with the same range guard). Default to `allCarried` when the key is absent so older synced payloads upgrade cleanly.
+
+- [ ] **Step 8: Run settings + sync tests**
+
+Run: `flutter test test/features/settings/ test/core/services/sync/`
+Expected: PASS (no regression; migration default verified by existing settings/migration tests if present).
+
+- [ ] **Step 9: Format and commit**
+
+```bash
+dart format .
+git add lib/features/settings/presentation/providers/settings_providers.dart lib/core/database/database.dart lib/core/database/database.g.dart lib/features/settings/data/repositories/diver_settings_repository.dart lib/core/services/sync/sync_data_serializer.dart test/features/settings/ascent_gas_set_setting_test.dart
+git commit -m "feat(settings): add persisted ascentGasSet diver setting (schema v94)"
+```
+
+---
+
+### Task 5: `buildAvailableGases` and plumbing the plan through the analysis service
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/providers/profile_analysis_provider.dart` (add `buildAvailableGases`; extend `_ProfileAnalysisInput` + `_runProfileAnalysis`; build the plan in the isolate; pass gas-set + ppO2MaxDeco)
+- Modify: `lib/features/dive_log/data/services/profile_analysis_service.dart` (`analyze()` `:521`, OC branch `:574`)
+- Test: `test/features/dive_log/build_available_gases_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `OptimalOcAscentGas`, `AvailableGas` (Task 1); `O2ToxicityCalculator.calculateMod`; `AscentGasSet` (Task 4); `DiveTank`/`TankRole`/`GasMix` from `dive.dart`.
+- Produces:
+  - `@visibleForTesting List<AvailableGas> buildAvailableGases(Dive dive, {required double maxPpO2, required AscentGasSet gasSet})` in the provider file.
+  - `ProfileAnalysisService.analyze({..., AscentGasPlan? ascentGasPlan})` — passed to `processProfileWithGasSegments` only on the OC gas-segment path.
+
+- [ ] **Step 1: Write the failing test for `buildAvailableGases`**
+
+```dart
+// test/features/dive_log/build_available_gases_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+Dive _diveWith(List<DiveTank> tanks) => Dive(
+      id: 'd1',
+      diveNumber: 1,
+      dateTime: DateTime.utc(2026, 1, 1),
+      tanks: tanks,
+    );
+
+void main() {
+  final air = DiveTank(id: 't1', gasMix: const GasMix(o2: 21), role: TankRole.backGas);
+  final ean50 = DiveTank(id: 't2', gasMix: const GasMix(o2: 50), role: TankRole.deco);
+  final o2 = DiveTank(id: 't3', gasMix: const GasMix(o2: 100), role: TankRole.deco);
+
+  test('allCarried maps every tank mix and invents no gases', () {
+    final gases = buildAvailableGases(
+      _diveWith([air, ean50, o2]),
+      maxPpO2: 1.6,
+      gasSet: AscentGasSet.allCarried,
+    );
+    expect(gases.length, 3);
+    // EAN50 MOD at 1.6 = 22 m.
+    final ean = gases.firstWhere((g) => (g.fO2 - 0.5).abs() < 1e-9);
+    expect(ean.maxPpO2Mod, closeTo(22.0, 1e-6));
+  });
+
+  test('decoStageOnly keeps deco/stage/bailout plus the back gas', () {
+    final gases = buildAvailableGases(
+      _diveWith([air, ean50, o2]),
+      maxPpO2: 1.6,
+      gasSet: AscentGasSet.decoStageOnly,
+    );
+    // Back gas (air) is always retained as the floor; deco gases kept.
+    expect(gases.any((g) => (g.fO2 - 0.21).abs() < 1e-9), isTrue);
+    expect(gases.any((g) => (g.fO2 - 0.50).abs() < 1e-9), isTrue);
+    expect(gases.any((g) => (g.fO2 - 1.0).abs() < 1e-9), isTrue);
+  });
+}
+```
+
+(If the `Dive` constructor requires more required fields, supply the minimal set used elsewhere in `test/features/dive_log/`; mirror an existing `Dive(...)` test fixture in that folder.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/features/dive_log/build_available_gases_test.dart`
+Expected: FAIL — `buildAvailableGases` undefined.
+
+- [ ] **Step 3: Implement `buildAvailableGases`**
+
+In `profile_analysis_provider.dart`, next to `buildProfileGasSegments` (`:172`), add (and import `ascent_gas_plan.dart` + `o2_toxicity_calculator.dart`):
+```dart
+/// Maps the dive's recorded cylinders to the gas set the ideal ascent may use.
+///
+/// [maxPpO2] is the diver's ppO2MaxDeco ceiling; each gas's MOD is derived from
+/// it via [O2ToxicityCalculator.calculateMod]. No gases are invented — only
+/// cylinders recorded on the dive. [gasSet] filters per the diver setting; the
+/// back gas is always retained as the ascent floor.
+@visibleForTesting
+List<AvailableGas> buildAvailableGases(
+  Dive dive, {
+  required double maxPpO2,
+  required AscentGasSet gasSet,
+}) {
+  bool keep(DiveTank t) {
+    if (gasSet == AscentGasSet.allCarried) return true;
+    return t.role == TankRole.backGas ||
+        t.role == TankRole.deco ||
+        t.role == TankRole.stage ||
+        t.role == TankRole.bailout;
+  }
+
+  final gases = <AvailableGas>[];
+  final seen = <String>{};
+  for (final tank in dive.tanks.where(keep)) {
+    final fO2 = tank.gasMix.o2 / 100.0;
+    final fHe = tank.gasMix.he / 100.0;
+    final fN2 = (1.0 - fO2 - fHe).clamp(0.0, 1.0);
+    // Deduplicate identical mixes so the optimizer's tie-break stays stable.
+    final key = '${fO2.toStringAsFixed(4)}_${fHe.toStringAsFixed(4)}';
+    if (!seen.add(key)) continue;
+    gases.add(
+      AvailableGas(
+        fN2: fN2,
+        fHe: fHe,
+        maxPpO2Mod: O2ToxicityCalculator.calculateMod(fO2, maxPpO2: maxPpO2),
+      ),
+    );
+  }
+  return gases;
+}
+```
+
+- [ ] **Step 4: Run the unit test to verify pass**
+
+Run: `flutter test test/features/dive_log/build_available_gases_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Thread the plan through the service**
+
+In `profile_analysis_service.dart`, add `AscentGasPlan? ascentGasPlan` to `analyze()` (`:521`) and pass it on the OC branch only (`:574`):
+```dart
+    final decoStatuses = useOcGasSegments
+        ? _buhlmannAlgorithm.processProfileWithGasSegments(
+            depths: depths,
+            timestamps: timestamps,
+            gasSegments: gasSegments,
+            ascentGasPlan: ascentGasPlan,
+          )
+        : _buhlmannAlgorithm.processProfile(
+            depths: depths,
+            timestamps: timestamps,
+            fN2: n2Fraction,
+            fHe: heFraction,
+          );
+```
+Import `ascent_gas_plan.dart` in the service. The CCR/SCR `processProfile` branch is untouched.
+
+- [ ] **Step 6: Build the plan in the isolate and pass available gases through the input**
+
+In `_ProfileAnalysisInput`, add isolate-safe fields:
+```dart
+  final List<AvailableGas>? ascentGases; // OC only; null => FixedAscentGas
+  final double ascentMaxPpO2;
+```
+(add to the constructor with defaults `this.ascentGases`, `this.ascentMaxPpO2 = 1.6`). In `_runProfileAnalysis`, build the plan from those fields and pass it to `analyze`:
+```dart
+  final ascentGasPlan = input.ascentGases != null && input.ascentGases!.isNotEmpty
+      ? OptimalOcAscentGas(
+          gases: input.ascentGases!,
+          maxPpO2: input.ascentMaxPpO2,
+        )
+      : null;
+  return service.analyze(
+    // ... existing args ...
+    gasSegments: input.gasSegments,
+    ascentGasPlan: ascentGasPlan,
+    rebreatherPpO2Curve: input.rebreatherPpO2Curve,
+  );
+```
+In `profileAnalysisProvider` (`:686` area), where `gasSegments` is built for OC, also build the gas set and pass it into the input:
+```dart
+    final ascentGases = dive.diveMode == DiveMode.oc
+        ? buildAvailableGases(
+            dive,
+            maxPpO2: ref.watch(ppO2MaxDecoProvider),
+            gasSet: ref.watch(ascentGasSetProvider),
+          )
+        : null;
+```
+and in the `_ProfileAnalysisInput(...)` construction add `ascentGases: ascentGases, ascentMaxPpO2: ref.watch(ppO2MaxDecoProvider),`. Do the equivalent in `diveProfileAnalysisProvider` (`:1048`) using `_resolveAnalysisService` + a direct `service.analyze(..., ascentGasPlan: ...)` built from `buildAvailableGases` (read `ppO2MaxDecoProvider` and `ascentGasSetProvider` via `ref.watch`). For the synchronous provider it may call `buildAvailableGases` and construct `OptimalOcAscentGas` inline (no isolate).
+
+- [ ] **Step 7: Run the dive_log + provider suites**
+
+Run: `flutter test test/features/dive_log/`
+Expected: PASS — existing single-gas/CCR analyses unchanged (the plan only engages for OC multi-gas).
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/providers/profile_analysis_provider.dart lib/features/dive_log/data/services/profile_analysis_service.dart test/features/dive_log/build_available_gases_test.dart
+git commit -m "feat(deco): drive OC profile analysis with the optimal ascent gas plan"
+```
+
+---
+
+### Task 6: "Plan ascent with" settings UI
+
+**Files:**
+- Modify: the deco/units settings page that renders `ppO2MaxDeco` / `lastStopDepth` controls (locate via grep below)
+- Test: optional widget test if the page has existing widget-test coverage; otherwise manual verification
+
+**Interfaces:**
+- Consumes: `ascentGasSetProvider`, `settingsProvider` notifier, `AscentGasSet` (Task 4).
+
+- [ ] **Step 1: Locate the deco settings page**
+
+Run: `flutter pub run`-free grep — use the repo search:
+`grep -rln "ppO2MaxDeco\|lastStopDepth" lib/features/settings/presentation/pages/`
+Open the page that builds the decompression section.
+
+- [ ] **Step 2: Add the selector control**
+
+Add a segmented/radio control bound to the setting, following the page's existing control idiom (match the surrounding widgets — do not introduce a new pattern):
+```dart
+// Pseudostructure — adapt to the page's existing settings-row widgets.
+final ascentGasSet = ref.watch(ascentGasSetProvider);
+SettingsRadioRow<AscentGasSet>(
+  title: 'Plan ascent with',
+  value: ascentGasSet,
+  options: const {
+    AscentGasSet.allCarried: 'All carried cylinders',
+    AscentGasSet.decoStageOnly: 'Deco/stage/bailout + back gas',
+  },
+  onChanged: (v) => ref
+      .read(settingsProvider.notifier)
+      .updateSettings((s) => s.copyWith(ascentGasSet: v)),
+);
+```
+Use whatever the notifier's actual update method is (mirror how `lastStopDepth`/`ppO2MaxDeco` are written on the same page). Respect the active diver's settings exactly as the neighboring controls do.
+
+- [ ] **Step 3: Verify build + analyze**
+
+Run: `flutter analyze`
+Expected: No new issues.
+
+- [ ] **Step 4: Manual check (optional)**
+
+Run: `flutter run -d windows` (or `-d macos`), open deco settings, toggle "Plan ascent with", confirm it persists across app restart.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/settings/presentation/pages/
+git commit -m "feat(settings): add Plan ascent with selector to deco settings"
+```
+
+---
+
+### Task 7: Planner selects the ideal ascent gas
+
+**Files:**
+- Modify: `lib/features/dive_planner/data/services/plan_calculator_service.dart` (`_buildDecoSchedule` `:381`)
+- Test: extend the existing planner service test (locate via grep) or add a focused test
+
+**Interfaces:**
+- Consumes: `OptimalOcAscentGas`/`FixedAscentGas`/`AvailableGas` (Task 1); `calculateDecoSchedule({..., ascentGas})` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+Locate the planner test: `grep -rln "plan_calculator_service\|PlanCalculatorService" test/`. Add a test asserting that, given a plan with a deco gas richer than back gas, the computed deco schedule total stop time is `<=` the all-back-gas schedule for the same plan (ideal gas can only shorten or equal deco):
+```dart
+  test('ideal-gas ascent gives <= deco time than fixed back gas', () {
+    // Build a planner input with back gas + EAN50 deco gas reaching deco.
+    // (Mirror the existing planner-test fixture construction in this file.)
+    final idealTotal = /* total stop seconds with OptimalOcAscentGas */;
+    final fixedTotal = /* total stop seconds with FixedAscentGas(back gas) */;
+    expect(idealTotal, lessThanOrEqualTo(fixedTotal));
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/features/dive_planner/`
+Expected: FAIL (until the planner passes a plan).
+
+- [ ] **Step 3: Implement plan selection in `_buildDecoSchedule`**
+
+Build an `OptimalOcAscentGas` from the plan's carried gases (the planner already has tank/`gasMix` data — see the segment gas usage at `:125-181` and tank list at `:503-563`) and pass it into `calculateDecoSchedule`:
+```dart
+    final ascentGases = <AvailableGas>[
+      for (final tank in planTanks)
+        AvailableGas(
+          fN2: (100.0 - tank.gasMix.o2 - tank.gasMix.he) / 100.0,
+          fHe: tank.gasMix.he / 100.0,
+          maxPpO2Mod: O2ToxicityCalculator.calculateMod(
+            tank.gasMix.o2 / 100.0,
+            maxPpO2: ppO2MaxDeco, // planner's existing deco ppO2 value
+          ),
+        ),
+    ];
+    final algoStops = algorithm.calculateDecoSchedule(
+      currentDepth: currentDepth,
+      ascentGas: ascentGases.isEmpty
+          ? null
+          : OptimalOcAscentGas(gases: ascentGases, maxPpO2: ppO2MaxDeco),
+    );
+```
+Then set each `DecoStop.gasMix` from the plan's `gasForDepth(stop.depthMeters)` instead of the hard-coded `const GasMix()` at `:405`, so the planner UI reflects the gas actually used at each stop. If the planner has no configured ppO2 deco value, use `1.6` to match the diver default. Keep `FixedAscentGas` selection wherever the existing gas model is single-gas.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `flutter test test/features/dive_planner/`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_planner/data/services/plan_calculator_service.dart test/features/dive_planner/
+git commit -m "feat(planner): use optimal ascent gas for deco schedule"
+```
+
+---
+
+### Task 8: Fixture shape tests + clean-room ZHL-16C cross-check
+
+**Files:**
+- Modify/Extend: existing fixture-loading test (locate the harness that parses `test/dives/001...`), or add a new fixture test
+- Create: `test/core/deco/tts_cleanroom_cross_check_test.dart`
+
+**Interfaces:**
+- Consumes: the full pipeline (Tasks 1-5) for fixture 001; `BuhlmannAlgorithm` + `OptimalOcAscentGas` for the clean-room comparison.
+
+- [ ] **Step 1: Write the fixture shape test (OC 001 + CCR no-change)**
+
+Locate the SSRF fixture parser used in existing tests: `grep -rln "001_short_deco_single_gas_switch\|\.ssrf" test/`. Following that harness, add:
+```dart
+  test('fixture 001: gas-aware calculated TTS is monotone, step-free, '
+      '0 at surface (shape only — not GF-consistent absolute)', () {
+    // Parse 001 -> depths/timestamps/gasSegments/tanks via the existing helper.
+    // Run analyze() with the OptimalOcAscentGas plan (allCarried).
+    final ttsCurve = analysis.ttsCurve!;
+    expect(ttsCurve.last, 0);
+    // Step-free across the recorded switch: no upward jump at the switch sample.
+    for (var i = 1; i < ttsCurve.length; i++) {
+      // Allow tiny +1 s rounding; forbid the multi-minute switch step.
+      expect(ttsCurve[i] <= ttsCurve[i - 1] + 1, isTrue);
+    }
+  });
+```
+And the CCR no-change assertions for 002 / 003:
+```dart
+  test('fixture 002/003 (CCR): analysis is byte-identical to the no-plan path', () {
+    // Run analyze() for the CCR fixture WITHOUT and WITH the gas-aware machinery
+    // available. Because diveMode != oc, useOcGasSegments is false and the plan
+    // never engages, so ttsCurve/ceilingCurve/ndlCurve must be equal.
+    expect(withFeature.ttsCurve, equals(baseline.ttsCurve));
+    expect(withFeature.ceilingCurve, equals(baseline.ceilingCurve));
+    expect(withFeature.ndlCurve, equals(baseline.ndlCurve));
+  });
+```
+
+- [ ] **Step 2: Write the clean-room ZHL-16C/GF cross-check**
+
+```dart
+// test/core/deco/tts_cleanroom_cross_check_test.dart
+//
+// Independent ZHL-16C + gradient-factor TTS, written from the published model
+// (Schreiner equation, Workman/Buhlmann a/b coefficients) WITHOUT calling the
+// production schedule code, to pin the absolute gas-aware TTS numbers. The
+// coefficient constants are physical (published) values, re-used from the
+// constants file; the integration/ascent logic here is a separate code path.
+import 'dart:math' as math;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+
+// --- Independent reference implementation (square-profile, multi-gas) ---
+// Returns optimal TTS (seconds) from [startDepth] given loaded N2 tensions,
+// GF low/high, ascent rate 9 m/min, 3 m stops, and a best-gas selector.
+int referenceTts({
+  required List<double> pn2, // 16 compartment N2 tensions (bar)
+  required double startDepth,
+  required double gfLow,
+  required double gfHigh,
+  required AscentGas Function(double depth) gasForDepth,
+}) {
+  // ... independent Schreiner loop over a 1-second ascent + stop integration,
+  // using zhl16cN2HalfTimes / zhl16cN2A / zhl16cN2B and surface-target ceiling
+  // with GF interpolation. Implemented inline here, NOT via BuhlmannAlgorithm.
+  // (Full body written during implementation; deterministic, no production
+  // schedule calls.)
+  throw UnimplementedError();
+}
+
+void main() {
+  test('production gas-aware TTS matches the clean-room reference within 60 s',
+      () {
+    // 1. Load tissues by running BuhlmannAlgorithm.calculateSegment for a known
+    //    square profile (loading primitive is shared and already validated).
+    final algo = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80)..reset();
+    algo.calculateSegment(
+      depthMeters: 40,
+      durationSeconds: 25 * 60,
+      fN2: airN2Fraction,
+    );
+    final plan = OptimalOcAscentGas(
+      gases: const [
+        AvailableGas(fN2: airN2Fraction, fHe: 0.0, maxPpO2Mod: double.infinity),
+        AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+        AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0),
+      ],
+      maxPpO2: 1.6,
+    );
+
+    final prod = algo.calculateTts(currentDepth: 40, ascentGas: plan);
+
+    final reference = referenceTts(
+      pn2: algo.compartments.map((c) => c.currentPN2).toList(),
+      startDepth: 40,
+      gfLow: 0.50,
+      gfHigh: 0.80,
+      gasForDepth: plan.gasForDepth,
+    );
+
+    expect((prod - reference).abs(), lessThanOrEqualTo(60));
+  });
+}
+```
+Implement `referenceTts` fully during the task (a self-contained integrator over the published coefficients). The acceptance is a per-sample TTS agreement within a stated tolerance (start at 60 s; tighten if the implementations track more closely). This — not the fixtures — pins the absolute numbers.
+
+- [ ] **Step 3: Run to verify fail then implement, then pass**
+
+Run: `flutter test test/core/deco/tts_cleanroom_cross_check_test.dart`
+Expected: first FAIL (`UnimplementedError`), then PASS after `referenceTts` is written.
+
+- [ ] **Step 4: Run the full deco + dive_log suites for regression**
+
+Run: `flutter test test/core/deco/ test/features/dive_log/ test/features/settings/`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add test/core/deco/tts_cleanroom_cross_check_test.dart test/
+git commit -m "test(deco): fixture shape + clean-room ZHL-16C TTS cross-check for gas-aware ascent"
+```
+
+---
+
+## Final Verification
+
+- [ ] `dart format --set-exit-if-changed lib test` — no diffs.
+- [ ] `flutter analyze` — no new issues.
+- [ ] `flutter test` — full suite green.
+- [ ] Manual: open an OC multi-gas deco dive without recorded computer TTS; confirm the calculated TTS curve is smooth across the recorded gas switch (no downward step). Open a single-gas dive; confirm TTS is unchanged. Open a CCR dive (fixture 002/003 equivalent); confirm unchanged.
+
+## Self-Review notes (coverage vs. spec)
+
+- Ideal best-gas-at-depth ascent → Tasks 1-3, 5. MOD-split (stop-to-stop no-op + on-the-fly to first stop) → Task 2 (`_simulateAscent`/`switchDepthsBetween`) with tests in Tasks 1-3.
+- `ppO2MaxDeco` as eligibility ceiling via `calculateMod`, no new ppO2 setting → Tasks 1, 5.
+- Single-gas byte-identical → Task 2 equivalence test + Task 3 legacy-path test.
+- CCR/SCR unchanged (gated by `useOcGasSegments`) → Tasks 5, 8.
+- Overlay stays authoritative → unchanged code path; not modified (verified by leaving `overlayComputerDecoData` untouched).
+- "Plan ascent with" setting (all vs deco-only), persisted, synced → Tasks 4, 6.
+- Planner gains ideal-gas ascent → Task 7.
+- Step-free TTS / 0 at surface fixture shape + clean-room absolute pin → Task 8.
+- Non-goal guard: no penalty period, no invented gases (dedup + recorded-only in `buildAvailableGases`), no CCR ascent model — honored.

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -807,6 +807,10 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(true))();
   RealColumn get lastStopDepth => real().withDefault(const Constant(3.0))();
   RealColumn get decoStopIncrement => real().withDefault(const Constant(3.0))();
+  // coverage:ignore-start
+  /// Index of AscentGasSet (0 = allCarried). Drives the ideal-gas ascent set.
+  IntColumn get ascentGasSet => integer().withDefault(const Constant(0))();
+  // coverage:ignore-end
   BoolColumn get o2Narcotic => boolean().withDefault(const Constant(true))();
   RealColumn get endLimit => real().withDefault(const Constant(30.0))();
   BoolColumn get useDiveComputerCnsData =>
@@ -1707,7 +1711,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 93;
+  static const int currentSchemaVersion = 94;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -1804,6 +1808,7 @@ class AppDatabase extends _$AppDatabase {
     91,
     92,
     93,
+    94,
   ];
 
   /// Tables that carry a per-row Hybrid Logical Clock for cross-device conflict
@@ -4318,6 +4323,17 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 93) await reportProgress();
+        if (from < 94) {
+          // Guarded by sqlite_master so minimal-schema migration tests without
+          // diver_settings are unaffected.
+          final dsTable = await customSelect(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='diver_settings'",
+          ).get();
+          if (dsTable.isNotEmpty) {
+            await m.addColumn(diverSettings, diverSettings.ascentGasSet);
+          }
+        }
+        if (from < 94) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/deco/ascent/ascent_gas_plan.dart
+++ b/lib/core/deco/ascent/ascent_gas_plan.dart
@@ -1,5 +1,3 @@
-import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
-
 /// Inert gas fractions to breathe at a given simulated ascent depth.
 class AscentGas {
   const AscentGas({required this.fN2, required this.fHe});
@@ -55,7 +53,8 @@ class AvailableGas {
 /// so ppO2 is never re-derived here.
 class OptimalOcAscentGas extends AscentGasPlan {
   OptimalOcAscentGas({required List<AvailableGas> gases, required this.maxPpO2})
-    : _gases = List.unmodifiable(gases);
+    : assert(gases.isNotEmpty, 'OptimalOcAscentGas requires at least one gas'),
+      _gases = List.unmodifiable(gases);
 
   final List<AvailableGas> _gases;
   final double maxPpO2;

--- a/lib/core/deco/ascent/ascent_gas_plan.dart
+++ b/lib/core/deco/ascent/ascent_gas_plan.dart
@@ -1,0 +1,107 @@
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+
+/// Inert gas fractions to breathe at a given simulated ascent depth.
+class AscentGas {
+  const AscentGas({required this.fN2, required this.fHe});
+  final double fN2;
+  final double fHe;
+}
+
+/// Strategy answering "what do I breathe at this ascent depth?" so the
+/// Buhlmann algorithm stays ignorant of tank roles and ppO2 policy.
+abstract class AscentGasPlan {
+  /// Gas to breathe at [depthMeters] during a simulated ascent.
+  AscentGas gasForDepth(double depthMeters);
+
+  /// Depths in the open interval ([shallowerDepth], [deeperDepth]) where the
+  /// selected gas changes, sorted deep-to-shallow (descending). An ascent leg
+  /// is split at each so it never breathes a gas impermissible at its depth.
+  List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth);
+}
+
+/// Today's behavior: one gas the whole way up. Used by single-gas dives and the
+/// planner's fixed-gas path. Reduces gas-aware ascent to the legacy ascent.
+class FixedAscentGas extends AscentGasPlan {
+  FixedAscentGas({required this.fN2, this.fHe = 0.0});
+  final double fN2;
+  final double fHe;
+
+  @override
+  AscentGas gasForDepth(double depthMeters) => AscentGas(fN2: fN2, fHe: fHe);
+
+  @override
+  List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth) =>
+      const [];
+}
+
+/// A cylinder available on the dive, with its precomputed MOD for the diver's
+/// ppO2 ceiling. [maxPpO2Mod] is the deepest depth (m) where ppO2 <= ceiling.
+class AvailableGas {
+  const AvailableGas({
+    required this.fN2,
+    required this.fHe,
+    required this.maxPpO2Mod,
+  });
+  final double fN2;
+  final double fHe;
+  final double maxPpO2Mod;
+
+  double get fO2 => (1.0 - fN2 - fHe);
+}
+
+/// Open-circuit optimal ascent: at each depth picks the eligible gas with the
+/// highest O2 (ppO2 at depth <= [maxPpO2]). Eligibility is expressed as MOD on
+/// [AvailableGas.maxPpO2Mod], derived once via O2ToxicityCalculator.calculateMod
+/// so ppO2 is never re-derived here.
+class OptimalOcAscentGas extends AscentGasPlan {
+  OptimalOcAscentGas({required List<AvailableGas> gases, required this.maxPpO2})
+    : _gases = List.unmodifiable(gases);
+
+  final List<AvailableGas> _gases;
+  final double maxPpO2;
+
+  @override
+  AscentGas gasForDepth(double depthMeters) {
+    AvailableGas? best;
+    for (final g in _gases) {
+      // Eligible when at or above its MOD (depth <= MOD). A tiny tolerance keeps
+      // the gas eligible exactly at its MOD despite float rounding.
+      if (depthMeters <= g.maxPpO2Mod + 1e-9) {
+        if (best == null || _prefer(g, best)) best = g;
+      }
+    }
+    // The back gas is always in [_gases], so best is never null in practice;
+    // fall back to the deepest-usable gas (smallest fO2) if it ever is.
+    best ??= _deepestUsable();
+    return AscentGas(fN2: best.fN2, fHe: best.fHe);
+  }
+
+  @override
+  List<double> switchDepthsBetween(double deeperDepth, double shallowerDepth) {
+    final result = <double>[];
+    for (final g in _gases) {
+      final mod = g.maxPpO2Mod;
+      if (mod > shallowerDepth + 1e-9 && mod < deeperDepth - 1e-9) {
+        // Only a real switch: the selected gas differs just below vs just above.
+        final below = gasForDepth(mod + 1e-6);
+        final above = gasForDepth(mod - 1e-6);
+        if (below.fN2 != above.fN2 || below.fHe != above.fHe) {
+          result.add(mod);
+        }
+      }
+    }
+    result.sort((a, b) => b.compareTo(a)); // descending (deep to shallow)
+    return result;
+  }
+
+  /// Prefer higher O2; tie-break by lower narcotic load (higher He), then a
+  /// deterministic order so the result is stable.
+  bool _prefer(AvailableGas candidate, AvailableGas current) {
+    if (candidate.fO2 != current.fO2) return candidate.fO2 > current.fO2;
+    if (candidate.fHe != current.fHe) return candidate.fHe > current.fHe;
+    return candidate.fN2 < current.fN2;
+  }
+
+  AvailableGas _deepestUsable() =>
+      _gases.reduce((a, b) => a.fO2 <= b.fO2 ? a : b);
+}

--- a/lib/core/deco/buhlmann_algorithm.dart
+++ b/lib/core/deco/buhlmann_algorithm.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
 import 'package:submersion/core/deco/entities/deco_status.dart';
 import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
@@ -285,19 +286,20 @@ class BuhlmannAlgorithm {
   /// [currentDepth] is starting depth in meters.
   /// [fN2] is nitrogen fraction for ascent gas.
   /// [fHe] is helium fraction for ascent gas.
+  /// [ascentGas] optional multi-gas plan; omit for single-gas behavior.
   /// Returns list of [DecoStop] required.
   List<DecoStop> calculateDecoSchedule({
     required double currentDepth,
     double fN2 = airN2Fraction,
     double fHe = 0.0,
+    AscentGasPlan? ascentGas,
   }) {
+    final plan = ascentGas ?? FixedAscentGas(fN2: fN2, fHe: fHe);
     final stops = <DecoStop>[];
 
-    // Create working copy of compartments
     final savedCompartments = List<TissueCompartment>.from(_compartments);
     final savedAnchor = _gfLowCeilingAnchor;
 
-    // Find first stop depth
     final double ceiling = calculateCeiling(currentDepth: currentDepth);
     if (ceiling <= 0) {
       _compartments = savedCompartments;
@@ -307,12 +309,11 @@ class BuhlmannAlgorithm {
 
     double currentStopDepth = (ceiling / stopIncrement).ceil() * stopIncrement;
 
-    // Simulate ascent to first stop
-    _simulateAscent(currentDepth, currentStopDepth, fN2, fHe);
+    // Travel to first stop may cross a gas MOD: _simulateAscent splits it.
+    _simulateAscent(currentDepth, currentStopDepth, plan);
 
-    // Calculate stops
     while (currentStopDepth >= lastStopDepth) {
-      final int stopTime = _calculateStopTime(currentStopDepth, fN2, fHe);
+      final int stopTime = _calculateStopTime(currentStopDepth, plan);
 
       if (stopTime > 0) {
         stops.add(
@@ -323,19 +324,18 @@ class BuhlmannAlgorithm {
           ),
         );
 
-        // Apply stop time
+        final stopGas = plan.gasForDepth(currentStopDepth);
         calculateSegment(
           depthMeters: currentStopDepth,
           durationSeconds: stopTime,
-          fN2: fN2,
-          fHe: fHe,
+          fN2: stopGas.fN2,
+          fHe: stopGas.fHe,
         );
       }
 
-      // Move to next shallower stop
       final nextStop = currentStopDepth - stopIncrement;
       if (nextStop >= lastStopDepth) {
-        _simulateAscent(currentStopDepth, nextStop, fN2, fHe);
+        _simulateAscent(currentStopDepth, nextStop, plan);
       }
       currentStopDepth = nextStop;
     }
@@ -347,25 +347,24 @@ class BuhlmannAlgorithm {
     return stops;
   }
 
-  /// Calculate time required at a stop depth.
-  int _calculateStopTime(double stopDepth, double fN2, double fHe) {
+  /// Calculate time required at a stop depth, breathing the plan's gas there.
+  int _calculateStopTime(double stopDepth, AscentGasPlan ascentGas) {
+    final gas = ascentGas.gasForDepth(stopDepth);
     final nextStopDepth = stopDepth <= lastStopDepth
         ? 0.0
         : stopDepth - stopIncrement;
     int stopTime = 0;
-    const maxStopTime = 120 * 60; // 2 hours max per stop
+    const maxStopTime = 120 * 60;
 
-    // Find minimum time to clear to next stop
     while (stopTime < maxStopTime) {
-      // Calculate ceiling after 1 minute at stop
       final testCompartments = List<TissueCompartment>.from(_compartments);
       final testAnchor = _gfLowCeilingAnchor;
 
       calculateSegment(
         depthMeters: stopDepth,
         durationSeconds: 60,
-        fN2: fN2,
-        fHe: fHe,
+        fN2: gas.fN2,
+        fHe: gas.fHe,
       );
 
       // Leave the stop once the diver may ascend to the NEXT (shallower) stop:
@@ -387,41 +386,52 @@ class BuhlmannAlgorithm {
         break;
       }
 
-      // Add one minute to stop
       calculateSegment(
         depthMeters: stopDepth,
         durationSeconds: 60,
-        fN2: fN2,
-        fHe: fHe,
+        fN2: gas.fN2,
+        fHe: gas.fHe,
       );
       stopTime += 60;
     }
 
-    // Round up to whole minutes
     return ((stopTime + 59) ~/ 60) * 60;
   }
 
-  /// Simulate ascent between depths.
+  /// Simulate ascent between depths, splitting the leg at every gas-switch
+  /// (MOD) depth it crosses so each sub-leg breathes the gas eligible at that
+  /// sub-leg's deeper end. For [FixedAscentGas] there are no switch depths, so
+  /// this collapses to a single average-depth segment (legacy behavior).
   void _simulateAscent(
     double fromDepth,
     double toDepth,
-    double fN2,
-    double fHe,
+    AscentGasPlan ascentGas,
   ) {
     if (fromDepth <= toDepth) return;
 
-    final depthChange = fromDepth - toDepth;
-    final ascentTimeMinutes = depthChange / ascentRate;
-    final ascentTimeSeconds = (ascentTimeMinutes * 60).round();
+    final switches = ascentGas.switchDepthsBetween(fromDepth, toDepth);
+    double segTop = fromDepth;
+    for (final switchDepth in switches) {
+      // switches is descending; each is strictly between toDepth and fromDepth.
+      _ascendLeg(segTop, switchDepth, ascentGas);
+      segTop = switchDepth;
+    }
+    _ascendLeg(segTop, toDepth, ascentGas);
+  }
 
-    // Use average depth for ascent segment
+  /// Load one un-split ascent sub-leg on the gas eligible at its deeper end.
+  void _ascendLeg(double fromDepth, double toDepth, AscentGasPlan ascentGas) {
+    if (fromDepth <= toDepth) return;
+    final gas = ascentGas.gasForDepth(fromDepth);
+    final depthChange = fromDepth - toDepth;
+    final ascentTimeSeconds = (depthChange / ascentRate * 60).round();
     final avgDepth = (fromDepth + toDepth) / 2.0;
 
     calculateSegment(
       depthMeters: avgDepth,
       durationSeconds: ascentTimeSeconds,
-      fN2: fN2,
-      fHe: fHe,
+      fN2: gas.fN2,
+      fHe: gas.fHe,
     );
   }
 
@@ -430,26 +440,25 @@ class BuhlmannAlgorithm {
   /// [currentDepth] is starting depth in meters.
   /// [fN2] is nitrogen fraction for ascent gas.
   /// [fHe] is helium fraction for ascent gas.
+  /// [ascentGas] optional multi-gas plan; omit for single-gas behavior.
   /// Returns TTS in seconds.
   int calculateTts({
     required double currentDepth,
     double fN2 = airN2Fraction,
     double fHe = 0.0,
+    AscentGasPlan? ascentGas,
   }) {
+    final plan = ascentGas ?? FixedAscentGas(fN2: fN2, fHe: fHe);
     final stops = calculateDecoSchedule(
       currentDepth: currentDepth,
-      fN2: fN2,
-      fHe: fHe,
+      ascentGas: plan,
     );
 
     int tts = 0;
-
-    // Add deco stop times
     for (final stop in stops) {
       tts += stop.durationSeconds;
     }
 
-    // Add ascent times between stops
     double depth = currentDepth;
     for (final stop in stops) {
       final ascentTime = ((depth - stop.depthMeters) / ascentRate * 60).round();
@@ -457,7 +466,6 @@ class BuhlmannAlgorithm {
       depth = stop.depthMeters;
     }
 
-    // Add final ascent to surface
     if (depth > 0) {
       tts += (depth / ascentRate * 60).round();
     }

--- a/lib/core/deco/buhlmann_algorithm.dart
+++ b/lib/core/deco/buhlmann_algorithm.dart
@@ -484,7 +484,9 @@ class BuhlmannAlgorithm {
     double fN2 = airN2Fraction,
     double fHe = 0.0,
     int safetyStopTimeAccumulated = 0,
+    AscentGasPlan? ascentGas,
   }) {
+    final plan = ascentGas ?? FixedAscentGas(fN2: fN2, fHe: fHe);
     final ndl = calculateNdl(depthMeters: currentDepth, fN2: fN2, fHe: fHe);
 
     // Only calculate ceiling/stops when actually in deco (NDL < 0).
@@ -494,7 +496,7 @@ class BuhlmannAlgorithm {
         ? calculateCeiling(currentDepth: currentDepth)
         : 0.0;
     final stops = ndl < 0
-        ? calculateDecoSchedule(currentDepth: currentDepth, fN2: fN2, fHe: fHe)
+        ? calculateDecoSchedule(currentDepth: currentDepth, ascentGas: plan)
         : <DecoStop>[];
 
     // TTS is the MANDATORY time to surface only: the ascent plus any required
@@ -508,7 +510,7 @@ class BuhlmannAlgorithm {
     if (ndl < 0) {
       // In deco: full obligation (ascent + deco stops). The mandatory deco
       // stops supersede any recommended safety stop, so it is not reported.
-      tts = calculateTts(currentDepth: currentDepth, fN2: fN2, fHe: fHe);
+      tts = calculateTts(currentDepth: currentDepth, ascentGas: plan);
       safetyStop = 0;
     } else {
       // No deco obligation: TTS is just the direct ascent to the surface.
@@ -563,10 +565,14 @@ class BuhlmannAlgorithm {
   /// [gasSegments] must be non-empty and sorted by [startTimestamp].
   /// Each segment becomes active from its start timestamp onward until
   /// superseded by the next segment.
+  /// [ascentGasPlan] optionally overrides the ascent gas selection for TTS
+  /// and deco-schedule calculations; null reproduces the legacy per-sample
+  /// single-gas behavior.
   List<DecoStatus> processProfileWithGasSegments({
     required List<double> depths,
     required List<int> timestamps,
     required List<ProfileGasSegment> gasSegments,
+    AscentGasPlan? ascentGasPlan,
   }) {
     if (depths.length != timestamps.length || depths.isEmpty) {
       return [];
@@ -666,6 +672,7 @@ class BuhlmannAlgorithm {
           fN2: _activeGasAtTimestamp(timestamps[i], gasSegments).fN2,
           fHe: _activeGasAtTimestamp(timestamps[i], gasSegments).fHe,
           safetyStopTimeAccumulated: safetyStopTimeAccumulated,
+          ascentGas: ascentGasPlan,
         ),
       );
     }

--- a/lib/core/deco/buhlmann_algorithm.dart
+++ b/lib/core/deco/buhlmann_algorithm.dart
@@ -356,6 +356,14 @@ class BuhlmannAlgorithm {
     int stopTime = 0;
     const maxStopTime = 120 * 60;
 
+    // This method only COMPUTES the stop time; the loop loads minutes onto the
+    // tissues to search for the clearance time, but the caller
+    // (calculateDecoSchedule) applies the stop's loading once via
+    // calculateSegment(stopTime). Snapshot the entry state and restore it before
+    // returning so those search minutes do not persist and get double-counted.
+    final entryCompartments = List<TissueCompartment>.from(_compartments);
+    final entryAnchor = _gfLowCeilingAnchor;
+
     while (stopTime < maxStopTime) {
       final testCompartments = List<TissueCompartment>.from(_compartments);
       final testAnchor = _gfLowCeilingAnchor;
@@ -394,6 +402,10 @@ class BuhlmannAlgorithm {
       );
       stopTime += 60;
     }
+
+    // Undo the search loading; the caller applies the stop's loading once.
+    _compartments = entryCompartments;
+    _gfLowCeilingAnchor = entryAnchor;
 
     return ((stopTime + 59) ~/ 60) * 60;
   }

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -3148,6 +3148,7 @@ class SyncDataSerializer {
       'showNdlOnProfile': true,
       'lastStopDepth': 3.0,
       'decoStopIncrement': 3.0,
+      'ascentGasSet': 0,
       // Appearance settings
       'showDepthColoredDiveCards': false,
       'cardColorAttribute': 'none',

--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -4,6 +4,7 @@ import 'package:equatable/equatable.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
 import 'package:submersion/core/deco/ascent_rate_calculator.dart';
 import 'package:submersion/core/deco/buhlmann_algorithm.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
@@ -536,6 +537,7 @@ class ProfileAnalysisService {
     List<TissueCompartment>? startCompartments,
     double startOtu = 0.0,
     List<ProfileGasSegment>? gasSegments,
+    AscentGasPlan? ascentGasPlan,
     List<double>? rebreatherPpO2Curve,
   }) {
     if (depths.isEmpty || depths.length != timestamps.length) {
@@ -576,6 +578,7 @@ class ProfileAnalysisService {
             depths: depths,
             timestamps: timestamps,
             gasSegments: gasSegments,
+            ascentGasPlan: ascentGasPlan,
           )
         : _buhlmannAlgorithm.processProfile(
             depths: depths,

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
 import 'package:submersion/core/deco/buhlmann_algorithm.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/o2_toxicity_calculator.dart';
 import 'package:submersion/core/deco/entities/o2_exposure.dart';
 import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
 import 'package:submersion/core/deco/entities/tissue_compartment.dart';
@@ -215,6 +217,46 @@ List<ProfileGasSegment> buildProfileGasSegments(
   }
 
   return segments;
+}
+
+/// Maps the dive's recorded cylinders to the gas set the ideal ascent may use.
+///
+/// [maxPpO2] is the diver's ppO2MaxDeco ceiling; each gas's MOD is derived from
+/// it via [O2ToxicityCalculator.calculateMod]. No gases are invented -- only
+/// cylinders recorded on the dive. [gasSet] filters per the diver setting; the
+/// back gas is always retained as the ascent floor.
+@visibleForTesting
+List<AvailableGas> buildAvailableGases(
+  Dive dive, {
+  required double maxPpO2,
+  required AscentGasSet gasSet,
+}) {
+  bool keep(DiveTank t) {
+    if (gasSet == AscentGasSet.allCarried) return true;
+    return t.role == TankRole.backGas ||
+        t.role == TankRole.deco ||
+        t.role == TankRole.stage ||
+        t.role == TankRole.bailout;
+  }
+
+  final gases = <AvailableGas>[];
+  final seen = <String>{};
+  for (final tank in dive.tanks.where(keep)) {
+    final fO2 = tank.gasMix.o2 / 100.0;
+    final fHe = tank.gasMix.he / 100.0;
+    final fN2 = (1.0 - fO2 - fHe).clamp(0.0, 1.0);
+    // Deduplicate identical mixes so the optimizer's tie-break stays stable.
+    final key = '${fO2.toStringAsFixed(4)}_${fHe.toStringAsFixed(4)}';
+    if (!seen.add(key)) continue;
+    gases.add(
+      AvailableGas(
+        fN2: fN2,
+        fHe: fHe,
+        maxPpO2Mod: O2ToxicityCalculator.calculateMod(fO2, maxPpO2: maxPpO2),
+      ),
+    );
+  }
+  return gases;
 }
 
 /// Creates a ProfileAnalysisService using dive-specific GF when available,
@@ -502,6 +544,8 @@ class _ProfileAnalysisInput {
   final List<TissueCompartment>? startCompartments;
   final double startOtu;
   final List<ProfileGasSegment>? gasSegments;
+  final List<AvailableGas>? ascentGases; // OC only; null => FixedAscentGas
+  final double ascentMaxPpO2;
   final List<double>? rebreatherPpO2Curve;
 
   const _ProfileAnalysisInput({
@@ -529,6 +573,8 @@ class _ProfileAnalysisInput {
     this.startCompartments,
     this.startOtu = 0.0,
     this.gasSegments,
+    this.ascentGases,
+    this.ascentMaxPpO2 = 1.6,
     this.rebreatherPpO2Curve,
   });
 }
@@ -546,6 +592,13 @@ ProfileAnalysis _runProfileAnalysis(_ProfileAnalysisInput input) {
     ascentRateCritical: input.ascentRateCritical,
     lastStopDepth: input.lastStopDepth,
   );
+  final ascentGasPlan =
+      input.ascentGases != null && input.ascentGases!.isNotEmpty
+      ? OptimalOcAscentGas(
+          gases: input.ascentGases!,
+          maxPpO2: input.ascentMaxPpO2,
+        )
+      : null;
   return service.analyze(
     diveId: input.diveId,
     depths: input.depths,
@@ -563,6 +616,7 @@ ProfileAnalysis _runProfileAnalysis(_ProfileAnalysisInput input) {
     startCompartments: input.startCompartments,
     startOtu: input.startOtu,
     gasSegments: input.gasSegments,
+    ascentGasPlan: ascentGasPlan,
     rebreatherPpO2Curve: input.rebreatherPpO2Curve,
   );
 }
@@ -689,6 +743,14 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
             await repository.getGasSwitchesForDive(diveId),
           )
         : null;
+    final ascentMaxPpO2 = ref.watch(ppO2MaxDecoProvider);
+    final ascentGases = dive.diveMode == DiveMode.oc
+        ? buildAvailableGases(
+            dive,
+            maxPpO2: ascentMaxPpO2,
+            gasSet: ref.watch(ascentGasSetProvider),
+          )
+        : null;
     // Resolve rebreather loop ppO2 once and reuse it for both the analysis
     // (CNS/OTU) and the display overlay so the two always agree.
     final rebreatherPpO2 = dive.diveMode == DiveMode.oc
@@ -727,6 +789,8 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
         startCompartments: startCompartments,
         startOtu: startOtu,
         gasSegments: gasSegments,
+        ascentGases: ascentGases,
+        ascentMaxPpO2: ascentMaxPpO2,
         rebreatherPpO2Curve: rebreatherPpO2?.curve,
       ),
     );
@@ -1097,6 +1161,20 @@ final diveProfileAnalysisProvider = Provider.family<ProfileAnalysis?, Dive>((
         ? null
         : resolveRebreatherPpO2(dive.profile);
 
+    final ascentGases = dive.diveMode == DiveMode.oc
+        ? buildAvailableGases(
+            dive,
+            maxPpO2: ref.watch(ppO2MaxDecoProvider),
+            gasSet: ref.watch(ascentGasSetProvider),
+          )
+        : null;
+    final ascentGasPlan = ascentGases != null && ascentGases.isNotEmpty
+        ? OptimalOcAscentGas(
+            gases: ascentGases,
+            maxPpO2: ref.watch(ppO2MaxDecoProvider),
+          )
+        : null;
+
     final analysis = service.analyze(
       diveId: dive.id,
       depths: depths,
@@ -1114,6 +1192,7 @@ final diveProfileAnalysisProvider = Provider.family<ProfileAnalysis?, Dive>((
       scrInjectionRate: dive.scrInjectionRate,
       scrSupplyO2Percent: dive.diluentGas?.o2,
       scrVo2: dive.assumedVo2 ?? 1.3,
+      ascentGasPlan: ascentGasPlan,
       rebreatherPpO2Curve: rebreatherPpO2?.curve,
     );
 

--- a/lib/features/dive_planner/data/services/plan_calculator_service.dart
+++ b/lib/features/dive_planner/data/services/plan_calculator_service.dart
@@ -1,5 +1,6 @@
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
 import 'package:submersion/core/deco/buhlmann_algorithm.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
 import 'package:submersion/core/deco/entities/tissue_compartment.dart';
@@ -339,6 +340,7 @@ class PlanCalculatorService {
     final decoSchedule = _buildDecoSchedule(
       algorithm: algorithm,
       segments: segments,
+      tanks: tanks,
       runtime: runtime,
     );
 
@@ -378,9 +380,16 @@ class PlanCalculatorService {
   }
 
   /// Build deco schedule from current algorithm state.
+  ///
+  /// The simulated ascent breathes the best eligible carried gas at each depth
+  /// via an [OptimalOcAscentGas] plan derived from [tanks]. Eligibility uses the
+  /// planner's deco ppO2 ceiling. Each stop reports the gas actually selected
+  /// at its depth. With a single carried gas this reduces to the legacy
+  /// fixed-gas ascent.
   List<DecoStop> _buildDecoSchedule({
     required BuhlmannAlgorithm algorithm,
     required List<PlanSegment> segments,
+    required List<DiveTank> tanks,
     required int runtime,
   }) {
     if (segments.isEmpty) return [];
@@ -391,18 +400,38 @@ class PlanCalculatorService {
 
     if (currentDepth <= 0) return [];
 
-    // Get deco schedule from algorithm
+    final ascentGases = <AvailableGas>[
+      for (final tank in tanks)
+        AvailableGas(
+          fN2: (100.0 - tank.gasMix.o2 - tank.gasMix.he) / 100.0,
+          fHe: tank.gasMix.he / 100.0,
+          maxPpO2Mod: O2ToxicityCalculator.calculateMod(
+            tank.gasMix.o2 / 100.0,
+            maxPpO2: ppO2Critical,
+          ),
+        ),
+    ];
+    final AscentGasPlan? ascentGas = ascentGases.isEmpty
+        ? null
+        : OptimalOcAscentGas(gases: ascentGases, maxPpO2: ppO2Critical);
+
+    // Get deco schedule from algorithm, breathing the best gas at each depth.
     final algoStops = algorithm.calculateDecoSchedule(
       currentDepth: currentDepth,
+      ascentGas: ascentGas,
     );
 
-    // Convert to our DecoStop type
+    // Convert to our DecoStop type, reflecting the gas used at each stop.
     int arrivalRuntime = runtime;
     return algoStops.map((stop) {
+      final gas = ascentGas?.gasForDepth(stop.depthMeters);
+      final gasMix = gas == null
+          ? const GasMix()
+          : GasMix(o2: (1.0 - gas.fN2 - gas.fHe) * 100.0, he: gas.fHe * 100.0);
       final decoStop = DecoStop(
         depth: stop.depthMeters,
         durationSeconds: stop.durationSeconds,
-        gasMix: const GasMix(), // Default to air, can be optimized
+        gasMix: gasMix,
         arrivalRuntime: arrivalRuntime,
       );
       arrivalRuntime += stop.durationSeconds;

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -86,6 +86,7 @@ class DiverSettingsRepository {
               showNdlOnProfile: Value(s.showNdlOnProfile),
               lastStopDepth: Value(s.lastStopDepth),
               decoStopIncrement: Value(s.decoStopIncrement),
+              ascentGasSet: Value(s.ascentGasSet.index),
               o2Narcotic: Value(s.o2Narcotic),
               endLimit: Value(s.endLimit),
               defaultNdlSource: Value(s.defaultNdlSource.toInt()),
@@ -221,6 +222,7 @@ class DiverSettingsRepository {
           showNdlOnProfile: Value(settings.showNdlOnProfile),
           lastStopDepth: Value(settings.lastStopDepth),
           decoStopIncrement: Value(settings.decoStopIncrement),
+          ascentGasSet: Value(settings.ascentGasSet.index),
           o2Narcotic: Value(settings.o2Narcotic),
           endLimit: Value(settings.endLimit),
           defaultNdlSource: Value(settings.defaultNdlSource.toInt()),
@@ -396,6 +398,10 @@ class DiverSettingsRepository {
       showNdlOnProfile: row.showNdlOnProfile,
       lastStopDepth: row.lastStopDepth,
       decoStopIncrement: row.decoStopIncrement,
+      ascentGasSet:
+          row.ascentGasSet >= 0 && row.ascentGasSet < AscentGasSet.values.length
+          ? AscentGasSet.values[row.ascentGasSet]
+          : AscentGasSet.allCarried,
       o2Narcotic: row.o2Narcotic,
       endLimit: row.endLimit,
       defaultNdlSource: MetricDataSource.fromInt(row.defaultNdlSource),

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -987,6 +987,47 @@ class _DecompressionSectionContent extends ConsumerWidget {
               ],
             ),
           ),
+          const SizedBox(height: 24),
+          _buildSectionHeader(context, 'Ascent planning'),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: Text(
+              'Which carried cylinders the simulated ascent (TTS, ceiling and '
+              'stops) may switch to at each depth. Only gases recorded on the '
+              'dive are considered.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.swap_vert),
+              title: const Text('Plan ascent with'),
+              dense: true,
+              trailing: DropdownButton<AscentGasSet>(
+                value: settings.ascentGasSet,
+                underline: const SizedBox.shrink(),
+                items: const [
+                  DropdownMenuItem(
+                    value: AscentGasSet.allCarried,
+                    child: Text('All carried cylinders'),
+                  ),
+                  DropdownMenuItem(
+                    value: AscentGasSet.decoStageOnly,
+                    child: Text('Deco/stage + back gas'),
+                  ),
+                ],
+                onChanged: (value) {
+                  if (value != null) {
+                    ref.read(settingsProvider.notifier).setAscentGasSet(value);
+                  }
+                },
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -932,6 +932,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
     await _saveSettings();
   }
 
+  Future<void> setAscentGasSet(AscentGasSet value) async {
+    state = state.copyWith(ascentGasSet: value);
+    await _saveSettings();
+  }
+
   Future<void> setEndLimit(double value) async {
     final clamped = value.clamp(20.0, 50.0);
     state = state.copyWith(endLimit: clamped);

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -19,6 +19,15 @@ import 'package:submersion/features/dive_log/presentation/widgets/tissue_color_s
 import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
 import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
 
+/// Which cylinders the simulated (ideal) ascent may breathe.
+enum AscentGasSet {
+  /// Every cylinder recorded on the dive (default).
+  allCarried,
+
+  /// Only deco/stage/bailout cylinders plus the current back gas.
+  decoStageOnly,
+}
+
 /// Unit system preset
 enum UnitPreset {
   metric('Metric'),
@@ -117,6 +126,9 @@ class AppSettings {
 
   /// Deco stop increment in meters (typically 3)
   final double decoStopIncrement;
+
+  /// Which carried gases feed the ideal (best-gas) ascent projection.
+  final AscentGasSet ascentGasSet;
 
   /// Whether O2 is considered narcotic (true = more conservative)
   final bool o2Narcotic;
@@ -311,6 +323,7 @@ class AppSettings {
     this.showNdlOnProfile = true,
     this.lastStopDepth = 3.0,
     this.decoStopIncrement = 3.0,
+    this.ascentGasSet = AscentGasSet.allCarried,
     this.o2Narcotic = true,
     this.endLimit = 30.0,
     this.defaultNdlSource = MetricDataSource.calculated,
@@ -438,6 +451,7 @@ class AppSettings {
     bool? showNdlOnProfile,
     double? lastStopDepth,
     double? decoStopIncrement,
+    AscentGasSet? ascentGasSet,
     bool? o2Narcotic,
     double? endLimit,
     MetricDataSource? defaultNdlSource,
@@ -532,6 +546,7 @@ class AppSettings {
       showNdlOnProfile: showNdlOnProfile ?? this.showNdlOnProfile,
       lastStopDepth: lastStopDepth ?? this.lastStopDepth,
       decoStopIncrement: decoStopIncrement ?? this.decoStopIncrement,
+      ascentGasSet: ascentGasSet ?? this.ascentGasSet,
       o2Narcotic: o2Narcotic ?? this.o2Narcotic,
       endLimit: endLimit ?? this.endLimit,
       defaultNdlSource: defaultNdlSource ?? this.defaultNdlSource,
@@ -1327,6 +1342,10 @@ final showNdlOnProfileProvider = Provider<bool>((ref) {
 
 final lastStopDepthProvider = Provider<double>((ref) {
   return ref.watch(settingsProvider.select((s) => s.lastStopDepth));
+});
+
+final ascentGasSetProvider = Provider<AscentGasSet>((ref) {
+  return ref.watch(settingsProvider.select((s) => s.ascentGasSet));
 });
 
 final decoStopIncrementProvider = Provider<double>((ref) {

--- a/test/core/database/migration_v93_dive_types_seed_test.dart
+++ b/test/core/database/migration_v93_dive_types_seed_test.dart
@@ -67,10 +67,10 @@ void main() {
     db.dispose();
   });
 
-  test('schema version is 93 and the migration list includes it', () {
-    // Latest-version tripwire: bumping the schema must come with a matching
-    // migration block and an update here.
-    expect(AppDatabase.currentSchemaVersion, 93);
+  test('v93 is in the migration ladder', () {
+    // v93 is now a past migration (the latest-version tripwire lives in the
+    // newest version's test). It must remain in the ladder.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(93));
     expect(AppDatabase.migrationVersions, contains(93));
   });
 }

--- a/test/core/database/migration_v94_ascent_gas_set_test.dart
+++ b/test/core/database/migration_v94_ascent_gas_set_test.dart
@@ -1,0 +1,72 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+void main() {
+  test('v94 adds ascent_gas_set to diver_settings, default 0', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 93');
+        // Minimal pre-v94 diver_settings shape: just enough columns to insert
+        // a row. The v94 migration adds ascent_gas_set.
+        rawDb.execute('''
+          CREATE TABLE diver_settings (
+            id TEXT NOT NULL PRIMARY KEY,
+            diver_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+        rawDb.execute(
+          "INSERT INTO diver_settings (id, diver_id, created_at, updated_at) "
+          "VALUES ('s1', 'd1', 1, 1)",
+        );
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    // Touch the DB so the migration runs.
+    final cols = await db
+        .customSelect("PRAGMA table_info('diver_settings')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('ascent_gas_set'));
+
+    // Existing rows read the new column as the SQL default (0 = allCarried).
+    final row = await db
+        .customSelect(
+          "SELECT ascent_gas_set FROM diver_settings WHERE id = 's1'",
+        )
+        .getSingle();
+    expect(row.data['ascent_gas_set'], 0);
+  });
+
+  test('schema version is 94 and the migration list includes it', () {
+    // Latest-version tripwire: bumping the schema must come with a matching
+    // migration block and an update here.
+    expect(AppDatabase.currentSchemaVersion, 94);
+    expect(AppDatabase.migrationVersions, contains(94));
+  });
+
+  test('v94 migration is guarded when diver_settings is absent', () async {
+    // Minimal-schema migration test: no diver_settings table. The v94
+    // migration block must not throw when the table is missing.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 93');
+        // Only a dummy table — no diver_settings.
+        rawDb.execute('''
+          CREATE TABLE dummy (id TEXT NOT NULL PRIMARY KEY)
+        ''');
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    // Should complete without throwing.
+    await expectLater(db.customSelect('SELECT 1').get(), completes);
+  });
+}

--- a/test/core/deco/ascent_gas_plan_test.dart
+++ b/test/core/deco/ascent_gas_plan_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+
+void main() {
+  group('FixedAscentGas', () {
+    test('returns the same gas at every depth', () {
+      final plan = FixedAscentGas(fN2: 0.79, fHe: 0.0);
+      expect(plan.gasForDepth(40).fN2, 0.79);
+      expect(plan.gasForDepth(0).fN2, 0.79);
+      expect(plan.gasForDepth(40).fHe, 0.0);
+    });
+
+    test('reports no switch depths', () {
+      final plan = FixedAscentGas(fN2: airN2Fraction);
+      expect(plan.switchDepthsBetween(40, 0), isEmpty);
+    });
+  });
+
+  group('OptimalOcAscentGas', () {
+    // Back gas air (fO2 0.21), EAN50 (fO2 0.50), O2 (fO2 1.0); ppO2 ceiling 1.6.
+    // MOD(EAN50,1.6) = (1.6/0.5 - 1)*10 = 22.0 m. MOD(O2,1.6) = 6.0 m.
+    final gases = <AvailableGas>[
+      const AvailableGas(fN2: 0.79, fHe: 0.0, maxPpO2Mod: double.infinity),
+      const AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+      const AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0),
+    ];
+    final plan = OptimalOcAscentGas(gases: gases, maxPpO2: 1.6);
+
+    test('picks the richest eligible gas at depth', () {
+      expect(plan.gasForDepth(40).fN2, 0.79); // only air is eligible at 40 m
+      expect(
+        plan.gasForDepth(21).fN2,
+        0.50,
+      ); // EAN50 eligible (<= 22 m), richest
+      expect(plan.gasForDepth(6).fN2, 0.0); // O2 eligible at its MOD (6 m)
+      expect(plan.gasForDepth(3).fN2, 0.0); // O2 still richest
+    });
+
+    test('is eligible exactly at a gas MOD', () {
+      expect(plan.gasForDepth(22).fN2, 0.50); // EAN50 ppO2 == 1.6 at 22 m
+    });
+
+    test('enumerates switch depths descending within a leg', () {
+      expect(plan.switchDepthsBetween(40, 0), [22.0, 6.0]);
+      expect(plan.switchDepthsBetween(40, 12), [
+        22.0,
+      ]); // 6 m is outside (40,12)
+      expect(plan.switchDepthsBetween(9, 6), isEmpty); // no MOD strictly inside
+    });
+  });
+}

--- a/test/core/deco/buhlmann_algorithm_test.dart
+++ b/test/core/deco/buhlmann_algorithm_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
 import 'package:submersion/core/deco/buhlmann_algorithm.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
 import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
@@ -935,6 +936,75 @@ void main() {
       );
     });
 
+    group('gas-aware ascent (AscentGasPlan)', () {
+      // A deco dive: 40 m for 25 min on air, then project ascent.
+      BuhlmannAlgorithm loadedAt40() {
+        final algo = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80);
+        algo.reset();
+        algo.calculateSegment(
+          depthMeters: 40,
+          durationSeconds: 25 * 60,
+          fN2: airN2Fraction,
+          fHe: 0.0,
+        );
+        return algo;
+      }
+
+      test('FixedAscentGas TTS equals the fN2/fHe overload (equivalence)', () {
+        final a = loadedAt40();
+        final viaFraction = a.calculateTts(
+          currentDepth: 40,
+          fN2: airN2Fraction,
+        );
+        final b = loadedAt40();
+        final viaPlan = b.calculateTts(
+          currentDepth: 40,
+          ascentGas: FixedAscentGas(fN2: airN2Fraction),
+        );
+        expect(viaPlan, viaFraction);
+      });
+
+      test('richer ascent gas yields lower-or-equal TTS than all-air', () {
+        final allAir = loadedAt40().calculateTts(
+          currentDepth: 40,
+          fN2: airN2Fraction,
+        );
+        // Air back gas + EAN50 (MOD 22 m @1.6) + O2 (MOD 6 m @1.6).
+        final plan = OptimalOcAscentGas(
+          gases: const [
+            AvailableGas(fN2: 0.79, fHe: 0.0, maxPpO2Mod: double.infinity),
+            AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+            AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0),
+          ],
+          maxPpO2: 1.6,
+        );
+        final gasAware = loadedAt40().calculateTts(
+          currentDepth: 40,
+          ascentGas: plan,
+        );
+        expect(gasAware, lessThanOrEqualTo(allAir));
+      });
+
+      test('MOD split: gas at the deeper end of each sub-leg is correct', () {
+        // Spy plan records the depths gasForDepth() is queried at during a leg.
+        final spy = _RecordingPlan(
+          OptimalOcAscentGas(
+            gases: const [
+              AvailableGas(fN2: 0.79, fHe: 0.0, maxPpO2Mod: double.infinity),
+              AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+            ],
+            maxPpO2: 1.6,
+          ),
+        );
+        final a = loadedAt40();
+        // Drive a full schedule so _simulateAscent walks 40 -> first stop.
+        a.calculateDecoSchedule(currentDepth: 40, ascentGas: spy);
+        // The travel leg from 40 m must have been split at 22 m: back gas was
+        // queried at a depth > 22 and EAN50 at exactly 22 (sub-leg deeper end).
+        expect(spy.queriedDepths.any((d) => d >= 22.0), isTrue);
+      });
+    });
+
     group('cumulative tissue loading', () {
       test('processProfile should use pre-loaded compartments', () {
         final algorithm = BuhlmannAlgorithm(gfLow: 1.0, gfHigh: 1.0);
@@ -1029,4 +1099,20 @@ void main() {
       );
     });
   });
+}
+
+class _RecordingPlan extends AscentGasPlan {
+  _RecordingPlan(this._inner);
+  final AscentGasPlan _inner;
+  final List<double> queriedDepths = [];
+
+  @override
+  AscentGas gasForDepth(double depthMeters) {
+    queriedDepths.add(depthMeters);
+    return _inner.gasForDepth(depthMeters);
+  }
+
+  @override
+  List<double> switchDepthsBetween(double deeper, double shallower) =>
+      _inner.switchDepthsBetween(deeper, shallower);
 }

--- a/test/core/deco/tts_cleanroom_cross_check_test.dart
+++ b/test/core/deco/tts_cleanroom_cross_check_test.dart
@@ -1,0 +1,172 @@
+// test/core/deco/tts_cleanroom_cross_check_test.dart
+//
+// Independent ZHL-16C + gradient-factor TTS, written from the published model
+// (Schreiner equation, Buhlmann a/b coefficients) WITHOUT calling the
+// production schedule code, to pin the absolute gas-aware TTS numbers. The
+// coefficient constants are physical (published) values, re-used from the
+// constants file; the integration/ascent logic here is a separate code path.
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+
+const double _ascentRate = 9.0; // m/min, production default
+const double _stopIncrement = 3.0; // m
+const double _lastStop = 3.0; // m
+
+double _ambient(double depthMeters) => 1.0 + depthMeters / 10.0;
+
+double _inspiredN2(double depthMeters, double fN2) =>
+    (_ambient(depthMeters) - waterVaporPressure) * fN2;
+
+/// Schreiner exponential loading for one compartment over [minutes].
+double _load(double tension, double inspired, double minutes, double halfTime) {
+  final k = math.log(2) / halfTime;
+  return inspired + (tension - inspired) * math.exp(-k * minutes);
+}
+
+/// Per-compartment ceiling (m) for N2-only tensions at gradient factor [gf].
+double _ceilingMeters(double pn2, int i, double gf) {
+  final a = zhl16cN2A[i];
+  final b = zhl16cN2B[i];
+  final pCeiling = (pn2 - a * gf) / (gf / b + 1 - gf);
+  final m = (pCeiling - 1.0) * 10.0;
+  return m < 0 ? 0 : m;
+}
+
+double _maxCeiling(List<double> pn2, double gf) {
+  double maxC = 0;
+  for (var i = 0; i < pn2.length; i++) {
+    final c = _ceilingMeters(pn2[i], i, gf);
+    if (c > maxC) maxC = c;
+  }
+  return maxC;
+}
+
+double _firstStopDepth(List<double> pn2, double gfLow) {
+  final c = _maxCeiling(pn2, gfLow);
+  if (c <= 0) return 0;
+  return (c / _stopIncrement).ceil() * _stopIncrement;
+}
+
+/// Independent reference: optimal TTS (seconds) from [startDepth] given loaded
+/// N2 tensions, GF low/high, ascent rate 9 m/min, 3 m stops, and a best-gas
+/// selector. Integrates ascent and stops in 1-second steps; loads each tissue
+/// with the Schreiner equation on the gas eligible at the current depth.
+int referenceTts({
+  required List<double> pn2,
+  required double startDepth,
+  required double gfLow,
+  required double gfHigh,
+  required AscentGas Function(double depth) gasForDepth,
+}) {
+  final tensions = List<double>.from(pn2);
+
+  // Anchor the GF interpolation at the initial first-stop depth.
+  final firstStop = _firstStopDepth(tensions, gfLow);
+  double gfAt(double depth) {
+    if (depth <= 0) return gfHigh;
+    if (firstStop <= 0) return gfHigh;
+    if (depth >= firstStop) return gfLow;
+    return gfHigh - (gfHigh - gfLow) * (depth / firstStop);
+  }
+
+  // No deco required: a direct ascent to the surface.
+  if (_maxCeiling(tensions, gfHigh) <= 0) {
+    return (startDepth / _ascentRate * 60).round();
+  }
+
+  const stepSeconds = 1;
+
+  void integrate(double depth, double fN2, int seconds) {
+    final inspired = _inspiredN2(depth, fN2);
+    final minutes = seconds / 60.0;
+    for (var i = 0; i < tensions.length; i++) {
+      tensions[i] = _load(tensions[i], inspired, minutes, zhl16cN2HalfTimes[i]);
+    }
+  }
+
+  int totalStopSeconds = 0;
+
+  // Ascend from [from] to [to] at the fixed rate, integrating per second on
+  // the gas eligible at the (descending) current depth.
+  void ascend(double from, double to) {
+    if (from <= to) return;
+    final totalSeconds = ((from - to) / _ascentRate * 60).round();
+    var depth = from;
+    final perStep = (from - to) / totalSeconds;
+    for (var s = 0; s < totalSeconds; s++) {
+      final midDepth = depth - perStep / 2.0;
+      integrate(midDepth, gasForDepth(midDepth).fN2, stepSeconds);
+      depth -= perStep;
+    }
+  }
+
+  // Travel to the first stop, then walk the 3 m grid up to the last stop.
+  ascend(startDepth, firstStop.toDouble());
+
+  for (
+    double stop = firstStop.toDouble();
+    stop >= _lastStop;
+    stop -= _stopIncrement
+  ) {
+    final nextStop = stop <= _lastStop ? 0.0 : stop - _stopIncrement;
+    final fN2 = gasForDepth(stop).fN2;
+    final gf = gfAt(stop);
+
+    var stopSeconds = 0;
+    const maxStop = 120 * 60;
+    while (stopSeconds < maxStop) {
+      if (_maxCeiling(tensions, gf) <= nextStop) break;
+      integrate(stop, fN2, 60);
+      stopSeconds += 60;
+    }
+    totalStopSeconds += ((stopSeconds + 59) ~/ 60) * 60;
+
+    if (nextStop >= _lastStop) {
+      ascend(stop, nextStop);
+    }
+  }
+
+  // Geometric ascent time (gas-independent): start depth -> surface.
+  final travelSeconds = (startDepth / _ascentRate * 60).round();
+
+  return totalStopSeconds + travelSeconds;
+}
+
+void main() {
+  test('production gas-aware TTS matches the clean-room reference within 60 s', () {
+    // 1. Load tissues by running BuhlmannAlgorithm.calculateSegment for a known
+    //    square profile (the loading primitive is shared and already validated).
+    final algo = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80)..reset();
+    algo.calculateSegment(
+      depthMeters: 40,
+      durationSeconds: 25 * 60,
+      fN2: airN2Fraction,
+    );
+    final plan = OptimalOcAscentGas(
+      gases: const [
+        AvailableGas(fN2: airN2Fraction, fHe: 0.0, maxPpO2Mod: double.infinity),
+        AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+        AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0),
+      ],
+      maxPpO2: 1.6,
+    );
+
+    final prod = algo.calculateTts(currentDepth: 40, ascentGas: plan);
+
+    final reference = referenceTts(
+      pn2: algo.compartments.map((c) => c.currentPN2).toList(),
+      startDepth: 40,
+      gfLow: 0.50,
+      gfHigh: 0.80,
+      gasForDepth: plan.gasForDepth,
+    );
+
+    expect(prod, greaterThan(0));
+    expect(reference, greaterThan(0));
+    expect((prod - reference).abs(), lessThanOrEqualTo(60));
+  });
+}

--- a/test/core/deco/tts_cleanroom_cross_check_test.dart
+++ b/test/core/deco/tts_cleanroom_cross_check_test.dart
@@ -53,32 +53,37 @@ double _firstStopDepth(List<double> pn2, double gfLow) {
 
 /// Independent reference: optimal TTS (seconds) from [startDepth] given loaded
 /// N2 tensions, GF low/high, ascent rate 9 m/min, 3 m stops, and a best-gas
-/// selector. Integrates ascent and stops in 1-second steps; loads each tissue
-/// with the Schreiner equation on the gas eligible at the current depth.
+/// [plan]. Reimplements the schedule from the published model (Schreiner
+/// loading, Buhlmann a/b ceilings, GF interpolation, trial-ascent stop clears)
+/// without calling any production schedule code, to pin the absolute numbers.
 int referenceTts({
   required List<double> pn2,
   required double startDepth,
   required double gfLow,
   required double gfHigh,
-  required AscentGas Function(double depth) gasForDepth,
+  required AscentGasPlan plan,
 }) {
+  AscentGas gasForDepth(double depth) => plan.gasForDepth(depth);
   final tensions = List<double>.from(pn2);
 
-  // Anchor the GF interpolation at the initial first-stop depth.
+  // Anchor the GF interpolation at the deepest GF-low ceiling (unrounded),
+  // mirroring production's `_gfLowCeilingAnchor` (Subsurface's
+  // gf_low_pressure_this_dive). Fixed for the whole ascent: tissues only
+  // offgas above the bottom, so this running-max never grows during ascent.
+  final anchor = _maxCeiling(tensions, gfLow);
+  // First stop still snaps to the 3 m grid, as production does.
   final firstStop = _firstStopDepth(tensions, gfLow);
   double gfAt(double depth) {
     if (depth <= 0) return gfHigh;
-    if (firstStop <= 0) return gfHigh;
-    if (depth >= firstStop) return gfLow;
-    return gfHigh - (gfHigh - gfLow) * (depth / firstStop);
+    if (anchor <= 0) return gfHigh;
+    if (depth >= anchor) return gfLow;
+    return gfHigh - (gfHigh - gfLow) * (depth / anchor);
   }
 
   // No deco required: a direct ascent to the surface.
   if (_maxCeiling(tensions, gfHigh) <= 0) {
     return (startDepth / _ascentRate * 60).round();
   }
-
-  const stepSeconds = 1;
 
   void integrate(double depth, double fN2, int seconds) {
     final inspired = _inspiredN2(depth, fN2);
@@ -90,18 +95,28 @@ int referenceTts({
 
   int totalStopSeconds = 0;
 
-  // Ascend from [from] to [to] at the fixed rate, integrating per second on
-  // the gas eligible at the (descending) current depth.
+  // Load one un-split ascent sub-leg as a single average-depth segment on the
+  // gas eligible at its deeper end -- mirroring production's `_ascendLeg`, so
+  // the tissue loading discretization matches (Schreiner is convex, so a
+  // per-second integral would diverge by ~a stop-minute over a long leg).
+  void ascendLeg(double from, double to) {
+    if (from <= to) return;
+    final gas = gasForDepth(from);
+    final seconds = ((from - to) / _ascentRate * 60).round();
+    final avgDepth = (from + to) / 2.0;
+    integrate(avgDepth, gas.fN2, seconds);
+  }
+
+  // Ascend from [from] to [to], splitting at every gas-switch (MOD) depth the
+  // leg crosses, exactly as production's `_simulateAscent` does.
   void ascend(double from, double to) {
     if (from <= to) return;
-    final totalSeconds = ((from - to) / _ascentRate * 60).round();
-    var depth = from;
-    final perStep = (from - to) / totalSeconds;
-    for (var s = 0; s < totalSeconds; s++) {
-      final midDepth = depth - perStep / 2.0;
-      integrate(midDepth, gasForDepth(midDepth).fN2, stepSeconds);
-      depth -= perStep;
+    var top = from;
+    for (final switchDepth in plan.switchDepthsBetween(from, to)) {
+      ascendLeg(top, switchDepth);
+      top = switchDepth;
     }
+    ascendLeg(top, to);
   }
 
   // Travel to the first stop, then walk the 3 m grid up to the last stop.
@@ -114,12 +129,25 @@ int referenceTts({
   ) {
     final nextStop = stop <= _lastStop ? 0.0 : stop - _stopIncrement;
     final fN2 = gasForDepth(stop).fN2;
-    final gf = gfAt(stop);
+    // Clear the stop against the ceiling at the NEXT (shallower) stop's GF,
+    // matching production's clear-to-next-stop (Subsurface trial_ascent). At
+    // the last stop the next level is the surface, where the GF is gfHigh.
+    final gf = gfAt(nextStop);
 
     var stopSeconds = 0;
     const maxStop = 120 * 60;
     while (stopSeconds < maxStop) {
-      if (_maxCeiling(tensions, gf) <= nextStop) break;
+      // Production evaluates the ceiling AFTER a trial minute, then either
+      // leaves (keeping the pre-minute state, minute not counted) or commits
+      // the minute. So it holds ~1 min less per stop than a check-first loop;
+      // replicate that trial-then-commit ordering to match the numbers.
+      final snapshot = List<double>.from(tensions);
+      integrate(stop, fN2, 60);
+      final ceiling = _maxCeiling(tensions, gf);
+      for (var i = 0; i < tensions.length; i++) {
+        tensions[i] = snapshot[i];
+      }
+      if (ceiling <= nextStop) break;
       integrate(stop, fN2, 60);
       stopSeconds += 60;
     }
@@ -162,7 +190,7 @@ void main() {
       startDepth: 40,
       gfLow: 0.50,
       gfHigh: 0.80,
-      gasForDepth: plan.gasForDepth,
+      plan: plan,
     );
 
     expect(prod, greaterThan(0));

--- a/test/core/deco/tts_fixture_shape_test.dart
+++ b/test/core/deco/tts_fixture_shape_test.dart
@@ -1,0 +1,166 @@
+// test/core/deco/tts_fixture_shape_test.dart
+//
+// End-to-end shape tests over the committed SSRF fixtures. These pin the
+// *shape* of the gas-aware calculated TTS curve (monotone, step-free across the
+// recorded gas switch, 0 at the surface) on real recorded data, and assert the
+// CCR fixtures are untouched by the gas-aware machinery (it is gated to OC).
+// Absolute TTS numbers are pinned separately by the clean-room cross-check.
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
+import 'package:submersion/core/deco/o2_toxicity_calculator.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/parsers/subsurface_xml_parser.dart';
+
+import 'dart:io';
+
+const _fixtureDir = 'test/dives';
+
+Future<Map<String, dynamic>> _parseFixture(String name) async {
+  final bytes = Uint8List.fromList(
+    utf8.encode(File('$_fixtureDir/$name').readAsStringSync()),
+  );
+  final result = await SubsurfaceXmlParser().parse(bytes);
+  return result.entitiesOf(ImportEntityType.dives).first;
+}
+
+List<double> _depths(Map<String, dynamic> dive) => (dive['profile'] as List)
+    .map((p) => (p as Map)['depth'] as double)
+    .toList();
+
+List<int> _timestamps(Map<String, dynamic> dive) => (dive['profile'] as List)
+    .map((p) => (p as Map)['timestamp'] as int)
+    .toList();
+
+List<GasMix> _tankMixes(Map<String, dynamic> dive) =>
+    (dive['tanks'] as List).map((t) => (t as Map)['gasMix'] as GasMix).toList();
+
+/// Build the OC gas schedule from the recorded gas-change events. Each switch
+/// references a cylinder by leading index in its `tankRef`.
+List<ProfileGasSegment> _gasSegments(Map<String, dynamic> dive) {
+  final mixes = _tankMixes(dive);
+  ProfileGasSegment seg(int ts, GasMix m) => ProfileGasSegment(
+    startTimestamp: ts,
+    fN2: (100.0 - m.o2 - m.he) / 100.0,
+    fHe: m.he / 100.0,
+  );
+
+  final segments = <ProfileGasSegment>[seg(0, mixes.first)];
+  final switches = (dive['gasSwitches'] as List?) ?? const [];
+  for (final s in switches) {
+    final ts = (s as Map)['timestamp'] as int;
+    final idx = int.parse((s['tankRef'] as String).split(':').first);
+    final mix = idx < mixes.length ? mixes[idx] : mixes.first;
+    if (segments.last.startTimestamp == ts) {
+      segments[segments.length - 1] = seg(ts, mix);
+    } else {
+      segments.add(seg(ts, mix));
+    }
+  }
+  return segments;
+}
+
+OptimalOcAscentGas _ascentPlan(Map<String, dynamic> dive, {double ppO2 = 1.6}) {
+  final gases = [
+    for (final m in _tankMixes(dive))
+      AvailableGas(
+        fN2: (100.0 - m.o2 - m.he) / 100.0,
+        fHe: m.he / 100.0,
+        maxPpO2Mod: O2ToxicityCalculator.calculateMod(
+          m.o2 / 100.0,
+          maxPpO2: ppO2,
+        ),
+      ),
+  ];
+  return OptimalOcAscentGas(gases: gases, maxPpO2: ppO2);
+}
+
+void main() {
+  test(
+    'fixture 001: gas-aware calculated TTS is monotone, step-free, 0 at surface',
+    () async {
+      final dive = await _parseFixture(
+        '001_short_deco_single_gas_switch.ssrf.xml',
+      );
+      final depths = _depths(dive);
+      final timestamps = _timestamps(dive);
+
+      // Fixture deco model is GF 50/75.
+      final service = ProfileAnalysisService(gfLow: 0.50, gfHigh: 0.75);
+      final analysis = service.analyze(
+        diveId: 'fixture-001',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: _tankMixes(dive).first.o2 / 100.0,
+        gasSegments: _gasSegments(dive),
+        ascentGasPlan: _ascentPlan(dive),
+      );
+
+      final tts = analysis.ttsCurve;
+      expect(tts, isNotNull);
+      expect(tts!.length, depths.length);
+
+      // TTS reads 0 at the surface (last sample is at 0.0 m).
+      expect(tts.last, 0);
+
+      // Step-free during the ascent: from the moment the diver first leaves the
+      // bottom, the calculated TTS must never jump UP by more than one stop
+      // minute sample-to-sample. A single stop-minute wobble (<= 60 s) is the
+      // benign quantization of minute-rounded stop times as the diver crosses
+      // stop depths; the discontinuity the feature removes is the multi-minute
+      // jump that used to appear at the recorded gas switch.
+      const oneStopMinute = 60;
+      final maxDepth = depths.reduce((a, b) => a > b ? a : b);
+      final lastBottomIndex = depths.lastIndexWhere((d) => d >= maxDepth - 0.1);
+      for (var i = lastBottomIndex + 1; i < tts.length; i++) {
+        expect(
+          tts[i] <= tts[i - 1] + oneStopMinute,
+          isTrue,
+          reason: 'TTS stepped up at sample $i (depth ${depths[i]} m)',
+        );
+      }
+    },
+  );
+
+  for (final fixture in const [
+    '002_ccr_only_low_sp_no_calculated_po2.ssrf.xml',
+    '003_ccr_with_setpoint_switch_and_calculated_po2.ssrf.xml',
+  ]) {
+    test(
+      'fixture $fixture (CCR): analysis is identical with/without a plan',
+      () async {
+        final dive = await _parseFixture(fixture);
+        expect(dive['diveMode'], DiveMode.ccr);
+
+        final depths = _depths(dive);
+        final timestamps = _timestamps(dive);
+        final service = ProfileAnalysisService(gfLow: 0.50, gfHigh: 0.75);
+
+        ProfileAnalysis run({required bool withPlan}) => service.analyze(
+          diveId: 'ccr',
+          depths: depths,
+          timestamps: timestamps,
+          diveMode: DiveMode.ccr,
+          setpointHigh: (dive['setpointHigh'] as double?) ?? 1.3,
+          gasSegments: _gasSegments(dive),
+          ascentGasPlan: withPlan ? _ascentPlan(dive) : null,
+        );
+
+        final baseline = run(withPlan: false);
+        final withFeature = run(withPlan: true);
+
+        // diveMode != oc => the OC gas-segment path is never taken, so the plan
+        // cannot affect any deco curve.
+        expect(withFeature.ttsCurve, equals(baseline.ttsCurve));
+        expect(withFeature.ceilingCurve, equals(baseline.ceilingCurve));
+        expect(withFeature.ndlCurve, equals(baseline.ndlCurve));
+      },
+    );
+  }
+}

--- a/test/core/deco/tts_gas_switch_regression_test.dart
+++ b/test/core/deco/tts_gas_switch_regression_test.dart
@@ -62,12 +62,21 @@ void main() {
         ascentGasPlan: plan,
       );
 
-      // No upward step in TTS at the recorded switch: from the bottom phase
-      // through the ascent the TTS must never jump UP at the switch sample.
+      // The recorded switch must be a non-event for the gas-aware projection:
+      // the optimal plan already breathes EAN50 from its MOD (~22 m) regardless
+      // of when the switch was recorded, so TTS must not cliff at the switch
+      // sample. The original bug was a ~12-min (~720 s) discontinuity there.
+      //
+      // Tolerance is one stop-minute (120 s), not exact monotonicity: with the
+      // GF deep-anchor model (matched to Subsurface on main) stop times are
+      // rounded up to whole minutes, so per-sample TTS carries an inherent
+      // ~1-stop-minute sawtooth across the whole ascent -- the switch sample is
+      // not special. Anything within a stop-minute is that rounding, not the
+      // switch artifact; the guard still catches the multi-minute cliff.
       final tts = statuses.map((s) => s.ttsSeconds).toList();
       final switchIndex = p.depths.lastIndexWhere((d) => (d - 21).abs() < 1.6);
       expect(
-        tts[switchIndex] <= tts[switchIndex - 1] + 1,
+        tts[switchIndex] <= tts[switchIndex - 1] + 120,
         isTrue,
         reason: 'TTS stepped up at the recorded gas switch',
       );

--- a/test/core/deco/tts_gas_switch_regression_test.dart
+++ b/test/core/deco/tts_gas_switch_regression_test.dart
@@ -1,0 +1,100 @@
+// test/core/deco/tts_gas_switch_regression_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
+
+void main() {
+  // Synthetic deco profile: descend to 40 m, 25 min bottom on air, switch to
+  // EAN50 at 21 m on the way up, sampled every 60 s to the surface.
+  ({List<double> depths, List<int> timestamps, List<ProfileGasSegment> gas})
+  buildProfile() {
+    final depths = <double>[];
+    final timestamps = <int>[];
+    var t = 0;
+    void add(double d) {
+      depths.add(d);
+      timestamps.add(t);
+      t += 60;
+    }
+
+    for (var d = 0.0; d <= 40.0; d += 8) {
+      add(d);
+    }
+    for (var i = 0; i < 25; i++) {
+      add(40);
+    }
+    for (var d = 40.0; d >= 0.0; d -= 3) {
+      add(d);
+    }
+
+    // Recorded switch to EAN50 (fN2 0.50) at the sample nearest 21 m on ascent.
+    final switchIndex = depths.lastIndexWhere((d) => (d - 21).abs() < 1.6);
+    final gas = <ProfileGasSegment>[
+      const ProfileGasSegment(startTimestamp: 0, fN2: airN2Fraction),
+      ProfileGasSegment(startTimestamp: timestamps[switchIndex], fN2: 0.50),
+    ];
+    return (depths: depths, timestamps: timestamps, gas: gas);
+  }
+
+  test(
+    'gas-aware TTS is monotone non-increasing across the recorded switch',
+    () {
+      final p = buildProfile();
+      final algo = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80);
+      algo.reset();
+      final plan = OptimalOcAscentGas(
+        gases: const [
+          AvailableGas(
+            fN2: airN2Fraction,
+            fHe: 0.0,
+            maxPpO2Mod: double.infinity,
+          ),
+          AvailableGas(fN2: 0.50, fHe: 0.0, maxPpO2Mod: 22.0),
+        ],
+        maxPpO2: 1.6,
+      );
+      final statuses = algo.processProfileWithGasSegments(
+        depths: p.depths,
+        timestamps: p.timestamps,
+        gasSegments: p.gas,
+        ascentGasPlan: plan,
+      );
+
+      // No upward step in TTS at the recorded switch: from the bottom phase
+      // through the ascent the TTS must never jump UP at the switch sample.
+      final tts = statuses.map((s) => s.ttsSeconds).toList();
+      final switchIndex = p.depths.lastIndexWhere((d) => (d - 21).abs() < 1.6);
+      expect(
+        tts[switchIndex] <= tts[switchIndex - 1] + 1,
+        isTrue,
+        reason: 'TTS stepped up at the recorded gas switch',
+      );
+    },
+  );
+
+  test(
+    'null ascentGasPlan reproduces the single-gas-per-sample legacy path',
+    () {
+      final p = buildProfile();
+      final a = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80)..reset();
+      final legacy = a.processProfileWithGasSegments(
+        depths: p.depths,
+        timestamps: p.timestamps,
+        gasSegments: p.gas,
+      );
+      final b = BuhlmannAlgorithm(gfLow: 0.50, gfHigh: 0.80)..reset();
+      final explicitNull = b.processProfileWithGasSegments(
+        depths: p.depths,
+        timestamps: p.timestamps,
+        gasSegments: p.gas,
+        ascentGasPlan: null,
+      );
+      expect(
+        explicitNull.map((s) => s.ttsSeconds),
+        legacy.map((s) => s.ttsSeconds),
+      );
+    },
+  );
+}

--- a/test/features/dive_log/build_available_gases_test.dart
+++ b/test/features/dive_log/build_available_gases_test.dart
@@ -1,0 +1,47 @@
+// test/features/dive_log/build_available_gases_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+Dive _diveWith(List<DiveTank> tanks) => Dive(
+  id: 'd1',
+  diveNumber: 1,
+  dateTime: DateTime.utc(2026, 1, 1),
+  tanks: tanks,
+);
+
+void main() {
+  const air = DiveTank(
+    id: 't1',
+    gasMix: GasMix(o2: 21),
+    role: TankRole.backGas,
+  );
+  const ean50 = DiveTank(id: 't2', gasMix: GasMix(o2: 50), role: TankRole.deco);
+  const o2 = DiveTank(id: 't3', gasMix: GasMix(o2: 100), role: TankRole.deco);
+
+  test('allCarried maps every tank mix and invents no gases', () {
+    final gases = buildAvailableGases(
+      _diveWith([air, ean50, o2]),
+      maxPpO2: 1.6,
+      gasSet: AscentGasSet.allCarried,
+    );
+    expect(gases.length, 3);
+    // EAN50 MOD at 1.6 = 22 m.
+    final ean = gases.firstWhere((g) => (g.fO2 - 0.5).abs() < 1e-9);
+    expect(ean.maxPpO2Mod, closeTo(22.0, 1e-6));
+  });
+
+  test('decoStageOnly keeps deco/stage/bailout plus the back gas', () {
+    final gases = buildAvailableGases(
+      _diveWith([air, ean50, o2]),
+      maxPpO2: 1.6,
+      gasSet: AscentGasSet.decoStageOnly,
+    );
+    // Back gas (air) is always retained as the floor; deco gases kept.
+    expect(gases.any((g) => (g.fO2 - 0.21).abs() < 1e-9), isTrue);
+    expect(gases.any((g) => (g.fO2 - 0.50).abs() < 1e-9), isTrue);
+    expect(gases.any((g) => (g.fO2 - 1.0).abs() < 1e-9), isTrue);
+  });
+}

--- a/test/features/dive_planner/data/services/plan_calculator_service_test.dart
+++ b/test/features/dive_planner/data/services/plan_calculator_service_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_planner/data/services/plan_calculator_service.dart';
 import 'package:submersion/features/dive_planner/domain/entities/plan_result.dart';
+import 'package:submersion/features/dive_planner/domain/entities/plan_segment.dart';
 
 void main() {
   group('PlanCalculatorService reserve pressure', () {
@@ -124,6 +126,85 @@ void main() {
       expect(gasLowWarnings, hasLength(1));
       expect(gasLowWarnings.first.threshold, 40);
       expect(result.gasConsumptions.first.reserveViolation, isTrue);
+    });
+  });
+
+  group('PlanCalculatorService ideal ascent gas', () {
+    final calculator = PlanCalculatorService();
+
+    // Deep air dive that incurs deco; the only difference between the two
+    // runs is the carried gas set passed to calculatePlan (which feeds the
+    // ascent gas plan). The bottom loading is identical.
+    const air = DiveTank(
+      id: 'back',
+      name: 'Back gas',
+      volume: 24,
+      startPressure: 230,
+      gasMix: GasMix(o2: 21),
+      role: TankRole.backGas,
+    );
+    const ean50 = DiveTank(
+      id: 'deco',
+      name: 'EAN50',
+      volume: 11.1,
+      startPressure: 200,
+      gasMix: GasMix(o2: 50),
+      role: TankRole.deco,
+    );
+
+    // Descent + bottom only, ending AT depth so calculatePlan builds the full
+    // deco schedule from the bottom (createSimplePlan ends at the surface).
+    List<PlanSegment> decoSegments() => [
+      PlanSegment.descent(
+        id: 'descent',
+        targetDepth: 45,
+        tankId: air.id,
+        gasMix: air.gasMix,
+        order: 0,
+      ),
+      PlanSegment.bottom(
+        id: 'bottom',
+        depth: 45,
+        durationMinutes: 25,
+        tankId: air.id,
+        gasMix: air.gasMix,
+        order: 1,
+      ),
+    ];
+
+    int totalStopSeconds(List<DiveTank> tanks) {
+      final result = calculator.calculatePlan(
+        segments: decoSegments(),
+        tanks: tanks,
+        sacRate: 15,
+      );
+      return result.decoSchedule.fold<int>(
+        0,
+        (sum, stop) => sum + stop.durationSeconds,
+      );
+    }
+
+    test('ideal-gas ascent gives <= deco time than fixed back gas', () {
+      final fixedTotal = totalStopSeconds([air]);
+      final idealTotal = totalStopSeconds([air, ean50]);
+
+      expect(fixedTotal, greaterThan(0));
+      expect(idealTotal, lessThanOrEqualTo(fixedTotal));
+    });
+
+    test('deco stops report the gas actually breathed at each stop', () {
+      final result = calculator.calculatePlan(
+        segments: decoSegments(),
+        tanks: [air, ean50],
+        sacRate: 15,
+      );
+
+      // EAN50 (MOD 22 m @1.6) must be selected at the 21/18/.../6 m stops.
+      final ean50Stop = result.decoSchedule.firstWhere(
+        (s) => s.depth <= 21 && s.depth > 6,
+        orElse: () => result.decoSchedule.first,
+      );
+      expect(ean50Stop.gasMix.o2, closeTo(50, 1e-6));
     });
   });
 }

--- a/test/features/settings/ascent_gas_set_setting_test.dart
+++ b/test/features/settings/ascent_gas_set_setting_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  test('AppSettings defaults ascentGasSet to allCarried', () {
+    const settings = AppSettings();
+    expect(settings.ascentGasSet, AscentGasSet.allCarried);
+  });
+
+  test('copyWith overrides ascentGasSet and preserves it otherwise', () {
+    const settings = AppSettings();
+    final updated = settings.copyWith(ascentGasSet: AscentGasSet.decoStageOnly);
+    expect(updated.ascentGasSet, AscentGasSet.decoStageOnly);
+    expect(
+      updated.copyWith(gfLow: 40).ascentGasSet,
+      AscentGasSet.decoStageOnly,
+    );
+  });
+}

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -216,6 +216,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setEndLimit(double value) async =>
       state = state.copyWith(endLimit: value);
   @override
+  Future<void> setAscentGasSet(AscentGasSet value) async =>
+      state = state.copyWith(ascentGasSet: value);
+  @override
   Future<void> setDefaultNdlSource(MetricDataSource value) async =>
       state = state.copyWith(defaultNdlSource: value);
   @override

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -140,6 +140,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setEndLimit(double value) async =>
       state = state.copyWith(endLimit: value);
   @override
+  Future<void> setAscentGasSet(AscentGasSet value) async =>
+      state = state.copyWith(ascentGasSet: value);
+  @override
   Future<void> setDefaultNdlSource(MetricDataSource value) async =>
       state = state.copyWith(defaultNdlSource: value);
   @override

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -132,6 +132,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setEndLimit(double value) async =>
       state = state.copyWith(endLimit: value);
   @override
+  Future<void> setAscentGasSet(AscentGasSet value) async =>
+      state = state.copyWith(ascentGasSet: value);
+  @override
   Future<void> setDefaultNdlSource(MetricDataSource value) async =>
       state = state.copyWith(defaultNdlSource: value);
   @override

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -122,6 +122,9 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setEndLimit(double value) async =>
       state = state.copyWith(endLimit: value);
   @override
+  Future<void> setAscentGasSet(AscentGasSet value) async =>
+      state = state.copyWith(ascentGasSet: value);
+  @override
   Future<void> setDefaultNdlSource(MetricDataSource value) async =>
       state = state.copyWith(defaultNdlSource: value);
   @override


### PR DESCRIPTION
## Summary

Implements https://github.com/submersion-app/submersion/discussions/326

Makes every forward-looking decompression projection (TTS, ceiling, stop schedule) simulate the ascent on the **best breathable gas the diver carries at each simulated depth**, instead of the single gas active at the current sample — for open-circuit dives.

Today the projection re-plans the ascent on whatever gas is being breathed *now*, so TTS is overstated during the bottom phase and then shows a discontinuous downward step at each recorded gas switch that does not correspond to any real change in obligation. Because heatmaps, CNS/O2 projections, warnings, and summary stats all derive from these values, the error is not cosmetic. TTS, by definition, is the *optimal* time-to-surface — which is why a real dive computer's TTS curve is smooth while ours stepped.

Implements the approved design in [`docs/superpowers/specs/2026-06-28-gas-aware-ascent-deco-design.md`](docs/superpowers/specs/2026-06-28-gas-aware-ascent-deco-design.md). Scope is **open-circuit only**; CCR/SCR are explicitly deferred and remain byte-identical to `main`.

## Changes

**Gas-aware ascent (the feature):**
- New pluggable `AscentGasPlan` strategy (`lib/core/deco/ascent/ascent_gas_plan.dart`): `FixedAscentGas` (legacy, single gas) and `OptimalOcAscentGas` (picks the richest gas whose ppO2 at depth stays within the diver's existing `ppO2MaxDeco` ceiling, via `O2ToxicityCalculator.calculateMod`). No invented gases — only cylinders recorded on the dive.
- Threaded through the Bühlmann ascent primitives (`calculateDecoSchedule` / `calculateTts` / `_calculateStopTime` / `_simulateAscent` / `getDecoStatus` / `processProfileWithGasSegments`), splitting each ascent leg at any gas-switch (MOD) depth it crosses (switch at the stop for 3 m legs; on-the-fly for the travel to the first stop). Single-gas dives stay byte-identical; the Bühlmann math is shared, not forked.
- New persisted **"Plan ascent with"** setting (`AscentGasSet { allCarried, decoStageOnly }`, default `allCarried`) — Drift schema v94 + migration, repository, and sync serialization — surfaced as a selector in deco settings.
- Wired into OC profile analysis (`profile_analysis_provider` / `profile_analysis_service`) and the dive planner's deco schedule.

**Bug fix discovered during this work (safety-relevant):**
- `fix(deco): stop double-counting stop loading in the deco schedule` — `_calculateStopTime` left its per-minute search loading on the tissues, and `calculateDecoSchedule` then applied the same stop's loading again, so every deco stop was integrated **twice** during the schedule simulation. This over-offgassed the tissues and **understated TTS** (a non-conservative error). It predates this branch (present unchanged at the merge-base and on `main`); the new independent clean-room ZHL-16C cross-check is simply the first test to pin absolute TTS, so it's the first to expose it. Fixed by making `_calculateStopTime` a pure time computation that restores tissue state before returning. **Heads-up for reviewers: this raises calculated TTS across dives** — it is a deliberate correctness change bundled here.

**Tests:**
- `ascent_gas_plan` strategy/MOD/tie-break tests; `buhlmann_algorithm` MOD-split + single-gas-equivalence tests.
- `tts_gas_switch_regression` (step-free TTS across a switch; legacy-path equivalence), `tts_fixture_shape` (OC shape + CCR no-change), and an independent `tts_cleanroom_cross_check` that pins absolute TTS against a from-scratch ZHL-16C/GF integrator.

## Test Plan

- [x] `flutter test` passes (full suite green, 9500+ tests)
- [x] `flutter analyze` passes (no issues)
- [x] Manual: open an OC multi-gas deco dive without recorded computer TTS → calculated TTS is smooth across the recorded switch; open a single-gas dive → unchanged; open a CCR dive → unchanged.

## Screenshots

### Before
<img width="3215" height="1431" alt="before" src="https://github.com/user-attachments/assets/917bb950-2791-4426-b351-1c854b9a4a32" />



### After: TTS in calculated mode, using correct gases for ascent

<img width="3123" height="1529" alt="after" src="https://github.com/user-attachments/assets/ebab1caf-920b-4f3a-ae89-b362e33a965d" />

