### PR TITLE
feat(dive-log): linear estimated tank pressure line for manual dives (#197)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-linear-tank-pressure-line.md
+++ b/docs/superpowers/plans/2026-07-06-linear-tank-pressure-line.md
@@ -1,0 +1,1091 @@
+# Linear Tank Pressure Line Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Draw a transmitter-style linear start→end pressure line on the dive profile chart for tanks that have manually-entered start/end pressures but no air-integrated (AI) time-series data, marked as "estimated".
+
+**Architecture:** A pure synthesis helper builds flat–drop–flat `TankPressurePoint` series in memory, windowed by gas switches; a composing Riverpod provider augments the real pressure map with these estimates and reports which tankIds are synthetic; the chart, legend, tooltip, and readout render the synthetic series like a normal pressure line but tagged "(est.)". Nothing is persisted — SAC analysis and exports keep reading real `TankPressureProfiles` data only.
+
+**Tech Stack:** Flutter, Drift (untouched here), Riverpod, fl_chart, Flutter gen-l10n.
+
+## Global Constraints
+
+- After every task: `dart format .` produces no changes, and `flutter analyze` is clean (whole project).
+- Synthesis is **in-memory only** — never written to the database, sync, or export.
+- **Trigger** for synthesizing a tank's line: the tank has no rows in the real pressure map AND `startPressure != null` AND `endPressure != null` AND `startPressure > endPressure` AND the dive has a depth profile (`diveDurationSeconds > 0`).
+- **Starting tank** (active from t=0) = the tank with the lowest `DiveTank.order`, identical to `buildGasUsageSegments`.
+- New user-facing string added to all **11** `lib/l10n/arb/app_*.arb` files (`ar, de, en, es, fr, he, hu, it, nl, pt, zh`), translated (not English fallbacks), then regenerated with `flutter gen-l10n`.
+- Commit messages: no `Co-Authored-By` trailers.
+- Branch: `issue-197-linear-tank-pressure-line`.
+
+## File Structure
+
+- `lib/features/dive_log/data/services/gas_usage_segments_service.dart` — add `buildActiveTankIntervals` (tank-keyed timeline, reuses the same walk rules as `buildGasUsageSegments`).
+- `lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart` (new) — `synthesizeEstimatedTankPressures`, `EstimatedTankPressures`, private `_buildFlatDropFlat`. DB-free pure service beside `gas_usage_segments_service.dart`.
+- `lib/features/dive_log/presentation/providers/dive_providers.dart` — add `estimatedTankPressuresProvider`.
+- `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` — new `estimatedTankIds` field; `isCurved:false` for estimated tanks; "(est.)" suffix in tooltip + readout rows; pass estimated set into the legend config.
+- `lib/features/dive_log/presentation/widgets/dive_profile_legend.dart` — `estimatedTankIds` on `ProfileLegendConfig`; "(est.)" suffix on estimated tank rows.
+- `lib/features/dive_log/presentation/widgets/dive_profile_panel.dart`, `lib/features/dive_log/presentation/pages/dive_detail_page.dart`, `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart` — consume `estimatedTankPressuresProvider`; pass `estimatedTankIds`.
+- `lib/l10n/arb/app_*.arb` (11) + regenerated `app_localizations*.dart`.
+- Tests: extend `test/features/dive_log/data/services/gas_usage_segments_service_test.dart`; new `test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart`; new `test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart`; extend `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart` and `dive_profile_legend_test.dart`.
+
+---
+
+### Task 1: `buildActiveTankIntervals` — per-tank active windows from gas switches
+
+**Files:**
+- Modify: `lib/features/dive_log/data/services/gas_usage_segments_service.dart` (append new function)
+- Test: `test/features/dive_log/data/services/gas_usage_segments_service_test.dart` (add new group)
+
+**Interfaces:**
+- Consumes: `DiveTank` (`.id`, `.order`), `GasSwitchWithTank` (`.timestamp`, `.tankId`) from `dive.dart` / `gas_switch.dart`.
+- Produces: `Map<String, List<({int start, int end})>> buildActiveTankIntervals({required List<DiveTank> tanks, required List<GasSwitchWithTank> gasSwitches, required int diveDurationSeconds})` — keys are tankIds; each value is that tank's ascending, non-overlapping active `[start, end)` intervals.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this group to the existing test file (reuse the file's existing `_tank` and `_switch` helpers):
+
+```dart
+  group('buildActiveTankIntervals', () {
+    test('empty when no tanks or zero duration', () {
+      expect(
+        buildActiveTankIntervals(
+          tanks: const [],
+          gasSwitches: const [],
+          diveDurationSeconds: 1800,
+        ),
+        isEmpty,
+      );
+      expect(
+        buildActiveTankIntervals(
+          tanks: [_tank(id: 't1', o2: 21)],
+          gasSwitches: const [],
+          diveDurationSeconds: 0,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('single tank, no switches -> one full-dive interval for lowest order', () {
+      final result = buildActiveTankIntervals(
+        tanks: [_tank(id: 'late', o2: 100, order: 2), _tank(id: 'first', o2: 21)],
+        gasSwitches: const [],
+        diveDurationSeconds: 2400,
+      );
+      expect(result.keys, ['first']);
+      expect(result['first'], [(start: 0, end: 2400)]);
+    });
+
+    test('deco bottle owns only its switch window', () {
+      final result = buildActiveTankIntervals(
+        tanks: [_tank(id: 'back', o2: 21), _tank(id: 'deco', o2: 50, order: 1)],
+        gasSwitches: [_switch(tankId: 'deco', timestamp: 1200, o2Fraction: 0.50)],
+        diveDurationSeconds: 1800,
+      );
+      expect(result['back'], [(start: 0, end: 1200)]);
+      expect(result['deco'], [(start: 1200, end: 1800)]);
+    });
+
+    test('back gas returned to yields two intervals with a gap', () {
+      final result = buildActiveTankIntervals(
+        tanks: [_tank(id: 'back', o2: 21), _tank(id: 'deco', o2: 50, order: 1)],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200, o2Fraction: 0.50),
+          _switch(tankId: 'back', timestamp: 1800, o2Fraction: 0.21),
+        ],
+        diveDurationSeconds: 2400,
+      );
+      expect(result['back'], [(start: 0, end: 1200), (start: 1800, end: 2400)]);
+      expect(result['deco'], [(start: 1200, end: 1800)]);
+    });
+
+    test('switch exactly at t=0 produces no zero-length leading interval', () {
+      final result = buildActiveTankIntervals(
+        tanks: [_tank(id: 'back', o2: 21), _tank(id: 'deco', o2: 50, order: 1)],
+        gasSwitches: [
+          _switch(tankId: 'back', timestamp: 0, o2Fraction: 0.21),
+          _switch(tankId: 'deco', timestamp: 1500, o2Fraction: 0.50),
+        ],
+        diveDurationSeconds: 3000,
+      );
+      expect(result['back'], [(start: 0, end: 1500)]);
+      expect(result['deco'], [(start: 1500, end: 3000)]);
+    });
+
+    test('out-of-bounds switches are dropped', () {
+      final result = buildActiveTankIntervals(
+        tanks: [_tank(id: 'back', o2: 21), _tank(id: 'deco', o2: 50, order: 1)],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: -10, o2Fraction: 0.50),
+          _switch(tankId: 'deco', timestamp: 9000, o2Fraction: 0.50),
+        ],
+        diveDurationSeconds: 1800,
+      );
+      expect(result['back'], [(start: 0, end: 1800)]);
+      expect(result.containsKey('deco'), isFalse);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/data/services/gas_usage_segments_service_test.dart`
+Expected: FAIL — `buildActiveTankIntervals` is not defined.
+
+- [ ] **Step 3: Implement `buildActiveTankIntervals`**
+
+Append to `gas_usage_segments_service.dart` (after `buildGasUsageSegments`):
+
+```dart
+/// Per-tank active intervals: for each tankId, the ascending, non-overlapping
+/// [start, end) windows during which it was the breathed gas.
+///
+/// Uses the same starting-tank + switch-walk rules as [buildGasUsageSegments]
+/// (starting tank = lowest [DiveTank.order]; switches sorted and clamped to
+/// [0, diveDurationSeconds]; the initial window runs from t=0 to the first
+/// switch), but keys by tankId with no gas-mix merging.
+///
+/// Returns an empty map when there are no tanks or the dive has no duration.
+Map<String, List<({int start, int end})>> buildActiveTankIntervals({
+  required List<DiveTank> tanks,
+  required List<GasSwitchWithTank> gasSwitches,
+  required int diveDurationSeconds,
+}) {
+  final result = <String, List<({int start, int end})>>{};
+  if (tanks.isEmpty || diveDurationSeconds <= 0) return result;
+
+  final startingTank = ([
+    ...tanks,
+  ]..sort((a, b) => a.order.compareTo(b.order))).first;
+
+  final inBounds =
+      ([...gasSwitches]..sort((a, b) => a.timestamp.compareTo(b.timestamp)))
+          .where((s) => s.timestamp >= 0 && s.timestamp <= diveDurationSeconds)
+          .toList(growable: false);
+
+  void add(String tankId, int start, int end) {
+    if (start >= end) return;
+    result.putIfAbsent(tankId, () => []).add((start: start, end: end));
+  }
+
+  if (inBounds.isEmpty) {
+    add(startingTank.id, 0, diveDurationSeconds);
+    return result;
+  }
+
+  if (inBounds.first.timestamp > 0) {
+    add(startingTank.id, 0, inBounds.first.timestamp);
+  }
+  for (var i = 0; i < inBounds.length; i++) {
+    final end = i + 1 < inBounds.length
+        ? inBounds[i + 1].timestamp
+        : diveDurationSeconds;
+    add(inBounds[i].tankId, inBounds[i].timestamp, end);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/data/services/gas_usage_segments_service_test.dart`
+Expected: PASS (existing `buildGasUsageSegments` tests plus the new group).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/data/services/gas_usage_segments_service.dart test/features/dive_log/data/services/gas_usage_segments_service_test.dart
+flutter analyze lib/features/dive_log/data/services/gas_usage_segments_service.dart
+git add lib/features/dive_log/data/services/gas_usage_segments_service.dart test/features/dive_log/data/services/gas_usage_segments_service_test.dart
+git commit -m "feat(dive-log): add buildActiveTankIntervals for per-tank gas windows"
+```
+
+---
+
+### Task 2: `synthesizeEstimatedTankPressures` — build the flat–drop–flat series
+
+**Files:**
+- Create: `lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart`
+- Test: `test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart`
+
+**Interfaces:**
+- Consumes: `buildActiveTankIntervals` (Task 1); `TankPressurePoint` (`.id/.tankId/.timestamp/.pressure`), `DiveTank` (`.id/.order/.startPressure/.endPressure`), `GasSwitchWithTank`.
+- Produces:
+  - `class EstimatedTankPressures { final Map<String, List<TankPressurePoint>> pressures; final Set<String> estimatedTankIds; const EstimatedTankPressures(this.pressures, this.estimatedTankIds); }`
+  - `EstimatedTankPressures synthesizeEstimatedTankPressures({required Map<String, List<TankPressurePoint>> existing, required List<DiveTank> tanks, required List<GasSwitchWithTank> gasSwitches, required int diveDurationSeconds})`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create the test file:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+
+DiveTank _tank({
+  required String id,
+  double? start,
+  double? end,
+  int order = 0,
+}) => DiveTank(
+  id: id,
+  gasMix: const GasMix(o2: 21),
+  order: order,
+  startPressure: start,
+  endPressure: end,
+);
+
+GasSwitchWithTank _switch({required String tankId, required int timestamp}) =>
+    GasSwitchWithTank(
+      gasSwitch: GasSwitch(
+        id: 'gs-$timestamp',
+        diveId: 'd1',
+        timestamp: timestamp,
+        tankId: tankId,
+        createdAt: DateTime(2026, 1, 1),
+      ),
+      tankName: '',
+      gasMix: '',
+      o2Fraction: 0.21,
+    );
+
+void main() {
+  group('synthesizeEstimatedTankPressures', () {
+    test('single tank, no switches -> straight two-point line', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [_tank(id: 't1', start: 200, end: 65)],
+        gasSwitches: const [],
+        diveDurationSeconds: 2400,
+      );
+      expect(result.estimatedTankIds, {'t1'});
+      final pts = result.pressures['t1']!;
+      expect(pts.map((p) => (p.timestamp, p.pressure)), [(0, 200.0), (2400, 65.0)]);
+    });
+
+    test('deco bottle -> flat, drop, flat', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [
+          _tank(id: 'back', start: 200, end: 90),
+          _tank(id: 'deco', start: 190, end: 130, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200),
+          _switch(tankId: 'back', timestamp: 1800),
+        ],
+        diveDurationSeconds: 2400,
+      );
+      final deco = result.pressures['deco']!.map((p) => (p.timestamp, p.pressure));
+      expect(deco, [(0, 190.0), (1200, 190.0), (1800, 130.0), (2400, 130.0)]);
+    });
+
+    test('back gas returned to -> drop split across windows by duration', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [
+          _tank(id: 'back', start: 200, end: 65),
+          _tank(id: 'deco', start: 190, end: 130, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200),
+          _switch(tankId: 'back', timestamp: 1800),
+        ],
+        diveDurationSeconds: 2400,
+      );
+      // active [0,1200]+[1800,2400] = 1800s, drop 135 -> 0.075 bar/s.
+      final back = result.pressures['back']!.map((p) => (p.timestamp, p.pressure));
+      expect(back, [(0, 200.0), (1200, 110.0), (1800, 110.0), (2400, 65.0)]);
+    });
+
+    test('real data passes through untouched and is not marked estimated', () {
+      final real = {
+        't1': const [
+          TankPressurePoint(id: 'r0', tankId: 't1', timestamp: 0, pressure: 205),
+          TankPressurePoint(id: 'r1', tankId: 't1', timestamp: 600, pressure: 150),
+        ],
+      };
+      final result = synthesizeEstimatedTankPressures(
+        existing: real,
+        tanks: [_tank(id: 't1', start: 200, end: 65)],
+        gasSwitches: const [],
+        diveDurationSeconds: 2400,
+      );
+      expect(result.estimatedTankIds, isEmpty);
+      expect(result.pressures['t1'], same(real['t1']));
+    });
+
+    test('skips when a pressure is missing, equal, or inverted', () {
+      for (final tank in [
+        _tank(id: 'x', start: 200), // no end
+        _tank(id: 'x', end: 100), // no start
+        _tank(id: 'x', start: 100, end: 100), // equal
+        _tank(id: 'x', start: 90, end: 120), // inverted
+      ]) {
+        final result = synthesizeEstimatedTankPressures(
+          existing: const {},
+          tanks: [tank],
+          gasSwitches: const [],
+          diveDurationSeconds: 2400,
+        );
+        expect(result.estimatedTankIds, isEmpty);
+        expect(result.pressures.containsKey('x'), isFalse);
+      }
+    });
+
+    test('no profile duration -> nothing synthesized', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [_tank(id: 't1', start: 200, end: 65)],
+        gasSwitches: const [],
+        diveDurationSeconds: 0,
+      );
+      expect(result.estimatedTankIds, isEmpty);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart`
+Expected: FAIL — file/functions do not exist.
+
+- [ ] **Step 3: Implement the synthesizer**
+
+Create `estimated_tank_pressure_synthesizer.dart`:
+
+```dart
+import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+
+/// Real per-tank pressures augmented with in-memory linear estimates, plus the
+/// set of tankIds that were synthesized (so the UI can label them "estimated").
+class EstimatedTankPressures {
+  final Map<String, List<TankPressurePoint>> pressures;
+  final Set<String> estimatedTankIds;
+  const EstimatedTankPressures(this.pressures, this.estimatedTankIds);
+}
+
+/// Builds transmitter-style linear pressure series for tanks that have both
+/// start/end pressures but no time-series data. Never persists; pure.
+///
+/// For each qualifying tank the series is flat at startPressure until the tank
+/// is first breathed, drops linearly while breathed (windowed by gas switches),
+/// holds flat during gaps, and ends flat at endPressure. The total drop is
+/// distributed across active windows in proportion to their duration.
+EstimatedTankPressures synthesizeEstimatedTankPressures({
+  required Map<String, List<TankPressurePoint>> existing,
+  required List<DiveTank> tanks,
+  required List<GasSwitchWithTank> gasSwitches,
+  required int diveDurationSeconds,
+}) {
+  final pressures = <String, List<TankPressurePoint>>{...existing};
+  final estimated = <String>{};
+  if (diveDurationSeconds <= 0) {
+    return EstimatedTankPressures(pressures, estimated);
+  }
+
+  final intervals = buildActiveTankIntervals(
+    tanks: tanks,
+    gasSwitches: gasSwitches,
+    diveDurationSeconds: diveDurationSeconds,
+  );
+
+  for (final tank in tanks) {
+    if (existing[tank.id]?.isNotEmpty ?? false) continue;
+    final start = tank.startPressure;
+    final end = tank.endPressure;
+    if (start == null || end == null || start <= end) continue;
+
+    final windows = intervals[tank.id] ?? const <({int start, int end})>[];
+    final points = _buildFlatDropFlat(
+      tankId: tank.id,
+      startPressure: start,
+      endPressure: end,
+      // Fallback: a tank with start/end but no gas-switch evidence gets a
+      // single full-dive window (a plain straight line).
+      windows: windows.isEmpty
+          ? [(start: 0, end: diveDurationSeconds)]
+          : windows,
+      diveDurationSeconds: diveDurationSeconds,
+    );
+    pressures[tank.id] = points;
+    estimated.add(tank.id);
+  }
+  return EstimatedTankPressures(pressures, estimated);
+}
+
+List<TankPressurePoint> _buildFlatDropFlat({
+  required String tankId,
+  required double startPressure,
+  required double endPressure,
+  required List<({int start, int end})> windows,
+  required int diveDurationSeconds,
+}) {
+  final sorted = [...windows]..sort((a, b) => a.start.compareTo(b.start));
+  final totalActive = sorted.fold<int>(0, (s, w) => s + (w.end - w.start));
+  if (totalActive <= 0) {
+    return [
+      _pt(tankId, 0, startPressure),
+      _pt(tankId, diveDurationSeconds, endPressure),
+    ];
+  }
+  final dropRate = (startPressure - endPressure) / totalActive;
+
+  final points = <TankPressurePoint>[_pt(tankId, 0, startPressure)];
+  var pressure = startPressure;
+
+  if (sorted.first.start > 0) {
+    points.add(_pt(tankId, sorted.first.start, startPressure));
+  }
+  for (var i = 0; i < sorted.length; i++) {
+    final w = sorted[i];
+    pressure -= dropRate * (w.end - w.start);
+    points.add(_pt(tankId, w.end, pressure));
+    if (i + 1 < sorted.length && sorted[i + 1].start > w.end) {
+      points.add(_pt(tankId, sorted[i + 1].start, pressure));
+    }
+  }
+  if (sorted.last.end < diveDurationSeconds) {
+    points.add(_pt(tankId, diveDurationSeconds, endPressure));
+  } else {
+    // Clamp the final vertex to endPressure to absorb floating-point drift.
+    points[points.length - 1] = _pt(tankId, sorted.last.end, endPressure);
+  }
+  return points;
+}
+
+TankPressurePoint _pt(String tankId, int ts, double pressure) =>
+    TankPressurePoint(
+      id: 'est-$tankId-$ts',
+      tankId: tankId,
+      timestamp: ts,
+      pressure: pressure,
+    );
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart
+flutter analyze lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
+git add lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart
+git commit -m "feat(dive-log): synthesize linear tank pressure series for manual dives"
+```
+
+---
+
+### Task 3: `estimatedTankPressuresProvider` — compose real + estimated
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/providers/dive_providers.dart`
+- Test: `test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart`
+
+**Interfaces:**
+- Consumes: `tankPressuresProvider` (family, `dive_providers.dart:950`), `diveProvider` (family, `:160`, returns `Dive?`), `gasSwitchesProvider` (family, `gas_switch_providers.dart:9`), `synthesizeEstimatedTankPressures` + `EstimatedTankPressures` (Task 2).
+- Produces: `final estimatedTankPressuresProvider = FutureProvider.family<EstimatedTankPressures, String>(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create the test file:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+
+void main() {
+  test('augments real map with an estimated line for a manual tank', () async {
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 1, 1),
+      tanks: const [
+        DiveTank(
+          id: 't1',
+          gasMix: GasMix(o2: 21),
+          startPressure: 200,
+          endPressure: 60,
+        ),
+      ],
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0),
+        DiveProfilePoint(timestamp: 1800, depth: 0),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        tankPressuresProvider('d1').overrideWith(
+          (ref) async => <String, List<TankPressurePoint>>{},
+        ),
+        diveProvider('d1').overrideWith((ref) async => dive),
+        gasSwitchesProvider('d1').overrideWith(
+          (ref) async => <GasSwitchWithTank>[],
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(estimatedTankPressuresProvider('d1').future);
+
+    expect(result.estimatedTankIds, {'t1'});
+    expect(result.pressures['t1']!.first.pressure, 200);
+    expect(result.pressures['t1']!.last.pressure, 60);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart`
+Expected: FAIL — `estimatedTankPressuresProvider` is not defined.
+
+- [ ] **Step 3: Add the provider**
+
+Add these imports near the other imports in `dive_providers.dart`:
+
+```dart
+import 'package:submersion/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+```
+
+Add the provider next to `tankPressuresProvider` (around `dive_providers.dart:959`):
+
+```dart
+/// Real per-tank pressures augmented with in-memory linear estimates for tanks
+/// that have start/end pressures but no transmitter data. Chart-only; the
+/// estimates are never persisted, so SAC analysis and exports (which read the
+/// repository directly) still see real data only.
+final estimatedTankPressuresProvider =
+    FutureProvider.family<EstimatedTankPressures, String>((ref, diveId) async {
+      final real = await ref.watch(tankPressuresProvider(diveId).future);
+      final dive = await ref.watch(diveProvider(diveId).future);
+      final switches = await ref.watch(gasSwitchesProvider(diveId).future);
+      if (dive == null) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      return synthesizeEstimatedTankPressures(
+        existing: real,
+        tanks: dive.tanks,
+        gasSwitches: switches,
+        diveDurationSeconds:
+            dive.profile.isEmpty ? 0 : dive.profile.last.timestamp,
+      );
+    });
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/providers/dive_providers.dart test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
+flutter analyze lib/features/dive_log/presentation/providers/dive_providers.dart
+git add lib/features/dive_log/presentation/providers/dive_providers.dart test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
+git commit -m "feat(dive-log): add estimatedTankPressuresProvider composing real+estimated pressures"
+```
+
+---
+
+### Task 4: Localized "(est.)" suffix string
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` (template, with description) and the other 10 arb files.
+- Regenerate: `lib/l10n/arb/app_localizations*.dart` via `flutter gen-l10n`.
+
+**Interfaces:**
+- Produces: `AppLocalizations.diveLog_pressure_estimatedSuffix` → getter returning the localized "(est.)" string, consumed by Tasks 6 and 7.
+
+- [ ] **Step 1: Add the key to `app_en.arb`**
+
+Insert after the `"diveLog_chartSection_tankPressures"` entry (near `app_en.arb:2229`):
+
+```json
+  "diveLog_pressure_estimatedSuffix": "(est.)",
+  "@diveLog_pressure_estimatedSuffix": {
+    "description": "Short suffix appended to a tank label when its pressure line is a linear start-to-end estimate rather than measured air-integrated data. Abbreviation of 'estimated'."
+  },
+```
+
+- [ ] **Step 2: Add the translated key to the other 10 arb files**
+
+Add the entry to each file with these values (no `@` metadata needed in non-template files):
+
+```
+app_de.arb: "diveLog_pressure_estimatedSuffix": "(gesch.)",
+app_es.arb: "diveLog_pressure_estimatedSuffix": "(est.)",
+app_fr.arb: "diveLog_pressure_estimatedSuffix": "(est.)",
+app_it.arb: "diveLog_pressure_estimatedSuffix": "(stim.)",
+app_pt.arb: "diveLog_pressure_estimatedSuffix": "(est.)",
+app_nl.arb: "diveLog_pressure_estimatedSuffix": "(gesch.)",
+app_hu.arb: "diveLog_pressure_estimatedSuffix": "(becs.)",
+app_ar.arb: "diveLog_pressure_estimatedSuffix": "(تقديري)",
+app_he.arb: "diveLog_pressure_estimatedSuffix": "(משוער)",
+app_zh.arb: "diveLog_pressure_estimatedSuffix": "(估算)",
+```
+
+Insert each in the same relative position as in the template (place it beside the existing `diveLog_chartSection_tankPressures` entry in each file to keep diffs local).
+
+- [ ] **Step 3: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: `lib/l10n/arb/app_localizations*.dart` updated; no errors.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `flutter analyze lib/l10n`
+Expected: clean. Confirm `AppLocalizations` now exposes `diveLog_pressure_estimatedSuffix`.
+
+- [ ] **Step 5: Format, commit**
+
+```bash
+dart format lib/l10n/arb/app_localizations.dart
+git add lib/l10n/arb
+git commit -m "i18n(dive-log): add estimated-pressure suffix string in all locales"
+```
+
+---
+
+### Task 5: Chart — `estimatedTankIds` field + crisp (straight) estimated line
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (field ~`:130`, ctor ~`:453`, `_buildMultiTankPressureLines` ~`:3653`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart` (helper `_buildChart` ~`:91/:142`, new test)
+
+**Interfaces:**
+- Consumes: `EstimatedTankPressures.estimatedTankIds` (Task 2/3) — passed in as `Set<String>?`.
+- Produces: `DiveProfileChart({..., Set<String>? estimatedTankIds})` field, and estimated pressure lines rendered with `isCurved: false`.
+
+- [ ] **Step 1: Write the failing test**
+
+First extend the `_buildChart` helper: add `Set<String>? estimatedTankIds,` to its parameter list (beside `tanks`) and `estimatedTankIds: estimatedTankIds,` to the `DiveProfileChart(...)` call. Then add this test (a synthesized single-tank line is straight + dashed; a real line is curved + dashed):
+
+```dart
+  testWidgets('estimated tank pressure line is straight (isCurved false)', (
+    tester,
+  ) async {
+    const tank = DiveTank(id: 't1', gasMix: GasMix(o2: 21), order: 0);
+    final points = const [
+      TankPressurePoint(id: 'e0', tankId: 't1', timestamp: 0, pressure: 200),
+      TankPressurePoint(id: 'e1', tankId: 't1', timestamp: 270, pressure: 60),
+    ];
+
+    await tester.pumpWidget(
+      _buildChart(
+        tanks: const [tank],
+        tankPressures: {'t1': points},
+        estimatedTankIds: const {'t1'},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final chart = tester.widget<LineChart>(find.byType(LineChart));
+    final estimatedBars = chart.data.lineBarsData
+        .where((b) => b.dashArray != null && b.isCurved == false)
+        .toList();
+    expect(estimatedBars, isNotEmpty);
+
+    // Control: same data, NOT estimated -> pressure line is curved.
+    await tester.pumpWidget(
+      _buildChart(tanks: const [tank], tankPressures: {'t1': points}),
+    );
+    await tester.pumpAndSettle();
+    final chart2 = tester.widget<LineChart>(find.byType(LineChart));
+    expect(
+      chart2.data.lineBarsData.where(
+        (b) => b.dashArray != null && b.isCurved == false,
+      ),
+      isEmpty,
+    );
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --plain-name "estimated tank pressure line is straight"`
+Expected: FAIL — `estimatedTankIds` is not a parameter of `DiveProfileChart` (compile error) or the estimated bar is still curved.
+
+- [ ] **Step 3: Add the field and use it**
+
+In `dive_profile_chart.dart`, declare the field next to `tankPressures` (after `:130`):
+
+```dart
+  /// Tank IDs whose pressure series is a synthesized linear estimate (no AI
+  /// data). Rendered straight and labelled "(est.)".
+  final Set<String>? estimatedTankIds;
+```
+
+Add to the constructor next to `this.tankPressures,` (after `:453`):
+
+```dart
+    this.estimatedTankIds,
+```
+
+In `_buildMultiTankPressureLines`, change the `LineChartBarData`'s `isCurved: true,` (`:3653`) to:
+
+```dart
+          isCurved: !(widget.estimatedTankIds?.contains(tankId) ?? false),
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --plain-name "estimated tank pressure line is straight"`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+flutter analyze lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "feat(dive-log): render estimated tank pressure lines straight on the profile chart"
+```
+
+---
+
+### Task 6: Chart — "(est.)" suffix in tooltip and readout rows
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (tooltip rows ~`:1254`, readout rows ~`:2843`, add helper)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart`
+
+**Interfaces:**
+- Consumes: `widget.estimatedTankIds` (Task 5), `context.l10n.diveLog_pressure_estimatedSuffix` (Task 4).
+- Produces: tooltip/readout tank rows whose label ends with the localized "(est.)" for estimated tanks.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test (long-press emits external tooltip rows, as in the existing `_emitExternalTooltip` tests):
+
+```dart
+  testWidgets('tooltip labels an estimated tank with the (est.) suffix', (
+    tester,
+  ) async {
+    // 20-point profile matching the proven long-press tooltip tests, so the
+    // gesture reliably lands on a data point and emits external tooltip rows.
+    final profile = List.generate(
+      20,
+      (i) => DiveProfilePoint(
+        timestamp: i * 30,
+        depth: i < 10 ? i * 3.0 : (19 - i) * 3.0,
+      ),
+    );
+    const tank = DiveTank(id: 't1', gasMix: GasMix(o2: 21), order: 0);
+    // A straight two-point estimate spanning the whole profile (0..570s).
+    const points = [
+      TankPressurePoint(id: 'e0', tankId: 't1', timestamp: 0, pressure: 200),
+      TankPressurePoint(id: 'e1', tankId: 't1', timestamp: 570, pressure: 60),
+    ];
+    List<TooltipRow>? rows;
+
+    await tester.pumpWidget(
+      _buildChart(
+        profile: profile,
+        tanks: const [tank],
+        tankPressures: {'t1': points},
+        estimatedTankIds: const {'t1'},
+        tooltipBelow: true,
+        onTooltipData: (r) => rows = r,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Long-press near the center; assert BEFORE releasing (release clears rows).
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(LineChart)),
+    );
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.moveBy(const Offset(2, 0));
+    await tester.pump();
+
+    expect(rows, isNotNull);
+    expect(rows!.where((r) => r.label.contains('(est.)')), isNotEmpty);
+    await gesture.up();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --plain-name "tooltip labels an estimated tank"`
+Expected: FAIL — no tank row label contains "(est.)".
+
+- [ ] **Step 3: Add the suffix helper and apply it**
+
+Add a helper method inside the `DiveProfileChart` state class (near the other tank helpers):
+
+```dart
+  String _estimatedSuffix(String tankId) =>
+      (widget.estimatedTankIds?.contains(tankId) ?? false)
+      ? ' ${context.l10n.diveLog_pressure_estimatedSuffix}'
+      : '';
+```
+
+In the **tooltip** builder (`:1254-1256`), append the suffix:
+
+```dart
+        final tankLabel =
+            DiveProfileChart.tankTooltipLabel(tank, 'Tank ${i + 1}') +
+            _tankSourceSuffix(tankId, tankComputerIds, contributingComputerIds) +
+            _estimatedSuffix(tankId);
+```
+
+In the **readout** builder (`:2843-2852`), append the suffix:
+
+```dart
+                        final tankLabel =
+                            DiveProfileChart.tankTooltipLabel(
+                              tank,
+                              context.l10n.diveLog_tank_title(i + 1),
+                            ) +
+                            _tankSourceSuffix(
+                              tankId,
+                              tankComputerIds,
+                              contributingComputerIds,
+                            ) +
+                            _estimatedSuffix(tankId);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart --plain-name "tooltip labels an estimated tank"`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+flutter analyze lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+git add lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+git commit -m "feat(dive-log): mark estimated tank pressure in chart tooltip and readout"
+```
+
+---
+
+### Task 7: Legend — "(est.)" suffix on estimated tank rows
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_legend.dart` (`ProfileLegendConfig` ~`:13-57`, tank-pressures section ~`:590-592`)
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (legend config build ~`:1478`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart`
+
+**Interfaces:**
+- Consumes: `widget.estimatedTankIds` (Task 5), `context.l10n.diveLog_pressure_estimatedSuffix` (Task 4).
+- Produces: `ProfileLegendConfig.estimatedTankIds` (`Set<String>`, default `const {}`), rendered as a "(est.)" suffix on matching tank rows in the "Tank Pressures" dialog section.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `dive_profile_legend_test.dart` (mirrors the existing tune-dialog pattern):
+
+```dart
+  testWidgets('estimated tank row shows the (est.) suffix', (tester) async {
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+        ],
+        child: DiveProfileLegend(
+          config: const ProfileLegendConfig(
+            hasMultiTankPressure: true,
+            tanks: _testTanks,
+            tankPressures: {
+              'tank-1': [
+                TankPressurePoint(
+                  id: 'e0',
+                  tankId: 'tank-1',
+                  timestamp: 0,
+                  pressure: 200,
+                ),
+              ],
+            },
+            estimatedTankIds: {'tank-1'},
+          ),
+          zoomLevel: 1.0,
+          onZoomIn: () {},
+          onZoomOut: () {},
+          onResetZoom: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tank Pressures lives in the "more options" (tune) dialog.
+    await tester.tap(find.byIcon(Icons.tune), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('(est.)'), findsWidgets);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart --plain-name "estimated tank row"`
+Expected: FAIL — `estimatedTankIds` is not a parameter of `ProfileLegendConfig` (compile error).
+
+- [ ] **Step 3: Add the config field**
+
+In `dive_profile_legend.dart`, add the field to `ProfileLegendConfig` (after `tankPressures`, `:28`):
+
+```dart
+  final Set<String> estimatedTankIds;
+```
+
+Add to the constructor (after `this.tankPressures,`):
+
+```dart
+    this.estimatedTankIds = const {},
+```
+
+- [ ] **Step 4: Render the suffix in the tank-pressures section**
+
+In the "Tank Pressures" section (`:590-592`), replace the `label` assignment:
+
+```dart
+        final baseLabel = tank != null
+            ? _buildTankLabel(context, tank, fallbackIndex: i + 1)
+            : context.l10n.diveLog_tank_title(i + 1);
+        final label = config.estimatedTankIds.contains(tankId)
+            ? '$baseLabel ${context.l10n.diveLog_pressure_estimatedSuffix}'
+            : baseLabel;
+```
+
+- [ ] **Step 5: Pass the set from the chart into the config**
+
+In `dive_profile_chart.dart`, in the `ProfileLegendConfig(...)` construction (after `tankPressures: widget.tankPressures,`, `:1478`):
+
+```dart
+      estimatedTankIds: widget.estimatedTankIds ?? const {},
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart --plain-name "estimated tank row"`
+Expected: PASS.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_legend.dart lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+flutter analyze lib/features/dive_log/presentation/widgets/dive_profile_legend.dart lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+git add lib/features/dive_log/presentation/widgets/dive_profile_legend.dart lib/features/dive_log/presentation/widgets/dive_profile_chart.dart test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+git commit -m "feat(dive-log): label estimated tanks in the profile legend"
+```
+
+---
+
+### Task 8: Wire the three chart hosts to the estimated provider
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_panel.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_detail_page.dart`
+- Modify: `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart`
+
+**Interfaces:**
+- Consumes: `estimatedTankPressuresProvider` (Task 3), `DiveProfileChart.estimatedTankIds` (Task 5).
+- Produces: all three chart hosts feed the augmented map + estimated set to the chart. No new public API.
+
+- [ ] **Step 1: Update `dive_profile_panel.dart`**
+
+Replace the `tankPressures` watch (around `:248`):
+
+```dart
+    final estimated = ref
+        .watch(estimatedTankPressuresProvider(widget.diveId))
+        .valueOrNull;
+    final tankPressures = estimated?.pressures;
+```
+
+Pass the estimated set to the chart alongside `tankPressures:` (around `:390`):
+
+```dart
+                  tankPressures: tankPressures,
+                  estimatedTankIds: estimated?.estimatedTankIds,
+```
+
+Add the import if not present:
+
+```dart
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+```
+(The panel already imports `dive_providers.dart` for `tankPressuresProvider`; keep a single import. Remove the now-unused `tankPressuresProvider` reference only if nothing else uses it.)
+
+- [ ] **Step 2: Update `dive_detail_page.dart`**
+
+Find where it reads `tankPressuresProvider(...)` (around `:1063-1064`) and passes `tankPressures:` to `DiveProfileChart` (around `:1334`). Apply the same change: read `estimatedTankPressuresProvider`, pass `tankPressures: estimated?.pressures` and add `estimatedTankIds: estimated?.estimatedTankIds`.
+
+```dart
+    final estimated = ref
+        .watch(estimatedTankPressuresProvider(dive.id))
+        .valueOrNull;
+```
+```dart
+              tankPressures: estimated?.pressures,
+              estimatedTankIds: estimated?.estimatedTankIds,
+```
+
+- [ ] **Step 3: Update `fullscreen_profile_page.dart`**
+
+Same change at its `tankPressuresProvider` read (around `:143`) and its `DiveProfileChart(...)` `tankPressures:` argument (around `:353/:365`):
+
+```dart
+    final estimated = ref
+        .watch(estimatedTankPressuresProvider(diveId))
+        .valueOrNull;
+```
+```dart
+            tankPressures: estimated?.pressures,
+            estimatedTankIds: estimated?.estimatedTankIds,
+```
+
+- [ ] **Step 4: Analyze and run affected tests**
+
+Run:
+```bash
+flutter analyze lib/features/dive_log/presentation/widgets/dive_profile_panel.dart lib/features/dive_log/presentation/pages/dive_detail_page.dart lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+```
+Expected: analyze clean; tests PASS.
+
+- [ ] **Step 5: Manual verification (per the verify skill)**
+
+Launch the app (`flutter run -d macos`), open a dive that has a tank with start/end pressures but no AI data (or add one via edit). Confirm:
+1. A dashed, gas-colored, **straight** pressure line appears on the profile chart.
+2. The legend's "Tank Pressures" (tune dialog) row and the hover tooltip/readout show the tank with a "(est.)" suffix.
+3. A dive **with** real AI pressure data still shows its curved line and no "(est.)" tag.
+
+- [ ] **Step 6: Format, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_profile_panel.dart lib/features/dive_log/presentation/pages/dive_detail_page.dart lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+git add lib/features/dive_log/presentation/widgets/dive_profile_panel.dart lib/features/dive_log/presentation/pages/dive_detail_page.dart lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+git commit -m "feat(dive-log): show estimated tank pressure lines on all profile chart hosts (#197)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full dive_log test suite:
+  ```bash
+  flutter test test/features/dive_log/
+  ```
+  Expected: all PASS.
+- [ ] Whole-project format + analyze:
+  ```bash
+  dart format . && flutter analyze
+  ```
+  Expected: no changes, no issues.

--- a/docs/superpowers/specs/2026-07-06-linear-tank-pressure-line-design.md
+++ b/docs/superpowers/specs/2026-07-06-linear-tank-pressure-line-design.md
@@ -1,0 +1,272 @@
+# Linear Tank Pressure Line — Design (issue #197)
+
+Date: 2026-07-06
+Branch: `issue-197-linear-tank-pressure-line`
+Status: Approved (design choices confirmed with user)
+
+## Problem
+
+Reported in [#197](https://github.com/submersion-app/submersion/issues/197): when a dive
+has a tank with manually-entered start/end pressures but **no air-integrated (AI)
+transmitter data**, the dive profile chart draws no pressure information at all. The
+request is to graph a linear start→end pressure line for such tanks so manual-entry dives
+still get a pressure visualization.
+
+### Why nothing is drawn today
+
+A dive's per-tank pressure lives in two places:
+
+- `DiveTanks.startPressure` / `endPressure` — two scalar values per tank
+  (`database.dart:595-596`; domain `DiveTank`, `dive.dart:911`). Present for manual entry
+  or computers that only log start/end.
+- `TankPressureProfiles` — the time-series table populated by AI transmitters
+  (`database.dart:1589`; domain `TankPressurePoint`, `dive.dart:893`).
+
+The chart's pressure curve is built solely from the time-series map. `_hasMultiTankPressure`
+(`dive_profile_chart.dart:532`) is `tankPressures != null && isNotEmpty`, and
+`_buildMultiTankPressureLines` (`dive_profile_chart.dart:3585`) early-returns `[]` when that
+is false. `TankPressureRepository.getTankPressuresForDive` (`tank_pressure_repository.dart:23`)
+only emits map keys for tanks that have rows. So a tank with start/end pressures but zero
+transmitter samples produces **no map key → no line**. The stored start/end pressures are
+used only by the equipment table and the tooltip's start/end resolution, never as a chart
+series. This is an unimplemented case, not a regression.
+
+## Goals
+
+1. Draw a linear start→end pressure line for any tank that has both pressures but no
+   time-series data.
+2. Shape the line like a real transmitter would have recorded it: flat while the tank is
+   unused, sloping while it is being breathed (windowed by gas switches), flat again after.
+3. Mark the line as **estimated** wherever pressure is surfaced (legend, tooltip, readout)
+   so an interpolation is never mistaken for measured data.
+4. No changes to stored data, SAC analysis, import, or export.
+
+Non-goals: feeding the synthetic series into SAC/consumption (the Cylinder SAC card already
+derives average SAC from start−end pressure); depth-weighting the drop rate (the issue asks
+for a *linear* line, and depth-weighting would reintroduce the SAC modeling we are excluding);
+persisting synthetic samples; changing how real AI pressure lines render.
+
+## Design
+
+The synthetic series is built **in memory at the chart-read path and never persisted.**
+`TankPressureProfiles` keeps meaning "real measured data," so SAC analysis
+(`profile_analysis_provider.dart:722`, which reads the repository directly) and UDDF export
+(which also reads the repository) continue to see real data only — no "is this row fake?"
+guard ever leaks into the data layer.
+
+### 1. Trigger (evaluated per tank)
+
+For each `DiveTank` in `dive.tanks`: if it already has rows in the real `tankPressures`
+map, use them unchanged. Otherwise synthesize **iff** all of:
+
+- `startPressure != null && endPressure != null`
+- `startPressure > endPressure` — skips a flat "no gas used" line (`start == end`) and a
+  physically impossible rising line (`end > start`, i.e. bad/absent data)
+- the dive has a depth profile (`diveDurationSeconds > 0`)
+
+Tanks that have real data and tanks that qualify for synthesis can coexist on the same dive
+(mixed AI + manual); each is decided independently.
+
+### 2. Active-tank intervals (new, reuses the proven timeline algorithm)
+
+To window the line we need, per tankId, the `[start, end)` intervals during which that tank
+was the breathed gas. `buildGasUsageSegments` (`gas_usage_segments_service.dart`) already
+implements exactly this walk for the gas-timeline strip — starting tank = lowest
+`DiveTank.order`, switches sorted and clamped to `[0, diveDurationSeconds]`, initial segment
+`0→firstSwitch` (skipped if a switch sits at t=0), each switch running to the next and the
+last to dive end — but it keys segments by **gas mix** and merges adjacent same-gas segments,
+which would blur two tanks that share a mix. So it is not directly reusable.
+
+Add a tank-keyed sibling in the same service file:
+
+```
+/// Per-tank active intervals: for each tankId, the [start, end) windows during
+/// which it was the breathed gas. Same starting-tank + switch-walk rules as
+/// buildGasUsageSegments, but keyed by tankId with NO gas-mix merging.
+Map<String, List<({int start, int end})>> buildActiveTankIntervals({
+  required List<DiveTank> tanks,
+  required List<GasSwitchWithTank> gasSwitches,
+  required int diveDurationSeconds,
+});
+```
+
+- Starting tank (active from t=0) = the tank with the lowest `order`, matching
+  `buildGasUsageSegments`. This is the one genuinely inferred input: "which tank you start
+  the dive on" is not explicitly recorded.
+- No switches → the starting tank owns one interval `[0, diveDurationSeconds]`; every other
+  tank has none.
+- A tank switched to and later away has one interval per use; a back gas returned to after a
+  deco excursion has two intervals with a gap between them.
+
+Optional cleanup (not required for v1, guarded by the existing gas-strip regression tests):
+extract the shared switch-walk into one private helper that both `buildGasUsageSegments` and
+`buildActiveTankIntervals` consume. Kept out of v1 scope to avoid perturbing the gas strip's
+merge behavior.
+
+### 3. Synthesized series shape (transmitter-style flat–drop–flat)
+
+For a synthesized tank with `startPressure` S, `endPressure` E (S > E) and active intervals
+`I = [(a1,b1), (a2,b2), …]` sorted by start:
+
+- `totalActive = Σ(bk − ak)`. If `I` is empty or `totalActive ≤ 0` (a tank with start/end but
+  no derivable window — e.g. never switched to and not the starting tank), **fall back** to a
+  single interval `[0, diveDurationSeconds]` — a plain full-dive straight line.
+- `dropRate = (S − E) / totalActive` (bar per second). Pressure is constant off-window and
+  drops linearly on-window, so the total drop is distributed across the active intervals in
+  proportion to their duration.
+- Emit `TankPressurePoint`s (linear segments between consecutive points):
+  - leading flat at S from `0` to `a1` if `a1 > 0`;
+  - for each interval `(ak, bk)`: point `(ak, P)`, then `P −= dropRate·(bk−ak)`, point `(bk, P)`;
+  - the gap to the next interval is drawn flat automatically by the segment from `(bk, P)` to
+    `(a{k+1}, P)`;
+  - trailing flat at E from the last `bn` to `diveDurationSeconds` (clamp the final pressure to
+    E to absorb floating-point drift).
+
+Worked example — a 40 min (2400 s) dive. Back gas AL80 (S=200, E=65) is the starting tank,
+with a deco excursion to an EAN50 bottle (S=190, E=130) from 20–30 min; two switches are
+recorded (to EAN50 at 1200 s, back to AL80 at 1800 s):
+
+```
+Back gas AL80  — active [0,1200]+[1800,2400], totalActive 1800 s, drop 135 bar (0.075 bar/s):
+  (0,200) (1200,110)     // breathed: 200 -> 110   (0.075 x 1200 = 90)
+  (1200,110) (1800,110)  // flat while on EAN50
+  (1800,110) (2400,65)   // breathed again: 110 -> 65   (0.075 x 600 = 45)
+
+Deco EAN50     — active [1200,1800], totalActive 600 s, drop 60 bar:
+  (0,190) (1200,190)     // flat, full, until first breathed
+  (1200,190) (1800,130)  // breathed: 190 -> 130
+  (1800,130) (2400,130)  // flat, ~empty, after switch-away
+```
+
+The back gas shows drop–flat–drop (its 135 bar split 90/45 across the two active windows in
+proportion to their durations); the deco bottle shows flat–drop–flat. For the common
+single-tank recreational dive this collapses to exactly two points `(0, S) (diveEnd, E)` —
+one straight line, zero added complexity.
+
+### 4. Rendering & "estimated" marking
+
+The synthesized points are placed into the same `tankPressures` map the chart already
+consumes (see §5), so `_hasMultiTankPressure`, per-tank visibility initialization
+(`_scheduleTankPressureVisibilityInitialization`, default visible), the tooltip interpolation
+`_interpolateTankPressure` (`dive_profile_chart.dart:673`), and the legend's per-tank section
+(`dive_profile_legend.dart:580`) all light up with no structural change.
+
+A new `Set<String> estimatedTankIds` is threaded from the provider (§5) into
+`DiveProfileChart` (new field) and its legend config. It drives three touch-ups:
+
+- **Line builder** `_buildMultiTankPressureLines` (`dive_profile_chart.dart:3585`): for a
+  tankId in `estimatedTankIds`, build the `LineChartBarData` with `isCurved: false` (crisp
+  piecewise-linear — curve smoothing would round the flat→drop corners). Color, dash pattern
+  (`_getTankDashPattern`), and `barWidth: 2` are unchanged, i.e. it looks like a normal
+  pressure line; its straightness plus the label carry the "estimated" meaning. Real lines
+  keep `isCurved: true`.
+- **Legend** (`dive_profile_legend.dart:580`): tank rows whose tankId is estimated get an
+  "estimated" badge/suffix next to the tank label. Toggle behavior is unchanged (per-tank
+  `toggleTankPressure`, default visible).
+- **Tooltip / draggable readout** (`dive_profile_chart.dart:1234` and `:2811`): append a
+  localized "(est.)" suffix to the pressure row for estimated tankIds. The interpolated value
+  itself needs no special handling.
+
+### 5. Provider wiring
+
+`tankPressuresProvider` (`dive_providers.dart:950`) is left untouched (it still feeds any
+non-chart consumers and, indirectly, is what we augment). Add a composing provider:
+
+```
+/// Real per-tank pressures augmented with in-memory linear estimates for tanks
+/// that have start/end pressures but no transmitter data. Chart-only; never persisted.
+final estimatedTankPressuresProvider =
+    FutureProvider.family<EstimatedTankPressures, String>((ref, diveId) async {
+  final real = await ref.watch(tankPressuresProvider(diveId).future);
+  final dive = await ref.watch(diveProvider(diveId).future);          // dive_providers.dart:160
+  final switches = await ref.watch(gasSwitchesProvider(diveId).future); // gas_switch_providers.dart:9
+  if (dive == null) return EstimatedTankPressures(real, const <String>{});
+  return synthesizeEstimatedTankPressures(
+    existing: real,
+    tanks: dive.tanks,
+    gasSwitches: switches,
+    diveDurationSeconds: dive.profile.isEmpty ? 0 : dive.profile.last.timestamp,
+  );
+});
+```
+
+`EstimatedTankPressures` is a small immutable holder for
+`({Map<String, List<TankPressurePoint>> pressures, Set<String> estimatedTankIds})`. It
+self-invalidates transitively because all three watched providers already invalidate on
+`watchDiveDetailChanges()`.
+
+`synthesizeEstimatedTankPressures(...)` is the pure, Flutter/DB-free entry point (§1–§3): it
+calls `buildActiveTankIntervals`, applies the trigger rule, builds the flat–drop–flat points,
+copies real entries through untouched, and returns the augmented map plus the set of
+synthesized tankIds. This is where the bulk of the unit tests point.
+
+The three chart hosts — `dive_profile_panel.dart` (`:248`+), `dive_detail_page.dart`, and
+`fullscreen_profile_page.dart` — replace their `tankPressuresProvider` watch with
+`estimatedTankPressuresProvider`, pass `result.pressures` to `tankPressures:`, and pass
+`result.estimatedTankIds` to the new `estimatedTankIds:` chart argument. Each host already
+holds `dive`, `gasSwitches`, and `tankPressures` in scope, so no other plumbing changes.
+
+## Data integrity
+
+Because synthesis happens only in `estimatedTankPressuresProvider` / the pure helper, the
+following remain fed exclusively by real `TankPressureProfiles` rows and are therefore
+unaffected: SAC curve and instrument tiles (`computeAnalysisForProfile` →
+`combineMultiTankPressures`, `profile_analysis_provider.dart:722`), the Cylinder SAC card,
+and all export paths (UDDF and others read `TankPressureRepository` directly). No migration,
+sync, or schema change.
+
+## Testing (TDD — failing tests first)
+
+Unit tests on the pure functions (no widget pumping):
+
+1. **`buildActiveTankIntervals`**: single tank / no switches → one full-dive interval for the
+   lowest-`order` tank, none for others; a stage switched to at 1800s and back at 2400s → the
+   stage owns `[1800,2400)`; a back gas returned to after an excursion → two intervals with a
+   gap; a switch exactly at t=0 → no zero-length leading interval; switches clamped to bounds.
+2. **`synthesizeEstimatedTankPressures` trigger**: synthesizes only when both pressures set,
+   `start > end`, and duration > 0; real-data tanks pass through untouched; `start == end`,
+   `end > start`, missing pressures, and empty profile all skip; mixed dive yields real for
+   one tank and synthetic for another.
+3. **Series shape**: single-tank dive → exactly `(0,S)`,`(end,E)`; stage bottle → leading flat
+   at S, single linear drop, endpoint at E; two-interval back gas → drop split proportionally,
+   flat in the gap, final point clamped to E; no-window tank → full-dive straight-line fallback.
+4. **`estimatedTankIds`**: contains exactly the synthesized tankIds and never a real-data tankId.
+
+Widget tests (pump `DiveProfileChart`, read `LineChart` `LineChartData`), following existing
+chart test patterns; mark new helpers `@visibleForTesting` where cleaner:
+
+5. **Line present & crisp**: a manual-only dive yields a pressure `LineChartBarData` with
+   `isCurved == false`; a real-AI dive keeps `isCurved == true`.
+6. **Legend**: an estimated tank row shows the "estimated" badge; a real tank row does not;
+   the per-tank toggle still hides/shows the synthetic line.
+7. **Tooltip/readout**: the pressure row for an estimated tank carries the "(est.)" suffix.
+8. **Regression**: existing `dive_profile_chart` / gas-strip tests still pass (no change to
+   `buildGasUsageSegments` output; real pressure rendering unchanged).
+
+## Localization
+
+New key(s) for the "estimated" badge and the "(est.)" suffix (a single key reused for both,
+or two keys) added to all 11 `lib/l10n/arb/app_*.arb` files (en + ar, de, es, fr, he, hu, it,
+nl, pt, zh — translated, not English fallbacks), then `flutter gen-l10n` regenerated.
+
+## Files touched
+
+- `lib/features/dive_log/data/services/gas_usage_segments_service.dart` — add
+  `buildActiveTankIntervals` (tank-keyed sibling).
+- `lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart` (new) —
+  pure `synthesizeEstimatedTankPressures` + `EstimatedTankPressures` holder (sits beside
+  `gas_usage_segments_service.dart`, which it depends on; both are DB-free pure services).
+- `lib/features/dive_log/presentation/providers/dive_providers.dart` — new
+  `estimatedTankPressuresProvider`.
+- `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` — new
+  `estimatedTankIds` field; `isCurved:false` for estimated tanks in
+  `_buildMultiTankPressureLines`; "(est.)" suffix in tooltip + readout rows; pass estimated
+  set into legend config.
+- `lib/features/dive_log/presentation/widgets/dive_profile_legend.dart` — "estimated" badge on
+  estimated tank rows; config field.
+- `lib/features/dive_log/presentation/widgets/dive_profile_panel.dart`,
+  `lib/features/dive_log/presentation/pages/dive_detail_page.dart`,
+  `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart` — consume
+  `estimatedTankPressuresProvider`; pass `estimatedTankIds`.
+- `lib/l10n/arb/app_*.arb` (11) + regenerated `app_localizations*.dart`.
+- Tests under `test/features/dive_log/...` (new unit + widget, updates to regressions).

--- a/lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
+++ b/lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
@@ -1,0 +1,108 @@
+import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+
+/// Real per-tank pressures augmented with in-memory linear estimates, plus the
+/// set of tankIds that were synthesized (so the UI can label them "estimated").
+class EstimatedTankPressures {
+  final Map<String, List<TankPressurePoint>> pressures;
+  final Set<String> estimatedTankIds;
+  const EstimatedTankPressures(this.pressures, this.estimatedTankIds);
+}
+
+/// Builds transmitter-style linear pressure series for tanks that have both
+/// start/end pressures but no time-series data. Never persists; pure.
+///
+/// For each qualifying tank the series is flat at startPressure until the tank
+/// is first breathed, drops linearly while breathed (windowed by gas switches),
+/// holds flat during gaps, and ends flat at endPressure. The total drop is
+/// distributed across active windows in proportion to their duration.
+EstimatedTankPressures synthesizeEstimatedTankPressures({
+  required Map<String, List<TankPressurePoint>> existing,
+  required List<DiveTank> tanks,
+  required List<GasSwitchWithTank> gasSwitches,
+  required int diveDurationSeconds,
+}) {
+  final pressures = <String, List<TankPressurePoint>>{...existing};
+  final estimated = <String>{};
+  if (diveDurationSeconds <= 0) {
+    return EstimatedTankPressures(pressures, estimated);
+  }
+
+  final intervals = buildActiveTankIntervals(
+    tanks: tanks,
+    gasSwitches: gasSwitches,
+    diveDurationSeconds: diveDurationSeconds,
+  );
+
+  for (final tank in tanks) {
+    if (existing[tank.id]?.isNotEmpty ?? false) continue;
+    final start = tank.startPressure;
+    final end = tank.endPressure;
+    if (start == null || end == null || start <= end) continue;
+
+    final windows = intervals[tank.id] ?? const <({int start, int end})>[];
+    final points = _buildFlatDropFlat(
+      tankId: tank.id,
+      startPressure: start,
+      endPressure: end,
+      // Fallback: a tank with start/end but no gas-switch evidence gets a
+      // single full-dive window (a plain straight line).
+      windows: windows.isEmpty
+          ? [(start: 0, end: diveDurationSeconds)]
+          : windows,
+      diveDurationSeconds: diveDurationSeconds,
+    );
+    pressures[tank.id] = points;
+    estimated.add(tank.id);
+  }
+  return EstimatedTankPressures(pressures, estimated);
+}
+
+List<TankPressurePoint> _buildFlatDropFlat({
+  required String tankId,
+  required double startPressure,
+  required double endPressure,
+  required List<({int start, int end})> windows,
+  required int diveDurationSeconds,
+}) {
+  final sorted = [...windows]..sort((a, b) => a.start.compareTo(b.start));
+  final totalActive = sorted.fold<int>(0, (s, w) => s + (w.end - w.start));
+  if (totalActive <= 0) {
+    return [
+      _pt(tankId, 0, startPressure),
+      _pt(tankId, diveDurationSeconds, endPressure),
+    ];
+  }
+  final dropRate = (startPressure - endPressure) / totalActive;
+
+  final points = <TankPressurePoint>[_pt(tankId, 0, startPressure)];
+  var pressure = startPressure;
+
+  if (sorted.first.start > 0) {
+    points.add(_pt(tankId, sorted.first.start, startPressure));
+  }
+  for (var i = 0; i < sorted.length; i++) {
+    final w = sorted[i];
+    pressure -= dropRate * (w.end - w.start);
+    points.add(_pt(tankId, w.end, pressure));
+    if (i + 1 < sorted.length && sorted[i + 1].start > w.end) {
+      points.add(_pt(tankId, sorted[i + 1].start, pressure));
+    }
+  }
+  if (sorted.last.end < diveDurationSeconds) {
+    points.add(_pt(tankId, diveDurationSeconds, endPressure));
+  } else {
+    // Clamp the final vertex to endPressure to absorb floating-point drift.
+    points[points.length - 1] = _pt(tankId, sorted.last.end, endPressure);
+  }
+  return points;
+}
+
+TankPressurePoint _pt(String tankId, int ts, double pressure) =>
+    TankPressurePoint(
+      id: 'est-$tankId-$ts',
+      tankId: tankId,
+      timestamp: ts,
+      pressure: pressure,
+    );

--- a/lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
+++ b/lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
@@ -84,17 +84,17 @@ List<TankPressurePoint> _buildFlatDropFlat({
   }
   for (var i = 0; i < sorted.length; i++) {
     final w = sorted[i];
+    final isLast = i == sorted.length - 1;
     pressure -= dropRate * (w.end - w.start);
-    points.add(_pt(tankId, w.end, pressure));
-    if (i + 1 < sorted.length && sorted[i + 1].start > w.end) {
+    // Clamp the final window-end vertex to endPressure so accumulated float
+    // drift never leaves the drop (or the flat tail) slightly sloped.
+    points.add(_pt(tankId, w.end, isLast ? endPressure : pressure));
+    if (!isLast && sorted[i + 1].start > w.end) {
       points.add(_pt(tankId, sorted[i + 1].start, pressure));
     }
   }
   if (sorted.last.end < diveDurationSeconds) {
     points.add(_pt(tankId, diveDurationSeconds, endPressure));
-  } else {
-    // Clamp the final vertex to endPressure to absorb floating-point drift.
-    points[points.length - 1] = _pt(tankId, sorted.last.end, endPressure);
   }
   return points;
 }

--- a/lib/features/dive_log/data/services/gas_usage_segments_service.dart
+++ b/lib/features/dive_log/data/services/gas_usage_segments_service.dart
@@ -127,3 +127,51 @@ List<GasUsageSegment> _mergeAdjacentSameGas(List<GasUsageSegment> segments) {
   }
   return merged;
 }
+
+/// Per-tank active intervals: for each tankId, the ascending, non-overlapping
+/// [start, end) windows during which it was the breathed gas.
+///
+/// Uses the same starting-tank + switch-walk rules as [buildGasUsageSegments]
+/// (starting tank = lowest [DiveTank.order]; switches sorted and clamped to
+/// [0, diveDurationSeconds]; the initial window runs from t=0 to the first
+/// switch), but keys by tankId with no gas-mix merging.
+///
+/// Returns an empty map when there are no tanks or the dive has no duration.
+Map<String, List<({int start, int end})>> buildActiveTankIntervals({
+  required List<DiveTank> tanks,
+  required List<GasSwitchWithTank> gasSwitches,
+  required int diveDurationSeconds,
+}) {
+  final result = <String, List<({int start, int end})>>{};
+  if (tanks.isEmpty || diveDurationSeconds <= 0) return result;
+
+  final startingTank = ([
+    ...tanks,
+  ]..sort((a, b) => a.order.compareTo(b.order))).first;
+
+  final inBounds =
+      ([...gasSwitches]..sort((a, b) => a.timestamp.compareTo(b.timestamp)))
+          .where((s) => s.timestamp >= 0 && s.timestamp <= diveDurationSeconds)
+          .toList(growable: false);
+
+  void add(String tankId, int start, int end) {
+    if (start >= end) return;
+    result.putIfAbsent(tankId, () => []).add((start: start, end: end));
+  }
+
+  if (inBounds.isEmpty) {
+    add(startingTank.id, 0, diveDurationSeconds);
+    return result;
+  }
+
+  if (inBounds.first.timestamp > 0) {
+    add(startingTank.id, 0, inBounds.first.timestamp);
+  }
+  for (var i = 0; i < inBounds.length; i++) {
+    final end = i + 1 < inBounds.length
+        ? inBounds[i + 1].timestamp
+        : diveDurationSeconds;
+    add(inBounds[i].tankId, inBounds[i].timestamp, end);
+  }
+  return result;
+}

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1063,6 +1063,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // Get per-tank pressure data for multi-tank visualization
     final tankPressuresAsync = ref.watch(tankPressuresProvider(dive.id));
     final tankPressures = tankPressuresAsync.valueOrNull;
+    // Chart-only: real pressures augmented with linear estimates (#197).
+    final estimatedTankPressures = ref
+        .watch(estimatedTankPressuresProvider(dive.id))
+        .valueOrNull;
 
     // Get playback state
     final playbackState = ref.watch(playbackProvider(dive.id));
@@ -1338,7 +1342,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                         showPressureThresholdMarkers:
                             showPressureThresholdMarkers,
                         tanks: dive.tanks,
-                        tankPressures: tankPressures,
+                        tankPressures:
+                            estimatedTankPressures?.pressures ?? tankPressures,
+                        estimatedTankIds:
+                            estimatedTankPressures?.estimatedTankIds,
                         gasSwitches: gasSwitchesAsync.valueOrNull,
                         gasSegments:
                             (dive.tanks.isEmpty || chartProfile.isEmpty)

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -141,6 +141,10 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     final overlayIds = ref.watch(overlaySourcesProvider(widget.diveId));
     final gasSwitches = ref.watch(gasSwitchesProvider(widget.diveId)).value;
     final tankPressures = ref.watch(tankPressuresProvider(widget.diveId)).value;
+    // Chart-only: real pressures augmented with linear estimates (#197).
+    final estimatedTankPressures = ref
+        .watch(estimatedTankPressuresProvider(widget.diveId))
+        .value;
     final reviewTimestamp = ref.watch(profileReviewProvider(widget.diveId));
     final showMaxDepthMarker = ref.watch(showMaxDepthMarkerProvider);
     final showPressureThresholdMarkers = ref.watch(
@@ -362,7 +366,11 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                           showPressureThresholdMarkers:
                               showPressureThresholdMarkers,
                           tanks: dive.tanks,
-                          tankPressures: tankPressures,
+                          tankPressures:
+                              estimatedTankPressures?.pressures ??
+                              tankPressures,
+                          estimatedTankIds:
+                              estimatedTankPressures?.estimatedTankIds,
                           gasSwitches: gasSwitches,
                           gasSegments:
                               (dive.tanks.isEmpty || chartProfile.isEmpty)

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -10,7 +10,9 @@ import 'package:submersion/features/dive_log/data/repositories/tank_pressure_rep
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/data/services/dive_merge_service.dart';
 import 'package:submersion/features/dive_log/data/services/dive_split_service.dart';
+import 'package:submersion/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
@@ -956,6 +958,28 @@ final tankPressuresProvider =
         ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
       );
       return repository.getTankPressuresForDive(diveId);
+    });
+
+/// Real per-tank pressures augmented with in-memory linear estimates for tanks
+/// that have start/end pressures but no transmitter data. Chart-only; the
+/// estimates are never persisted, so SAC analysis and exports (which read the
+/// repository directly) still see real measured data only.
+final estimatedTankPressuresProvider =
+    FutureProvider.family<EstimatedTankPressures, String>((ref, diveId) async {
+      final real = await ref.watch(tankPressuresProvider(diveId).future);
+      final dive = await ref.watch(diveProvider(diveId).future);
+      final switches = await ref.watch(gasSwitchesProvider(diveId).future);
+      if (dive == null) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      return synthesizeEstimatedTankPressures(
+        existing: real,
+        tanks: dive.tanks,
+        gasSwitches: switches,
+        diveDurationSeconds: dive.profile.isEmpty
+            ? 0
+            : dive.profile.last.timestamp,
+      );
     });
 
 /// Provider to load data sources for a dive.

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -966,12 +966,17 @@ final tankPressuresProvider =
 /// repository directly) still see real measured data only.
 final estimatedTankPressuresProvider =
     FutureProvider.family<EstimatedTankPressures, String>((ref, diveId) async {
-      final real = await ref.watch(tankPressuresProvider(diveId).future);
-      final dive = await ref.watch(diveProvider(diveId).future);
-      final switches = await ref.watch(gasSwitchesProvider(diveId).future);
+      // Start the independent fetches concurrently to avoid a request waterfall
+      // on the chart load path.
+      final realFuture = ref.watch(tankPressuresProvider(diveId).future);
+      final diveFuture = ref.watch(diveProvider(diveId).future);
+      final switchesFuture = ref.watch(gasSwitchesProvider(diveId).future);
+      final real = await realFuture;
+      final dive = await diveFuture;
       if (dive == null) {
         return EstimatedTankPressures(real, const <String>{});
       }
+      final switches = await switchesFuture;
       return synthesizeEstimatedTankPressures(
         existing: real,
         tanks: dive.tanks,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -129,6 +129,10 @@ class DiveProfileChart extends ConsumerStatefulWidget {
   /// Used for multi-tank pressure visualization
   final Map<String, List<TankPressurePoint>>? tankPressures;
 
+  /// Tank IDs whose pressure series is a synthesized linear estimate (no AI
+  /// data). Rendered as a straight line and labelled "(est.)".
+  final Set<String>? estimatedTankIds;
+
   /// Gas-usage segments rendered as a horizontal strip directly between the
   /// plot area and the X-axis tick labels. When non-empty, the chart
   /// reserves [gasTimelineHeight] of extra space at the bottom and the
@@ -451,6 +455,7 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     this.gasSwitches,
     this.tanks,
     this.tankPressures,
+    this.estimatedTankIds,
     this.gasSegments,
     this.diveDurationSeconds,
     this.exportKey,
@@ -3650,7 +3655,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 ),
               )
               .toList(),
-          isCurved: true,
+          // Synthesized estimates are straight (flat-drop-flat); curve
+          // smoothing would round their corners. Real AI data stays curved.
+          isCurved: !(widget.estimatedTankIds?.contains(tankId) ?? false),
           curveSmoothness: 0.2,
           color: color,
           barWidth: 2,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1493,6 +1493,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               widget.diveDurationSeconds! > 0),
       tanks: widget.tanks,
       tankPressures: widget.tankPressures,
+      estimatedTankIds: widget.estimatedTankIds ?? const {},
       hasNdlData: hasNdlData,
       hasPpO2Data: hasPpO2Data,
       hasPpN2Data: hasPpN2Data,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -744,6 +744,13 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
   }
 
+  /// Localized " (est.)" suffix for a synthesized (estimated) tank; empty for
+  /// tanks backed by real air-integrated data.
+  String _estimatedSuffix(String tankId) =>
+      (widget.estimatedTankIds?.contains(tankId) ?? false)
+      ? ' ${context.l10n.diveLog_pressure_estimatedSuffix}'
+      : '';
+
   // Zoom/pan state — see profile_chart_viewport.dart.
   ProfileChartViewport _viewport = ProfileChartViewport.reset;
 
@@ -1258,7 +1265,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             : _getTankColor(i);
         final tankLabel =
             DiveProfileChart.tankTooltipLabel(tank, 'Tank ${i + 1}') +
-            _tankSourceSuffix(tankId, tankComputerIds, contributingComputerIds);
+            _tankSourceSuffix(
+              tankId,
+              tankComputerIds,
+              contributingComputerIds,
+            ) +
+            _estimatedSuffix(tankId);
         rows.add(
           TooltipRow(
             label: tankLabel,
@@ -2854,7 +2866,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                               tankId,
                               tankComputerIds,
                               contributingComputerIds,
-                            );
+                            ) +
+                            _estimatedSuffix(tankId);
                         final pressValue = pressure != null
                             ? units.formatPressure(pressure)
                             : '—';

--- a/lib/features/dive_log/presentation/widgets/dive_profile_legend.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_legend.dart
@@ -27,6 +27,10 @@ class ProfileLegendConfig {
   final List<DiveTank>? tanks;
   final Map<String, List<TankPressurePoint>>? tankPressures;
 
+  /// Tank IDs whose pressure series is a synthesized linear estimate (#197),
+  /// labelled with a "(est.)" suffix in the Tank Pressures section.
+  final Set<String> estimatedTankIds;
+
   // Advanced decompression/gas data availability
   final bool hasNdlData;
   final bool hasPpO2Data;
@@ -56,6 +60,7 @@ class ProfileLegendConfig {
     this.hasGasData = false,
     this.tanks,
     this.tankPressures,
+    this.estimatedTankIds = const {},
     this.hasNdlData = false,
     this.hasPpO2Data = false,
     this.hasPpN2Data = false,
@@ -587,9 +592,12 @@ class _ChartOptionsDialog extends StatelessWidget {
         final color = tank != null
             ? GasColors.forGasMix(tank.gasMix)
             : _getTankColor(i);
-        final label = tank != null
+        final baseLabel = tank != null
             ? _buildTankLabel(context, tank, fallbackIndex: i + 1)
             : context.l10n.diveLog_tank_title(i + 1);
+        final label = config.estimatedTankIds.contains(tankId)
+            ? '$baseLabel ${context.l10n.diveLog_pressure_estimatedSuffix}'
+            : baseLabel;
 
         tankItems.add(
           _buildToggleItem(

--- a/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
@@ -248,6 +248,10 @@ class _DiveProfilePanelContentState
     final tankPressures = ref
         .watch(tankPressuresProvider(widget.diveId))
         .valueOrNull;
+    // Chart-only: real pressures augmented with linear estimates (#197).
+    final estimatedTankPressures = ref
+        .watch(estimatedTankPressuresProvider(widget.diveId))
+        .valueOrNull;
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
     final colorScheme = Theme.of(context).colorScheme;
@@ -388,7 +392,9 @@ class _DiveProfilePanelContentState
                   showMaxDepthMarker: showMaxDepthMarker,
                   showPressureThresholdMarkers: showPressureThresholdMarkers,
                   tanks: dive.tanks,
-                  tankPressures: tankPressures,
+                  tankPressures:
+                      estimatedTankPressures?.pressures ?? tankPressures,
+                  estimatedTankIds: estimatedTankPressures?.estimatedTankIds,
                   gasSwitches: gasSwitches,
                   gasSegments: (dive.tanks.isEmpty || dive.profile.isEmpty)
                       ? null

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4844,6 +4844,7 @@
   "diveLog_chartSection_other": "أخرى",
   "diveLog_chartSection_overlays": "طبقات إضافية",
   "diveLog_chartSection_tankPressures": "ضغوط الأسطوانات",
+  "diveLog_pressure_estimatedSuffix": "(تقديري)",
   "diveLog_legend_source_calc": "محسوب",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "الوضع",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4844,6 +4844,7 @@
   "diveLog_chartSection_other": "Sonstiges",
   "diveLog_chartSection_overlays": "Einblendungen",
   "diveLog_chartSection_tankPressures": "Flaschendrucke",
+  "diveLog_pressure_estimatedSuffix": "(gesch.)",
   "diveLog_legend_source_calc": "Ber.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Modus",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2227,6 +2227,10 @@
   "diveLog_chartSection_gasAnalysis": "Gas Analysis",
   "diveLog_chartSection_other": "Other",
   "diveLog_chartSection_tankPressures": "Tank Pressures",
+  "diveLog_pressure_estimatedSuffix": "(est.)",
+  "@diveLog_pressure_estimatedSuffix": {
+    "description": "Short suffix appended to a tank label when its pressure line is a linear start-to-end estimate rather than measured air-integrated data. Abbreviation of 'estimated'."
+  },
   "diveLog_listPage_appBar_diveMap": "Dive Map",
   "diveLog_listPage_compactTitle": "Dives",
   "diveLog_listPage_errorLoading": "Error: {error}",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4844,6 +4844,7 @@
   "diveLog_chartSection_other": "Otros",
   "diveLog_chartSection_overlays": "Superposiciones",
   "diveLog_chartSection_tankPressures": "Presiones de botellas",
+  "diveLog_pressure_estimatedSuffix": "(est.)",
   "diveLog_legend_source_calc": "Calc.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Modo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4810,6 +4810,7 @@
   "diveLog_chartSection_other": "Autre",
   "diveLog_chartSection_overlays": "Superpositions",
   "diveLog_chartSection_tankPressures": "Pressions des blocs",
+  "diveLog_pressure_estimatedSuffix": "(est.)",
   "diveLog_legend_source_calc": "Calc.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Mode",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4844,6 +4844,7 @@
   "diveLog_chartSection_other": "אחר",
   "diveLog_chartSection_overlays": "שכבות על",
   "diveLog_chartSection_tankPressures": "לחצי מיכלים",
+  "diveLog_pressure_estimatedSuffix": "(משוער)",
   "diveLog_legend_source_calc": "מחושב",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "מצב",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4810,6 +4810,7 @@
   "diveLog_chartSection_other": "Egyeb",
   "diveLog_chartSection_overlays": "Rategek",
   "diveLog_chartSection_tankPressures": "Palacknyomasok",
+  "diveLog_pressure_estimatedSuffix": "(becs.)",
   "diveLog_legend_source_calc": "Szam.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Mod",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4806,6 +4806,7 @@
   "diveLog_chartSection_other": "Altro",
   "diveLog_chartSection_overlays": "Sovrapposizioni",
   "diveLog_chartSection_tankPressures": "Pressioni delle bombole",
+  "diveLog_pressure_estimatedSuffix": "(stim.)",
   "diveLog_legend_source_calc": "Calc.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Modalita",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -7820,6 +7820,12 @@ abstract class AppLocalizations {
   /// **'Tank Pressures'**
   String get diveLog_chartSection_tankPressures;
 
+  /// Short suffix appended to a tank label when its pressure line is a linear start-to-end estimate rather than measured air-integrated data. Abbreviation of 'estimated'.
+  ///
+  /// In en, this message translates to:
+  /// **'(est.)'**
+  String get diveLog_pressure_estimatedSuffix;
+
   /// No description provided for @diveLog_listPage_appBar_diveMap.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -4542,6 +4542,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'ضغوط الأسطوانات';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(تقديري)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'خريطة الغوص';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -4645,6 +4645,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Flaschendrucke';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(gesch.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Tauchkarte';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -4565,6 +4565,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Tank Pressures';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(est.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Dive Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -4647,6 +4647,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Presiones de botellas';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(est.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Mapa de inmersiones';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -4669,6 +4669,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Pressions des blocs';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(est.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Carte des plongees';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -4520,6 +4520,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'לחצי מיכלים';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(משוער)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'מפת צלילות';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -4631,6 +4631,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Palacknyomasok';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(becs.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Merulesi terkep';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -4651,6 +4651,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Pressioni delle bombole';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(stim.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Mappa immersioni';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -4613,6 +4613,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Flesdrukken';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(gesch.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Duikkaart';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -4651,6 +4651,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => 'Pressoes dos cilindros';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(est.)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => 'Mapa de Mergulhos';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -4425,6 +4425,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_chartSection_tankPressures => '气瓶压力';
 
   @override
+  String get diveLog_pressure_estimatedSuffix => '(估算)';
+
+  @override
   String get diveLog_listPage_appBar_diveMap => '潜水地图';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4844,6 +4844,7 @@
   "diveLog_chartSection_other": "Overig",
   "diveLog_chartSection_overlays": "Overlays",
   "diveLog_chartSection_tankPressures": "Flesdrukken",
+  "diveLog_pressure_estimatedSuffix": "(gesch.)",
   "diveLog_legend_source_calc": "Ber.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Modus",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4844,6 +4844,7 @@
   "diveLog_chartSection_other": "Outros",
   "diveLog_chartSection_overlays": "Sobreposicoes",
   "diveLog_chartSection_tankPressures": "Pressoes dos cilindros",
+  "diveLog_pressure_estimatedSuffix": "(est.)",
   "diveLog_legend_source_calc": "Calc.",
   "diveLog_legend_source_dc": "DC",
   "settings_appearance_header_mode": "Modo",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1196,6 +1196,7 @@
   "diveLog_chartSection_other": "其他",
   "diveLog_chartSection_overlays": "叠加层",
   "diveLog_chartSection_tankPressures": "气瓶压力",
+  "diveLog_pressure_estimatedSuffix": "(估算)",
   "diveLog_collapsible_semantics_collapse": "折叠{title}部分",
   "diveLog_collapsible_semantics_expand": "展开{title}部分",
   "diveLog_combine_confirm": "合并为一次潜水",

--- a/test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart
+++ b/test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+
+DiveTank _tank({
+  required String id,
+  double? start,
+  double? end,
+  int order = 0,
+}) => DiveTank(
+  id: id,
+  gasMix: const GasMix(o2: 21),
+  order: order,
+  startPressure: start,
+  endPressure: end,
+);
+
+GasSwitchWithTank _switch({required String tankId, required int timestamp}) =>
+    GasSwitchWithTank(
+      gasSwitch: GasSwitch(
+        id: 'gs-$timestamp',
+        diveId: 'd1',
+        timestamp: timestamp,
+        tankId: tankId,
+        createdAt: DateTime(2026, 1, 1),
+      ),
+      tankName: '',
+      gasMix: '',
+      o2Fraction: 0.21,
+    );
+
+void main() {
+  group('synthesizeEstimatedTankPressures', () {
+    test('single tank, no switches -> straight two-point line', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [_tank(id: 't1', start: 200, end: 65)],
+        gasSwitches: const [],
+        diveDurationSeconds: 2400,
+      );
+      expect(result.estimatedTankIds, {'t1'});
+      final pts = result.pressures['t1']!;
+      expect(pts.map((p) => (p.timestamp, p.pressure)), [
+        (0, 200.0),
+        (2400, 65.0),
+      ]);
+    });
+
+    test('deco bottle -> flat, drop, flat', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [
+          _tank(id: 'back', start: 200, end: 90),
+          _tank(id: 'deco', start: 190, end: 130, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200),
+          _switch(tankId: 'back', timestamp: 1800),
+        ],
+        diveDurationSeconds: 2400,
+      );
+      final deco = result.pressures['deco']!.map(
+        (p) => (p.timestamp, p.pressure),
+      );
+      expect(deco, [(0, 190.0), (1200, 190.0), (1800, 130.0), (2400, 130.0)]);
+    });
+
+    test('back gas returned to -> drop split across windows by duration', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [
+          _tank(id: 'back', start: 200, end: 65),
+          _tank(id: 'deco', start: 190, end: 130, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200),
+          _switch(tankId: 'back', timestamp: 1800),
+        ],
+        diveDurationSeconds: 2400,
+      );
+      // active [0,1200]+[1800,2400] = 1800s, drop 135 -> 0.075 bar/s.
+      final back = result.pressures['back']!.map(
+        (p) => (p.timestamp, p.pressure),
+      );
+      expect(back, [(0, 200.0), (1200, 110.0), (1800, 110.0), (2400, 65.0)]);
+    });
+
+    test('real data passes through untouched and is not marked estimated', () {
+      final real = {
+        't1': const [
+          TankPressurePoint(
+            id: 'r0',
+            tankId: 't1',
+            timestamp: 0,
+            pressure: 205,
+          ),
+          TankPressurePoint(
+            id: 'r1',
+            tankId: 't1',
+            timestamp: 600,
+            pressure: 150,
+          ),
+        ],
+      };
+      final result = synthesizeEstimatedTankPressures(
+        existing: real,
+        tanks: [_tank(id: 't1', start: 200, end: 65)],
+        gasSwitches: const [],
+        diveDurationSeconds: 2400,
+      );
+      expect(result.estimatedTankIds, isEmpty);
+      expect(result.pressures['t1'], same(real['t1']));
+    });
+
+    test('skips when a pressure is missing, equal, or inverted', () {
+      for (final tank in [
+        _tank(id: 'x', start: 200), // no end
+        _tank(id: 'x', end: 100), // no start
+        _tank(id: 'x', start: 100, end: 100), // equal
+        _tank(id: 'x', start: 90, end: 120), // inverted
+      ]) {
+        final result = synthesizeEstimatedTankPressures(
+          existing: const {},
+          tanks: [tank],
+          gasSwitches: const [],
+          diveDurationSeconds: 2400,
+        );
+        expect(result.estimatedTankIds, isEmpty);
+        expect(result.pressures.containsKey('x'), isFalse);
+      }
+    });
+
+    test('no profile duration -> nothing synthesized', () {
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [_tank(id: 't1', start: 200, end: 65)],
+        gasSwitches: const [],
+        diveDurationSeconds: 0,
+      );
+      expect(result.estimatedTankIds, isEmpty);
+    });
+  });
+}

--- a/test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart
+++ b/test/features/dive_log/data/services/estimated_tank_pressure_synthesizer_test.dart
@@ -131,6 +131,32 @@ void main() {
       }
     });
 
+    test('trailing flat is perfectly flat despite float drift', () {
+      // deco: 210 -> 100 over a single 300s window ([700,1000]) on a 1400s dive.
+      // 210 - (110/300)*300 == 100.00000000000001 in IEEE-754, so the computed
+      // window-end vertex lands one ULP off 100; the tail after last use must be
+      // clamped to endPressure so it stays perfectly flat. (Verified drifting
+      // parameters, not a hypothetical.)
+      final result = synthesizeEstimatedTankPressures(
+        existing: const {},
+        tanks: [
+          _tank(id: 'back', start: 220, end: 120),
+          _tank(id: 'deco', start: 210, end: 100, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 700),
+          _switch(tankId: 'back', timestamp: 1000),
+        ],
+        diveDurationSeconds: 1400,
+      );
+      final deco = result.pressures['deco']!;
+      final atLastUse = deco.firstWhere((p) => p.timestamp == 1000);
+      final atDiveEnd = deco.firstWhere((p) => p.timestamp == 1400);
+      // Both vertices are exactly endPressure -> the tail is perfectly flat.
+      expect(atLastUse.pressure, 100.0);
+      expect(atDiveEnd.pressure, 100.0);
+    });
+
     test('no profile duration -> nothing synthesized', () {
       final result = synthesizeEstimatedTankPressures(
         existing: const {},

--- a/test/features/dive_log/data/services/gas_usage_segments_service_test.dart
+++ b/test/features/dive_log/data/services/gas_usage_segments_service_test.dart
@@ -200,4 +200,104 @@ void main() {
       expect(segments.single.label, 'Tx 18/45');
     });
   });
+
+  group('buildActiveTankIntervals', () {
+    test('empty when no tanks or zero duration', () {
+      expect(
+        buildActiveTankIntervals(
+          tanks: const [],
+          gasSwitches: const [],
+          diveDurationSeconds: 1800,
+        ),
+        isEmpty,
+      );
+      expect(
+        buildActiveTankIntervals(
+          tanks: [_tank(id: 't1', o2: 21)],
+          gasSwitches: const [],
+          diveDurationSeconds: 0,
+        ),
+        isEmpty,
+      );
+    });
+
+    test(
+      'single tank, no switches -> one full-dive interval for lowest order',
+      () {
+        final result = buildActiveTankIntervals(
+          tanks: [
+            _tank(id: 'late', o2: 100, order: 2),
+            _tank(id: 'first', o2: 21),
+          ],
+          gasSwitches: const [],
+          diveDurationSeconds: 2400,
+        );
+        expect(result.keys, ['first']);
+        expect(result['first'], [(start: 0, end: 2400)]);
+      },
+    );
+
+    test('deco bottle owns only its switch window', () {
+      final result = buildActiveTankIntervals(
+        tanks: [
+          _tank(id: 'back', o2: 21),
+          _tank(id: 'deco', o2: 50, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200, o2Fraction: 0.50),
+        ],
+        diveDurationSeconds: 1800,
+      );
+      expect(result['back'], [(start: 0, end: 1200)]);
+      expect(result['deco'], [(start: 1200, end: 1800)]);
+    });
+
+    test('back gas returned to yields two intervals with a gap', () {
+      final result = buildActiveTankIntervals(
+        tanks: [
+          _tank(id: 'back', o2: 21),
+          _tank(id: 'deco', o2: 50, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: 1200, o2Fraction: 0.50),
+          _switch(tankId: 'back', timestamp: 1800, o2Fraction: 0.21),
+        ],
+        diveDurationSeconds: 2400,
+      );
+      expect(result['back'], [(start: 0, end: 1200), (start: 1800, end: 2400)]);
+      expect(result['deco'], [(start: 1200, end: 1800)]);
+    });
+
+    test('switch exactly at t=0 produces no zero-length leading interval', () {
+      final result = buildActiveTankIntervals(
+        tanks: [
+          _tank(id: 'back', o2: 21),
+          _tank(id: 'deco', o2: 50, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'back', timestamp: 0, o2Fraction: 0.21),
+          _switch(tankId: 'deco', timestamp: 1500, o2Fraction: 0.50),
+        ],
+        diveDurationSeconds: 3000,
+      );
+      expect(result['back'], [(start: 0, end: 1500)]);
+      expect(result['deco'], [(start: 1500, end: 3000)]);
+    });
+
+    test('out-of-bounds switches are dropped', () {
+      final result = buildActiveTankIntervals(
+        tanks: [
+          _tank(id: 'back', o2: 21),
+          _tank(id: 'deco', o2: 50, order: 1),
+        ],
+        gasSwitches: [
+          _switch(tankId: 'deco', timestamp: -10, o2Fraction: 0.50),
+          _switch(tankId: 'deco', timestamp: 9000, o2Fraction: 0.50),
+        ],
+        diveDurationSeconds: 1800,
+      );
+      expect(result['back'], [(start: 0, end: 1800)]);
+      expect(result.containsKey('deco'), isFalse);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+
+void main() {
+  test('augments real map with an estimated line for a manual tank', () async {
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 1, 1),
+      tanks: const [
+        DiveTank(
+          id: 't1',
+          gasMix: GasMix(o2: 21),
+          startPressure: 200,
+          endPressure: 60,
+        ),
+      ],
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0),
+        DiveProfilePoint(timestamp: 1800, depth: 0),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        tankPressuresProvider(
+          'd1',
+        ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+        diveProvider('d1').overrideWith((ref) async => dive),
+        gasSwitchesProvider(
+          'd1',
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      estimatedTankPressuresProvider('d1').future,
+    );
+
+    expect(result.estimatedTankIds, {'t1'});
+    expect(result.pressures['t1']!.first.pressure, 200);
+    expect(result.pressures['t1']!.last.pressure, 60);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -306,6 +306,51 @@ void main() {
         isEmpty,
       );
     });
+
+    testWidgets('tooltip labels an estimated tank with the (est.) suffix', (
+      tester,
+    ) async {
+      // 20-point profile matching the proven long-press tooltip tests, so the
+      // gesture reliably lands on a data point and emits external tooltip rows.
+      final profile = List.generate(
+        20,
+        (i) => DiveProfilePoint(
+          timestamp: i * 30,
+          depth: i < 10 ? i * 3.0 : (19 - i) * 3.0,
+        ),
+      );
+      const tank = DiveTank(id: 't1', gasMix: GasMix(o2: 21), order: 0);
+      // A straight two-point estimate spanning the whole profile (0..570s).
+      const points = [
+        TankPressurePoint(id: 'e0', tankId: 't1', timestamp: 0, pressure: 200),
+        TankPressurePoint(id: 'e1', tankId: 't1', timestamp: 570, pressure: 60),
+      ];
+      List<TooltipRow>? rows;
+
+      await tester.pumpWidget(
+        _buildChart(
+          profile: profile,
+          tanks: const [tank],
+          tankPressures: {'t1': points},
+          estimatedTankIds: const {'t1'},
+          tooltipBelow: true,
+          onTooltipData: (r) => rows = r,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Long-press near the center; assert BEFORE releasing (release clears).
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(LineChart)),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await gesture.moveBy(const Offset(2, 0));
+      await tester.pump();
+
+      expect(rows, isNotNull);
+      expect(rows!.where((r) => r.label.contains('(est.)')), isNotEmpty);
+      await gesture.up();
+    });
   });
 
   group('DiveProfileChart - single profile rendering', () {

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -90,6 +90,7 @@ Widget _buildChart({
   Map<String, String>? computerNames,
   Map<String, List<TankPressurePoint>>? tankPressures,
   List<DiveTank>? tanks,
+  Set<String>? estimatedTankIds,
   List<double>? ceilingCurve,
   List<AscentRatePoint>? ascentRates,
   List<ProfileEvent>? events,
@@ -141,6 +142,7 @@ Widget _buildChart({
             computerNames: computerNames,
             tankPressures: tankPressures,
             tanks: tanks,
+            estimatedTankIds: estimatedTankIds,
             ceilingCurve: ceilingCurve,
             ascentRates: ascentRates,
             events: events,
@@ -186,6 +188,7 @@ Widget _buildChartAllMetrics({
   List<DiveProfilePoint>? profile,
   Map<String, List<TankPressurePoint>>? tankPressures,
   List<DiveTank>? tanks,
+  Set<String>? estimatedTankIds,
   List<double>? ceilingCurve,
   List<AscentRatePoint>? ascentRates,
   List<int>? ndlCurve,
@@ -227,6 +230,7 @@ Widget _buildChartAllMetrics({
             profile: profile ?? _makeProfile(),
             tankPressures: tankPressures,
             tanks: tanks,
+            estimatedTankIds: estimatedTankIds,
             ceilingCurve: ceilingCurve,
             ascentRates: ascentRates,
             ndlCurve: ndlCurve,
@@ -264,6 +268,46 @@ Widget _buildChartAllMetrics({
 // ---------------------------------------------------------------------------
 
 void main() {
+  group('DiveProfileChart - estimated tank pressure', () {
+    testWidgets('estimated tank pressure line is straight (isCurved false)', (
+      tester,
+    ) async {
+      const tank = DiveTank(id: 't1', gasMix: GasMix(o2: 21), order: 0);
+      const points = [
+        TankPressurePoint(id: 'e0', tankId: 't1', timestamp: 0, pressure: 200),
+        TankPressurePoint(id: 'e1', tankId: 't1', timestamp: 270, pressure: 60),
+      ];
+
+      await tester.pumpWidget(
+        _buildChart(
+          tanks: const [tank],
+          tankPressures: {'t1': points},
+          estimatedTankIds: const {'t1'},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      final estimatedBars = chart.data.lineBarsData
+          .where((b) => b.dashArray != null && b.isCurved == false)
+          .toList();
+      expect(estimatedBars, isNotEmpty);
+
+      // Control: same data, NOT estimated -> pressure line is curved.
+      await tester.pumpWidget(
+        _buildChart(tanks: const [tank], tankPressures: {'t1': points}),
+      );
+      await tester.pumpAndSettle();
+      final chart2 = tester.widget<LineChart>(find.byType(LineChart));
+      expect(
+        chart2.data.lineBarsData.where(
+          (b) => b.dashArray != null && b.isCurved == false,
+        ),
+        isEmpty,
+      );
+    });
+  });
+
   group('DiveProfileChart - single profile rendering', () {
     testWidgets('renders without crashing with profile data', (tester) async {
       await tester.pumpWidget(_buildChart());

--- a/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
@@ -30,6 +30,46 @@ const _testTanks = [
 ];
 
 void main() {
+  group('DiveProfileLegend - estimated tank pressure', () {
+    testWidgets('estimated tank row shows the (est.) suffix', (tester) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          ],
+          child: DiveProfileLegend(
+            config: const ProfileLegendConfig(
+              hasMultiTankPressure: true,
+              tanks: _testTanks,
+              tankPressures: {
+                'tank-1': [
+                  TankPressurePoint(
+                    id: 'e0',
+                    tankId: 'tank-1',
+                    timestamp: 0,
+                    pressure: 200,
+                  ),
+                ],
+              },
+              estimatedTankIds: {'tank-1'},
+            ),
+            zoomLevel: 1.0,
+            onZoomIn: () {},
+            onZoomOut: () {},
+            onResetZoom: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tank Pressures lives in the "more options" (tune) dialog.
+      await tester.tap(find.byIcon(Icons.tune), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('(est.)'), findsWidgets);
+    });
+  });
+
   group('DiveProfileLegend - primary toggles', () {
     testWidgets('shows Events toggle when hasEvents is true', (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary

Closes #197. When a dive has a tank with manually-entered start/end pressures but **no air-integrated (AI) transmitter data**, the profile chart previously drew no pressure line at all. This adds a linear **estimated** pressure line so manual-entry dives still get a pressure visualization.

The line is shaped like a real transmitter would have recorded it: flat at the start pressure while the tank is unused, dropping linearly while it is breathed (windowed by gas switches), flat during gaps, and flat at the end pressure afterward. The total drop is distributed across the tank's active windows in proportion to their duration. For the common single-tank dive this collapses to one straight `start → end` line.

Synthesis happens **in memory at the chart-read path and is never persisted** — SAC analysis and UDDF/other exports read the repository directly, so they continue to see real measured data only. The estimated line is drawn straight (real AI lines stay curved) and marked "(est.)" in the legend, tooltip, and readout so an interpolation is never mistaken for a transmitter trace.

Design spec and implementation plan: `docs/superpowers/specs/2026-07-06-linear-tank-pressure-line-design.md`, `docs/superpowers/plans/2026-07-06-linear-tank-pressure-line.md`.

## Changes

- **`buildActiveTankIntervals`** (`gas_usage_segments_service.dart`) — per-tank active `[start,end)` windows from gas switches, reusing the same starting-tank + switch-walk rules as `buildGasUsageSegments` (keyed by tankId, no gas-mix merging).
- **`synthesizeEstimatedTankPressures` + `EstimatedTankPressures`** (new `estimated_tank_pressure_synthesizer.dart`) — pure flat–drop–flat series builder with duration-proportional drop distribution and full-dive fallbacks; only synthesizes when a tank has both pressures, `start > end`, no real time-series data, and the dive has a profile.
- **`estimatedTankPressuresProvider`** (`dive_providers.dart`) — composes real pressures + estimates; chart-only.
- **Chart** (`dive_profile_chart.dart`) — new `estimatedTankIds` field; estimated lines rendered `isCurved: false`; "(est.)" suffix in tooltip and draggable-readout rows.
- **Legend** (`dive_profile_legend.dart`) — "(est.)" suffix on estimated tank rows in the Tank Pressures section.
- **Hosts** (`dive_profile_panel`, `dive_detail_page`, `fullscreen_profile_page`) — pass the augmented map + `estimatedTankIds` to the chart only; SAC-normalization and marker builders keep reading the real map.
- **i18n** — new `diveLog_pressure_estimatedSuffix` string translated across all 11 locales.

## Test Plan

- [x] `flutter analyze` passes (whole project, locally clean)
- [x] `flutter test test/features/dive_log/` passes (1825 tests; full suite runs in CI)
- New coverage: interval derivation, synthesizer trigger/shape/edge cases (incl. the two spec worked examples), provider composition, straight-line rendering, and the "(est.)" label in tooltip/readout/legend.
- [ ] Manual testing on: **macOS deferred** (branch built in a checkout shared with a concurrent session). Recommend a visual check on a real manual-entry dive before merge.