### PR TITLE
fix(dive_log): tissue bar highlight overflows its slot on hover

### DIFF
--- a/lib/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart
@@ -280,20 +280,25 @@ class _CompactTissueLoadingCardState
       ),
     ];
 
-    // Wrap bar segments in an outline when highlighted.
-    // The outline container is only as tall as the bar itself.
+    final barColumn = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: barSegments,
+    );
+
+    // Highlight via foregroundDecoration so the outline is painted OVER the
+    // bar without enlarging it. A decoration border would inset the child and
+    // add its width to the box on every side, making the bar taller than its
+    // fixed-height slot (overflowing when the bar is already full height) and
+    // wider than its unhighlighted neighbours (hover jitter).
     final bar = outlineColor != null
         ? Container(
-            decoration: BoxDecoration(
+            foregroundDecoration: BoxDecoration(
               border: Border.all(color: outlineColor, width: 2),
               borderRadius: BorderRadius.circular(2),
             ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: barSegments,
-            ),
+            child: barColumn,
           )
-        : Column(mainAxisSize: MainAxisSize.min, children: barSegments);
+        : barColumn;
 
     return Tooltip(
       message:

--- a/test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart
@@ -32,7 +32,35 @@ const _status = DecoStatus(
   ambientPressureBar: 2.0,
 );
 
+// A compartment loaded well past its M-value. surfaceMValue for these
+// coefficients is ~3.24 bar, so currentPN2 4.5 is ~139% loading, which clamps
+// the bar to full chart height -- the case where the highlight outline used to
+// overflow the fixed-height bar slot.
+const _overloadedComp = TissueCompartment(
+  compartmentNumber: 1,
+  halfTimeN2: 4.0,
+  halfTimeHe: 1.51,
+  mValueAN2: 1.2599,
+  mValueBN2: 0.5050,
+  mValueAHe: 1.7424,
+  mValueBHe: 0.4245,
+  currentPN2: 4.5,
+);
+
+const _overloadedStatus = DecoStatus(
+  compartments: [_overloadedComp],
+  ndlSeconds: -1,
+  ceilingMeters: 6.0,
+  ttsSeconds: 300,
+  gfLow: 0.4,
+  gfHigh: 0.85,
+  decoStops: [],
+  currentDepthMeters: 30.0,
+  ambientPressureBar: 4.0,
+);
+
 Widget buildCard({
+  DecoStatus status = _status,
   List<DecoStatus>? decoStatuses,
   bool expandVisualization = false,
 }) {
@@ -43,7 +71,7 @@ Widget buildCard({
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: CompactTissueLoadingCard(
-          status: _status,
+          status: status,
           decoStatuses: decoStatuses,
           expandVisualization: expandVisualization,
         ),
@@ -53,6 +81,19 @@ Widget buildCard({
 }
 
 void main() {
+  testWidgets(
+    'does not overflow when the highlighted compartment bar is full height',
+    (tester) async {
+      await tester.pumpWidget(buildCard(status: _overloadedStatus));
+      await tester.pumpAndSettle();
+
+      // The leading (only) compartment is >120% loaded, so its bar fills the
+      // whole chart height and is highlighted by default. The highlight must
+      // not push the bar past its fixed-height slot.
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   group('CompactTissueLoadingCard heatmap labels', () {
     testWidgets('shows Fast and Slow labels when heatmap data is provided', (
       tester,


### PR DESCRIPTION
## Summary

Fixes a `RenderFlex` bottom overflow ("BOTTOM OVERFLOWED" stripe) in the tissue-loading card's compartment bar chart, seen when hovering a heavily-saturated dive.

The highlighted compartment bar (the leading one by default, or the hovered one) was wrapped in a `Container` with a **`decoration`** border. A decoration border insets the child and adds its width to the box on every side, so the highlighted bar became ~4 px taller and wider than an unhighlighted one. When a compartment is at/past 120% loading its bar already fills the fixed 50 px chart slot, so the extra height overflowed the `SizedBox`. It also made the highlighted bar jitter larger than its neighbours.

Fix: paint the outline with **`foregroundDecoration`** instead — drawn over the bar without changing its layout size. The bar stays exactly the size of its unhighlighted neighbours; the highlight is now purely visual.

## Changes

- `lib/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart` — `_buildSubsurfaceBar` highlight uses `foregroundDecoration` (overlay) instead of a size-affecting `decoration` border.
- `test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart` — regression test: pumps an over-120%-loaded (full-height, highlighted-by-default) compartment and asserts no layout overflow. Fails before the fix, passes after.

## Test Plan

- [x] `flutter test` passes (new regression test + full `dive_log/presentation/widgets` suite, 533 tests)
- [x] `flutter analyze` passes (no issues)
- [X] Manual: hover a deco dive with a compartment >120% loaded → no overflow stripe, highlighted bar no longer jitters.

## Screenshots

Before:
<img width="1190" height="229" alt="image" src="https://github.com/user-attachments/assets/3b13e2ca-f49f-4db9-a028-7557772cfe8b" />
