### PR TITLE
fix(sync): publish post-adopt edits as base-less changesets, not a full base

### DIFF
--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -61,12 +61,22 @@ class ChangesetWriter {
     // recovers the seq counter (knownHeadSeq) so the new base never reuses a
     // number.
     final hasBase = ownManifest?.baseSeq != null;
+    // The post-adopt marker (a publish-state row with a null baseSeq): this
+    // device's library IS the adopted epoch the peers already published, so
+    // publishing its own base would redundantly re-upload the whole library --
+    // and every peer would have to re-download it just to reach the deltas
+    // behind it (the post-adopt "changes don't show up" unreliability). While
+    // the marker holds, publish changesets with NO base: a reader cold-starts
+    // a base-less manifest by applying changesets from seq 1 (the adopted
+    // content itself comes from the epoch peers' bases). Compaction
+    // eventually folds the log into a real base, clearing the marker.
+    final adoptedNoBase = !hasBase && state != null && state.baseSeq == null;
     final watermark = ownManifest?.publishedHlcHigh ?? state?.publishedHlcHigh;
 
     final newSeq = knownHeadSeq + 1;
     final now = DateTime.now().millisecondsSinceEpoch;
 
-    if (!hasBase) {
+    if (!hasBase && !adoptedNoBase) {
       // Stream the base to a temp file and slice-upload it, so a large library
       // is never materialized in RAM (#358 write side). Do NOT call
       // exportChangeset(null) here -- that is the OOM path.
@@ -124,8 +134,11 @@ class ChangesetWriter {
     }
 
     // Changeset: reuse the base fields from the (authoritative) own manifest;
-    // only headSeq / publishedHlcHigh advance. The incremental delta stays in
-    // memory (small); only the base path above is streamed (#358).
+    // only headSeq / publishedHlcHigh advance. In the adopted mode there is no
+    // manifest yet (or a base-less one), so the base fields stay null and the
+    // watermark comes from the publish state (the adopted library's max HLC,
+    // recorded at adopt). The incremental delta stays in memory (small); only
+    // the base path above is streamed (#358).
     final payload = await _serializer.exportChangeset(
       deviceId: deviceId,
       hlcWatermark: watermark,
@@ -143,17 +156,17 @@ class ChangesetWriter {
       ChangesetLogLayout.changesetName(deviceId, newSeq),
       folderId: folderId,
     );
-    final base = ownManifest!;
+    final publishedHigh = payload.toHlc ?? watermark;
     final manifest = SyncManifest(
       deviceId: deviceId,
       provider: providerId,
-      baseSeq: base.baseSeq,
-      basePartCount: base.basePartCount,
-      baseBytes: base.baseBytes,
-      baseChecksum: base.baseChecksum,
-      basePartChecksums: base.basePartChecksums,
+      baseSeq: ownManifest?.baseSeq,
+      basePartCount: ownManifest?.basePartCount,
+      baseBytes: ownManifest?.baseBytes,
+      baseChecksum: ownManifest?.baseChecksum,
+      basePartChecksums: ownManifest?.basePartChecksums ?? const [],
       headSeq: newSeq,
-      publishedHlcHigh: payload.toHlc ?? base.publishedHlcHigh,
+      publishedHlcHigh: publishedHigh,
       epochId: epochId,
       uploadNonce: uploadNonce,
       updatedAt: now,
@@ -162,11 +175,11 @@ class ChangesetWriter {
     await _publishState.upsert(
       LocalPublishStatesCompanion(
         provider: Value(providerId),
-        baseSeq: Value(base.baseSeq),
-        basePartCount: Value(base.basePartCount),
-        baseBytes: Value(base.baseBytes),
+        baseSeq: Value(ownManifest?.baseSeq),
+        basePartCount: Value(ownManifest?.basePartCount),
+        baseBytes: Value(ownManifest?.baseBytes),
         headSeq: Value(newSeq),
-        publishedHlcHigh: Value(payload.toHlc ?? base.publishedHlcHigh),
+        publishedHlcHigh: Value(publishedHigh),
         changesetBytesSinceBase: Value(
           (state?.changesetBytesSinceBase ?? 0) + bytes.length,
         ),
@@ -175,9 +188,12 @@ class ChangesetWriter {
     );
 
     final bytesSinceBase = (state?.changesetBytesSinceBase ?? 0) + bytes.length;
-    final baseBytes = base.baseBytes ?? 0;
+    final baseBytes = ownManifest?.baseBytes ?? 0;
+    // A base-less (post-adopt) log counts changesets from seq 0 so it still
+    // trips the count threshold and folds into a real base -- the deferred
+    // base finally gets published once, amortized, instead of never.
     final tripped =
-        (newSeq - (base.baseSeq ?? newSeq)) >= compactionMaxChangesets ||
+        (newSeq - (ownManifest?.baseSeq ?? 0)) >= compactionMaxChangesets ||
         (baseBytes > 0 && bytesSinceBase >= compactionByteRatio * baseBytes);
     if (tripped) {
       final compSeq = await _compact(

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -61,6 +61,7 @@ class ChangesetWriter {
     // recovers the seq counter (knownHeadSeq) so the new base never reuses a
     // number.
     final hasBase = ownManifest?.baseSeq != null;
+    final watermark = ownManifest?.publishedHlcHigh ?? state?.publishedHlcHigh;
     // The post-adopt marker (a publish-state row with a null baseSeq): this
     // device's library IS the adopted epoch the peers already published, so
     // publishing its own base would redundantly re-upload the whole library --
@@ -70,8 +71,14 @@ class ChangesetWriter {
     // a base-less manifest by applying changesets from seq 1 (the adopted
     // content itself comes from the epoch peers' bases). Compaction
     // eventually folds the log into a real base, clearing the marker.
-    final adoptedNoBase = !hasBase && state != null && state.baseSeq == null;
-    final watermark = ownManifest?.publishedHlcHigh ?? state?.publishedHlcHigh;
+    //
+    // A null watermark disables this mode: with nothing to delta against,
+    // exportChangeset would materialize the ENTIRE library in memory (the
+    // exact full-upload/OOM this path avoids, #358). maxRowHlc() is null at
+    // adopt for an empty library (the base below no-ops) or one whose rows
+    // all predate HLC stamping (one streamed base publish, safely bounded).
+    final adoptedNoBase =
+        !hasBase && state != null && state.baseSeq == null && watermark != null;
 
     final newSeq = knownHeadSeq + 1;
     final now = DateTime.now().millisecondsSinceEpoch;

--- a/lib/core/services/sync/changeset_log/publish_state_store.dart
+++ b/lib/core/services/sync/changeset_log/publish_state_store.dart
@@ -23,10 +23,13 @@ class PublishStateStore {
 
   /// Record the post-adopt "deferred self-base" marker for [provider]: a row
   /// with a NULL `baseSeq` (no base published yet) carrying the adopted
-  /// library's [adoptedHlcHigh]. The writer always sets `baseSeq` when it
-  /// publishes, so the null uniquely marks "adopted, nothing of our own to
-  /// publish yet" -- which SyncService uses to skip re-uploading a redundant
-  /// full base (a copy of the epoch the peers already hold, #358). Call after
+  /// library's [adoptedHlcHigh]. Only adopt writes a null `baseSeq` -- the
+  /// writer either sets it (base publish, compaction) or preserves the null
+  /// while publishing post-adopt changesets without a base -- so a null here
+  /// always means "adopted, no self-base yet". SyncService uses it to skip a
+  /// publish with nothing to say, and ChangesetWriter uses it to publish
+  /// deltas against [adoptedHlcHigh] instead of re-uploading a redundant full
+  /// base (a copy of the epoch the peers already hold, #358). Call after
   /// `resetSyncState` has cleared any prior row (so this inserts fresh).
   Future<void> markAdoptedPendingBase(
     String provider,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -437,20 +437,17 @@ class SyncService {
       // ---- Upload: publish our delta ----
       _reportProgress(SyncPhase.uploading, 0.8, 'Publishing changes...');
       final deletions = await _syncRepository.getAllDeletions();
-      if (await _shouldDeferSelfBaseAfterAdopt(
-        provider.providerId,
-        deletions,
-      )) {
+      var publishAttempted = false;
+      if (await _shouldSkipPublishAfterAdopt(provider.providerId, deletions)) {
         // Just adopted a restored library and have nothing of our own yet: our
-        // library == the adopted epoch the peers already published. Publishing
-        // our own full base here would redundantly re-upload the whole library
-        // (#358, the slow first sync after adopt). Defer until we have a local
-        // change of our own to contribute (checked before the nonce so a
-        // deferred sync does not consume a nonce ring slot).
-        _log.info(
-          'Deferring redundant self-base publish after adopt (no local changes)',
-        );
+        // library == the adopted epoch the peers already published, so there
+        // is nothing to say. Skip the publish entirely (checked before the
+        // nonce so a skipped sync does not consume a nonce ring slot). Once a
+        // local change exists, the writer publishes it as a small changeset
+        // against the adopted watermark -- never a redundant full base (#358).
+        _log.info('Skipping publish after adopt (no local changes yet)');
       } else {
+        publishAttempted = true;
         final uploadNonce = _uuid.v4();
         // Record the nonce BEFORE publishing: a lost response (timeout, app
         // death) still leaves our manifest carrying this nonce, and an
@@ -493,9 +490,16 @@ class SyncService {
       }
       await _syncRepository.persistSyncClock();
       await _syncRepository.clearOldDeletions();
-      await _syncRepository.clearPendingRecords();
-      if (conflictsFound == 0) {
-        await _syncRepository.clearAllSyncRecords();
+      // Clear upload-side bookkeeping only when a publish actually ran. On a
+      // skipped (post-adopt, nothing-to-say) sync, an edit can land between
+      // the skip decision and this cleanup; wiping its pending row here would
+      // make every following sync skip again and the edit would never publish
+      // until some unrelated later edit re-tripped the gate.
+      if (publishAttempted) {
+        await _syncRepository.clearPendingRecords();
+        if (conflictsFound == 0) {
+          await _syncRepository.clearAllSyncRecords();
+        }
       }
 
       _reportProgress(SyncPhase.complete, 1.0, 'Sync complete');
@@ -2169,9 +2173,10 @@ class SyncService {
         );
       }
       // Record the deferred self-base marker: our library is now exactly the
-      // adopted epoch, which the peers already published. The next sync must
-      // NOT re-upload our own full base (a redundant copy) until we actually
-      // make a local change of our own (#358, the slow first sync after adopt).
+      // adopted epoch, which the peers already published, so no sync may ever
+      // re-upload it as our own full base (#358, the slow first sync after
+      // adopt). Local changes publish as changesets against the adopted max
+      // HLC recorded here; the log folds into a real base at compaction.
       await _publishStateStore.markAdoptedPendingBase(
         provider.providerId,
         await _syncRepository.maxRowHlc(),
@@ -2371,21 +2376,22 @@ class SyncService {
     ),
   );
 
-  /// True when we just adopted a restored library and have nothing of our own
-  /// to publish yet -- so the next sync must NOT re-upload our own full base, a
-  /// redundant copy of the epoch the peers already published (#358, the slow
-  /// first sync after adopt).
+  /// True when we adopted a restored library and have nothing of our own to
+  /// publish yet -- so this sync skips the publish entirely (saving a nonce
+  /// ring slot and the manifest round-trip). This gate is an optimization
+  /// only: if it misfires towards publishing, the writer sees no rows above
+  /// the adopted watermark and no-ops.
   ///
-  /// The deferred marker is a publish-state row with a null `baseSeq`: adopt
-  /// records it, and the writer always sets `baseSeq` when it publishes, so a
-  /// null there uniquely means "adopted, no self-base yet". A device that has
-  /// published (baseSeq set -- including a cloud-manifest-lost cold-start that
-  /// legitimately re-bases) or never adopted (no row at all) falls straight
-  /// through and publishes normally. The deferral clears the moment we have any
+  /// The marker is a publish-state row with a null `baseSeq`: adopt records
+  /// it, and it stays null while the writer publishes post-adopt changesets
+  /// without a base, until compaction folds the log into a real base (or a
+  /// cloud-manifest-lost cold-start re-bases). A device that has published a
+  /// base (baseSeq set) or never adopted (no row at all) falls straight
+  /// through and publishes normally. The skip clears the moment we have any
   /// local change: [SyncRepository.hasUnsyncedChanges] counts pending / conflict
   /// / deletion rows, which are written in the same transaction as the edit, so
   /// it is reliable even in the window before the HLC clock is reconfigured.
-  Future<bool> _shouldDeferSelfBaseAfterAdopt(
+  Future<bool> _shouldSkipPublishAfterAdopt(
     String providerId,
     List<DeletionLogData> deletions,
   ) async {

--- a/test/core/services/sync/changeset_log/changeset_reader_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_test.dart
@@ -6,10 +6,12 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
 import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
 import '../../../../helpers/changeset_test_helpers.dart';
@@ -179,5 +181,68 @@ void main() {
     final result = await pullAs(peerId); // pull AS the publisher
     expect(result.peersProcessed, 0);
     expect(applied, isEmpty);
+  });
+
+  test('cold-start from a base-less manifest (post-adopt peer) applies its '
+      'changesets in order and advances the cursor', () async {
+    // A peer that adopted a Replace-restored library publishes changesets
+    // with NO base of its own (the adopted epoch is already published by the
+    // other devices). Hand-craft that log shape: changesets 1..2 and a
+    // manifest with a null baseSeq.
+    final serializer = SyncDataSerializer();
+    final codec = ChangesetCodec(serializer);
+    const peerId = 'adopted-peer';
+
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'edit-1', diveNumber: 1),
+    );
+    final cs1 = await serializer.exportChangeset(
+      deviceId: peerId,
+      hlcWatermark: null,
+      deletions: const [],
+      seq: 1,
+    );
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'edit-2', diveNumber: 2),
+    );
+    final cs2 = await serializer.exportChangeset(
+      deviceId: peerId,
+      hlcWatermark: cs1.toHlc,
+      deletions: const [],
+      seq: 2,
+    );
+    await provider.uploadFile(
+      codec.encodeChangeset(cs1),
+      ChangesetLogLayout.changesetName(peerId, 1),
+      folderId: folder,
+    );
+    await provider.uploadFile(
+      codec.encodeChangeset(cs2),
+      ChangesetLogLayout.changesetName(peerId, 2),
+      folderId: folder,
+    );
+    await provider.uploadFile(
+      SyncManifest(
+        deviceId: peerId,
+        provider: provider.providerId,
+        headSeq: 2,
+        publishedHlcHigh: cs2.toHlc,
+        updatedAt: 0,
+      ).toBytes(),
+      ChangesetLogLayout.manifestName(peerId),
+      folderId: folder,
+    );
+
+    final result = await pullAs('reader-x');
+
+    expect(result.peersProcessed, 1);
+    expect(applied.length, 2);
+    expect(applied.first.data.dives.map((d) => d['id']), contains('edit-1'));
+    expect(applied.last.data.dives.map((d) => d['id']), contains('edit-2'));
+    final cursor = await PeerCursorStore(
+      DatabaseService.instance.database,
+    ).get(peerId, provider.providerId);
+    expect(cursor!.lastSeqApplied, 2);
+    expect(cursor.baseSeqApplied, isNull);
   });
 }

--- a/test/core/services/sync/changeset_log/changeset_writer_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_writer_test.dart
@@ -406,6 +406,33 @@ void main() {
       },
     );
 
+    test('a null adopted watermark falls back to a streamed base publish '
+        '(never exportChangeset(null), the in-memory OOM path)', () async {
+      // maxRowHlc() can legitimately be null at adopt: an empty adopted
+      // library, or one whose rows all predate HLC stamping. A null
+      // watermark in the changeset path would export the ENTIRE library
+      // in memory -- the exact full-upload/OOM this mode exists to avoid.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'legacy-dive', diveNumber: 1),
+      );
+      await PublishStateStore(
+        DatabaseService.instance.database,
+      ).markAdoptedPendingBase(provider.providerId, null);
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'my-edit', diveNumber: 2),
+      );
+
+      final result = await publish();
+
+      expect(
+        result.kind,
+        ChangesetWriteKind.base,
+        reason:
+            'with no watermark to delta against, the only safe publish '
+            'is the streamed full base',
+      );
+    });
+
     test(
       'a base-less log folds into a real base when compaction trips',
       () async {

--- a/test/core/services/sync/changeset_log/changeset_writer_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_writer_test.dart
@@ -288,4 +288,167 @@ void main() {
       expect(diveIds, {'d1', 'd2'});
     },
   );
+
+  group('post-adopt deferred base (changeset without a base)', () {
+    /// Put the device in the adopted state: the library content exists
+    /// locally (the adopted epoch, already published by the peers) and the
+    /// publish state carries the null-baseSeq marker with the adopted
+    /// watermark. Anything written AFTER this is a post-adopt local change.
+    Future<void> adoptWithLibrary() async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'adopted-dive', diveNumber: 1),
+      );
+      await PublishStateStore(
+        DatabaseService.instance.database,
+      ).markAdoptedPendingBase(
+        provider.providerId,
+        await SyncRepository().maxRowHlc(),
+      );
+    }
+
+    Future<SyncManifest> readOwnManifest() async {
+      final deviceId = await SyncRepository().getDeviceId();
+      return SyncManifest.fromBytes(
+        await provider.downloadFile(
+          '$folder/${ChangesetLogLayout.manifestName(deviceId)}',
+        ),
+      );
+    }
+
+    test('the first publish after adopt writes a changeset, NOT a full base '
+        '(the adopted library is already in the cloud)', () async {
+      await adoptWithLibrary();
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'my-edit', diveNumber: 2),
+      );
+
+      final result = await publish();
+
+      expect(result.kind, ChangesetWriteKind.changeset);
+      expect(result.seq, 1);
+      final ns = await names();
+      expect(
+        ns.any((n) => ChangesetLogLayout.basePartOf(n) != null),
+        isFalse,
+        reason:
+            'no base part may be uploaded -- that is the redundant '
+            'full-library re-upload this path exists to avoid',
+      );
+
+      final manifest = await readOwnManifest();
+      expect(manifest.baseSeq, isNull);
+      expect(manifest.headSeq, 1);
+
+      final deviceId = await SyncRepository().getDeviceId();
+      final payload = ChangesetCodec(SyncDataSerializer()).decodeChangeset(
+        await provider.downloadFile(
+          '$folder/${ChangesetLogLayout.changesetName(deviceId, 1)}',
+        ),
+      );
+      final diveIds = payload.data.dives.map((d) => d['id']).toSet();
+      expect(diveIds.contains('my-edit'), isTrue);
+      expect(
+        diveIds.contains('adopted-dive'),
+        isFalse,
+        reason:
+            'rows at or below the adopted watermark are already published '
+            'by the peers',
+      );
+    });
+
+    test(
+      'a second post-adopt publish appends the next changeset seq',
+      () async {
+        await adoptWithLibrary();
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'edit-1', diveNumber: 2),
+        );
+        await publish();
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'edit-2', diveNumber: 3),
+        );
+
+        final result = await publish();
+
+        expect(result.kind, ChangesetWriteKind.changeset);
+        expect(result.seq, 2);
+        final manifest = await readOwnManifest();
+        expect(manifest.baseSeq, isNull);
+        expect(manifest.headSeq, 2);
+      },
+    );
+
+    test('a post-adopt publish with nothing new is a no-op', () async {
+      await adoptWithLibrary();
+
+      final result = await publish();
+
+      expect(result.kind, ChangesetWriteKind.noop);
+      expect(await names(), isEmpty);
+    });
+
+    test(
+      'a post-adopt deletion publishes its tombstone as a changeset',
+      () async {
+        await adoptWithLibrary();
+        await DiveRepository().deleteDive('adopted-dive');
+
+        final result = await publish();
+
+        expect(result.kind, ChangesetWriteKind.changeset);
+        final deviceId = await SyncRepository().getDeviceId();
+        final payload = ChangesetCodec(SyncDataSerializer()).decodeChangeset(
+          await provider.downloadFile(
+            '$folder/${ChangesetLogLayout.changesetName(deviceId, 1)}',
+          ),
+        );
+        expect(payload.deletions['dives'], isNotEmpty);
+      },
+    );
+
+    test(
+      'a base-less log folds into a real base when compaction trips',
+      () async {
+        final compactingWriter = ChangesetWriter(
+          SyncDataSerializer(),
+          ChangesetCodec(SyncDataSerializer()),
+          PublishStateStore(DatabaseService.instance.database),
+          compactionByteRatio: 1000.0,
+          compactionMaxChangesets: 2,
+        );
+        await adoptWithLibrary();
+        final deviceId = await SyncRepository().getDeviceId();
+
+        Future<ChangesetWriteResult> publishCompacting() async =>
+            compactingWriter.publish(
+              provider: provider,
+              deviceId: deviceId,
+              folderId: folder,
+              deletions: await SyncRepository().getAllDeletions(),
+            );
+
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'edit-1', diveNumber: 2),
+        );
+        final first = await publishCompacting();
+        expect(first.kind, ChangesetWriteKind.changeset);
+
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'edit-2', diveNumber: 3),
+        );
+        final second = await publishCompacting();
+
+        expect(
+          second.kind,
+          ChangesetWriteKind.compacted,
+          reason:
+              'a log with no base must eventually fold into a real base so '
+              'the device is a durable source for future cold-starts',
+        );
+        final manifest = await readOwnManifest();
+        expect(manifest.baseSeq, isNotNull);
+        expect(manifest.headSeq, manifest.baseSeq);
+      },
+    );
+  });
 }

--- a/test/core/services/sync/sync_service_epoch_test.dart
+++ b/test/core/services/sync/sync_service_epoch_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
@@ -427,28 +428,109 @@ void main() {
       },
     );
 
-    test(
-      'after adoption, a local change re-enables the self-base publish',
-      () async {
-        await DiveRepository().createDive(
-          createTestDiveWithBottomTime(id: 'cloud-dive'),
-        );
-        await seedPeerLog(cloud, 'replacer', epochId: 'e1');
-        final service = buildService();
-        await service.writeLibraryEpochMarker(cloud, marker);
-        await service.adoptReplacedLibrary();
+    test('after adoption, a local change publishes a changeset against the '
+        'adopted watermark -- NOT a redundant full base', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'cloud-dive'),
+      );
+      await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+      await service.adoptReplacedLibrary();
 
-        // A local edit means we now have something of our own to contribute, so
-        // the deferral clears and we publish a base.
-        await DiveRepository().createDive(
-          createTestDiveWithBottomTime(id: 'my-dive', maxDepth: 42),
-        );
-        await service.performSync();
+      // A local edit means we now have something of our own to contribute.
+      // Publishing it as a full base would re-upload the whole adopted
+      // library and force every peer to re-download it -- the post-#450
+      // "changes don't show up until the base lands" unreliability. The
+      // edit must go out as a small changeset instead.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'my-dive', maxDepth: 42),
+      );
+      await service.performSync();
 
-        final deviceId = await SyncRepository().getDeviceId();
-        expect(await hasPublishedLog(cloud, deviceId), isTrue);
-      },
-    );
+      final deviceId = await SyncRepository().getDeviceId();
+      expect(await hasPublishedLog(cloud, deviceId), isTrue);
+      final manifest = await ownManifest(cloud, deviceId);
+      expect(
+        manifest!.baseSeq,
+        isNull,
+        reason:
+            'the adopted library is already published by the peers; '
+            'only the delta may be uploaded',
+      );
+      expect(manifest.headSeq, 1);
+      expect(manifest.epochId, 'e1');
+
+      final files = await cloud.listFiles(
+        namePattern: ChangesetLogLayout.prefix,
+      );
+      expect(
+        files.any(
+          (f) =>
+              ChangesetLogLayout.deviceIdOf(f.name) == deviceId &&
+              ChangesetLogLayout.basePartOf(f.name) != null,
+        ),
+        isFalse,
+        reason: 'no base part may be uploaded on the first post-adopt edit',
+      );
+
+      final csFile = files
+          .where((f) => f.name == ChangesetLogLayout.changesetName(deviceId, 1))
+          .single;
+      final payload = ChangesetCodec(
+        SyncDataSerializer(),
+      ).decodeChangeset(await cloud.downloadFile(csFile.id));
+      final diveIds = payload.data.dives.map((d) => d['id']).toSet();
+      expect(diveIds.contains('my-dive'), isTrue);
+      expect(
+        diveIds.contains('cloud-dive'),
+        isFalse,
+        reason: 'adopted rows sit at or below the watermark',
+      );
+    });
+
+    test('a deferred sync must not clear pending records that appeared after '
+        'the deferral check (the lost-edit race)', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'cloud-dive'),
+      );
+      await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+      await service.adoptReplacedLibrary();
+
+      // Emulate an edit landing between the deferral check and the
+      // end-of-sync cleanup: the gate cannot see the pending row (the
+      // blind repository reports zero), but the row is real in the DB.
+      await SyncRepository().markRecordPending(
+        entityType: 'dives',
+        recordId: 'raced-dive',
+        localUpdatedAt: DateTime.now().millisecondsSinceEpoch,
+      );
+      final racedService = SyncService(
+        syncRepository: _GateBlindSyncRepository(),
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+        epochStore: epochStore,
+      );
+      final result = await racedService.performSync();
+
+      expect(result.isSuccess, isTrue);
+      final deviceId = await SyncRepository().getDeviceId();
+      expect(
+        await hasPublishedLog(cloud, deviceId),
+        isFalse,
+        reason: 'the gate saw no changes, so the publish deferred',
+      );
+      expect(
+        await SyncRepository().getPendingCount(),
+        1,
+        reason:
+            'a sync that published nothing must not clear pending '
+            'records -- wiping them makes the next sync defer again and '
+            'the edit never publishes',
+      );
+    });
 
     test('adoption preserves device identity', () async {
       await DiveRepository().createDive(
@@ -764,6 +846,14 @@ void main() {
       },
     );
   });
+}
+
+/// Reports zero pending records to the publish-deferral gate while the real
+/// rows stay in the DB -- emulating an edit that lands AFTER the gate check
+/// but before the end-of-sync cleanup (the lost-edit race window).
+class _GateBlindSyncRepository extends SyncRepository {
+  @override
+  Future<int> getPendingCount() async => 0;
 }
 
 /// Fails only the listing for [failPattern], leaving other listings (and


### PR DESCRIPTION
Fixes the sync unreliability introduced by #450: since the deferred self-base, changes made after a Replace-adopt didn't appear on other devices until much later, unpredictably.

## Root cause

#450 deferred the post-adopt self-base publish until the device had a local change — but when that first edit arrived, the writer (with no cloud manifest of its own; the replace wiped the folder) published the **entire library as a fresh base**. Every peer held no cursor for that device, so each one had to download the whole base just to reach the one edit behind it. Until that full upload *and* each full download completed (iCloud propagates base parts lazily; the reader silently skips a peer whose parts are incomplete and retries next sync), **none** of the editor's changes were visible anywhere. Pre-#450 the same heavy exchange happened at restore time, where slowness was expected; #450 moved it to first-edit time, where it read as broken sync.

## Fix

**Base-less changesets while the adopt marker holds** (`ChangesetWriter.publish`): with the null-`baseSeq` marker set and no cloud base, publish the delta as a changeset against the adopted library's max HLC (recorded by `markAdoptedPendingBase` — now load-bearing), writing a manifest with a null `baseSeq`. `ChangesetReader.pull` already cold-starts base-less manifests by applying changesets from seq 1; the adopted content itself comes from the epoch peers' bases, which their logs retain. The watermark is safe by construction: `ensureSyncClockConfigured` seeds lazily from the max on-disk row HLC at the write choke point, so every post-adopt edit exceeds it.

**Compaction folds the log into a real base**: the count trip now measures from seq 0 for base-less logs, so after `compactionMaxChangesets` the deferred base finally publishes once, amortized, keeping the device a durable cold-start source.

**Lost-edit race closed** (`performSync`): `clearPendingRecords` / `clearAllSyncRecords` now run only when a publish was attempted. Previously, an edit landing between the skip decision and the end-of-sync cleanup had its pending row wiped — every following sync skipped again and the edit stayed unpublished until an unrelated later edit re-tripped the gate.

The skip gate deliberately stays pending/conflict/deletion-row based rather than HLC-based: rows merged from peers during pull sit above the device's own watermark, so an HLC gate would force passive viewers to publish echo changesets — recreating the very upload #450 eliminated.

## Verification

- New writer tests: first post-adopt publish is a changeset (no base parts uploaded), seq appends, clean no-op, deletion-only tombstone changeset, base-less log folds into a real base at the compaction trip.
- New reader test: cold-start from a base-less manifest applies changesets in order and advances the cursor (`baseSeqApplied` null).
- Epoch service tests updated: the first post-adopt edit publishes a base-less changeset carrying only the delta; a gate-blind race test proves a skipped sync leaves pending records intact.
- Full sync suite green (390), settings providers green (175), whole-project analyze + format clean.