### PR TITLE
fix(statistics): stop Overview crash from reified vars list type

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1882,13 +1882,16 @@ class DiveRepository {
   }) async {
     try {
       final whereClause = diverId != null ? 'WHERE diver_id = ?' : '';
-      final vars = diverId != null
-          ? [Variable<String>(diverId)]
-          : <Variable<Object>>[];
+      // Explicitly typed List<Variable<Object>>: a bare `[Variable<String>(...)]`
+      // literal would reify as List<Variable<String>>, and the later
+      // `vars.addAll(filterVars)` (filterVars is List<Variable<Object>>) would
+      // then throw a runtime type error whenever diverId is non-null.
+      final List<Variable<Object>> vars = [
+        if (diverId != null) Variable<String>(diverId),
+      ];
 
       final df = buildFilteredDiveIdSubquery(filter);
-      // Typed as Variable<Object> (not Variable<Object?>) to match the method's
-      // `vars` list type; params are always non-null so `p!` is safe.
+      // params are always non-null so `p!` is safe.
       final filterVars = df.params.map((p) => Variable<Object>(p!)).toList();
       // Clause fragments per table alias used below.
       final fBare = df.subquery.isEmpty ? '' : 'AND id IN (${df.subquery})';

--- a/test/features/dive_log/data/repositories/dive_statistics_filter_test.dart
+++ b/test/features/dive_log/data/repositories/dive_statistics_filter_test.dart
@@ -20,12 +20,26 @@ void main() {
 
   final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
 
-  Future<void> dive(String id, {DateTime? date}) async {
+  Future<void> diver(String id) async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value(id),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> dive(String id, {DateTime? date, String? diverId}) async {
     await db
         .into(db.dives)
         .insert(
           DivesCompanion(
             id: Value(id),
+            diverId: Value(diverId),
             diveDateTime: Value(
               (date ?? DateTime(2026, 6, 1)).millisecondsSinceEpoch,
             ),
@@ -81,4 +95,39 @@ void main() {
     );
     expect(stats.totalDives, 1);
   });
+
+  // Regression: production always calls getStatistics with a non-null diverId
+  // (filteredDiveStatisticsProvider passes currentDiverId). Before the fix, the
+  // `vars` list reified as List<Variable<String>> in that branch and
+  // `vars.addAll(filterVars)` threw a runtime type error for ANY filter,
+  // including the empty default filter on a fresh page load. See #453.
+  test(
+    'getStatistics with a non-null diverId does not throw (empty filter)',
+    () async {
+      await diver('diver1');
+      await dive('a', diverId: 'diver1');
+      await dive('b', diverId: 'diver1');
+      final stats = await repo.getStatistics(
+        diverId: 'diver1',
+        filter: const DiveFilterState(),
+      );
+      expect(stats.totalDives, 2);
+    },
+  );
+
+  test(
+    'getStatistics with a non-null diverId honors an active filter',
+    () async {
+      await diver('diver1');
+      await dive('a', diverId: 'diver1');
+      await dive('b', diverId: 'diver1');
+      await tag('dry');
+      await link('a', 'dry');
+      final stats = await repo.getStatistics(
+        diverId: 'diver1',
+        filter: const DiveFilterState(tagIds: ['dry']),
+      );
+      expect(stats.totalDives, 1);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

The Statistics **Overview** page threw *"Error loading statistics"* on load after the #453 filter feature landed. The cause was not SQL — it was a Dart **reified-generics** crash in `DiveRepository.getStatistics`.

`vars` was built with a ternary whose non-null-`diverId` branch, `[Variable<String>(diverId)]`, reifies at runtime as `List<Variable<String>>`. The #453 filter code then calls `vars.addAll(filterVars)`, where `filterVars` is a `List<Variable<Object>>`. Because `Variable<Object>` is not a subtype of `Variable<String>`, `addAll` throws:

```
type 'List<Variable<Object>>' is not a subtype of type 'Iterable<Variable<String>>' of 'iterable'
```

The check is on the argument's type, not its contents, so it throws for **any** filter — including the empty default filter — whenever a diver is selected (i.e. always, in production). Only the Overview page surfaced it because the `statistics_error_loadingStatistics` string is wired solely to `filteredDiveStatisticsProvider` → `getStatistics`.

**Why it slipped past CI:** `flutter analyze` couldn't catch it (the ternary's *static* type is the LUB `List<Variable<Object>>`, so the call type-checks; the mismatch is runtime-only), and every pre-existing `getStatistics` test called it with `diverId == null` — the one branch where the types happen to align, masking the production path.

The other 34 filter-threaded methods in `statistics_repository.dart` are unaffected: they use `variables: params.map((p) => Variable(p)).toList()` (a fresh list, no `addAll`).

## Changes

- **`getStatistics`**: declare `vars` as `List<Variable<Object>>` via a collection-`if` literal, so the reified runtime type always matches `addAll(filterVars)`.
- **Tests**: add two regression tests to `dive_statistics_filter_test.dart` that call `getStatistics` with a non-null `diverId` (empty filter + active tag filter). These fail with the exact runtime type error before the fix and pass after — closing the test/prod-shape coverage gap.

## Test Plan

- [x] `flutter test` passes (full suite, 10,110 tests, via the pre-push hook)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] Manual testing on: not run on-device; the added regression test reproduces the exact reported crash and passes with the fix