### PR TITLE
fix: honor title and date slot assignments on detailed dive cards

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -666,6 +666,27 @@ class DiveListTile extends ConsumerWidget {
 
     final stat1Field = slotField('stat1', DiveField.maxDepth);
     final stat2Field = slotField('stat2', DiveField.runtime);
+    final titleField = slotField('title', DiveField.siteName);
+    final dateField = slotField('date', DiveField.dateTime);
+
+    // Resolve the title and date lines from their slot assignments, keeping
+    // the legacy rendering when the slot holds its default field (mirrors
+    // CompactDiveListTile).
+    String buildTitleText() {
+      if (summary != null && titleField != DiveField.siteName) {
+        final value = titleField.extractFromSummary(summary!);
+        return titleField.formatValue(value, units);
+      }
+      return siteName ?? context.l10n.diveLog_listPage_unknownSite;
+    }
+
+    String buildDateText() {
+      if (summary != null && dateField != DiveField.dateTime) {
+        final value = dateField.extractFromSummary(summary!);
+        return dateField.formatValue(value, units);
+      }
+      return units.formatDateTime(dateTime, l10n: context.l10n);
+    }
 
     // Build the content widget (used in both map and non-map variants)
     Widget buildContent() {
@@ -724,8 +745,7 @@ class DiveListTile extends ConsumerWidget {
                             children: [
                               Expanded(
                                 child: Text(
-                                  siteName ??
-                                      context.l10n.diveLog_listPage_unknownSite,
+                                  buildTitleText(),
                                   style: Theme.of(context).textTheme.titleMedium
                                       ?.copyWith(
                                         fontWeight: FontWeight.w600,
@@ -777,9 +797,9 @@ class DiveListTile extends ConsumerWidget {
                             ),
                           ],
                           const SizedBox(height: 4),
-                          // Date and time
+                          // Date/subtitle line (configurable via 'date' slot)
                           Text(
-                            units.formatDateTime(dateTime, l10n: context.l10n),
+                            buildDateText(),
                             style: Theme.of(context).textTheme.bodyMedium
                                 ?.copyWith(color: secondaryTextColor),
                           ),

--- a/test/features/dive_log/presentation/pages/dive_list_tile_slots_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_list_tile_slots_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(super.initial);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestCardConfigNotifier extends CardViewConfigNotifier {
+  _TestCardConfigNotifier(CardViewConfig config)
+    : super.withMode(ListViewMode.detailed) {
+    state = config;
+  }
+}
+
+void main() {
+  DiveSummary summary({String? name, String? siteName}) => DiveSummary(
+    id: 'd1',
+    diveNumber: 7,
+    dateTime: DateTime(2024, 6, 1),
+    name: name,
+    siteName: siteName,
+    maxDepth: 30.0,
+    sortTimestamp: 0,
+  );
+
+  Widget buildTile({
+    required CardViewConfig config,
+    required DiveSummary diveSummary,
+  }) {
+    return testApp(
+      overrides: [
+        settingsProvider.overrideWith(
+          (ref) => _TestSettingsNotifier(const AppSettings()),
+        ),
+        detailedCardConfigProvider.overrideWith(
+          (ref) => _TestCardConfigNotifier(config),
+        ),
+      ],
+      child: DiveListTile(
+        diveId: 'd1',
+        diveNumber: 7,
+        dateTime: DateTime(2024, 6, 1),
+        siteName: diveSummary.siteName,
+        summary: diveSummary,
+      ),
+    );
+  }
+
+  CardViewConfig configWithSlot(String slotId, DiveField field) {
+    final base = CardViewConfig.defaultDetailed();
+    return base.copyWith(
+      slots: [
+        for (final slot in base.slots)
+          if (slot.slotId == slotId)
+            CardSlotConfig(slotId: slotId, field: field)
+          else
+            slot,
+      ],
+    );
+  }
+
+  group('DiveListTile detailed slot assignments', () {
+    testWidgets('title slot diveName shows the custom dive name', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTile(
+          config: configWithSlot('title', DiveField.diveName),
+          diveSummary: summary(
+            name: 'Wreck penetration dive',
+            siteName: 'Blue Hole',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Wreck penetration dive'), findsOneWidget);
+    });
+
+    testWidgets('title slot diveName falls back to site name when unnamed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTile(
+          config: configWithSlot('title', DiveField.diveName),
+          diveSummary: summary(siteName: 'Blue Hole'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Blue Hole'), findsOneWidget);
+    });
+
+    testWidgets('default title slot renders the site name as before', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTile(
+          config: CardViewConfig.defaultDetailed(),
+          diveSummary: summary(
+            name: 'Wreck penetration dive',
+            siteName: 'Blue Hole',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Default (siteName) slot keeps legacy behavior: the site, not the name.
+      expect(find.text('Blue Hole'), findsOneWidget);
+      expect(find.text('Wreck penetration dive'), findsNothing);
+    });
+
+    testWidgets('date slot honors a non-default field', (tester) async {
+      await tester.pumpWidget(
+        buildTile(
+          config: configWithSlot('date', DiveField.maxDepth),
+          diveSummary: summary(siteName: 'Blue Hole'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The date line now shows the configured field (max depth, 30 m)
+      // instead of the formatted date.
+      expect(find.textContaining('30'), findsWidgets);
+      expect(find.textContaining('2024'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

In Settings > Appearance > Dives > "Dive list fields in detailed mode", the Title and Date/Subtitle pickers had no effect: the detailed-mode `DiveListTile` read only the `stat1`/`stat2` slots from `detailedCardConfigProvider`, while the title was hardcoded to the site name and the subtitle line to the formatted date. This predates #400 — the new "Dive Name" title option just made it visible.

The fix resolves the `title` and `date` slots the same way the compact tile does: a non-default field renders via `extractFromSummary`/`formatValue` (so "Dive Name" shows the custom name and falls back to the site for unnamed dives), and the default field keeps the exact legacy rendering.

## Test plan

- [x] New widget tests: title slot = Dive Name shows the custom name; unnamed dive falls back to the site name; default slots render exactly as before; date slot honors a non-default field
- [x] Existing `DiveListTile` SAC and `DiveListPage` layout tests still pass (28 total)
- [x] `flutter analyze` 0 issues; `dart format` clean