### PR TITLE
fix(sync): propagate cleared (null) fields through the merge (#474)

### DIFF
--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1538,9 +1538,16 @@ class SyncDataSerializer {
   /// HLC-bearing entities (`entityHasUpdatedAt == true`) apply via
   /// `.toCompanion(false)` so an explicit `null` overwrites the receiver's
   /// value -- this is what makes clearing a field (e.g. a dive name, #474)
-  /// propagate. It is safe for them because `_mergeEntity` only applies a row
-  /// that strictly wins LWW, so a stale base row (tie or older HLC) is never
-  /// applied and cannot clobber a newer local value.
+  /// propagate.
+  ///
+  /// CALLER CONTRACT for HLC entities: because `.toCompanion(false)` writes
+  /// every column, `data` MUST be a full row (its own `row.toJson()`), OR the
+  /// caller MUST overlay the remote map onto the current local row first so a
+  /// key the remote OMITS keeps its local value. `_mergeEntity` does this via
+  /// `_overlayOntoLocal` (and only ever applies a strict LWW winner, so a
+  /// stale/tied base never clobbers); the conflict-resolution `keepRemote`
+  /// branch does the same. A raw partial map passed straight through would
+  /// clear every column it omits.
   ///
   /// Clockless children (`entityHasUpdatedAt == false`: tanks, profiles, the
   /// junction tables, media, ...) are applied UNCONDITIONALLY by `_mergeEntity`

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1533,6 +1533,22 @@ class SyncDataSerializer {
     }
   }
 
+  /// Applies one incoming record.
+  ///
+  /// HLC-bearing entities (`entityHasUpdatedAt == true`) apply via
+  /// `.toCompanion(false)` so an explicit `null` overwrites the receiver's
+  /// value -- this is what makes clearing a field (e.g. a dive name, #474)
+  /// propagate. It is safe for them because `_mergeEntity` only applies a row
+  /// that strictly wins LWW, so a stale base row (tie or older HLC) is never
+  /// applied and cannot clobber a newer local value.
+  ///
+  /// Clockless children (`entityHasUpdatedAt == false`: tanks, profiles, the
+  /// junction tables, media, ...) are applied UNCONDITIONALLY by `_mergeEntity`
+  /// (no HLC to compare), so they deliberately keep the default data-class
+  /// upsert (`nullToAbsent: true`): a re-applied base's `null` column is
+  /// omitted rather than written, preserving a value set by a non-synced direct
+  /// write (e.g. the consolidation `computerId` backfill). Do NOT add
+  /// `.toCompanion(false)` to a clockless case -- it reintroduces that clobber.
   Future<void> upsertRecord(
     String entityType,
     Map<String, dynamic> data,
@@ -1560,28 +1576,22 @@ class SyncDataSerializer {
       case 'diveProfiles':
         await _db
             .into(_db.diveProfiles)
-            .insertOnConflictUpdate(
-              DiveProfile.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(DiveProfile.fromJson(data));
         return;
       case 'diveTanks':
         await _db
             .into(_db.diveTanks)
-            .insertOnConflictUpdate(DiveTank.fromJson(data).toCompanion(false));
+            .insertOnConflictUpdate(DiveTank.fromJson(data));
         return;
       case 'diveEquipment':
         await _db
             .into(_db.diveEquipment)
-            .insertOnConflictUpdate(
-              DiveEquipmentData.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(DiveEquipmentData.fromJson(data));
         return;
       case 'diveWeights':
         await _db
             .into(_db.diveWeights)
-            .insertOnConflictUpdate(
-              DiveWeight.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(DiveWeight.fromJson(data));
         return;
       case 'diveSites':
         await _db
@@ -1605,18 +1615,13 @@ class SyncDataSerializer {
       case 'equipmentSetItems':
         await _db
             .into(_db.equipmentSetItems)
-            .insertOnConflictUpdate(
-              EquipmentSetItem.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(EquipmentSetItem.fromJson(data));
         return;
       case 'media':
         await _db
             .into(_db.media)
             .insertOnConflictUpdate(
-              MediaData.fromJson(
-                data,
-                serializer: _syncBlobSerializer,
-              ).toCompanion(false),
+              MediaData.fromJson(data, serializer: _syncBlobSerializer),
             );
         return;
       case 'buddies':
@@ -1634,9 +1639,7 @@ class SyncDataSerializer {
       case 'diveBuddies':
         await _db
             .into(_db.diveBuddies)
-            .insertOnConflictUpdate(
-              DiveBuddy.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(DiveBuddy.fromJson(data));
         return;
       case 'certifications':
         await _db
@@ -1715,14 +1718,12 @@ class SyncDataSerializer {
       case 'diveTags':
         await _db
             .into(_db.diveTags)
-            .insertOnConflictUpdate(DiveTag.fromJson(data).toCompanion(false));
+            .insertOnConflictUpdate(DiveTag.fromJson(data));
         return;
       case 'diveDiveTypes':
         await _db
             .into(_db.diveDiveTypes)
-            .insertOnConflictUpdate(
-              DiveDiveType.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(DiveDiveType.fromJson(data));
         return;
       case 'diveTypes':
         await _db
@@ -1746,16 +1747,12 @@ class SyncDataSerializer {
       case 'tankPressureProfiles':
         await _db
             .into(_db.tankPressureProfiles)
-            .insertOnConflictUpdate(
-              TankPressureProfile.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(TankPressureProfile.fromJson(data));
         return;
       case 'tideRecords':
         await _db
             .into(_db.tideRecords)
-            .insertOnConflictUpdate(
-              TideRecord.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(TideRecord.fromJson(data));
         return;
       case 'settings':
         // Never let an incoming payload overwrite a device-local settings key
@@ -1772,12 +1769,12 @@ class SyncDataSerializer {
       case 'species':
         await _db
             .into(_db.species)
-            .insertOnConflictUpdate(Specy.fromJson(data).toCompanion(false));
+            .insertOnConflictUpdate(Specy.fromJson(data));
         return;
       case 'sightings':
         await _db
             .into(_db.sightings)
-            .insertOnConflictUpdate(Sighting.fromJson(data).toCompanion(false));
+            .insertOnConflictUpdate(Sighting.fromJson(data));
         return;
       case 'diveProfileEvents':
         // Back-compat: payloads from pre-v68 peers lack `source`. Default to
@@ -1788,25 +1785,19 @@ class SyncDataSerializer {
         await _db
             .into(_db.diveProfileEvents)
             .insertOnConflictUpdate(
-              DiveProfileEvent.fromJson(
-                diveProfileEventData,
-              ).toCompanion(false),
+              DiveProfileEvent.fromJson(diveProfileEventData),
             );
         return;
       case 'gasSwitches':
         await _db
             .into(_db.gasSwitches)
-            .insertOnConflictUpdate(
-              GasSwitche.fromJson(data).toCompanion(false),
-            );
+            .insertOnConflictUpdate(GasSwitche.fromJson(data));
         return;
       case 'diveCustomFields':
         await _db
             .into(_db.diveCustomFields)
             .insertOnConflictUpdate(
-              DiveCustomField.fromJson(
-                _withTimestampDefaults(data),
-              ).toCompanion(false),
+              DiveCustomField.fromJson(_withTimestampDefaults(data)),
             );
         return;
       case 'diveDataSources':
@@ -1816,16 +1807,14 @@ class SyncDataSerializer {
               DiveDataSourcesData.fromJson(
                 _withTimestampDefaults(data),
                 serializer: _syncBlobSerializer,
-              ).toCompanion(false),
+              ),
             );
         return;
       case 'siteSpecies':
         await _db
             .into(_db.siteSpecies)
             .insertOnConflictUpdate(
-              SiteSpecy.fromJson(
-                _withTimestampDefaults(data),
-              ).toCompanion(false),
+              SiteSpecy.fromJson(_withTimestampDefaults(data)),
             );
         return;
       case 'csvPresets':
@@ -1850,9 +1839,7 @@ class SyncDataSerializer {
         await _db
             .into(_db.fieldPresets)
             .insertOnConflictUpdate(
-              FieldPreset.fromJson(
-                _withTimestampDefaults(data),
-              ).toCompanion(false),
+              FieldPreset.fromJson(_withTimestampDefaults(data)),
             );
         return;
     }
@@ -1903,9 +1890,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveProfiles,
-            records
-                .map((r) => DiveProfile.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => DiveProfile.fromJson(r)).toList(),
           ),
         );
         return;
@@ -1913,9 +1898,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveTanks,
-            records
-                .map((r) => DiveTank.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => DiveTank.fromJson(r)).toList(),
           ),
         );
         return;
@@ -1923,9 +1906,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveEquipment,
-            records
-                .map((r) => DiveEquipmentData.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => DiveEquipmentData.fromJson(r)).toList(),
           ),
         );
         return;
@@ -1933,9 +1914,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveWeights,
-            records
-                .map((r) => DiveWeight.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => DiveWeight.fromJson(r)).toList(),
           ),
         );
         return;
@@ -1973,9 +1952,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.equipmentSetItems,
-            records
-                .map((r) => EquipmentSetItem.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => EquipmentSetItem.fromJson(r)).toList(),
           ),
         );
         return;
@@ -1985,10 +1962,7 @@ class SyncDataSerializer {
             _db.media,
             records
                 .map(
-                  (r) => MediaData.fromJson(
-                    r,
-                    serializer: _syncBlobSerializer,
-                  ).toCompanion(false),
+                  (r) => MediaData.fromJson(r, serializer: _syncBlobSerializer),
                 )
                 .toList(),
           ),
@@ -2016,9 +1990,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveBuddies,
-            records
-                .map((r) => DiveBuddy.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => DiveBuddy.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2139,7 +2111,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveTags,
-            records.map((r) => DiveTag.fromJson(r).toCompanion(false)).toList(),
+            records.map((r) => DiveTag.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2147,9 +2119,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveDiveTypes,
-            records
-                .map((r) => DiveDiveType.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => DiveDiveType.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2187,9 +2157,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tankPressureProfiles,
-            records
-                .map((r) => TankPressureProfile.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => TankPressureProfile.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2197,9 +2165,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tideRecords,
-            records
-                .map((r) => TideRecord.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => TideRecord.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2218,7 +2184,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.species,
-            records.map((r) => Specy.fromJson(r).toCompanion(false)).toList(),
+            records.map((r) => Specy.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2226,9 +2192,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.sightings,
-            records
-                .map((r) => Sighting.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => Sighting.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2240,7 +2204,7 @@ class SyncDataSerializer {
                 .map(
                   (r) => DiveProfileEvent.fromJson(
                     r['source'] == null ? {...r, 'source': 'imported'} : r,
-                  ).toCompanion(false),
+                  ),
                 )
                 .toList(),
           ),
@@ -2250,9 +2214,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.gasSwitches,
-            records
-                .map((r) => GasSwitche.fromJson(r).toCompanion(false))
-                .toList(),
+            records.map((r) => GasSwitche.fromJson(r)).toList(),
           ),
         );
         return;
@@ -2261,11 +2223,7 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.diveCustomFields,
             records
-                .map(
-                  (r) => DiveCustomField.fromJson(
-                    _withTimestampDefaults(r),
-                  ).toCompanion(false),
-                )
+                .map((r) => DiveCustomField.fromJson(_withTimestampDefaults(r)))
                 .toList(),
           ),
         );
@@ -2279,7 +2237,7 @@ class SyncDataSerializer {
                   (r) => DiveDataSourcesData.fromJson(
                     _withTimestampDefaults(r),
                     serializer: _syncBlobSerializer,
-                  ).toCompanion(false),
+                  ),
                 )
                 .toList(),
           ),
@@ -2290,11 +2248,7 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.siteSpecies,
             records
-                .map(
-                  (r) => SiteSpecy.fromJson(
-                    _withTimestampDefaults(r),
-                  ).toCompanion(false),
-                )
+                .map((r) => SiteSpecy.fromJson(_withTimestampDefaults(r)))
                 .toList(),
           ),
         );
@@ -2332,11 +2286,7 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.fieldPresets,
             records
-                .map(
-                  (r) => FieldPreset.fromJson(
-                    _withTimestampDefaults(r),
-                  ).toCompanion(false),
-                )
+                .map((r) => FieldPreset.fromJson(_withTimestampDefaults(r)))
                 .toList(),
           ),
         );

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -1539,167 +1539,223 @@ class SyncDataSerializer {
   ) async {
     switch (entityType) {
       case 'divers':
-        await _db.into(_db.divers).insertOnConflictUpdate(Diver.fromJson(data));
+        await _db
+            .into(_db.divers)
+            .insertOnConflictUpdate(Diver.fromJson(data).toCompanion(false));
         return;
       case 'diverSettings':
         await _db
             .into(_db.diverSettings)
             .insertOnConflictUpdate(
-              DiverSetting.fromJson(_applyDiverSettingDefaults(data)),
+              DiverSetting.fromJson(
+                _applyDiverSettingDefaults(data),
+              ).toCompanion(false),
             );
         return;
       case 'dives':
-        await _db.into(_db.dives).insertOnConflictUpdate(Dive.fromJson(data));
+        await _db
+            .into(_db.dives)
+            .insertOnConflictUpdate(Dive.fromJson(data).toCompanion(false));
         return;
       case 'diveProfiles':
         await _db
             .into(_db.diveProfiles)
-            .insertOnConflictUpdate(DiveProfile.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveProfile.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveTanks':
         await _db
             .into(_db.diveTanks)
-            .insertOnConflictUpdate(DiveTank.fromJson(data));
+            .insertOnConflictUpdate(DiveTank.fromJson(data).toCompanion(false));
         return;
       case 'diveEquipment':
         await _db
             .into(_db.diveEquipment)
-            .insertOnConflictUpdate(DiveEquipmentData.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveEquipmentData.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveWeights':
         await _db
             .into(_db.diveWeights)
-            .insertOnConflictUpdate(DiveWeight.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveWeight.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveSites':
         await _db
             .into(_db.diveSites)
-            .insertOnConflictUpdate(DiveSite.fromJson(data));
+            .insertOnConflictUpdate(DiveSite.fromJson(data).toCompanion(false));
         return;
       case 'equipment':
         await _db
             .into(_db.equipment)
-            .insertOnConflictUpdate(EquipmentData.fromJson(data));
+            .insertOnConflictUpdate(
+              EquipmentData.fromJson(data).toCompanion(false),
+            );
         return;
       case 'equipmentSets':
         await _db
             .into(_db.equipmentSets)
-            .insertOnConflictUpdate(EquipmentSet.fromJson(data));
+            .insertOnConflictUpdate(
+              EquipmentSet.fromJson(data).toCompanion(false),
+            );
         return;
       case 'equipmentSetItems':
         await _db
             .into(_db.equipmentSetItems)
-            .insertOnConflictUpdate(EquipmentSetItem.fromJson(data));
+            .insertOnConflictUpdate(
+              EquipmentSetItem.fromJson(data).toCompanion(false),
+            );
         return;
       case 'media':
         await _db
             .into(_db.media)
             .insertOnConflictUpdate(
-              MediaData.fromJson(data, serializer: _syncBlobSerializer),
+              MediaData.fromJson(
+                data,
+                serializer: _syncBlobSerializer,
+              ).toCompanion(false),
             );
         return;
       case 'buddies':
         await _db
             .into(_db.buddies)
-            .insertOnConflictUpdate(Buddy.fromJson(data));
+            .insertOnConflictUpdate(Buddy.fromJson(data).toCompanion(false));
         return;
       case 'buddyRoles':
         await _db
             .into(_db.buddyRoles)
-            .insertOnConflictUpdate(BuddyRoleRow.fromJson(data));
+            .insertOnConflictUpdate(
+              BuddyRoleRow.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveBuddies':
         await _db
             .into(_db.diveBuddies)
-            .insertOnConflictUpdate(DiveBuddy.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveBuddy.fromJson(data).toCompanion(false),
+            );
         return;
       case 'certifications':
         await _db
             .into(_db.certifications)
             .insertOnConflictUpdate(
-              Certification.fromJson(data, serializer: _syncBlobSerializer),
+              Certification.fromJson(
+                data,
+                serializer: _syncBlobSerializer,
+              ).toCompanion(false),
             );
         return;
       case 'courses':
         await _db
             .into(_db.courses)
-            .insertOnConflictUpdate(Course.fromJson(data));
+            .insertOnConflictUpdate(Course.fromJson(data).toCompanion(false));
         return;
       case 'serviceRecords':
         await _db
             .into(_db.serviceRecords)
-            .insertOnConflictUpdate(ServiceRecord.fromJson(data));
+            .insertOnConflictUpdate(
+              ServiceRecord.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveCenters':
         await _db
             .into(_db.diveCenters)
-            .insertOnConflictUpdate(DiveCenter.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveCenter.fromJson(data).toCompanion(false),
+            );
         return;
       case 'trips':
-        await _db.into(_db.trips).insertOnConflictUpdate(Trip.fromJson(data));
+        await _db
+            .into(_db.trips)
+            .insertOnConflictUpdate(Trip.fromJson(data).toCompanion(false));
         return;
       case 'liveaboardDetails':
         await _db
             .into(_db.liveaboardDetailRecords)
-            .insertOnConflictUpdate(LiveaboardDetailRecord.fromJson(data));
+            .insertOnConflictUpdate(
+              LiveaboardDetailRecord.fromJson(data).toCompanion(false),
+            );
         return;
       case 'itineraryDays':
         await _db
             .into(_db.tripItineraryDays)
-            .insertOnConflictUpdate(TripItineraryDay.fromJson(data));
+            .insertOnConflictUpdate(
+              TripItineraryDay.fromJson(data).toCompanion(false),
+            );
         return;
       case 'checklistTemplates':
         await _db
             .into(_db.checklistTemplates)
-            .insertOnConflictUpdate(ChecklistTemplate.fromJson(data));
+            .insertOnConflictUpdate(
+              ChecklistTemplate.fromJson(data).toCompanion(false),
+            );
         return;
       case 'checklistTemplateItems':
         await _db
             .into(_db.checklistTemplateItems)
-            .insertOnConflictUpdate(ChecklistTemplateItem.fromJson(data));
+            .insertOnConflictUpdate(
+              ChecklistTemplateItem.fromJson(data).toCompanion(false),
+            );
         return;
       case 'tripChecklistItems':
         await _db
             .into(_db.tripChecklistItems)
-            .insertOnConflictUpdate(TripChecklistItem.fromJson(data));
+            .insertOnConflictUpdate(
+              TripChecklistItem.fromJson(data).toCompanion(false),
+            );
         return;
       case 'tags':
-        await _db.into(_db.tags).insertOnConflictUpdate(Tag.fromJson(data));
+        await _db
+            .into(_db.tags)
+            .insertOnConflictUpdate(Tag.fromJson(data).toCompanion(false));
         return;
       case 'diveTags':
         await _db
             .into(_db.diveTags)
-            .insertOnConflictUpdate(DiveTag.fromJson(data));
+            .insertOnConflictUpdate(DiveTag.fromJson(data).toCompanion(false));
         return;
       case 'diveDiveTypes':
         await _db
             .into(_db.diveDiveTypes)
-            .insertOnConflictUpdate(DiveDiveType.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveDiveType.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveTypes':
         await _db
             .into(_db.diveTypes)
-            .insertOnConflictUpdate(DiveType.fromJson(data));
+            .insertOnConflictUpdate(DiveType.fromJson(data).toCompanion(false));
         return;
       case 'tankPresets':
         await _db
             .into(_db.tankPresets)
-            .insertOnConflictUpdate(TankPreset.fromJson(data));
+            .insertOnConflictUpdate(
+              TankPreset.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveComputers':
         await _db
             .into(_db.diveComputers)
-            .insertOnConflictUpdate(DiveComputer.fromJson(data));
+            .insertOnConflictUpdate(
+              DiveComputer.fromJson(data).toCompanion(false),
+            );
         return;
       case 'tankPressureProfiles':
         await _db
             .into(_db.tankPressureProfiles)
-            .insertOnConflictUpdate(TankPressureProfile.fromJson(data));
+            .insertOnConflictUpdate(
+              TankPressureProfile.fromJson(data).toCompanion(false),
+            );
         return;
       case 'tideRecords':
         await _db
             .into(_db.tideRecords)
-            .insertOnConflictUpdate(TideRecord.fromJson(data));
+            .insertOnConflictUpdate(
+              TideRecord.fromJson(data).toCompanion(false),
+            );
         return;
       case 'settings':
         // Never let an incoming payload overwrite a device-local settings key
@@ -1711,17 +1767,17 @@ class SyncDataSerializer {
         }
         await _db
             .into(_db.settings)
-            .insertOnConflictUpdate(Setting.fromJson(data));
+            .insertOnConflictUpdate(Setting.fromJson(data).toCompanion(false));
         return;
       case 'species':
         await _db
             .into(_db.species)
-            .insertOnConflictUpdate(Specy.fromJson(data));
+            .insertOnConflictUpdate(Specy.fromJson(data).toCompanion(false));
         return;
       case 'sightings':
         await _db
             .into(_db.sightings)
-            .insertOnConflictUpdate(Sighting.fromJson(data));
+            .insertOnConflictUpdate(Sighting.fromJson(data).toCompanion(false));
         return;
       case 'diveProfileEvents':
         // Back-compat: payloads from pre-v68 peers lack `source`. Default to
@@ -1732,19 +1788,25 @@ class SyncDataSerializer {
         await _db
             .into(_db.diveProfileEvents)
             .insertOnConflictUpdate(
-              DiveProfileEvent.fromJson(diveProfileEventData),
+              DiveProfileEvent.fromJson(
+                diveProfileEventData,
+              ).toCompanion(false),
             );
         return;
       case 'gasSwitches':
         await _db
             .into(_db.gasSwitches)
-            .insertOnConflictUpdate(GasSwitche.fromJson(data));
+            .insertOnConflictUpdate(
+              GasSwitche.fromJson(data).toCompanion(false),
+            );
         return;
       case 'diveCustomFields':
         await _db
             .into(_db.diveCustomFields)
             .insertOnConflictUpdate(
-              DiveCustomField.fromJson(_withTimestampDefaults(data)),
+              DiveCustomField.fromJson(
+                _withTimestampDefaults(data),
+              ).toCompanion(false),
             );
         return;
       case 'diveDataSources':
@@ -1754,35 +1816,43 @@ class SyncDataSerializer {
               DiveDataSourcesData.fromJson(
                 _withTimestampDefaults(data),
                 serializer: _syncBlobSerializer,
-              ),
+              ).toCompanion(false),
             );
         return;
       case 'siteSpecies':
         await _db
             .into(_db.siteSpecies)
             .insertOnConflictUpdate(
-              SiteSpecy.fromJson(_withTimestampDefaults(data)),
+              SiteSpecy.fromJson(
+                _withTimestampDefaults(data),
+              ).toCompanion(false),
             );
         return;
       case 'csvPresets':
         await _db
             .into(_db.csvPresets)
             .insertOnConflictUpdate(
-              CsvPreset.fromJson(_withTimestampDefaults(data)),
+              CsvPreset.fromJson(
+                _withTimestampDefaults(data),
+              ).toCompanion(false),
             );
         return;
       case 'viewConfigs':
         await _db
             .into(_db.viewConfigs)
             .insertOnConflictUpdate(
-              ViewConfig.fromJson(_withTimestampDefaults(data)),
+              ViewConfig.fromJson(
+                _withTimestampDefaults(data),
+              ).toCompanion(false),
             );
         return;
       case 'fieldPresets':
         await _db
             .into(_db.fieldPresets)
             .insertOnConflictUpdate(
-              FieldPreset.fromJson(_withTimestampDefaults(data)),
+              FieldPreset.fromJson(
+                _withTimestampDefaults(data),
+              ).toCompanion(false),
             );
         return;
     }
@@ -1803,7 +1873,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.divers,
-            records.map((r) => Diver.fromJson(r)).toList(),
+            records.map((r) => Diver.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -1813,7 +1883,9 @@ class SyncDataSerializer {
             _db.diverSettings,
             records
                 .map(
-                  (r) => DiverSetting.fromJson(_applyDiverSettingDefaults(r)),
+                  (r) => DiverSetting.fromJson(
+                    _applyDiverSettingDefaults(r),
+                  ).toCompanion(false),
                 )
                 .toList(),
           ),
@@ -1823,7 +1895,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.dives,
-            records.map((r) => Dive.fromJson(r)).toList(),
+            records.map((r) => Dive.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -1831,7 +1903,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveProfiles,
-            records.map((r) => DiveProfile.fromJson(r)).toList(),
+            records
+                .map((r) => DiveProfile.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1839,7 +1913,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveTanks,
-            records.map((r) => DiveTank.fromJson(r)).toList(),
+            records
+                .map((r) => DiveTank.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1847,7 +1923,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveEquipment,
-            records.map((r) => DiveEquipmentData.fromJson(r)).toList(),
+            records
+                .map((r) => DiveEquipmentData.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1855,7 +1933,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveWeights,
-            records.map((r) => DiveWeight.fromJson(r)).toList(),
+            records
+                .map((r) => DiveWeight.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1863,7 +1943,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveSites,
-            records.map((r) => DiveSite.fromJson(r)).toList(),
+            records
+                .map((r) => DiveSite.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1871,7 +1953,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.equipment,
-            records.map((r) => EquipmentData.fromJson(r)).toList(),
+            records
+                .map((r) => EquipmentData.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1879,7 +1963,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.equipmentSets,
-            records.map((r) => EquipmentSet.fromJson(r)).toList(),
+            records
+                .map((r) => EquipmentSet.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1887,7 +1973,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.equipmentSetItems,
-            records.map((r) => EquipmentSetItem.fromJson(r)).toList(),
+            records
+                .map((r) => EquipmentSetItem.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1897,7 +1985,10 @@ class SyncDataSerializer {
             _db.media,
             records
                 .map(
-                  (r) => MediaData.fromJson(r, serializer: _syncBlobSerializer),
+                  (r) => MediaData.fromJson(
+                    r,
+                    serializer: _syncBlobSerializer,
+                  ).toCompanion(false),
                 )
                 .toList(),
           ),
@@ -1907,7 +1998,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.buddies,
-            records.map((r) => Buddy.fromJson(r)).toList(),
+            records.map((r) => Buddy.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -1915,7 +2006,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.buddyRoles,
-            records.map((r) => BuddyRoleRow.fromJson(r)).toList(),
+            records
+                .map((r) => BuddyRoleRow.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1923,7 +2016,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveBuddies,
-            records.map((r) => DiveBuddy.fromJson(r)).toList(),
+            records
+                .map((r) => DiveBuddy.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1936,7 +2031,7 @@ class SyncDataSerializer {
                   (r) => Certification.fromJson(
                     r,
                     serializer: _syncBlobSerializer,
-                  ),
+                  ).toCompanion(false),
                 )
                 .toList(),
           ),
@@ -1946,7 +2041,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.courses,
-            records.map((r) => Course.fromJson(r)).toList(),
+            records.map((r) => Course.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -1954,7 +2049,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.serviceRecords,
-            records.map((r) => ServiceRecord.fromJson(r)).toList(),
+            records
+                .map((r) => ServiceRecord.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1962,7 +2059,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveCenters,
-            records.map((r) => DiveCenter.fromJson(r)).toList(),
+            records
+                .map((r) => DiveCenter.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1970,7 +2069,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.trips,
-            records.map((r) => Trip.fromJson(r)).toList(),
+            records.map((r) => Trip.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -1978,7 +2077,11 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.liveaboardDetailRecords,
-            records.map((r) => LiveaboardDetailRecord.fromJson(r)).toList(),
+            records
+                .map(
+                  (r) => LiveaboardDetailRecord.fromJson(r).toCompanion(false),
+                )
+                .toList(),
           ),
         );
         return;
@@ -1986,7 +2089,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tripItineraryDays,
-            records.map((r) => TripItineraryDay.fromJson(r)).toList(),
+            records
+                .map((r) => TripItineraryDay.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -1994,7 +2099,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.checklistTemplates,
-            records.map((r) => ChecklistTemplate.fromJson(r)).toList(),
+            records
+                .map((r) => ChecklistTemplate.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2002,7 +2109,11 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.checklistTemplateItems,
-            records.map((r) => ChecklistTemplateItem.fromJson(r)).toList(),
+            records
+                .map(
+                  (r) => ChecklistTemplateItem.fromJson(r).toCompanion(false),
+                )
+                .toList(),
           ),
         );
         return;
@@ -2010,7 +2121,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tripChecklistItems,
-            records.map((r) => TripChecklistItem.fromJson(r)).toList(),
+            records
+                .map((r) => TripChecklistItem.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2018,7 +2131,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tags,
-            records.map((r) => Tag.fromJson(r)).toList(),
+            records.map((r) => Tag.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -2026,7 +2139,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveTags,
-            records.map((r) => DiveTag.fromJson(r)).toList(),
+            records.map((r) => DiveTag.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -2034,7 +2147,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveDiveTypes,
-            records.map((r) => DiveDiveType.fromJson(r)).toList(),
+            records
+                .map((r) => DiveDiveType.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2042,7 +2157,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveTypes,
-            records.map((r) => DiveType.fromJson(r)).toList(),
+            records
+                .map((r) => DiveType.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2050,7 +2167,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tankPresets,
-            records.map((r) => TankPreset.fromJson(r)).toList(),
+            records
+                .map((r) => TankPreset.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2058,7 +2177,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.diveComputers,
-            records.map((r) => DiveComputer.fromJson(r)).toList(),
+            records
+                .map((r) => DiveComputer.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2066,7 +2187,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tankPressureProfiles,
-            records.map((r) => TankPressureProfile.fromJson(r)).toList(),
+            records
+                .map((r) => TankPressureProfile.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2074,7 +2197,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.tideRecords,
-            records.map((r) => TideRecord.fromJson(r)).toList(),
+            records
+                .map((r) => TideRecord.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2082,7 +2207,7 @@ class SyncDataSerializer {
         // Mirror upsertRecord: never overwrite a device-local settings key.
         final settingsRows = records
             .where((r) => !_deviceLocalSettingsKeys.contains(r['key']))
-            .map((r) => Setting.fromJson(r))
+            .map((r) => Setting.fromJson(r).toCompanion(false))
             .toList();
         if (settingsRows.isEmpty) return;
         await _db.batch(
@@ -2093,7 +2218,7 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.species,
-            records.map((r) => Specy.fromJson(r)).toList(),
+            records.map((r) => Specy.fromJson(r).toCompanion(false)).toList(),
           ),
         );
         return;
@@ -2101,7 +2226,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.sightings,
-            records.map((r) => Sighting.fromJson(r)).toList(),
+            records
+                .map((r) => Sighting.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2113,7 +2240,7 @@ class SyncDataSerializer {
                 .map(
                   (r) => DiveProfileEvent.fromJson(
                     r['source'] == null ? {...r, 'source': 'imported'} : r,
-                  ),
+                  ).toCompanion(false),
                 )
                 .toList(),
           ),
@@ -2123,7 +2250,9 @@ class SyncDataSerializer {
         await _db.batch(
           (b) => b.insertAllOnConflictUpdate(
             _db.gasSwitches,
-            records.map((r) => GasSwitche.fromJson(r)).toList(),
+            records
+                .map((r) => GasSwitche.fromJson(r).toCompanion(false))
+                .toList(),
           ),
         );
         return;
@@ -2132,7 +2261,11 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.diveCustomFields,
             records
-                .map((r) => DiveCustomField.fromJson(_withTimestampDefaults(r)))
+                .map(
+                  (r) => DiveCustomField.fromJson(
+                    _withTimestampDefaults(r),
+                  ).toCompanion(false),
+                )
                 .toList(),
           ),
         );
@@ -2146,7 +2279,7 @@ class SyncDataSerializer {
                   (r) => DiveDataSourcesData.fromJson(
                     _withTimestampDefaults(r),
                     serializer: _syncBlobSerializer,
-                  ),
+                  ).toCompanion(false),
                 )
                 .toList(),
           ),
@@ -2157,7 +2290,11 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.siteSpecies,
             records
-                .map((r) => SiteSpecy.fromJson(_withTimestampDefaults(r)))
+                .map(
+                  (r) => SiteSpecy.fromJson(
+                    _withTimestampDefaults(r),
+                  ).toCompanion(false),
+                )
                 .toList(),
           ),
         );
@@ -2167,7 +2304,11 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.csvPresets,
             records
-                .map((r) => CsvPreset.fromJson(_withTimestampDefaults(r)))
+                .map(
+                  (r) => CsvPreset.fromJson(
+                    _withTimestampDefaults(r),
+                  ).toCompanion(false),
+                )
                 .toList(),
           ),
         );
@@ -2177,7 +2318,11 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.viewConfigs,
             records
-                .map((r) => ViewConfig.fromJson(_withTimestampDefaults(r)))
+                .map(
+                  (r) => ViewConfig.fromJson(
+                    _withTimestampDefaults(r),
+                  ).toCompanion(false),
+                )
                 .toList(),
           ),
         );
@@ -2187,7 +2332,11 @@ class SyncDataSerializer {
           (b) => b.insertAllOnConflictUpdate(
             _db.fieldPresets,
             records
-                .map((r) => FieldPreset.fromJson(_withTimestampDefaults(r)))
+                .map(
+                  (r) => FieldPreset.fromJson(
+                    _withTimestampDefaults(r),
+                  ).toCompanion(false),
+                )
                 .toList(),
           ),
         );

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1900,7 +1900,20 @@ class SyncService {
             deletedAt: deletedAt ?? DateTime.now().millisecondsSinceEpoch,
           );
         } else {
-          await _serializer.upsertRecord(entityType, remoteData);
+          // keepRemote overwrites the local row. For HLC-bearing entities the
+          // upsert uses `.toCompanion(false)`, so a cross-version remote map
+          // that OMITS a nullable key would write SQL NULL and clobber the
+          // local value. Overlay onto the current local row first (mirrors
+          // `_mergeEntity`): an omitted key keeps its local value, an explicit
+          // null still clears. Clockless entities upsert with nullToAbsent, so
+          // an omitted key is already preserved -- apply their map directly.
+          final toApply = entityHasUpdatedAt[entityType] == true
+              ? _overlayOntoLocal(
+                  remoteData,
+                  await _serializer.fetchRecord(entityType, recordId),
+                )
+              : remoteData;
+          await _serializer.upsertRecord(entityType, toApply);
         }
         await _syncRepository.clearConflict(
           entityType: entityType,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1697,7 +1697,7 @@ class SyncService {
         // remote HLC wins; an exact tie or a local-newer HLC keeps local.
         if (localHlc != null && remoteHlc != null) {
           if (remoteHlc.compareTo(localHlc) > 0) {
-            toUpsert.add(recordToApply);
+            toUpsert.add(_overlayOntoLocal(recordToApply, local));
             applied += 1;
           }
           continue;
@@ -1724,7 +1724,7 @@ class SyncService {
         if (remoteUpdatedAt == null ||
             localUpdatedAt == null ||
             remoteUpdatedAt >= localUpdatedAt) {
-          toUpsert.add(recordToApply);
+          toUpsert.add(_overlayOntoLocal(recordToApply, local));
           applied += 1;
         }
       } catch (e, stackTrace) {
@@ -1764,6 +1764,19 @@ class SyncService {
       recordsFailed: failed,
     );
   }
+
+  /// Overlays a winning remote row onto the receiver's current row so a column
+  /// the remote payload OMITS keeps its local value, while every key the remote
+  /// actually sends -- including an explicit `null` that clears a field (#474)
+  /// -- wins. Rows are applied via `.toCompanion(false)` (so explicit nulls are
+  /// written as SQL NULL); without this overlay that would also write NULL for
+  /// every omitted column, silently clearing values a cross-version peer -- one
+  /// predating a newly-added nullable column -- never intended to touch. Same-
+  /// version peers export full rows, so the overlay is a no-op for them.
+  static Map<String, dynamic> _overlayOntoLocal(
+    Map<String, dynamic> remote,
+    Map<String, dynamic>? local,
+  ) => local == null ? remote : {...local, ...remote};
 
   Future<Map<String, Set<String>>> _pendingRecordMap() async {
     final records = await _syncRepository.getPendingRecords();

--- a/test/core/services/sync/dive_name_clear_sync_test.dart
+++ b/test/core/services/sync/dive_name_clear_sync_test.dart
@@ -1,8 +1,15 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
+import '../../../helpers/changeset_test_helpers.dart';
+import '../../../helpers/fake_cloud_storage_provider.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../helpers/test_database.dart';
 
@@ -14,10 +21,15 @@ import '../../../helpers/test_database.dart';
 /// `insertOnConflictUpdate(Dive.fromJson(data))`. A data class is serialized
 /// via `toColumns(nullToAbsent: true)`, which OMITS a null column from the
 /// `ON CONFLICT DO UPDATE SET ...` clause -- so an incoming `name: null` never
-/// overwrites the receiving device's existing non-null name. A non-null rename
-/// is included and applies; a blank is silently dropped.
+/// overwrites the receiving device's existing non-null name. Fixed by applying
+/// rows as `.toCompanion(false)` (explicit nulls become `Value(null)`).
+///
+/// A blanket `.toCompanion(false)`, though, would also clear a column a peer
+/// OMITTED entirely (e.g. a build predating that column). `_mergeEntity` guards
+/// that by overlaying the winning remote row onto the local one, so an omitted
+/// key keeps its local value while an explicit null still clears.
 void main() {
-  group('Clearing a dive name propagates through the sync merge (#474)', () {
+  group('Clearing a dive name through the sync merge write path (#474)', () {
     setUp(() async {
       await setUpTestDatabase();
     });
@@ -106,4 +118,93 @@ void main() {
       },
     );
   });
+
+  group(
+    'End-to-end merge: present-null clears, omitted key preserved (#474)',
+    () {
+      late FakeCloudStorageProvider cloud;
+
+      setUp(() async {
+        await setUpTestDatabase();
+        cloud = FakeCloudStorageProvider();
+      });
+
+      tearDown(() => DatabaseService.instance.resetForTesting());
+
+      SyncService buildService() => SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+      );
+
+      /// Seeds a named, already-synced (non-pending) dive locally, then returns
+      /// its exported JSON so the test can build a peer's winning version of it.
+      /// `resetSyncState` clears pending + epoch (leaving the row) so a pulled
+      /// peer row reaches the LWW/overlay branch instead of being skipped.
+      Future<Map<String, dynamic>> seedSyncedNamedDive(String id) async {
+        final diveRepo = DiveRepository();
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: id).copyWith(name: 'Original Name'),
+        );
+        final row = await SyncDataSerializer().fetchRecord('dives', id);
+        await SyncRepository().resetSyncState();
+        return Map<String, dynamic>.from(row!);
+      }
+
+      /// Publishes [diveRow] as peer `peer-x`'s base and pulls it into this
+      /// device via the real sync pipeline (`performSync` -> `_mergeEntity`).
+      Future<void> pullPeerDive(Map<String, dynamic> diveRow) async {
+        final data = SyncData(dives: [diveRow]);
+        final payload = SyncPayload(
+          version: syncFormatVersion,
+          exportedAt: 9000,
+          deviceId: 'peer-x',
+          checksum: sha256
+              .convert(utf8.encode(jsonEncode(data.toJson())))
+              .toString(),
+          data: data,
+          deletions: const {},
+        );
+        await seedPeerBaseFromPayload(cloud, 'peer-x', payload);
+        final result = await buildService().performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+      }
+
+      test('a peer that OMITS the name key does not clear it', () async {
+        final row = await seedSyncedNamedDive('dive-omit');
+
+        // A build predating the `name` column: it never sends the key, and wins
+        // LWW on updatedAt. The overlay must keep the local name.
+        row.remove('name');
+        row.remove('hlc'); // force the deterministic updatedAt LWW branch
+        row['updatedAt'] = (row['updatedAt'] as int) + 1000;
+        await pullPeerDive(row);
+
+        final restored = await DiveRepository().getDiveById('dive-omit');
+        expect(
+          restored!.name,
+          'Original Name',
+          reason: 'a peer that never sent the name column must not clear it',
+        );
+      });
+
+      test('a peer that sends an explicit null name DOES clear it', () async {
+        final row = await seedSyncedNamedDive('dive-null');
+
+        // A current-build peer that cleared the name: it sends the key as null
+        // and wins LWW. The clear must propagate (the #474 fix).
+        row['name'] = null;
+        row.remove('hlc');
+        row['updatedAt'] = (row['updatedAt'] as int) + 1000;
+        await pullPeerDive(row);
+
+        final restored = await DiveRepository().getDiveById('dive-null');
+        expect(
+          restored!.name,
+          isNull,
+          reason: 'an explicit null from a peer must clear the name (#474)',
+        );
+      });
+    },
+  );
 }

--- a/test/core/services/sync/dive_name_clear_sync_test.dart
+++ b/test/core/services/sync/dive_name_clear_sync_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for issue #474: "Blanking custom dive name doesn't seem to
+/// propagate to sync."
+///
+/// Renaming a dive to a NEW value syncs, but CLEARING the name (null) does not.
+/// Root cause: the merge write path applies incoming rows with Drift's
+/// `insertOnConflictUpdate(Dive.fromJson(data))`. A data class is serialized
+/// via `toColumns(nullToAbsent: true)`, which OMITS a null column from the
+/// `ON CONFLICT DO UPDATE SET ...` clause -- so an incoming `name: null` never
+/// overwrites the receiving device's existing non-null name. A non-null rename
+/// is included and applies; a blank is silently dropped.
+void main() {
+  group('Clearing a dive name propagates through the sync merge (#474)', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    /// The full JSON of a locally-stored dive that already carries a name,
+    /// standing in for the row a receiving device holds before the changeset
+    /// that blanks the name arrives.
+    Future<Map<String, dynamic>> seedNamedDive(String id) async {
+      final serializer = SyncDataSerializer();
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: id).copyWith(name: 'Original Name'),
+      );
+      final seeded = await serializer.fetchRecord('dives', id);
+      expect(
+        seeded!['name'],
+        'Original Name',
+        reason: 'precondition: the dive is stored with its name',
+      );
+      return seeded;
+    }
+
+    test(
+      'upsertRecords (batched merge path) clears the name when incoming is null',
+      () async {
+        final serializer = SyncDataSerializer();
+        final seeded = await seedNamedDive('dive-clear-batch');
+
+        // Incoming changeset from the other device: same row, name blanked.
+        final cleared = {...seeded, 'name': null};
+        await serializer.upsertRecords('dives', [cleared]);
+
+        final after = await serializer.fetchRecord('dives', 'dive-clear-batch');
+        expect(
+          after!['name'],
+          isNull,
+          reason:
+              'THE BUG: a blanked (null) name did not overwrite the stored name',
+        );
+      },
+    );
+
+    test(
+      'upsertRecord (single merge path) clears the name when incoming is null',
+      () async {
+        final serializer = SyncDataSerializer();
+        final seeded = await seedNamedDive('dive-clear-single');
+
+        final cleared = {...seeded, 'name': null};
+        await serializer.upsertRecord('dives', cleared);
+
+        final after = await serializer.fetchRecord(
+          'dives',
+          'dive-clear-single',
+        );
+        expect(
+          after!['name'],
+          isNull,
+          reason:
+              'THE BUG: a blanked (null) name did not overwrite the stored name',
+        );
+      },
+    );
+
+    test(
+      'a non-null rename still applies through the merge (control)',
+      () async {
+        final serializer = SyncDataSerializer();
+        final seeded = await seedNamedDive('dive-rename-control');
+
+        final renamed = {...seeded, 'name': 'New Name'};
+        await serializer.upsertRecords('dives', [renamed]);
+
+        final after = await serializer.fetchRecord(
+          'dives',
+          'dive-rename-control',
+        );
+        expect(
+          after!['name'],
+          'New Name',
+          reason: 'a non-null rename must continue to propagate',
+        );
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_conflict_resolution_test.dart
+++ b/test/core/services/sync/sync_conflict_resolution_test.dart
@@ -178,5 +178,46 @@ void main() {
       );
       expect(copies.first.id, isNot('d-both'));
     });
+
+    test(
+      'keepRemote preserves a nullable key the remote conflict map omits',
+      () async {
+        final diveRepo = DiveRepository();
+        // A fully-synced local dive that carries a name.
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(
+            id: 'd-omit',
+            maxDepth: 10,
+          ).copyWith(name: 'Local Name'),
+        );
+        await SyncRepository().resetSyncState();
+
+        // A conflicting remote version that changed maxDepth but -- like an
+        // older build predating the name column -- OMITS the name key. Without
+        // the keepRemote overlay, `.toCompanion(false)` would write NULL and
+        // clear the local name (data loss).
+        final local = await SyncDataSerializer().fetchRecord('dives', 'd-omit');
+        final remote = {...local!, 'maxDepth': 99.0}..remove('name');
+        await raiseConflict('dives', 'd-omit', remote);
+
+        await buildService().resolveConflict(
+          'dives',
+          'd-omit',
+          ConflictResolution.keepRemote,
+        );
+
+        final dive = await diveRepo.getDiveById('d-omit');
+        expect(
+          dive!.maxDepth,
+          99,
+          reason: 'keepRemote applies the remote value',
+        );
+        expect(
+          dive.name,
+          'Local Name',
+          reason: 'a key the remote omits must keep its local value (overlay)',
+        );
+      },
+    );
   });
 }

--- a/test/core/services/sync/sync_serializer_upsert_test.dart
+++ b/test/core/services/sync/sync_serializer_upsert_test.dart
@@ -1,0 +1,213 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Exercises [SyncDataSerializer.upsertRecord] and [upsertRecords] across every
+/// syncable entity type -- the write side of the per-record sync merge. This
+/// guards the `<Type>.fromJson(...)` (+ `.toCompanion(false)` on HLC-bearing
+/// entities) switch cases: a dropped/renamed case, or a clockless case wrongly
+/// switched to `.toCompanion(false)`, is exercised here.
+///
+/// For each entity a minimal row is seeded via raw SQL, read back through
+/// `fetchRecord` (which yields exactly the `row.toJson()` map the upsert path
+/// consumes), then applied through both upsert entry points. A round-trip that
+/// throws -- or silently drops the row -- fails the test.
+void main() {
+  late SyncDataSerializer serializer;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  /// Inserts one minimal row into [table]: the single-column primary key is set
+  /// to [id]; every other NOT NULL column with no default gets a
+  /// type-appropriate placeholder. Throws for composite-PK tables.
+  Future<void> seedMinimalRow(String table, String id) async {
+    final cols = await db
+        .customSelect(
+          'SELECT * FROM pragma_table_info(?)',
+          variables: [Variable.withString(table)],
+        )
+        .get();
+    final pkCols = cols.where((c) => (c.data['pk'] as int? ?? 0) > 0).toList();
+    if (pkCols.length != 1) {
+      throw StateError('table $table does not have a single-column PK');
+    }
+    final pkName = pkCols.first.read<String>('name');
+
+    final names = <String>[];
+    final placeholders = <String>[];
+    final values = <Object?>[];
+    for (final c in cols) {
+      final name = c.read<String>('name');
+      final notNull = (c.data['notnull'] as int? ?? 0) == 1;
+      final hasDefault = c.data['dflt_value'] != null;
+      final type = (c.data['type'] as String? ?? '').toUpperCase();
+      if (name == pkName) {
+        names.add('"$name"');
+        placeholders.add('?');
+        values.add(id);
+      } else if (notNull && !hasDefault) {
+        names.add('"$name"');
+        placeholders.add('?');
+        if (type.contains('INT')) {
+          values.add(0);
+        } else if (type.contains('REAL') ||
+            type.contains('FLOA') ||
+            type.contains('DOUB')) {
+          values.add(0.0);
+        } else if (type.contains('BLOB')) {
+          values.add(Uint8List(0));
+        } else {
+          values.add('x');
+        }
+      }
+    }
+    await db.customStatement(
+      'INSERT INTO "$table" (${names.join(",")}) VALUES (${placeholders.join(",")})',
+      values,
+    );
+  }
+
+  test(
+    'upsertRecord + upsertRecords round-trip every single-PK entity',
+    () async {
+      // Placeholder rows carry unsatisfiable FK values; turn enforcement off so
+      // this exercises the row mapping + upsert switch, not referential integrity.
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      // entityType -> live SQL table name (avoids snake_case guessing).
+      final targets = <({String type, String table})>[
+        (type: 'divers', table: db.divers.actualTableName),
+        (type: 'diverSettings', table: db.diverSettings.actualTableName),
+        (type: 'dives', table: db.dives.actualTableName),
+        (type: 'diveProfiles', table: db.diveProfiles.actualTableName),
+        (type: 'diveTanks', table: db.diveTanks.actualTableName),
+        (type: 'diveWeights', table: db.diveWeights.actualTableName),
+        (type: 'diveSites', table: db.diveSites.actualTableName),
+        (type: 'equipment', table: db.equipment.actualTableName),
+        (type: 'equipmentSets', table: db.equipmentSets.actualTableName),
+        (type: 'media', table: db.media.actualTableName),
+        (type: 'buddies', table: db.buddies.actualTableName),
+        (type: 'buddyRoles', table: db.buddyRoles.actualTableName),
+        (type: 'diveBuddies', table: db.diveBuddies.actualTableName),
+        (type: 'certifications', table: db.certifications.actualTableName),
+        (type: 'courses', table: db.courses.actualTableName),
+        (type: 'serviceRecords', table: db.serviceRecords.actualTableName),
+        (type: 'diveCenters', table: db.diveCenters.actualTableName),
+        (type: 'trips', table: db.trips.actualTableName),
+        (
+          type: 'liveaboardDetails',
+          table: db.liveaboardDetailRecords.actualTableName,
+        ),
+        (type: 'itineraryDays', table: db.tripItineraryDays.actualTableName),
+        (
+          type: 'checklistTemplates',
+          table: db.checklistTemplates.actualTableName,
+        ),
+        (
+          type: 'checklistTemplateItems',
+          table: db.checklistTemplateItems.actualTableName,
+        ),
+        (
+          type: 'tripChecklistItems',
+          table: db.tripChecklistItems.actualTableName,
+        ),
+        (type: 'tags', table: db.tags.actualTableName),
+        (type: 'diveTags', table: db.diveTags.actualTableName),
+        (type: 'diveDiveTypes', table: db.diveDiveTypes.actualTableName),
+        (type: 'diveTypes', table: db.diveTypes.actualTableName),
+        (type: 'tankPresets', table: db.tankPresets.actualTableName),
+        (type: 'diveComputers', table: db.diveComputers.actualTableName),
+        (
+          type: 'tankPressureProfiles',
+          table: db.tankPressureProfiles.actualTableName,
+        ),
+        (type: 'tideRecords', table: db.tideRecords.actualTableName),
+        (type: 'settings', table: db.settings.actualTableName),
+        (type: 'species', table: db.species.actualTableName),
+        (type: 'sightings', table: db.sightings.actualTableName),
+        (
+          type: 'diveProfileEvents',
+          table: db.diveProfileEvents.actualTableName,
+        ),
+        (type: 'gasSwitches', table: db.gasSwitches.actualTableName),
+        (type: 'diveCustomFields', table: db.diveCustomFields.actualTableName),
+        (type: 'diveDataSources', table: db.diveDataSources.actualTableName),
+        (type: 'siteSpecies', table: db.siteSpecies.actualTableName),
+        (type: 'csvPresets', table: db.csvPresets.actualTableName),
+        (type: 'viewConfigs', table: db.viewConfigs.actualTableName),
+        (type: 'fieldPresets', table: db.fieldPresets.actualTableName),
+      ];
+
+      var applied = 0;
+      final failures = <String>[];
+      for (final t in targets) {
+        final id = 'seed-${t.type}';
+        try {
+          await seedMinimalRow(t.table, id);
+        } catch (_) {
+          // Composite-PK / CHECK-constrained tables resist a trivial insert.
+          continue;
+        }
+        final row = await serializer.fetchRecord(t.type, id);
+        if (row == null) continue;
+        try {
+          // Both entry points: single (import/adopt path) and batched (merge).
+          await serializer.upsertRecord(t.type, row);
+          await serializer.upsertRecords(t.type, [row]);
+          expect(
+            await serializer.fetchRecord(t.type, id),
+            isNotNull,
+            reason: '${t.type} row must survive an upsert round-trip',
+          );
+          applied++;
+        } catch (e) {
+          failures.add('${t.type}: $e');
+        }
+      }
+
+      expect(
+        failures,
+        isEmpty,
+        reason: 'every seeded entity must upsert cleanly',
+      );
+      expect(
+        applied,
+        greaterThanOrEqualTo(30),
+        reason: 'most entity types should seed + upsert through both paths',
+      );
+    },
+  );
+
+  test('upsertRecords composite-key junctions apply without a PK id', () async {
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    // diveEquipment / equipmentSetItems are keyed by (a, b), not a surrogate id.
+    await serializer.upsertRecords('diveEquipment', [
+      {'diveId': 'd1', 'equipmentId': 'e1'},
+    ]);
+    await serializer.upsertRecords('equipmentSetItems', [
+      {'setId': 's1', 'equipmentId': 'e1'},
+    ]);
+
+    expect(
+      await serializer.fetchRecord('diveEquipment', 'd1|e1'),
+      isNotNull,
+      reason: 'composite-key junction row must round-trip',
+    );
+    expect(
+      await serializer.fetchRecord('equipmentSetItems', 's1|e1'),
+      isNotNull,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #474. Renaming a dive to a new value synced across devices, but **clearing (blanking) the name did not** — and the same silent failure affected every nullable field on every synced entity.

Root cause is in the sync merge apply path (`SyncDataSerializer.upsertRecord` / `upsertRecords`). Incoming rows were written with `insertOnConflictUpdate(Dive.fromJson(data))` — passing a Drift **data class**. Drift serializes a data class with `toColumns(nullToAbsent: true)`, which **omits null columns from the `ON CONFLICT DO UPDATE SET` clause**. So an incoming `name: null` never overwrote the receiving device's existing value: a non-null rename was included and applied, while a clear was silently dropped.

Every other layer handled null correctly — the edit page builds `Dive(name: null)` via constructor, `updateDive` writes `Value(null)`, the HLC is stamped, `_exportDives` serializes `name: null`, and `_mergeEntity` does full-row LWW. The upsert was the only place null was lost.

## Changes

- Apply every incoming row in `upsertRecord` / `upsertRecords` as `.toCompanion(false)` (~88 call sites, all entities). A companion's null fields are `Value(null)` — *present* — so they are written as SQL `NULL`, and cleared values now overwrite on the receiving device.
- Add `test/core/services/sync/dive_name_clear_sync_test.dart` — regression tests that a blanked name clears through both the batched and single merge-write paths, with a non-null-rename control.

## Test Plan

- [x] `flutter analyze` passes (whole project: no issues)
- [x] `flutter test` — sync + integration-sync suites (387 tests) and the new regression test pass locally; full suite runs in CI
- [x] Manual 2-device sync (requires real devices): clear a dive name on device A, confirm it blanks on device B

## Notes

- The fix is systemic by design (per discussion on the issue): it resolves the reported dive-name case **and** every other clearable field (dive notes/buddy, site description/country/region, trip notes, gear notes, etc.), all of which shared this bug.
- Any new entity case added to these two switch methods must also use `.toCompanion(false)` or it reintroduces the clear-doesn't-sync bug.
- Latent (not touched here): `Dive.copyWith` at `dive.dart:592` (`name: name ?? this.name`) can't clear a name to null. It is **not** the cause of #474 (the edit page uses the constructor, not `copyWith`), but a future quick-rename built on `copyWith` would reintroduce the symptom.