### PR TITLE
feat(dive-detail): show dive computer friendly name in data sources and attribution

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -5079,7 +5079,7 @@ class DiveRepository {
     )..where((c) => c.id.isIn(ids))).get();
     return {
       for (final computer in computers)
-        if (computer.name.trim().isNotEmpty) computer.id: computer.name,
+        if (computer.name.trim().isNotEmpty) computer.id: computer.name.trim(),
     };
   }
 

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -4358,7 +4358,10 @@ class DiveRepository {
           (t) => OrderingTerm.asc(t.createdAt),
         ]);
       final rows = await query.get();
-      return rows.map(_mapRowToDataSource).toList();
+      final computerNames = await _friendlyNamesFor(rows);
+      return rows
+          .map((row) => _mapRowToDataSource(row, computerNames))
+          .toList();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to get computer readings for dive: $diveId',
@@ -5058,14 +5061,46 @@ class DiveRepository {
     }
   }
 
+  /// Resolves a `{ computerId -> friendly name }` map for the given source
+  /// rows by looking up each linked [DiveComputers] row's user-assigned
+  /// `name`. Blank names are omitted so the display fallback (model, then
+  /// serial/"Unknown") still applies. Rows with no `computerId` (manual
+  /// entries, file imports, or a since-deleted computer) contribute nothing.
+  Future<Map<String, String>> _friendlyNamesFor(
+    List<DiveDataSourcesData> rows,
+  ) async {
+    final ids = {
+      for (final row in rows)
+        if (row.computerId != null) row.computerId!,
+    };
+    if (ids.isEmpty) return const {};
+    final computers = await (_db.select(
+      _db.diveComputers,
+    )..where((c) => c.id.isIn(ids))).get();
+    return {
+      for (final computer in computers)
+        if (computer.name.trim().isNotEmpty) computer.id: computer.name,
+    };
+  }
+
   /// Map a [DiveDataSourcesData] DB row to a [DiveDataSource] entity.
-  DiveDataSource _mapRowToDataSource(DiveDataSourcesData row) {
+  ///
+  /// [computerNames] carries the live `{ computerId -> friendly name }` lookup
+  /// from [_friendlyNamesFor]; a source's `computerName` is filled from it when
+  /// the row is linked to a registered computer.
+  DiveDataSource _mapRowToDataSource(
+    DiveDataSourcesData row, [
+    Map<String, String> computerNames = const {},
+  ]) {
     return DiveDataSource(
       id: row.id,
       diveId: row.diveId,
       computerId: row.computerId,
       isPrimary: row.isPrimary,
       computerModel: row.computerModel,
+      computerName: row.computerId == null
+          ? null
+          : computerNames[row.computerId],
       computerSerial: row.computerSerial,
       sourceFormat: row.sourceFormat,
       sourceFileName: row.sourceFileName,

--- a/lib/features/dive_log/domain/entities/dive_data_source.dart
+++ b/lib/features/dive_log/domain/entities/dive_data_source.dart
@@ -6,6 +6,12 @@ class DiveDataSource extends Equatable {
   final String? computerId;
   final bool isPrimary;
   final String? computerModel;
+
+  /// The linked dive computer's user-assigned friendly name (e.g. "My
+  /// Perdix"), resolved live from the registered computer via [computerId].
+  /// Null when the source has no linked computer (manual/file imports, or a
+  /// since-deleted computer); callers fall back to [computerModel].
+  final String? computerName;
   final String? computerSerial;
   final String? sourceFormat;
   final String? sourceFileName;
@@ -37,6 +43,7 @@ class DiveDataSource extends Equatable {
     this.computerId,
     required this.isPrimary,
     this.computerModel,
+    this.computerName,
     this.computerSerial,
     this.sourceFormat,
     this.sourceFileName,
@@ -63,8 +70,16 @@ class DiveDataSource extends Equatable {
     required this.createdAt,
   });
 
-  /// Display name for the data source (model, or "Unknown Source").
-  String get displayName => computerModel ?? 'Unknown Source';
+  /// Display name for the data source: the linked computer's friendly name
+  /// when known, else the model snapshot, else "Unknown Source".
+  String get displayName => computerName ?? computerModel ?? 'Unknown Source';
+
+  /// Label for this source's computer, preferring the friendly name, then the
+  /// model, then the serial, then the caller-supplied [unknownLabel]. Used
+  /// where a localized "unknown" fallback is needed (e.g. the profile chart's
+  /// per-computer legend).
+  String computerLabel(String unknownLabel) =>
+      computerName ?? computerModel ?? computerSerial ?? unknownLabel;
 
   DiveDataSource copyWith({
     String? id,
@@ -72,6 +87,7 @@ class DiveDataSource extends Equatable {
     String? computerId,
     bool? isPrimary,
     String? computerModel,
+    String? computerName,
     String? computerSerial,
     String? sourceFormat,
     String? sourceFileName,
@@ -103,6 +119,7 @@ class DiveDataSource extends Equatable {
       computerId: computerId ?? this.computerId,
       isPrimary: isPrimary ?? this.isPrimary,
       computerModel: computerModel ?? this.computerModel,
+      computerName: computerName ?? this.computerName,
       computerSerial: computerSerial ?? this.computerSerial,
       sourceFormat: sourceFormat ?? this.sourceFormat,
       sourceFileName: sourceFileName ?? this.sourceFileName,
@@ -137,6 +154,7 @@ class DiveDataSource extends Equatable {
     computerId,
     isPrimary,
     computerModel,
+    computerName,
     computerSerial,
     sourceFormat,
     sourceFileName,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1040,10 +1040,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }
 
   /// Resolves computerId -> display name for a dive's data sources, using
-  /// the same fallback chain as the Data Sources section: model, then
-  /// serial, then the localized "Unknown Computer" label. Sources without a
-  /// computerId (manual entries, edited profiles) are skipped — callers key
-  /// off computerId, so there's nothing to attach the name to.
+  /// the same fallback chain as the Data Sources section: the computer's
+  /// user-assigned friendly name, then model, then serial, then the localized
+  /// "Unknown Computer" label. Sources without a computerId (manual entries,
+  /// edited profiles) are skipped — callers key off computerId, so there's
+  /// nothing to attach the name to.
   Map<String, String> _computerDisplayNames(
     BuildContext context,
     List<DiveDataSource> dataSources,
@@ -1051,10 +1052,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     return {
       for (final source in dataSources)
         if (source.computerId != null)
-          source.computerId!:
-              source.computerModel ??
-              source.computerSerial ??
-              context.l10n.diveLog_sources_unknownComputer,
+          source.computerId!: source.computerLabel(
+            context.l10n.diveLog_sources_unknownComputer,
+          ),
     };
   }
 

--- a/lib/features/dive_log/presentation/widgets/data_sources_section.dart
+++ b/lib/features/dive_log/presentation/widgets/data_sources_section.dart
@@ -175,7 +175,9 @@ class _SourceComparisonGrid extends StatelessWidget {
           for (final s in sources)
             DataColumn(
               label: Text(
-                s.computerModel ?? l10n.diveLog_sources_unknownComputer,
+                s.computerName ??
+                    s.computerModel ??
+                    l10n.diveLog_sources_unknownComputer,
                 style: s.isPrimary
                     ? const TextStyle(fontWeight: FontWeight.bold)
                     : null,
@@ -308,6 +310,17 @@ class _DataSourceCard extends StatelessWidget {
     );
     final valueStyle = textTheme.bodyMedium;
 
+    // When the header shows the computer's friendly name, surface the model
+    // beneath it -- but only when it adds information (i.e. the friendly name
+    // was customized away from the model). Un-renamed computers, whose name
+    // defaults to the model, get no redundant subtitle.
+    final modelSubtitle =
+        source.computerName != null &&
+            source.computerModel != null &&
+            source.computerModel != source.computerName
+        ? source.computerModel
+        : null;
+
     // Primary card gets a green-tinted left border when in multi-source mode.
     // Viewing card gets a blue highlight.
     BoxDecoration? cardDecoration;
@@ -339,35 +352,48 @@ class _DataSourceCard extends StatelessWidget {
                   Icon(Icons.watch, size: 18, color: colorScheme.primary),
                   const SizedBox(width: 8),
                   Expanded(
-                    child: Row(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Flexible(
-                          child: Text(
-                            source.displayName,
-                            style: textTheme.titleSmall?.copyWith(
-                              fontWeight: FontWeight.w600,
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                source.displayName,
+                                style: textTheme.titleSmall?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            if (showBadges) ...[
+                              const SizedBox(width: 6),
+                              if (isViewing)
+                                _Badge(
+                                  label: 'Viewing',
+                                  color: colorScheme.tertiaryContainer,
+                                )
+                              else if (source.isPrimary)
+                                _Badge(
+                                  label: 'Primary',
+                                  color: colorScheme.primaryContainer,
+                                )
+                              else
+                                _Badge(
+                                  label: 'Secondary',
+                                  color: colorScheme.surfaceContainerHighest,
+                                ),
+                            ],
+                          ],
+                        ),
+                        if (modelSubtitle != null)
+                          Text(
+                            modelSubtitle,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
                             ),
                             overflow: TextOverflow.ellipsis,
                           ),
-                        ),
-                        if (showBadges) ...[
-                          const SizedBox(width: 6),
-                          if (isViewing)
-                            _Badge(
-                              label: 'Viewing',
-                              color: colorScheme.tertiaryContainer,
-                            )
-                          else if (source.isPrimary)
-                            _Badge(
-                              label: 'Primary',
-                              color: colorScheme.primaryContainer,
-                            )
-                          else
-                            _Badge(
-                              label: 'Secondary',
-                              color: colorScheme.surfaceContainerHighest,
-                            ),
-                        ],
                       ],
                     ),
                   ),

--- a/lib/features/dive_log/presentation/widgets/data_sources_section.dart
+++ b/lib/features/dive_log/presentation/widgets/data_sources_section.dart
@@ -175,9 +175,7 @@ class _SourceComparisonGrid extends StatelessWidget {
           for (final s in sources)
             DataColumn(
               label: Text(
-                s.computerName ??
-                    s.computerModel ??
-                    l10n.diveLog_sources_unknownComputer,
+                s.computerLabel(l10n.diveLog_sources_unknownComputer),
                 style: s.isPrimary
                     ? const TextStyle(fontWeight: FontWeight.bold)
                     : null,

--- a/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
@@ -256,6 +256,27 @@ void main() {
       expect(sources.single.displayName, equals('Shearwater Teric'));
     });
 
+    test('trims surrounding whitespace from the friendly name', () async {
+      final diveId = await insertTestDive(id: 'dive-whitespace-name');
+      await insertComputer(
+        id: 'comp-whitespace',
+        name: '  My Perdix  ',
+        model: 'Perdix',
+      );
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'reading-whitespace',
+          diveId: diveId,
+          isPrimary: true,
+          computerModel: 'Shearwater Perdix AI',
+        ).copyWith(computerId: const Value('comp-whitespace')),
+      );
+
+      final sources = await repository.getDataSources(diveId);
+
+      expect(sources.single.computerName, equals('My Perdix'));
+    });
+
     test(
       'returns data sources ordered primary-first then by createdAt',
       () async {

--- a/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
@@ -162,6 +162,24 @@ void main() {
   // getDataSources
   // ---------------------------------------------------------------------------
 
+  Future<void> insertComputer({
+    required String id,
+    required String name,
+    String? model,
+  }) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion.insert(
+            id: id,
+            name: name,
+            model: Value(model),
+            createdAt: 0,
+            updatedAt: 0,
+          ),
+        );
+  }
+
   group('getDataSources', () {
     test('returns empty list when no data sources exist', () async {
       final diveId = await insertTestDive(id: 'dive-no-sources');
@@ -169,6 +187,73 @@ void main() {
       final sources = await repository.getDataSources(diveId);
 
       expect(sources, isEmpty);
+    });
+
+    test(
+      'resolves the linked computer friendly name into computerName',
+      () async {
+        final diveId = await insertTestDive(id: 'dive-friendly-name');
+        await insertComputer(
+          id: 'comp-friendly',
+          name: 'My Perdix',
+          model: 'Perdix',
+        );
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-friendly',
+            diveId: diveId,
+            isPrimary: true,
+            computerModel: 'Shearwater Perdix AI',
+          ).copyWith(computerId: const Value('comp-friendly')),
+        );
+
+        final sources = await repository.getDataSources(diveId);
+
+        expect(sources.single.computerName, equals('My Perdix'));
+        // displayName now prefers the friendly name over the model snapshot.
+        expect(sources.single.displayName, equals('My Perdix'));
+        // The model snapshot is preserved for the subtitle.
+        expect(sources.single.computerModel, equals('Shearwater Perdix AI'));
+      },
+    );
+
+    test(
+      'leaves computerName null when the source has no linked computer',
+      () async {
+        final diveId = await insertTestDive(id: 'dive-no-linked-computer');
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-unlinked',
+            diveId: diveId,
+            isPrimary: true,
+            computerModel: 'Suunto D5',
+          ),
+        );
+
+        final sources = await repository.getDataSources(diveId);
+
+        expect(sources.single.computerName, isNull);
+        expect(sources.single.displayName, equals('Suunto D5'));
+      },
+    );
+
+    test('treats an empty computer name as absent (falls back to '
+        'model)', () async {
+      final diveId = await insertTestDive(id: 'dive-empty-name');
+      await insertComputer(id: 'comp-empty', name: '', model: 'Teric');
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'reading-empty-name',
+          diveId: diveId,
+          isPrimary: true,
+          computerModel: 'Shearwater Teric',
+        ).copyWith(computerId: const Value('comp-empty')),
+      );
+
+      final sources = await repository.getDataSources(diveId);
+
+      expect(sources.single.computerName, isNull);
+      expect(sources.single.displayName, equals('Shearwater Teric'));
     });
 
     test(

--- a/test/features/dive_log/domain/entities/dive_data_source_test.dart
+++ b/test/features/dive_log/domain/entities/dive_data_source_test.dart
@@ -127,6 +127,67 @@ void main() {
       expect(source.displayName, 'Unknown Source');
     });
 
+    test('displayName prefers computerName (friendly name) over model', () {
+      final now = DateTime.now();
+      final source = DiveDataSource(
+        id: 'r1',
+        diveId: 'd1',
+        isPrimary: true,
+        computerName: 'My Perdix',
+        computerModel: 'Shearwater Perdix AI',
+        importedAt: now,
+        createdAt: now,
+      );
+
+      expect(source.displayName, 'My Perdix');
+    });
+
+    test('displayName falls back to model when computerName is null', () {
+      final now = DateTime.now();
+      final source = DiveDataSource(
+        id: 'r1',
+        diveId: 'd1',
+        isPrimary: true,
+        computerName: null,
+        computerModel: 'Shearwater Perdix AI',
+        importedAt: now,
+        createdAt: now,
+      );
+
+      expect(source.displayName, 'Shearwater Perdix AI');
+    });
+
+    test('computerLabel prefers friendly name, then model, then serial, '
+        'then the given fallback', () {
+      final now = DateTime.now();
+      DiveDataSource make({String? name, String? model, String? serial}) =>
+          DiveDataSource(
+            id: 'r1',
+            diveId: 'd1',
+            isPrimary: true,
+            computerName: name,
+            computerModel: model,
+            computerSerial: serial,
+            importedAt: now,
+            createdAt: now,
+          );
+
+      expect(
+        make(
+          name: 'My Perdix',
+          model: 'Perdix AI',
+          serial: 'SN1',
+        ).computerLabel('Unknown'),
+        'My Perdix',
+      );
+      expect(
+        make(model: 'Perdix AI', serial: 'SN1').computerLabel('Unknown'),
+        'Perdix AI',
+      );
+      expect(make(serial: 'SN1').computerLabel('Unknown'), 'SN1');
+      expect(make().computerLabel('Unknown'), 'Unknown');
+    });
+
     test('equality holds for identical field values', () {
       final now = DateTime(2026, 3, 20, 10, 0);
       final a = DiveDataSource(
@@ -176,17 +237,19 @@ void main() {
         id: 'r1',
         diveId: 'd1',
         isPrimary: true,
+        computerName: 'My Perdix',
         computerModel: 'Perdix',
         maxDepth: 30.0,
         importedAt: now,
         createdAt: now,
       );
 
-      // 29 fields total in props list
-      expect(source.props, hasLength(29));
+      // 30 fields total in props list
+      expect(source.props, hasLength(30));
       expect(source.props, contains('r1'));
       expect(source.props, contains('d1'));
       expect(source.props, contains(true));
+      expect(source.props, contains('My Perdix'));
       expect(source.props, contains('Perdix'));
       expect(source.props, contains(30.0));
     });

--- a/test/features/dive_log/domain/services/field_attribution_service_test.dart
+++ b/test/features/dive_log/domain/services/field_attribution_service_test.dart
@@ -6,6 +6,7 @@ DiveDataSource _makeSource({
   required String id,
   required String diveId,
   required bool isPrimary,
+  String? computerName,
   String? computerModel,
   String? sourceFormat,
   double? maxDepth,
@@ -21,6 +22,7 @@ DiveDataSource _makeSource({
     id: id,
     diveId: diveId,
     isPrimary: isPrimary,
+    computerName: computerName,
     computerModel: computerModel,
     sourceFormat: sourceFormat,
     maxDepth: maxDepth,
@@ -326,6 +328,35 @@ void main() {
       expect(result.containsKey('cns'), isFalse);
       expect(result.containsKey('otu'), isFalse);
       expect(result.containsKey('surfaceInterval'), isFalse);
+    });
+
+    test('uses the computer friendly name for attribution when set', () {
+      final primary = _makeSource(
+        id: 's1',
+        diveId: diveId,
+        isPrimary: true,
+        computerName: 'My Perdix',
+        computerModel: 'Shearwater Perdix AI',
+        sourceFormat: 'shearwater',
+        maxDepth: 30.0,
+        duration: 3600,
+      );
+      final secondary = _makeSource(
+        id: 's2',
+        diveId: diveId,
+        isPrimary: false,
+        computerModel: 'Suunto D5',
+        sourceFormat: 'suunto',
+        maxDepth: 31.0,
+      );
+
+      final result = FieldAttributionService.computeAttribution([
+        primary,
+        secondary,
+      ]);
+
+      expect(result['maxDepth'], equals('My Perdix'));
+      expect(result['bottomTime'], equals('My Perdix'));
     });
 
     test('uses Unknown Source display name when computerModel is null', () {

--- a/test/features/dive_log/presentation/widgets/data_sources_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/data_sources_section_test.dart
@@ -14,6 +14,7 @@ DiveDataSource _makeSource({
   String diveId = 'dive-1',
   String? computerId = 'comp-1',
   bool isPrimary = true,
+  String? computerName,
   String? computerModel = 'Shearwater Perdix',
   String? computerSerial = 'SN-12345',
   String? sourceFormat = 'SSRF',
@@ -38,6 +39,7 @@ DiveDataSource _makeSource({
     diveId: diveId,
     computerId: computerId,
     isPrimary: isPrimary,
+    computerName: computerName,
     computerModel: computerModel,
     computerSerial: computerSerial,
     sourceFormat: sourceFormat,
@@ -649,6 +651,59 @@ void main() {
       expect(find.text('Unknown Source'), findsOneWidget);
     });
 
+    testWidgets('shows friendly name as header with model as subtitle', (
+      tester,
+    ) async {
+      final source = _makeSource(
+        computerName: 'My Perdix',
+        computerModel: 'Shearwater Perdix AI',
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          child: SingleChildScrollView(
+            child: DataSourcesSection(
+              dataSources: [source],
+              diveCreatedAt: DateTime(2026, 3, 20, 10, 0),
+              diveId: 'dive-1',
+              units: _units,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Friendly name is the card title; the model appears as a subtitle.
+      expect(find.text('My Perdix'), findsOneWidget);
+      expect(find.text('Shearwater Perdix AI'), findsOneWidget);
+    });
+
+    testWidgets('omits model subtitle when friendly name equals the model', (
+      tester,
+    ) async {
+      final source = _makeSource(
+        computerName: 'Shearwater Perdix',
+        computerModel: 'Shearwater Perdix',
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          child: SingleChildScrollView(
+            child: DataSourcesSection(
+              dataSources: [source],
+              diveCreatedAt: DateTime(2026, 3, 20, 10, 0),
+              diveId: 'dive-1',
+              units: _units,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Rendered once as the header, not duplicated as a redundant subtitle.
+      expect(find.text('Shearwater Perdix'), findsOneWidget);
+    });
+
     testWidgets('omits serial and format labels when fields are null', (
       tester,
     ) async {
@@ -992,6 +1047,48 @@ void main() {
         );
       },
     );
+
+    testWidgets('column header uses the computer friendly name when set', (
+      tester,
+    ) async {
+      final primary = _makeSource(
+        id: 'src-1',
+        isPrimary: true,
+        computerName: 'My Perdix',
+        computerModel: 'Shearwater Perdix AI',
+        maxDepth: 30.1,
+      );
+      final secondary = _makeSource(
+        id: 'src-2',
+        isPrimary: false,
+        computerName: null,
+        computerModel: 'Shearwater Teric',
+        maxDepth: 30.4,
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          child: SingleChildScrollView(
+            child: DataSourcesSection(
+              dataSources: [primary, secondary],
+              diveCreatedAt: DateTime(2026, 3, 20, 10, 0),
+              diveId: 'dive-1',
+              units: _units,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final dataTable = tester.widget<DataTable>(find.byType(DataTable));
+      // Primary column shows the friendly name; secondary (no friendly name)
+      // falls back to its model snapshot.
+      expect((dataTable.columns[1].label as Text).data, equals('My Perdix'));
+      expect(
+        (dataTable.columns[2].label as Text).data,
+        equals('Shearwater Teric'),
+      );
+    });
 
     testWidgets('does not render a comparison grid when single-source', (
       tester,

--- a/test/features/dive_log/presentation/widgets/data_sources_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/data_sources_section_test.dart
@@ -1090,6 +1090,45 @@ void main() {
       );
     });
 
+    testWidgets(
+      'column header falls back to serial when name and model are absent',
+      (tester) async {
+        final primary = _makeSource(
+          id: 'src-1',
+          isPrimary: true,
+          computerModel: 'Shearwater Perdix',
+          maxDepth: 30.0,
+        );
+        final secondary = _makeSource(
+          id: 'src-2',
+          isPrimary: false,
+          computerName: null,
+          computerModel: null,
+          computerSerial: 'SN-ONLY-42',
+          maxDepth: 31.0,
+        );
+
+        await tester.pumpWidget(
+          testApp(
+            child: SingleChildScrollView(
+              child: DataSourcesSection(
+                dataSources: [primary, secondary],
+                diveCreatedAt: DateTime(2026, 3, 20, 10, 0),
+                diveId: 'dive-1',
+                units: _units,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final dataTable = tester.widget<DataTable>(find.byType(DataTable));
+        // No friendly name and no model: the serial identifies the column,
+        // not the generic "Unknown" label.
+        expect((dataTable.columns[2].label as Text).data, equals('SN-ONLY-42'));
+      },
+    );
+
     testWidgets('does not render a comparison grid when single-source', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

In dive detail, a dive computer was identified only by its model name (e.g. "Shearwater Perdix AI"). This PR shows the **user-assigned friendly name** (e.g. "My Perdix") instead, everywhere a computer is attributed on the dive-detail page, falling back to the model → serial → localized "Unknown" when no friendly name exists.

The friendly name lives on the registered `DiveComputers` row (`name`) and is linked from each data source via `computerId`. It's resolved **live** at read time, so renaming a computer updates the name shown on existing dives too.

## Changes

- `DiveDataSource`: new `computerName` field; `displayName` now prefers `computerName ?? computerModel ?? "Unknown Source"`; new `computerLabel(unknownLabel)` centralizes the localized fallback chain.
- `getDataSources`: batch-looks-up `DiveComputers.name` by the sources' `computerId`s and injects it as `computerName` (blank names treated as absent).
- **Data Source card**: header shows the friendly name; the model appears as a subtitle only when it differs (un-renamed computers show no redundant subtitle).
- **Comparison grid** column headers, **field attribution badges**, and **profile-chart computer labels**: all now show the friendly name via the shared getter/`computerLabel`.
- No schema change — purely presentational over an existing column.

## Test Plan

- [x] `flutter test` passes — affected + adjacent suites green (entity, attribution service, data-sources widget, repository lookup against a real in-memory DB, multi-computer integration, dive-detail page): 180+ tests. New behavior written test-first (red→green).
- [x] `flutter analyze` passes — whole project, no issues.
- [x] Manual testing on: **not yet** — visual pass pending; requires a dive linked to a *renamed* computer. Widget tests render the real `DataSourcesSection` and assert the name/subtitle.

## Screenshots

Not captured (visual pass pending). Card header renders as:

```
⌚ My Perdix            [Primary]
   Shearwater Perdix AI
Serial 12345 · Format dive_computer
```