### PR TITLE
feat(import): enable Consolidate action in dive computer import review

### DIFF
--- a/lib/core/presentation/widgets/dive_comparison_card.dart
+++ b/lib/core/presentation/widgets/dive_comparison_card.dart
@@ -450,7 +450,7 @@ class DiveComparisonCard extends ConsumerWidget {
         _ActionButton(
           label: 'Consolidate',
           subtitle: 'Add as 2nd computer reading',
-          onPressed: null, // Disabled — consolidation is under development.
+          onPressed: callbackFor(DuplicateAction.consolidate, onConsolidate),
           style: styleFor(
             DuplicateAction.consolidate,
             _ActionButtonStyle.outlined,

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -984,9 +984,13 @@ class _BulkActionRow extends StatelessWidget {
               ),
             ),
           if (availableActions.contains(DuplicateAction.consolidate))
-            // TODO(#200): enable when bulk-consolidate is implemented end-to-end.
             OutlinedButton.icon(
-              onPressed: null,
+              // Enabled only when at least one pending row qualifies for
+              // consolidation (score >= 0.7). With nothing to consolidate the
+              // button stays disabled rather than firing a no-op bulk action.
+              onPressed: matchableConsolidateCount > 0
+                  ? () => onBulkAction(DuplicateAction.consolidate)
+                  : null,
               icon: const Icon(Icons.merge_type, size: 16),
               label: Text(
                 context.l10n.universalImport_bulk_consolidateMatched(

--- a/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/entity_review_list.dart
@@ -297,14 +297,22 @@ class EntityReviewList extends StatelessWidget {
     return group.items.any((item) => item.diveData != null);
   }
 
-  /// Number of pending rows whose match score is high enough (>= 0.7) to
-  /// qualify for bulk consolidation.
+  /// Number of pending rows eligible for bulk consolidation.
+  ///
+  /// Mirrors the predicate in `ImportWizardNotifier.applyBulkAction`: a row
+  /// qualifies only when its match score is high enough (>= 0.7) AND it is not
+  /// a `matchedExistingSource` re-download (exact-source hits are never valid
+  /// consolidate targets). Keeping the two in sync ensures the displayed count
+  /// and button enablement match what a bulk tap actually consolidates.
   int _matchableConsolidateCount() {
     final matchResults = group.matchResults;
     if (matchResults == null) return 0;
-    return pendingIndices
-        .where((i) => (matchResults[i]?.score ?? 0) >= 0.7)
-        .length;
+    return pendingIndices.where((i) {
+      final match = matchResults[i];
+      return match != null &&
+          match.score >= 0.7 &&
+          !match.matchedExistingSource;
+    }).length;
   }
 
   String _itemCountText(int nonDuplicates, int duplicates, int selectedCount) {
@@ -985,9 +993,10 @@ class _BulkActionRow extends StatelessWidget {
             ),
           if (availableActions.contains(DuplicateAction.consolidate))
             OutlinedButton.icon(
-              // Enabled only when at least one pending row qualifies for
-              // consolidation (score >= 0.7). With nothing to consolidate the
-              // button stays disabled rather than firing a no-op bulk action.
+              // Enabled only when at least one pending row is eligible for
+              // consolidation (see _matchableConsolidateCount). With nothing to
+              // consolidate the button stays disabled rather than firing a
+              // no-op bulk action.
               onPressed: matchableConsolidateCount > 0
                   ? () => onBulkAction(DuplicateAction.consolidate)
                   : null,

--- a/test/core/presentation/widgets/dive_comparison_card_test.dart
+++ b/test/core/presentation/widgets/dive_comparison_card_test.dart
@@ -130,7 +130,9 @@ void main() {
         expect(importCalled, isTrue);
       });
 
-      testWidgets('Consolidate button is disabled', (tester) async {
+      testWidgets('Consolidate button fires onConsolidate callback', (
+        tester,
+      ) async {
         var consolidateCalled = false;
         await tester.pumpWidget(
           _buildCard(
@@ -144,12 +146,12 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // Consolidate button should be visible but disabled.
+        // Consolidate button is enabled and fires its callback on tap.
         expect(find.text('Consolidate'), findsOneWidget);
         await tester.tap(find.text('Consolidate'));
         await tester.pump();
 
-        expect(consolidateCalled, isFalse);
+        expect(consolidateCalled, isTrue);
       });
     },
   );
@@ -254,7 +256,7 @@ void main() {
       },
     );
 
-    testWidgets('Consolidate button is disabled in tri-state mode', (
+    testWidgets('tapping Consolidate calls onActionChanged with consolidate', (
       tester,
     ) async {
       DuplicateAction? received;
@@ -271,12 +273,12 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Consolidate button should be visible but disabled.
+      // Consolidate button is enabled and reports its action on tap.
       expect(find.text('Consolidate'), findsOneWidget);
       await tester.tap(find.text('Consolidate'));
       await tester.pump();
 
-      expect(received, isNull);
+      expect(received, DuplicateAction.consolidate);
     });
 
     testWidgets('availableActions hides Consolidate button when not in set', (

--- a/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
@@ -344,6 +344,39 @@ void main() {
 
       expect(firedAction, DuplicateAction.skip);
     });
+
+    testWidgets(
+      'tapping bulk Consolidate button fires onBulkAction with consolidate',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 1200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        DuplicateAction? firedAction;
+
+        // Both pending items have score >= 0.7, so the bulk consolidate
+        // button is enabled with a matched count of 2.
+        final group = EntityGroup(
+          items: [_dup0, _dup1],
+          duplicateIndices: const {0, 1},
+          matchResults: const {0: _highMatch, 1: _midMatch},
+        );
+
+        await tester.pumpWidget(
+          _pumpList(
+            group: group,
+            pendingIndices: const {0, 1},
+            onBulkAction: (a) => firedAction = a,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Consolidate matched (2)'));
+        await tester.pump();
+
+        expect(firedAction, DuplicateAction.consolidate);
+      },
+    );
   });
 
   group('EntityReviewList pending-first sort', () {

--- a/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
+++ b/test/features/import_wizard/presentation/widgets/entity_review_list_pending_test.dart
@@ -275,6 +275,45 @@ void main() {
       expect(find.text('Consolidate matched (2)'), findsOneWidget);
     });
 
+    testWidgets(
+      'consolidate count excludes matchedExistingSource re-downloads',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 1200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        // A high-score match that is an exact-source re-download. The provider's
+        // applyBulkAction excludes matchedExistingSource rows, so the count and
+        // button enablement must exclude them too (otherwise the button reads
+        // "matched (1)" yet a tap consolidates nothing).
+        const sourceHitMatch = DiveMatchResult(
+          diveId: _testDiveId,
+          score: 0.95,
+          timeDifferenceMs: 60000,
+          matchedExistingSource: true,
+        );
+
+        final group = EntityGroup(
+          items: [_dup0],
+          duplicateIndices: const {0},
+          matchResults: const {0: sourceHitMatch},
+        );
+
+        await tester.pumpWidget(
+          _pumpList(group: group, pendingIndices: const {0}),
+        );
+        await tester.pump();
+
+        // Count is 0 despite score >= 0.7, so the button stays disabled.
+        final finder = find.widgetWithText(
+          OutlinedButton,
+          'Consolidate matched (0)',
+        );
+        expect(finder, findsOneWidget);
+        expect(tester.widget<OutlinedButton>(finder).onPressed, isNull);
+      },
+    );
+
     testWidgets('Replace Source bulk button shown when action is available', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

Enables the **Consolidate** duplicate-resolution action in the dive computer
import review page, both the per-dive button and the bulk "Consolidate matched
(N)" button at the top of the list.

The consolidation engine was already fully wired end-to-end
(`DiveConsolidationService`, the adapter's import-then-fold in
`DiveComputerAdapter._consolidateDive`, the provider's `applyBulkAction`, and
the `>= 0.85` cross-computer auto-consolidate default) and already runs in
production for auto-consolidated dives. Only two leftover `onPressed: null` UI
gates — stale since #466 landed `DiveConsolidationService` — blocked users from
selecting it manually. This PR removes those gates.

## Changes

- **Per-dive Consolidate button** (`dive_comparison_card.dart`): route
  `onPressed` through the existing `callbackFor(...)` machinery like every other
  action button. Because this widget is shared, it enables the button in **both**
  the dive computer wizard and the universal file-import flow, each of which has
  a complete, tested execution path.
- **Bulk "Consolidate matched (N)" button** (`entity_review_list.dart`): enable
  it when `matchableConsolidateCount > 0`, wiring to the already-implemented
  `onBulkAction` → `applyBulkAction`. It stays disabled at `(0)` so it never
  fires a no-op. Removes the stale `TODO(#200)`.
- **Tests**: flip the two "Consolidate button is disabled" tests to assert the
  callback now fires (immediate-action and tri-state modes); add a "bulk
  Consolidate fires `onBulkAction`" test.

## Test Plan

- [x] `flutter test` passes — full `import_wizard` feature (614 tests) +
  `universal_import` presentation (425) + the consolidate integration test, all
  green; RED→GREEN confirmed for the three behavior tests.
- [x] `flutter analyze` passes — no issues (whole project).
- [x] Manual testing on: not yet exercised on a physical device / real download.
  Behavior is covered by widget tests that tap the button and assert the wired
  callback fires, plus the end-to-end consolidation integration test.

## Screenshots

Before: the per-dive **Consolidate** button and the bulk **Consolidate matched
(N)** button render greyed-out / non-tappable. After: both are enabled (bulk
enabled only when at least one pending row scores >= 0.7).