### PR TITLE
fix(dive-log): tri-state bulk reference-collection editing + save-as-set diver fix

### DIFF
--- a/docs/superpowers/plans/2026-07-06-bulk-membership-editing.md
+++ b/docs/superpowers/plans/2026-07-06-bulk-membership-editing.md
@@ -1,0 +1,556 @@
+# Bulk membership editing (tri-state) + gear bug fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the confusing Add/Remove/Replace mode-chip UI for bulk-editing id-based reference collections (Tags, Dive Types, Buddies, Equipment) with a safe tri-state membership list, and fix the "Save as Set" diver-scoping bug.
+
+**Architecture:** All new logic is presentation-layer plus one read query per collection. A reusable `BulkMembershipEditor` renders tri-state rows; a pure `MembershipDelta.from(...)` converts the user's choices into `(addIds, removeIds)`; `_collectCollectionOps` emits existing `AddOp`/`RemoveOp`. The service, sealed op types, `bulkAdd*`/`bulkRemove*`/`bulkReplace*` repo writes, and the undo snapshot are untouched.
+
+**Tech Stack:** Flutter (Material 3), Drift (SQLite), Riverpod, flutter_test.
+
+## Global Constraints
+
+- Engine is frozen: do NOT modify `BulkDiveEditService`, the sealed `BulkCollectionOp` types, `bulkAddEquipment/Tags/DiveTypes/Buddies`, `bulkRemove*`, `bulkReplace*`, or the undo snapshot.
+- Owned collections (Tanks, Weights, Sightings) keep their current editors — do not touch them.
+- New user-facing strings: add to `lib/l10n/arb/app_en.arb`, then translate into all 10 non-en locales (`ar, de, es, fr, he, hu, it, nl, pt, zh`), then run `flutter gen-l10n`.
+- `dart format .` must be clean and `flutter analyze` must pass over the whole project before the final commit.
+- Run specific test files (not whole directories) to avoid runner timeouts.
+- Buddies bulk-add uses default role `BuddyRole.buddy`; existing buddies' roles are never modified.
+- Work in the worktree at `.claude/worktrees/gear-multi-dive-edit`. Commit per task.
+
+---
+
+### Task 1: Bug 1 regression tests — bulk equipment "add" merges, never wipes
+
+Characterization/regression guard. Behavior is already correct on `main` (commit `30da9f93835`); these tests lock it in. They are expected to PASS immediately.
+
+**Files:**
+- Modify: `test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+- Modify: `test/features/dive_log/data/services/bulk_dive_edit_service_test.dart`
+
+- [ ] **Step 1: Add repo-level test** inside the existing `group('bulk equipment', ...)`:
+
+```dart
+test('bulkAddEquipment merges with pre-existing gear, never wipes', () async {
+  // d1 already has e1; d2 already has e2.
+  await repository.bulkAddEquipment(['d1'], ['e1']);
+  await repository.bulkAddEquipment(['d2'], ['e2']);
+
+  // Bulk-add e3 to BOTH dives.
+  await repository.bulkAddEquipment(['d1', 'd2'], ['e3']);
+
+  final d1 = await (db.select(db.diveEquipment)
+        ..where((t) => t.diveId.equals('d1'))).get();
+  final d2 = await (db.select(db.diveEquipment)
+        ..where((t) => t.diveId.equals('d2'))).get();
+  expect(d1.map((r) => r.equipmentId).toSet(), {'e1', 'e3'}); // e1 survived
+  expect(d2.map((r) => r.equipmentId).toSet(), {'e2', 'e3'}); // e2 survived
+});
+```
+
+- [ ] **Step 2: Add service-level test** (mirrors the reporter's exact flow) after the existing `apply handles add and remove modes` test:
+
+```dart
+test('EquipmentOp add preserves existing gear on each dive', () async {
+  await seed('d1');
+  await diveRepo.bulkAddEquipment(['d1'], ['origEq']);
+
+  await service.apply(
+    BulkEditRequest(
+      diveIds: const ['d1'],
+      ops: [
+        const EquipmentOp(mode: BulkCollectionMode.add, equipmentIds: ['newEq']),
+      ],
+    ),
+  );
+
+  expect((await equipOf('d1')).toSet(), {'origEq', 'newEq'});
+});
+```
+
+- [ ] **Step 3: Run and verify PASS**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart test/features/dive_log/data/services/bulk_dive_edit_service_test.dart`
+Expected: All tests pass. (If either fails, STOP — the engine regressed.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/features/dive_log/data/repositories/dive_repository_bulk_test.dart test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+git commit -m "test(dive-log): lock in bulk equipment add-merges-not-wipes behavior"
+```
+
+---
+
+### Task 2: Bug 2 fix — "Save as Set" stamps the active diver (failing-first)
+
+**Files:**
+- Create: `test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (`_saveEquipmentAsSet`, ~line 2845)
+
+**Interfaces:**
+- Consumes: `equipmentSetListNotifierProvider` (from `lib/features/equipment/presentation/providers/equipment_set_providers.dart`), whose `.notifier.addSet(EquipmentSet)` stamps the validated diver id and refreshes.
+
+- [ ] **Step 1: Write the failing widget test.** Seed a diver, seed an equipment item + a dive that references it, override `currentDiverIdProvider` to that diver, pump `DiveEditPage(diveId: 'd1')`, tap "Save as Set", type a name, tap Save, then assert the set is visible under that diver.
+
+```dart
+// Setup mirrors bulk_dive_edit_form_test.dart: setUpTestDatabase(), getBaseOverrides().
+// Seed a diver row (db.into(db.divers).insert(...)) with id 'diver-1'.
+// Create an equipment item via EquipmentRepository().createEquipment(...) -> id 'eq-1'.
+// Create dive 'd1' with equipment:[that item] via DiveRepository().createDive(...).
+// Override currentDiverIdProvider so state == 'diver-1' (see note below).
+
+testWidgets('saving gear as a set makes it visible to the current diver',
+    (tester) async {
+  await pumpEditPage(tester, diveId: 'd1'); // helper defined in the test
+  await tester.tap(find.text('Save as Set'));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextField).first, 'Tropical');
+  await tester.tap(find.text('Save'));
+  await tester.pumpAndSettle();
+
+  final sets = await EquipmentSetRepository().getAllSets(diverId: 'diver-1');
+  expect(sets.map((s) => s.name), contains('Tropical'));
+});
+```
+
+Note on the diver override: `getBaseOverrides()` uses `MockCurrentDiverIdNotifier()` which starts null. Add an override that seeds the id, e.g. call `container` isn't available in `testWidgets`; instead override `validatedCurrentDiverIdProvider.overrideWith((ref) async => 'diver-1')` in the ProviderScope so both the read path and the save path resolve `diver-1`. Import it from `lib/features/divers/presentation/providers/diver_providers.dart`.
+
+- [ ] **Step 2: Run to verify it FAILS**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart`
+Expected: FAIL — `getAllSets(diverId: 'diver-1')` is empty because the set was written with `diverId = null`.
+
+- [ ] **Step 3: Apply the fix.** In `_saveEquipmentAsSet`, replace the direct repository call:
+
+```dart
+// BEFORE (~2845-2849):
+final repository = ref.read(equipmentSetRepositoryProvider);
+await repository.createSet(set);
+ref.invalidate(equipmentSetsProvider);
+
+// AFTER:
+await ref.read(equipmentSetListNotifierProvider.notifier).addSet(set);
+```
+
+`addSet` stamps the validated diver id via `copyWith(diverId: ...)` and calls `refresh()` (which invalidates `equipmentSetsProvider`), so the manual invalidate is no longer needed. Leave the `EquipmentSet(...)` construction as-is; `addSet` supplies the diverId.
+
+- [ ] **Step 4: Run to verify it PASSES**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart
+git commit -m "fix(dive-log): save-as-set stamps active diver so the set is visible (#gear)"
+```
+
+---
+
+### Task 3: Count queries — how many selected dives have each item
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (add 3 methods near the bulk methods, ~line 4000)
+- Modify: `lib/features/buddies/data/repositories/buddy_repository.dart` (add 1 method)
+- Modify: `test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `DiveRepository.equipmentCountsForDives(List<String> diveIds) -> Future<Map<String,int>>`
+  - `DiveRepository.tagCountsForDives(List<String> diveIds) -> Future<Map<String,int>>`
+  - `DiveRepository.diveTypeCountsForDives(List<String> diveIds) -> Future<Map<String,int>>`
+  - `BuddyRepository.buddyCountsForDives(List<String> diveIds) -> Future<Map<String,int>>`
+  - Each returns `{itemId: numberOfSelectedDivesThatHaveIt}`. Junctions have a composite PK on `(diveId, itemId)`, so a plain `COUNT(diveId)` grouped by itemId equals the distinct-dive count.
+
+- [ ] **Step 1: Write the failing repo test** in `dive_repository_bulk_test.dart`:
+
+```dart
+test('equipmentCountsForDives returns per-item dive counts', () async {
+  await repository.bulkAddEquipment(['d1', 'd2'], ['shared']); // on both
+  await repository.bulkAddEquipment(['d1'], ['onlyD1']);       // on one
+  final counts = await repository.equipmentCountsForDives(['d1', 'd2']);
+  expect(counts['shared'], 2);
+  expect(counts['onlyD1'], 1);
+  expect(counts.containsKey('missing'), isFalse);
+  expect(await repository.equipmentCountsForDives(const []), isEmpty);
+});
+```
+
+- [ ] **Step 2: Run to verify it FAILS**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: FAIL — method not defined.
+
+- [ ] **Step 3: Implement `equipmentCountsForDives`** in `dive_repository_impl.dart`:
+
+```dart
+/// {equipmentId: number of the given dives that reference it}.
+Future<Map<String, int>> equipmentCountsForDives(List<String> diveIds) async {
+  if (diveIds.isEmpty) return {};
+  final j = _db.diveEquipment;
+  final countExpr = j.diveId.count();
+  final rows = await (_db.selectOnly(j)
+        ..addColumns([j.equipmentId, countExpr])
+        ..where(j.diveId.isIn(diveIds))
+        ..groupBy([j.equipmentId]))
+      .get();
+  return {
+    for (final r in rows) r.read(j.equipmentId)!: r.read(countExpr)!,
+  };
+}
+```
+
+- [ ] **Step 4: Implement the other three** by mirroring Step 3 with the right table/column:
+  - `tagCountsForDives`: table `_db.diveTags`, column `tagId`.
+  - `diveTypeCountsForDives`: table `_db.diveDiveTypes`, column `diveTypeId`.
+  - `buddyCountsForDives` (in `buddy_repository.dart`): the dive-buddy junction used by `getBuddiesForDive` (grep that method for the table/column names), grouping by the buddy-id column.
+
+Add analogous tests for tags, dive types, and buddies (mirror Step 1; seed via `bulkAddTags` / `bulkAddDiveTypes` / `bulkAddBuddies`).
+
+- [ ] **Step 5: Run to verify PASS**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_repository_bulk_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/dive_log/data/repositories/dive_repository_impl.dart lib/features/buddies/data/repositories/buddy_repository.dart test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+git commit -m "feat(dive-log): per-item membership count queries for bulk edit"
+```
+
+---
+
+### Task 4: `MembershipDelta` + view-model (pure logic)
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart` (types only for now)
+- Create: `test/features/dive_log/presentation/widgets/bulk_membership_delta_test.dart`
+
+**Interfaces:**
+- Produces: `MembershipPresence { all, some, none }`, `MembershipChoice { ensureOn, ensureOff, leaveAsIs }`, `BulkMembershipItem { String id; String label; IconData? icon }`, and `MembershipDelta { List<String> addIds; List<String> removeIds; static MembershipDelta from(Map<String,MembershipPresence> initial, Map<String,MembershipChoice> choices) }`.
+
+- [ ] **Step 1: Write failing tests**:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+
+void main() {
+  test('ensureOn on a "some" item adds it (to the dives missing it)', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.some},
+      {'a': MembershipChoice.ensureOn},
+    );
+    expect(d.addIds, ['a']);
+    expect(d.removeIds, isEmpty);
+  });
+
+  test('ensureOn on an "all" item is a no-op', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.all},
+      {'a': MembershipChoice.ensureOn},
+    );
+    expect(d.addIds, isEmpty);
+    expect(d.removeIds, isEmpty);
+  });
+
+  test('ensureOff on "all" or "some" removes; on "none" is a no-op', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.all, 'b': MembershipPresence.some, 'c': MembershipPresence.none},
+      {'a': MembershipChoice.ensureOff, 'b': MembershipChoice.ensureOff, 'c': MembershipChoice.ensureOff},
+    );
+    expect(d.removeIds.toSet(), {'a', 'b'});
+    expect(d.addIds, isEmpty);
+  });
+
+  test('leaveAsIs never changes anything', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.some},
+      {'a': MembershipChoice.leaveAsIs},
+    );
+    expect(d.addIds, isEmpty);
+    expect(d.removeIds, isEmpty);
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `flutter test test/features/dive_log/presentation/widgets/bulk_membership_delta_test.dart` → FAIL (types undefined).
+
+- [ ] **Step 3: Implement the types** in `bulk_membership_editor.dart`:
+
+```dart
+import 'package:flutter/widgets.dart';
+
+enum MembershipPresence { all, some, none }
+enum MembershipChoice { ensureOn, ensureOff, leaveAsIs }
+
+class BulkMembershipItem {
+  final String id;
+  final String label;
+  final IconData? icon;
+  const BulkMembershipItem({required this.id, required this.label, this.icon});
+}
+
+class MembershipDelta {
+  final List<String> addIds;
+  final List<String> removeIds;
+  const MembershipDelta(this.addIds, this.removeIds);
+
+  static MembershipDelta from(
+    Map<String, MembershipPresence> initial,
+    Map<String, MembershipChoice> choices,
+  ) {
+    final add = <String>[];
+    final remove = <String>[];
+    for (final entry in choices.entries) {
+      final presence = initial[entry.key] ?? MembershipPresence.none;
+      switch (entry.value) {
+        case MembershipChoice.ensureOn:
+          if (presence != MembershipPresence.all) add.add(entry.key);
+        case MembershipChoice.ensureOff:
+          if (presence != MembershipPresence.none) remove.add(entry.key);
+        case MembershipChoice.leaveAsIs:
+          break;
+      }
+    }
+    return MembershipDelta(add, remove);
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify PASS**, then **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart test/features/dive_log/presentation/widgets/bulk_membership_delta_test.dart
+git commit -m "feat(dive-log): tri-state membership delta logic for bulk edit"
+```
+
+---
+
+### Task 5: l10n strings for the membership editor
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` + the 10 non-en arb files
+- Run: `flutter gen-l10n`
+
+- [ ] **Step 1: Add keys to `app_en.arb`** (with descriptions):
+
+```json
+"diveLog_bulkEdit_membership_onAll": "on all {count}",
+"@diveLog_bulkEdit_membership_onAll": { "placeholders": { "count": { "type": "int" } } },
+"diveLog_bulkEdit_membership_onSome": "on {count} of {total}",
+"@diveLog_bulkEdit_membership_onSome": { "placeholders": { "count": { "type": "int" }, "total": { "type": "int" } } },
+"diveLog_bulkEdit_membership_adding": "adding to all {total}",
+"@diveLog_bulkEdit_membership_adding": { "placeholders": { "total": { "type": "int" } } },
+"diveLog_bulkEdit_membership_removing": "removing from all",
+"@diveLog_bulkEdit_membership_removing": {},
+"diveLog_bulkEdit_membership_empty": "No items on the selected dives yet",
+"@diveLog_bulkEdit_membership_empty": {}
+```
+
+- [ ] **Step 2: Translate into all 10 non-en locales** (`ar, de, es, fr, he, hu, it, nl, pt, zh`), keeping the placeholders identical. (Follow the existing translation convention in each file.)
+
+- [ ] **Step 3: Regenerate + verify**
+
+Run: `flutter gen-l10n && flutter analyze lib/l10n`
+Expected: generation succeeds; the new getters exist on `AppLocalizations`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/l10n/arb
+git commit -m "i18n(dive-log): strings for bulk membership editor"
+```
+
+---
+
+### Task 6: `BulkMembershipEditor` widget
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart`
+- Create: `test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart`
+
+**Interfaces:**
+- Produces a `StatefulWidget`:
+```dart
+BulkMembershipEditor({
+  required String title,
+  required int totalDives,
+  required List<BulkMembershipItem> items,      // items on >=1 dive, plus user-added
+  required Map<String, MembershipPresence> presence, // per-item initial presence
+  required VoidCallback onAdd,                   // opens the collection's picker
+  Widget? addLabel,                              // e.g. "Use set" secondary action slot
+  required ValueChanged<MembershipDelta> onChanged,
+})
+```
+- Behavior: holds `Map<String, MembershipChoice> _choices`, initialized from `presence` (all->ensureOn, some->leaveAsIs, none->ensureOn). Renders one row per item with a tri-state control and a subtitle from the l10n keys (Task 5) based on presence + current choice. Tapping cycles: presence.all/none -> ensureOn<->ensureOff; presence.some -> leaveAsIs->ensureOn->ensureOff->leaveAsIs. After any change, calls `onChanged(MembershipDelta.from(presence, _choices))`. Rendering mirrors the row/`ListTile` style in `dive_edit_page.dart`'s `_equipmentChild` (leading CircleAvatar with `item.icon`, title `item.label`).
+
+- [ ] **Step 1: Write widget tests**:
+
+```dart
+// Pump a MaterialApp with AppLocalizations delegates (see bulk_dive_edit_form_test.dart).
+// Provide 3 items: a(all), b(some), c(none/just-added). totalDives: 3.
+
+testWidgets('renders presence subtitles', (tester) async {
+  MembershipDelta? last;
+  await pumpEditor(tester, onChanged: (d) => last = d);
+  expect(find.text('on all 3'), findsOneWidget);       // a
+  expect(find.text('on 2 of 3'), findsOneWidget);      // b (seed count 2)
+  // c starts checked -> "adding to all 3"
+  expect(find.text('adding to all 3'), findsOneWidget);
+});
+
+testWidgets('unchecking an all-item yields a remove', (tester) async {
+  MembershipDelta? last;
+  await pumpEditor(tester, onChanged: (d) => last = d);
+  await tester.tap(find.byKey(const ValueKey('membership-toggle-a')));
+  await tester.pump();
+  expect(last!.removeIds, contains('a'));
+});
+
+testWidgets('a some-item defaults to no change', (tester) async {
+  MembershipDelta? last;
+  await pumpEditor(tester, onChanged: (d) => last = d);
+  // c is added(checked) by default -> add; a is all -> no-op; b is some -> leaveAsIs.
+  expect(last?.addIds ?? const [], isNot(contains('b')));
+  expect(last?.removeIds ?? const [], isNot(contains('b')));
+});
+```
+
+Give each toggle a `ValueKey('membership-toggle-<id>')` in the widget so tests can target it.
+
+- [ ] **Step 2: Run to verify FAIL**, then **Step 3: Implement the widget** per the Interfaces block, then **Step 4: Run to verify PASS**.
+
+Run: `flutter test test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
+git commit -m "feat(dive-log): tri-state BulkMembershipEditor widget"
+```
+
+---
+
+### Task 7: Wire Equipment into the bulk form (+ hide Save as Set in bulk)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart`
+- Modify: `test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart`
+
+**Interfaces:**
+- Consumes: `equipmentCountsForDives` (Task 3), `BulkMembershipEditor` + `MembershipDelta` (Tasks 4/6).
+
+- [ ] **Step 1:** Add bulk state: `MembershipDelta _equipmentDelta = const MembershipDelta([], [])`, a `Map<String, MembershipPresence> _equipmentPresence = {}`, and the loaded `List<BulkMembershipItem>`. In the bulk init path (`if (widget.isBulk)` around line 293/655), load `equipmentCountsForDives(bulkDiveIds!)`, resolve each id to an `EquipmentItem` (via the existing equipment fetch-by-ids), and classify presence (count==total -> all, else some). Store into state.
+
+- [ ] **Step 2:** In `_buildBulkCollectionsSection`, replace the equipment `_collectionEntry(...)` with a `BulkMembershipEditor` bound to the equipment state; its `onAdd` opens the existing `_showEquipmentPicker` (added items -> presence.none, choice ensureOn); its secondary action is "Use set" (`_showEquipmentSetPicker`). Its `onChanged` sets `_equipmentDelta`.
+
+- [ ] **Step 3:** In `_collectCollectionOps`, replace the equipment block with:
+
+```dart
+if (_equipmentDelta.addIds.isNotEmpty) {
+  ops.add(EquipmentOp(mode: BulkCollectionMode.add, equipmentIds: _equipmentDelta.addIds));
+}
+if (_equipmentDelta.removeIds.isNotEmpty) {
+  ops.add(EquipmentOp(mode: BulkCollectionMode.remove, equipmentIds: _equipmentDelta.removeIds));
+}
+```
+
+- [ ] **Step 4:** In `_equipmentChild` (single-dive editor), guard the "Save as Set" button with `if (!widget.isBulk)` so it does not render in bulk mode.
+
+- [ ] **Step 5:** Update `bulk_dive_edit_form_test.dart`: the `BulkCollectionModeSelector` count drops from 7 to 6 (equipment no longer uses it); add an assertion that a `BulkMembershipEditor` renders. Then add a flow test: seed d1 with e1, d2 empty; pump bulk; the editor shows e1 as "on 1 of 2"; add e2 via the picker; save; assert d1 == {e1, e2} and d2 == {e2} (existing gear preserved, no wipe).
+
+- [ ] **Step 6: Run** `flutter test test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart` → PASS. **Step 7: Commit.**
+
+```bash
+git commit -am "feat(dive-log): tri-state bulk gear editing; hide save-as-set in bulk"
+```
+
+---
+
+### Task 8: Wire Tags, Dive Types, and Buddies into the bulk form
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart`
+- Modify: `test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart`
+
+- [ ] **Step 1:** Repeat Task 7's pattern for each collection, reusing the same state/wiring shape:
+  - **Tags:** counts via `tagCountsForDives`; labels from `Tag.name`; `onAdd` uses the existing tag input; emit `TagsOp(add/remove)`.
+  - **Dive types:** counts via `diveTypeCountsForDives`; labels from `diveTypesProvider` (`DiveTypeEntity` id->name); `onAdd` uses the existing dive-type multiselect; emit `DiveTypesOp(add/remove)`.
+  - **Buddies:** counts via `buddyCountsForDives`; labels from `Buddy.name`; `onAdd` uses the existing `BuddyPicker`; for the AddOp build `BuddyWithRole(buddy: <buddy>, role: BuddyRole.buddy)`; for the RemoveOp pass `BuddyWithRole` entries whose `.buddy.id` are the removeIds. Emit `BuddiesOp(add/remove)`.
+
+- [ ] **Step 2:** Remove the now-unused `_collectionModes` handling for these four reference collections and their `_collectionEntry` blocks. Keep `_collectionEntry` + `_collectionModes` for the owned collections (tanks/weights/sightings).
+
+- [ ] **Step 3:** Update `bulk_dive_edit_form_test.dart`: `BulkCollectionModeSelector` now renders only for the 3 owned collections (findsNWidgets(3)); assert 4 `BulkMembershipEditor` widgets render.
+
+- [ ] **Step 4: Run** the bulk form test → PASS. **Step 5: Commit.**
+
+```bash
+git commit -am "feat(dive-log): tri-state bulk editing for tags, dive types, buddies"
+```
+
+---
+
+### Task 9: Service test — Add + Remove ops for one collection in a single request
+
+**Files:**
+- Modify: `test/features/dive_log/data/services/bulk_dive_edit_service_test.dart`
+
+- [ ] **Step 1: Write the test** (proves the tri-state decomposition applies correctly and undo restores):
+
+```dart
+test('apply handles simultaneous add + remove ops for one collection', () async {
+  await seed('d1');
+  await diveRepo.bulkAddEquipment(['d1'], ['keep', 'drop']);
+
+  final snap = await service.apply(
+    BulkEditRequest(
+      diveIds: const ['d1'],
+      ops: [
+        const EquipmentOp(mode: BulkCollectionMode.add, equipmentIds: ['added']),
+        const EquipmentOp(mode: BulkCollectionMode.remove, equipmentIds: ['drop']),
+      ],
+    ),
+  );
+  expect((await equipOf('d1')).toSet(), {'keep', 'added'});
+
+  await service.undo(snap);
+  expect((await equipOf('d1')).toSet(), {'keep', 'drop'}); // restored
+});
+```
+
+- [ ] **Step 2: Run to verify PASS** (engine already supports this) — `flutter test test/features/dive_log/data/services/bulk_dive_edit_service_test.dart`. **Step 3: Commit.**
+
+```bash
+git commit -am "test(dive-log): bulk apply handles add+remove for one collection with undo"
+```
+
+---
+
+### Task 10: Final verification
+
+- [ ] **Step 1:** `dart format .`
+- [ ] **Step 2:** `flutter analyze` (whole project) — zero issues.
+- [ ] **Step 3:** Run the affected suites:
+
+```bash
+flutter test \
+  test/features/dive_log/data/repositories/dive_repository_bulk_test.dart \
+  test/features/dive_log/data/services/bulk_dive_edit_service_test.dart \
+  test/features/dive_log/domain/entities/bulk_edit_request_test.dart \
+  test/features/dive_log/presentation/widgets/bulk_membership_delta_test.dart \
+  test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart \
+  test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart \
+  test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart
+```
+
+- [ ] **Step 4:** Commit any formatting; summarize outcome for the user.
+
+## Self-review notes
+
+- Spec coverage: interaction model (Tasks 4/6), architecture/op-gen (Tasks 7/8), 4 count queries (Task 3), per-collection wrinkles incl. buddy default role (Task 8), Bug 2 fix (Task 2), Bug 1 regression (Task 1), undo (Task 9), l10n (Task 5). All covered.
+- Type consistency: `MembershipDelta.from`, `BulkMembershipItem`, `MembershipPresence`, `MembershipChoice` used identically in Tasks 4/6/7/8. Count methods return `Map<String,int>` consumed identically.
+- Owned collections untouched; engine untouched.

--- a/docs/superpowers/specs/2026-07-06-bulk-membership-editing-design.md
+++ b/docs/superpowers/specs/2026-07-06-bulk-membership-editing-design.md
@@ -1,0 +1,194 @@
+# Bulk membership editing (tri-state) + gear bug fixes
+
+Date: 2026-07-06
+Status: Approved design, pending implementation plan
+Branch: worktree-gear-multi-dive-edit
+
+## Origin
+
+A user report (r/submersion) raised two problems on the "gear" surface:
+
+1. **Bulk gear edit wipes data.** Selecting multiple dives and adding one gear
+   item wiped all existing gear on every selected dive, replacing it with the
+   single added item; removing/replacing gear in bulk "didn't function."
+2. **"Save as Set" doesn't save.** Editing gear on a single dive and choosing
+   "Save as Set" appeared to do nothing.
+
+## Investigation summary (root causes)
+
+### Bug 1 — bulk gear wipe: already fixed in shipped code
+
+The full current chain is correct on `main`:
+
+- Bulk mode renders `_buildBulkCollectionsSection` with Add/Remove/Replace mode
+  chips per collection (`dive_edit_page.dart`).
+- `_collectCollectionOps` builds `EquipmentOp(mode, ids)` from the chosen mode.
+- `BulkDiveEditService._applyOp` dispatches add/remove/replace to
+  `bulkAddEquipment` / `bulkRemoveEquipment` / `bulkReplaceEquipment`.
+- `bulkAddEquipment` uses `insertOnConflictUpdate` (a true merge; never deletes
+  existing rows).
+
+The "add wipes everything" symptom is the pre-fix behavior, resolved by commit
+`30da9f93835` (2026-06-23, "bulk form collections … with Add/Remove/Replace"),
+released in **v1.5.9.113**. The reporter was on an older build. Existing bulk
+tests pass (+16).
+
+Residual issue: the Add/Remove/Replace chip model is confusing and unsafe — the
+editor is hidden until a mode is chosen, never shows the dives' current gear,
+makes "remove" mean "add the item to a list to remove it," and lets "Replace"
+silently wipe. That UX is what this design replaces.
+
+### Bug 2 — "Save as Set" orphaned by null diverId: real, current bug
+
+`_saveEquipmentAsSet` (`dive_edit_page.dart`) builds an `EquipmentSet` with **no
+`diverId`** and calls `EquipmentSetRepository.createSet()` **directly**,
+bypassing `EquipmentSetListNotifier.addSet()` — the only code that stamps the
+active diver's id. The row is inserted (a success snackbar even shows) with
+`diverId = NULL`. Every read path filters `WHERE diverId = <current diver>`
+(`equipment_set_repository_impl.dart`), and SQL `NULL = '<id>'` is never true, so
+the set is orphaned and invisible in both the sets list and the picker. The
+standalone "New Set" page (`equipment_set_edit_page.dart`) does it correctly:
+resolves `diverId` and routes through `notifier.addSet`.
+
+## Goals
+
+- Make bulk editing of id-based "reference" collections (Tags, Dive Types,
+  Buddies, Equipment) clear, safe, and grounded in the dives' current state.
+- Never silently destroy membership; heterogeneous selections default to
+  "no change."
+- Fix Bug 2 so sets saved from dive-edit are visible to the current diver.
+- Add a regression test locking in Bug 1's correct "add merges" behavior.
+
+## Non-goals
+
+- No change to owned collections (Tanks, Weights, Sightings) — they keep their
+  current editors (rich per-item cards; add/replace only).
+- No change to `BulkDiveEditService`, the sealed op types, the `bulkAdd*` /
+  `bulkRemove*` / `bulkReplace*` repo writes, or the undo snapshot mechanism.
+- No redesign of single-dive gear editing (only the Bug 2 save path changes).
+- No per-dive role editing for buddies inside the bulk list.
+
+## Design
+
+### Interaction model
+
+In bulk mode, each reference collection renders a **membership list**: every item
+present on any selected dive, each with a tri-state checkbox, plus an "＋ Add…"
+affordance that opens that collection's existing picker to bring in items not yet
+on any dive.
+
+```
+Equipment · on these 3 dives
+──────────────────────────────────────
+  [x]  Regulator            on all 3
+  [-]  Wetsuit 5mm          on 2 of 3
+  [x]  Dive computer        on all 3
+  [x]  Camera               just added -> all 3
+                                + Add gear    Use set
+```
+
+Checkbox semantics at save:
+
+| State | Meaning |
+| ----- | ------- |
+| checked | Ensure on **all** selected dives (add to those missing it) |
+| empty | Ensure on **none** (remove from all that have it) |
+| dash (indeterminate) | **Leave as-is** — no change |
+
+Tap-cycling:
+
+- Item initially on all: toggles checked <-> empty.
+- Item initially on some: cycles dash -> checked -> empty -> dash (add-to-all,
+  remove-from-all, or leave the mix untouched).
+- Freshly added item: starts checked.
+
+The dash state is the safety net: for a heterogeneous selection the default is
+"don't touch," so nothing is silently wiped. The Add/Remove/Replace chips and the
+destructive Replace are removed for these four collections.
+
+### Architecture
+
+All new logic is in the presentation layer plus one read query per collection.
+The service and repo writes are unchanged; a tri-state toggle decomposes into an
+existing AddOp (checked items) and RemoveOp (unchecked items).
+
+- **`BulkMembershipEditor` (new, reusable widget).** One responsibility: given the
+  current items with per-item dive counts and the total dive count, render
+  tri-state rows and report the resulting `(addIds, removeIds)`. Generic over the
+  item type via a small view-model (id, label, icon). Owns its own toggle state;
+  reports changes up via a callback. Testable in isolation. Replaces the four
+  `_collectionEntry` mode-chip blocks in the bulk form.
+- **Op generation.** `_collectCollectionOps` reads each editor's `(addIds,
+  removeIds)` and emits `…Op(mode: add, ids: addIds)` and
+  `…Op(mode: remove, ids: removeIds)`, each only when non-empty. Empty deltas emit
+  no ops, so opening and closing the editor writes nothing. The service already
+  applies multiple ops per collection type and the undo snapshot already captures
+  add/remove, so undo keeps working unchanged.
+
+### Data layer — count queries
+
+Each collection needs "how many of the selected dives have each item":
+`SELECT itemId, COUNT(DISTINCT diveId) FROM <junction> WHERE diveId IN (…)
+GROUP BY itemId`, returning `Map<String, int>`. Combined with
+`diveIds.length` this classifies each item as all / some / none.
+
+- `DiveRepository.equipmentCountsForDives(diveIds)`
+- `DiveRepository.tagCountsForDives(diveIds)`
+- `DiveRepository.diveTypeCountsForDives(diveIds)`
+- `BuddyRepository.buddyCountsForDives(diveIds)`
+
+Item display data (names, icons) comes from the existing per-collection
+fetch-by-ids paths.
+
+### Per-collection wrinkles
+
+- **Buddies** carry a per-dive role. Tri-state governs **membership only**:
+  checking adds the buddy to all dives with a **default role**; existing buddies'
+  roles are never modified (add/remove only). Role refinement stays in
+  single-dive edit.
+- **Dive types**: membership only; the dive's representative-type column is
+  unaffected. Removing a dive's last type already falls back to `recreational` in
+  the repo.
+- **Tags**: the "＋ Add" affordance is the existing tag input (including
+  create-new); added tags appear as checked rows.
+- **Equipment**: keeps "Use set" as an add-source. **"Save as Set" is hidden in
+  bulk mode** (ambiguous whose gear it would save); it remains on single-dive
+  edit, where Bug 2 is fixed.
+
+### Bug 2 fix
+
+`_saveEquipmentAsSet` routes through
+`ref.read(equipmentSetListNotifierProvider.notifier).addSet(set)` (which stamps
+the active `diverId` and refreshes) instead of calling `repository.createSet()`
+directly.
+
+## Testing (TDD — tests first)
+
+- `BulkMembershipEditor` widget tests: renders checked/dash/empty for
+  all/some/none; each tap-cycle yields the correct `(addIds, removeIds)`; added
+  items produce adds; unchecking an "all" item produces a remove; leaving a
+  "some" item as dash produces nothing.
+- Service test: one `BulkEditRequest` carrying both an AddOp and a RemoveOp for
+  the same collection applies both, and undo restores prior membership.
+- Count-query tests: all/some/none counts across a 3-dive selection per
+  collection.
+- Bug 2 widget test: seed a diver + a dive with gear, tap Save as Set, assert the
+  set is visible to the current diver (fails pre-fix, passes post-fix).
+- Bug 1 regression test: dive has gear A; bulk-add B -> {A, B}; multi-dive
+  variant (d1={A}, d2={B}; add C -> d1={A,C}, d2={B,C}).
+
+## Safety & undo
+
+Add/Remove ops are already captured by the existing per-dive snapshot, so bulk
+Undo works unchanged. There is no destructive replace path from this UI, and
+empty deltas emit no ops.
+
+## Approximate change surface
+
+- New: `bulk_membership_editor.dart` (widget) + view-model.
+- New: 4 count-query methods (`DiveRepository` x3, `BuddyRepository` x1).
+- Edit: `dive_edit_page.dart` — replace the four reference-collection
+  `_collectionEntry` blocks; update `_collectCollectionOps`; hide "Save as Set" in
+  bulk; fix `_saveEquipmentAsSet`.
+- New/updated tests as above.
+- l10n additions for any new strings, translated into all locales.

--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -24,6 +24,22 @@ export 'package:submersion/features/buddies/data/repositories/buddy_merge_reposi
 
 class BuddyRepository {
   AppDatabase get _db => DatabaseService.instance.database;
+
+  /// {buddyId: number of the given dives that include the buddy}. Junction PK
+  /// is (diveId, buddyId), so COUNT(diveId) equals the distinct-dive count.
+  Future<Map<String, int>> buddyCountsForDives(List<String> diveIds) async {
+    if (diveIds.isEmpty) return {};
+    final j = _db.diveBuddies;
+    final countExpr = j.diveId.count();
+    final rows =
+        await (_db.selectOnly(j)
+              ..addColumns([j.buddyId, countExpr])
+              ..where(j.diveId.isIn(diveIds))
+              ..groupBy([j.buddyId]))
+            .get();
+    return {for (final r in rows) r.read(j.buddyId)!: r.read(countExpr)!};
+  }
+
   final SyncRepository _syncRepository = SyncRepository();
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(BuddyRepository);

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -4091,6 +4091,49 @@ class DiveRepository {
     await _bumpDives(diveIds, now);
   }
 
+  /// {equipmentId: number of the given dives that reference it}. Junction PK
+  /// is (diveId, equipmentId), so COUNT(diveId) equals the distinct-dive count.
+  Future<Map<String, int>> equipmentCountsForDives(List<String> diveIds) async {
+    if (diveIds.isEmpty) return {};
+    final j = _db.diveEquipment;
+    final countExpr = j.diveId.count();
+    final rows =
+        await (_db.selectOnly(j)
+              ..addColumns([j.equipmentId, countExpr])
+              ..where(j.diveId.isIn(diveIds))
+              ..groupBy([j.equipmentId]))
+            .get();
+    return {for (final r in rows) r.read(j.equipmentId)!: r.read(countExpr)!};
+  }
+
+  /// {tagId: number of the given dives that carry it}.
+  Future<Map<String, int>> tagCountsForDives(List<String> diveIds) async {
+    if (diveIds.isEmpty) return {};
+    final j = _db.diveTags;
+    final countExpr = j.diveId.count();
+    final rows =
+        await (_db.selectOnly(j)
+              ..addColumns([j.tagId, countExpr])
+              ..where(j.diveId.isIn(diveIds))
+              ..groupBy([j.tagId]))
+            .get();
+    return {for (final r in rows) r.read(j.tagId)!: r.read(countExpr)!};
+  }
+
+  /// {diveTypeId: number of the given dives that have it}.
+  Future<Map<String, int>> diveTypeCountsForDives(List<String> diveIds) async {
+    if (diveIds.isEmpty) return {};
+    final j = _db.diveDiveTypes;
+    final countExpr = j.diveId.count();
+    final rows =
+        await (_db.selectOnly(j)
+              ..addColumns([j.diveTypeId, countExpr])
+              ..where(j.diveId.isIn(diveIds))
+              ..groupBy([j.diveTypeId]))
+            .get();
+    return {for (final r in rows) r.read(j.diveTypeId)!: r.read(countExpr)!};
+  }
+
   DiveTanksCompanion _tankCompanion(
     String id,
     String diveId,

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -2850,6 +2850,10 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     final tagName = {for (final t in allTags) t.id: t.name};
     final typeName = {for (final t in allTypes) t.id: t.name};
     final buddyMap = {for (final b in allBuddies) b.id: b};
+    // The count queries group by id with no ORDER BY, so sort each member list
+    // by label to keep the bulk editor's row order stable across loads/devices.
+    int byLabel(BulkMembershipItem a, BulkMembershipItem b) =>
+        a.label.toLowerCase().compareTo(b.label.toLowerCase());
     setState(() {
       _equipmentCounts = equipCounts;
       _equipmentMembers = [
@@ -2859,7 +2863,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             label: e.name,
             icon: _getEquipmentIcon(e.type),
           ),
-      ];
+      ]..sort(byLabel);
       _tagCounts = tagCounts;
       _tagMembers = [
         for (final id in tagCounts.keys)
@@ -2868,7 +2872,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             label: tagName[id] ?? id,
             icon: Icons.label_outline,
           ),
-      ];
+      ]..sort(byLabel);
       _diveTypeCounts = typeCounts;
       _diveTypeNames
         ..clear()
@@ -2880,7 +2884,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             label: typeName[id] ?? id,
             icon: Icons.scuba_diving,
           ),
-      ];
+      ]..sort(byLabel);
       _buddyCounts = buddyCounts;
       _buddyById
         ..clear()
@@ -2892,7 +2896,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             label: buddyMap[id]?.name ?? id,
             icon: Icons.person_outline,
           ),
-      ];
+      ]..sort(byLabel);
     });
   }
 

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -2842,11 +2842,14 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
                   updatedAt: DateTime.now(),
                 );
 
-                final repository = ref.read(equipmentSetRepositoryProvider);
-                await repository.createSet(set);
-
-                // Invalidate the sets provider to refresh the list
-                ref.invalidate(equipmentSetsProvider);
+                // Route through the notifier so the set is stamped with the
+                // active diver id. Calling the repository directly leaves
+                // diverId null, orphaning the set from the diver-scoped list
+                // (it silently "doesn't save"). addSet also refreshes the
+                // list providers.
+                await ref
+                    .read(equipmentSetListNotifierProvider.notifier)
+                    .addSet(set);
 
                 if (context.mounted) {
                   Navigator.of(context).pop();

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -734,9 +734,9 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   final Map<BulkCollectionType, BulkCollectionMode> _collectionModes = {};
   bool _bulkTankOnlyIfEmpty = false;
 
-  // Bulk tri-state membership: equipment members shown across the selected
-  // dives (existing + picker-added), their per-item dive counts, and the
-  // resulting add/remove delta. Tags/diveTypes/buddies follow in a later task.
+  // Bulk tri-state membership state for each reference collection: the members
+  // shown across the selected dives (existing + picker-added), their per-item
+  // dive counts, and the resulting add/remove delta.
   Map<String, int> _equipmentCounts = {};
   List<BulkMembershipItem> _equipmentMembers = [];
   MembershipDelta _equipmentDelta = MembershipDelta.empty;

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/buddies/presentation/providers/buddy_provide
 import 'package:submersion/features/buddies/presentation/widgets/buddy_picker.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_set_providers.dart';
@@ -46,6 +47,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/
 import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/trip_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/computer_source_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/edit_sighting_sheet.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_set_picker_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart';
@@ -298,6 +300,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       // default would make enabling the collection silently operate on it.
       _selectedDiveTypeIds = <String>[];
       _suppressDirty = false;
+      _loadBulkEquipment();
     } else if (widget.isEditing) {
       _loadExistingDive();
     } else {
@@ -729,6 +732,13 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   final Map<BulkCollectionType, BulkCollectionMode> _collectionModes = {};
   bool _bulkTankOnlyIfEmpty = false;
 
+  // Bulk tri-state membership: equipment members shown across the selected
+  // dives (existing + picker-added), their per-item dive counts, and the
+  // resulting add/remove delta. Tags/diveTypes/buddies follow in a later task.
+  Map<String, int> _equipmentCounts = {};
+  List<BulkMembershipItem> _equipmentMembers = [];
+  MembershipDelta _equipmentDelta = MembershipDelta.empty;
+
   Widget _gatedRow(BulkField field, Widget child) {
     return BulkFieldGate(
       enabled: _bulkEnabled.contains(field),
@@ -994,11 +1004,18 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             allowEmpty: true,
           ),
         ),
-        _collectionEntry(
-          type: BulkCollectionType.equipment,
-          label: l10n.diveLog_edit_section_equipment,
-          allowed: refModes,
-          editor: _equipmentChild(),
+        BulkMembershipEditor(
+          title: l10n.diveLog_edit_section_equipment,
+          totalDives: widget.bulkDiveIds!.length,
+          items: _equipmentMembers,
+          counts: _equipmentCounts,
+          onAdd: _bulkAddEquipment,
+          secondaryAction: TextButton.icon(
+            onPressed: _bulkUseEquipmentSet,
+            icon: const Icon(Icons.folder_special, size: 18),
+            label: Text(l10n.diveLog_edit_useSet),
+          ),
+          onChanged: (d) => setState(() => _equipmentDelta = d),
         ),
         _collectionEntry(
           type: BulkCollectionType.buddies,
@@ -1045,12 +1062,19 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         DiveTypesOp(mode: diveTypesMode, diveTypeIds: _selectedDiveTypeIds),
       );
     }
-    final equipMode = _collectionModes[BulkCollectionType.equipment];
-    if (equipMode != null) {
+    if (_equipmentDelta.addIds.isNotEmpty) {
       ops.add(
         EquipmentOp(
-          mode: equipMode,
-          equipmentIds: _selectedEquipment.map((e) => e.id).toList(),
+          mode: BulkCollectionMode.add,
+          equipmentIds: _equipmentDelta.addIds,
+        ),
+      );
+    }
+    if (_equipmentDelta.removeIds.isNotEmpty) {
+      ops.add(
+        EquipmentOp(
+          mode: BulkCollectionMode.remove,
+          equipmentIds: _equipmentDelta.removeIds,
         ),
       );
     }
@@ -2650,12 +2674,16 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  TextButton.icon(
-                    onPressed: _saveEquipmentAsSet,
-                    icon: const Icon(Icons.save_alt, size: 18),
-                    label: Text(context.l10n.diveLog_edit_saveAsSet),
-                  ),
-                  const SizedBox(width: 8),
+                  // "Save as Set" is single-dive only; in bulk mode the
+                  // membership editor replaces this editor entirely.
+                  if (!widget.isBulk) ...[
+                    TextButton.icon(
+                      onPressed: _saveEquipmentAsSet,
+                      icon: const Icon(Icons.save_alt, size: 18),
+                      label: Text(context.l10n.diveLog_edit_saveAsSet),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
                   TextButton(
                     onPressed: () {
                       setState(() {
@@ -2760,6 +2788,94 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
                   _selectedEquipment.add(item);
                 }
               }
+            });
+            Navigator.of(context).pop();
+          },
+        ),
+      ),
+    );
+  }
+
+  /// Load the equipment present across the selected dives (with per-item dive
+  /// counts) so the bulk membership editor can show all/some/none state.
+  Future<void> _loadBulkEquipment() async {
+    final ids = widget.bulkDiveIds!;
+    final counts = await ref
+        .read(diveRepositoryProvider)
+        .equipmentCountsForDives(ids);
+    final items = await EquipmentRepository().getEquipmentByIds(
+      counts.keys.toList(),
+    );
+    if (!mounted) return;
+    setState(() {
+      _equipmentCounts = counts;
+      _equipmentMembers = [
+        for (final e in items)
+          BulkMembershipItem(
+            id: e.id,
+            label: e.name,
+            icon: _getEquipmentIcon(e.type),
+          ),
+      ];
+    });
+  }
+
+  void _bulkAddEquipment() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.7,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        expand: false,
+        builder: (context, scrollController) => EquipmentPickerSheet(
+          scrollController: scrollController,
+          selectedEquipmentIds: _equipmentMembers.map((e) => e.id).toSet(),
+          onEquipmentSelected: (equipment) {
+            setState(() {
+              if (!_equipmentMembers.any((e) => e.id == equipment.id)) {
+                _equipmentMembers = [
+                  ..._equipmentMembers,
+                  BulkMembershipItem(
+                    id: equipment.id,
+                    label: equipment.name,
+                    icon: _getEquipmentIcon(equipment.type),
+                  ),
+                ];
+              }
+            });
+            Navigator.of(context).pop();
+          },
+        ),
+      ),
+    );
+  }
+
+  void _bulkUseEquipmentSet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.7,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        expand: false,
+        builder: (context, scrollController) => EquipmentSetPickerSheet(
+          scrollController: scrollController,
+          onSetSelected: (set, items) {
+            setState(() {
+              final existing = _equipmentMembers.map((e) => e.id).toSet();
+              _equipmentMembers = [
+                ..._equipmentMembers,
+                for (final item in items)
+                  if (!existing.contains(item.id))
+                    BulkMembershipItem(
+                      id: item.id,
+                      label: item.name,
+                      icon: _getEquipmentIcon(item.type),
+                    ),
+              ];
             });
             Navigator.of(context).pop();
           },

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -25,6 +25,8 @@ import 'package:submersion/features/dive_centers/domain/entities/dive_center.dar
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/dive_centers/presentation/widgets/dive_center_picker.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
+import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
+import 'package:submersion/features/dive_types/presentation/providers/dive_type_providers.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -300,7 +302,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       // default would make enabling the collection silently operate on it.
       _selectedDiveTypeIds = <String>[];
       _suppressDirty = false;
-      _loadBulkEquipment();
+      _loadBulkMembers();
     } else if (widget.isEditing) {
       _loadExistingDive();
     } else {
@@ -739,6 +741,20 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   List<BulkMembershipItem> _equipmentMembers = [];
   MembershipDelta _equipmentDelta = MembershipDelta.empty;
 
+  Map<String, int> _tagCounts = {};
+  List<BulkMembershipItem> _tagMembers = [];
+  MembershipDelta _tagDelta = MembershipDelta.empty;
+
+  Map<String, int> _diveTypeCounts = {};
+  final Map<String, String> _diveTypeNames = {};
+  List<BulkMembershipItem> _diveTypeMembers = [];
+  MembershipDelta _diveTypeDelta = MembershipDelta.empty;
+
+  Map<String, int> _buddyCounts = {};
+  final Map<String, Buddy> _buddyById = {};
+  List<BulkMembershipItem> _buddyMembers = [];
+  MembershipDelta _buddyDelta = MembershipDelta.empty;
+
   Widget _gatedRow(BulkField field, Widget child) {
     return BulkFieldGate(
       enabled: _bulkEnabled.contains(field),
@@ -974,35 +990,27 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
 
   Widget _buildBulkCollectionsSection(UnitFormatter units) {
     final l10n = context.l10n;
-    const refModes = [
-      BulkCollectionMode.add,
-      BulkCollectionMode.remove,
-      BulkCollectionMode.replace,
-    ];
     const ownedModes = [BulkCollectionMode.add, BulkCollectionMode.replace];
     return FormSection(
       label: context.l10n.diveLog_bulkEdit_groupCollections,
       expanded: true,
       onToggle: null,
       children: [
-        _collectionEntry(
-          type: BulkCollectionType.tags,
-          label: l10n.diveLog_edit_section_tags,
-          allowed: refModes,
-          editor: TagInputWidget(
-            selectedTags: _selectedTags,
-            onTagsChanged: (tags) => setState(() => _selectedTags = tags),
-          ),
+        BulkMembershipEditor(
+          title: l10n.diveLog_edit_section_tags,
+          totalDives: widget.bulkDiveIds!.length,
+          items: _tagMembers,
+          counts: _tagCounts,
+          onAdd: _bulkAddTags,
+          onChanged: (d) => setState(() => _tagDelta = d),
         ),
-        _collectionEntry(
-          type: BulkCollectionType.diveTypes,
-          label: l10n.diveLog_edit_label_diveTypes,
-          allowed: refModes,
-          editor: DiveTypeMultiSelectField(
-            selectedTypeIds: _selectedDiveTypeIds,
-            onChanged: (ids) => setState(() => _selectedDiveTypeIds = ids),
-            allowEmpty: true,
-          ),
+        BulkMembershipEditor(
+          title: l10n.diveLog_edit_label_diveTypes,
+          totalDives: widget.bulkDiveIds!.length,
+          items: _diveTypeMembers,
+          counts: _diveTypeCounts,
+          onAdd: _bulkAddDiveTypes,
+          onChanged: (d) => setState(() => _diveTypeDelta = d),
         ),
         BulkMembershipEditor(
           title: l10n.diveLog_edit_section_equipment,
@@ -1017,14 +1025,13 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           ),
           onChanged: (d) => setState(() => _equipmentDelta = d),
         ),
-        _collectionEntry(
-          type: BulkCollectionType.buddies,
-          label: l10n.diveLog_edit_group_buddies,
-          allowed: refModes,
-          editor: BuddyPicker(
-            selectedBuddies: _selectedBuddies,
-            onChanged: (b) => setState(() => _selectedBuddies = b),
-          ),
+        BulkMembershipEditor(
+          title: l10n.diveLog_edit_group_buddies,
+          totalDives: widget.bulkDiveIds!.length,
+          items: _buddyMembers,
+          counts: _buddyCounts,
+          onAdd: _bulkAddBuddies,
+          onChanged: (d) => setState(() => _buddyDelta = d),
         ),
         _collectionEntry(
           type: BulkCollectionType.weights,
@@ -1050,16 +1057,28 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
 
   List<BulkCollectionOp> _collectCollectionOps() {
     final ops = <BulkCollectionOp>[];
-    final tagsMode = _collectionModes[BulkCollectionType.tags];
-    if (tagsMode != null) {
+    if (_tagDelta.addIds.isNotEmpty) {
+      ops.add(TagsOp(mode: BulkCollectionMode.add, tagIds: _tagDelta.addIds));
+    }
+    if (_tagDelta.removeIds.isNotEmpty) {
       ops.add(
-        TagsOp(mode: tagsMode, tagIds: _selectedTags.map((t) => t.id).toList()),
+        TagsOp(mode: BulkCollectionMode.remove, tagIds: _tagDelta.removeIds),
       );
     }
-    final diveTypesMode = _collectionModes[BulkCollectionType.diveTypes];
-    if (diveTypesMode != null && _selectedDiveTypeIds.isNotEmpty) {
+    if (_diveTypeDelta.addIds.isNotEmpty) {
       ops.add(
-        DiveTypesOp(mode: diveTypesMode, diveTypeIds: _selectedDiveTypeIds),
+        DiveTypesOp(
+          mode: BulkCollectionMode.add,
+          diveTypeIds: _diveTypeDelta.addIds,
+        ),
+      );
+    }
+    if (_diveTypeDelta.removeIds.isNotEmpty) {
+      ops.add(
+        DiveTypesOp(
+          mode: BulkCollectionMode.remove,
+          diveTypeIds: _diveTypeDelta.removeIds,
+        ),
       );
     }
     if (_equipmentDelta.addIds.isNotEmpty) {
@@ -1078,9 +1097,21 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         ),
       );
     }
-    final buddiesMode = _collectionModes[BulkCollectionType.buddies];
-    if (buddiesMode != null) {
-      ops.add(BuddiesOp(mode: buddiesMode, buddies: _selectedBuddies));
+    if (_buddyDelta.addIds.isNotEmpty) {
+      ops.add(
+        BuddiesOp(
+          mode: BulkCollectionMode.add,
+          buddies: _buddyDelta.addIds.map(_buddyWithRole).toList(),
+        ),
+      );
+    }
+    if (_buddyDelta.removeIds.isNotEmpty) {
+      ops.add(
+        BuddiesOp(
+          mode: BulkCollectionMode.remove,
+          buddies: _buddyDelta.removeIds.map(_buddyWithRole).toList(),
+        ),
+      );
     }
     final tanksMode = _collectionModes[BulkCollectionType.tanks];
     if (tanksMode != null) {
@@ -2796,25 +2827,70 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     );
   }
 
-  /// Load the equipment present across the selected dives (with per-item dive
-  /// counts) so the bulk membership editor can show all/some/none state.
-  Future<void> _loadBulkEquipment() async {
+  /// Load the members (with per-item dive counts) of every id-based reference
+  /// collection across the selected dives, so each tri-state editor can show
+  /// its all/some/none state.
+  Future<void> _loadBulkMembers() async {
     final ids = widget.bulkDiveIds!;
-    final counts = await ref
-        .read(diveRepositoryProvider)
-        .equipmentCountsForDives(ids);
-    final items = await EquipmentRepository().getEquipmentByIds(
-      counts.keys.toList(),
+    final repo = ref.read(diveRepositoryProvider);
+    final equipCounts = await repo.equipmentCountsForDives(ids);
+    final tagCounts = await repo.tagCountsForDives(ids);
+    final typeCounts = await repo.diveTypeCountsForDives(ids);
+    final buddyRepo = ref.read(buddyRepositoryProvider);
+    final buddyCounts = await buddyRepo.buddyCountsForDives(ids);
+
+    final equip = await EquipmentRepository().getEquipmentByIds(
+      equipCounts.keys.toList(),
     );
+    final allTags = await ref.read(tagsProvider.future);
+    final allTypes = await ref.read(diveTypesProvider.future);
+    final allBuddies = await buddyRepo.getAllBuddies();
     if (!mounted) return;
+
+    final tagName = {for (final t in allTags) t.id: t.name};
+    final typeName = {for (final t in allTypes) t.id: t.name};
+    final buddyMap = {for (final b in allBuddies) b.id: b};
     setState(() {
-      _equipmentCounts = counts;
+      _equipmentCounts = equipCounts;
       _equipmentMembers = [
-        for (final e in items)
+        for (final e in equip)
           BulkMembershipItem(
             id: e.id,
             label: e.name,
             icon: _getEquipmentIcon(e.type),
+          ),
+      ];
+      _tagCounts = tagCounts;
+      _tagMembers = [
+        for (final id in tagCounts.keys)
+          BulkMembershipItem(
+            id: id,
+            label: tagName[id] ?? id,
+            icon: Icons.label_outline,
+          ),
+      ];
+      _diveTypeCounts = typeCounts;
+      _diveTypeNames
+        ..clear()
+        ..addAll(typeName);
+      _diveTypeMembers = [
+        for (final id in typeCounts.keys)
+          BulkMembershipItem(
+            id: id,
+            label: typeName[id] ?? id,
+            icon: Icons.scuba_diving,
+          ),
+      ];
+      _buddyCounts = buddyCounts;
+      _buddyById
+        ..clear()
+        ..addAll(buddyMap);
+      _buddyMembers = [
+        for (final id in buddyCounts.keys)
+          BulkMembershipItem(
+            id: id,
+            label: buddyMap[id]?.name ?? id,
+            icon: Icons.person_outline,
           ),
       ];
     });
@@ -2883,6 +2959,163 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       ),
     );
   }
+
+  void _bulkAddTags() {
+    var picked = <Tag>[];
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.diveLog_edit_section_tags),
+        content: StatefulBuilder(
+          builder: (ctx, setSt) => TagInputWidget(
+            selectedTags: picked,
+            onTagsChanged: (t) => setSt(() => picked = t),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(context.l10n.diveLog_edit_cancel),
+          ),
+          FilledButton(
+            onPressed: () {
+              _addTagMembers(picked);
+              Navigator.pop(ctx);
+            },
+            child: Text(context.l10n.diveLog_edit_add),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _addTagMembers(List<Tag> tags) {
+    setState(() {
+      final existing = _tagMembers.map((e) => e.id).toSet();
+      _tagMembers = [
+        ..._tagMembers,
+        for (final t in tags)
+          if (!existing.contains(t.id))
+            BulkMembershipItem(
+              id: t.id,
+              label: t.name,
+              icon: Icons.label_outline,
+            ),
+      ];
+    });
+  }
+
+  void _bulkAddDiveTypes() {
+    var picked = <String>[];
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.diveLog_edit_label_diveTypes),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: StatefulBuilder(
+            builder: (ctx, setSt) => DiveTypeMultiSelectField(
+              selectedTypeIds: picked,
+              allowEmpty: true,
+              onChanged: (ids) => setSt(() => picked = ids),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(context.l10n.diveLog_edit_cancel),
+          ),
+          FilledButton(
+            onPressed: () {
+              _addDiveTypeMembers(picked);
+              Navigator.pop(ctx);
+            },
+            child: Text(context.l10n.diveLog_edit_add),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _addDiveTypeMembers(List<String> ids) {
+    setState(() {
+      final existing = _diveTypeMembers.map((e) => e.id).toSet();
+      _diveTypeMembers = [
+        ..._diveTypeMembers,
+        for (final id in ids)
+          if (!existing.contains(id))
+            BulkMembershipItem(
+              id: id,
+              label: _diveTypeNames[id] ?? id,
+              icon: Icons.scuba_diving,
+            ),
+      ];
+    });
+  }
+
+  void _bulkAddBuddies() {
+    var picked = <BuddyWithRole>[];
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.diveLog_edit_group_buddies),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: StatefulBuilder(
+            builder: (ctx, setSt) => BuddyPicker(
+              selectedBuddies: picked,
+              onChanged: (b) => setSt(() => picked = b),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(context.l10n.diveLog_edit_cancel),
+          ),
+          FilledButton(
+            onPressed: () {
+              _addBuddyMembers(picked);
+              Navigator.pop(ctx);
+            },
+            child: Text(context.l10n.diveLog_edit_add),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _addBuddyMembers(List<BuddyWithRole> buddies) {
+    setState(() {
+      final existing = _buddyMembers.map((e) => e.id).toSet();
+      for (final bwr in buddies) {
+        _buddyById[bwr.buddy.id] = bwr.buddy;
+      }
+      _buddyMembers = [
+        ..._buddyMembers,
+        for (final bwr in buddies)
+          if (!existing.contains(bwr.buddy.id))
+            BulkMembershipItem(
+              id: bwr.buddy.id,
+              label: bwr.buddy.name,
+              icon: Icons.person_outline,
+            ),
+      ];
+    });
+  }
+
+  BuddyWithRole _buddyWithRole(String id) => BuddyWithRole(
+    buddy:
+        _buddyById[id] ??
+        Buddy(
+          id: id,
+          name: '',
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+    role: BuddyRole.buddy,
+  );
 
   void _saveEquipmentAsSet() {
     if (_selectedEquipment.isEmpty) return;

--- a/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
@@ -191,16 +191,12 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
         presence == MembershipPresence.none
             ? null
             : l10n.diveLog_bulkEdit_membership_removing,
-      MembershipChoice.leaveAsIs => switch (presence) {
-        MembershipPresence.some => l10n.diveLog_bulkEdit_membership_onSome(
-          count,
-          widget.totalDives,
-        ),
-        MembershipPresence.all => l10n.diveLog_bulkEdit_membership_onAll(
-          widget.totalDives,
-        ),
-        MembershipPresence.none => null,
-      },
+      // leaveAsIs only arises for a "some" item (all/none default to a
+      // definite choice), so any other presence is a no-op -> no status line.
+      MembershipChoice.leaveAsIs =>
+        presence == MembershipPresence.some
+            ? l10n.diveLog_bulkEdit_membership_onSome(count, widget.totalDives)
+            : null,
     };
   }
 

--- a/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
@@ -173,30 +173,34 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
     MembershipChoice.leaveAsIs => null,
   };
 
-  String _subtitle(BuildContext context, String id) {
+  /// The status line for a row, or null when the choice is a no-op for this
+  /// item (e.g. a just-added "none" item toggled back off) so the subtitle
+  /// never claims a change the delta won't actually make.
+  String? _subtitle(BuildContext context, String id) {
     final l10n = context.l10n;
     final presence = _presenceOf(id);
     final choice = _choices[id] ?? _defaultChoice(presence);
     final count = widget.counts[id] ?? 0;
-    if (choice == MembershipChoice.ensureOn &&
-        presence != MembershipPresence.all) {
-      return l10n.diveLog_bulkEdit_membership_adding(widget.totalDives);
-    }
-    if (choice == MembershipChoice.ensureOff &&
-        presence != MembershipPresence.none) {
-      return l10n.diveLog_bulkEdit_membership_removing;
-    }
-    return switch (presence) {
-      MembershipPresence.all => l10n.diveLog_bulkEdit_membership_onAll(
-        widget.totalDives,
-      ),
-      MembershipPresence.some => l10n.diveLog_bulkEdit_membership_onSome(
-        count,
-        widget.totalDives,
-      ),
-      MembershipPresence.none => l10n.diveLog_bulkEdit_membership_adding(
-        widget.totalDives,
-      ),
+    return switch (choice) {
+      MembershipChoice.ensureOn =>
+        presence == MembershipPresence.all
+            ? l10n.diveLog_bulkEdit_membership_onAll(widget.totalDives)
+            : l10n.diveLog_bulkEdit_membership_adding(widget.totalDives),
+      // "off" on an item that's on no dives changes nothing -> no status line.
+      MembershipChoice.ensureOff =>
+        presence == MembershipPresence.none
+            ? null
+            : l10n.diveLog_bulkEdit_membership_removing,
+      MembershipChoice.leaveAsIs => switch (presence) {
+        MembershipPresence.some => l10n.diveLog_bulkEdit_membership_onSome(
+          count,
+          widget.totalDives,
+        ),
+        MembershipPresence.all => l10n.diveLog_bulkEdit_membership_onAll(
+          widget.totalDives,
+        ),
+        MembershipPresence.none => null,
+      },
     };
   }
 
@@ -259,7 +263,10 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
                     Expanded(child: Text(item.label)),
                   ],
                 ),
-                subtitle: Text(_subtitle(context, item.id)),
+                subtitle: switch (_subtitle(context, item.id)) {
+                  final s? => Text(s),
+                  _ => null,
+                },
                 onTap: () => _cycle(item.id),
               ),
         ],

--- a/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Initial presence of an item across the selected dives.
 enum MembershipPresence { all, some, none }
@@ -51,5 +53,217 @@ class MembershipDelta {
       }
     }
     return MembershipDelta(add, remove);
+  }
+}
+
+/// A tri-state membership editor for one id-based collection in bulk mode.
+///
+/// Shows every [items] row with a tri-state checkbox reflecting how many of
+/// the [totalDives] selected dives currently have it (from [counts]):
+/// checked = on all, dash = on some (leave as-is), and lets the user ensure
+/// an item onto all or off all dives. Reports the resulting add/remove sets
+/// via [onChanged]. The parent owns the [items] list and handles [onAdd]
+/// (opening the collection's picker to bring in new items).
+class BulkMembershipEditor extends StatefulWidget {
+  const BulkMembershipEditor({
+    super.key,
+    required this.title,
+    required this.totalDives,
+    required this.items,
+    required this.counts,
+    required this.onAdd,
+    required this.onChanged,
+    this.addLabel,
+    this.secondaryAction,
+  });
+
+  final String title;
+  final int totalDives;
+  final List<BulkMembershipItem> items;
+  final Map<String, int> counts;
+  final VoidCallback onAdd;
+  final ValueChanged<MembershipDelta> onChanged;
+  final String? addLabel;
+  final Widget? secondaryAction;
+
+  @override
+  State<BulkMembershipEditor> createState() => _BulkMembershipEditorState();
+}
+
+class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
+  final Map<String, MembershipChoice> _choices = {};
+
+  @override
+  void initState() {
+    super.initState();
+    for (final item in widget.items) {
+      _choices[item.id] = _defaultChoice(_presenceOf(item.id));
+    }
+    // Emit the baseline so the parent has a delta before any interaction.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onChanged(_delta());
+    });
+  }
+
+  @override
+  void didUpdateWidget(BulkMembershipEditor old) {
+    super.didUpdateWidget(old);
+    final ids = widget.items.map((e) => e.id).toSet();
+    var changed = false;
+    for (final item in widget.items) {
+      if (!_choices.containsKey(item.id)) {
+        _choices[item.id] = _defaultChoice(_presenceOf(item.id));
+        changed = true;
+      }
+    }
+    final before = _choices.length;
+    _choices.removeWhere((id, _) => !ids.contains(id));
+    changed = changed || _choices.length != before;
+    if (changed) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onChanged(_delta());
+      });
+    }
+  }
+
+  MembershipPresence _presenceOf(String id) {
+    final c = widget.counts[id] ?? 0;
+    if (widget.totalDives > 0 && c >= widget.totalDives) {
+      return MembershipPresence.all;
+    }
+    if (c <= 0) return MembershipPresence.none;
+    return MembershipPresence.some;
+  }
+
+  MembershipChoice _defaultChoice(MembershipPresence p) => switch (p) {
+    MembershipPresence.all => MembershipChoice.ensureOn,
+    MembershipPresence.none => MembershipChoice.ensureOn,
+    MembershipPresence.some => MembershipChoice.leaveAsIs,
+  };
+
+  MembershipDelta _delta() => MembershipDelta.from({
+    for (final item in widget.items) item.id: _presenceOf(item.id),
+  }, _choices);
+
+  void _cycle(String id) {
+    final presence = _presenceOf(id);
+    final current = _choices[id] ?? _defaultChoice(presence);
+    setState(() => _choices[id] = _next(presence, current));
+    widget.onChanged(_delta());
+  }
+
+  // "some" items cycle through all three states so the user can add-to-all,
+  // remove-from-all, or leave the mix untouched; "all"/"none" items toggle.
+  MembershipChoice _next(MembershipPresence p, MembershipChoice c) {
+    if (p == MembershipPresence.some) {
+      return switch (c) {
+        MembershipChoice.leaveAsIs => MembershipChoice.ensureOn,
+        MembershipChoice.ensureOn => MembershipChoice.ensureOff,
+        MembershipChoice.ensureOff => MembershipChoice.leaveAsIs,
+      };
+    }
+    return c == MembershipChoice.ensureOn
+        ? MembershipChoice.ensureOff
+        : MembershipChoice.ensureOn;
+  }
+
+  bool? _checkboxValue(MembershipChoice c) => switch (c) {
+    MembershipChoice.ensureOn => true,
+    MembershipChoice.ensureOff => false,
+    MembershipChoice.leaveAsIs => null,
+  };
+
+  String _subtitle(BuildContext context, String id) {
+    final l10n = context.l10n;
+    final presence = _presenceOf(id);
+    final choice = _choices[id] ?? _defaultChoice(presence);
+    final count = widget.counts[id] ?? 0;
+    if (choice == MembershipChoice.ensureOn &&
+        presence != MembershipPresence.all) {
+      return l10n.diveLog_bulkEdit_membership_adding(widget.totalDives);
+    }
+    if (choice == MembershipChoice.ensureOff &&
+        presence != MembershipPresence.none) {
+      return l10n.diveLog_bulkEdit_membership_removing;
+    }
+    return switch (presence) {
+      MembershipPresence.all => l10n.diveLog_bulkEdit_membership_onAll(
+        widget.totalDives,
+      ),
+      MembershipPresence.some => l10n.diveLog_bulkEdit_membership_onSome(
+        count,
+        widget.totalDives,
+      ),
+      MembershipPresence.none => l10n.diveLog_bulkEdit_membership_adding(
+        widget.totalDives,
+      ),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 10, 14, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(widget.title, style: theme.textTheme.titleMedium),
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ?widget.secondaryAction,
+                  TextButton.icon(
+                    onPressed: widget.onAdd,
+                    icon: const Icon(Icons.add, size: 18),
+                    label: Text(widget.addLabel ?? l10n.diveLog_edit_add),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          if (widget.items.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: Text(
+                l10n.diveLog_bulkEdit_membership_empty,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            )
+          else
+            for (final item in widget.items)
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: Checkbox(
+                  key: ValueKey('membership-toggle-${item.id}'),
+                  tristate: true,
+                  value: _checkboxValue(
+                    _choices[item.id] ?? _defaultChoice(_presenceOf(item.id)),
+                  ),
+                  onChanged: (_) => _cycle(item.id),
+                ),
+                title: Row(
+                  children: [
+                    if (item.icon != null) ...[
+                      Icon(item.icon, size: 18),
+                      const SizedBox(width: 8),
+                    ],
+                    Expanded(child: Text(item.label)),
+                  ],
+                ),
+                subtitle: Text(_subtitle(context, item.id)),
+                onTap: () => _cycle(item.id),
+              ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/widgets.dart';
+
+/// Initial presence of an item across the selected dives.
+enum MembershipPresence { all, some, none }
+
+/// The desired end-state the user picked for an item in a bulk edit.
+///
+/// - [ensureOn]: the item must end up on ALL selected dives.
+/// - [ensureOff]: the item must end up on NONE of the selected dives.
+/// - [leaveAsIs]: do not change membership (the safe default for "on some").
+enum MembershipChoice { ensureOn, ensureOff, leaveAsIs }
+
+/// One row in the bulk membership editor: a display label + optional icon.
+class BulkMembershipItem {
+  final String id;
+  final String label;
+  final IconData? icon;
+  const BulkMembershipItem({required this.id, required this.label, this.icon});
+}
+
+/// Pure derivation of the (addIds, removeIds) to apply, given each item's
+/// initial presence across the selection and the user's chosen end-state.
+///
+/// A checked item that was not already on all dives becomes an add; an
+/// unchecked item that was on some/all becomes a remove; "leave as-is" (and
+/// no-op cases like checking an already-on-all item) produce nothing.
+class MembershipDelta {
+  final List<String> addIds;
+  final List<String> removeIds;
+  const MembershipDelta(this.addIds, this.removeIds);
+
+  static const empty = MembershipDelta([], []);
+
+  bool get isEmpty => addIds.isEmpty && removeIds.isEmpty;
+
+  static MembershipDelta from(
+    Map<String, MembershipPresence> initial,
+    Map<String, MembershipChoice> choices,
+  ) {
+    final add = <String>[];
+    final remove = <String>[];
+    for (final entry in choices.entries) {
+      final presence = initial[entry.key] ?? MembershipPresence.none;
+      switch (entry.value) {
+        case MembershipChoice.ensureOn:
+          if (presence != MembershipPresence.all) add.add(entry.key);
+        case MembershipChoice.ensureOff:
+          if (presence != MembershipPresence.none) remove.add(entry.key);
+        case MembershipChoice.leaveAsIs:
+          break;
+      }
+    }
+    return MembershipDelta(add, remove);
+  }
+}

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "اختيار موقع التخزين",
   "db_location_internal": "التخزين الداخلي",
   "db_location_sd_card": "بطاقة SD",
-  "db_location_external_note": "تُحذف الملفات هنا عند إلغاء تثبيت التطبيق."
+  "db_location_external_note": "تُحذف الملفات هنا عند إلغاء تثبيت التطبيق.",
+  "diveLog_bulkEdit_membership_onAll": "في كل الـ {count}",
+  "diveLog_bulkEdit_membership_onSome": "في {count} من {total}",
+  "diveLog_bulkEdit_membership_adding": "إضافة إلى كل الـ {total}",
+  "diveLog_bulkEdit_membership_removing": "إزالة من الكل",
+  "diveLog_bulkEdit_membership_empty": "لا توجد عناصر في الغطسات المحددة بعد"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Speicherort wählen",
   "db_location_internal": "Interner Speicher",
   "db_location_sd_card": "SD-Karte",
-  "db_location_external_note": "Dateien hier werden entfernt, wenn Sie die App deinstallieren."
+  "db_location_external_note": "Dateien hier werden entfernt, wenn Sie die App deinstallieren.",
+  "diveLog_bulkEdit_membership_onAll": "auf allen {count}",
+  "diveLog_bulkEdit_membership_onSome": "auf {count} von {total}",
+  "diveLog_bulkEdit_membership_adding": "wird zu allen {total} hinzugefügt",
+  "diveLog_bulkEdit_membership_removing": "wird von allen entfernt",
+  "diveLog_bulkEdit_membership_empty": "Noch keine Elemente bei den ausgewählten Tauchgängen"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -11051,5 +11051,15 @@
   "db_location_choose_volume": "Choose storage location",
   "db_location_internal": "Internal storage",
   "db_location_sd_card": "SD card",
-  "db_location_external_note": "Files here are removed if you uninstall the app."
+  "db_location_external_note": "Files here are removed if you uninstall the app.",
+  "diveLog_bulkEdit_membership_onAll": "on all {count}",
+  "@diveLog_bulkEdit_membership_onAll": { "placeholders": { "count": { "type": "int" } } },
+  "diveLog_bulkEdit_membership_onSome": "on {count} of {total}",
+  "@diveLog_bulkEdit_membership_onSome": { "placeholders": { "count": { "type": "int" }, "total": { "type": "int" } } },
+  "diveLog_bulkEdit_membership_adding": "adding to all {total}",
+  "@diveLog_bulkEdit_membership_adding": { "placeholders": { "total": { "type": "int" } } },
+  "diveLog_bulkEdit_membership_removing": "removing from all",
+  "@diveLog_bulkEdit_membership_removing": {},
+  "diveLog_bulkEdit_membership_empty": "No items on the selected dives yet",
+  "@diveLog_bulkEdit_membership_empty": {}
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Elegir ubicación de almacenamiento",
   "db_location_internal": "Almacenamiento interno",
   "db_location_sd_card": "Tarjeta SD",
-  "db_location_external_note": "Los archivos aquí se eliminan si desinstalas la aplicación."
+  "db_location_external_note": "Los archivos aquí se eliminan si desinstalas la aplicación.",
+  "diveLog_bulkEdit_membership_onAll": "en todas las {count}",
+  "diveLog_bulkEdit_membership_onSome": "en {count} de {total}",
+  "diveLog_bulkEdit_membership_adding": "añadiendo a todas ({total})",
+  "diveLog_bulkEdit_membership_removing": "quitando de todas",
+  "diveLog_bulkEdit_membership_empty": "Aún no hay elementos en las inmersiones seleccionadas"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Choisir l'emplacement de stockage",
   "db_location_internal": "Stockage interne",
   "db_location_sd_card": "Carte SD",
-  "db_location_external_note": "Les fichiers ici sont supprimés si vous désinstallez l'application."
+  "db_location_external_note": "Les fichiers ici sont supprimés si vous désinstallez l'application.",
+  "diveLog_bulkEdit_membership_onAll": "sur toutes les {count}",
+  "diveLog_bulkEdit_membership_onSome": "sur {count} sur {total}",
+  "diveLog_bulkEdit_membership_adding": "ajout à toutes les {total}",
+  "diveLog_bulkEdit_membership_removing": "retrait de toutes",
+  "diveLog_bulkEdit_membership_empty": "Aucun élément sur les plongées sélectionnées pour l'instant"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "בחירת מיקום אחסון",
   "db_location_internal": "אחסון פנימי",
   "db_location_sd_card": "כרטיס SD",
-  "db_location_external_note": "הקבצים כאן נמחקים אם מסירים את האפליקציה."
+  "db_location_external_note": "הקבצים כאן נמחקים אם מסירים את האפליקציה.",
+  "diveLog_bulkEdit_membership_onAll": "בכל {count}",
+  "diveLog_bulkEdit_membership_onSome": "ב-{count} מתוך {total}",
+  "diveLog_bulkEdit_membership_adding": "מוסיף לכל {total}",
+  "diveLog_bulkEdit_membership_removing": "מסיר מהכול",
+  "diveLog_bulkEdit_membership_empty": "אין עדיין פריטים בצלילות שנבחרו"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Tárhely kiválasztása",
   "db_location_internal": "Belső tárhely",
   "db_location_sd_card": "SD-kártya",
-  "db_location_external_note": "Az itt tárolt fájlok törlődnek, ha eltávolítja az alkalmazást."
+  "db_location_external_note": "Az itt tárolt fájlok törlődnek, ha eltávolítja az alkalmazást.",
+  "diveLog_bulkEdit_membership_onAll": "mind a {count} merülésen",
+  "diveLog_bulkEdit_membership_onSome": "{count}/{total} merülésen",
+  "diveLog_bulkEdit_membership_adding": "hozzáadás mind a {total} merüléshez",
+  "diveLog_bulkEdit_membership_removing": "eltávolítás az összesből",
+  "diveLog_bulkEdit_membership_empty": "Még nincsenek elemek a kiválasztott merüléseken"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Scegli posizione di archiviazione",
   "db_location_internal": "Memoria interna",
   "db_location_sd_card": "Scheda SD",
-  "db_location_external_note": "I file qui vengono rimossi se disinstalli l'app."
+  "db_location_external_note": "I file qui vengono rimossi se disinstalli l'app.",
+  "diveLog_bulkEdit_membership_onAll": "su tutte le {count}",
+  "diveLog_bulkEdit_membership_onSome": "su {count} di {total}",
+  "diveLog_bulkEdit_membership_adding": "aggiunta a tutte le {total}",
+  "diveLog_bulkEdit_membership_removing": "rimozione da tutte",
+  "diveLog_bulkEdit_membership_empty": "Ancora nessun elemento nelle immersioni selezionate"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -30361,6 +30361,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Files here are removed if you uninstall the app.'**
   String get db_location_external_note;
+
+  /// No description provided for @diveLog_bulkEdit_membership_onAll.
+  ///
+  /// In en, this message translates to:
+  /// **'on all {count}'**
+  String diveLog_bulkEdit_membership_onAll(int count);
+
+  /// No description provided for @diveLog_bulkEdit_membership_onSome.
+  ///
+  /// In en, this message translates to:
+  /// **'on {count} of {total}'**
+  String diveLog_bulkEdit_membership_onSome(int count, int total);
+
+  /// No description provided for @diveLog_bulkEdit_membership_adding.
+  ///
+  /// In en, this message translates to:
+  /// **'adding to all {total}'**
+  String diveLog_bulkEdit_membership_adding(int total);
+
+  /// No description provided for @diveLog_bulkEdit_membership_removing.
+  ///
+  /// In en, this message translates to:
+  /// **'removing from all'**
+  String get diveLog_bulkEdit_membership_removing;
+
+  /// No description provided for @diveLog_bulkEdit_membership_empty.
+  ///
+  /// In en, this message translates to:
+  /// **'No items on the selected dives yet'**
+  String get diveLog_bulkEdit_membership_empty;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -17768,4 +17768,26 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'تُحذف الملفات هنا عند إلغاء تثبيت التطبيق.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'في كل الـ $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'في $count من $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'إضافة إلى كل الـ $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'إزالة من الكل';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'لا توجد عناصر في الغطسات المحددة بعد';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -18073,4 +18073,26 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Dateien hier werden entfernt, wenn Sie die App deinstallieren.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'auf allen $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'auf $count von $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'wird zu allen $total hinzugefügt';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'wird von allen entfernt';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Noch keine Elemente bei den ausgewählten Tauchgängen';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -17804,4 +17804,26 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Files here are removed if you uninstall the app.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'on all $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'on $count of $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'adding to all $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'removing from all';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'No items on the selected dives yet';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -18114,4 +18114,26 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Los archivos aquí se eliminan si desinstalas la aplicación.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'en todas las $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'en $count de $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'añadiendo a todas ($total)';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'quitando de todas';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Aún no hay elementos en las inmersiones seleccionadas';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -18168,4 +18168,26 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Les fichiers ici sont supprimés si vous désinstallez l\'application.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'sur toutes les $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'sur $count sur $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'ajout à toutes les $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'retrait de toutes';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Aucun élément sur les plongées sélectionnées pour l\'instant';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -17642,4 +17642,26 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'הקבצים כאן נמחקים אם מסירים את האפליקציה.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'בכל $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'ב-$count מתוך $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'מוסיף לכל $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'מסיר מהכול';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'אין עדיין פריטים בצלילות שנבחרו';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -18057,4 +18057,26 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Az itt tárolt fájlok törlődnek, ha eltávolítja az alkalmazást.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'mind a $count merülésen';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return '$count/$total merülésen';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'hozzáadás mind a $total merüléshez';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'eltávolítás az összesből';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Még nincsenek elemek a kiválasztott merüléseken';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -18104,4 +18104,26 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'I file qui vengono rimossi se disinstalli l\'app.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'su tutte le $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'su $count di $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'aggiunta a tutte le $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'rimozione da tutte';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Ancora nessun elemento nelle immersioni selezionate';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -17960,4 +17960,26 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Bestanden hier worden verwijderd als je de app verwijdert.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'op alle $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'op $count van $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'toevoegen aan alle $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'verwijderen van alle';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Nog geen items bij de geselecteerde duiken';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -18112,4 +18112,26 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get db_location_external_note =>
       'Os arquivos aqui são removidos se você desinstalar o aplicativo.';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return 'em todos os $count';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return 'em $count de $total';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return 'adicionando a todos os $total';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => 'removendo de todos';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty =>
+      'Ainda não há itens nos mergulhos selecionados';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -17233,4 +17233,25 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get db_location_external_note => '卸载应用后，此处的文件将被删除。';
+
+  @override
+  String diveLog_bulkEdit_membership_onAll(int count) {
+    return '全部 $count 次潜水';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_onSome(int count, int total) {
+    return '$count/$total 次潜水';
+  }
+
+  @override
+  String diveLog_bulkEdit_membership_adding(int total) {
+    return '添加到全部 $total 次';
+  }
+
+  @override
+  String get diveLog_bulkEdit_membership_removing => '从全部移除';
+
+  @override
+  String get diveLog_bulkEdit_membership_empty => '所选潜水尚无项目';
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Opslaglocatie kiezen",
   "db_location_internal": "Interne opslag",
   "db_location_sd_card": "SD-kaart",
-  "db_location_external_note": "Bestanden hier worden verwijderd als je de app verwijdert."
+  "db_location_external_note": "Bestanden hier worden verwijderd als je de app verwijdert.",
+  "diveLog_bulkEdit_membership_onAll": "op alle {count}",
+  "diveLog_bulkEdit_membership_onSome": "op {count} van {total}",
+  "diveLog_bulkEdit_membership_adding": "toevoegen aan alle {total}",
+  "diveLog_bulkEdit_membership_removing": "verwijderen van alle",
+  "diveLog_bulkEdit_membership_empty": "Nog geen items bij de geselecteerde duiken"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "Escolher local de armazenamento",
   "db_location_internal": "Armazenamento interno",
   "db_location_sd_card": "Cartão SD",
-  "db_location_external_note": "Os arquivos aqui são removidos se você desinstalar o aplicativo."
+  "db_location_external_note": "Os arquivos aqui são removidos se você desinstalar o aplicativo.",
+  "diveLog_bulkEdit_membership_onAll": "em todos os {count}",
+  "diveLog_bulkEdit_membership_onSome": "em {count} de {total}",
+  "diveLog_bulkEdit_membership_adding": "adicionando a todos os {total}",
+  "diveLog_bulkEdit_membership_removing": "removendo de todos",
+  "diveLog_bulkEdit_membership_empty": "Ainda não há itens nos mergulhos selecionados"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5116,5 +5116,10 @@
   "db_location_choose_volume": "选择存储位置",
   "db_location_internal": "内部存储",
   "db_location_sd_card": "SD卡",
-  "db_location_external_note": "卸载应用后，此处的文件将被删除。"
+  "db_location_external_note": "卸载应用后，此处的文件将被删除。",
+  "diveLog_bulkEdit_membership_onAll": "全部 {count} 次潜水",
+  "diveLog_bulkEdit_membership_onSome": "{count}/{total} 次潜水",
+  "diveLog_bulkEdit_membership_adding": "添加到全部 {total} 次",
+  "diveLog_bulkEdit_membership_removing": "从全部移除",
+  "diveLog_bulkEdit_membership_empty": "所选潜水尚无项目"
 }

--- a/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
+++ b/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
@@ -43,6 +43,15 @@ void main() {
     expect(d2.length, 2);
   });
 
+  test('buddyCountsForDives returns per-buddy dive counts', () async {
+    await repository.bulkAddBuddies(['d1', 'd2'], [bwr('shared')]);
+    await repository.bulkAddBuddies(['d1'], [bwr('onlyD1')]);
+    final counts = await repository.buddyCountsForDives(['d1', 'd2']);
+    expect(counts['shared'], 2);
+    expect(counts['onlyD1'], 1);
+    expect(await repository.buddyCountsForDives(const []), isEmpty);
+  });
+
   test('bulkReplaceBuddies overwrites; bulkRemoveBuddies subtracts', () async {
     await repository.bulkAddBuddies(['d1'], [bwr('x'), bwr('y')]);
     await repository.bulkReplaceBuddies(['d1'], [bwr('z')]);

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -138,24 +138,59 @@ void main() {
       expect(rows.map((r) => r.equipmentId).toSet(), {'e9'});
     });
 
-    test('add merges with pre-existing gear on each dive, never wipes', () async {
-      // Reproduces the r/submersion report: d1 has e1, d2 has e2.
-      await seed('d1');
-      await seed('d2');
-      await repository.bulkAddEquipment(['d1'], ['e1']);
-      await repository.bulkAddEquipment(['d2'], ['e2']);
+    test(
+      'add merges with pre-existing gear on each dive, never wipes',
+      () async {
+        // Reproduces the r/submersion report: d1 has e1, d2 has e2.
+        await seed('d1');
+        await seed('d2');
+        await repository.bulkAddEquipment(['d1'], ['e1']);
+        await repository.bulkAddEquipment(['d2'], ['e2']);
 
-      // Bulk-add e3 to BOTH dives; existing gear must survive.
-      await repository.bulkAddEquipment(['d1', 'd2'], ['e3']);
+        // Bulk-add e3 to BOTH dives; existing gear must survive.
+        await repository.bulkAddEquipment(['d1', 'd2'], ['e3']);
 
-      final d1 = await (db.select(
-        db.diveEquipment,
-      )..where((t) => t.diveId.equals('d1'))).get();
-      final d2 = await (db.select(
-        db.diveEquipment,
-      )..where((t) => t.diveId.equals('d2'))).get();
-      expect(d1.map((r) => r.equipmentId).toSet(), {'e1', 'e3'});
-      expect(d2.map((r) => r.equipmentId).toSet(), {'e2', 'e3'});
+        final d1 = await (db.select(
+          db.diveEquipment,
+        )..where((t) => t.diveId.equals('d1'))).get();
+        final d2 = await (db.select(
+          db.diveEquipment,
+        )..where((t) => t.diveId.equals('d2'))).get();
+        expect(d1.map((r) => r.equipmentId).toSet(), {'e1', 'e3'});
+        expect(d2.map((r) => r.equipmentId).toSet(), {'e2', 'e3'});
+      },
+    );
+  });
+
+  group('membership counts', () {
+    setUp(() async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+    });
+
+    test('equipmentCountsForDives returns per-item dive counts', () async {
+      await repository.bulkAddEquipment(['d1', 'd2'], ['shared']); // both
+      await repository.bulkAddEquipment(['d1'], ['onlyD1']); // one
+      final counts = await repository.equipmentCountsForDives(['d1', 'd2']);
+      expect(counts['shared'], 2);
+      expect(counts['onlyD1'], 1);
+      expect(counts.containsKey('missing'), isFalse);
+      expect(await repository.equipmentCountsForDives(const []), isEmpty);
+    });
+
+    test('tagCountsForDives returns per-tag dive counts', () async {
+      await repository.bulkAddTags(['d1', 'd2'], ['shared']);
+      await repository.bulkAddTags(['d1'], ['onlyD1']);
+      final counts = await repository.tagCountsForDives(['d1', 'd2']);
+      expect(counts['shared'], 2);
+      expect(counts['onlyD1'], 1);
+    });
+
+    test('diveTypeCountsForDives returns per-type dive counts', () async {
+      await repository.bulkAddDiveTypes(['d1', 'd2'], ['shared']);
+      await repository.bulkAddDiveTypes(['d1'], ['onlyD1']);
+      final counts = await repository.diveTypeCountsForDives(['d1', 'd2']);
+      expect(counts['shared'], 2);
+      expect(counts['onlyD1'], 1);
     });
   });
 

--- a/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_bulk_test.dart
@@ -137,6 +137,26 @@ void main() {
       )..where((t) => t.diveId.equals('d1'))).get();
       expect(rows.map((r) => r.equipmentId).toSet(), {'e9'});
     });
+
+    test('add merges with pre-existing gear on each dive, never wipes', () async {
+      // Reproduces the r/submersion report: d1 has e1, d2 has e2.
+      await seed('d1');
+      await seed('d2');
+      await repository.bulkAddEquipment(['d1'], ['e1']);
+      await repository.bulkAddEquipment(['d2'], ['e2']);
+
+      // Bulk-add e3 to BOTH dives; existing gear must survive.
+      await repository.bulkAddEquipment(['d1', 'd2'], ['e3']);
+
+      final d1 = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      final d2 = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('d2'))).get();
+      expect(d1.map((r) => r.equipmentId).toSet(), {'e1', 'e3'});
+      expect(d2.map((r) => r.equipmentId).toSet(), {'e2', 'e3'});
+    });
   });
 
   group('bulk tanks', () {

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -249,6 +249,27 @@ void main() {
     expect(await buddiesOf('d1'), isEmpty);
   });
 
+  test('EquipmentOp add preserves existing gear on each dive', () async {
+    // Reproduces the r/submersion report at the service layer: adding one
+    // item in bulk must not wipe gear the dive already has.
+    await seed('d1');
+    await diveRepo.bulkAddEquipment(['d1'], ['origEq']);
+
+    await service.apply(
+      BulkEditRequest(
+        diveIds: const ['d1'],
+        ops: [
+          const EquipmentOp(
+            mode: BulkCollectionMode.add,
+            equipmentIds: ['newEq'],
+          ),
+        ],
+      ),
+    );
+
+    expect((await equipOf('d1')).toSet(), {'origEq', 'newEq'});
+  });
+
   test(
     'apply with no dives returns an empty snapshot; undo is a no-op',
     () async {

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -256,13 +256,10 @@ void main() {
     await diveRepo.bulkAddEquipment(['d1'], ['origEq']);
 
     await service.apply(
-      BulkEditRequest(
-        diveIds: const ['d1'],
+      const BulkEditRequest(
+        diveIds: ['d1'],
         ops: [
-          const EquipmentOp(
-            mode: BulkCollectionMode.add,
-            equipmentIds: ['newEq'],
-          ),
+          EquipmentOp(mode: BulkCollectionMode.add, equipmentIds: ['newEq']),
         ],
       ),
     );
@@ -279,14 +276,11 @@ void main() {
       await diveRepo.bulkAddEquipment(['d1'], ['keep', 'drop']);
 
       final snap = await service.apply(
-        BulkEditRequest(
-          diveIds: const ['d1'],
+        const BulkEditRequest(
+          diveIds: ['d1'],
           ops: [
-            const EquipmentOp(
-              mode: BulkCollectionMode.add,
-              equipmentIds: ['added'],
-            ),
-            const EquipmentOp(
+            EquipmentOp(mode: BulkCollectionMode.add, equipmentIds: ['added']),
+            EquipmentOp(
               mode: BulkCollectionMode.remove,
               equipmentIds: ['drop'],
             ),

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -271,6 +271,36 @@ void main() {
   });
 
   test(
+    'apply handles simultaneous add + remove ops for one collection',
+    () async {
+      // The tri-state editor decomposes into an AddOp + a RemoveOp; both must
+      // apply in one request and undo must restore the prior membership.
+      await seed('d1');
+      await diveRepo.bulkAddEquipment(['d1'], ['keep', 'drop']);
+
+      final snap = await service.apply(
+        BulkEditRequest(
+          diveIds: const ['d1'],
+          ops: [
+            const EquipmentOp(
+              mode: BulkCollectionMode.add,
+              equipmentIds: ['added'],
+            ),
+            const EquipmentOp(
+              mode: BulkCollectionMode.remove,
+              equipmentIds: ['drop'],
+            ),
+          ],
+        ),
+      );
+      expect((await equipOf('d1')).toSet(), {'keep', 'added'});
+
+      await service.undo(snap);
+      expect((await equipOf('d1')).toSet(), {'keep', 'drop'});
+    },
+  );
+
+  test(
     'apply with no dives returns an empty snapshot; undo is a no-op',
     () async {
       final snap = await service.apply(const BulkEditRequest(diveIds: []));

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -65,10 +65,11 @@ void main() {
       // (dive type moved from a scalar gate to the collection lane, #414)
       expect(find.byType(BulkFieldGate), findsNWidgets(26));
       expect(find.text('Favorite'), findsOneWidget);
-      // 6 collections still use a mode selector (tags, diveTypes, buddies,
-      // weights, tanks, sightings); equipment now uses the tri-state editor.
-      expect(find.byType(BulkCollectionModeSelector), findsNWidgets(6));
-      expect(find.byType(BulkMembershipEditor), findsOneWidget);
+      // Only the 3 owned collections (weights, tanks, sightings) still use a
+      // mode selector; the 4 reference collections (tags, diveTypes,
+      // equipment, buddies) use the tri-state membership editor.
+      expect(find.byType(BulkCollectionModeSelector), findsNWidgets(3));
+      expect(find.byType(BulkMembershipEditor), findsNWidgets(4));
     });
 
     testWidgets('equipment membership reflects current gear and a toggle', (
@@ -179,11 +180,22 @@ void main() {
       expect(find.byType(SnackBar), findsOneWidget);
     });
 
-    testWidgets('selecting a collection mode is included in the save', (
+    testWidgets('a membership toggle flows through the bulk apply to the DB', (
       tester,
     ) async {
+      const reg = EquipmentItem(
+        id: 'e1',
+        name: 'Regulator',
+        type: EquipmentType.regulator,
+      );
+      await EquipmentRepository().createEquipment(reg);
       final d1 = await repository.createDive(
-        createTestDiveWithBottomTime().copyWith(id: 'coll-1'),
+        Dive(
+          id: 'coll-1',
+          dateTime: DateTime(2026, 1, 1),
+          notes: '',
+          equipment: const [reg],
+        ),
       );
       final overrides = await getBaseOverrides();
       await tester.pumpWidget(
@@ -200,9 +212,10 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Turn on the first collection's "Add" mode (Tags).
-      await tester.ensureVisible(find.text('Add').first);
-      await tester.tap(find.text('Add').first);
+      // e1 is on the (single) dive -> checked. Toggle it off -> remove op.
+      final toggle = find.byKey(const ValueKey('membership-toggle-e1'));
+      await tester.ensureVisible(toggle);
+      await tester.tap(toggle);
       await tester.pumpAndSettle();
 
       await tester.ensureVisible(find.text('Save'));
@@ -211,8 +224,9 @@ void main() {
       await tester.tap(find.text('Apply'));
       await tester.pumpAndSettle();
 
-      // The apply path (collection op) ran and reported success.
+      // The apply path ran end-to-end: e1 was removed from the dive.
       expect(find.byType(SnackBar), findsOneWidget);
+      expect((await repository.getDiveById(d1.id))!.equipment, isEmpty);
     });
 
     testWidgets('OC mode with a rebreather field enabled is blocked', (

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -6,6 +6,11 @@ import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.d
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/bulk_collection_mode_selector.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/bulk_field_gate.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -60,9 +65,45 @@ void main() {
       // (dive type moved from a scalar gate to the collection lane, #414)
       expect(find.byType(BulkFieldGate), findsNWidgets(26));
       expect(find.text('Favorite'), findsOneWidget);
-      // 7 collections (tags, diveTypes, equipment, buddies, weights, tanks,
-      // sightings) each render a mode selector.
-      expect(find.byType(BulkCollectionModeSelector), findsNWidgets(7));
+      // 6 collections still use a mode selector (tags, diveTypes, buddies,
+      // weights, tanks, sightings); equipment now uses the tri-state editor.
+      expect(find.byType(BulkCollectionModeSelector), findsNWidgets(6));
+      expect(find.byType(BulkMembershipEditor), findsOneWidget);
+    });
+
+    testWidgets('equipment membership reflects current gear and a toggle', (
+      tester,
+    ) async {
+      const reg = EquipmentItem(
+        id: 'e1',
+        name: 'Regulator',
+        type: EquipmentType.regulator,
+      );
+      await EquipmentRepository().createEquipment(reg);
+      await repository.createDive(
+        Dive(
+          id: 'd1',
+          dateTime: DateTime(2026, 1, 1),
+          notes: '',
+          equipment: const [reg],
+        ),
+      );
+      await repository.createDive(
+        Dive(id: 'd2', dateTime: DateTime(2026, 1, 1), notes: ''),
+      );
+
+      await pumpBulk(tester);
+
+      // e1 is on 1 of the 2 selected dives.
+      expect(find.text('Regulator'), findsOneWidget);
+      expect(find.text('on 1 of 2'), findsOneWidget);
+
+      // Toggling a "some" item to on flips its subtitle to "adding to all 2".
+      final toggle = find.byKey(const ValueKey('membership-toggle-e1'));
+      await tester.ensureVisible(toggle);
+      await tester.tap(toggle);
+      await tester.pump();
+      expect(find.text('adding to all 2'), findsOneWidget);
     });
 
     testWidgets('toggling a gate enables its checkbox', (tester) async {

--- a/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
@@ -1,0 +1,322 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart' hide Buddy, Dive;
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_set_picker_sheet.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Covers the bulk tri-state membership wiring in DiveEditPage: loading members
+/// for every reference collection, the add-affordance dialogs/sheets, and the
+/// delta -> add/remove op path through apply.
+void main() {
+  group('DiveEditPage bulk membership wiring', () {
+    late DiveRepository repository;
+    late BuddyRepository buddyRepo;
+    late AppDatabase db;
+
+    setUp(() async {
+      db = await setUpTestDatabase();
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+      repository = DiveRepository();
+      buddyRepo = BuddyRepository();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    BuddyWithRole bwr(String id, String name) => BuddyWithRole(
+      buddy: Buddy(
+        id: id,
+        name: name,
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+      role: BuddyRole.buddy,
+    );
+
+    Future<void> seedTag(String id, String name) => db
+        .into(db.tags)
+        .insert(
+          TagsCompanion(
+            id: Value(id),
+            name: Value(name),
+            createdAt: const Value(0),
+            updatedAt: const Value(0),
+          ),
+        );
+
+    Future<void> seedBuddy(String id, String name) => db
+        .into(db.buddies)
+        .insert(
+          BuddiesCompanion(
+            id: Value(id),
+            name: Value(name),
+            createdAt: const Value(0),
+            updatedAt: const Value(0),
+          ),
+        );
+
+    Future<void> seedDive(String id) => repository.createDive(
+      Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: ''),
+    );
+
+    Future<void> pump(WidgetTester tester, List<String> ids) async {
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            diveRepositoryProvider.overrideWithValue(repository),
+            diveListNotifierProvider.overrideWith(
+              (ref) => DiveListNotifier(repository, ref),
+            ),
+            customTankPresetsProvider.overrideWith((ref) async => []),
+          ].cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(bulkDiveIds: ids, embedded: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    Finder editorFor(String title) => find.ancestor(
+      of: find.text(title),
+      matching: find.byType(BulkMembershipEditor),
+    );
+
+    Future<void> tapAdd(WidgetTester tester, String title) async {
+      final btn = find.descendant(
+        of: editorFor(title),
+        matching: find.widgetWithText(TextButton, 'Add'),
+      );
+      await tester.ensureVisible(btn);
+      await tester.tap(btn);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'loads and renders members for all four reference collections',
+      (tester) async {
+        await seedTag('t1', 'Nitrox');
+        await seedBuddy('b1', 'Alice');
+        await EquipmentRepository().createEquipment(
+          const EquipmentItem(
+            id: 'e1',
+            name: 'Regulator',
+            type: EquipmentType.regulator,
+          ),
+        );
+        await seedDive('d1');
+        await seedDive('d2');
+        await repository.bulkAddTags(['d1'], ['t1']);
+        await repository.bulkAddDiveTypes(['d1'], ['deep']);
+        await buddyRepo.bulkAddBuddies(['d1'], [bwr('b1', 'Alice')]);
+        await repository.bulkAddEquipment(['d1'], ['e1']);
+
+        await pump(tester, ['d1', 'd2']);
+
+        expect(find.byType(BulkMembershipEditor), findsNWidgets(4));
+        expect(find.text('Nitrox'), findsOneWidget);
+        expect(find.text('Alice'), findsOneWidget);
+        expect(find.text('Regulator'), findsOneWidget);
+        // Each seeded item is on 1 of the 2 selected dives.
+        expect(find.text('on 1 of 2'), findsNWidgets(4));
+
+        // Tapping a row body (not just the checkbox) also cycles the item.
+        await tester.ensureVisible(find.text('Nitrox'));
+        await tester.tap(find.text('Nitrox'));
+        await tester.pumpAndSettle();
+        expect(find.text('adding to all 2'), findsWidgets);
+      },
+    );
+
+    testWidgets('toggling seeded members off applies remove ops on save', (
+      tester,
+    ) async {
+      await seedTag('t1', 'Nitrox');
+      await seedBuddy('b1', 'Alice');
+      await seedDive('d1');
+      await repository.bulkAddTags(['d1'], ['t1']);
+      await repository.bulkAddDiveTypes(['d1'], ['deep', 'wreck']);
+      await buddyRepo.bulkAddBuddies(['d1'], [bwr('b1', 'Alice')]);
+
+      await pump(tester, ['d1']);
+
+      // Single dive -> each is "on all 1" (checked); toggle each off.
+      for (final id in ['t1', 'deep', 'b1']) {
+        final f = find.byKey(ValueKey('membership-toggle-$id'));
+        await tester.ensureVisible(f);
+        await tester.tap(f);
+        await tester.pumpAndSettle();
+      }
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      final tags = await (db.select(
+        db.diveTags,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      final types = await (db.select(
+        db.diveDiveTypes,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      final buddies = await (db.select(
+        db.diveBuddies,
+      )..where((t) => t.diveId.equals('d1'))).get();
+      expect(tags, isEmpty); // t1 removed
+      expect(buddies, isEmpty); // b1 removed
+      expect(
+        types.map((r) => r.diveTypeId),
+        isNot(contains('deep')),
+      ); // removed
+    });
+
+    testWidgets('toggling "some" members on applies add ops on save', (
+      tester,
+    ) async {
+      await seedTag('t1', 'Nitrox');
+      await seedBuddy('b1', 'Alice');
+      await EquipmentRepository().createEquipment(
+        const EquipmentItem(
+          id: 'e1',
+          name: 'Regulator',
+          type: EquipmentType.regulator,
+        ),
+      );
+      await seedDive('d1');
+      await seedDive('d2');
+      // Each seeded on d1 only -> "on 1 of 2" (some).
+      await repository.bulkAddTags(['d1'], ['t1']);
+      await repository.bulkAddDiveTypes(['d1'], ['deep']);
+      await buddyRepo.bulkAddBuddies(['d1'], [bwr('b1', 'Alice')]);
+      await repository.bulkAddEquipment(['d1'], ['e1']);
+
+      await pump(tester, ['d1', 'd2']);
+
+      // "some" (dash) + one tap -> ensureOn (add to all).
+      for (final id in ['t1', 'deep', 'b1', 'e1']) {
+        final f = find.byKey(ValueKey('membership-toggle-$id'));
+        await tester.ensureVisible(f);
+        await tester.tap(f);
+        await tester.pumpAndSettle();
+      }
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      // Each item was added to the previously-missing dive (d2).
+      final d2tags = await (db.select(
+        db.diveTags,
+      )..where((t) => t.diveId.equals('d2'))).get();
+      final d2types = await (db.select(
+        db.diveDiveTypes,
+      )..where((t) => t.diveId.equals('d2'))).get();
+      final d2buddies = await (db.select(
+        db.diveBuddies,
+      )..where((t) => t.diveId.equals('d2'))).get();
+      final d2equip = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('d2'))).get();
+      expect(d2tags.map((r) => r.tagId), contains('t1'));
+      expect(d2types.map((r) => r.diveTypeId), contains('deep'));
+      expect(d2buddies.map((r) => r.buddyId), contains('b1'));
+      expect(d2equip.map((r) => r.equipmentId), contains('e1'));
+    });
+
+    testWidgets('reference-collection add dialogs open and confirm safely', (
+      tester,
+    ) async {
+      await seedDive('d1');
+      await seedDive('d2');
+      await pump(tester, ['d1', 'd2']);
+
+      // Tags: typing a name creates + selects a tag, then confirm merges it
+      // as a member (covers onTagsChanged + the _addTagMembers construction).
+      await tapAdd(tester, 'Tags');
+      expect(find.byType(AlertDialog), findsOneWidget);
+      await tester.enterText(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.byType(TextField),
+        ),
+        'Deco',
+      );
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Add'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Deco'), findsOneWidget); // added as a tag member
+
+      // Dive Types and Buddies: open and confirm (empty is a safe no-op merge).
+      for (final title in const ['Dive Types', 'Buddies']) {
+        await tapAdd(tester, title);
+        expect(find.byType(AlertDialog), findsOneWidget);
+        await tester.tap(
+          find.descendant(
+            of: find.byType(AlertDialog),
+            matching: find.widgetWithText(FilledButton, 'Add'),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(AlertDialog), findsNothing);
+      }
+    });
+
+    testWidgets('equipment add and use-set open their pickers', (tester) async {
+      await EquipmentRepository().createEquipment(
+        const EquipmentItem(id: 'e9', name: 'Fins', type: EquipmentType.fins),
+      );
+      await seedDive('d1');
+      await seedDive('d2');
+      await pump(tester, ['d1', 'd2']);
+
+      // "+ Add" opens the equipment picker sheet.
+      await tapAdd(tester, 'Equipment');
+      expect(find.byType(EquipmentPickerSheet), findsOneWidget);
+      await tester.tapAt(const Offset(20, 20)); // dismiss
+      await tester.pumpAndSettle();
+
+      // "Use Set" opens the equipment-set picker sheet.
+      final useSet = find.descendant(
+        of: editorFor('Equipment'),
+        matching: find.widgetWithText(TextButton, 'Use Set'),
+      );
+      await tester.ensureVisible(useSet);
+      await tester.tap(useSet);
+      await tester.pumpAndSettle();
+      expect(find.byType(EquipmentSetPickerSheet), findsOneWidget);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Regression test for the r/submersion report: "Save as Set" appeared to do
+/// nothing. Root cause: the handler wrote the set with a null diverId, so it
+/// was orphaned and invisible to the diver-scoped set list.
+void main() {
+  group('DiveEditPage save-as-set', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      final db = await setUpTestDatabase();
+      // Seed without FK enforcement so we don't need a full divers row graph.
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+      repository = DiveRepository();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    testWidgets('saving gear as a set makes it visible to the current diver', (
+      tester,
+    ) async {
+      // A catalog equipment item, referenced by the dive so the equipment
+      // list (and its "Save as Set" action) renders.
+      const regulator = EquipmentItem(
+        id: 'eq-1',
+        name: 'Apeks XTX50',
+        type: EquipmentType.regulator,
+      );
+      await EquipmentRepository().createEquipment(regulator);
+      await repository.createDive(
+        Dive(
+          id: 'd1',
+          dateTime: DateTime(2026, 1, 1),
+          notes: '',
+          equipment: const [regulator],
+        ),
+      );
+
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            diveRepositoryProvider.overrideWithValue(repository),
+            diveListNotifierProvider.overrideWith(
+              (ref) => DiveListNotifier(repository, ref),
+            ),
+            customTankPresetsProvider.overrideWith((ref) async => []),
+            validatedCurrentDiverIdProvider.overrideWith(
+              (ref) async => 'diver-1',
+            ),
+          ].cast(),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(diveId: 'd1', embedded: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Gas & Gear starts collapsed when editing an existing dive and sits
+      // below the fold. Scroll its collapsed summary bar into view, then tap
+      // it (the summary lives inside the toggle InkWell) to expand the section
+      // and reveal the equipment list with its "Save as Set" action.
+      final gasGearSummary = find.text('1 tank · Air · 1 item');
+      await tester.ensureVisible(gasGearSummary);
+      await tester.pumpAndSettle();
+      await tester.tap(gasGearSummary);
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save as Set'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save as Set'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find
+            .descendant(
+              of: find.byType(AlertDialog),
+              matching: find.byType(TextField),
+            )
+            .first,
+        'Tropical',
+      );
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Save'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final sets = await EquipmentSetRepository().getAllSets(
+        diverId: 'diver-1',
+      );
+      expect(sets.map((s) => s.name), contains('Tropical'));
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_save_as_set_test.dart
@@ -71,9 +71,7 @@ void main() {
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: DiveEditPage(diveId: 'd1', embedded: true),
-            ),
+            home: Scaffold(body: DiveEditPage(diveId: 'd1', embedded: true)),
           ),
         ),
       );

--- a/test/features/dive_log/presentation/widgets/bulk_membership_delta_test.dart
+++ b/test/features/dive_log/presentation/widgets/bulk_membership_delta_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+
+void main() {
+  test('ensureOn on a "some" item adds it (to the dives missing it)', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.some},
+      {'a': MembershipChoice.ensureOn},
+    );
+    expect(d.addIds, ['a']);
+    expect(d.removeIds, isEmpty);
+  });
+
+  test('ensureOn on an "all" item is a no-op', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.all},
+      {'a': MembershipChoice.ensureOn},
+    );
+    expect(d.addIds, isEmpty);
+    expect(d.removeIds, isEmpty);
+  });
+
+  test('ensureOn on a "none" item (just added) adds it', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.none},
+      {'a': MembershipChoice.ensureOn},
+    );
+    expect(d.addIds, ['a']);
+    expect(d.removeIds, isEmpty);
+  });
+
+  test('ensureOff on "all" or "some" removes; on "none" is a no-op', () {
+    final d = MembershipDelta.from(
+      {
+        'a': MembershipPresence.all,
+        'b': MembershipPresence.some,
+        'c': MembershipPresence.none,
+      },
+      {
+        'a': MembershipChoice.ensureOff,
+        'b': MembershipChoice.ensureOff,
+        'c': MembershipChoice.ensureOff,
+      },
+    );
+    expect(d.removeIds.toSet(), {'a', 'b'});
+    expect(d.addIds, isEmpty);
+  });
+
+  test('leaveAsIs never changes anything', () {
+    final d = MembershipDelta.from(
+      {'a': MembershipPresence.some},
+      {'a': MembershipChoice.leaveAsIs},
+    );
+    expect(d.addIds, isEmpty);
+    expect(d.removeIds, isEmpty);
+    expect(d.isEmpty, isTrue);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
+++ b/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  // a is on all 3 dives, b on 2 of 3, c on none (just added via the picker).
+  const items = [
+    BulkMembershipItem(id: 'a', label: 'Regulator'),
+    BulkMembershipItem(id: 'b', label: 'Wetsuit'),
+    BulkMembershipItem(id: 'c', label: 'Camera'),
+  ];
+  const counts = {'a': 3, 'b': 2, 'c': 0};
+
+  Future<void> pumpEditor(
+    WidgetTester tester, {
+    void Function(MembershipDelta)? onChanged,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: BulkMembershipEditor(
+            title: 'Equipment',
+            totalDives: 3,
+            items: items,
+            counts: counts,
+            onAdd: () {},
+            onChanged: onChanged ?? (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders a presence subtitle per row', (tester) async {
+    await pumpEditor(tester);
+    expect(find.text('on all 3'), findsOneWidget); // a
+    expect(find.text('on 2 of 3'), findsOneWidget); // b
+    expect(find.text('adding to all 3'), findsOneWidget); // c (just added)
+  });
+
+  testWidgets('unchecking an on-all item yields a remove', (tester) async {
+    MembershipDelta? last;
+    await pumpEditor(tester, onChanged: (d) => last = d);
+    await tester.tap(find.byKey(const ValueKey('membership-toggle-a')));
+    await tester.pump();
+    expect(last!.removeIds, contains('a'));
+    expect(find.text('removing from all'), findsOneWidget);
+  });
+
+  testWidgets('a some-item is left unchanged; an added item is an add', (
+    tester,
+  ) async {
+    MembershipDelta? last;
+    await pumpEditor(tester, onChanged: (d) => last = d);
+    // Baseline emitted post-frame: c (none) -> add; a (all) and b (some) no-op.
+    expect(last, isNotNull);
+    expect(last!.addIds, contains('c'));
+    expect(last!.addIds, isNot(contains('b')));
+    expect(last!.removeIds, isNot(contains('b')));
+  });
+
+  testWidgets('a some-item cycles leave -> add -> remove -> leave', (
+    tester,
+  ) async {
+    MembershipDelta? last;
+    await pumpEditor(tester, onChanged: (d) => last = d);
+    final toggleB = find.byKey(const ValueKey('membership-toggle-b'));
+
+    await tester.tap(toggleB); // -> ensureOn
+    await tester.pump();
+    expect(last!.addIds, contains('b'));
+
+    await tester.tap(toggleB); // -> ensureOff
+    await tester.pump();
+    expect(last!.removeIds, contains('b'));
+    expect(last!.addIds, isNot(contains('b')));
+
+    await tester.tap(toggleB); // -> leaveAsIs
+    await tester.pump();
+    expect(last!.addIds, isNot(contains('b')));
+    expect(last!.removeIds, isNot(contains('b')));
+  });
+}

--- a/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
+++ b/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
@@ -84,4 +84,22 @@ void main() {
     expect(last!.addIds, isNot(contains('b')));
     expect(last!.removeIds, isNot(contains('b')));
   });
+
+  testWidgets(
+    'unchecking a just-added item is a no-op with no false subtitle',
+    (tester) async {
+      MembershipDelta? last;
+      await pumpEditor(tester, onChanged: (d) => last = d);
+      // c (on no dives) starts checked -> "adding to all 3".
+      expect(find.text('adding to all 3'), findsOneWidget);
+
+      // Toggle c off: it changes nothing, so the subtitle must not still claim
+      // "adding to all", and c must not appear in the delta.
+      await tester.tap(find.byKey(const ValueKey('membership-toggle-c')));
+      await tester.pump();
+      expect(find.text('adding to all 3'), findsNothing);
+      expect(last!.addIds, isNot(contains('c')));
+      expect(last!.removeIds, isNot(contains('c')));
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Addresses an [r/submersion report](https://www.reddit.com/r/submersion/comments/1uobske/) about gear editing across multiple dives, which turned out to be **two separate bugs**, and (per product direction) redesigns bulk editing of all id-based **reference collections** to a safe tri-state model.

- **Bug 1 — "bulk add wipes all gear on the selected dives":** already fixed in shipped code (the Add/Remove/Replace machinery landed 2026-06-23, released in v1.5.9.113); the reporter was on an older build. This PR adds regression guards locking in "bulk **add** merges, never wipes," then replaces the confusing chip UI.
- **Bug 2 — "Save as Set does nothing":** a real, current bug. `_saveEquipmentAsSet` wrote the `EquipmentSet` with a null `diverId` and called the repository directly, bypassing the notifier that stamps the active diver. The row persisted (a success snackbar even showed) but was filtered out of every diver-scoped read. Fixed by routing through `EquipmentSetListNotifier.addSet`.

## Changes

- **`fix(dive-log)`** save-as-set now routes through `equipmentSetListNotifierProvider.notifier.addSet` so the set is stamped with the active diver and is visible (Bug 2).
- **New `BulkMembershipEditor`** tri-state widget: for each item across the selected dives, checked = ensure on all, empty = ensure off all, dash = leave the mix untouched (safe default). Emits a `MembershipDelta` (add/remove id sets).
- **Wired into the bulk form** for all four reference collections — tags, dive types, buddies, equipment — replacing the Add/Remove/Replace mode chips. Owned collections (tanks/weights/sightings) keep their existing editors.
- **Four new per-item count queries** (`equipment/tag/diveType/buddyCountsForDives`) drive the all/some/none classification.
- **Engine untouched:** `BulkDiveEditService`, the sealed ops, `bulkAdd*`/`bulkRemove*` writes, and the undo snapshot are unchanged — a tri-state toggle just decomposes into existing Add + Remove ops. Buddies stamp the default `BuddyRole.buddy` on adds.
- **"Save as Set" hidden in bulk mode** (single-dive only).
- New l10n strings translated into all 10 non-en locales.
- Design spec + implementation plan under `docs/superpowers/`.

## Test Plan

- [x] `flutter test` passes — 66 tests across the affected + adjacent `DiveEditPage` suites (repo count queries, service add/remove+undo, membership delta + widget, bulk form incl. an end-to-end "toggle removes gear from the DB" test, save-as-set widget test, and all other DiveEditPage page tests — no regressions)
- [x] `flutter analyze` passes (whole project, clean)
- [x] Manual testing on: **pending** — verified via widget tests that pump the real `DiveEditPage` and drive the bulk apply through to the DB, but a manual macOS pass of the tri-state UX is still recommended

## Screenshots

UI change (bulk reference-collection editors are now tri-state lists). No screenshots captured in this pass; a manual macOS run is recommended before merge.