### PR TITLE
feat: infer cylinder role on dive-computer download

### DIFF
--- a/lib/features/dive_computer/data/services/dive_parser.dart
+++ b/lib/features/dive_computer/data/services/dive_parser.dart
@@ -69,6 +69,7 @@ class DiveParser {
           startPressure: tank.startPressure,
           endPressure: tank.endPressure,
           volumeLiters: tank.volumeLiters,
+          role: tank.role,
         ),
       );
     }

--- a/lib/features/dive_computer/data/services/parsed_tank_resolver.dart
+++ b/lib/features/dive_computer/data/services/parsed_tank_resolver.dart
@@ -1,4 +1,5 @@
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 
 /// Resolve a parsed dive's gas mixes to concrete cylinders, shared by the
@@ -95,6 +96,7 @@ _ResolvedCylinders _resolveCylinders(pigeon.ParsedDive parsed) {
           index: g.index,
           o2Percent: g.o2Percent,
           hePercent: g.hePercent,
+          role: _inferRole(null, g.o2Percent, g.hePercent),
         ),
       );
     }
@@ -112,15 +114,18 @@ _ResolvedCylinders _resolveCylinders(pigeon.ParsedDive parsed) {
       consumed.add(gasIndex);
       gasIndexToTankIndex[gasIndex] = tank.index;
     }
+    final o2 = gas?.o2Percent ?? 21.0;
+    final he = gas?.hePercent ?? 0.0;
     result.add(
       DownloadedTank(
         index: tank.index,
         // No gas mixes (e.g. gauge mode): default to air rather than mislabel.
-        o2Percent: gas?.o2Percent ?? 21.0,
-        hePercent: gas?.hePercent ?? 0.0,
+        o2Percent: o2,
+        hePercent: he,
         startPressure: tank.startPressureBar,
         endPressure: tank.endPressureBar,
         volumeLiters: tank.volumeLiters,
+        role: _inferRole(tank.usage, o2, he),
       ),
     );
   }
@@ -138,11 +143,29 @@ _ResolvedCylinders _resolveCylinders(pigeon.ParsedDive parsed) {
         index: nextIndex++,
         o2Percent: gasMixes[i].o2Percent,
         hePercent: gasMixes[i].hePercent,
+        role: _inferRole(null, gasMixes[i].o2Percent, gasMixes[i].hePercent),
       ),
     );
   }
 
   return _ResolvedCylinders(result, gasIndexToTankIndex);
+}
+
+/// Infer a cylinder [TankRole] (returned as its `.name`). The computer's tank
+/// [usage] (libdivecomputer `dc_usage_t`: 1=oxygen, 2=diluent) is authoritative
+/// when present; otherwise fall back to an open-circuit gas heuristic where a
+/// nitrox mix of 41% O2 or more is a deco gas. Everything else is back gas.
+String _inferRole(int? usage, double o2Percent, double hePercent) {
+  switch (usage) {
+    case 1: // DC_USAGE_OXYGEN
+      return TankRole.oxygenSupply.name;
+    case 2: // DC_USAGE_DILUENT
+      return TankRole.diluent.name;
+  }
+  if (hePercent == 0.0 && o2Percent >= 41.0) {
+    return TankRole.deco.name;
+  }
+  return TankRole.backGas.name;
 }
 
 /// The gas-mix index (position in [gasMixes]) for [tank], preferring the gas

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -580,7 +580,7 @@ class ReparseService {
                 o2Percent: Value(tank.o2Percent),
                 hePercent: Value(tank.hePercent),
                 tankOrder: Value(tank.index),
-                tankRole: const Value('backGas'),
+                tankRole: Value(tank.role ?? 'backGas'),
               ),
             );
       }

--- a/lib/features/dive_computer/domain/entities/downloaded_dive.dart
+++ b/lib/features/dive_computer/domain/entities/downloaded_dive.dart
@@ -287,6 +287,10 @@ class DownloadedTank {
   /// Tank volume in liters
   final double? volumeLiters;
 
+  /// Inferred cylinder role (a [TankRole] name, e.g. 'deco'), or null to use
+  /// the default. Derived from the computer's tank usage / the gas mix.
+  final String? role;
+
   const DownloadedTank({
     required this.index,
     required this.o2Percent,
@@ -294,6 +298,7 @@ class DownloadedTank {
     this.startPressure,
     this.endPressure,
     this.volumeLiters,
+    this.role,
   });
 
   /// Whether this is air (21% O2)

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -1064,7 +1064,7 @@ class DiveComputerRepository {
                 o2Percent: Value(tank.o2Percent),
                 hePercent: Value(tank.hePercent),
                 tankOrder: Value(tank.index),
-                tankRole: const Value('backGas'),
+                tankRole: Value(tank.role ?? 'backGas'),
               ),
             );
             _log.info(
@@ -1711,6 +1711,9 @@ class TankData {
   final double? endPressure;
   final double? volumeLiters;
 
+  /// Inferred cylinder role (a [TankRole] name), or null for the default.
+  final String? role;
+
   const TankData({
     required this.index,
     required this.o2Percent,
@@ -1718,6 +1721,7 @@ class TankData {
     this.startPressure,
     this.endPressure,
     this.volumeLiters,
+    this.role,
   });
 }
 

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -975,16 +975,17 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveTank(
     if (index < 0 || static_cast<unsigned int>(index) >= dive->tank_count) return nullptr;
 
     const libdc_tank_t *tk = &dive->tanks[index];
-    // Return [gasmix, volume, workpressure, beginpressure, endpressure]
-    jdouble values[5] = {
+    // Return [gasmix, volume, workpressure, beginpressure, endpressure, usage]
+    jdouble values[6] = {
         static_cast<jdouble>(tk->gasmix),
         tk->volume,
         tk->workpressure,
         tk->beginpressure,
-        tk->endpressure
+        tk->endpressure,
+        static_cast<jdouble>(tk->usage)
     };
-    jdoubleArray result = env->NewDoubleArray(5);
-    env->SetDoubleArrayRegion(result, 0, 5, values);
+    jdoubleArray result = env->NewDoubleArray(6);
+    env->SetDoubleArrayRegion(result, 0, 6, values);
     return result;
 }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
@@ -239,7 +239,12 @@ data class TankInfo (
   val gasMixIndex: Long,
   val volumeLiters: Double? = null,
   val startPressureBar: Double? = null,
-  val endPressureBar: Double? = null
+  val endPressureBar: Double? = null,
+  /**
+   * Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+   * 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+   */
+  val usage: Long? = null
 )
  {
   companion object {
@@ -249,7 +254,8 @@ data class TankInfo (
       val volumeLiters = pigeonVar_list[2] as Double?
       val startPressureBar = pigeonVar_list[3] as Double?
       val endPressureBar = pigeonVar_list[4] as Double?
-      return TankInfo(index, gasMixIndex, volumeLiters, startPressureBar, endPressureBar)
+      val usage = pigeonVar_list[5] as Long?
+      return TankInfo(index, gasMixIndex, volumeLiters, startPressureBar, endPressureBar, usage)
     }
   }
   fun toList(): List<Any?> {
@@ -259,6 +265,7 @@ data class TankInfo (
       volumeLiters,
       startPressureBar,
       endPressureBar,
+      usage,
     )
   }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -580,7 +580,8 @@ class DiveComputerHostApiImpl(
                 gasMixIndex = tk[0].toLong(),
                 volumeLiters = if (tk[1] > 0) tk[1] else null,
                 startPressureBar = if (tk[3] > 0) tk[3] else null,
-                endPressureBar = if (tk[4] > 0) tk[4] else null
+                endPressureBar = if (tk[4] > 0) tk[4] else null,
+                usage = if (tk[5].toLong() == 0L) null else tk[5].toLong(),
             )
         }
 

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -634,7 +634,8 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
                     gasMixIndex: Int64(tk.gasmix),
                     volumeLiters: tk.volume > 0 ? tk.volume : nil,
                     startPressureBar: tk.beginpressure > 0 ? tk.beginpressure : nil,
-                    endPressureBar: tk.endpressure > 0 ? tk.endpressure : nil
+                    endPressureBar: tk.endpressure > 0 ? tk.endpressure : nil,
+                    usage: tk.usage == 0 ? nil : Int64(tk.usage)
                 ))
             }
         }

--- a/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
@@ -287,6 +287,9 @@ struct TankInfo {
   var volumeLiters: Double? = nil
   var startPressureBar: Double? = nil
   var endPressureBar: Double? = nil
+  /// Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+  /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+  var usage: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -296,13 +299,15 @@ struct TankInfo {
     let volumeLiters: Double? = nilOrValue(pigeonVar_list[2])
     let startPressureBar: Double? = nilOrValue(pigeonVar_list[3])
     let endPressureBar: Double? = nilOrValue(pigeonVar_list[4])
+    let usage: Int64? = nilOrValue(pigeonVar_list[5])
 
     return TankInfo(
       index: index,
       gasMixIndex: gasMixIndex,
       volumeLiters: volumeLiters,
       startPressureBar: startPressureBar,
-      endPressureBar: endPressureBar
+      endPressureBar: endPressureBar,
+      usage: usage
     )
   }
   func toList() -> [Any?] {
@@ -312,6 +317,7 @@ struct TankInfo {
       volumeLiters,
       startPressureBar,
       endPressureBar,
+      usage,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
+++ b/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
@@ -261,6 +261,7 @@ class TankInfo {
     this.volumeLiters,
     this.startPressureBar,
     this.endPressureBar,
+    this.usage,
   });
 
   int index;
@@ -273,6 +274,10 @@ class TankInfo {
 
   double? endPressureBar;
 
+  /// Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+  /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+  int? usage;
+
   Object encode() {
     return <Object?>[
       index,
@@ -280,6 +285,7 @@ class TankInfo {
       volumeLiters,
       startPressureBar,
       endPressureBar,
+      usage,
     ];
   }
 
@@ -291,6 +297,7 @@ class TankInfo {
       volumeLiters: result[2] as double?,
       startPressureBar: result[3] as double?,
       endPressureBar: result[4] as double?,
+      usage: result[5] as int?,
     );
   }
 }

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
@@ -725,6 +725,7 @@ struct _LibdivecomputerPluginTankInfo {
   double* volume_liters;
   double* start_pressure_bar;
   double* end_pressure_bar;
+  int64_t* usage;
 };
 
 G_DEFINE_TYPE(LibdivecomputerPluginTankInfo, libdivecomputer_plugin_tank_info, G_TYPE_OBJECT)
@@ -734,6 +735,7 @@ static void libdivecomputer_plugin_tank_info_dispose(GObject* object) {
   g_clear_pointer(&self->volume_liters, g_free);
   g_clear_pointer(&self->start_pressure_bar, g_free);
   g_clear_pointer(&self->end_pressure_bar, g_free);
+  g_clear_pointer(&self->usage, g_free);
   G_OBJECT_CLASS(libdivecomputer_plugin_tank_info_parent_class)->dispose(object);
 }
 
@@ -744,7 +746,7 @@ static void libdivecomputer_plugin_tank_info_class_init(LibdivecomputerPluginTan
   G_OBJECT_CLASS(klass)->dispose = libdivecomputer_plugin_tank_info_dispose;
 }
 
-LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar) {
+LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar, int64_t* usage) {
   LibdivecomputerPluginTankInfo* self = LIBDIVECOMPUTER_PLUGIN_TANK_INFO(g_object_new(libdivecomputer_plugin_tank_info_get_type(), nullptr));
   self->index = index;
   self->gas_mix_index = gas_mix_index;
@@ -768,6 +770,13 @@ LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t inde
   }
   else {
     self->end_pressure_bar = nullptr;
+  }
+  if (usage != nullptr) {
+    self->usage = static_cast<int64_t*>(malloc(sizeof(int64_t)));
+    *self->usage = *usage;
+  }
+  else {
+    self->usage = nullptr;
   }
   return self;
 }
@@ -797,6 +806,11 @@ double* libdivecomputer_plugin_tank_info_get_end_pressure_bar(LibdivecomputerPlu
   return self->end_pressure_bar;
 }
 
+int64_t* libdivecomputer_plugin_tank_info_get_usage(LibdivecomputerPluginTankInfo* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_TANK_INFO(self), nullptr);
+  return self->usage;
+}
+
 static FlValue* libdivecomputer_plugin_tank_info_to_list(LibdivecomputerPluginTankInfo* self) {
   FlValue* values = fl_value_new_list();
   fl_value_append_take(values, fl_value_new_int(self->index));
@@ -804,6 +818,7 @@ static FlValue* libdivecomputer_plugin_tank_info_to_list(LibdivecomputerPluginTa
   fl_value_append_take(values, self->volume_liters != nullptr ? fl_value_new_float(*self->volume_liters) : fl_value_new_null());
   fl_value_append_take(values, self->start_pressure_bar != nullptr ? fl_value_new_float(*self->start_pressure_bar) : fl_value_new_null());
   fl_value_append_take(values, self->end_pressure_bar != nullptr ? fl_value_new_float(*self->end_pressure_bar) : fl_value_new_null());
+  fl_value_append_take(values, self->usage != nullptr ? fl_value_new_int(*self->usage) : fl_value_new_null());
   return values;
 }
 
@@ -833,7 +848,14 @@ static LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new_from_
     end_pressure_bar_value = fl_value_get_float(value4);
     end_pressure_bar = &end_pressure_bar_value;
   }
-  return libdivecomputer_plugin_tank_info_new(index, gas_mix_index, volume_liters, start_pressure_bar, end_pressure_bar);
+  FlValue* value5 = fl_value_get_list_value(values, 5);
+  int64_t* usage = nullptr;
+  int64_t usage_value;
+  if (fl_value_get_type(value5) != FL_VALUE_TYPE_NULL) {
+    usage_value = fl_value_get_int(value5);
+    usage = &usage_value;
+  }
+  return libdivecomputer_plugin_tank_info_new(index, gas_mix_index, volume_liters, start_pressure_bar, end_pressure_bar, usage);
 }
 
 struct _LibdivecomputerPluginDiveEvent {

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
@@ -478,12 +478,13 @@ G_DECLARE_FINAL_TYPE(LibdivecomputerPluginTankInfo, libdivecomputer_plugin_tank_
  * volume_liters: field in this object.
  * start_pressure_bar: field in this object.
  * end_pressure_bar: field in this object.
+ * usage: field in this object.
  *
  * Creates a new #TankInfo object.
  *
  * Returns: a new #LibdivecomputerPluginTankInfo
  */
-LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar);
+LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar, int64_t* usage);
 
 /**
  * libdivecomputer_plugin_tank_info_get_index
@@ -534,6 +535,17 @@ double* libdivecomputer_plugin_tank_info_get_start_pressure_bar(LibdivecomputerP
  * Returns: the field value.
  */
 double* libdivecomputer_plugin_tank_info_get_end_pressure_bar(LibdivecomputerPluginTankInfo* object);
+
+/**
+ * libdivecomputer_plugin_tank_info_get_usage
+ * @object: a #LibdivecomputerPluginTankInfo.
+ *
+ * Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+ * 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+ *
+ * Returns: the field value.
+ */
+int64_t* libdivecomputer_plugin_tank_info_get_usage(LibdivecomputerPluginTankInfo* object);
 
 /**
  * LibdivecomputerPluginDiveEvent:

--- a/packages/libdivecomputer_plugin/linux/dive_converter.c
+++ b/packages/libdivecomputer_plugin/linux/dive_converter.c
@@ -170,9 +170,12 @@ LibdivecomputerPluginParsedDive* convert_parsed_dive(
         double ep_val = tk->endpressure;
         double* end_p = (ep_val == 0.0) ? NULL : &ep_val;
 
+        int64_t usage_val = (int64_t)tk->usage;
+        int64_t* usage = (tk->usage == 0) ? NULL : &usage_val;
+
         LibdivecomputerPluginTankInfo* tank =
             libdivecomputer_plugin_tank_info_new(
-                (int64_t)i, (int64_t)tk->gasmix, volume, begin_p, end_p);
+                (int64_t)i, (int64_t)tk->gasmix, volume, begin_p, end_p, usage);
         fl_value_append_take(
             tanks,
             fl_value_new_custom_object(134, G_OBJECT(tank)));

--- a/packages/libdivecomputer_plugin/macos/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/DiveComputerApi.g.swift
@@ -287,6 +287,9 @@ struct TankInfo {
   var volumeLiters: Double? = nil
   var startPressureBar: Double? = nil
   var endPressureBar: Double? = nil
+  /// Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+  /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+  var usage: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -296,13 +299,15 @@ struct TankInfo {
     let volumeLiters: Double? = nilOrValue(pigeonVar_list[2])
     let startPressureBar: Double? = nilOrValue(pigeonVar_list[3])
     let endPressureBar: Double? = nilOrValue(pigeonVar_list[4])
+    let usage: Int64? = nilOrValue(pigeonVar_list[5])
 
     return TankInfo(
       index: index,
       gasMixIndex: gasMixIndex,
       volumeLiters: volumeLiters,
       startPressureBar: startPressureBar,
-      endPressureBar: endPressureBar
+      endPressureBar: endPressureBar,
+      usage: usage
     )
   }
   func toList() -> [Any?] {
@@ -312,6 +317,7 @@ struct TankInfo {
       volumeLiters,
       startPressureBar,
       endPressureBar,
+      usage,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -338,6 +338,7 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
                 dive->tanks[i].workpressure = tk.workpressure;
                 dive->tanks[i].beginpressure = tk.beginpressure;
                 dive->tanks[i].endpressure = tk.endpressure;
+                dive->tanks[i].usage = tk.usage;
             }
         }
         dive->tank_count = tank_count;

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -165,6 +165,7 @@ typedef struct {
     double workpressure;       // bar
     double beginpressure;      // bar
     double endpressure;        // bar
+    unsigned int usage;        // dc_usage_t (0=none, 1=oxygen, 2=diluent, 3=sidemount)
 } libdc_tank_t;
 
 #define LIBDC_MAX_EVENTS 256

--- a/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
+++ b/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
@@ -122,12 +122,17 @@ class TankInfo {
     this.volumeLiters,
     this.startPressureBar,
     this.endPressureBar,
+    this.usage,
   });
   final int index;
   final int gasMixIndex;
   final double? volumeLiters;
   final double? startPressureBar;
   final double? endPressureBar;
+
+  /// Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+  /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+  final int? usage;
 }
 
 class DiveEvent {

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
@@ -701,12 +701,14 @@ TankInfo::TankInfo(
   int64_t gas_mix_index,
   const double* volume_liters,
   const double* start_pressure_bar,
-  const double* end_pressure_bar)
+  const double* end_pressure_bar,
+  const int64_t* usage)
  : index_(index),
     gas_mix_index_(gas_mix_index),
     volume_liters_(volume_liters ? std::optional<double>(*volume_liters) : std::nullopt),
     start_pressure_bar_(start_pressure_bar ? std::optional<double>(*start_pressure_bar) : std::nullopt),
-    end_pressure_bar_(end_pressure_bar ? std::optional<double>(*end_pressure_bar) : std::nullopt) {}
+    end_pressure_bar_(end_pressure_bar ? std::optional<double>(*end_pressure_bar) : std::nullopt),
+    usage_(usage ? std::optional<int64_t>(*usage) : std::nullopt) {}
 
 int64_t TankInfo::index() const {
   return index_;
@@ -765,14 +767,28 @@ void TankInfo::set_end_pressure_bar(double value_arg) {
 }
 
 
+const int64_t* TankInfo::usage() const {
+  return usage_ ? &(*usage_) : nullptr;
+}
+
+void TankInfo::set_usage(const int64_t* value_arg) {
+  usage_ = value_arg ? std::optional<int64_t>(*value_arg) : std::nullopt;
+}
+
+void TankInfo::set_usage(int64_t value_arg) {
+  usage_ = value_arg;
+}
+
+
 EncodableList TankInfo::ToEncodableList() const {
   EncodableList list;
-  list.reserve(5);
+  list.reserve(6);
   list.push_back(EncodableValue(index_));
   list.push_back(EncodableValue(gas_mix_index_));
   list.push_back(volume_liters_ ? EncodableValue(*volume_liters_) : EncodableValue());
   list.push_back(start_pressure_bar_ ? EncodableValue(*start_pressure_bar_) : EncodableValue());
   list.push_back(end_pressure_bar_ ? EncodableValue(*end_pressure_bar_) : EncodableValue());
+  list.push_back(usage_ ? EncodableValue(*usage_) : EncodableValue());
   return list;
 }
 
@@ -791,6 +807,10 @@ TankInfo TankInfo::FromEncodableList(const EncodableList& list) {
   auto& encodable_end_pressure_bar = list[4];
   if (!encodable_end_pressure_bar.IsNull()) {
     decoded.set_end_pressure_bar(std::get<double>(encodable_end_pressure_bar));
+  }
+  auto& encodable_usage = list[5];
+  if (!encodable_usage.IsNull()) {
+    decoded.set_usage(std::get<int64_t>(encodable_usage));
   }
   return decoded;
 }

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
@@ -355,7 +355,8 @@ class TankInfo {
     int64_t gas_mix_index,
     const double* volume_liters,
     const double* start_pressure_bar,
-    const double* end_pressure_bar);
+    const double* end_pressure_bar,
+    const int64_t* usage);
 
   int64_t index() const;
   void set_index(int64_t value_arg);
@@ -375,6 +376,12 @@ class TankInfo {
   void set_end_pressure_bar(const double* value_arg);
   void set_end_pressure_bar(double value_arg);
 
+  // Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
+  // 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
+  const int64_t* usage() const;
+  void set_usage(const int64_t* value_arg);
+  void set_usage(int64_t value_arg);
+
 
  private:
   static TankInfo FromEncodableList(const flutter::EncodableList& list);
@@ -387,6 +394,7 @@ class TankInfo {
   std::optional<double> volume_liters_;
   std::optional<double> start_pressure_bar_;
   std::optional<double> end_pressure_bar_;
+  std::optional<int64_t> usage_;
 
 };
 

--- a/packages/libdivecomputer_plugin/windows/dive_converter.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_converter.cc
@@ -185,13 +185,17 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
             (begin_p == 0.0) ? std::nullopt : std::optional<double>(begin_p);
         std::optional<double> opt_end =
             (end_p == 0.0) ? std::nullopt : std::optional<double>(end_p);
+        std::optional<int64_t> opt_usage =
+            (tk.usage == 0) ? std::nullopt
+                            : std::optional<int64_t>(static_cast<int64_t>(tk.usage));
 
         tanks.push_back(flutter::CustomEncodableValue(TankInfo(
             static_cast<int64_t>(i),
             static_cast<int64_t>(tk.gasmix),
             opt_vol ? &*opt_vol : nullptr,
             opt_begin ? &*opt_begin : nullptr,
-            opt_end ? &*opt_end : nullptr)));
+            opt_end ? &*opt_end : nullptr,
+            opt_usage ? &*opt_usage : nullptr)));
     }
 
     // Convert events.

--- a/test/features/dive_computer/data/services/parsed_tank_resolver_test.dart
+++ b/test/features/dive_computer/data/services/parsed_tank_resolver_test.dart
@@ -263,6 +263,86 @@ void main() {
       expect(tanks[0].o2Percent, 21.0);
       expect(tanks[0].isAir, isTrue);
     });
+
+    group('role inference', () {
+      String? roleOf(pigeon.ParsedDive parsed, double o2) =>
+          resolveParsedTanks(parsed).firstWhere((t) => t.o2Percent == o2).role;
+
+      test('open circuit: O2 >= 41% is deco, below is back gas', () {
+        final parsed = makeParsedDive(
+          gasMixes: [
+            pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0),
+            pigeon.GasMix(index: 1, o2Percent: 41.0, hePercent: 0.0),
+            pigeon.GasMix(index: 2, o2Percent: 100.0, hePercent: 0.0),
+          ],
+        );
+        expect(roleOf(parsed, 32.0), 'backGas');
+        expect(roleOf(parsed, 41.0), 'deco');
+        expect(roleOf(parsed, 100.0), 'deco');
+      });
+
+      test('open circuit: trimix bottom gas (He>0, O2<41) is back gas', () {
+        final parsed = makeParsedDive(
+          gasMixes: [pigeon.GasMix(index: 0, o2Percent: 18.0, hePercent: 45.0)],
+        );
+        expect(roleOf(parsed, 18.0), 'backGas');
+      });
+
+      test('native usage maps oxygen -> oxygenSupply, diluent -> diluent', () {
+        final parsed = makeParsedDive(
+          gasMixes: [
+            pigeon.GasMix(index: 0, o2Percent: 100.0, hePercent: 0.0),
+            pigeon.GasMix(index: 1, o2Percent: 21.0, hePercent: 0.0),
+          ],
+          tanks: [
+            pigeon.TankInfo(
+              index: 0,
+              gasMixIndex: 0,
+              startPressureBar: 200.0,
+              usage: 1, // DC_USAGE_OXYGEN
+            ),
+            pigeon.TankInfo(
+              index: 1,
+              gasMixIndex: 1,
+              startPressureBar: 200.0,
+              usage: 2, // DC_USAGE_DILUENT
+            ),
+          ],
+        );
+        final tanks = resolveParsedTanks(parsed);
+        expect(tanks.firstWhere((t) => t.index == 0).role, 'oxygenSupply');
+        expect(tanks.firstWhere((t) => t.index == 1).role, 'diluent');
+      });
+
+      test('native usage wins over the O2 heuristic', () {
+        // usage = oxygen on a 32% gas still resolves to oxygenSupply.
+        final parsed = makeParsedDive(
+          gasMixes: [pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0)],
+          tanks: [pigeon.TankInfo(index: 0, gasMixIndex: 0, usage: 1)],
+        );
+        expect(resolveParsedTanks(parsed).single.role, 'oxygenSupply');
+      });
+
+      test('synthesized deco cylinder (no transmitter) gets the deco role', () {
+        final parsed = makeParsedDive(
+          gasMixes: [
+            pigeon.GasMix(index: 0, o2Percent: 99.0, hePercent: 0.0),
+            pigeon.GasMix(index: 1, o2Percent: 32.0, hePercent: 0.0),
+          ],
+          tanks: [
+            pigeon.TankInfo(
+              index: 0,
+              gasMixIndex: unknownGasMixIndex,
+              startPressureBar: 240.0,
+            ),
+          ],
+          samples: [sample(2, 0, 1), sample(100, 0, 1), sample(5958, 0, 0)],
+        );
+        final tanks = resolveParsedTanks(parsed);
+        expect(tanks.firstWhere((t) => t.o2Percent == 32.0).role, 'backGas');
+        expect(tanks.firstWhere((t) => t.o2Percent == 99.0).role, 'deco');
+      });
+    });
   });
 
   group('resolveGasSwitches', () {


### PR DESCRIPTION
## Summary
Closes #463. Follow-up to #424 (now merged). Downloaded cylinders were always labeled **Back Gas** — a 99% O₂ deco bottle imported from the computer showed as back gas. This infers each cylinder's role from the dive computer's own tank usage when available, falling back to a gas-mix heuristic.

## What changed
- **Native (shared core):** capture libdivecomputer's tank `usage` (`dc_usage_t`) in `libdc_download.c` / `libdc_wrapper.h`.
- **Pigeon:** expose it as a nullable `TankInfo.usage` (appended last — no serialization shift); regenerated bindings, populated in the **Apple, Linux, Windows, and Android** converters (`DC_USAGE_NONE`→null).
- **Role inference** (`resolveParsedTanks`): native usage wins — `OXYGEN → oxygenSupply`, `DILUENT → diluent`; otherwise an open-circuit heuristic where a nitrox mix of **O₂ ≥ 41% → deco**, else **back gas**.
- The role flows to the `dive_tanks` write on both **download** and **reparse**, and **never overwrites a user-set role** (reparse only infers on new-tank insert).
- Resolver role tests added.

## Testing
- `flutter analyze`, `dart format`, `flutter test test/features/dive_computer/` (247 pass), and a macOS build.

## Notes
- Generated `*.g.*` files are produced by `pigeon` under the repo's pinned Flutter (3.44.4); no hand-edits.