### PR TITLE
fix(dive-profile): stop caching null analysis lost to a dive-load race

### DIFF
--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -632,22 +632,18 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
   diveId,
 ) async {
   try {
-    // Get the dive with profile data
-    final diveAsync = ref.watch(diveProvider(diveId));
-
-    // Await the dive data
-    final dive = await diveAsync.when(
-      data: (d) async => d,
-      loading: () async => null,
-      error: (e, st) async {
-        _log.error(
-          'Error loading dive for analysis: $diveId',
-          error: e,
-          stackTrace: st,
-        );
-        return null;
-      },
-    );
+    // Await the dive itself (not just its current AsyncValue snapshot). Reading
+    // `diveProvider(id).future` suspends this provider until the dive resolves,
+    // rather than mapping a momentary loading state to a resolved null. The old
+    // `ref.watch(diveProvider(id)).when(loading: () => null)` form committed an
+    // AsyncData(null) whenever the analysis built while the dive was still
+    // loading -- which a concurrent evaluator (residual-CNS/tissue/OTU lookback
+    // from another dive, or stats aggregation) reliably triggers, especially
+    // for the heavier merged profile of a multi-computer dive. Riverpod then
+    // retained that null and never recomputed until a detail-table write or an
+    // app restart, blanking every analysis-derived overlay and the deco/tissue
+    // panels in the meantime. Errors surface to the outer catch below.
+    final dive = await ref.watch(diveProvider(diveId).future);
 
     if (dive == null || dive.profile.isEmpty) {
       _log.debug('No profile data for dive $diveId');

--- a/test/features/dive_log/presentation/providers/profile_analysis_loading_race_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_analysis_loading_race_test.dart
@@ -1,0 +1,108 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Regression test for the multi-computer dive-profile overlay bug.
+///
+/// The dive detail page hid every analysis-derived overlay (deco/NDL/TTS/CNS
+/// curves, gas analysis, SAC) and the deco/tissue panels for dives with more
+/// than one dive computer, until the app was restarted.
+///
+/// Root cause: [profileAnalysisProvider] read the dive with
+/// `ref.watch(diveProvider(id)).when(loading: () => null)`. When the provider
+/// built while `diveProvider` was still loading -- which a concurrent evaluator
+/// (residual-CNS/tissue/OTU lookback from another dive, or stats aggregation)
+/// reliably triggers, more so for the heavier merged profile of a
+/// multi-computer dive -- it committed a *resolved* `AsyncData(null)` rather
+/// than suspending. Riverpod then retained that null, so the analysis never
+/// recomputed until a detail-table write or an app restart invalidated it.
+///
+/// This test reproduces the race directly: it reads
+/// `profileAnalysisProvider(id).future` as the first access to the provider
+/// (exactly what a lookback does) while `diveProvider(id)` is still loading.
+/// Before the fix the future completes with null; after the fix it awaits the
+/// dive and completes with a real analysis.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> seedDiveWithProfile(String diveId) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(diveId),
+            diveDateTime: Value(now),
+            maxDepth: const Value(30.0),
+            avgDepth: const Value(18.0),
+            bottomTime: const Value(1800),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+
+    // A simple descent -> bottom -> ascent profile, enough samples for the
+    // Buhlmann pass to emit a non-empty decoStatuses list.
+    final depths = <double>[0, 10, 20, 30, 30, 30, 30, 30, 20, 10, 6, 6, 3, 0];
+    await db.batch((batch) {
+      for (var i = 0; i < depths.length; i++) {
+        batch.insert(
+          db.diveProfiles,
+          DiveProfilesCompanion(
+            id: Value('$diveId-p$i'),
+            diveId: Value(diveId),
+            isPrimary: const Value(true),
+            timestamp: Value(i * 60),
+            depth: Value(depths[i]),
+          ),
+        );
+      }
+    });
+  }
+
+  test(
+    'analysis resolves even when read while diveProvider is still loading',
+    () async {
+      const diveId = 'race-dive';
+      await seedDiveWithProfile(diveId);
+
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      // First-ever access to profileAnalysisProvider is this .future read, so
+      // its build races diveProvider's load -- the exact bug condition.
+      final analysis = await container.read(
+        profileAnalysisProvider(diveId).future,
+      );
+
+      expect(
+        analysis,
+        isNotNull,
+        reason:
+            'analysis must not resolve to null just because diveProvider '
+            'was momentarily loading when the provider first built',
+      );
+      expect(analysis!.decoStatuses, isNotEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Dives with more than one dive computer showed a "data is missing" profile chart: the overlay menu collapsed to just Gases / Pressure Thresholds / Tank Pressures, and the deco/tissue panels below the chart disappeared — until the app was restarted, after which everything rendered correctly.

Root cause is a Riverpod loading-race that cached a *resolved* null, not anything wrong with the multi-computer data. `profileAnalysisProvider` (which feeds both the overlay menu and the deco/tissue panels) read the dive via `ref.watch(diveProvider(id)).when(loading: () async => null, …)`. When the analysis provider built while `diveProvider` was still loading, that branch committed an `AsyncData(null)` — a *finished* value, so Riverpod retained it and never recomputed until a detail-table write or an app restart.

A concurrent evaluator — the residual CNS/tissue/OTU lookback from another dive, or stats aggregation — reaches this provider via `ref.read(...future)` and reliably loses that race for the heavier merged profile of a multi-computer dive (≈2× the rows, plus a second tank and pressure series, so `diveProvider` resolves slower). With `analysis == null`, every analysis-derived overlay (ceiling, NDL, TTS, CNS, ppO₂, SAC, GF) and the deco/tissue panels blanked out. Single-computer dives resolve fast enough to usually win the race, and a restart — navigating straight to the dive with it already resolved — computes it correctly, which is the "works after restart" symptom.

## Changes

- `profileAnalysisProvider` now awaits `diveProvider(id).future` instead of mapping `diveProvider`'s momentary loading state to a resolved null. The provider suspends (stays `AsyncLoading`) until the dive resolves, still re-subscribes so the analysis recomputes on later dive edits, and errors surface to the existing outer `catch`.
- Also fixes silent zero-residuals when a residual CNS/tissue/OTU lookback lost the same race.
- Adds a regression test that reads the analysis future while the dive is still loading: it resolves to `null` before this change and to a real analysis after (verified by reverting).

## Test Plan

- [x] `flutter test` passes — new regression test plus 116 existing tests (66 provider + 50 detail-page/panel/fullscreen), including the deco/O2 and SAC last-good-retention tests
- [x] `flutter analyze` passes (changed files, no issues)
- [x] Manual testing on: macOS — open a dive with two associated computers without restarting and confirm the deco/gas overlays and deco/tissue panels render

## Screenshots

Before: multi-computer dive overlay menu limited to Gases / Pressure Thresholds / Tank Pressures, deco/tissue panels absent (see linked issue/report).
