### PR TITLE
Fullscreen profile: always-visible draggable readout card

### DIFF
--- a/docs/superpowers/plans/2026-07-05-dive-planner-phase1-engine.md
+++ b/docs/superpowers/plans/2026-07-05-dive-planner-phase1-engine.md
@@ -1,0 +1,2948 @@
+# Dive Planner Phase 1: Deco Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the shared deco engine in `lib/core/deco/` with environment-aware pressure (altitude/salinity), CCR constant-ppO2 tissue loading, a schedule policy (gas-switch stops, air breaks), a `DecoModel` interface for future VPM-B, compressibility-correct gas consumption, and a golden-vector validation suite.
+
+**Architecture:** Evolve `BuhlmannAlgorithm` in place (new `DiveEnvironment` + `BreathingConfig` parameters, default values preserve current behavior exactly), then wrap it in a `BuhlmannGf implements DecoModel` facade. A Python reference implementation generates golden vectors that pin the engine's numerics independently of the Dart code.
+
+**Tech Stack:** Pure Dart (no Flutter imports in `lib/core/deco/`), flutter_test, python3 (vector generation only).
+
+**Spec:** `docs/superpowers/specs/2026-07-05-dive-planner-redesign-design.md`
+
+## Global Constraints
+
+- `lib/core/deco/` stays pure Dart: no Flutter imports (importing `lib/core/constants/enums.dart` is fine — it is pure Dart).
+- All engine math is metric and internal: meters, bar, liters, seconds.
+- **Behavior preservation:** `DiveEnvironment.standard` must reproduce today's numbers exactly (surface 1.0 bar, exactly 0.1 bar per meter). All 14 existing test files in `test/core/deco/` must pass UNCHANGED after every task. If one fails, the change is wrong — do not edit those tests.
+- Golden/test vector numbers must be computed with `python3` at implementation time — never from memory/recall. Steps that say "compute with python3" mean run the command and paste the actual output into the test.
+- Run `dart format .` (whole repo) before every commit; commits must also pass `flutter analyze` with no new issues (run without piping through `tail`/`head`).
+- Run specific test files (`flutter test test/core/deco/<file>.dart`), not broad directories, to avoid Bash timeouts. `test/core/deco/` as a whole is pure Dart and fast — it is the one directory-level run allowed.
+- Commit after each task (plan-approved work pre-authorizes these commits). No Co-Authored-By lines in commit messages.
+- Schema/database: NO changes in this phase.
+
+---
+
+### Task 1: DiveEnvironment entity
+
+**Files:**
+- Create: `lib/core/deco/entities/dive_environment.dart`
+- Test: `test/core/deco/dive_environment_test.dart`
+
+**Interfaces:**
+- Consumes: `AltitudeCalculator.calculateBarometricPressure(double)` from `lib/core/deco/altitude_calculator.dart`; `WaterType` enum from `lib/core/constants/enums.dart`.
+- Produces: `DiveEnvironment` with `surfacePressureBar`, `waterDensityKgM3`, `barPerMeter`, `pressureAtDepth(double)`, `depthAtPressure(double)`, `DiveEnvironment.standard`, `DiveEnvironment.forConditions({double? altitudeMeters, WaterType? waterType, double? surfacePressureBar})`. Every later task depends on these exact names.
+
+- [ ] **Step 1: Compute expected test values with python3**
+
+Run:
+```bash
+python3 -c "
+g = 9.80665
+for name, rho in [('fresh', 1000.0), ('brackish', 1010.0), ('en13319', 1019.716213), ('salt', 1025.0)]:
+    bpm = rho * g / 100000.0
+    print(name, 'barPerMeter =', repr(bpm), ' P@30m =', repr(1.0 + 30.0 * bpm))
+p0, L, exp = 1.01325, 0.0000225577, 5.25588
+print('surface@2000m =', repr(p0 * (1 - L * 2000.0) ** exp))
+"
+```
+Record the printed values; they go into the test below (replace the `closeTo` targets with the exact printed numbers — the values shown below are what python3 should print, verify they match).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `test/core/deco/dive_environment_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+
+void main() {
+  group('DiveEnvironment', () {
+    test('standard reproduces legacy 1 bar surface and 10 m/bar exactly', () {
+      const env = DiveEnvironment.standard;
+      expect(env.surfacePressureBar, 1.0);
+      expect(env.barPerMeter, closeTo(0.1, 1e-9));
+      expect(env.pressureAtDepth(30.0), closeTo(4.0, 1e-7));
+      expect(env.depthAtPressure(4.0), closeTo(30.0, 1e-6));
+    });
+
+    test('salt water is denser than standard', () {
+      const env = DiveEnvironment(
+        waterDensityKgM3: DiveEnvironment.saltWaterDensity,
+      );
+      // python3: 1025 * 9.80665 / 100000 = 0.1005181625
+      expect(env.barPerMeter, closeTo(0.1005181625, 1e-9));
+      expect(env.pressureAtDepth(30.0), closeTo(4.015544875, 1e-7));
+    });
+
+    test('fresh water is lighter than standard', () {
+      const env = DiveEnvironment(
+        waterDensityKgM3: DiveEnvironment.freshWaterDensity,
+      );
+      // python3: 1000 * 9.80665 / 100000 = 0.0980665
+      expect(env.barPerMeter, closeTo(0.0980665, 1e-9));
+      expect(env.pressureAtDepth(30.0), closeTo(3.941995, 1e-6));
+    });
+
+    test('forConditions with altitude uses barometric pressure', () {
+      final env = DiveEnvironment.forConditions(altitudeMeters: 2000.0);
+      // python3 ISA: 1.01325 * (1 - 0.0000225577*2000)^5.25588
+      expect(env.surfacePressureBar, closeTo(0.7950, 0.001));
+      expect(env.surfacePressureBar, lessThan(1.0));
+    });
+
+    test('forConditions maps water types to densities', () {
+      expect(
+        DiveEnvironment.forConditions(waterType: WaterType.fresh)
+            .waterDensityKgM3,
+        DiveEnvironment.freshWaterDensity,
+      );
+      expect(
+        DiveEnvironment.forConditions(waterType: WaterType.salt)
+            .waterDensityKgM3,
+        DiveEnvironment.saltWaterDensity,
+      );
+      expect(
+        DiveEnvironment.forConditions(waterType: WaterType.brackish)
+            .waterDensityKgM3,
+        DiveEnvironment.brackishWaterDensity,
+      );
+      expect(
+        DiveEnvironment.forConditions().waterDensityKgM3,
+        DiveEnvironment.en13319Density,
+      );
+    });
+
+    test('forConditions: explicit surface pressure wins over altitude', () {
+      final env = DiveEnvironment.forConditions(
+        altitudeMeters: 2000.0,
+        surfacePressureBar: 0.9,
+      );
+      expect(env.surfacePressureBar, 0.9);
+    });
+
+    test('forConditions: null altitude keeps legacy 1.0 bar', () {
+      expect(
+        DiveEnvironment.forConditions().surfacePressureBar,
+        1.0,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/dive_environment_test.dart`
+Expected: FAIL — `dive_environment.dart` does not exist.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `lib/core/deco/entities/dive_environment.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/deco/altitude_calculator.dart';
+
+/// Physical environment for decompression calculations.
+///
+/// Replaces the engine's historical hardcoded assumptions (1.0 bar surface,
+/// exactly 10 m of water per bar). [standard] reproduces those assumptions
+/// exactly so existing behavior is preserved wherever no environment is
+/// supplied.
+class DiveEnvironment extends Equatable {
+  /// Atmospheric pressure at the dive site surface, in bar.
+  final double surfacePressureBar;
+
+  /// Water density in kg/m3.
+  final double waterDensityKgM3;
+
+  const DiveEnvironment({
+    this.surfacePressureBar = 1.0,
+    this.waterDensityKgM3 = en13319Density,
+  });
+
+  /// Fresh water density (kg/m3).
+  static const double freshWaterDensity = 1000.0;
+
+  /// Brackish water density (kg/m3).
+  static const double brackishWaterDensity = 1010.0;
+
+  /// EN13319 dive-computer standard density: exactly 1 bar per 10 m.
+  static const double en13319Density = 1019.716213;
+
+  /// Sea water density (kg/m3).
+  static const double saltWaterDensity = 1025.0;
+
+  /// Legacy-equivalent default: 1.0 bar surface, exactly 10 m/bar.
+  static const DiveEnvironment standard = DiveEnvironment();
+
+  /// Build an environment from dive conditions.
+  ///
+  /// An explicit [surfacePressureBar] wins over [altitudeMeters]. A null
+  /// altitude keeps the legacy 1.0 bar surface so dives without altitude
+  /// data are unchanged.
+  factory DiveEnvironment.forConditions({
+    double? altitudeMeters,
+    WaterType? waterType,
+    double? surfacePressureBar,
+  }) {
+    final surface =
+        surfacePressureBar ??
+        (altitudeMeters != null
+            ? AltitudeCalculator.calculateBarometricPressure(altitudeMeters)
+            : 1.0);
+    final density = switch (waterType) {
+      WaterType.fresh => freshWaterDensity,
+      WaterType.brackish => brackishWaterDensity,
+      WaterType.salt => saltWaterDensity,
+      null => en13319Density,
+    };
+    return DiveEnvironment(
+      surfacePressureBar: surface,
+      waterDensityKgM3: density,
+    );
+  }
+
+  static const double _gravity = 9.80665;
+
+  /// Pressure increase per meter of depth, in bar.
+  double get barPerMeter => waterDensityKgM3 * _gravity / 100000.0;
+
+  /// Absolute ambient pressure at [depthMeters], in bar.
+  double pressureAtDepth(double depthMeters) =>
+      surfacePressureBar + depthMeters * barPerMeter;
+
+  /// Depth in meters at absolute [pressureBar].
+  double depthAtPressure(double pressureBar) =>
+      (pressureBar - surfacePressureBar) / barPerMeter;
+
+  @override
+  List<Object?> get props => [surfacePressureBar, waterDensityKgM3];
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `flutter test test/core/deco/dive_environment_test.dart`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/entities/dive_environment.dart test/core/deco/dive_environment_test.dart
+git commit -m "feat(deco): add DiveEnvironment for altitude and salinity aware pressure"
+```
+
+---
+
+### Task 2: Pressure-space ceiling on TissueCompartment; env-aware SurfGF on DecoStatus
+
+**Files:**
+- Modify: `lib/core/deco/entities/tissue_compartment.dart` (ceiling method, ~line 103-116)
+- Modify: `lib/core/deco/entities/deco_status.dart` (surfGf, constructor, copyWith, props)
+- Test: `test/core/deco/tissue_compartment_env_test.dart`
+
+**Interfaces:**
+- Produces: `TissueCompartment.ceilingPressureBar({double gf})` returning absolute pressure in bar (no depth conversion — the algorithm converts via `DiveEnvironment`). `DecoStatus.surfacePressureBar` field (default 1.0) used by `surfGf`.
+- The legacy `TissueCompartment.ceiling({gf})` keeps its exact current behavior (1 bar surface, 10 m/bar) for existing widget consumers.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/deco/tissue_compartment_env_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/entities/deco_status.dart';
+import 'package:submersion/core/deco/entities/tissue_compartment.dart';
+
+TissueCompartment _comp1({double pN2 = 2.5, double pHe = 0.0}) {
+  return TissueCompartment(
+    compartmentNumber: 1,
+    halfTimeN2: zhl16cN2HalfTimes[0],
+    halfTimeHe: zhl16cHeHalfTimes[0],
+    mValueAN2: zhl16cN2A[0],
+    mValueBN2: zhl16cN2B[0],
+    mValueAHe: zhl16cHeA[0],
+    mValueBHe: zhl16cHeB[0],
+    currentPN2: pN2,
+    currentPHe: pHe,
+  );
+}
+
+void main() {
+  test('ceilingPressureBar is the pressure form of the legacy ceiling', () {
+    final comp = _comp1();
+    // Legacy: meters = (pBar - 1.0) * 10.0, clamped at 0.
+    final pBar = comp.ceilingPressureBar(gf: 0.8);
+    final legacyMeters = comp.ceiling(gf: 0.8);
+    expect(legacyMeters, closeTo(((pBar - 1.0) * 10.0).clamp(0, 999), 1e-9));
+  });
+
+  test('ceilingPressureBar can be below 1 bar (clean tissue)', () {
+    final comp = _comp1(pN2: inspiredSurfaceN2Bar);
+    expect(comp.ceilingPressureBar(gf: 1.0), lessThan(1.0));
+    expect(comp.ceiling(gf: 1.0), 0.0); // legacy clamps to 0
+  });
+
+  test('DecoStatus.surfGf evaluates at its surfacePressureBar', () {
+    final comp = _comp1(pN2: 2.5);
+    final atSeaLevel = DecoStatus(
+      compartments: [comp],
+      ndlSeconds: -1,
+      ceilingMeters: 5,
+      ttsSeconds: 600,
+      gfLow: 0.3,
+      gfHigh: 0.7,
+      decoStops: const [],
+      currentDepthMeters: 10,
+      ambientPressureBar: 2.0,
+    );
+    final atAltitude = atSeaLevel.copyWith(surfacePressureBar: 0.795);
+    // Lower surface pressure -> bigger supersaturation gradient at surface.
+    expect(atAltitude.surfGf, greaterThan(atSeaLevel.surfGf));
+    // Default (1.0 bar) matches the legacy surfaceGradientFactor path.
+    expect(
+      atSeaLevel.surfGf,
+      closeTo((comp.surfaceGradientFactor * 100.0).clamp(0.0, 9999), 1e-9),
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/tissue_compartment_env_test.dart`
+Expected: FAIL — `ceilingPressureBar` and `surfacePressureBar` are not defined.
+
+- [ ] **Step 3: Implement**
+
+In `lib/core/deco/entities/tissue_compartment.dart`, replace the existing `ceiling` method (lines 103-116) with:
+
+```dart
+  /// Ceiling as an absolute ambient pressure in bar for this compartment,
+  /// with gradient factor [gf] applied. Depth conversion is the caller's
+  /// job (via DiveEnvironment) so this stays environment-agnostic.
+  double ceilingPressureBar({double gf = 1.0}) {
+    final a = blendedA;
+    final b = blendedB;
+    return (totalInertGas - a * gf) / (gf / b + 1 - gf);
+  }
+
+  /// Calculate ceiling (minimum safe depth) in meters for this compartment
+  /// using gradient factor to add conservatism.
+  ///
+  /// LEGACY: assumes 1.0 bar surface and 10 m/bar. The Buhlmann engine now
+  /// converts [ceilingPressureBar] through its DiveEnvironment instead;
+  /// this remains for display widgets that predate environments.
+  double ceiling({double gf = 1.0}) {
+    final ceilingMeters = (ceilingPressureBar(gf: gf) - 1.0) * 10.0;
+    return ceilingMeters < 0 ? 0 : ceilingMeters;
+  }
+```
+
+In `lib/core/deco/entities/deco_status.dart`:
+
+1. Add the field after `ambientPressureBar` (line 43):
+
+```dart
+  /// Surface pressure in bar used for surface-referenced metrics (SurfGF).
+  final double surfacePressureBar;
+```
+
+2. Add to the constructor (after `required this.ambientPressureBar,`):
+
+```dart
+    this.surfacePressureBar = 1.0,
+```
+
+3. Replace the `surfGf` getter body's use of `comp.surfaceGradientFactor`:
+
+```dart
+  double get surfGf {
+    if (compartments.isEmpty) return 0.0;
+    double maxGf = double.negativeInfinity;
+    for (final comp in compartments) {
+      final gf = comp.gradientFactor(surfacePressureBar);
+      if (gf > maxGf) maxGf = gf;
+    }
+    // Clamp at 0: negative SurfGF means all tissues are below surface
+    // equilibrium, which is not meaningful to display.
+    return (maxGf * 100.0).clamp(0.0, double.infinity);
+  }
+```
+
+4. Add `surfacePressureBar` to `copyWith` (parameter `double? surfacePressureBar` and `surfacePressureBar: surfacePressureBar ?? this.surfacePressureBar`) and to the `props` list.
+
+Note: `comp.gradientFactor(1.0)` equals `comp.surfaceGradientFactor` by construction, so the default is behavior-identical.
+
+- [ ] **Step 4: Run tests**
+
+Run: `flutter test test/core/deco/tissue_compartment_env_test.dart test/core/deco/tissue_compartment_gf_test.dart test/core/deco/deco_status_gf_test.dart`
+Expected: PASS (new and existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/entities/tissue_compartment.dart lib/core/deco/entities/deco_status.dart test/core/deco/tissue_compartment_env_test.dart
+git commit -m "feat(deco): pressure-space compartment ceiling and env-aware SurfGF"
+```
+
+---
+
+### Task 3: Thread DiveEnvironment through BuhlmannAlgorithm
+
+**Files:**
+- Modify: `lib/core/deco/buhlmann_algorithm.dart`
+- Test: `test/core/deco/buhlmann_environment_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveEnvironment` (Task 1), `ceilingPressureBar` (Task 2).
+- Produces: `BuhlmannAlgorithm({..., DiveEnvironment environment = DiveEnvironment.standard})`; `algorithm.environment`; `algorithm.restoreState(List<TissueCompartment> compartments, {double gfLowCeilingAnchor = 0.0})`; `double get gfLowCeilingAnchor`. Tasks 5, 7, 9, 11 rely on these exact names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/deco/buhlmann_environment_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+
+void main() {
+  group('BuhlmannAlgorithm with DiveEnvironment', () {
+    test('default environment reproduces legacy results', () {
+      final legacy = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+      final explicit = BuhlmannAlgorithm(
+        gfLow: 0.5,
+        gfHigh: 0.8,
+        environment: DiveEnvironment.standard,
+      );
+      for (final algo in [legacy, explicit]) {
+        algo.calculateSegment(depthMeters: 30, durationSeconds: 25 * 60);
+      }
+      expect(
+        legacy.calculateNdl(depthMeters: 30),
+        explicit.calculateNdl(depthMeters: 30),
+      );
+      expect(legacy.compartments, explicit.compartments);
+    });
+
+    test('altitude shortens NDL for the same exposure', () {
+      final seaLevel = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+      final altitude = BuhlmannAlgorithm(
+        gfLow: 0.5,
+        gfHigh: 0.8,
+        environment: DiveEnvironment.forConditions(altitudeMeters: 2000),
+      );
+      final ndlSea = seaLevel.calculateNdl(depthMeters: 25);
+      final ndlAlt = altitude.calculateNdl(depthMeters: 25);
+      expect(ndlAlt, lessThan(ndlSea));
+    });
+
+    test('altitude produces more deco for the same dive', () {
+      int decoSeconds(DiveEnvironment env) {
+        final algo = BuhlmannAlgorithm(
+          gfLow: 0.5,
+          gfHigh: 0.8,
+          environment: env,
+        );
+        algo.calculateSegment(depthMeters: 40, durationSeconds: 25 * 60);
+        return algo.calculateTts(currentDepth: 40);
+      }
+
+      expect(
+        decoSeconds(DiveEnvironment.forConditions(altitudeMeters: 2500)),
+        greaterThan(decoSeconds(DiveEnvironment.standard)),
+      );
+    });
+
+    test('fresh water gives slightly longer NDL than salt at same depth', () {
+      final salt = BuhlmannAlgorithm(
+        gfLow: 0.5,
+        gfHigh: 0.8,
+        environment: const DiveEnvironment(
+          waterDensityKgM3: DiveEnvironment.saltWaterDensity,
+        ),
+      );
+      final fresh = BuhlmannAlgorithm(
+        gfLow: 0.5,
+        gfHigh: 0.8,
+        environment: const DiveEnvironment(
+          waterDensityKgM3: DiveEnvironment.freshWaterDensity,
+        ),
+      );
+      expect(
+        fresh.calculateNdl(depthMeters: 30),
+        greaterThanOrEqualTo(salt.calculateNdl(depthMeters: 30)),
+      );
+    });
+
+    test('surface saturation at altitude starts below sea-level tension', () {
+      final altitude = BuhlmannAlgorithm(
+        environment: DiveEnvironment.forConditions(altitudeMeters: 2000),
+      );
+      final seaLevel = BuhlmannAlgorithm();
+      expect(
+        altitude.compartments.first.currentPN2,
+        lessThan(seaLevel.compartments.first.currentPN2),
+      );
+    });
+
+    test('restoreState round-trips compartments and anchor', () {
+      final algo = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+      algo.calculateSegment(depthMeters: 40, durationSeconds: 20 * 60);
+      final savedComps = algo.compartments;
+      final savedAnchor = algo.gfLowCeilingAnchor;
+
+      final other = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+      other.restoreState(savedComps, gfLowCeilingAnchor: savedAnchor);
+      expect(other.compartments, savedComps);
+      expect(other.gfLowCeilingAnchor, savedAnchor);
+      expect(
+        other.calculateTts(currentDepth: 40),
+        algo.calculateTts(currentDepth: 40),
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/buhlmann_environment_test.dart`
+Expected: FAIL — no `environment` parameter, no `restoreState`, no `gfLowCeilingAnchor` getter.
+
+- [ ] **Step 3: Implement in `lib/core/deco/buhlmann_algorithm.dart`**
+
+1. Add import:
+
+```dart
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+```
+
+2. Add field and constructor parameter; make the initial compartments environment-aware:
+
+```dart
+  /// Physical environment (surface pressure, water density).
+  final DiveEnvironment environment;
+
+  BuhlmannAlgorithm({
+    this.gfLow = 0.30,
+    this.gfHigh = 0.70,
+    this.lastStopDepth = 3.0,
+    this.stopIncrement = 3.0,
+    this.ascentRate = 9.0,
+    this.environment = DiveEnvironment.standard,
+  }) : _compartments = _createSurfaceSaturatedCompartments(environment);
+```
+
+3. Change `_createSurfaceSaturatedCompartments` to take the environment:
+
+```dart
+  static List<TissueCompartment> _createSurfaceSaturatedCompartments(
+    DiveEnvironment environment,
+  ) {
+    final compartments = <TissueCompartment>[];
+
+    // Surface N2 tension = inspired N2 at the site's surface pressure.
+    final surfaceN2 = calculateInspiredN2(
+      environment.surfacePressureBar,
+      airN2Fraction,
+    );
+    // ... rest identical, using surfaceN2 as before ...
+```
+
+Update `reset()` to call `_createSurfaceSaturatedCompartments(environment)`.
+
+4. Add a single ceiling-conversion helper and use it in the three ceiling scans (`_updateGfAnchor`, `calculateCeiling`, `_calculateSurfaceTargetCeiling`), replacing every `comp.ceiling(gf: ...)` call inside this class:
+
+```dart
+  /// Compartment ceiling in meters under this algorithm's environment.
+  double _ceilingMetersFor(TissueCompartment comp, double gf) {
+    final meters = environment.depthAtPressure(
+      comp.ceilingPressureBar(gf: gf),
+    );
+    return meters < 0 ? 0 : meters;
+  }
+```
+
+Example — `_updateGfAnchor` becomes:
+
+```dart
+  void _updateGfAnchor() {
+    double ceiling = 0;
+    for (final comp in _compartments) {
+      final c = _ceilingMetersFor(comp, gfLow);
+      if (c > ceiling) ceiling = c;
+    }
+    if (ceiling > _gfLowCeilingAnchor) _gfLowCeilingAnchor = ceiling;
+  }
+```
+
+Apply the same substitution in `calculateCeiling` (with the interpolated `gf`) and `_calculateSurfaceTargetCeiling` (with `gfHigh`).
+
+5. In `calculateSegment`, replace the ambient-pressure line:
+
+```dart
+    final ambientPressure = environment.pressureAtDepth(depthMeters);
+```
+
+6. In `getDecoStatus`, replace the `ambientPressureBar` argument and pass the surface pressure:
+
+```dart
+      currentDepthMeters: currentDepth,
+      ambientPressureBar: environment.pressureAtDepth(currentDepth),
+      surfacePressureBar: environment.surfacePressureBar,
+```
+
+7. Add the state accessors after `setCompartments`:
+
+```dart
+  /// Deepest GF-low ceiling reached so far this dive (meters).
+  double get gfLowCeilingAnchor => _gfLowCeilingAnchor;
+
+  /// Restore a previously captured tissue state (compartments + GF anchor).
+  /// Unlike [setCompartments], this does NOT re-derive the anchor: pass the
+  /// anchor captured alongside the compartments so mid-dive state (e.g. the
+  /// DecoModel facade) round-trips exactly.
+  void restoreState(
+    List<TissueCompartment> compartments, {
+    double gfLowCeilingAnchor = 0.0,
+  }) {
+    if (compartments.length == zhl16CompartmentCount) {
+      _compartments = List.from(compartments);
+      _gfLowCeilingAnchor = gfLowCeilingAnchor;
+    }
+  }
+```
+
+- [ ] **Step 4: Run the new test AND the full existing deco suite**
+
+Run: `flutter test test/core/deco/`
+Expected: ALL PASS. The existing 14 files must pass unchanged (standard environment is numerically identical: surface 1.0 bar, 0.1 bar/m to within 1e-9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/buhlmann_algorithm.dart test/core/deco/buhlmann_environment_test.dart
+git commit -m "feat(deco): thread DiveEnvironment through the Buhlmann engine"
+```
+
+---
+
+### Task 4: BreathingConfig (open circuit, CCR constant-ppO2, SCR)
+
+**Files:**
+- Create: `lib/core/deco/entities/breathing_config.dart`
+- Test: `test/core/deco/breathing_config_test.dart`
+
+**Interfaces:**
+- Consumes: `waterVaporPressure` constant from `buhlmann_coefficients.dart`; `ScrCalculator.calculateCmfSteadyStateFo2` from `scr_calculator.dart`.
+- Produces: `InspiredGas{pN2, pHe, pO2}`; `sealed class BreathingConfig` with `InspiredGas inspiredAt(double ambientPressureBar)`; `OpenCircuit({required double fO2, double fHe})`; `ClosedCircuit({required double setpoint, required double diluentFO2, double diluentFHe})`; `Scr({required double supplyFO2, double supplyFHe, required double injectionRateLpm, double vo2})`. Tasks 5, 7, 9 use these exact constructors.
+
+- [ ] **Step 1: Compute CCR expected values with python3**
+
+Run:
+```bash
+python3 -c "
+wv = 0.0627
+amb = 5.0                      # 40 m in standard env
+p_alv = amb - wv
+sp = 1.3
+p_inert = p_alv - sp
+f_n2, f_he = 0.37, 0.45        # Tx 18/45 diluent
+share_n2 = f_n2 / (f_n2 + f_he)
+print('pN2 =', repr(p_inert * share_n2))
+print('pHe =', repr(p_inert * (1 - share_n2)))
+# shallow clamp: 3 m, amb 1.3, setpoint 1.3 > p_alv
+amb2 = 1.3
+p_alv2 = amb2 - wv
+print('shallow pO2 =', repr(min(1.3, p_alv2)), 'inert =', repr(max(p_alv2 - min(1.3, p_alv2), 0.0)))
+# OC air at 30 m
+print('oc pN2 @30m =', repr((4.0 - wv) * 0.7902))
+"
+```
+Paste the exact printed values into the test expectations below (verify the ones shown match).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `test/core/deco/breathing_config_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/entities/breathing_config.dart';
+
+void main() {
+  group('OpenCircuit', () {
+    test('matches the legacy inspired-gas helpers', () {
+      const oc = OpenCircuit(fO2: 0.2098, fHe: 0.0);
+      final inspired = oc.inspiredAt(4.0); // 30 m standard
+      // python3: (4.0 - 0.0627) * 0.7902 = 3.11122446
+      expect(inspired.pN2, closeTo(calculateInspiredN2(4.0, oc.fN2), 1e-12));
+      expect(inspired.pN2, closeTo(3.11122446, 1e-6));
+      expect(inspired.pHe, 0.0);
+    });
+
+    test('trimix splits inert pressures by fraction', () {
+      const oc = OpenCircuit(fO2: 0.18, fHe: 0.45);
+      final inspired = oc.inspiredAt(7.0); // 60 m standard
+      expect(inspired.pHe, closeTo((7.0 - waterVaporPressure) * 0.45, 1e-12));
+      expect(inspired.pN2, closeTo((7.0 - waterVaporPressure) * 0.37, 1e-12));
+    });
+  });
+
+  group('ClosedCircuit', () {
+    test('constant ppO2 at depth: inert = alveolar minus setpoint', () {
+      const ccr = ClosedCircuit(
+        setpoint: 1.3,
+        diluentFO2: 0.18,
+        diluentFHe: 0.45,
+      );
+      final inspired = ccr.inspiredAt(5.0); // 40 m standard
+      expect(inspired.pO2, closeTo(1.3, 1e-12));
+      // python3 values from Step 1:
+      expect(inspired.pN2, closeTo(1.641243902439024, 1e-9));
+      expect(inspired.pHe, closeTo(1.996056097560976, 1e-9));
+    });
+
+    test('shallow clamp: loop goes pure O2 when setpoint >= alveolar', () {
+      const ccr = ClosedCircuit(
+        setpoint: 1.3,
+        diluentFO2: 0.18,
+        diluentFHe: 0.45,
+      );
+      final inspired = ccr.inspiredAt(1.3); // 3 m standard
+      expect(inspired.pO2, closeTo(1.3 - waterVaporPressure, 1e-12));
+      expect(inspired.pN2, 0.0);
+      expect(inspired.pHe, 0.0);
+    });
+
+    test('CCR loads less inert gas than OC on the diluent at depth', () {
+      const ccr = ClosedCircuit(
+        setpoint: 1.3,
+        diluentFO2: 0.18,
+        diluentFHe: 0.45,
+      );
+      const oc = OpenCircuit(fO2: 0.18, fHe: 0.45);
+      final ambient = 5.0;
+      final ccrInert =
+          ccr.inspiredAt(ambient).pN2 + ccr.inspiredAt(ambient).pHe;
+      final ocInert = oc.inspiredAt(ambient).pN2 + oc.inspiredAt(ambient).pHe;
+      expect(ccrInert, lessThan(ocInert));
+    });
+  });
+
+  group('Scr', () {
+    test('steady-state loop is leaner than the supply gas', () {
+      final scr = Scr(
+        supplyFO2: 0.32,
+        injectionRateLpm: 10.0,
+        vo2: 1.3,
+      );
+      final inspired = scr.inspiredAt(3.0); // 20 m standard
+      final supply = const OpenCircuit(fO2: 0.32).inspiredAt(3.0);
+      expect(inspired.pO2, lessThan(supply.pO2));
+      expect(inspired.pN2, greaterThan(supply.pN2));
+    });
+
+    test('preserves the supply He:N2 ratio in the loop', () {
+      final scr = Scr(
+        supplyFO2: 0.30,
+        supplyFHe: 0.30,
+        injectionRateLpm: 10.0,
+      );
+      final inspired = scr.inspiredAt(4.0);
+      // Supply inert split is 30 He / 40 N2 -> He share 0.4285714...
+      expect(
+        inspired.pHe / (inspired.pHe + inspired.pN2),
+        closeTo(0.30 / 0.70, 1e-9),
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/breathing_config_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `lib/core/deco/entities/breathing_config.dart`:
+
+```dart
+import 'dart:math' as math;
+
+import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
+import 'package:submersion/core/deco/scr_calculator.dart';
+
+/// Partial pressures of the inspired gas at some ambient pressure.
+class InspiredGas {
+  const InspiredGas({
+    required this.pN2,
+    required this.pHe,
+    required this.pO2,
+  });
+
+  final double pN2;
+  final double pHe;
+  final double pO2;
+}
+
+/// What the diver is breathing, independent of depth.
+///
+/// The engine asks a BreathingConfig for inspired partial pressures at an
+/// ambient pressure; open circuit, constant-ppO2 CCR, and steady-state SCR
+/// answer differently. All account for alveolar water vapor.
+sealed class BreathingConfig {
+  const BreathingConfig();
+
+  /// Inspired partial pressures at [ambientPressureBar].
+  InspiredGas inspiredAt(double ambientPressureBar);
+}
+
+/// Open circuit: fixed gas fractions at ambient pressure.
+class OpenCircuit extends BreathingConfig {
+  const OpenCircuit({required this.fO2, this.fHe = 0.0});
+
+  final double fO2;
+  final double fHe;
+
+  double get fN2 => 1.0 - fO2 - fHe;
+
+  @override
+  InspiredGas inspiredAt(double ambientPressureBar) {
+    final pAlv = math.max(ambientPressureBar - waterVaporPressure, 0.0);
+    return InspiredGas(pN2: pAlv * fN2, pHe: pAlv * fHe, pO2: pAlv * fO2);
+  }
+}
+
+/// Closed-circuit rebreather at a constant ppO2 setpoint.
+///
+/// Inspired inert pressure is what remains of the alveolar pressure after
+/// the setpoint's O2, split by the diluent's N2:He ratio. Shallower than
+/// the setpoint the loop is effectively pure O2 (the O2 pressure is capped
+/// by the available alveolar pressure).
+class ClosedCircuit extends BreathingConfig {
+  const ClosedCircuit({
+    required this.setpoint,
+    required this.diluentFO2,
+    this.diluentFHe = 0.0,
+  });
+
+  final double setpoint;
+  final double diluentFO2;
+  final double diluentFHe;
+
+  double get diluentFN2 => 1.0 - diluentFO2 - diluentFHe;
+
+  @override
+  InspiredGas inspiredAt(double ambientPressureBar) {
+    final pAlv = math.max(ambientPressureBar - waterVaporPressure, 0.0);
+    final pO2 = math.min(setpoint, pAlv);
+    final pInert = math.max(pAlv - pO2, 0.0);
+    final inertFraction = diluentFN2 + diluentFHe;
+    if (inertFraction <= 0) {
+      return InspiredGas(pN2: 0, pHe: 0, pO2: pAlv);
+    }
+    final n2Share = diluentFN2 / inertFraction;
+    return InspiredGas(
+      pN2: pInert * n2Share,
+      pHe: pInert * (1.0 - n2Share),
+      pO2: pO2,
+    );
+  }
+}
+
+/// CMF semi-closed rebreather at steady state.
+///
+/// The loop behaves like open circuit on the steady-state loop mix derived
+/// from the supply gas via [ScrCalculator.calculateCmfSteadyStateFo2]. The
+/// supply's He:N2 ratio is preserved in the loop (metabolism only removes
+/// O2). If the flow is insufficient (hypoxic), the supply mix is used and
+/// callers surface that as a warning.
+class Scr extends BreathingConfig {
+  Scr({
+    required this.supplyFO2,
+    this.supplyFHe = 0.0,
+    required this.injectionRateLpm,
+    this.vo2 = ScrCalculator.defaultVo2,
+  }) : _loop = _steadyStateLoop(supplyFO2, supplyFHe, injectionRateLpm, vo2);
+
+  final double supplyFO2;
+  final double supplyFHe;
+  final double injectionRateLpm;
+  final double vo2;
+  final OpenCircuit _loop;
+
+  static OpenCircuit _steadyStateLoop(
+    double supplyFO2,
+    double supplyFHe,
+    double injectionRateLpm,
+    double vo2,
+  ) {
+    final loopFO2 =
+        ScrCalculator.calculateCmfSteadyStateFo2(
+          injectionRateLpm: injectionRateLpm,
+          supplyO2Percent: supplyFO2 * 100.0,
+          vo2: vo2,
+        ) ??
+        supplyFO2;
+    final supplyInert = 1.0 - supplyFO2;
+    final heShare = supplyInert > 0 ? supplyFHe / supplyInert : 0.0;
+    final loopInert = 1.0 - loopFO2;
+    return OpenCircuit(fO2: loopFO2, fHe: loopInert * heShare);
+  }
+
+  @override
+  InspiredGas inspiredAt(double ambientPressureBar) =>
+      _loop.inspiredAt(ambientPressureBar);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `flutter test test/core/deco/breathing_config_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/entities/breathing_config.dart test/core/deco/breathing_config_test.dart
+git commit -m "feat(deco): BreathingConfig with OC, constant-ppO2 CCR, and SCR modes"
+```
+
+---
+
+### Task 5: CCR tissue loading in the engine and profile processing
+
+**Files:**
+- Modify: `lib/core/deco/buhlmann_algorithm.dart` (`calculateSegment`, `calculateNdl`, `getDecoStatus`, `processProfileWithGasSegments`)
+- Modify: `lib/core/deco/entities/profile_gas_segment.dart` (add `setpoint`)
+- Test: `test/core/deco/buhlmann_ccr_test.dart`
+
+**Interfaces:**
+- Consumes: `BreathingConfig` (Task 4), environment threading (Task 3).
+- Produces: `calculateSegment({..., BreathingConfig? breathing})`, `calculateNdl({..., BreathingConfig? breathing})`, `getDecoStatus({..., BreathingConfig? breathing})`, `ProfileGasSegment.setpoint` (`double?`, null = OC). Task 7 and 9 rely on the `breathing` parameter name; Task 11 relies on `ProfileGasSegment.setpoint`.
+- Documented limitation (Phase 4 removes it): the deco SCHEDULE/TTS still breathes open-circuit via `AscentGasPlan` even when loading ran CCR — matching current behavior where ascent planning is OC.
+
+- [ ] **Step 1: Read `lib/core/deco/entities/profile_gas_segment.dart`** to confirm its exact current shape (a small entity with `startTimestamp`, `fN2`, `fHe`), then add a nullable setpoint field, constructor parameter, and (if it is Equatable) props entry:
+
+```dart
+  /// CCR setpoint in bar for this segment; null means open circuit.
+  final double? setpoint;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `test/core/deco/buhlmann_ccr_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/entities/breathing_config.dart';
+import 'package:submersion/core/deco/entities/profile_gas_segment.dart';
+
+void main() {
+  group('CCR tissue loading', () {
+    test('CCR at setpoint loads less inert gas than OC diluent at 40 m', () {
+      final oc = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+      final ccr = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+
+      oc.calculateSegment(
+        depthMeters: 40,
+        durationSeconds: 20 * 60,
+        fN2: 0.37,
+        fHe: 0.45,
+      );
+      ccr.calculateSegment(
+        depthMeters: 40,
+        durationSeconds: 20 * 60,
+        breathing: const ClosedCircuit(
+          setpoint: 1.3,
+          diluentFO2: 0.18,
+          diluentFHe: 0.45,
+        ),
+      );
+
+      final ocInert = oc.compartments
+          .map((c) => c.totalInertGas)
+          .reduce((a, b) => a + b);
+      final ccrInert = ccr.compartments
+          .map((c) => c.totalInertGas)
+          .reduce((a, b) => a + b);
+      expect(ccrInert, lessThan(ocInert));
+    });
+
+    test('CCR NDL at setpoint is longer than OC NDL on the diluent', () {
+      final algo = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8);
+      final ndlOc = algo.calculateNdl(
+        depthMeters: 30,
+        fN2: 0.7902,
+        fHe: 0.0,
+      );
+      final ndlCcr = algo.calculateNdl(
+        depthMeters: 30,
+        breathing: const ClosedCircuit(setpoint: 1.3, diluentFO2: 0.21),
+      );
+      expect(ndlCcr, greaterThan(ndlOc));
+    });
+
+    test('breathing parameter takes precedence over fN2/fHe', () {
+      final a = BuhlmannAlgorithm();
+      final b = BuhlmannAlgorithm();
+      a.calculateSegment(
+        depthMeters: 30,
+        durationSeconds: 600,
+        fN2: 0.5,
+        fHe: 0.4,
+        breathing: const OpenCircuit(fO2: 0.2098),
+      );
+      b.calculateSegment(
+        depthMeters: 30,
+        durationSeconds: 600,
+        fN2: 0.7902,
+        fHe: 0.0,
+      );
+      expect(a.compartments, b.compartments);
+    });
+
+    test('processProfileWithGasSegments honors segment setpoints', () {
+      final depths = [0.0, 30.0, 30.0, 30.0, 0.0];
+      final times = [0, 120, 600, 1200, 1500];
+
+      final ocStatuses = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8)
+          .processProfileWithGasSegments(
+        depths: depths,
+        timestamps: times,
+        gasSegments: [
+          ProfileGasSegment(startTimestamp: 0, fN2: 0.7902, fHe: 0.0),
+        ],
+      );
+      final ccrStatuses = BuhlmannAlgorithm(gfLow: 0.5, gfHigh: 0.8)
+          .processProfileWithGasSegments(
+        depths: depths,
+        timestamps: times,
+        gasSegments: [
+          ProfileGasSegment(
+            startTimestamp: 0,
+            fN2: 0.7902,
+            fHe: 0.0,
+            setpoint: 1.3,
+          ),
+        ],
+      );
+
+      // At the last bottom sample the CCR diver has less N2 loaded.
+      final ocN2 = ocStatuses[3].compartments.first.currentPN2;
+      final ccrN2 = ccrStatuses[3].compartments.first.currentPN2;
+      expect(ccrN2, lessThan(ocN2));
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/buhlmann_ccr_test.dart`
+Expected: FAIL — no `breathing` parameter, no `setpoint` field.
+
+- [ ] **Step 4: Implement**
+
+In `buhlmann_algorithm.dart`:
+
+1. Import `breathing_config.dart`.
+2. `calculateSegment` gains `BreathingConfig? breathing`; the inspired-pressure block becomes:
+
+```dart
+  void calculateSegment({
+    required double depthMeters,
+    required int durationSeconds,
+    double fN2 = airN2Fraction,
+    double fHe = 0.0,
+    BreathingConfig? breathing,
+  }) {
+    final ambientPressure = environment.pressureAtDepth(depthMeters);
+    final double inspiredN2;
+    final double inspiredHe;
+    if (breathing != null) {
+      final inspired = breathing.inspiredAt(ambientPressure);
+      inspiredN2 = inspired.pN2;
+      inspiredHe = inspired.pHe;
+    } else {
+      inspiredN2 = calculateInspiredN2(ambientPressure, fN2);
+      inspiredHe = calculateInspiredHe(ambientPressure, fHe);
+    }
+    final durationMinutes = durationSeconds / 60.0;
+    // ... rest of the method unchanged ...
+```
+
+3. `calculateNdl` gains `BreathingConfig? breathing` and forwards it to its internal `calculateSegment` simulation call.
+4. `getDecoStatus` gains `BreathingConfig? breathing` and forwards it to `calculateNdl`. (Ceiling/schedule stay as they are: schedule ascent is OC via `AscentGasPlan` — documented Phase 1 limitation.)
+5. In `processProfileWithGasSegments`, where the active gas drives loading (the `calculateSegment` call around line 663) and the status (around line 682), build the breathing config from the segment:
+
+```dart
+          final gas = _activeGasAtTimestamp(subIntervalStart, gasSegments);
+          final breathing = gas.setpoint != null
+              ? ClosedCircuit(
+                  setpoint: gas.setpoint!,
+                  diluentFO2: 1.0 - gas.fN2 - gas.fHe,
+                  diluentFHe: gas.fHe,
+                )
+              : null;
+
+          calculateSegment(
+            depthMeters: avgDepth,
+            durationSeconds: duration,
+            fN2: gas.fN2,
+            fHe: gas.fHe,
+            breathing: breathing,
+          );
+```
+
+and for the per-sample status, pass the same construction as `breathing:` to `getDecoStatus`.
+
+- [ ] **Step 5: Run the new test AND the full deco suite**
+
+Run: `flutter test test/core/deco/`
+Expected: ALL PASS (no `setpoint` on existing call sites means null means OC — behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/buhlmann_algorithm.dart lib/core/deco/entities/profile_gas_segment.dart test/core/deco/buhlmann_ccr_test.dart
+git commit -m "feat(deco): constant-ppO2 CCR tissue loading"
+```
+
+---
+
+### Task 6: SchedulePolicy — gas-switch stop time and O2 air breaks
+
+**Files:**
+- Create: `lib/core/deco/schedule_policy.dart`
+- Modify: `lib/core/deco/buhlmann_algorithm.dart` (`calculateDecoSchedule`, `_calculateStopTime`, `_simulateAscent`, `_ascendLeg`, `calculateTts`)
+- Modify: `lib/core/deco/entities/deco_status.dart` (`DecoStop.airBreakSeconds`)
+- Modify: `lib/core/deco/ascent/ascent_gas_plan.dart` (`breakGasForDepth`)
+- Test: `test/core/deco/schedule_policy_test.dart`
+
+**Interfaces:**
+- Produces: `SchedulePolicy({double stopIncrement = 3.0, double lastStopDepth = 3.0, double ascentRate = 9.0, int gasSwitchStopSeconds = 0, AirBreakPolicy? airBreaks})`; `AirBreakPolicy({int o2Seconds = 1200, int breakSeconds = 300})`; `DecoStop.airBreakSeconds` (int, default 0, INCLUDED in `durationSeconds`); `AscentGasPlan.breakGasForDepth(double)` returning `AscentGas?` (base returns null; `OptimalOcAscentGas` returns the best eligible gas with fO2 < 0.9, or null).
+- `calculateDecoSchedule`, `calculateTts`, `getDecoStatus` gain `SchedulePolicy? policy`; null builds one from the algorithm's legacy fields (`stopIncrement`, `lastStopDepth`, `ascentRate`) — existing callers unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/deco/schedule_policy_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/schedule_policy.dart';
+
+/// Loads a deco-obligated dive: air, 45 m for 25 min.
+BuhlmannAlgorithm _loadedAlgo() {
+  final algo = BuhlmannAlgorithm(gfLow: 0.4, gfHigh: 0.8);
+  algo.calculateSegment(depthMeters: 45, durationSeconds: 25 * 60);
+  return algo;
+}
+
+AscentGasPlan _airPlusO2() => OptimalOcAscentGas(
+      maxPpO2: 1.6,
+      gases: const [
+        AvailableGas(fN2: 0.7902, fHe: 0.0, maxPpO2Mod: 66.0),
+        AvailableGas(fN2: 0.0, fHe: 0.0, maxPpO2Mod: 6.0), // pure O2
+      ],
+    );
+
+void main() {
+  test('null policy reproduces legacy schedule exactly', () {
+    final a = _loadedAlgo();
+    final b = _loadedAlgo();
+    final legacy = a.calculateDecoSchedule(currentDepth: 45);
+    final viaPolicy = b.calculateDecoSchedule(
+      currentDepth: 45,
+      policy: const SchedulePolicy(),
+    );
+    expect(viaPolicy.length, legacy.length);
+    for (int i = 0; i < legacy.length; i++) {
+      expect(viaPolicy[i].depthMeters, legacy[i].depthMeters);
+      expect(viaPolicy[i].durationSeconds, legacy[i].durationSeconds);
+    }
+  });
+
+  test('last stop at 6 m removes the 3 m stop', () {
+    final algo = _loadedAlgo();
+    final stops = algo.calculateDecoSchedule(
+      currentDepth: 45,
+      policy: const SchedulePolicy(lastStopDepth: 6.0),
+    );
+    expect(stops.every((s) => s.depthMeters >= 6.0), isTrue);
+    expect(stops.last.depthMeters, 6.0);
+  });
+
+  test('gas-switch stop time enforces a minimum stop at the switch', () {
+    final algo = _loadedAlgo();
+    final plan = _airPlusO2();
+    final stops = algo.calculateDecoSchedule(
+      currentDepth: 45,
+      ascentGas: plan,
+      policy: const SchedulePolicy(gasSwitchStopSeconds: 120),
+    );
+    // The first stop at or above 6 m (the O2 switch) lasts >= 120 s.
+    final switchStop = stops.firstWhere((s) => s.depthMeters <= 6.0);
+    expect(switchStop.durationSeconds, greaterThanOrEqualTo(120));
+  });
+
+  test('air breaks lengthen O2 stops and are annotated', () {
+    int totalDeco(SchedulePolicy policy) {
+      final algo = BuhlmannAlgorithm(gfLow: 0.4, gfHigh: 0.8);
+      algo.calculateSegment(depthMeters: 45, durationSeconds: 45 * 60);
+      final stops = algo.calculateDecoSchedule(
+        currentDepth: 45,
+        ascentGas: _airPlusO2(),
+        policy: policy,
+      );
+      return stops.fold(0, (sum, s) => sum + s.durationSeconds);
+    }
+
+    const withBreaks = SchedulePolicy(
+      airBreaks: AirBreakPolicy(o2Seconds: 12 * 60, breakSeconds: 6 * 60),
+    );
+    final baseline = totalDeco(const SchedulePolicy());
+    final broken = totalDeco(withBreaks);
+    // Breathing back gas during breaks off-gasses slower -> longer deco.
+    expect(broken, greaterThan(baseline));
+
+    final algo = BuhlmannAlgorithm(gfLow: 0.4, gfHigh: 0.8);
+    algo.calculateSegment(depthMeters: 45, durationSeconds: 45 * 60);
+    final stops = algo.calculateDecoSchedule(
+      currentDepth: 45,
+      ascentGas: _airPlusO2(),
+      policy: withBreaks,
+    );
+    final o2Stop = stops.firstWhere((s) => s.depthMeters <= 6.0);
+    expect(o2Stop.airBreakSeconds, greaterThan(0));
+    expect(o2Stop.airBreakSeconds, lessThan(o2Stop.durationSeconds));
+  });
+
+  test('breakGasForDepth: OptimalOcAscentGas offers a non-O2 gas', () {
+    final plan = _airPlusO2();
+    final atSix = plan.breakGasForDepth(6.0);
+    expect(atSix, isNotNull);
+    expect(atSix!.fN2, closeTo(0.7902, 1e-9));
+    // FixedAscentGas has no alternative gas.
+    expect(FixedAscentGas(fN2: 0.7902).breakGasForDepth(6.0), isNull);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/schedule_policy_test.dart`
+Expected: FAIL — `schedule_policy.dart` does not exist.
+
+- [ ] **Step 3: Create `lib/core/deco/schedule_policy.dart`**
+
+```dart
+/// Air-break policy for long oxygen stops: after [o2Seconds] on a pure-O2
+/// stop gas, breathe the break gas for [breakSeconds], then repeat.
+class AirBreakPolicy {
+  const AirBreakPolicy({this.o2Seconds = 20 * 60, this.breakSeconds = 5 * 60});
+
+  final int o2Seconds;
+  final int breakSeconds;
+}
+
+/// How a decompression schedule is generated, independent of the tissue
+/// model. Defaults reproduce the engine's legacy behavior.
+class SchedulePolicy {
+  const SchedulePolicy({
+    this.stopIncrement = 3.0,
+    this.lastStopDepth = 3.0,
+    this.ascentRate = 9.0,
+    this.gasSwitchStopSeconds = 0,
+    this.airBreaks,
+  });
+
+  /// Deco stop depth increment in meters.
+  final double stopIncrement;
+
+  /// Shallowest deco stop depth in meters (3 or 6).
+  final double lastStopDepth;
+
+  /// Ascent rate in meters per minute.
+  final double ascentRate;
+
+  /// Minimum time in seconds to hold at a stop where the breathed gas
+  /// changes (0 = no minimum).
+  final int gasSwitchStopSeconds;
+
+  /// Optional O2 air-break policy; null = no air breaks.
+  final AirBreakPolicy? airBreaks;
+}
+```
+
+- [ ] **Step 4: Add `breakGasForDepth` to `lib/core/deco/ascent/ascent_gas_plan.dart`**
+
+On the abstract class:
+
+```dart
+  /// Best gas to breathe during an air break at [depthMeters] — the highest
+  /// O2 eligible gas that is NOT effectively pure O2. Null when the plan has
+  /// no such alternative (no air breaks possible).
+  AscentGas? breakGasForDepth(double depthMeters) => null;
+```
+
+(Change `abstract class AscentGasPlan` members accordingly — this one has a default body, so `FixedAscentGas` needs no change.)
+
+On `OptimalOcAscentGas`, override:
+
+```dart
+  @override
+  AscentGas? breakGasForDepth(double depthMeters) {
+    AvailableGas? best;
+    for (final g in _gases) {
+      if (g.fO2 >= 0.9) continue; // skip O2 itself
+      if (depthMeters <= g.maxPpO2Mod + 1e-9) {
+        if (best == null || _prefer(g, best)) best = g;
+      }
+    }
+    if (best == null) return null;
+    return AscentGas(fN2: best.fN2, fHe: best.fHe);
+  }
+```
+
+- [ ] **Step 5: Add `airBreakSeconds` to `DecoStop` in `deco_status.dart`**
+
+```dart
+  /// Seconds of this stop spent on the break gas (air breaks). Included in
+  /// [durationSeconds]. Zero when no air breaks occurred.
+  final int airBreakSeconds;
+```
+
+Add `this.airBreakSeconds = 0,` to the constructor and `airBreakSeconds` to `props`.
+
+- [ ] **Step 6: Rework `calculateDecoSchedule` and `_calculateStopTime` in `buhlmann_algorithm.dart`**
+
+Import `schedule_policy.dart`. Signature changes:
+
+```dart
+  List<DecoStop> calculateDecoSchedule({
+    required double currentDepth,
+    double fN2 = airN2Fraction,
+    double fHe = 0.0,
+    AscentGasPlan? ascentGas,
+    SchedulePolicy? policy,
+  }) {
+    final p =
+        policy ??
+        SchedulePolicy(
+          stopIncrement: stopIncrement,
+          lastStopDepth: lastStopDepth,
+          ascentRate: ascentRate,
+        );
+```
+
+Inside, replace every use of `stopIncrement`/`lastStopDepth`/`ascentRate` with `p.stopIncrement`/`p.lastStopDepth`/`p.ascentRate` (thread `p` through `_simulateAscent`/`_ascendLeg` as a parameter). The stop loop becomes:
+
+```dart
+    AscentGas previousGas = plan.gasForDepth(currentDepth);
+    while (currentStopDepth >= p.lastStopDepth) {
+      final stopGas = plan.gasForDepth(currentStopDepth);
+      final switched =
+          stopGas.fN2 != previousGas.fN2 || stopGas.fHe != previousGas.fHe;
+
+      final result = _calculateStopTime(currentStopDepth, plan, p);
+      int stopTime = result.totalSeconds;
+      if (switched && p.gasSwitchStopSeconds > 0) {
+        stopTime = math.max(stopTime, p.gasSwitchStopSeconds);
+      }
+
+      if (stopTime > 0) {
+        stops.add(
+          DecoStop(
+            depthMeters: currentStopDepth,
+            durationSeconds: stopTime,
+            isDeepStop: currentStopDepth > 9,
+            airBreakSeconds: result.breakSeconds,
+          ),
+        );
+        _loadStopMinutes(currentStopDepth, stopTime, plan, p);
+      }
+      previousGas = stopGas;
+
+      final nextStop = currentStopDepth - p.stopIncrement;
+      if (nextStop >= p.lastStopDepth) {
+        _simulateAscent(currentStopDepth, nextStop, plan, p);
+      }
+      currentStopDepth = nextStop;
+    }
+```
+
+`_calculateStopTime` returns a record and simulates minute-by-minute with air-break gas selection; `_loadStopMinutes` applies the stop's loading minute-by-minute with the SAME gas sequence (so search and application agree):
+
+```dart
+  /// Gas to breathe during minute [minuteIndex] of a stop at [stopDepth]:
+  /// the plan's stop gas, interrupted by air breaks per policy when the
+  /// stop gas is effectively pure O2 and the plan offers a break gas.
+  AscentGas _gasForStopMinute(
+    double stopDepth,
+    int minuteIndex,
+    AscentGasPlan plan,
+    SchedulePolicy policy,
+  ) {
+    final primary = plan.gasForDepth(stopDepth);
+    final breaks = policy.airBreaks;
+    final isPureO2 = (primary.fN2 + primary.fHe) < 0.01;
+    if (breaks == null || !isPureO2) return primary;
+    final breakGas = plan.breakGasForDepth(stopDepth);
+    if (breakGas == null) return primary;
+    final cycle = breaks.o2Seconds + breaks.breakSeconds;
+    final posInCycle = (minuteIndex * 60) % cycle;
+    return posInCycle < breaks.o2Seconds ? primary : breakGas;
+  }
+
+  ({int totalSeconds, int breakSeconds}) _calculateStopTime(
+    double stopDepth,
+    AscentGasPlan ascentGas,
+    SchedulePolicy policy,
+  ) {
+    final nextStopDepth = stopDepth <= policy.lastStopDepth
+        ? 0.0
+        : stopDepth - policy.stopIncrement;
+    int stopTime = 0;
+    int breakTime = 0;
+    const maxStopTime = 120 * 60;
+
+    final entryCompartments = List<TissueCompartment>.from(_compartments);
+    final entryAnchor = _gfLowCeilingAnchor;
+
+    while (stopTime < maxStopTime) {
+      final minuteGas = _gasForStopMinute(
+        stopDepth,
+        stopTime ~/ 60,
+        ascentGas,
+        policy,
+      );
+      final primary = ascentGas.gasForDepth(stopDepth);
+      final onBreak =
+          minuteGas.fN2 != primary.fN2 || minuteGas.fHe != primary.fHe;
+
+      final testCompartments = List<TissueCompartment>.from(_compartments);
+      final testAnchor = _gfLowCeilingAnchor;
+
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: 60,
+        fN2: minuteGas.fN2,
+        fHe: minuteGas.fHe,
+      );
+      final ceiling = calculateCeiling(currentDepth: nextStopDepth);
+      _compartments = testCompartments;
+      _gfLowCeilingAnchor = testAnchor;
+
+      // Leaving mid-break is fine: the cleared check is gas-independent.
+      if (ceiling <= nextStopDepth) break;
+
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: 60,
+        fN2: minuteGas.fN2,
+        fHe: minuteGas.fHe,
+      );
+      stopTime += 60;
+      if (onBreak) breakTime += 60;
+    }
+
+    _compartments = entryCompartments;
+    _gfLowCeilingAnchor = entryAnchor;
+
+    return (totalSeconds: stopTime, breakSeconds: breakTime);
+  }
+
+  /// Apply a stop's tissue loading using the same gas sequence the
+  /// stop-time search used (air breaks included). When the gas cannot vary
+  /// (no air breaks in play), load in ONE Schreiner call — bit-identical to
+  /// the legacy single-segment application, so pinned TTS tests stay exact.
+  void _loadStopMinutes(
+    double stopDepth,
+    int stopSeconds,
+    AscentGasPlan plan,
+    SchedulePolicy policy,
+  ) {
+    final primary = plan.gasForDepth(stopDepth);
+    final canBreak = policy.airBreaks != null &&
+        (primary.fN2 + primary.fHe) < 0.01 &&
+        plan.breakGasForDepth(stopDepth) != null;
+    if (!canBreak) {
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: stopSeconds,
+        fN2: primary.fN2,
+        fHe: primary.fHe,
+      );
+      return;
+    }
+    for (int minute = 0; minute < stopSeconds ~/ 60; minute++) {
+      final gas = _gasForStopMinute(stopDepth, minute, plan, policy);
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: 60,
+        fN2: gas.fN2,
+        fHe: gas.fHe,
+      );
+    }
+    final remainder = stopSeconds % 60;
+    if (remainder > 0) {
+      final gas = plan.gasForDepth(stopDepth);
+      calculateSegment(
+        depthMeters: stopDepth,
+        durationSeconds: remainder,
+        fN2: gas.fN2,
+        fHe: gas.fHe,
+      );
+    }
+  }
+```
+
+IMPORTANT: the old code applied the stop's loading with ONE `calculateSegment(stopTime)` call on the stop gas. With no air breaks and no switch minimum, `_loadStopMinutes` produces the same result (exponential composition is associative), so the "null policy reproduces legacy" test pins this.
+
+`calculateTts` gains `SchedulePolicy? policy`, forwards it to `calculateDecoSchedule`, and uses `p.ascentRate` for its ascent legs. `getDecoStatus` gains and forwards `SchedulePolicy? policy` too.
+
+- [ ] **Step 7: Run the new test AND the full deco suite**
+
+Run: `flutter test test/core/deco/`
+Expected: ALL PASS. Pay attention to `tts_cleanroom_cross_check_test.dart` and `tts_gas_switch_regression_test.dart` — they pin the legacy schedule numerics.
+
+- [ ] **Step 8: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/schedule_policy.dart lib/core/deco/buhlmann_algorithm.dart lib/core/deco/entities/deco_status.dart lib/core/deco/ascent/ascent_gas_plan.dart test/core/deco/schedule_policy_test.dart
+git commit -m "feat(deco): SchedulePolicy with gas-switch minimums and O2 air breaks"
+```
+
+---
+
+### Task 7: DecoModel interface and BuhlmannGf facade
+
+**Files:**
+- Create: `lib/core/deco/deco_model.dart`
+- Test: `test/core/deco/deco_model_test.dart`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6.
+- Produces (Phase 2's `PlanEngine` builds on exactly these):
+
+```dart
+abstract class TissueState
+class BuhlmannState extends TissueState { List<TissueCompartment> compartments; double gfLowCeilingAnchor; }
+class DecoSegment { double startDepth; double endDepth; int durationSeconds; }
+class DecoSchedule { List<DecoStop> stops; int ttsSeconds; }
+abstract class DecoModel {
+  TissueState initial();
+  TissueState applySegment(TissueState state, DecoSegment segment, BreathingConfig breathing);
+  double ceilingMeters(TissueState state, {double currentDepth = 0});
+  int ndlSeconds(TissueState state, {required double depthMeters, required BreathingConfig breathing});
+  DecoSchedule schedule(TissueState state, {required double currentDepth, required AscentGasPlan gases});
+}
+class BuhlmannGf implements DecoModel  // ctor: ({double gfLow, double gfHigh, DiveEnvironment environment, SchedulePolicy policy})
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/deco/deco_model_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/deco_model.dart';
+import 'package:submersion/core/deco/entities/breathing_config.dart';
+import 'package:submersion/core/deco/schedule_policy.dart';
+
+void main() {
+  const air = OpenCircuit(fO2: 0.2098);
+
+  group('BuhlmannGf', () {
+    test('reproduces raw BuhlmannAlgorithm results', () {
+      final model = BuhlmannGf(gfLow: 0.4, gfHigh: 0.8);
+      var state = model.initial();
+      state = model.applySegment(
+        state,
+        const DecoSegment(startDepth: 0, endDepth: 40, durationSeconds: 133),
+        air,
+      );
+      state = model.applySegment(
+        state,
+        const DecoSegment(startDepth: 40, endDepth: 40, durationSeconds: 1500),
+        air,
+      );
+      final schedule = model.schedule(
+        state,
+        currentDepth: 40,
+        gases: FixedAscentGas(fN2: 0.7902),
+      );
+
+      // Same dive on the raw algorithm.
+      final algo = BuhlmannAlgorithm(gfLow: 0.4, gfHigh: 0.8);
+      algo.calculateSegment(depthMeters: 20, durationSeconds: 133); // avg
+      algo.calculateSegment(depthMeters: 40, durationSeconds: 1500);
+      final rawStops = algo.calculateDecoSchedule(currentDepth: 40);
+      final rawTts = algo.calculateTts(currentDepth: 40);
+
+      expect(schedule.stops.length, rawStops.length);
+      for (int i = 0; i < rawStops.length; i++) {
+        expect(schedule.stops[i].depthMeters, rawStops[i].depthMeters);
+        expect(schedule.stops[i].durationSeconds, rawStops[i].durationSeconds);
+      }
+      expect(schedule.ttsSeconds, rawTts);
+    });
+
+    test('is pure: same state in, same result out, state unchanged', () {
+      final model = BuhlmannGf(gfLow: 0.4, gfHigh: 0.8);
+      var state = model.initial();
+      state = model.applySegment(
+        state,
+        const DecoSegment(startDepth: 0, endDepth: 40, durationSeconds: 133),
+        air,
+      );
+      final s = state as BuhlmannState;
+      final compsBefore = List.of(s.compartments);
+
+      final first = model.schedule(
+        state,
+        currentDepth: 40,
+        gases: FixedAscentGas(fN2: 0.7902),
+      );
+      final second = model.schedule(
+        state,
+        currentDepth: 40,
+        gases: FixedAscentGas(fN2: 0.7902),
+      );
+      expect(first.ttsSeconds, second.ttsSeconds);
+      expect(s.compartments, compsBefore);
+    });
+
+    test('ndlSeconds supports CCR breathing', () {
+      final model = BuhlmannGf(gfLow: 0.5, gfHigh: 0.8);
+      final state = model.initial();
+      final ndlOc = model.ndlSeconds(
+        state,
+        depthMeters: 30,
+        breathing: air,
+      );
+      final ndlCcr = model.ndlSeconds(
+        state,
+        depthMeters: 30,
+        breathing: const ClosedCircuit(setpoint: 1.3, diluentFO2: 0.21),
+      );
+      expect(ndlCcr, greaterThan(ndlOc));
+    });
+
+    test('ceilingMeters reports the loaded ceiling', () {
+      final model = BuhlmannGf(gfLow: 0.4, gfHigh: 0.8);
+      var state = model.initial();
+      expect(model.ceilingMeters(state, currentDepth: 40), 0.0);
+      state = model.applySegment(
+        state,
+        const DecoSegment(startDepth: 40, endDepth: 40, durationSeconds: 2400),
+        air,
+      );
+      expect(model.ceilingMeters(state, currentDepth: 40), greaterThan(0));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/deco/deco_model_test.dart`
+Expected: FAIL — `deco_model.dart` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/core/deco/deco_model.dart`:
+
+```dart
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/entities/breathing_config.dart';
+import 'package:submersion/core/deco/entities/deco_status.dart';
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+import 'package:submersion/core/deco/entities/tissue_compartment.dart';
+import 'package:submersion/core/deco/schedule_policy.dart';
+
+/// Model-opaque tissue state. Each [DecoModel] defines its own concrete
+/// state (Buhlmann: compartment tensions; a future VPM-B: bubble
+/// parameters). Callers treat it as a token: obtain it from the model,
+/// hand it back to the model.
+abstract class TissueState {
+  const TissueState();
+}
+
+/// Buhlmann ZH-L16C state: 16 compartments plus the GF-low ceiling anchor.
+class BuhlmannState extends TissueState {
+  const BuhlmannState({
+    required this.compartments,
+    this.gfLowCeilingAnchor = 0.0,
+  });
+
+  final List<TissueCompartment> compartments;
+  final double gfLowCeilingAnchor;
+}
+
+/// One constant-or-linear depth leg of a dive.
+class DecoSegment {
+  const DecoSegment({
+    required this.startDepth,
+    required this.endDepth,
+    required this.durationSeconds,
+  });
+
+  final double startDepth;
+  final double endDepth;
+  final int durationSeconds;
+}
+
+/// A computed decompression schedule.
+class DecoSchedule {
+  const DecoSchedule({required this.stops, required this.ttsSeconds});
+
+  final List<DecoStop> stops;
+  final int ttsSeconds;
+}
+
+/// A decompression model: the seam where VPM-B slots in beside Buhlmann.
+///
+/// Implementations are PURE with respect to [TissueState]: methods never
+/// mutate the state passed in; [applySegment] returns a new state.
+abstract class DecoModel {
+  /// Surface-equilibrated state for this model's environment.
+  TissueState initial();
+
+  /// State after breathing [breathing] over [segment].
+  TissueState applySegment(
+    TissueState state,
+    DecoSegment segment,
+    BreathingConfig breathing,
+  );
+
+  /// Current ceiling in meters (0 = clear to surface).
+  double ceilingMeters(TissueState state, {double currentDepth = 0});
+
+  /// No-deco limit in seconds at [depthMeters] on [breathing];
+  /// -1 when already in deco.
+  int ndlSeconds(
+    TissueState state, {
+    required double depthMeters,
+    required BreathingConfig breathing,
+  });
+
+  /// Full deco schedule from [currentDepth] ascending on [gases].
+  DecoSchedule schedule(
+    TissueState state, {
+    required double currentDepth,
+    required AscentGasPlan gases,
+  });
+}
+
+/// Buhlmann ZH-L16C with gradient factors, wrapping [BuhlmannAlgorithm].
+class BuhlmannGf implements DecoModel {
+  BuhlmannGf({
+    double gfLow = 0.30,
+    double gfHigh = 0.70,
+    DiveEnvironment environment = DiveEnvironment.standard,
+    this.policy = const SchedulePolicy(),
+  }) : _algorithm = BuhlmannAlgorithm(
+         gfLow: gfLow,
+         gfHigh: gfHigh,
+         lastStopDepth: policy.lastStopDepth,
+         stopIncrement: policy.stopIncrement,
+         ascentRate: policy.ascentRate,
+         environment: environment,
+       );
+
+  final SchedulePolicy policy;
+  final BuhlmannAlgorithm _algorithm;
+
+  void _restore(TissueState state) {
+    final s = state as BuhlmannState;
+    _algorithm.restoreState(
+      s.compartments,
+      gfLowCeilingAnchor: s.gfLowCeilingAnchor,
+    );
+  }
+
+  BuhlmannState _capture() => BuhlmannState(
+        compartments: _algorithm.compartments,
+        gfLowCeilingAnchor: _algorithm.gfLowCeilingAnchor,
+      );
+
+  @override
+  TissueState initial() {
+    _algorithm.reset();
+    return _capture();
+  }
+
+  @override
+  TissueState applySegment(
+    TissueState state,
+    DecoSegment segment,
+    BreathingConfig breathing,
+  ) {
+    _restore(state);
+    final avgDepth = (segment.startDepth + segment.endDepth) / 2.0;
+    _algorithm.calculateSegment(
+      depthMeters: avgDepth,
+      durationSeconds: segment.durationSeconds,
+      breathing: breathing,
+    );
+    return _capture();
+  }
+
+  @override
+  double ceilingMeters(TissueState state, {double currentDepth = 0}) {
+    _restore(state);
+    return _algorithm.calculateCeiling(currentDepth: currentDepth);
+  }
+
+  @override
+  int ndlSeconds(
+    TissueState state, {
+    required double depthMeters,
+    required BreathingConfig breathing,
+  }) {
+    _restore(state);
+    return _algorithm.calculateNdl(
+      depthMeters: depthMeters,
+      breathing: breathing,
+    );
+  }
+
+  @override
+  DecoSchedule schedule(
+    TissueState state, {
+    required double currentDepth,
+    required AscentGasPlan gases,
+  }) {
+    _restore(state);
+    final stops = _algorithm.calculateDecoSchedule(
+      currentDepth: currentDepth,
+      ascentGas: gases,
+      policy: policy,
+    );
+    _restore(state);
+    final tts = _algorithm.calculateTts(
+      currentDepth: currentDepth,
+      ascentGas: gases,
+      policy: policy,
+    );
+    return DecoSchedule(stops: stops, ttsSeconds: tts);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/deco/deco_model_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+dart format .
+git add lib/core/deco/deco_model.dart test/core/deco/deco_model_test.dart
+git commit -m "feat(deco): DecoModel interface with BuhlmannGf implementation"
+```
+
+---
+
+### Task 8: Compressibility-correct gas consumption
+
+**Files:**
+- Modify: `lib/core/utils/gas_compressibility.dart` (add `pressureAfterConsuming`)
+- Modify: `lib/features/dive_planner/data/services/plan_calculator_service.dart` (`_GasUsageTracker`, tracker initialization ~line 103)
+- Test: `test/core/utils/gas_compressibility_test.dart` (extend or create), `test/features/dive_planner/plan_gas_consumption_test.dart`
+
+**Interfaces:**
+- Consumes: existing `gasVolume(...)` in `gas_compressibility.dart`.
+- Produces: top-level `double pressureAfterConsuming({required double tankSizeLiters, required double startPressureBar, required double litersConsumed, required double o2Percent, double hePercent = 0})`. `_GasUsageTracker` gains `o2Percent`/`hePercent` fields; `remainingPressure`, `gasUsedBar`, `percentUsed` become compressibility-aware.
+
+- [ ] **Step 1: Compute expected values with python3**
+
+Run (this mirrors the Dart virial model exactly — coefficients from `gas_compressibility.dart`):
+
+```bash
+python3 -c "
+o2c = [-7.18092073703e-04, 2.81852572808e-06, -1.50290620492e-09]
+n2c = [-2.19260353292e-04, 2.92844845532e-06, -2.07613482075e-09]
+hec = [4.87320026468e-04, -8.83632921053e-08, 5.33304543646e-11]
+def z(o2, he, bar):
+    p = min(max(bar, 0.0), 500.0)
+    v = lambda c: p*c[0] + p*p*c[1] + p*p*p*c[2]
+    n2 = 1.0 - o2/100.0 - he/100.0
+    return 1.0 + v(o2c)*o2/100.0 + v(hec)*he/100.0 + v(n2c)*n2
+def vol(size, bar, o2, he=0.0):
+    return 0.0 if bar <= 0 else size * (bar/1.01325) / z(o2, he, bar)
+start = vol(11.1, 207.0, 21.0)
+print('AL80 air @207 bar =', repr(start), 'ideal =', repr(11.1*207/1.01325))
+# consume 500 L: solve for end pressure by bisection
+target = start - 500.0
+lo, hi = 0.0, 207.0
+for _ in range(80):
+    mid = (lo+hi)/2
+    if vol(11.1, mid, 21.0) > target: hi = mid
+    else: lo = mid
+print('after 500 L =', repr((lo+hi)/2), 'ideal =', repr(207.0 - 500.0/11.1*1.01325))
+"
+```
+
+Note the ideal-gas convention: the existing tracker treats `volume * pressure_bar` as surface liters with 1 bar reference; `gasVolume` uses 1 atm. Pin whatever python prints — the test asserts against those exact numbers.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create (or extend if it exists — check first with `ls test/core/utils/`) `test/core/utils/gas_compressibility_test.dart`; add:
+
+```dart
+  group('pressureAfterConsuming', () {
+    test('consuming zero keeps start pressure', () {
+      expect(
+        pressureAfterConsuming(
+          tankSizeLiters: 11.1,
+          startPressureBar: 207,
+          litersConsumed: 0,
+          o2Percent: 21,
+        ),
+        closeTo(207.0, 0.01),
+      );
+    });
+
+    test('matches python bisection for 500 L from an AL80', () {
+      final end = pressureAfterConsuming(
+        tankSizeLiters: 11.1,
+        startPressureBar: 207,
+        litersConsumed: 500,
+        o2Percent: 21,
+      );
+      // Paste the exact python3 value from Step 1 here:
+      expect(end, closeTo(/* python value */ 0, 0.05));
+    });
+
+    test('consuming everything returns 0', () {
+      expect(
+        pressureAfterConsuming(
+          tankSizeLiters: 11.1,
+          startPressureBar: 207,
+          litersConsumed: 99999,
+          o2Percent: 21,
+        ),
+        0.0,
+      );
+    });
+
+    test('round-trips with gasVolume', () {
+      const consumed = 800.0;
+      final end = pressureAfterConsuming(
+        tankSizeLiters: 12.0,
+        startPressureBar: 232,
+        litersConsumed: consumed,
+        o2Percent: 18,
+        hePercent: 45,
+      );
+      final startVol = gasVolume(
+        tankSizeLiters: 12.0,
+        pressureBar: 232,
+        o2Percent: 18,
+        hePercent: 45,
+      );
+      final endVol = gasVolume(
+        tankSizeLiters: 12.0,
+        pressureBar: end,
+        o2Percent: 18,
+        hePercent: 45,
+      );
+      expect(startVol - endVol, closeTo(consumed, 0.5));
+    });
+  });
+```
+
+(The `closeTo(/* python value */ 0, 0.05)` placeholder MUST be replaced with the number python printed in Step 1 before running.)
+
+- [ ] **Step 3: Implement `pressureAfterConsuming`**
+
+Append to `lib/core/utils/gas_compressibility.dart`:
+
+```dart
+/// Cylinder pressure remaining after consuming [litersConsumed] surface
+/// liters, honoring compressibility. Solves
+/// gasVolume(start) - gasVolume(end) == litersConsumed by bisection.
+///
+/// Returns 0 when the demand exceeds the cylinder's content.
+double pressureAfterConsuming({
+  required double tankSizeLiters,
+  required double startPressureBar,
+  required double litersConsumed,
+  required double o2Percent,
+  double hePercent = 0,
+}) {
+  if (startPressureBar <= 0 || tankSizeLiters <= 0) return 0;
+  final startVolume = gasVolume(
+    tankSizeLiters: tankSizeLiters,
+    pressureBar: startPressureBar,
+    o2Percent: o2Percent,
+    hePercent: hePercent,
+  );
+  final target = startVolume - litersConsumed;
+  if (target <= 0) return 0;
+
+  double lo = 0.0;
+  double hi = startPressureBar;
+  for (int i = 0; i < 60; i++) {
+    final mid = (lo + hi) / 2;
+    final v = gasVolume(
+      tankSizeLiters: tankSizeLiters,
+      pressureBar: mid,
+      o2Percent: o2Percent,
+      hePercent: hePercent,
+    );
+    if (v > target) {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+  return (lo + hi) / 2;
+}
+```
+
+Run: `flutter test test/core/utils/gas_compressibility_test.dart` — expected PASS.
+
+- [ ] **Step 4: Wire the planner's `_GasUsageTracker`**
+
+In `plan_calculator_service.dart`, import `package:submersion/core/utils/gas_compressibility.dart` and replace `_GasUsageTracker` (line ~604):
+
+```dart
+class _GasUsageTracker {
+  final double? startPressure;
+  final double volume;
+  final double o2Percent;
+  final double hePercent;
+  double gasUsedLiters = 0;
+
+  _GasUsageTracker({
+    this.startPressure,
+    required this.volume,
+    this.o2Percent = 21.0,
+    this.hePercent = 0.0,
+  });
+
+  void addGasUsed(double liters) {
+    gasUsedLiters += liters;
+  }
+
+  /// Remaining pressure honoring gas compressibility.
+  double? get remainingPressure {
+    if (startPressure == null) return null;
+    return pressureAfterConsuming(
+      tankSizeLiters: volume,
+      startPressureBar: startPressure!,
+      litersConsumed: gasUsedLiters,
+      o2Percent: o2Percent,
+      hePercent: hePercent,
+    );
+  }
+
+  /// Bar consumed (start minus compressibility-aware remaining).
+  double get gasUsedBar {
+    if (startPressure == null) {
+      return volume > 0 ? gasUsedLiters / volume : 0;
+    }
+    return startPressure! - (remainingPressure ?? 0);
+  }
+
+  /// Percentage of the tank's content used.
+  double get percentUsed {
+    if (startPressure == null || startPressure == 0) return 0;
+    return (gasUsedBar / startPressure!) * 100;
+  }
+}
+```
+
+Update the tracker initialization (~line 103) to pass the tank's gas:
+
+```dart
+    for (final tank in tanks) {
+      gasUsageByTank[tank.id] = _GasUsageTracker(
+        startPressure: tank.startPressure,
+        volume: tank.volume ?? 11.0, // Default AL80 if not specified
+        o2Percent: tank.gasMix.o2,
+        hePercent: tank.gasMix.he,
+      );
+    }
+```
+
+(Verify the field access compiles — `DiveTank.gasMix` is a `GasMix` with `o2`/`he` as 0-100 percentages, defined in `lib/features/dive_log/domain/entities/dive.dart:1000`.)
+
+- [ ] **Step 5: Write the planner-level test**
+
+Create `test/features/dive_planner/plan_gas_consumption_test.dart` — check first whether a test for `PlanCalculatorService` already exists under `test/features/dive_planner/` and extend it instead if so:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_planner/data/services/plan_calculator_service.dart';
+import 'package:submersion/features/dive_planner/domain/entities/plan_segment.dart';
+
+void main() {
+  test('remaining pressure accounts for compressibility', () {
+    final service = PlanCalculatorService(gfLow: 50, gfHigh: 80);
+    const gas = GasMix(o2: 21.0, he: 0.0);
+    const tank = DiveTank(
+      id: 'tank-1',
+      volume: 11.1,
+      workingPressure: 207.0,
+      startPressure: 207.0,
+      gasMix: gas,
+    );
+    final segments = [
+      PlanSegment.descent(
+        id: 'seg-1',
+        targetDepth: 30.0,
+        tankId: 'tank-1',
+        gasMix: gas,
+        order: 0,
+      ),
+      PlanSegment.bottom(
+        id: 'seg-2',
+        depth: 30.0,
+        durationMinutes: 25,
+        tankId: 'tank-1',
+        gasMix: gas,
+        order: 1,
+      ),
+      PlanSegment.ascent(
+        id: 'seg-3',
+        fromDepth: 30.0,
+        toDepth: 0.0,
+        tankId: 'tank-1',
+        gasMix: gas,
+        order: 2,
+      ),
+    ];
+
+    final result = service.calculatePlan(
+      segments: segments,
+      tanks: const [tank],
+      sacRate: 16.0,
+    );
+
+    final consumption = result.gasConsumptions.first;
+    final litersUsed = consumption.gasUsedLiters;
+    expect(litersUsed, greaterThan(0));
+
+    // Ideal-gas remaining: start minus liters/volume. Compressibility means
+    // the same surface liters cost MORE bar at high pressure, so the real
+    // remaining pressure must be LOWER than the ideal figure.
+    final idealRemaining = 207.0 - litersUsed / 11.1;
+    expect(consumption.remainingPressure, isNotNull);
+    expect(consumption.remainingPressure!, lessThan(idealRemaining + 0.01));
+    expect(consumption.remainingPressure!, greaterThan(0));
+  });
+}
+```
+
+(Field names on the consumption result: check `GasConsumption` in `lib/features/dive_planner/domain/entities/plan_result.dart` — the fields are `gasUsedLiters` and `remainingPressure`; if the actual names differ, use the actual names.) `DiveTank.role` defaults to `TankRole.backGas`, so it can be omitted. Note for Phase 4: `TankRole.diluent` and `TankRole.oxygenSupply` already exist in `lib/core/constants/enums.dart:243`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `flutter test test/core/utils/gas_compressibility_test.dart test/features/dive_planner/plan_gas_consumption_test.dart`
+Expected: PASS. Also run any pre-existing `plan_calculator_service` tests under `test/features/dive_planner/` — consumption numbers there may legitimately shift; update ONLY assertions that pinned the old ideal-gas remaining pressure, and say so in the commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+dart format .
+git add lib/core/utils/gas_compressibility.dart lib/features/dive_planner/data/services/plan_calculator_service.dart test/core/utils/gas_compressibility_test.dart test/features/dive_planner/plan_gas_consumption_test.dart
+git commit -m "feat(planner): compressibility-correct gas consumption"
+```
+
+---
+
+### Task 9: Golden-vector validation suite
+
+**Files:**
+- Create: `scripts/deco_golden/generate_vectors.py`
+- Create: `scripts/deco_golden/README.md`
+- Create: `test/core/deco/golden/vectors.json` (generated, committed)
+- Test: `test/core/deco/golden/golden_vector_test.dart`
+
+**Interfaces:**
+- Consumes: the full engine API from Tasks 1-6.
+- Produces: a committed `vectors.json` and a Dart test that replays every case. The Python script is an INDEPENDENT implementation of ZH-L16C + GF (same published coefficients, same pinned semantics) — agreement between the two implementations is the accuracy claim. Tolerances: each stop ±60 s, TTS ±90 s, tissue tensions ±5e-4 bar.
+
+**Pinned semantics both implementations must share** (this is the contract — the Python script documents each):
+1. Inspired inert gas: `(P_amb - 0.0627) * fraction`; surface saturation `(P_surface - 0.0627) * 0.7902`.
+2. Depth-pressure: `P = P_surface + depth * rho * 9.80665 / 1e5`.
+3. Schreiner constant-depth loading with `k = ln(2)/halfTime`.
+4. GF-low anchor: running max of the GF-low ceiling (meters) after every applied loading step; GF at depth d interpolates `gfHigh - (gfHigh-gfLow) * d/anchor`, clamped to gfLow below the anchor, gfHigh at surface or when anchor is 0.
+5. Compartment ceiling pressure: `(P_inert - a*gf) / (gf/b + 1 - gf)` with tension-blended a/b; meters via the environment, clamped >= 0.
+6. First stop: `ceil(ceiling_at_current_gf / 3) * 3`.
+7. Ascent legs: average depth, duration `round(delta_depth / rate * 60)` seconds, split at gas-switch (MOD) depths, gas chosen at the leg's deeper end.
+8. Stop time search: minute-by-minute; leave when the ceiling evaluated at the NEXT stop's interpolated GF is <= the next stop depth; the checked trial minute is not counted; stop minutes are then applied to the tissues.
+9. Gas selection during ascent/stops: highest-O2 gas whose MOD (given in the vector) is >= the depth.
+10. CCR loading: `pO2 = min(setpoint, P_amb - 0.0627)`; inert = remainder split by diluent N2:He ratio.
+11. TTS: sum of stop seconds plus `round()` of each ascent leg at the policy rate, including final stop to surface.
+
+- [ ] **Step 1: Write the Python generator**
+
+Create `scripts/deco_golden/generate_vectors.py`. Full implementation (~250 lines). Skeleton with all the load-bearing parts spelled out — the executor completes the `zhl16c` coefficient tables by copying the 6 arrays verbatim from `lib/core/deco/constants/buhlmann_coefficients.dart`:
+
+```python
+#!/usr/bin/env python3
+"""Golden-vector generator for the Submersion deco engine.
+
+Independent ZH-L16C + gradient-factor implementation. Semantics are pinned
+to the contract in docs/superpowers/plans/2026-07-05-dive-planner-phase1-engine.md
+(Task 9). Regenerate with:
+
+    python3 scripts/deco_golden/generate_vectors.py > test/core/deco/golden/vectors.json
+"""
+import json
+import math
+
+# --- ZH-L16C tables: copy the 6 arrays VERBATIM from
+# --- lib/core/deco/constants/buhlmann_coefficients.dart
+N2_HALF = [4.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0,
+           109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0]
+HE_HALF = [1.51, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11,
+           41.20, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03]
+N2_A = [1.2599, 1.0000, 0.8618, 0.7562, 0.6200, 0.5043, 0.4410, 0.4000,
+        0.3750, 0.3500, 0.3295, 0.3065, 0.2835, 0.2610, 0.2480, 0.2327]
+N2_B = [0.5050, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.8910,
+        0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653]
+HE_A = [1.7424, 1.3830, 1.1919, 1.0458, 0.9220, 0.8205, 0.7305, 0.6502,
+        0.5950, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119]
+HE_B = [0.4245, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553,
+        0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267]
+
+WV = 0.0627
+AIR_N2 = 0.7902
+G = 9.80665
+
+
+class Env:
+    def __init__(self, surface=1.0, density=1019.716213):
+        self.surface = surface
+        self.density = density
+
+    @property
+    def bar_per_m(self):
+        return self.density * G / 100000.0
+
+    def p_at(self, depth):
+        return self.surface + depth * self.bar_per_m
+
+    def depth_at(self, p):
+        return (p - self.surface) / self.bar_per_m
+
+
+class State:
+    def __init__(self, env):
+        self.env = env
+        surf_n2 = (env.surface - WV) * AIR_N2
+        self.n2 = [surf_n2] * 16
+        self.he = [0.0] * 16
+        self.anchor = 0.0  # deepest GF-low ceiling so far, meters
+
+    def clone(self):
+        s = State(self.env)
+        s.n2, s.he, s.anchor = list(self.n2), list(self.he), self.anchor
+        return s
+
+
+def schreiner(p0, pi, minutes, half):
+    k = math.log(2) / half
+    return pi + (p0 - pi) * math.exp(-k * minutes)
+
+
+def ceiling_pressure(state, i, gf):
+    pn, ph = state.n2[i], state.he[i]
+    total = pn + ph
+    if total == 0:
+        a, b = N2_A[i], N2_B[i]
+    else:
+        a = (pn * N2_A[i] + ph * HE_A[i]) / total
+        b = (pn * N2_B[i] + ph * HE_B[i]) / total
+    return (total - a * gf) / (gf / b + 1 - gf)
+
+
+def ceiling_m(state, gf):
+    worst = 0.0
+    for i in range(16):
+        m = state.env.depth_at(ceiling_pressure(state, i, gf))
+        worst = max(worst, m)
+    return worst
+
+
+def interp_gf(state, depth, gf_low, gf_high):
+    if depth <= 0 or state.anchor <= 0:
+        return gf_high
+    if depth >= state.anchor:
+        return gf_low
+    return gf_high - (gf_high - gf_low) * (depth / state.anchor)
+
+
+def load(state, depth, seconds, f_n2, f_he, gf_low, setpoint=None):
+    amb = state.env.p_at(depth)
+    p_alv = max(amb - WV, 0.0)
+    if setpoint is None:
+        i_n2, i_he = p_alv * f_n2, p_alv * f_he
+    else:
+        p_o2 = min(setpoint, p_alv)
+        inert = max(p_alv - p_o2, 0.0)
+        tot = f_n2 + f_he
+        share = f_n2 / tot if tot > 0 else 0.0
+        i_n2, i_he = inert * share, inert * (1 - share)
+    minutes = seconds / 60.0
+    for i in range(16):
+        state.n2[i] = schreiner(state.n2[i], i_n2, minutes, N2_HALF[i])
+        state.he[i] = schreiner(state.he[i], i_he, minutes, HE_HALF[i])
+    state.anchor = max(state.anchor, ceiling_m(state, gf_low))
+
+
+def gas_at(gases, depth):
+    """Highest-O2 gas eligible at depth (depth <= mod)."""
+    best = None
+    for g in gases:
+        if depth <= g["mod_m"] + 1e-9:
+            fo2 = 1.0 - g["f_n2"] - g["f_he"]
+            if best is None or fo2 > (1.0 - best["f_n2"] - best["f_he"]):
+                best = g
+    return best if best else min(gases, key=lambda g: 1 - g["f_n2"] - g["f_he"])
+
+
+def switch_depths(gases, deeper, shallower):
+    out = []
+    for g in gases:
+        m = g["mod_m"]
+        if shallower + 1e-9 < m < deeper - 1e-9:
+            below, above = gas_at(gases, m + 1e-6), gas_at(gases, m - 1e-6)
+            if below is not above:
+                out.append(m)
+    return sorted(out, reverse=True)
+
+
+def ascend(state, frm, to, rate, gases, gf_low):
+    if frm <= to:
+        return 0
+    total = 0
+    seg_top = frm
+    for sw in switch_depths(gases, frm, to):
+        total += _leg(state, seg_top, sw, rate, gases, gf_low)
+        seg_top = sw
+    total += _leg(state, seg_top, to, rate, gases, gf_low)
+    return total
+
+
+def _leg(state, frm, to, rate, gases, gf_low):
+    if frm <= to:
+        return 0
+    g = gas_at(gases, frm)
+    secs = round((frm - to) / rate * 60)
+    load(state, (frm + to) / 2.0, secs, g["f_n2"], g["f_he"], gf_low)
+    return secs
+
+
+def stop_time(state, depth, gases, gf_low, gf_high, last_stop, incr):
+    nxt = 0.0 if depth <= last_stop else depth - incr
+    g = gas_at(gases, depth)
+    t = 0
+    while t < 120 * 60:
+        trial = state.clone()
+        load(trial, depth, 60, g["f_n2"], g["f_he"], gf_low)
+        gf = interp_gf(trial, nxt, gf_low, gf_high)
+        if ceiling_m(trial, gf) <= nxt:
+            break
+        state.n2, state.he, state.anchor = trial.n2, trial.he, trial.anchor
+        t += 60
+    return t
+
+
+def schedule(state, depth, gases, gf_low, gf_high,
+             last_stop=3.0, incr=3.0, rate=9.0):
+    stops = []
+    work = state.clone()
+    gf_here = interp_gf(work, depth, gf_low, gf_high)
+    ceil0 = ceiling_m(work, gf_here)
+    if ceil0 <= 0:
+        return stops, round(depth / rate * 60)
+    stop = math.ceil(ceil0 / incr) * incr
+    tts = ascend(work, depth, stop, rate, gases, gf_low)
+    while stop >= last_stop:
+        t = stop_time(work, stop, gases, gf_low, gf_high, last_stop, incr)
+        if t > 0:
+            stops.append({"depth_m": stop, "seconds": t})
+            tts += t
+        nxt = stop - incr
+        if nxt >= last_stop:
+            tts += ascend(work, stop, nxt, rate, gases, gf_low)
+        stop = nxt
+    tts += round(last_stop / rate * 60)
+    return stops, tts
+```
+
+The TTS accumulation above must mirror the Dart `calculateTts`: Dart sums stop seconds plus per-leg `round((d1-d2)/rate*60)` transitions from the ORIGINAL depth through each stop depth to the surface, WITHOUT gas-switch splitting of the travel legs in the time sum. Reconcile the two carefully — if Dart and Python disagree by more than the tolerance, print both breakdowns and fix the PYTHON side to match the pinned Dart semantics (the Dart side is pinned by `tts_cleanroom_cross_check_test.dart`).
+
+Then the case table and main:
+
+```python
+def run_case(name, env, gf, segments, sched_depth, gases,
+             tissues=False, ccr_ceiling_at=None):
+    st = State(env)
+    for seg in segments:
+        load(st, seg["avg_depth_m"], seg["seconds"], seg["f_n2"],
+             seg["f_he"], gf[0] / 100.0, seg.get("setpoint"))
+    expected = {}
+    if sched_depth is not None:
+        stops, tts = schedule(st, sched_depth, gases,
+                              gf[0] / 100.0, gf[1] / 100.0)
+        expected["stops"] = stops
+        expected["tts_seconds"] = tts
+    if tissues:
+        expected["tissues_p_n2_bar"] = [round(x, 6) for x in st.n2]
+        expected["tissues_p_he_bar"] = [round(x, 6) for x in st.he]
+    if ccr_ceiling_at is not None:
+        gf_here = interp_gf(st, ccr_ceiling_at, gf[0] / 100.0, gf[1] / 100.0)
+        expected["ceiling_m"] = round(ceiling_m(st, gf_here), 3)
+    return {
+        "name": name,
+        "environment": {"surface_pressure_bar": env.surface,
+                        "water_density_kg_m3": env.density},
+        "gf": gf,
+        "segments": segments,
+        "schedule_from_depth_m": sched_depth,
+        "gases": gases,
+        "expected": expected,
+    }
+
+
+AIR = {"f_n2": 0.7902, "f_he": 0.0, "mod_m": 66.0}
+EAN50 = {"f_n2": 0.50, "f_he": 0.0, "mod_m": 22.0}   # ppO2 1.6
+O2 = {"f_n2": 0.0, "f_he": 0.0, "mod_m": 6.0}        # ppO2 1.6
+TX1845 = {"f_n2": 0.37, "f_he": 0.45, "mod_m": 78.0}
+
+STD = Env()
+cases = [
+    run_case("air-30m-25min-gf5080", STD, [50, 80],
+             [{"avg_depth_m": 15.0, "seconds": 100,
+               "f_n2": 0.7902, "f_he": 0.0},
+              {"avg_depth_m": 30.0, "seconds": 1500,
+               "f_n2": 0.7902, "f_he": 0.0}],
+             30.0, [AIR], tissues=True),
+    run_case("air-40m-20min-gf3070", STD, [30, 70],
+             [{"avg_depth_m": 20.0, "seconds": 133,
+               "f_n2": 0.7902, "f_he": 0.0},
+              {"avg_depth_m": 40.0, "seconds": 1200,
+               "f_n2": 0.7902, "f_he": 0.0}],
+             40.0, [AIR]),
+    run_case("ean32-30m-40min-gf5080", STD, [50, 80],
+             [{"avg_depth_m": 15.0, "seconds": 100,
+               "f_n2": 0.68, "f_he": 0.0},
+              {"avg_depth_m": 30.0, "seconds": 2400,
+               "f_n2": 0.68, "f_he": 0.0}],
+             30.0, [{"f_n2": 0.68, "f_he": 0.0, "mod_m": 40.0}]),
+    run_case("tx1845-60m-25min-ean50-o2-gf5080", STD, [50, 80],
+             [{"avg_depth_m": 30.0, "seconds": 200,
+               "f_n2": 0.37, "f_he": 0.45},
+              {"avg_depth_m": 60.0, "seconds": 1500,
+               "f_n2": 0.37, "f_he": 0.45}],
+             60.0, [TX1845, EAN50, O2]),
+    run_case("air-30m-20min-altitude2000m", Env(surface=0.794973), [50, 80],
+             [{"avg_depth_m": 15.0, "seconds": 100,
+               "f_n2": 0.7902, "f_he": 0.0},
+              {"avg_depth_m": 30.0, "seconds": 1200,
+               "f_n2": 0.7902, "f_he": 0.0}],
+             30.0, [AIR]),
+    run_case("air-30m-25min-freshwater", Env(density=1000.0), [50, 80],
+             [{"avg_depth_m": 15.0, "seconds": 100,
+               "f_n2": 0.7902, "f_he": 0.0},
+              {"avg_depth_m": 30.0, "seconds": 1500,
+               "f_n2": 0.7902, "f_he": 0.0}],
+             30.0, [AIR]),
+    run_case("ccr-sp13-dil1845-60m-25min-loading", STD, [50, 80],
+             [{"avg_depth_m": 30.0, "seconds": 200, "f_n2": 0.37,
+               "f_he": 0.45, "setpoint": 1.3},
+              {"avg_depth_m": 60.0, "seconds": 1500, "f_n2": 0.37,
+               "f_he": 0.45, "setpoint": 1.3}],
+             None, [], tissues=True, ccr_ceiling_at=60.0),
+]
+
+# The altitude surface pressure must equal the Dart ISA value; recompute it
+# here rather than trusting the literal above:
+isa = 1.01325 * (1 - 0.0000225577 * 2000.0) ** 5.25588
+assert abs(cases[4]["environment"]["surface_pressure_bar"] - isa) < 1e-4, isa
+
+print(json.dumps({"generator": "scripts/deco_golden/generate_vectors.py",
+                  "semantics_version": 1, "cases": cases}, indent=2))
+```
+
+- [ ] **Step 2: Generate the vectors**
+
+Run:
+```bash
+mkdir -p test/core/deco/golden
+python3 scripts/deco_golden/generate_vectors.py > test/core/deco/golden/vectors.json
+python3 -m json.tool test/core/deco/golden/vectors.json > /dev/null && echo OK
+```
+Expected: `OK`. Sanity-read the file: the trimix case must have stops at 21 m or deeper through 3 m; the altitude case must show MORE deco than the matching sea-level case.
+
+- [ ] **Step 3: Write the Dart golden runner**
+
+Create `test/core/deco/golden/golden_vector_test.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/ascent/ascent_gas_plan.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/entities/breathing_config.dart';
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+
+void main() {
+  final file = File('test/core/deco/golden/vectors.json');
+  final doc = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  final cases = (doc['cases'] as List).cast<Map<String, dynamic>>();
+
+  for (final c in cases) {
+    test('golden: ${c['name']}', () {
+      final envJson = c['environment'] as Map<String, dynamic>;
+      final env = DiveEnvironment(
+        surfacePressureBar: (envJson['surface_pressure_bar'] as num)
+            .toDouble(),
+        waterDensityKgM3: (envJson['water_density_kg_m3'] as num).toDouble(),
+      );
+      final gf = (c['gf'] as List).cast<num>();
+      final algo = BuhlmannAlgorithm(
+        gfLow: gf[0] / 100.0,
+        gfHigh: gf[1] / 100.0,
+        environment: env,
+      );
+
+      for (final seg in (c['segments'] as List).cast<Map<String, dynamic>>()) {
+        final setpoint = (seg['setpoint'] as num?)?.toDouble();
+        final fN2 = (seg['f_n2'] as num).toDouble();
+        final fHe = (seg['f_he'] as num).toDouble();
+        algo.calculateSegment(
+          depthMeters: (seg['avg_depth_m'] as num).toDouble(),
+          durationSeconds: (seg['seconds'] as num).toInt(),
+          fN2: fN2,
+          fHe: fHe,
+          breathing: setpoint != null
+              ? ClosedCircuit(
+                  setpoint: setpoint,
+                  diluentFO2: 1.0 - fN2 - fHe,
+                  diluentFHe: fHe,
+                )
+              : null,
+        );
+      }
+
+      final expected = c['expected'] as Map<String, dynamic>;
+
+      if (expected.containsKey('tissues_p_n2_bar')) {
+        final expN2 = (expected['tissues_p_n2_bar'] as List).cast<num>();
+        final expHe = (expected['tissues_p_he_bar'] as List).cast<num>();
+        for (int i = 0; i < 16; i++) {
+          expect(
+            algo.compartments[i].currentPN2,
+            closeTo(expN2[i].toDouble(), 5e-4),
+            reason: '${c['name']} compartment ${i + 1} pN2',
+          );
+          expect(
+            algo.compartments[i].currentPHe,
+            closeTo(expHe[i].toDouble(), 5e-4),
+            reason: '${c['name']} compartment ${i + 1} pHe',
+          );
+        }
+      }
+
+      if (expected.containsKey('ceiling_m')) {
+        final depth = (c['segments'] as List).last['avg_depth_m'] as num;
+        expect(
+          algo.calculateCeiling(currentDepth: depth.toDouble()),
+          closeTo((expected['ceiling_m'] as num).toDouble(), 0.5),
+          reason: '${c['name']} ceiling',
+        );
+      }
+
+      final schedDepth = c['schedule_from_depth_m'] as num?;
+      if (schedDepth != null && expected.containsKey('stops')) {
+        final gases = (c['gases'] as List)
+            .cast<Map<String, dynamic>>()
+            .map(
+              (g) => AvailableGas(
+                fN2: (g['f_n2'] as num).toDouble(),
+                fHe: (g['f_he'] as num).toDouble(),
+                maxPpO2Mod: (g['mod_m'] as num).toDouble(),
+              ),
+            )
+            .toList();
+        final plan = OptimalOcAscentGas(gases: gases, maxPpO2: 1.6);
+        final stops = algo.calculateDecoSchedule(
+          currentDepth: schedDepth.toDouble(),
+          ascentGas: plan,
+        );
+        final expStops =
+            (expected['stops'] as List).cast<Map<String, dynamic>>();
+        expect(
+          stops.length,
+          expStops.length,
+          reason: '${c['name']} stop count: '
+              'got ${stops.map((s) => '${s.depthMeters}m/${s.durationSeconds}s')}',
+        );
+        for (int i = 0; i < expStops.length; i++) {
+          expect(
+            stops[i].depthMeters,
+            (expStops[i]['depth_m'] as num).toDouble(),
+            reason: '${c['name']} stop $i depth',
+          );
+          expect(
+            stops[i].durationSeconds,
+            closeTo((expStops[i]['seconds'] as num).toDouble(), 60),
+            reason: '${c['name']} stop $i duration',
+          );
+        }
+        final tts = algo.calculateTts(
+          currentDepth: schedDepth.toDouble(),
+          ascentGas: plan,
+        );
+        expect(
+          tts,
+          closeTo((expected['tts_seconds'] as num).toDouble(), 90),
+          reason: '${c['name']} tts',
+        );
+      }
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run and reconcile**
+
+Run: `flutter test test/core/deco/golden/golden_vector_test.dart`
+
+This is the cross-validation moment. If a case disagrees beyond tolerance, print both sides' stop lists and find the semantic divergence — work through pinned semantics 1-11 in order (anchor handling and TTS leg rounding are the two most likely culprits). Fix the PYTHON side unless the Dart side plainly violates its own pinned semantics (existing Dart tests define ground truth for legacy behavior). Regenerate `vectors.json` after any Python change. Do not widen tolerances to force a pass.
+
+Expected once reconciled: ALL cases PASS.
+
+- [ ] **Step 5: Write `scripts/deco_golden/README.md`**
+
+```markdown
+# Deco golden vectors
+
+`generate_vectors.py` is an independent Python implementation of the
+ZH-L16C + gradient-factor model, sharing pinned semantics with the Dart
+engine (see docs/superpowers/plans/2026-07-05-dive-planner-phase1-engine.md,
+Task 9). It generates `test/core/deco/golden/vectors.json`, which
+`golden_vector_test.dart` replays against the Dart engine.
+
+Regenerate after any intentional engine-semantics change:
+
+    python3 scripts/deco_golden/generate_vectors.py > test/core/deco/golden/vectors.json
+
+Never edit vectors.json by hand. Never derive expected values from an
+LLM's recall — only from this script or a published external source.
+
+Release gate: before each planner release, additionally compare a standard
+plan set against MultiDeco by hand (see the design spec, Testing section).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+dart format .
+git add scripts/deco_golden/ test/core/deco/golden/
+git commit -m "test(deco): golden-vector suite cross-validated against independent python model"
+```
+
+---
+
+### Task 10: Property tests — model invariants
+
+**Files:**
+- Test: `test/core/deco/deco_property_test.dart`
+
+**Interfaces:** consumes the engine API only; produces no new code.
+
+- [ ] **Step 1: Write the tests**
+
+Create `test/core/deco/deco_property_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/buhlmann_algorithm.dart';
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+
+int _tts({
+  required double depth,
+  required int bottomMinutes,
+  double gfLow = 0.4,
+  double gfHigh = 0.8,
+  DiveEnvironment env = DiveEnvironment.standard,
+}) {
+  final algo = BuhlmannAlgorithm(
+    gfLow: gfLow,
+    gfHigh: gfHigh,
+    environment: env,
+  );
+  algo.calculateSegment(
+    depthMeters: depth,
+    durationSeconds: bottomMinutes * 60,
+  );
+  return algo.calculateTts(currentDepth: depth);
+}
+
+void main() {
+  group('deco invariants', () {
+    test('longer bottom time never shortens TTS', () {
+      for (final depth in [30.0, 45.0, 60.0]) {
+        int previous = 0;
+        for (int minutes = 10; minutes <= 60; minutes += 5) {
+          final tts = _tts(depth: depth, bottomMinutes: minutes);
+          expect(
+            tts,
+            greaterThanOrEqualTo(previous),
+            reason: 'depth $depth, $minutes min',
+          );
+          previous = tts;
+        }
+      }
+    });
+
+    test('deeper dives never shorten TTS at fixed bottom time', () {
+      int previous = 0;
+      for (double depth = 20; depth <= 60; depth += 5) {
+        final tts = _tts(depth: depth, bottomMinutes: 25);
+        expect(tts, greaterThanOrEqualTo(previous), reason: 'depth $depth');
+        previous = tts;
+      }
+    });
+
+    test('raising GF-high never increases TTS', () {
+      for (final depth in [40.0, 55.0]) {
+        int? previous;
+        for (double gfHigh = 0.6; gfHigh <= 0.95; gfHigh += 0.05) {
+          final tts = _tts(
+            depth: depth,
+            bottomMinutes: 30,
+            gfHigh: gfHigh,
+          );
+          if (previous != null) {
+            expect(
+              tts,
+              lessThanOrEqualTo(previous),
+              reason: 'depth $depth, gfHigh $gfHigh',
+            );
+          }
+          previous = tts;
+        }
+      }
+    });
+
+    test('higher altitude never shortens NDL', () {
+      int? previous;
+      for (double alt = 0; alt <= 3000; alt += 500) {
+        final algo = BuhlmannAlgorithm(
+          gfLow: 0.5,
+          gfHigh: 0.8,
+          environment: DiveEnvironment.forConditions(altitudeMeters: alt),
+        );
+        final ndl = algo.calculateNdl(depthMeters: 25);
+        if (previous != null) {
+          expect(ndl, lessThanOrEqualTo(previous), reason: 'altitude $alt');
+        }
+        previous = ndl;
+      }
+    });
+
+    test('denser water never lengthens NDL at the same depth', () {
+      int? previous;
+      for (final density in [
+        DiveEnvironment.freshWaterDensity,
+        DiveEnvironment.brackishWaterDensity,
+        DiveEnvironment.en13319Density,
+        DiveEnvironment.saltWaterDensity,
+      ]) {
+        final algo = BuhlmannAlgorithm(
+          gfLow: 0.5,
+          gfHigh: 0.8,
+          environment: DiveEnvironment(waterDensityKgM3: density),
+        );
+        final ndl = algo.calculateNdl(depthMeters: 30);
+        if (previous != null) {
+          expect(ndl, lessThanOrEqualTo(previous), reason: 'density $density');
+        }
+        previous = ndl;
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `flutter test test/core/deco/deco_property_test.dart`
+Expected: PASS. Any failure here is an engine bug (or a genuinely surprising model property) — investigate before touching the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+dart format .
+git add test/core/deco/deco_property_test.dart
+git commit -m "test(deco): property tests for deco model invariants"
+```
+
+---
+
+### Task 11: Wire DiveEnvironment into the app's orchestrators
+
+**Files:**
+- Modify: `lib/features/dive_log/data/services/profile_analysis_service.dart` (constructor, ~line 467)
+- Modify: `lib/features/dive_log/presentation/providers/profile_analysis_provider.dart` (`_resolveAnalysisService`, plus the bare `BuhlmannAlgorithm(...)` at ~line 1026)
+- Modify: `lib/features/dive_planner/data/services/plan_calculator_service.dart` (`calculatePlan`, both `BuhlmannAlgorithm(...)` constructions at ~lines 73 and 451)
+- Modify: `lib/features/dive_planner/presentation/providers/dive_planner_providers.dart` (`planResultsProvider` call site)
+- Test: `test/features/dive_log/profile_analysis_environment_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveEnvironment.forConditions` (Task 1). `Dive` already has `altitude` (meters, `double?`), `waterType` (`WaterType?`), and `surfacePressure` (bar, `double?`) — no schema change.
+- Produces: `ProfileAnalysisService({..., DiveEnvironment environment = DiveEnvironment.standard})`; `PlanCalculatorService.calculatePlan({..., DiveEnvironment environment = DiveEnvironment.standard})`. Dive details and the planner now honor altitude/salinity. The deco calculator and surface-interval tool keep `DiveEnvironment.standard` implicitly (no edits).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/profile_analysis_environment_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/deco/entities/dive_environment.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+
+void main() {
+  // A square 30 m / 25 min profile sampled every 30 s.
+  final depths = <double>[];
+  final timestamps = <int>[];
+  for (int t = 0; t <= 1620; t += 30) {
+    timestamps.add(t);
+    if (t < 120) {
+      depths.add(30.0 * t / 120.0);
+    } else if (t <= 1500) {
+      depths.add(30.0);
+    } else {
+      depths.add(30.0 * (1620 - t) / 120.0);
+    }
+  }
+
+  test('altitude environment yields shorter NDL in the analysis', () {
+    final seaLevel = ProfileAnalysisService(gfLow: 0.5, gfHigh: 0.8);
+    final altitude = ProfileAnalysisService(
+      gfLow: 0.5,
+      gfHigh: 0.8,
+      environment: DiveEnvironment.forConditions(altitudeMeters: 2500),
+    );
+
+    final seaAnalysis = seaLevel.analyze(
+      diveId: 'test',
+      depths: depths,
+      timestamps: timestamps,
+    );
+    final altAnalysis = altitude.analyze(
+      diveId: 'test',
+      depths: depths,
+      timestamps: timestamps,
+    );
+
+    // Mid-bottom NDL is shorter at altitude.
+    final mid = depths.length ~/ 2;
+    expect(
+      altAnalysis.ndlCurve[mid],
+      lessThan(seaAnalysis.ndlCurve[mid]),
+    );
+  });
+}
+```
+
+(Adjust the `analyze` call's named parameters to the real signature — read the method before writing; the parameters shown are the minimum from its docs. If `analyze` requires more arguments, supply their simplest values as existing tests under `test/features/dive_log/` do.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/profile_analysis_environment_test.dart`
+Expected: FAIL — `environment` parameter does not exist.
+
+- [ ] **Step 3: Implement**
+
+1. `ProfileAnalysisService`: add `DiveEnvironment environment = DiveEnvironment.standard` to the constructor and pass `environment: environment` into its `BuhlmannAlgorithm(...)` initializer.
+
+2. `profile_analysis_provider.dart`: in `_resolveAnalysisService` (which already reads per-dive GF), build and pass the environment from the dive:
+
+```dart
+    final environment = DiveEnvironment.forConditions(
+      altitudeMeters: dive.altitude,
+      waterType: dive.waterType,
+      surfacePressureBar: dive.surfacePressure,
+    );
+```
+
+and pass `environment: environment` to the `ProfileAnalysisService(...)` construction there. For the settings-only `profileAnalysisServiceProvider` (no dive in scope) leave the default. At line ~1026 (`BuhlmannAlgorithm(gfLow: gfLow, gfHigh: gfHigh)`): check whether a `Dive` is in scope in that provider; if yes, pass `environment: DiveEnvironment.forConditions(altitudeMeters: dive.altitude, waterType: dive.waterType, surfacePressureBar: dive.surfacePressure)`; if not, leave it (standard default).
+
+3. `PlanCalculatorService.calculatePlan`: add parameter `DiveEnvironment environment = DiveEnvironment.standard`, pass `environment: environment` to BOTH `BuhlmannAlgorithm(...)` constructions (lines ~73 and ~451 — the second is in `calculateSurfaceInterval`; give that method the same optional parameter).
+
+4. `dive_planner_providers.dart`: in `planResultsProvider`, where `calculatePlan` is invoked, pass:
+
+```dart
+      environment: DiveEnvironment.forConditions(
+        altitudeMeters: state.altitude > 0 ? state.altitude : null,
+      ),
+```
+
+(`state.altitude` is non-null with default 0 in `DivePlanState`; treat 0 as sea level legacy. Water type comes to the planner in Phase 2.)
+
+- [ ] **Step 4: Run tests and full verification**
+
+```bash
+flutter test test/features/dive_log/profile_analysis_environment_test.dart
+flutter test test/core/deco/
+flutter analyze
+dart format .
+```
+Expected: new test PASS, deco suite PASS, analyze clean, format no changes. Then run the existing analysis/planner test files: `ls test/features/dive_log/ test/features/dive_planner/` and run each file that mentions `profile_analysis` or `plan_calculator` individually.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/data/services/profile_analysis_service.dart lib/features/dive_log/presentation/providers/profile_analysis_provider.dart lib/features/dive_planner/data/services/plan_calculator_service.dart lib/features/dive_planner/presentation/providers/dive_planner_providers.dart test/features/dive_log/profile_analysis_environment_test.dart
+git commit -m "feat(deco): honor dive altitude and water type in analysis and planning"
+```
+
+---
+
+## Completion checklist (run after Task 11)
+
+- [ ] `flutter test test/core/deco/` — all green (including golden + property suites)
+- [ ] `flutter analyze` — no new issues
+- [ ] `dart format .` — no changes
+- [ ] The engine API is now FROZEN for Phase 2-7 parallel work: `DiveEnvironment`, `BreathingConfig`, `SchedulePolicy`, `DecoModel`/`BuhlmannGf`, `restoreState`, `pressureAfterConsuming`
+- [ ] Known Phase 1 limitations carried forward (documented in the spec): deco SCHEDULES still breathe OC even for CCR loading (Phase 4 adds loop deco/bailout schedules); measured-ppO2-driven CCR loading (vs setpoint) is Phase 4; air-break CNS bookkeeping stays in `O2ToxicityCalculator` unchanged

--- a/docs/superpowers/plans/2026-07-05-fullscreen-draggable-readout.md
+++ b/docs/superpowers/plans/2026-07-05-fullscreen-draggable-readout.md
@@ -1,0 +1,1013 @@
+# Fullscreen Draggable Readout Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the fullscreen profile page's clipped hover tooltip with an always-visible draggable readout card whose position persists in settings.
+
+**Architecture:** The chart's existing external-tooltip mode (`tooltipBelow: true` + `onTooltipData`) suppresses the painted bubble and streams `TooltipRow` data to the page, which renders it in a new `DraggableReadoutCard` positioned inside a `Stack` over the chart area. Position is a `FractionalOffset`-style fraction of the movable range, clamped, and saved to two new nullable `AppSettings` doubles on drag end.
+
+**Tech Stack:** Flutter widgets (Stack/Align/GestureDetector), Riverpod settings notifier, SharedPreferences, flutter gen-l10n.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-fullscreen-draggable-readout-design.md`
+
+## Global Constraints
+
+- WORKTREE: all paths are relative to the worktree root `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/fullscreen-tooltip-clamp` (branch `worktree-fullscreen-draggable-readout`). Never edit files under the main checkout path. Do not run bare `git stash`.
+- Run `dart format .` (whole repo) before every commit; commit only if it reports the files you touched (or 0 changed).
+- No emojis anywhere. Sound null safety. New strings translated into all 10 non-English locales: ar, de, es, fr, he, hu, it, nl, pt, zh, then `flutter gen-l10n`.
+- `flutter analyze` must stay at the baseline 22 pre-existing issues (none in touched files).
+- Run specific test files, never whole directories (Bash timeout).
+- Commits per task are pre-authorized by plan approval. Plain commit messages, no Co-Authored-By trailers.
+
+---
+
+### Task 1: Reset the interim clamp work; keep the detail-page placement pin
+
+The branch has uncommitted `tooltipInsidePlot` changes (an interim fix this
+feature supersedes). Reset them, then re-add the one test worth keeping:
+the pin on the detail page's above-the-chart placement.
+
+**Files:**
+- Reset: `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart`, `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`, `test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart`, `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+- Modify: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+
+**Interfaces:**
+- Produces: clean HEAD state for all later tasks; a `DiveProfileChart - tooltip placement` test group other tasks must keep passing.
+
+- [ ] **Step 1: Reset the four files to HEAD**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/fullscreen-tooltip-clamp
+git checkout -- \
+  lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart \
+  lib/features/dive_log/presentation/widgets/dive_profile_chart.dart \
+  test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart \
+  test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git status --short
+```
+
+Expected: `git status --short` prints nothing (clean tree).
+
+- [ ] **Step 2: Add the detail-page placement pin test**
+
+In `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`,
+insert this group directly above the line
+`// =========================================================================`
+that precedes `group('DiveProfileChart.tankTooltipLabel', () {`:
+
+```dart
+  group('DiveProfileChart - tooltip placement', () {
+    testWidgets('default keeps the bubble pinned above the chart box '
+        '(detail-page behavior)', (tester) async {
+      await tester.pumpWidget(_buildChart());
+      await tester.pumpAndSettle();
+
+      final tooltip = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineTouchData
+          .touchTooltipData;
+      expect(tooltip.showOnTopOfTheChartBoxArea, isTrue);
+      expect(tooltip.fitInsideVertically, isFalse);
+      expect(tooltip.tooltipMargin, 0);
+    });
+  });
+
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --plain-name 'tooltip placement'
+```
+
+Expected: `+1: All tests passed!`
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+dart format .
+git add test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "test(dive_log): pin detail-page tooltip placement above the chart box"
+```
+
+---
+
+### Task 2: Settings plumbing for the card position
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/settings_providers.dart`
+- Modify: `test/features/settings/presentation/providers/settings_notifier_real_test.dart`
+- Modify: `test/helpers/mock_providers.dart`, `test/features/settings/presentation/pages/settings_page_test.dart`, `test/features/statistics/presentation/pages/records_page_test.dart`
+
+**Interfaces:**
+- Produces: `AppSettings.fullscreenReadoutCardX` / `AppSettings.fullscreenReadoutCardY` (`double?`, null = unset) and `Future<void> SettingsNotifier.setFullscreenReadoutCardPosition(double x, double y)`. Task 5 consumes all three.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/features/settings/presentation/providers/settings_notifier_real_test.dart`,
+add this group inside `main()`, after the closing `});` of the existing
+`group('Real SettingsNotifier.setShowDetailsPaneForSection', ...)`. It reuses
+the file-level fakes (`_InMemorySettingsRepository`, `_EmptyDiverRepository`,
+`_NullDiverIdNotifier`) and mirrors the existing group's setUp:
+
+```dart
+  group('Real SettingsNotifier.setFullscreenReadoutCardPosition', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diverSettingsRepositoryProvider.overrideWithValue(
+            _InMemorySettingsRepository(),
+          ),
+          diverRepositoryProvider.overrideWithValue(_EmptyDiverRepository()),
+          currentDiverIdProvider.overrideWith((ref) => _NullDiverIdNotifier()),
+        ],
+      );
+
+      await Future.delayed(const Duration(milliseconds: 50));
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('defaults to null and round-trips through SharedPreferences',
+        () async {
+      // Let the notifier's async _initializeAndLoad settle.
+      for (var i = 0; i < 10; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final notifier = container.read(settingsProvider.notifier);
+
+      expect(container.read(settingsProvider).fullscreenReadoutCardX, isNull);
+      expect(container.read(settingsProvider).fullscreenReadoutCardY, isNull);
+
+      await notifier.setFullscreenReadoutCardPosition(0.25, 0.75);
+
+      expect(container.read(settingsProvider).fullscreenReadoutCardX, 0.25);
+      expect(container.read(settingsProvider).fullscreenReadoutCardY, 0.75);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('fullscreen_readout_card_x'), 0.25);
+      expect(prefs.getDouble('fullscreen_readout_card_y'), 0.75);
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+flutter test test/features/settings/presentation/providers/settings_notifier_real_test.dart
+```
+
+Expected: FAIL to compile with "The getter 'fullscreenReadoutCardX' isn't defined" (and the setter missing).
+
+- [ ] **Step 3: Implement the settings plumbing**
+
+All edits in `lib/features/settings/presentation/providers/settings_providers.dart`.
+
+(a) In `SettingsKeys`, directly after
+`static const String fullscreenHiddenTiles = 'fullscreen_hidden_tiles';` (line ~75):
+
+```dart
+  static const String fullscreenReadoutCardX = 'fullscreen_readout_card_x';
+  static const String fullscreenReadoutCardY = 'fullscreen_readout_card_y';
+```
+
+(b) In `AppSettings`, directly after
+`final List<String> fullscreenHiddenTiles;` (line ~308):
+
+```dart
+  /// Fullscreen readout card position as fractions (0..1) of the movable
+  /// range; null means the default corner. See DraggableReadoutCard.
+  final double? fullscreenReadoutCardX;
+  final double? fullscreenReadoutCardY;
+```
+
+(c) In the `AppSettings` constructor, directly after
+`this.fullscreenHiddenTiles = const [],` (line ~405):
+
+```dart
+    this.fullscreenReadoutCardX,
+    this.fullscreenReadoutCardY,
+```
+
+(d) In `copyWith`, add parameters directly after
+`List<String>? fullscreenHiddenTiles,` (line ~535):
+
+```dart
+    double? fullscreenReadoutCardX,
+    double? fullscreenReadoutCardY,
+```
+
+and assignments directly after the
+`fullscreenHiddenTiles: fullscreenHiddenTiles ?? this.fullscreenHiddenTiles,`
+line (~line 655):
+
+```dart
+      fullscreenReadoutCardX:
+          fullscreenReadoutCardX ?? this.fullscreenReadoutCardX,
+      fullscreenReadoutCardY:
+          fullscreenReadoutCardY ?? this.fullscreenReadoutCardY,
+```
+
+(There is no clear-to-null requirement; positions are only ever set.)
+
+(e) In `_loadSettings`, directly after the
+`final fullscreenHiddenTiles = prefs.getStringList(...) ?? const [];`
+statement (line ~750):
+
+```dart
+      final fullscreenReadoutCardX = prefs.getDouble(
+        SettingsKeys.fullscreenReadoutCardX,
+      );
+      final fullscreenReadoutCardY = prefs.getDouble(
+        SettingsKeys.fullscreenReadoutCardY,
+      );
+```
+
+Then find BOTH `AppSettings(`/`copyWith(` construction sites inside
+`_loadSettings` that pass `fullscreenTileOrder: fullscreenTileOrder,`
+(lines ~757 and ~766; `grep -n "fullscreenTileOrder: fullscreenTileOrder"`)
+and add to each, right after their `fullscreenHiddenTiles:` argument:
+
+```dart
+        fullscreenReadoutCardX: fullscreenReadoutCardX,
+        fullscreenReadoutCardY: fullscreenReadoutCardY,
+```
+
+(f) In `_saveSettings`, directly after the
+`await prefs.setStringList(SettingsKeys.fullscreenTileOrder, ...)` statement
+group (there is a matching `fullscreenHiddenTiles` write just below it; add
+after both, keeping the device-local comment block intact):
+
+```dart
+    final readoutCardX = state.fullscreenReadoutCardX;
+    if (readoutCardX != null) {
+      await prefs.setDouble(SettingsKeys.fullscreenReadoutCardX, readoutCardX);
+    }
+    final readoutCardY = state.fullscreenReadoutCardY;
+    if (readoutCardY != null) {
+      await prefs.setDouble(SettingsKeys.fullscreenReadoutCardY, readoutCardY);
+    }
+```
+
+(g) In `SettingsNotifier`, directly after the closing brace of
+`setFullscreenTilePreferences` (line ~1267):
+
+```dart
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    state = state.copyWith(
+      fullscreenReadoutCardX: x,
+      fullscreenReadoutCardY: y,
+    );
+    await _saveSettings();
+  }
+```
+
+- [ ] **Step 4: Stub the explicit fakes**
+
+Three test fakes implement `SettingsNotifier` without `noSuchMethod` and
+need the new member. In each of
+`test/helpers/mock_providers.dart`,
+`test/features/settings/presentation/pages/settings_page_test.dart`,
+`test/features/statistics/presentation/pages/records_page_test.dart`,
+add inside the fake class (next to its other setter overrides):
+
+```dart
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    state = state.copyWith(
+      fullscreenReadoutCardX: x,
+      fullscreenReadoutCardY: y,
+    );
+  }
+```
+
+If a fake's class does not expose `state` mutation that way, an empty body
+`async {}` is acceptable there; match each file's existing stub style.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+flutter test test/features/settings/presentation/providers/settings_notifier_real_test.dart
+flutter analyze
+```
+
+Expected: settings test file all pass; analyze reports exactly the baseline
+22 pre-existing issues and nothing in the files touched here. If analyze
+flags another `SettingsNotifier` fake, add the same stub there.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/settings/presentation/providers/settings_providers.dart \
+  test/features/settings/presentation/providers/settings_notifier_real_test.dart \
+  test/helpers/mock_providers.dart \
+  test/features/settings/presentation/pages/settings_page_test.dart \
+  test/features/statistics/presentation/pages/records_page_test.dart
+git commit -m "feat(settings): persist fullscreen readout card position"
+```
+
+---
+
+### Task 3: Localized placeholder hint
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` plus `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`
+- Regenerate: `lib/l10n/arb/app_localizations*.dart` via `flutter gen-l10n`
+
+**Interfaces:**
+- Produces: `context.l10n.diveLog_fullscreenProfile_readoutHint` (Task 4 consumes it).
+
+- [ ] **Step 1: Add the key to the template arb**
+
+In `lib/l10n/arb/app_en.arb`, next to the existing
+`"diveLog_fullscreenProfile_close"` entry (line ~2189), add:
+
+```json
+  "diveLog_fullscreenProfile_readoutHint": "Hover or scrub the profile",
+  "@diveLog_fullscreenProfile_readoutHint": {
+    "description": "Placeholder shown in the fullscreen readout card before any profile point has been hovered or scrubbed"
+  },
+```
+
+- [ ] **Step 2: Add translations to the 10 locale arbs**
+
+Add `"diveLog_fullscreenProfile_readoutHint": "<value>"` to each locale file
+(next to that locale's `diveLog_fullscreenProfile_close` entry; locale files
+carry values only, no `@` metadata). Before inserting, check how each file
+translates "profile" in its other `diveLog_fullscreenProfile_*` keys and
+keep the same noun. Values:
+
+| File | Value |
+| --- | --- |
+| app_ar.arb | "مرر المؤشر أو اسحب فوق ملف الغوص" |
+| app_de.arb | "Zeiger über das Profil bewegen oder scrubben" |
+| app_es.arb | "Pasa el cursor o desliza sobre el perfil" |
+| app_fr.arb | "Survolez ou faites glisser sur le profil" |
+| app_he.arb | "רחפו או גררו על הפרופיל" |
+| app_hu.arb | "Vigye az egérmutatót a profil fölé, vagy húzza rajta az ujját" |
+| app_it.arb | "Passa il cursore o scorri sul profilo" |
+| app_nl.arb | "Beweeg de muis over het profiel of veeg erover" |
+| app_pt.arb | "Passe o cursor ou deslize sobre o perfil" |
+| app_zh.arb | "悬停或滑动查看剖面图" |
+
+- [ ] **Step 3: Regenerate and verify**
+
+```bash
+flutter gen-l10n
+flutter test test/l10n/localization_test.dart
+```
+
+Expected: generation succeeds; localization test passes (it checks key
+parity across locales).
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+dart format .
+git add lib/l10n/arb/
+git commit -m "feat(l10n): add fullscreen readout card hint string"
+```
+
+---
+
+### Task 4: DraggableReadoutCard widget (TDD)
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/draggable_readout_card.dart`
+- Create: `test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart`
+
+**Interfaces:**
+- Consumes: `TooltipRow` (label/value/bulletColor) from `dive_profile_chart.dart`; the l10n hint from Task 3.
+- Produces: `DraggableReadoutCard({required List<TooltipRow>? rows, required Offset? initialFraction, required ValueChanged<Offset> onDragEnd})`, `DraggableReadoutCard.defaultFraction == Offset(1, 0)`, and the inner card's `ValueKey('readout-card')`. Task 5 consumes all of these. The widget must be placed directly inside a `Stack` (it renders `Positioned.fill`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/draggable_readout_card.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+const _cardKey = ValueKey('readout-card');
+
+Widget _wrap({
+  List<TooltipRow>? rows,
+  Offset? initialFraction,
+  ValueChanged<Offset>? onDragEnd,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          key: const ValueKey('arena'),
+          width: 600,
+          height: 400,
+          child: Stack(
+            children: [
+              DraggableReadoutCard(
+                rows: rows,
+                initialFraction: initialFraction,
+                onDragEnd: onDragEnd ?? (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows the localized hint before any rows arrive', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(rows: null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hover or scrub the profile'), findsOneWidget);
+  });
+
+  testWidgets('renders rows with label and value, hint gone', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        rows: const [
+          TooltipRow(label: 'Depth', value: '18.2 m', bulletColor: Colors.blue),
+          TooltipRow(label: 'Temp', value: '22 C', bulletColor: Colors.red),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hover or scrub the profile'), findsNothing);
+    expect(find.text('Depth'), findsOneWidget);
+    expect(find.text('18.2 m'), findsOneWidget);
+    expect(find.text('Temp'), findsOneWidget);
+  });
+
+  testWidgets('defaults to the top-right corner', (tester) async {
+    await tester.pumpWidget(_wrap(rows: null));
+    await tester.pumpAndSettle();
+
+    final stackRect = tester.getRect(find.byKey(const ValueKey('arena')));
+    final cardRect = tester.getRect(find.byKey(_cardKey));
+    // Right edge inset by the 12px padding; top edge likewise.
+    expect(cardRect.right, closeTo(stackRect.right - 12, 1.0));
+    expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+  });
+
+  testWidgets('dragging moves the card and clamps at the bounds', (
+    tester,
+  ) async {
+    Offset? lastFraction;
+    await tester.pumpWidget(
+      _wrap(rows: null, onDragEnd: (f) => lastFraction = f),
+    );
+    await tester.pumpAndSettle();
+
+    // Drag far past the top-left corner: must clamp to fraction (0,0).
+    await tester.drag(find.byKey(_cardKey), const Offset(-2000, -2000));
+    await tester.pumpAndSettle();
+
+    final stackRect = tester.getRect(find.byKey(const ValueKey('arena')));
+    final cardRect = tester.getRect(find.byKey(_cardKey));
+    expect(cardRect.left, closeTo(stackRect.left + 12, 1.0));
+    expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+    expect(lastFraction, const Offset(0, 0));
+  });
+
+  testWidgets('a partial drag reports an interior fraction', (tester) async {
+    Offset? lastFraction;
+    await tester.pumpWidget(
+      _wrap(
+        rows: null,
+        initialFraction: const Offset(0, 0),
+        onDragEnd: (f) => lastFraction = f,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byKey(_cardKey), const Offset(80, 60));
+    await tester.pumpAndSettle();
+
+    expect(lastFraction, isNotNull);
+    expect(lastFraction!.dx, greaterThan(0));
+    expect(lastFraction!.dx, lessThan(1));
+    expect(lastFraction!.dy, greaterThan(0));
+    expect(lastFraction!.dy, lessThan(1));
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+flutter test test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+```
+
+Expected: FAIL to compile ("draggable_readout_card.dart" not found).
+
+- [ ] **Step 3: Implement the widget**
+
+Create `lib/features/dive_log/presentation/widgets/draggable_readout_card.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Always-visible floating readout for the fullscreen profile page.
+///
+/// Renders the latest externally emitted tooltip rows (see
+/// [DiveProfileChart.onTooltipData]) in a compact card the user can drag
+/// anywhere within the enclosing [Stack]. Position is a fraction of the
+/// movable range (stack size minus card size): (0,0) is flush top-left,
+/// (1,1) flush bottom-right. Must be placed directly inside a [Stack].
+class DraggableReadoutCard extends StatefulWidget {
+  /// Latest tooltip rows; null or empty shows the placeholder hint.
+  final List<TooltipRow>? rows;
+
+  /// Starting position fraction; null uses [defaultFraction].
+  final Offset? initialFraction;
+
+  /// Called with the final position fraction when a drag ends. The caller
+  /// persists it (fullscreen page saves to settings).
+  final ValueChanged<Offset> onDragEnd;
+
+  const DraggableReadoutCard({
+    super.key,
+    required this.rows,
+    required this.initialFraction,
+    required this.onDragEnd,
+  });
+
+  /// Default position: top-right corner.
+  static const Offset defaultFraction = Offset(1, 0);
+
+  @override
+  State<DraggableReadoutCard> createState() => _DraggableReadoutCardState();
+}
+
+class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
+  static const _inset = 12.0;
+  final GlobalKey _cardKey = GlobalKey();
+  late Offset _fraction =
+      widget.initialFraction ?? DraggableReadoutCard.defaultFraction;
+
+  void _onPanUpdate(DragUpdateDetails details, BoxConstraints constraints) {
+    final cardSize = _cardKey.currentContext?.size;
+    if (cardSize == null) return;
+    final movableW = constraints.maxWidth - cardSize.width;
+    final movableH = constraints.maxHeight - cardSize.height;
+    setState(() {
+      _fraction = Offset(
+        movableW <= 0
+            ? 0
+            : (_fraction.dx + details.delta.dx / movableW).clamp(0.0, 1.0),
+        movableH <= 0
+            ? 0
+            : (_fraction.dy + details.delta.dy / movableH).clamp(0.0, 1.0),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final rows = widget.rows;
+
+    return Positioned.fill(
+      child: Padding(
+        padding: const EdgeInsets.all(_inset),
+        child: LayoutBuilder(
+          builder: (context, constraints) => Align(
+            alignment: FractionalOffset(_fraction.dx, _fraction.dy),
+            child: GestureDetector(
+              onPanUpdate: (details) => _onPanUpdate(details, constraints),
+              onPanEnd: (_) => widget.onDragEnd(_fraction),
+              child: Container(
+                key: const ValueKey('readout-card'),
+                constraints: const BoxConstraints(maxWidth: 240),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: colorScheme.outlineVariant),
+                ),
+                child: rows == null || rows.isEmpty
+                    ? Text(
+                        context.l10n.diveLog_fullscreenProfile_readoutHint,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (final row in rows)
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 1),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Container(
+                                    width: 8,
+                                    height: 8,
+                                    decoration: BoxDecoration(
+                                      color: row.bulletColor,
+                                      shape: BoxShape.circle,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 6),
+                                  Flexible(
+                                    child: Text(
+                                      row.label,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: textTheme.bodySmall?.copyWith(
+                                        color: colorScheme.onSurfaceVariant,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(row.value, style: textTheme.bodySmall),
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+flutter test test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+```
+
+Expected: `+5: All tests passed!`
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/widgets/draggable_readout_card.dart \
+  test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+git commit -m "feat(dive_log): add draggable readout card widget"
+```
+
+---
+
+### Task 5: Fullscreen page wiring
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart`
+- Modify: `test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart`
+
+**Interfaces:**
+- Consumes: `DraggableReadoutCard` (Task 4), `setFullscreenReadoutCardPosition` + the two `AppSettings` fields (Task 2), `DiveProfileChart.tooltipBelow`/`onTooltipData` (existing).
+
+- [ ] **Step 1: Write the failing page tests**
+
+In `test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart`:
+
+(a) Add imports next to the existing widget imports:
+
+```dart
+import 'package:fl_chart/fl_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/draggable_readout_card.dart';
+```
+
+(b) Replace the `_FakeSettingsNotifier` class with a version that captures
+the persisted position (keep `noSuchMethod`):
+
+```dart
+class _FakeSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _FakeSettingsNotifier([AppSettings? initial])
+    : super(initial ?? const AppSettings());
+
+  double? savedCardX;
+  double? savedCardY;
+
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    savedCardX = x;
+    savedCardY = y;
+    state = state.copyWith(
+      fullscreenReadoutCardX: x,
+      fullscreenReadoutCardY: y,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+```
+
+(c) Add these tests after the `'renders chart and instrument bar'` test:
+
+```dart
+  testWidgets('shows the readout card with the placeholder hint', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_defaultOverrides()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DraggableReadoutCard), findsOneWidget);
+    expect(find.text('Hover or scrub the profile'), findsOneWidget);
+  });
+
+  testWidgets('chart runs in external-tooltip mode (no painted bubble)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_defaultOverrides()));
+    await tester.pumpAndSettle();
+
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    expect(chart.tooltipBelow, isTrue);
+    expect(chart.onTooltipData, isNotNull);
+  });
+
+  testWidgets('long-press populates the card and values stick after release', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_defaultOverrides()));
+    await tester.pumpAndSettle();
+
+    final chartCenter = tester.getCenter(find.byType(LineChart).first);
+    final gesture = await tester.startGesture(chartCenter);
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.moveBy(const Offset(2, 0));
+    await tester.pump();
+
+    // Rows arrived: hint is gone from the card.
+    expect(find.text('Hover or scrub the profile'), findsNothing);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Sticky: hover ended but the card keeps the last values.
+    expect(find.text('Hover or scrub the profile'), findsNothing);
+  });
+
+  testWidgets('dragging the card persists a clamped fraction to settings', (
+    tester,
+  ) async {
+    final fake = _FakeSettingsNotifier();
+    final overrides = _defaultOverrides()
+      ..removeAt(0)
+      ..insert(0, settingsProvider.overrideWith((ref) => fake));
+    await tester.pumpWidget(_wrap(overrides));
+    await tester.pumpAndSettle();
+
+    await tester.drag(
+      find.byKey(const ValueKey('readout-card')),
+      const Offset(-3000, 3000),
+    );
+    await tester.pumpAndSettle();
+
+    expect(fake.savedCardX, 0.0);
+    expect(fake.savedCardY, 1.0);
+  });
+
+  testWidgets('saved position seeds the card at bottom-left', (tester) async {
+    final overrides = _defaultOverrides()
+      ..removeAt(0)
+      ..insert(
+        0,
+        settingsProvider.overrideWith(
+          (ref) => _FakeSettingsNotifier(
+            const AppSettings(
+              fullscreenReadoutCardX: 0,
+              fullscreenReadoutCardY: 1,
+            ),
+          ),
+        ),
+      );
+    await tester.pumpWidget(_wrap(overrides));
+    await tester.pumpAndSettle();
+
+    final chartRect = tester.getRect(find.byType(DiveProfileChart));
+    final cardRect = tester.getRect(
+      find.byKey(const ValueKey('readout-card')),
+    );
+    expect(cardRect.left, lessThan(chartRect.center.dx));
+    expect(cardRect.bottom, greaterThan(chartRect.center.dy));
+  });
+```
+
+Note: `_defaultOverrides()` puts the settings override at index 0; the
+`removeAt(0)`/`insert(0, ...)` pattern swaps in the parameterized fake.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+flutter test test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+```
+
+Expected: FAIL (card type not found / `tooltipBelow` false).
+
+- [ ] **Step 3: Wire the page**
+
+All edits in `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart`.
+
+(a) Add the import next to the other widget imports:
+
+```dart
+import 'package:submersion/features/dive_log/presentation/widgets/draggable_readout_card.dart';
+```
+
+(b) In `_FullscreenProfilePageState`, add a field next to the existing state
+fields at the top of the class:
+
+```dart
+  /// Last non-null tooltip rows; the readout card keeps showing these after
+  /// the hover ends (sticky values).
+  List<TooltipRow>? _readoutRows;
+```
+
+and this method next to the other private helpers:
+
+```dart
+  void _onTooltipData(List<TooltipRow>? rows) {
+    if (rows == null || rows.isEmpty) return; // sticky: keep last values
+    setState(() => _readoutRows = rows);
+  }
+```
+
+(c) In `build`, wrap the chart in a `Stack` and add the card. The current
+code is:
+
+```dart
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                    child: DiveProfileChart(
+```
+
+Change to (the chart's argument list is unchanged apart from (d) below;
+`settings` is defined in (e)):
+
+```dart
+                Expanded(
+                  child: Stack(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                        child: DiveProfileChart(
+```
+
+and close the new `Stack` after the chart's `Padding`: the current closing
+sequence at the end of the chart call is
+
+```dart
+                    ),
+                  ),
+                ),
+                // Source switching and overlay comparison, mirroring the
+```
+
+which becomes
+
+```dart
+                        ),
+                      ),
+                      DraggableReadoutCard(
+                        // Re-key on the saved position so a settings load
+                        // that lands after first build still seeds the card.
+                        key: ValueKey(
+                          'readout-card-seed-'
+                          '${settings.fullscreenReadoutCardX}-'
+                          '${settings.fullscreenReadoutCardY}',
+                        ),
+                        rows: _readoutRows,
+                        initialFraction:
+                            settings.fullscreenReadoutCardX != null &&
+                                settings.fullscreenReadoutCardY != null
+                            ? Offset(
+                                settings.fullscreenReadoutCardX!,
+                                settings.fullscreenReadoutCardY!,
+                              )
+                            : null,
+                        onDragEnd: (fraction) => ref
+                            .read(settingsProvider.notifier)
+                            .setFullscreenReadoutCardPosition(
+                              fraction.dx,
+                              fraction.dy,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+                // Source switching and overlay comparison, mirroring the
+```
+
+(Re-indent the whole chart argument block by four extra spaces to match;
+`dart format .` normalizes any misses.)
+
+(d) Inside the chart's argument list, directly after
+`maxDepth: dive.maxDepth,`, add:
+
+```dart
+                          // The painted tooltip would clip at the screen edge
+                          // (no headroom above the plot in fullscreen); the
+                          // draggable readout card renders the data instead.
+                          tooltipBelow: true,
+                          onTooltipData: _onTooltipData,
+```
+
+(e) At the top of `build`, next to the other `ref.watch` calls (around
+`final showMaxDepthMarker = ref.watch(showMaxDepthMarkerProvider);`), add:
+
+```dart
+    final settings = ref.watch(settingsProvider);
+```
+
+and add the import for it if not already present:
+
+```dart
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+flutter test test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+```
+
+Expected: all pass, including the pre-existing page tests.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart \
+  test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+git commit -m "feat(dive_log): draggable readout card on fullscreen profile"
+```
+
+---
+
+### Task 6: Full verification sweep
+
+**Files:** none new; fixes only if something fails.
+
+- [ ] **Step 1: Run every touched test file**
+
+```bash
+flutter test \
+  test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart \
+  test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart \
+  test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart \
+  test/features/settings/presentation/providers/settings_notifier_real_test.dart \
+  test/l10n/localization_test.dart
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Whole-project format and analyze**
+
+```bash
+dart format .
+flutter analyze
+```
+
+Expected: format 0 changed; analyze at the 22-issue pre-existing baseline
+with nothing in files this plan touched. Fix and re-run if not.
+
+- [ ] **Step 3: Commit any verification fixes**
+
+Only if Steps 1-2 required changes:
+
+```bash
+git add -A
+git commit -m "test(dive_log): verification fixes for draggable readout card"
+```

--- a/docs/superpowers/specs/2026-07-05-dive-planner-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-05-dive-planner-redesign-design.md
@@ -1,0 +1,279 @@
+# Dive Planner Redesign — Design Spec
+
+Date: 2026-07-05
+Status: Approved design, pending implementation planning
+
+## Goal
+
+Replace the current dive planner with a technical dive planner that matches the
+feature depth of MultiDeco and V-Planner, the usability of Divekit, and adds a
+capability no competitor has: deep integration with the dive log. All deco
+calculations use the same shared engine as the dive details page.
+
+## Problem
+
+The current planner (`lib/features/planning/` + `lib/features/dive_planner/`,
+~5,100 lines) is clunky, incomplete, and inaccurate:
+
+- No persistence: save and convert-to-dive are TODO stubs; plans cannot be
+  reloaded.
+- Altitude input exists but is cosmetic — the engine hardcodes surface pressure
+  at 1.0 bar. Salinity is not modeled (fixed 10 m/bar).
+- Repetitive-dive tissue seeding is a stub.
+- CCR affects only ppO2/CNS display, not inert-gas loading. No bailout
+  planning.
+- Gas consumption ignores compressibility. No contingency planning of any
+  kind (deviation plans, lost gas, turn pressure).
+- UI is a static 3-tab form with no live feedback loop.
+
+## Decisions made during brainstorming
+
+| Question | Decision |
+| --- | --- |
+| Deco models | Buhlmann ZH-L16C + GF only for now; define a `DecoModel` interface so VPM-B can be added later without rework |
+| CCR | Full support: constant-ppO2 loading, setpoints, OC bailout with worst-case bailout point |
+| Recreational NDL mode | No — one tech-focused planner |
+| Log integration | All four: tissue seeding, SAC auto-fill, plan-vs-actual, convert-to-dive |
+| Contingencies | All four: one-tap deviation plans, lost-gas plans, turn pressure, reserve validation |
+| Outputs | All four: runtime table + slate PDF, share as file, multi-plan compare, range tables |
+| Form factor | Adaptive, phone-first |
+| UI model | Live Profile Canvas (chart is the centerpiece, live recalc, no Calculate button) |
+| Hub | Redesign the `/planning` hub and restyle the standalone calculators to match |
+| Strategy | Engine-first with validation suite, clean UI rebuild alongside the old planner, parallel worktree tracks for post-engine phases |
+
+## Architecture
+
+Three layers, strict dependency direction (UI -> domain -> engine):
+
+1. **Engine** (`lib/core/deco/`) — pure Dart, no Flutter imports, metric-only.
+2. **Plan domain** (`lib/features/planner/domain/` + Drift tables) — the
+   persisted `DivePlan` aggregate and the `PlanEngine` orchestrator.
+3. **Planner UI** (`lib/features/planner/presentation/`) — the Live Profile
+   Canvas. Built as a fresh feature module; the old `dive_planner` feature
+   stays routed until cutover, then is deleted.
+
+### Phases
+
+Phases 1-3 are strictly sequential. Phases 4-7 are independent once the engine
+API freezes at the end of Phase 1, and can run as parallel worktree tracks.
+The app is releasable after every phase.
+
+| Phase | Deliverable |
+| --- | --- |
+| 1 | Engine: `DecoModel` interface, altitude/salinity, CCR constant-ppO2 loading, gas compressibility, golden-vector validation suite |
+| 2 | Plan domain: entities, persistence (schema v98+), sync, `PlanEngine` |
+| 3 | Planner UI: Live Profile Canvas, OC planning end-to-end, cutover from old planner |
+| 4 | CCR planning + bailout solver + scrub-to-bailout UI |
+| 5 | Contingencies: deviation plans, lost-gas, turn pressure, reserve validation |
+| 6 | Log integration: tissue seeding, SAC auto-fill, plan-vs-actual, convert-to-dive |
+| 7 | Outputs (slate/PDF, share file, compare, range tables) + hub restyle |
+
+## Engine design (Phase 1)
+
+### DecoModel interface
+
+```dart
+abstract class DecoModel {
+  TissueState initial(DiveEnvironment env);
+  TissueState applySegment(TissueState s, Segment seg, InspiredGas gas);
+  double ceiling(TissueState s);          // meters; GF-interpolated for Buhlmann
+  Duration ndl(TissueState s, InspiredGas gas, DiveEnvironment env);
+  DecoSchedule schedule(TissueState s, SchedulePolicy policy, AscentGasPlan gases);
+}
+```
+
+- `TissueState` is model-opaque (Buhlmann: 16x2 tensions; VPM later: bubble
+  parameters). Existing `BuhlmannAlgorithm` internals are reused — this is a
+  re-facing plus fixes, not a rewrite.
+- `BuhlmannGf` is the only implementation shipped now.
+
+### DiveEnvironment
+
+- `surfacePressure` derived from altitude via the existing
+  `AltitudeCalculator`.
+- `waterDensity`: fresh 1000 / EN13319 1020 / salt 1025 kg/m3.
+- Both feed all depth<->pressure conversions, replacing the hardcoded 1.0 bar
+  and 10 m/bar. Dive details (`ProfileAnalysisService`) inherits these fixes;
+  existing displayed values will shift slightly — that is the accuracy fix
+  working, not a regression.
+
+### BreathingConfig
+
+- `OpenCircuit(gasMix)`, `ClosedCircuit(setpoint, diluent)`, `Scr(supplyGas)`.
+- CCR inspired inert pressure = (P_amb - setpoint - P_water_vapor),
+  partitioned by the diluent N2:He ratio, clamped when setpoint >= P_amb
+  (shallow: loop is effectively pure O2). This makes Buhlmann loading correct
+  for CCR; currently it wrongly uses OC fractions.
+
+### SchedulePolicy
+
+Stop increment (3 m), minimum stop granularity (1 min), configurable last stop
+(3/6 m), descent/ascent rates, gas-switch stop time, optional O2 air breaks
+(e.g. 20 min O2 / 5 min back-gas, MultiDeco-style).
+
+### Consumption
+
+Z-factor gas compressibility (wire in the existing
+`lib/core/utils/gas_compressibility.dart`) for tank capacity and consumption.
+
+### Validation (the accuracy claim)
+
+- Golden vectors in `test/core/deco/golden/`: canonical OC trimix, CCR,
+  altitude, and repetitive-dive plans cross-checked against MultiDeco,
+  Subsurface, and DecoTengu published outputs. Tolerance: +/-1 min per stop.
+  Vectors are computed externally, never from model recall.
+- Property tests: deeper/longer never shortens deco; raising GF-high never
+  increases TTS.
+
+## Plan domain and persistence (Phase 2)
+
+### DivePlan aggregate (inputs only; results always recomputed)
+
+- Identity: id, name, notes, optional dive site link, timestamps.
+- Mode: OC or CCR (plan-level; bailout legs are OC inside a CCR plan).
+- Environment: altitude, water type.
+- Settings: GF low/high, descent/ascent rates, last stop depth, air-break
+  policy, three SAC rates (bottom, deco, stressed).
+- Segments: ordered user waypoints (depth, duration, tank) for the bottom
+  portion only; ascent/deco is always computed.
+- Tanks: volume, working/start pressure, gas, role
+  (`bottom | deco | bailout | diluent | o2`).
+- Contingency config: deviation deltas (+5 m / +5 min defaults), lost-gas
+  toggles, turn-pressure rule (all-usable / halves / thirds / custom).
+- Repetitive context: surface interval + linked source dive (tissue seeding)
+  or explicit start state; plans can chain (plan B follows plan A).
+
+### Persistence
+
+- New Drift tables `dive_plans`, `dive_plan_segments`, `dive_plan_tanks` at
+  schema v98+, all with HLC columns so plans ride the existing sync/changeset
+  infrastructure.
+- Denormalized summary columns (max depth, runtime, TTS) on `dive_plans` so
+  the saved-plans list renders without running the engine.
+
+### PlanEngine (replaces PlanCalculatorService)
+
+`DivePlan -> PlanOutcome`: schedule, per-segment tissue timeline, per-tank
+consumption with reserve status, CNS/OTU, and a severity-sorted `PlanIssue`
+list: ppO2 violations, END over limit, gas density over 5.2/6.2 g/L
+(warn/critical), CNS/OTU thresholds, reserve/turn-pressure violations,
+NDL-exceeded-without-deco-gas, hypoxic gas at depth, bailout insufficient.
+
+## Planner UI — Live Profile Canvas (Phase 3)
+
+Phone-first; desktop spreads the same regions into three panels (editor left,
+chart + runtime table center, issues/gas/contingencies right).
+
+- **Edit only the bottom of the dive.** Segments are user waypoints; the
+  ascent/deco tail is computed and drawn live. Change bottom time, watch the
+  deco tail grow.
+- **Chart is display + selection + scrubbing, not drag-editing.** Tap a
+  segment (chart or card) to edit with steppers. Drag along the chart to scrub
+  a cursor showing runtime, depth, ceiling, TTS at that instant. Reuses
+  dive-details chart interaction patterns and existing zoom infrastructure.
+  Direct waypoint dragging is deferred.
+- **Overlays**: ceiling envelope (dashed), gas-switch markers, stop labels,
+  contingency ghost profile (dashed, toggled by chip).
+- **Live status chips** always visible: runtime, TTS, deco time, CNS, issue
+  count. Tapping a chip opens the results sheet to that section.
+- **Persistent swipe-up results sheet**: runtime table, per-tank gas plan,
+  severity-sorted issues, tissue bars at the scrub point.
+- Live recalculation, no Calculate button, debounced ~150 ms.
+- Mockups: `.superpowers/brainstorm/5337-1783228181/content/planner-canvas.html`
+  (session artifact; composition approved 2026-07-05).
+
+## CCR and bailout (Phase 4)
+
+- Plan-level OC/CCR toggle. Low/high setpoint with configurable switch depth
+  (defaults 0.7 bar shallow, 1.3 bar below 10 m); per-segment setpoint
+  override for deco.
+- Tank roles diluent + O2; consumption = metabolic O2 rate (default 1.0
+  L/min, configurable) plus diluent for descent volume and flushes. END and
+  density warnings evaluate the diluent.
+- **Bailout solver**: for every minute of the CCR plan, compute the full OC
+  bailout outcome (bailout gases, stressed SAC, OC deco). Mark the worst-case
+  point (max gas required) on the chart; validate bailout tanks against it.
+- **Scrub-to-bailout**: scrub anywhere, tap "Bailout from here" — chart ghosts
+  the bailout profile from that instant with its own runtime table.
+- Bailout scan computes lazily after the main outcome renders (performance).
+
+## Contingencies (Phase 5)
+
+- **Deviation plans**: +5 m / +5 min / both (configurable deltas) as full
+  outcomes — ghost overlay, tables in results sheet, on the slate export.
+- **Lost-gas plans**: recompute schedule without each deco gas. CCR loop loss
+  is the bailout plan.
+- **Turn pressure**: per-plan rule -> turn pressure on each bottom tank chip.
+- **Reserve validation**: rock-bottom at worst point (stressed SAC,
+  configurable buddy factor), per-tank issues.
+
+## Log integration (Phase 6)
+
+- **Tissue seeding**: "Following" row — pick a logged dive (default most
+  recent) + surface interval; engine starts from that dive's end tissue state
+  (from `ProfileAnalysis`) with surface off-gassing applied.
+- **SAC auto-fill**: bottom SAC defaults to rolling average from logged dives,
+  tagged "from your log", per-plan override. Deco/stressed default to 0.8x /
+  2.5x until edited.
+- **Plan-vs-actual**: plans link to dives; dive-detail chart gains a "show
+  plan" toggle overlaying planned profile and stops on the actual.
+- **Convert-to-dive**: creates a dive skeleton (date, site, tanks, gases,
+  planned runtime) linked to the plan; computer download fills the profile.
+
+## Outputs (Phase 7)
+
+- **Dive slate**: high-contrast printable page — main runtime table, deviation
+  tables, lost-gas tables, gas plan. PDF via `pdf`/`printing` packages (new
+  dependencies).
+- **Share as file**: versioned JSON (`.subplan`) via share sheet; importable
+  by any Submersion install. QR/web viewer explicitly out of scope.
+- **Multi-plan compare**: 2-3 saved plans -> overlaid profiles + diff table
+  (runtime, TTS, deco time, per-tank gas, CNS).
+- **Range tables**: matrix around the base plan (depth +/-3/6 m x time +/-5/10
+  min, configurable) showing runtime/TTS; included in slate PDF.
+
+## Hub redesign (Phase 7)
+
+`/planning` reorganized around the planner: saved plans list + "New plan"
+front and center; calculators (deco calculator, MOD/END/best mix, consumption,
+rock bottom, weight, surface interval) as a tools grid, restyled to the new
+visual language (chips, live-recalc cards, no Calculate buttons). The deco
+calculator picks up altitude/salinity via the shared engine.
+
+## Error handling
+
+- The engine never throws on an undiveable plan: best-effort schedule +
+  critical `PlanIssue`s. The canvas renders a "not diveable as planned" state
+  with the issues list — never a crash or blank chart.
+- Input guards: max depth 200 m, max runtime 24 h.
+- Recalc debounced ~150 ms; moves to an isolate if profiling shows jank.
+
+## Testing
+
+- Golden-vector suite (Phase 1 foundation) — runs on every engine change.
+- Property tests for model invariants.
+- Unit tests: PlanEngine consumption / turn pressure / issue generation;
+  contingency and bailout solvers.
+- Persistence round-trip + FK-ON sync tests for new tables.
+- Widget tests: canvas panels, results sheet, issue rendering.
+- Release gate: manual checklist comparing a standard plan set against
+  MultiDeco before each planner release.
+
+## Explicitly out of scope
+
+- VPM-B implementation (interface designed for it; no implementation now).
+- Recreational/NDL-first mode.
+- Direct drag-editing of waypoints on the chart.
+- QR-code / web-viewer plan sharing.
+- Cave "same-way-back" planning (turn-pressure covers penetration basics).
+- Gas blending calculator (exists separately; not part of this redesign).
+
+## Competitive context (research summary)
+
+Table stakes across MultiDeco/V-Planner/Divekit/Dive Tools/Subsurface:
+ZH-L16 + GF, multi-level multi-gas OC, CCR with setpoints + bailout, CNS/OTU,
+runtime tables, altitude/salinity, configurable rates/last stop, offline,
+print/share. Differentiators this design captures: log-integrated planning
+(unique to Submersion), scrub-to-bailout (beyond Divekit's worst-case point),
+one-tap contingency ghosts, live tissue/GF visualization, multi-plan compare,
+range tables, published validation vectors (trust, per Divekit's playbook).

--- a/docs/superpowers/specs/2026-07-05-fullscreen-draggable-readout-design.md
+++ b/docs/superpowers/specs/2026-07-05-fullscreen-draggable-readout-design.md
@@ -1,0 +1,119 @@
+# Fullscreen Profile Draggable Readout Card
+
+Date: 2026-07-05
+Status: Approved
+
+## Problem
+
+The dive profile chart pins its hover tooltip above the chart's plot box
+(`showOnTopOfTheChartBoxArea: true`, `fitInsideVertically: false`) so the
+bubble never covers the profile. That works on the dive detail page, where
+scroll content above the chart gives the overflow room to paint. The
+fullscreen profile page has no headroom -- the plot top sits at the screen
+edge -- so the bubble clips off-screen and hover data is unreadable.
+
+An interim fix (uncommitted on this branch) clamped the bubble inside the
+plot via a `tooltipInsidePlot` flag. Feedback: a bubble inside the plot
+covers the profile while hovering. The chosen direction is a readout card
+that never chases the cursor and can be dragged out of the way.
+
+## Decisions
+
+1. The fullscreen page gets an always-visible floating readout card that
+   shows the hovered/scrubbed sample. Before the first hover it shows a
+   placeholder hint line.
+2. The card replaces the painted tooltip bubble on the fullscreen page.
+   The bottom instrument bar stays unchanged. The interim
+   `tooltipInsidePlot` flag is reverted (superseded).
+3. The card's dragged position is remembered across sessions in app
+   settings.
+4. The dive detail page keeps its current above-the-chart tooltip,
+   pinned by a widget test.
+
+## Architecture
+
+Page-owned overlay. The fullscreen page wraps its chart area in a `Stack`;
+the card is a `Positioned` child owned by the page. The chart runs in its
+existing external-tooltip mode (`tooltipBelow: true` + `onTooltipData`),
+which suppresses the painted bubble and emits structured `TooltipRow`
+data (label, value, bulletColor -- already unit-formatted, localized, and
+multi-computer-aware). No new chart plumbing.
+
+Alternatives rejected:
+
+- `OverlayPortal`: lets the card cover the instrument bar and transport
+  controls, which is an anti-feature; more lifecycle complexity.
+- Hosting the card inside `DiveProfileChart`: leaks a page concern into a
+  shared widget that is already far over the repo's file-size ceiling.
+
+## Components
+
+### DraggableReadoutCard (new widget, `draggable_readout_card.dart`)
+
+- Renders the latest `List<TooltipRow>`: one row per metric with a color
+  bullet, label, and value, in a compact vertical list. Styling:
+  `surfaceContainerLow` background, rounded corners, `outlineVariant`
+  border, elevation-free.
+- Placeholder state (no rows yet): a single localized hint line,
+  "Hover or scrub the profile" (works for pointer and touch). One new
+  l10n string, translated into all 10 non-English locales.
+- The whole card is the drag surface (`GestureDetector.onPanUpdate`).
+  No close button, no resizing.
+- Constructor takes: rows (nullable), current fractional position,
+  callbacks for position change (during drag) and drag end (persist).
+
+### Fullscreen page wiring (`fullscreen_profile_page.dart`)
+
+- Wrap the chart `Padding` in a `Stack`; add the card as a positioned
+  overlay clamped to the chart region (it cannot cover the source bar or
+  instrument bar, which sit below in the `Column`).
+- Pass `tooltipBelow: true` and `onTooltipData` to the chart. Keep the
+  existing `onPointSelected` wiring (instrument bar and playback sync are
+  untouched).
+- State: hold the last non-null rows; `onTooltipData(null)` (hover end)
+  does NOT clear the card -- values are sticky. The card starts in
+  placeholder state each page open.
+
+### Position model and persistence
+
+- Position is stored as fractional coordinates (0..1) of the card's
+  top-left over the movable range (stack size minus card size), so 0 is
+  flush left/top, 1 is flush right/bottom, and different window and
+  screen sizes re-derive a sensible spot.
+- Clamped on every layout so the card stays fully inside the chart area.
+- Default (unset): top-right corner with a 12 px inset.
+- Two new nullable doubles on `AppSettings`:
+  `fullscreenReadoutCardX`, `fullscreenReadoutCardY` (null = default),
+  persisted by a new `SettingsNotifier` setter
+  `setFullscreenReadoutCardPosition(double x, double y)`. The four
+  settings test mocks gain the new member.
+- Position saves on drag end only (not per-frame).
+
+## Reverts
+
+The uncommitted `tooltipInsidePlot` changes on this branch are dropped:
+the flag, its `LineTouchTooltipData` ternaries, its two placement tests,
+and the fullscreen page's `tooltipInsidePlot: true`. Kept: the
+"default keeps the bubble pinned above the chart box" widget test, which
+pins the detail-page behavior against future drift.
+
+## Testing
+
+- Card widget tests: renders rows with bullet colors; placeholder before
+  first data; pan gesture moves the card; position clamps at the bounds;
+  drag end invokes the persist callback with fractional coordinates.
+- Fullscreen page tests: chart receives `tooltipBelow: true`; card is
+  present; simulated touch emission populates the card (reuse the
+  existing touch-interaction test pattern from the chart tests); rows
+  survive hover end (sticky).
+- Settings: round-trip of the new fields through the existing settings
+  persistence test pattern; mocks updated.
+- Detail page: existing default-placement test continues to pass
+  unchanged.
+
+## Non-goals
+
+- Hide/show toggle for the card.
+- Card resizing.
+- Using the card on the dive detail page.
+- Replacing or changing the instrument tile row.

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -488,7 +488,9 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                   ),
                 ProfileInstrumentBar(
                   diveId: widget.diveId,
-                  dive: dive,
+                  // The same profile the chart renders and the analysis is
+                  // computed from; tile values are index-aligned to it.
+                  profile: chartProfile,
                   analysis: analysis,
                   tankPressures: tankPressures,
                 ),

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -146,7 +146,16 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     final showPressureThresholdMarkers = ref.watch(
       showPressureThresholdMarkersProvider,
     );
-    final settings = ref.watch(settingsProvider);
+    // Select only the readout-card fields: watching all of settings would
+    // rebuild the whole page on every unrelated settings write.
+    final settings = ref.watch(
+      settingsProvider.select(
+        (s) => (
+          fullscreenReadoutCardX: s.fullscreenReadoutCardX,
+          fullscreenReadoutCardY: s.fullscreenReadoutCardY,
+        ),
+      ),
+    );
 
     final photoMedia =
         ref.watch(mediaForDiveProvider(widget.diveId)).value ?? const [];

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_play
 import 'package:submersion/features/dive_log/presentation/providers/profile_review_provider.dart';
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/draggable_readout_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_instrument_bar.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/source_bar.dart';
@@ -55,6 +56,15 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
   /// asked for (and the 25ms ticker doesn't keep running in the background).
   late final bool _wasPlaybackActiveOnEntry;
   bool _isPlaybackActiveNow = false;
+
+  /// Last non-null tooltip rows; the readout card keeps showing these after
+  /// the hover ends (sticky values).
+  List<TooltipRow>? _readoutRows;
+
+  void _onTooltipData(List<TooltipRow>? rows) {
+    if (rows == null || rows.isEmpty) return; // sticky: keep last values
+    setState(() => _readoutRows = rows);
+  }
 
   @override
   void initState() {
@@ -136,6 +146,7 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     final showPressureThresholdMarkers = ref.watch(
       showPressureThresholdMarkersProvider,
     );
+    final settings = ref.watch(settingsProvider);
 
     final photoMedia =
         ref.watch(mediaForDiveProvider(widget.diveId)).value ?? const [];
@@ -263,109 +274,148 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
             child: Column(
               children: [
                 Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
-                    child: DiveProfileChart(
-                      profile: chartProfile,
-                      overlays: overlays.isEmpty ? null : overlays,
-                      activeComputerId: activeProfile?.computerId,
-                      diveDuration: dive.effectiveRuntime,
-                      maxDepth: dive.maxDepth,
-                      legendLeading: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.close),
-                            tooltip:
-                                context.l10n.diveLog_fullscreenProfile_close,
-                            visualDensity: VisualDensity.compact,
-                            onPressed: () => Navigator.of(context).pop(),
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.only(right: 12),
-                            child: Text(
-                              context.l10n.diveLog_fullscreenProfile_title(
-                                dive.diveNumber ?? 0,
+                  child: Stack(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                        child: DiveProfileChart(
+                          profile: chartProfile,
+                          overlays: overlays.isEmpty ? null : overlays,
+                          activeComputerId: activeProfile?.computerId,
+                          diveDuration: dive.effectiveRuntime,
+                          maxDepth: dive.maxDepth,
+                          // The painted tooltip would clip at the screen edge
+                          // (no headroom above the plot in fullscreen); the
+                          // draggable readout card renders the data instead.
+                          tooltipBelow: true,
+                          onTooltipData: _onTooltipData,
+                          legendLeading: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: const Icon(Icons.close),
+                                tooltip: context
+                                    .l10n
+                                    .diveLog_fullscreenProfile_close,
+                                visualDensity: VisualDensity.compact,
+                                onPressed: () => Navigator.of(context).pop(),
                               ),
-                              style: Theme.of(context).textTheme.titleSmall,
-                            ),
+                              Padding(
+                                padding: const EdgeInsets.only(right: 12),
+                                child: Text(
+                                  context.l10n.diveLog_fullscreenProfile_title(
+                                    dive.diveNumber ?? 0,
+                                  ),
+                                  style: Theme.of(context).textTheme.titleSmall,
+                                ),
+                              ),
+                            ],
                           ),
-                        ],
+                          // Analysis curves: identical wiring to the old
+                          // fullscreen call site (dive_detail_page.dart:4946-4990)
+                          ceilingCurve: analysis?.ceilingCurve,
+                          ascentRates: analysis?.ascentRates,
+                          events: analysis?.events,
+                          ndlCurve: analysis?.ndlCurve,
+                          sacCurve: analysis?.smoothedSacCurve,
+                          ppO2Curve: analysis?.ppO2Curve,
+                          o2SensorCurves: analysis?.o2SensorCurves,
+                          ppO2FromSensorAverage:
+                              analysis?.ppO2FromSensorAverage ?? false,
+                          ppN2Curve: analysis?.ppN2Curve,
+                          ppHeCurve: analysis?.ppHeCurve,
+                          modCurve: analysis?.modCurve,
+                          densityCurve: analysis?.densityCurve,
+                          gfCurve: analysis?.gfCurve,
+                          surfaceGfCurve: analysis?.surfaceGfCurve,
+                          meanDepthCurve: analysis?.meanDepthCurve,
+                          ttsCurve: analysis?.ttsCurve,
+                          cnsCurve: analysis?.cnsCurve,
+                          otuCurve: analysis?.otuCurve,
+                          tankVolume: dive.tanks
+                              .where((t) => t.volume != null && t.volume! > 0)
+                              .map((t) => t.volume!)
+                              .firstOrNull,
+                          sacNormalizationFactor:
+                              calculateSacNormalizationFactor(dive, analysis),
+                          markers: _calculateMarkers(
+                            dive: dive,
+                            analysis: analysis,
+                            tankPressures: tankPressures,
+                            showMaxDepth: showMaxDepthMarker,
+                            showPressureThresholds:
+                                showPressureThresholdMarkers,
+                          ),
+                          photoMarkers: photoMarkers.isEmpty
+                              ? null
+                              : photoMarkers,
+                          showMaxDepthMarker: showMaxDepthMarker,
+                          showPressureThresholdMarkers:
+                              showPressureThresholdMarkers,
+                          tanks: dive.tanks,
+                          tankPressures: tankPressures,
+                          gasSwitches: gasSwitches,
+                          gasSegments:
+                              (dive.tanks.isEmpty || chartProfile.isEmpty)
+                              ? null
+                              : buildGasUsageSegments(
+                                  tanks: dive.tanks,
+                                  gasSwitches: gasSwitches ?? const [],
+                                  diveDurationSeconds:
+                                      chartProfile.last.timestamp,
+                                ),
+                          diveDurationSeconds: chartProfile.isEmpty
+                              ? null
+                              : chartProfile.last.timestamp,
+                          highlightedTimestamp: reviewTimestamp,
+                          onPointSelected: (index) {
+                            if (index == null || index >= chartProfile.length) {
+                              return;
+                            }
+                            final timestamp = chartProfile[index].timestamp;
+                            ref
+                                    .read(
+                                      profileReviewProvider(
+                                        widget.diveId,
+                                      ).notifier,
+                                    )
+                                    .state =
+                                timestamp;
+                            // Keep playback in sync so play resumes from here.
+                            final playback = ref.read(
+                              playbackProvider(widget.diveId),
+                            );
+                            if (playback.isActive) {
+                              notifier.seekTo(timestamp);
+                            }
+                          },
+                        ),
                       ),
-                      // Analysis curves: identical wiring to the old
-                      // fullscreen call site (dive_detail_page.dart:4946-4990)
-                      ceilingCurve: analysis?.ceilingCurve,
-                      ascentRates: analysis?.ascentRates,
-                      events: analysis?.events,
-                      ndlCurve: analysis?.ndlCurve,
-                      sacCurve: analysis?.smoothedSacCurve,
-                      ppO2Curve: analysis?.ppO2Curve,
-                      o2SensorCurves: analysis?.o2SensorCurves,
-                      ppO2FromSensorAverage:
-                          analysis?.ppO2FromSensorAverage ?? false,
-                      ppN2Curve: analysis?.ppN2Curve,
-                      ppHeCurve: analysis?.ppHeCurve,
-                      modCurve: analysis?.modCurve,
-                      densityCurve: analysis?.densityCurve,
-                      gfCurve: analysis?.gfCurve,
-                      surfaceGfCurve: analysis?.surfaceGfCurve,
-                      meanDepthCurve: analysis?.meanDepthCurve,
-                      ttsCurve: analysis?.ttsCurve,
-                      cnsCurve: analysis?.cnsCurve,
-                      otuCurve: analysis?.otuCurve,
-                      tankVolume: dive.tanks
-                          .where((t) => t.volume != null && t.volume! > 0)
-                          .map((t) => t.volume!)
-                          .firstOrNull,
-                      sacNormalizationFactor: calculateSacNormalizationFactor(
-                        dive,
-                        analysis,
-                      ),
-                      markers: _calculateMarkers(
-                        dive: dive,
-                        analysis: analysis,
-                        tankPressures: tankPressures,
-                        showMaxDepth: showMaxDepthMarker,
-                        showPressureThresholds: showPressureThresholdMarkers,
-                      ),
-                      photoMarkers: photoMarkers.isEmpty ? null : photoMarkers,
-                      showMaxDepthMarker: showMaxDepthMarker,
-                      showPressureThresholdMarkers:
-                          showPressureThresholdMarkers,
-                      tanks: dive.tanks,
-                      tankPressures: tankPressures,
-                      gasSwitches: gasSwitches,
-                      gasSegments: (dive.tanks.isEmpty || chartProfile.isEmpty)
-                          ? null
-                          : buildGasUsageSegments(
-                              tanks: dive.tanks,
-                              gasSwitches: gasSwitches ?? const [],
-                              diveDurationSeconds: chartProfile.last.timestamp,
+                      DraggableReadoutCard(
+                        // Re-key on the saved position so a settings load
+                        // that lands after first build still seeds the card.
+                        key: ValueKey(
+                          'readout-card-seed-'
+                          '${settings.fullscreenReadoutCardX}-'
+                          '${settings.fullscreenReadoutCardY}',
+                        ),
+                        rows: _readoutRows,
+                        initialFraction:
+                            settings.fullscreenReadoutCardX != null &&
+                                settings.fullscreenReadoutCardY != null
+                            ? Offset(
+                                settings.fullscreenReadoutCardX!,
+                                settings.fullscreenReadoutCardY!,
+                              )
+                            : null,
+                        onDragEnd: (fraction) => ref
+                            .read(settingsProvider.notifier)
+                            .setFullscreenReadoutCardPosition(
+                              fraction.dx,
+                              fraction.dy,
                             ),
-                      diveDurationSeconds: chartProfile.isEmpty
-                          ? null
-                          : chartProfile.last.timestamp,
-                      highlightedTimestamp: reviewTimestamp,
-                      onPointSelected: (index) {
-                        if (index == null || index >= chartProfile.length) {
-                          return;
-                        }
-                        final timestamp = chartProfile[index].timestamp;
-                        ref
-                                .read(
-                                  profileReviewProvider(widget.diveId).notifier,
-                                )
-                                .state =
-                            timestamp;
-                        // Keep playback in sync so play resumes from here.
-                        final playback = ref.read(
-                          playbackProvider(widget.diveId),
-                        );
-                        if (playback.isActive) {
-                          notifier.seekTo(timestamp);
-                        }
-                      },
-                    ),
+                      ),
+                    ],
                   ),
                 ),
                 // Source switching and overlay comparison, mirroring the

--- a/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:submersion/core/constants/profile_metrics.dart';
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 part 'profile_legend_provider.g.dart';
@@ -306,8 +307,45 @@ class ProfileLegendState {
 class ProfileLegend extends _$ProfileLegend {
   @override
   ProfileLegendState build() {
-    // Initialize from user settings
-    final settings = ref.watch(settingsProvider);
+    // Initialize from user settings. Select ONLY the default-visibility
+    // fields consumed below: watching the whole settingsProvider would
+    // rebuild this provider (discarding the session's toggle state) on any
+    // unrelated settings write, e.g. persisting the fullscreen readout
+    // card position on drag end.
+    final settings = ref.watch(
+      settingsProvider.select(
+        (s) => (
+          defaultShowTemperature: s.defaultShowTemperature,
+          defaultShowPressure: s.defaultShowPressure,
+          showCeilingOnProfile: s.showCeilingOnProfile,
+          defaultShowHeartRate: s.defaultShowHeartRate,
+          defaultShowSac: s.defaultShowSac,
+          showAscentRateColors: s.showAscentRateColors,
+          defaultShowAscentRateLine: s.defaultShowAscentRateLine,
+          defaultShowEvents: s.defaultShowEvents,
+          showMaxDepthMarker: s.showMaxDepthMarker,
+          showPressureThresholdMarkers: s.showPressureThresholdMarkers,
+          defaultShowGasSwitchMarkers: s.defaultShowGasSwitchMarkers,
+          defaultShowPhotoMarkers: s.defaultShowPhotoMarkers,
+          defaultShowGasTimeline: s.defaultShowGasTimeline,
+          showNdlOnProfile: s.showNdlOnProfile,
+          defaultShowPpO2: s.defaultShowPpO2,
+          defaultShowPpN2: s.defaultShowPpN2,
+          defaultShowPpHe: s.defaultShowPpHe,
+          defaultShowGasDensity: s.defaultShowGasDensity,
+          defaultShowGf: s.defaultShowGf,
+          defaultShowSurfaceGf: s.defaultShowSurfaceGf,
+          defaultShowMeanDepth: s.defaultShowMeanDepth,
+          defaultShowTts: s.defaultShowTts,
+          defaultShowCns: s.defaultShowCns,
+          defaultShowOtu: s.defaultShowOtu,
+          defaultNdlSource: s.defaultNdlSource,
+          defaultCeilingSource: s.defaultCeilingSource,
+          defaultTtsSource: s.defaultTtsSource,
+          defaultCnsSource: s.defaultCnsSource,
+        ),
+      ),
+    );
     return ProfileLegendState(
       // rightAxisMetric is null initially - uses setting default via fallback
       showTemperature: settings.defaultShowTemperature,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -266,8 +266,8 @@ class DiveProfileChart extends ConsumerStatefulWidget {
   /// The label is padded to [labelWidth] but never truncated; when it already
   /// fills (or overruns) the column a single separating space is kept so a long
   /// label such as "Tank 1 (EAN32)" never abuts the value. The value is clamped
-  /// only if it would overflow [valueWidth].
-  @visibleForTesting
+  /// only if it would overflow [valueWidth]. Also used by the fullscreen
+  /// readout card so both readouts share one row format.
   static String tooltipRowText(
     String label,
     String value,

--- a/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
+++ b/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Always-visible floating readout for the fullscreen profile page.
+///
+/// Renders the latest externally emitted tooltip rows (see
+/// [DiveProfileChart.onTooltipData]) in a compact card the user can drag
+/// anywhere within the enclosing [Stack]. Position is a fraction of the
+/// movable range (stack size minus card size): (0,0) is flush top-left,
+/// (1,1) flush bottom-right. Must be placed directly inside a [Stack].
+class DraggableReadoutCard extends StatefulWidget {
+  /// Latest tooltip rows; null or empty shows the placeholder hint.
+  final List<TooltipRow>? rows;
+
+  /// Starting position fraction; null uses [defaultFraction].
+  final Offset? initialFraction;
+
+  /// Called with the final position fraction when a drag ends. The caller
+  /// persists it (the fullscreen page saves it to settings).
+  final ValueChanged<Offset> onDragEnd;
+
+  const DraggableReadoutCard({
+    super.key,
+    required this.rows,
+    required this.initialFraction,
+    required this.onDragEnd,
+  });
+
+  /// Default position: top-right corner.
+  static const Offset defaultFraction = Offset(1, 0);
+
+  @override
+  State<DraggableReadoutCard> createState() => _DraggableReadoutCardState();
+}
+
+class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
+  static const _inset = 12.0;
+  final GlobalKey _cardKey = GlobalKey();
+  late Offset _fraction =
+      widget.initialFraction ?? DraggableReadoutCard.defaultFraction;
+
+  void _onPanUpdate(DragUpdateDetails details, BoxConstraints constraints) {
+    final cardSize = _cardKey.currentContext?.size;
+    if (cardSize == null) return;
+    final movableW = constraints.maxWidth - cardSize.width;
+    final movableH = constraints.maxHeight - cardSize.height;
+    setState(() {
+      _fraction = Offset(
+        movableW <= 0
+            ? 0
+            : (_fraction.dx + details.delta.dx / movableW).clamp(0.0, 1.0),
+        movableH <= 0
+            ? 0
+            : (_fraction.dy + details.delta.dy / movableH).clamp(0.0, 1.0),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final rows = widget.rows;
+
+    return Positioned.fill(
+      child: Padding(
+        padding: const EdgeInsets.all(_inset),
+        child: LayoutBuilder(
+          builder: (context, constraints) => Align(
+            alignment: FractionalOffset(_fraction.dx, _fraction.dy),
+            child: GestureDetector(
+              // Sized by its child: measuring this context yields the card
+              // size for the fraction math in _onPanUpdate.
+              key: _cardKey,
+              onPanUpdate: (details) => _onPanUpdate(details, constraints),
+              onPanEnd: (_) => widget.onDragEnd(_fraction),
+              child: Container(
+                key: const ValueKey('readout-card'),
+                constraints: const BoxConstraints(maxWidth: 240),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: colorScheme.outlineVariant),
+                ),
+                child: rows == null || rows.isEmpty
+                    ? Text(
+                        context.l10n.diveLog_fullscreenProfile_readoutHint,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (final row in rows)
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 1),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Container(
+                                    width: 8,
+                                    height: 8,
+                                    decoration: BoxDecoration(
+                                      color: row.bulletColor,
+                                      shape: BoxShape.circle,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 6),
+                                  Flexible(
+                                    child: Text(
+                                      row.label,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: textTheme.bodySmall?.copyWith(
+                                        color: colorScheme.onSurfaceVariant,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(row.value, style: textTheme.bodySmall),
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
+++ b/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
@@ -40,6 +40,15 @@ class DraggableReadoutCard extends StatefulWidget {
 
 class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
   static const _inset = 12.0;
+
+  // Fixed character columns, mirroring the detail-page tooltip
+  // (DiveProfileChart's labelWidth/valueWidth). Every row pads to the same
+  // character count and renders in monospace, so value-length changes while
+  // scrubbing never resize the card.
+  static const _labelChars = 8;
+  static const _valueChars = 16;
+  static const _rowChars = _labelChars + _valueChars;
+
   final GlobalKey _cardKey = GlobalKey();
   late Offset _fraction = _sanitize(
     widget.initialFraction ?? DraggableReadoutCard.defaultFraction,
@@ -97,7 +106,7 @@ class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
               onPanEnd: (_) => widget.onDragEnd(_fraction),
               child: Container(
                 key: const ValueKey('readout-card'),
-                constraints: const BoxConstraints(maxWidth: 240),
+                constraints: const BoxConstraints(maxWidth: 320),
                 padding: const EdgeInsets.symmetric(
                   horizontal: 10,
                   vertical: 8,
@@ -135,15 +144,22 @@ class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
                                   const SizedBox(width: 6),
                                   Flexible(
                                     child: Text(
-                                      row.label,
-                                      overflow: TextOverflow.ellipsis,
+                                      DiveProfileChart.tooltipRowText(
+                                        row.label,
+                                        row.value,
+                                        _labelChars,
+                                        _valueChars,
+                                      ).padRight(_rowChars),
+                                      softWrap: false,
+                                      overflow: TextOverflow.clip,
                                       style: textTheme.bodySmall?.copyWith(
-                                        color: colorScheme.onSurfaceVariant,
+                                        fontFamily: 'RobotoMono',
+                                        fontFeatures: const [
+                                          FontFeature.tabularFigures(),
+                                        ],
                                       ),
                                     ),
                                   ),
-                                  const SizedBox(width: 8),
-                                  Text(row.value, style: textTheme.bodySmall),
                                 ],
                               ),
                             ),

--- a/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
+++ b/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
@@ -41,15 +41,24 @@ class DraggableReadoutCard extends StatefulWidget {
 class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
   static const _inset = 12.0;
   final GlobalKey _cardKey = GlobalKey();
-  late Offset _fraction = _clamp01(
+  late Offset _fraction = _sanitize(
     widget.initialFraction ?? DraggableReadoutCard.defaultFraction,
   );
 
   /// Nothing enforces the 0..1 contract on persisted values, and the Stack
   /// clips: an out-of-range fraction would render the card invisible and
-  /// undraggable with no way to recover.
-  static Offset _clamp01(Offset fraction) =>
-      Offset(fraction.dx.clamp(0.0, 1.0), fraction.dy.clamp(0.0, 1.0));
+  /// undraggable with no way to recover. Dart's clamp would map non-finite
+  /// values in-range anyway (compareTo orders NaN after all values, so
+  /// NaN.clamp(0, 1) is 1.0), but that lands on an arbitrary corner; treat
+  /// non-finite components as the default corner explicitly instead.
+  static Offset _sanitize(Offset fraction) => Offset(
+    fraction.dx.isFinite
+        ? fraction.dx.clamp(0.0, 1.0)
+        : DraggableReadoutCard.defaultFraction.dx,
+    fraction.dy.isFinite
+        ? fraction.dy.clamp(0.0, 1.0)
+        : DraggableReadoutCard.defaultFraction.dy,
+  );
 
   void _onPanUpdate(DragUpdateDetails details, BoxConstraints constraints) {
     final cardSize = _cardKey.currentContext?.size;

--- a/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
+++ b/lib/features/dive_log/presentation/widgets/draggable_readout_card.dart
@@ -8,8 +8,11 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// Renders the latest externally emitted tooltip rows (see
 /// [DiveProfileChart.onTooltipData]) in a compact card the user can drag
 /// anywhere within the enclosing [Stack]. Position is a fraction of the
-/// movable range (stack size minus card size): (0,0) is flush top-left,
-/// (1,1) flush bottom-right. Must be placed directly inside a [Stack].
+/// movable range (the stack area minus a 12 px inset margin, minus the card
+/// size): (0,0) puts the card at the inset top-left corner, (1,1) at the
+/// inset bottom-right. Out-of-range fractions are clamped so a bad persisted
+/// value can never strand the card outside the visible (clipped) area. Must
+/// be placed directly inside a [Stack].
 class DraggableReadoutCard extends StatefulWidget {
   /// Latest tooltip rows; null or empty shows the placeholder hint.
   final List<TooltipRow>? rows;
@@ -38,8 +41,15 @@ class DraggableReadoutCard extends StatefulWidget {
 class _DraggableReadoutCardState extends State<DraggableReadoutCard> {
   static const _inset = 12.0;
   final GlobalKey _cardKey = GlobalKey();
-  late Offset _fraction =
-      widget.initialFraction ?? DraggableReadoutCard.defaultFraction;
+  late Offset _fraction = _clamp01(
+    widget.initialFraction ?? DraggableReadoutCard.defaultFraction,
+  );
+
+  /// Nothing enforces the 0..1 contract on persisted values, and the Stack
+  /// clips: an out-of-range fraction would render the card invisible and
+  /// undraggable with no way to recover.
+  static Offset _clamp01(Offset fraction) =>
+      Offset(fraction.dx.clamp(0.0, 1.0), fraction.dy.clamp(0.0, 1.0));
 
   void _onPanUpdate(DragUpdateDetails details, BoxConstraints constraints) {
     final cardSize = _cardKey.currentContext?.size;

--- a/lib/features/dive_log/presentation/widgets/instrument_tiles.dart
+++ b/lib/features/dive_log/presentation/widgets/instrument_tiles.dart
@@ -49,11 +49,10 @@ const List<InstrumentTileId> _priorityOrder = [
 
 /// Tiles the dive's data can actually populate, in priority order.
 List<InstrumentTileId> computeCandidateTiles({
-  required Dive dive,
+  required List<DiveProfilePoint> profile,
   ProfileAnalysis? analysis,
   Map<String, List<TankPressurePoint>>? tankPressures,
 }) {
-  final profile = dive.profile;
   bool anyPoint(bool Function(DiveProfilePoint) test) => profile.any(test);
 
   final available = <InstrumentTileId>{
@@ -196,16 +195,21 @@ class InstrumentSample {
 
 /// Resolves instrument values at [timestamp] (dive-seconds).
 InstrumentSample resolveSample({
-  required Dive dive,
+  /// The profile the analysis curves were computed over (the active source's
+  /// rendered profile). Curve values are read by INDEX, so passing any other
+  /// array (e.g. dive.profile when a different source is active, or when the
+  /// sources sample at different rates) reads wrong values where the arrays
+  /// diverge and null past the shorter one's end.
+  required List<DiveProfilePoint> profile,
   ProfileAnalysis? analysis,
   Map<String, List<TankPressurePoint>>? tankPressures,
   required int timestamp,
 }) {
-  final index = indexForTimestamp(dive.profile, timestamp);
+  final index = indexForTimestamp(profile, timestamp);
   if (index == null) {
     return InstrumentSample(runtimeSeconds: timestamp);
   }
-  final point = dive.profile[index];
+  final point = profile[index];
 
   T? curveAt<T>(List<T>? curve) =>
       (curve != null && index < curve.length) ? curve[index] : null;

--- a/lib/features/dive_log/presentation/widgets/profile_instrument_bar.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_instrument_bar.dart
@@ -15,14 +15,19 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// transport plus adaptive dive-computer readout tiles.
 class ProfileInstrumentBar extends ConsumerWidget {
   final String diveId;
-  final Dive dive;
+
+  /// The profile the chart renders and the analysis was computed over (the
+  /// active source's points). Tile values are resolved by index into the
+  /// analysis curves, so this must be that same array -- not dive.profile,
+  /// which can be a different source sampled at a different rate.
+  final List<DiveProfilePoint> profile;
   final ProfileAnalysis? analysis;
   final Map<String, List<TankPressurePoint>>? tankPressures;
 
   const ProfileInstrumentBar({
     super.key,
     required this.diveId,
-    required this.dive,
+    required this.profile,
     required this.analysis,
     required this.tankPressures,
   });
@@ -34,7 +39,7 @@ class ProfileInstrumentBar extends ConsumerWidget {
     final reviewTimestamp = ref.watch(profileReviewProvider(diveId));
 
     final candidates = computeCandidateTiles(
-      dive: dive,
+      profile: profile,
       analysis: analysis,
       tankPressures: tankPressures,
     );
@@ -44,7 +49,7 @@ class ProfileInstrumentBar extends ConsumerWidget {
       hidden: settings.fullscreenHiddenTiles,
     );
     final sample = resolveSample(
-      dive: dive,
+      profile: profile,
       analysis: analysis,
       tankPressures: tankPressures,
       timestamp: reviewTimestamp ?? 0,
@@ -77,7 +82,7 @@ class ProfileInstrumentBar extends ConsumerWidget {
               Expanded(
                 child: ProfileTransportControls(
                   diveId: diveId,
-                  profile: dive.profile,
+                  profile: profile,
                 ),
               ),
               IconButton(

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -73,6 +73,8 @@ class SettingsKeys {
   // stored directly in SharedPreferences rather than per-diver in the DB).
   static const String fullscreenTileOrder = 'fullscreen_tile_order';
   static const String fullscreenHiddenTiles = 'fullscreen_hidden_tiles';
+  static const String fullscreenReadoutCardX = 'fullscreen_readout_card_x';
+  static const String fullscreenReadoutCardY = 'fullscreen_readout_card_y';
 }
 
 /// App settings state
@@ -307,6 +309,11 @@ class AppSettings {
   /// Instrument tiles the user has hidden in the fullscreen profile view.
   final List<String> fullscreenHiddenTiles;
 
+  /// Fullscreen readout card position as fractions (0..1) of the movable
+  /// range; null means the default corner. See DraggableReadoutCard.
+  final double? fullscreenReadoutCardX;
+  final double? fullscreenReadoutCardY;
+
   const AppSettings({
     this.depthUnit = DepthUnit.meters,
     this.temperatureUnit = TemperatureUnit.celsius,
@@ -403,6 +410,8 @@ class AppSettings {
     this.diveDetailSections = DiveDetailSectionConfig.defaultSections,
     this.fullscreenTileOrder = const [],
     this.fullscreenHiddenTiles = const [],
+    this.fullscreenReadoutCardX,
+    this.fullscreenReadoutCardY,
   });
 
   /// Compute the current unit preset based on actual unit values
@@ -533,6 +542,8 @@ class AppSettings {
     bool clearDiveDetailSections = false,
     List<String>? fullscreenTileOrder,
     List<String>? fullscreenHiddenTiles,
+    double? fullscreenReadoutCardX,
+    double? fullscreenReadoutCardY,
   }) {
     return AppSettings(
       depthUnit: depthUnit ?? this.depthUnit,
@@ -654,6 +665,10 @@ class AppSettings {
       fullscreenTileOrder: fullscreenTileOrder ?? this.fullscreenTileOrder,
       fullscreenHiddenTiles:
           fullscreenHiddenTiles ?? this.fullscreenHiddenTiles,
+      fullscreenReadoutCardX:
+          fullscreenReadoutCardX ?? this.fullscreenReadoutCardX,
+      fullscreenReadoutCardY:
+          fullscreenReadoutCardY ?? this.fullscreenReadoutCardY,
     );
   }
 }
@@ -749,6 +764,12 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
           prefs.getStringList(SettingsKeys.fullscreenTileOrder) ?? const [];
       final fullscreenHiddenTiles =
           prefs.getStringList(SettingsKeys.fullscreenHiddenTiles) ?? const [];
+      final fullscreenReadoutCardX = prefs.getDouble(
+        SettingsKeys.fullscreenReadoutCardX,
+      );
+      final fullscreenReadoutCardY = prefs.getDouble(
+        SettingsKeys.fullscreenReadoutCardY,
+      );
 
       final diverId = _validatedDiverId;
       if (diverId == null) {
@@ -756,6 +777,8 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
         state = AppSettings(
           fullscreenTileOrder: fullscreenTileOrder,
           fullscreenHiddenTiles: fullscreenHiddenTiles,
+          fullscreenReadoutCardX: fullscreenReadoutCardX,
+          fullscreenReadoutCardY: fullscreenReadoutCardY,
         );
         return;
       }
@@ -765,6 +788,8 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
       state = settings.copyWith(
         fullscreenTileOrder: fullscreenTileOrder,
         fullscreenHiddenTiles: fullscreenHiddenTiles,
+        fullscreenReadoutCardX: fullscreenReadoutCardX,
+        fullscreenReadoutCardY: fullscreenReadoutCardY,
       );
 
       // Schedule notifications with the loaded settings
@@ -808,6 +833,14 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
       SettingsKeys.fullscreenHiddenTiles,
       state.fullscreenHiddenTiles,
     );
+    final readoutCardX = state.fullscreenReadoutCardX;
+    if (readoutCardX != null) {
+      await prefs.setDouble(SettingsKeys.fullscreenReadoutCardX, readoutCardX);
+    }
+    final readoutCardY = state.fullscreenReadoutCardY;
+    if (readoutCardY != null) {
+      await prefs.setDouble(SettingsKeys.fullscreenReadoutCardY, readoutCardY);
+    }
 
     final diverId = _validatedDiverId;
     if (diverId == null) return;
@@ -1262,6 +1295,14 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
     state = state.copyWith(
       fullscreenTileOrder: order,
       fullscreenHiddenTiles: hidden,
+    );
+    await _saveSettings();
+  }
+
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    state = state.copyWith(
+      fullscreenReadoutCardX: x,
+      fullscreenReadoutCardY: y,
     );
     await _saveSettings();
   }

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -1302,10 +1302,14 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
   Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
     // Positions are fractions of the card's movable range; clamp so
     // persisted values always honor the 0..1 contract (an out-of-range
-    // value would seed the card off-screen on next launch).
+    // value would seed the card off-screen on next launch). Dart's clamp
+    // already maps non-finite values in-range (compareTo orders NaN after
+    // all values, so NaN.clamp(0, 1) is 1.0), but canonicalize them to the
+    // default top-right corner (1, 0) explicitly rather than rely on that
+    // ordering accident. Matches DraggableReadoutCard.defaultFraction.
     state = state.copyWith(
-      fullscreenReadoutCardX: x.clamp(0.0, 1.0),
-      fullscreenReadoutCardY: y.clamp(0.0, 1.0),
+      fullscreenReadoutCardX: x.isFinite ? x.clamp(0.0, 1.0) : 1.0,
+      fullscreenReadoutCardY: y.isFinite ? y.clamp(0.0, 1.0) : 0.0,
     );
     await _saveSettings();
   }

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -1300,9 +1300,12 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
   }
 
   Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    // Positions are fractions of the card's movable range; clamp so
+    // persisted values always honor the 0..1 contract (an out-of-range
+    // value would seed the card off-screen on next launch).
     state = state.copyWith(
-      fullscreenReadoutCardX: x,
-      fullscreenReadoutCardY: y,
+      fullscreenReadoutCardX: x.clamp(0.0, 1.0),
+      fullscreenReadoutCardY: y.clamp(0.0, 1.0),
     );
     await _saveSettings();
   }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1479,6 +1479,7 @@
   "diveLog_filter_title": "تصفية الغوصات",
   "diveLog_filter_tooltip_close": "إغلاق التصفية",
   "diveLog_fullscreenProfile_close": "إغلاق ملء الشاشة",
+  "diveLog_fullscreenProfile_readoutHint": "مرر المؤشر أو اسحب فوق ملف الغوصة",
   "diveLog_fullscreenProfile_title": "ملف الغوصة #{number}",
   "diveLog_instruments_customize": "تخصيص الأدوات",
   "diveLog_instruments_customizeHint": "قم بتشغيل الأدوات أو إيقافها. اسحب لإعادة الترتيب.",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1479,6 +1479,7 @@
   "diveLog_filter_title": "Tauchgänge filtern",
   "diveLog_filter_tooltip_close": "Filter schließen",
   "diveLog_fullscreenProfile_close": "Vollbild schließen",
+  "diveLog_fullscreenProfile_readoutHint": "Zeiger über das Profil bewegen oder scrubben",
   "diveLog_fullscreenProfile_title": "Tauchgang #{number} Profil",
   "diveLog_instruments_customize": "Instrumente anpassen",
   "diveLog_instruments_customizeHint": "Instrumente ein- oder ausschalten. Zum Sortieren ziehen.",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2187,6 +2187,7 @@
   "diveLog_filter_title": "Filter Dives",
   "diveLog_filter_tooltip_close": "Close filter",
   "diveLog_fullscreenProfile_close": "Close fullscreen",
+  "diveLog_fullscreenProfile_readoutHint": "Hover or scrub the profile",
   "diveLog_fullscreenProfile_title": "Dive #{number} Profile",
   "diveLog_instruments_customize": "Customize instruments",
   "diveLog_instruments_customizeHint": "Toggle instruments on or off. Drag to reorder.",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1479,6 +1479,7 @@
   "diveLog_filter_title": "Filtrar inmersiones",
   "diveLog_filter_tooltip_close": "Cerrar filtro",
   "diveLog_fullscreenProfile_close": "Cerrar pantalla completa",
+  "diveLog_fullscreenProfile_readoutHint": "Pasa el cursor o desliza sobre el perfil",
   "diveLog_fullscreenProfile_title": "Perfil de inmersión #{number}",
   "diveLog_instruments_customize": "Personalizar instrumentos",
   "diveLog_instruments_customizeHint": "Activa o desactiva instrumentos. Arrastra para reordenar.",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1445,6 +1445,7 @@
   "diveLog_filter_title": "Filtrer les plongees",
   "diveLog_filter_tooltip_close": "Fermer le filtre",
   "diveLog_fullscreenProfile_close": "Fermer le plein ecran",
+  "diveLog_fullscreenProfile_readoutHint": "Survolez ou faites glisser sur le profil",
   "diveLog_fullscreenProfile_title": "Profil de la plongee n{number}",
   "diveLog_instruments_customize": "Personnaliser les instruments",
   "diveLog_instruments_customizeHint": "Activez ou désactivez les instruments. Faites glisser pour réorganiser.",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1445,6 +1445,7 @@
   "diveLog_filter_title": "סינון צלילות",
   "diveLog_filter_tooltip_close": "סגירת מסנן",
   "diveLog_fullscreenProfile_close": "סגירת מסך מלא",
+  "diveLog_fullscreenProfile_readoutHint": "רחפו או גררו על הפרופיל",
   "diveLog_fullscreenProfile_title": "פרופיל צלילה #{number}",
   "diveLog_instruments_customize": "התאמה אישית של מכשירים",
   "diveLog_instruments_customizeHint": "הפעל או כבה מכשירים. גרור כדי לסדר מחדש.",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1445,6 +1445,7 @@
   "diveLog_filter_title": "Merulesek szurese",
   "diveLog_filter_tooltip_close": "Szuro bezarasa",
   "diveLog_fullscreenProfile_close": "Teljes kepernyo bezarasa",
+  "diveLog_fullscreenProfile_readoutHint": "Vigye az egermutatot a profil fole, vagy huzza rajta az ujjat",
   "diveLog_fullscreenProfile_title": "Merules #{number} profil",
   "diveLog_instruments_customize": "Műszerek testreszabása",
   "diveLog_instruments_customizeHint": "Kapcsolja be vagy ki a műszereket. Húzza az átrendezéshez.",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1445,6 +1445,7 @@
   "diveLog_filter_title": "Filtra immersioni",
   "diveLog_filter_tooltip_close": "Chiudi filtro",
   "diveLog_fullscreenProfile_close": "Chiudi schermo intero",
+  "diveLog_fullscreenProfile_readoutHint": "Passa il cursore o scorri sul profilo",
   "diveLog_fullscreenProfile_title": "Profilo immersione #{number}",
   "diveLog_instruments_customize": "Personalizza strumenti",
   "diveLog_instruments_customizeHint": "Attiva o disattiva gli strumenti. Trascina per riordinare.",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -7580,6 +7580,12 @@ abstract class AppLocalizations {
   /// **'Close fullscreen'**
   String get diveLog_fullscreenProfile_close;
 
+  /// No description provided for @diveLog_fullscreenProfile_readoutHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Hover or scrub the profile'**
+  String get diveLog_fullscreenProfile_readoutHint;
+
   /// No description provided for @diveLog_fullscreenProfile_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -4418,6 +4418,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'إغلاق ملء الشاشة';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'مرر المؤشر أو اسحب فوق ملف الغوصة';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'ملف الغوصة #$number';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -4520,6 +4520,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Vollbild schließen';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Zeiger über das Profil bewegen oder scrubben';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Tauchgang #$number Profil';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -4441,6 +4441,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Close fullscreen';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Hover or scrub the profile';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Dive #$number Profile';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -4522,6 +4522,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Cerrar pantalla completa';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Pasa el cursor o desliza sobre el perfil';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Perfil de inmersión #$number';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -4544,6 +4544,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Fermer le plein ecran';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Survolez ou faites glisser sur le profil';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Profil de la plongee n$number';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -4397,6 +4397,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'סגירת מסך מלא';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint => 'רחפו או גררו על הפרופיל';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'פרופיל צלילה #$number';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -4506,6 +4506,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Teljes kepernyo bezarasa';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Vigye az egermutatot a profil fole, vagy huzza rajta az ujjat';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Merules #$number profil';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -4526,6 +4526,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Chiudi schermo intero';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Passa il cursore o scorri sul profilo';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Profilo immersione #$number';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -4489,6 +4489,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Volledig scherm sluiten';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Beweeg de muis over het profiel of veeg erover';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Duik #$number profiel';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -4527,6 +4527,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => 'Fechar tela cheia';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint =>
+      'Passe o cursor ou deslize sobre o perfil';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return 'Perfil do Mergulho #$number';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -4303,6 +4303,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_fullscreenProfile_close => '关闭全屏';
 
   @override
+  String get diveLog_fullscreenProfile_readoutHint => '悬停或滑动查看轮廓';
+
+  @override
   String diveLog_fullscreenProfile_title(Object number) {
     return '潜水 #$number 轮廓';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1479,6 +1479,7 @@
   "diveLog_filter_title": "Duiken filteren",
   "diveLog_filter_tooltip_close": "Filter sluiten",
   "diveLog_fullscreenProfile_close": "Volledig scherm sluiten",
+  "diveLog_fullscreenProfile_readoutHint": "Beweeg de muis over het profiel of veeg erover",
   "diveLog_fullscreenProfile_title": "Duik #{number} profiel",
   "diveLog_instruments_customize": "Instrumenten aanpassen",
   "diveLog_instruments_customizeHint": "Schakel instrumenten in of uit. Sleep om te herschikken.",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1479,6 +1479,7 @@
   "diveLog_filter_title": "Filtrar Mergulhos",
   "diveLog_filter_tooltip_close": "Fechar filtro",
   "diveLog_fullscreenProfile_close": "Fechar tela cheia",
+  "diveLog_fullscreenProfile_readoutHint": "Passe o cursor ou deslize sobre o perfil",
   "diveLog_fullscreenProfile_title": "Perfil do Mergulho #{number}",
   "diveLog_instruments_customize": "Personalizar instrumentos",
   "diveLog_instruments_customizeHint": "Ative ou desative instrumentos. Arraste para reordenar.",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1606,6 +1606,7 @@
   "diveLog_filter_title": "筛选潜水",
   "diveLog_filter_tooltip_close": "关闭筛选",
   "diveLog_fullscreenProfile_close": "关闭全屏",
+  "diveLog_fullscreenProfile_readoutHint": "悬停或滑动查看轮廓",
   "diveLog_fullscreenProfile_title": "潜水 #{number} 轮廓",
   "diveLog_instruments_customize": "自定义仪表",
   "diveLog_instruments_customizeHint": "开启或关闭仪表。拖动以重新排序。",

--- a/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+++ b/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
@@ -321,6 +321,16 @@ void main() {
         tester.widget<DiveProfileChart>(find.byType(DiveProfileChart)).profile,
         hasLength(61),
       );
+      // The instrument bar must resolve tiles against the SAME profile the
+      // chart renders and the analysis is computed from; indexing analysis
+      // curves with dive.profile positions reads wrong/blank values once the
+      // arrays differ (issue: gauges wrong/blank mid-dive on 2-source dives).
+      expect(
+        tester
+            .widget<ProfileInstrumentBar>(find.byType(ProfileInstrumentBar))
+            .profile,
+        hasLength(61),
+      );
 
       await tester.tap(
         find.descendant(
@@ -333,6 +343,12 @@ void main() {
 
       expect(
         tester.widget<DiveProfileChart>(find.byType(DiveProfileChart)).profile,
+        hasLength(40),
+      );
+      expect(
+        tester
+            .widget<ProfileInstrumentBar>(find.byType(ProfileInstrumentBar))
+            .profile,
         hasLength(40),
       );
     },

--- a/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+++ b/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -11,6 +12,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_anal
 import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_review_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/draggable_readout_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_instrument_bar.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/source_bar.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -22,6 +24,19 @@ class _FakeSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _FakeSettingsNotifier([AppSettings? initial])
     : super(initial ?? const AppSettings());
+
+  double? savedCardX;
+  double? savedCardY;
+
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    savedCardX = x;
+    savedCardY = y;
+    state = state.copyWith(
+      fullscreenReadoutCardX: x,
+      fullscreenReadoutCardY: y,
+    );
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -75,6 +90,94 @@ void main() {
     expect(find.byType(DiveProfileChart), findsOneWidget);
     expect(find.byType(ProfileInstrumentBar), findsOneWidget);
     expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+
+  testWidgets('shows the readout card with the placeholder hint', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_defaultOverrides()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DraggableReadoutCard), findsOneWidget);
+    expect(find.text('Hover or scrub the profile'), findsOneWidget);
+  });
+
+  testWidgets('chart runs in external-tooltip mode (no painted bubble)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_defaultOverrides()));
+    await tester.pumpAndSettle();
+
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    expect(chart.tooltipBelow, isTrue);
+    expect(chart.onTooltipData, isNotNull);
+  });
+
+  testWidgets('long-press populates the card and values stick after release', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_defaultOverrides()));
+    await tester.pumpAndSettle();
+
+    final chartCenter = tester.getCenter(find.byType(LineChart).first);
+    final gesture = await tester.startGesture(chartCenter);
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.moveBy(const Offset(2, 0));
+    await tester.pump();
+
+    // Rows arrived: hint is gone from the card.
+    expect(find.text('Hover or scrub the profile'), findsNothing);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Sticky: hover ended but the card keeps the last values.
+    expect(find.text('Hover or scrub the profile'), findsNothing);
+  });
+
+  testWidgets('dragging the card persists a clamped fraction to settings', (
+    tester,
+  ) async {
+    final fake = _FakeSettingsNotifier();
+    final overrides = _defaultOverrides()
+      ..removeAt(0)
+      ..insert(0, settingsProvider.overrideWith((ref) => fake));
+    await tester.pumpWidget(_wrap(overrides));
+    await tester.pumpAndSettle();
+
+    await tester.drag(
+      find.byKey(const ValueKey('readout-card')),
+      const Offset(-3000, 3000),
+    );
+    await tester.pumpAndSettle();
+
+    expect(fake.savedCardX, 0.0);
+    expect(fake.savedCardY, 1.0);
+  });
+
+  testWidgets('saved position seeds the card at bottom-left', (tester) async {
+    final overrides = _defaultOverrides()
+      ..removeAt(0)
+      ..insert(
+        0,
+        settingsProvider.overrideWith(
+          (ref) => _FakeSettingsNotifier(
+            const AppSettings(
+              fullscreenReadoutCardX: 0,
+              fullscreenReadoutCardY: 1,
+            ),
+          ),
+        ),
+      );
+    await tester.pumpWidget(_wrap(overrides));
+    await tester.pumpAndSettle();
+
+    final chartRect = tester.getRect(find.byType(DiveProfileChart));
+    final cardRect = tester.getRect(find.byKey(const ValueKey('readout-card')));
+    expect(cardRect.left, lessThan(chartRect.center.dx));
+    expect(cardRect.bottom, greaterThan(chartRect.center.dy));
   });
 
   testWidgets('chart fills most of the screen height', (tester) async {

--- a/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
@@ -10,10 +10,52 @@ class _StubSettingsNotifier extends StateNotifier<AppSettings>
     : super(settings ?? const AppSettings());
 
   @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async {
+    state = state.copyWith(
+      fullscreenReadoutCardX: x,
+      fullscreenReadoutCardY: y,
+    );
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 void main() {
+  group('ProfileLegend survives unrelated settings writes', () {
+    test(
+      'session toggles persist when the readout card position is saved',
+      () async {
+        final stub = _StubSettingsNotifier();
+        final container = ProviderContainer(
+          overrides: [settingsProvider.overrideWith((ref) => stub)],
+        );
+        addTearDown(container.dispose);
+
+        // Keep the autoDispose provider alive, like a mounted chart would.
+        final sub = container.listen(profileLegendProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        final notifier = container.read(profileLegendProvider.notifier);
+        expect(container.read(profileLegendProvider).showSac, isFalse);
+        notifier.toggleSac();
+        expect(container.read(profileLegendProvider).showSac, isTrue);
+
+        // What dragging the readout card does: an unrelated settings write.
+        await stub.setFullscreenReadoutCardPosition(0.5, 0.5);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(profileLegendProvider).showSac,
+          isTrue,
+          reason:
+              'session legend toggles must survive settings writes that '
+              'do not touch the legend default fields',
+        );
+      },
+    );
+  });
+
   group('ProfileLegendState', () {
     group('sectionExpanded', () {
       test('defaults to expected initial values', () {

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -1369,6 +1369,23 @@ void main() {
     );
   });
 
+  group('DiveProfileChart - tooltip placement', () {
+    testWidgets('default keeps the bubble pinned above the chart box '
+        '(detail-page behavior)', (tester) async {
+      await tester.pumpWidget(_buildChart());
+      await tester.pumpAndSettle();
+
+      final tooltip = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineTouchData
+          .touchTooltipData;
+      expect(tooltip.showOnTopOfTheChartBoxArea, isTrue);
+      expect(tooltip.fitInsideVertically, isFalse);
+      expect(tooltip.tooltipMargin, 0);
+    });
+  });
+
   // =========================================================================
   // Static helper coverage
   // =========================================================================

--- a/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
@@ -91,6 +91,22 @@ void main() {
     expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
   });
 
+  testWidgets('a non-finite initial fraction falls back to the default '
+      'corner', (tester) async {
+    // NaN survives double.clamp (NaN.clamp(0,1) is NaN) and would reach
+    // FractionalOffset as invalid layout input; the card must fall back to
+    // the default corner instead.
+    await tester.pumpWidget(
+      _wrap(rows: null, initialFraction: const Offset(double.nan, double.nan)),
+    );
+    await tester.pumpAndSettle();
+
+    final stackRect = tester.getRect(find.byKey(const ValueKey('arena')));
+    final cardRect = tester.getRect(find.byKey(_cardKey));
+    expect(cardRect.right, closeTo(stackRect.right - 12, 1.0));
+    expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+  });
+
   testWidgets('dragging moves the card and clamps at the bounds', (
     tester,
   ) async {

--- a/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
@@ -57,9 +57,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Hover or scrub the profile'), findsNothing);
-    expect(find.text('Depth'), findsOneWidget);
-    expect(find.text('18.2 m'), findsOneWidget);
-    expect(find.text('Temp'), findsOneWidget);
+    // Rows render as one monospace column-aligned string per row.
+    expect(find.textContaining('Depth'), findsOneWidget);
+    expect(find.textContaining('18.2 m'), findsOneWidget);
+    expect(find.textContaining('Temp'), findsOneWidget);
   });
 
   testWidgets('defaults to the top-right corner', (tester) async {
@@ -89,6 +90,43 @@ void main() {
     // Clamped to (1, 0): flush to the inset top-right corner.
     expect(cardRect.right, closeTo(stackRect.right - 12, 1.0));
     expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+  });
+
+  testWidgets('card width stays constant as value text lengths change '
+      '(no resize jitter while scrubbing)', (tester) async {
+    // Short values (early in a dive).
+    await tester.pumpWidget(
+      _wrap(
+        rows: const [
+          TooltipRow(label: 'Depth', value: '3.4 m', bulletColor: Colors.blue),
+          TooltipRow(label: 'Time', value: '2:00', bulletColor: Colors.grey),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    final narrow = tester.getSize(find.byKey(_cardKey));
+
+    // Longer values (deep, late in the dive) with the same row set.
+    await tester.pumpWidget(
+      _wrap(
+        rows: const [
+          TooltipRow(
+            label: 'Depth',
+            value: '102.3 m',
+            bulletColor: Colors.blue,
+          ),
+          TooltipRow(label: 'Time', value: '148:30', bulletColor: Colors.grey),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    final wide = tester.getSize(find.byKey(_cardKey));
+
+    expect(
+      wide.width,
+      narrow.width,
+      reason: 'value-length changes must not resize the card',
+    );
   });
 
   testWidgets('a non-finite initial fraction falls back to the default '

--- a/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/draggable_readout_card.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+const _cardKey = ValueKey('readout-card');
+
+Widget _wrap({
+  List<TooltipRow>? rows,
+  Offset? initialFraction,
+  ValueChanged<Offset>? onDragEnd,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          key: const ValueKey('arena'),
+          width: 600,
+          height: 400,
+          child: Stack(
+            children: [
+              DraggableReadoutCard(
+                rows: rows,
+                initialFraction: initialFraction,
+                onDragEnd: onDragEnd ?? (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows the localized hint before any rows arrive', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(rows: null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hover or scrub the profile'), findsOneWidget);
+  });
+
+  testWidgets('renders rows with label and value, hint gone', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        rows: const [
+          TooltipRow(label: 'Depth', value: '18.2 m', bulletColor: Colors.blue),
+          TooltipRow(label: 'Temp', value: '22 C', bulletColor: Colors.red),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hover or scrub the profile'), findsNothing);
+    expect(find.text('Depth'), findsOneWidget);
+    expect(find.text('18.2 m'), findsOneWidget);
+    expect(find.text('Temp'), findsOneWidget);
+  });
+
+  testWidgets('defaults to the top-right corner', (tester) async {
+    await tester.pumpWidget(_wrap(rows: null));
+    await tester.pumpAndSettle();
+
+    final stackRect = tester.getRect(find.byKey(const ValueKey('arena')));
+    final cardRect = tester.getRect(find.byKey(_cardKey));
+    // Right edge inset by the 12px padding; top edge likewise.
+    expect(cardRect.right, closeTo(stackRect.right - 12, 1.0));
+    expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+  });
+
+  testWidgets('dragging moves the card and clamps at the bounds', (
+    tester,
+  ) async {
+    Offset? lastFraction;
+    await tester.pumpWidget(
+      _wrap(rows: null, onDragEnd: (f) => lastFraction = f),
+    );
+    await tester.pumpAndSettle();
+
+    // Drag far past the top-left corner: must clamp to fraction (0,0).
+    await tester.drag(find.byKey(_cardKey), const Offset(-2000, -2000));
+    await tester.pumpAndSettle();
+
+    final stackRect = tester.getRect(find.byKey(const ValueKey('arena')));
+    final cardRect = tester.getRect(find.byKey(_cardKey));
+    expect(cardRect.left, closeTo(stackRect.left + 12, 1.0));
+    expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+    expect(lastFraction, const Offset(0, 0));
+  });
+
+  testWidgets('a partial drag reports an interior fraction', (tester) async {
+    Offset? lastFraction;
+    await tester.pumpWidget(
+      _wrap(
+        rows: null,
+        initialFraction: const Offset(0, 0),
+        onDragEnd: (f) => lastFraction = f,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byKey(_cardKey), const Offset(80, 60));
+    await tester.pumpAndSettle();
+
+    expect(lastFraction, isNotNull);
+    expect(lastFraction!.dx, greaterThan(0));
+    expect(lastFraction!.dx, lessThan(1));
+    expect(lastFraction!.dy, greaterThan(0));
+    expect(lastFraction!.dy, lessThan(1));
+  });
+}

--- a/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/draggable_readout_card_test.dart
@@ -73,6 +73,24 @@ void main() {
     expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
   });
 
+  testWidgets('an out-of-range initial fraction is clamped into view', (
+    tester,
+  ) async {
+    // Simulates corrupted/out-of-contract persisted values: the card must
+    // still land inside the bounds (Stack clips, so an off-range card would
+    // be invisible and undraggable forever).
+    await tester.pumpWidget(
+      _wrap(rows: null, initialFraction: const Offset(5, -3)),
+    );
+    await tester.pumpAndSettle();
+
+    final stackRect = tester.getRect(find.byKey(const ValueKey('arena')));
+    final cardRect = tester.getRect(find.byKey(_cardKey));
+    // Clamped to (1, 0): flush to the inset top-right corner.
+    expect(cardRect.right, closeTo(stackRect.right - 12, 1.0));
+    expect(cardRect.top, closeTo(stackRect.top + 12, 1.0));
+  });
+
   testWidgets('dragging moves the card and clamps at the bounds', (
     tester,
   ) async {

--- a/test/features/dive_log/presentation/widgets/instrument_tiles_test.dart
+++ b/test/features/dive_log/presentation/widgets/instrument_tiles_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/deco/ascent_rate_calculator.dart';
 import 'package:submersion/core/deco/entities/o2_exposure.dart';
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
@@ -91,7 +92,10 @@ void main() {
   group('computeCandidateTiles', () {
     test('rec dive: depth, runtime, temperature only', () {
       final dive = _recDive();
-      final tiles = computeCandidateTiles(dive: dive, analysis: null);
+      final tiles = computeCandidateTiles(
+        profile: dive.profile,
+        analysis: null,
+      );
       expect(tiles, [
         InstrumentTileId.depth,
         InstrumentTileId.runtime,
@@ -103,7 +107,7 @@ void main() {
       final techDive = _techDive();
       final techAnalysis = _techAnalysis();
       final tiles = computeCandidateTiles(
-        dive: techDive,
+        profile: techDive.profile,
         analysis: techAnalysis,
         tankPressures: _techTankPressures(),
       );
@@ -120,9 +124,8 @@ void main() {
       );
     });
 
-    test('empty dive yields no candidates', () {
-      final dive = Dive(id: 'empty', dateTime: DateTime(2026, 1, 1, 10));
-      final tiles = computeCandidateTiles(dive: dive, analysis: null);
+    test('empty profile yields no candidates', () {
+      final tiles = computeCandidateTiles(profile: const [], analysis: null);
       expect(tiles, isEmpty);
     });
   });
@@ -231,7 +234,7 @@ void main() {
   group('resolveSample', () {
     test('reads point fields and curve values at the derived index', () {
       final sample = resolveSample(
-        dive: _techDive(),
+        profile: _techDive().profile,
         analysis: _techAnalysis(),
         tankPressures: _techTankPressures(),
         timestamp: 300,
@@ -246,7 +249,7 @@ void main() {
 
     test('null-at-position values stay null (temperature gap)', () {
       final sample = resolveSample(
-        dive: _recDiveNoTemp(),
+        profile: _recDiveNoTemp().profile,
         analysis: null,
         timestamp: 60,
       );
@@ -255,7 +258,7 @@ void main() {
 
     test('inDeco reflects decoType at the position', () {
       final sample = resolveSample(
-        dive: _techDive(),
+        profile: _techDive().profile,
         analysis: _techAnalysis(),
         timestamp: 300,
       );
@@ -264,7 +267,7 @@ void main() {
 
     test('not in deco before the deco boundary', () {
       final sample = resolveSample(
-        dive: _techDive(),
+        profile: _techDive().profile,
         analysis: _techAnalysis(),
         timestamp: 0,
       );
@@ -273,12 +276,48 @@ void main() {
     });
 
     test('empty profile returns a bare sample keyed on the timestamp', () {
-      final dive = Dive(id: 'empty', dateTime: DateTime(2026, 1, 1, 10));
-      final sample = resolveSample(dive: dive, analysis: null, timestamp: 42);
+      final sample = resolveSample(
+        profile: const [],
+        analysis: null,
+        timestamp: 42,
+      );
       expect(sample.runtimeSeconds, 42);
       expect(sample.depthMeters, isNull);
       expect(sample.tankPressuresBar, isEmpty);
       expect(sample.inDeco, isFalse);
+    });
+
+    test('curve values align to the passed profile late in the dive '
+        '(the profile must be the analysis basis, not dive.profile)', () {
+      // A short, coarsely-sampled active-source profile: 5 points at 60s
+      // intervals. The analysis curves are index-aligned to THIS array.
+      final profile = List.generate(
+        5,
+        (i) => DiveProfilePoint(timestamp: i * 60, depth: 10),
+      );
+      final analysis = ProfileAnalysis.empty().copyWith(
+        cnsCurve: [1.0, 2.0, 3.0, 4.0, 5.0],
+        ascentRates: [
+          for (var i = 0; i < 5; i++)
+            AscentRatePoint(
+              timestamp: i * 60,
+              depth: 10,
+              rateMetersPerMin: i.toDouble(),
+              category: AscentRateCategory.safe,
+            ),
+        ],
+      );
+
+      // Late in the dive: index 4 of the profile. Before the fix the index
+      // came from dive.profile (a longer, differently-sampled array), which
+      // read wrong values here and null past the curves' end.
+      final sample = resolveSample(
+        profile: profile,
+        analysis: analysis,
+        timestamp: 240,
+      );
+      expect(sample.cnsPercent, 5.0);
+      expect(sample.ascentRateMetersPerMin, 4.0);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/profile_instrument_bar_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_instrument_bar_test.dart
@@ -76,7 +76,7 @@ void main() {
         home: Scaffold(
           body: ProfileInstrumentBar(
             diveId: dive.id,
-            dive: dive,
+            profile: dive.profile,
             analysis: null,
             tankPressures: null,
           ),
@@ -166,7 +166,7 @@ void main() {
           home: Scaffold(
             body: ProfileInstrumentBar(
               diveId: dive.id,
-              dive: dive,
+              profile: dive.profile,
               analysis: null,
               tankPressures: null,
             ),

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -403,6 +403,13 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
     fullscreenTileOrder: order,
     fullscreenHiddenTiles: hidden,
   );
+
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async =>
+      state = state.copyWith(
+        fullscreenReadoutCardX: x,
+        fullscreenReadoutCardY: y,
+      );
 }
 
 /// Mock CurrentDiverIdNotifier that doesn't access the database.

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -328,6 +328,13 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
     fullscreenTileOrder: order,
     fullscreenHiddenTiles: hidden,
   );
+
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async =>
+      state = state.copyWith(
+        fullscreenReadoutCardX: x,
+        fullscreenReadoutCardY: y,
+      );
 }
 
 /// Mock CurrentDiverIdNotifier that doesn't access the database

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -358,6 +358,23 @@ void main() {
       ]);
       expect(prefs.getStringList('fullscreen_hidden_tiles'), ['heartRate']);
     });
+
+    test('readout card position defaults to null and persists', () async {
+      final notifier = container.read(settingsProvider.notifier);
+      await waitForInit();
+
+      expect(container.read(settingsProvider).fullscreenReadoutCardX, isNull);
+      expect(container.read(settingsProvider).fullscreenReadoutCardY, isNull);
+
+      await notifier.setFullscreenReadoutCardPosition(0.25, 0.75);
+
+      expect(container.read(settingsProvider).fullscreenReadoutCardX, 0.25);
+      expect(container.read(settingsProvider).fullscreenReadoutCardY, 0.75);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('fullscreen_readout_card_x'), 0.25);
+      expect(prefs.getDouble('fullscreen_readout_card_y'), 0.75);
+    });
   });
 }
 

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -375,6 +375,22 @@ void main() {
       expect(prefs.getDouble('fullscreen_readout_card_x'), 0.25);
       expect(prefs.getDouble('fullscreen_readout_card_y'), 0.75);
     });
+
+    test('readout card position clamps out-of-range values', () async {
+      final notifier = container.read(settingsProvider.notifier);
+      await waitForInit();
+
+      // Keep persisted data inside the 0..1 contract even if a future call
+      // site passes junk; the widget clamps on read too, but stored values
+      // should stay canonical.
+      await notifier.setFullscreenReadoutCardPosition(5.0, -3.0);
+
+      expect(container.read(settingsProvider).fullscreenReadoutCardX, 1.0);
+      expect(container.read(settingsProvider).fullscreenReadoutCardY, 0.0);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('fullscreen_readout_card_x'), 1.0);
+      expect(prefs.getDouble('fullscreen_readout_card_y'), 0.0);
+    });
   });
 }
 

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -391,6 +391,25 @@ void main() {
       expect(prefs.getDouble('fullscreen_readout_card_x'), 1.0);
       expect(prefs.getDouble('fullscreen_readout_card_y'), 0.0);
     });
+
+    test('readout card position sanitizes non-finite values', () async {
+      final notifier = container.read(settingsProvider.notifier);
+      await waitForInit();
+
+      // NaN bypasses clamp (NaN.clamp(0,1) is NaN); it must never be
+      // persisted or the card would seed with invalid layout input.
+      await notifier.setFullscreenReadoutCardPosition(
+        double.nan,
+        double.negativeInfinity,
+      );
+
+      // Non-finite inputs canonicalize to the default corner (1, 0).
+      expect(container.read(settingsProvider).fullscreenReadoutCardX, 1.0);
+      expect(container.read(settingsProvider).fullscreenReadoutCardY, 0.0);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('fullscreen_readout_card_x'), 1.0);
+      expect(prefs.getDouble('fullscreen_readout_card_y'), 0.0);
+    });
   });
 }
 

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -320,6 +320,13 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
     fullscreenTileOrder: order,
     fullscreenHiddenTiles: hidden,
   );
+
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async =>
+      state = state.copyWith(
+        fullscreenReadoutCardX: x,
+        fullscreenReadoutCardY: y,
+      );
 }
 
 /// Mock CurrentDiverIdNotifier that doesn't access the database

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -326,6 +326,13 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
     fullscreenTileOrder: order,
     fullscreenHiddenTiles: hidden,
   );
+
+  @override
+  Future<void> setFullscreenReadoutCardPosition(double x, double y) async =>
+      state = state.copyWith(
+        fullscreenReadoutCardX: x,
+        fullscreenReadoutCardY: y,
+      );
 }
 
 /// Mock CurrentDiverIdNotifier that doesn't access the database


### PR DESCRIPTION
## Summary

The fullscreen profile page's hover tooltip was unreadable: the chart pins its painted tooltip above the plot box (`showOnTopOfTheChartBoxArea: true` + `fitInsideVertically: false`) so it never covers the profile, which relies on headroom above the chart to paint into. The dive detail page has that headroom; fullscreen has none (the plot top sits at the screen edge), so the tooltip clipped off-screen.

This replaces the painted bubble on the fullscreen page with an **always-visible draggable readout card** ([spec](docs/superpowers/specs/2026-07-05-fullscreen-draggable-readout-design.md), [plan](docs/superpowers/plans/2026-07-05-fullscreen-draggable-readout.md)).

### How it works

- The chart runs in its existing external-tooltip mode (`tooltipBelow: true` + `onTooltipData`), which suppresses the painted bubble and streams the same `TooltipRow` data (unit-formatted, localized, multi-computer-aware) the detail-page tooltip shows.
- A new `DraggableReadoutCard` renders those rows in a compact card floating over the chart area. Values are sticky: the card keeps the last hovered sample after the cursor leaves the chart.
- Before the first hover it shows a localized hint ("Hover or scrub the profile", translated into all 10 non-English locales).
- The whole card is the drag surface. Position is expressed as a fraction of the movable range (`Align` + `FractionalOffset`, so 0/1 mean flush-to-edge on any screen size), clamps to the chart area, and persists across sessions via two new `AppSettings` doubles saved on drag end. Default: top-right corner.
- The bottom instrument bar is untouched and still updates live on hover via `profileReviewProvider`.

### Detail page unchanged

The detail page keeps the above-the-chart placement, now pinned by a widget test (`showOnTopOfTheChartBoxArea`/`fitInsideVertically`/`tooltipMargin` asserted on the default config).

### Testing

- 5 new `DraggableReadoutCard` widget tests: placeholder hint, row rendering, default corner, drag + clamp at bounds, fraction reporting on drag end.
- 5 new fullscreen page tests: card present with hint, chart in external-tooltip mode, long-press populates + values stick after release, drag persists a clamped fraction to settings, saved position seeds the card.
- Settings round-trip test through the real `SettingsNotifier` (state + SharedPreferences), plus the four explicit settings fakes updated.
- Localization key-parity tests pass for all locales; `flutter analyze` clean; whole-repo `dart format` clean.
- 222 tests green across all touched surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PaSGCDVCi7gpSpgMxZrbz
