### PR TITLE
fix(android): keep JNI-resolved serial handler methods from R8 stripping (#318)

### DIFF
--- a/packages/libdivecomputer_plugin/android/consumer-rules.pro
+++ b/packages/libdivecomputer_plugin/android/consumer-rules.pro
@@ -18,11 +18,12 @@
 # Keeping the interfaces pins the method names on every implementation, the
 # same mechanism that already protected BleIoHandler implementers above; the
 # implements-wildcard is belt and braces for the concrete classes
-# (UsbSerialIoStream, BleIoStream, and any future handler). Class NAMES may
-# still be renamed harmlessly (JNI uses GetObjectClass, never FindClass), but
-# method names must survive verbatim. Guarded in CI by
-# scripts/check_proguard_serial_keep.py against the release mapping.txt.
-# DO NOT REMOVE.
+# (UsbSerialIoStream, BleIoStream, and any future handler) and also pins
+# their class names. Strictly only the METHOD names need to survive (JNI
+# resolves the class via GetObjectClass, never FindClass, so a renamed class
+# would be harmless) -- the CI guard in scripts/check_proguard_serial_keep.py
+# enforces exactly that minimal contract against the release mapping.txt,
+# while these rules are deliberately broader for safety. DO NOT REMOVE.
 -keep interface com.submersion.libdivecomputer.IoHandler { *; }
 -keep interface com.submersion.libdivecomputer.SerialIoHandler { *; }
 -keep class * implements com.submersion.libdivecomputer.IoHandler { *; }

--- a/packages/libdivecomputer_plugin/android/consumer-rules.pro
+++ b/packages/libdivecomputer_plugin/android/consumer-rules.pro
@@ -7,6 +7,26 @@
 -keep interface com.submersion.libdivecomputer.BleIoHandler { *; }
 -keep interface com.submersion.libdivecomputer.DownloadCallback { *; }
 
+# libdc_jni.cpp resolves the I/O handler passed to nativeDownloadRun by METHOD
+# NAME: GetMethodID(GetObjectClass(handler), "read"/"write"/"purge"/"close"/
+# "configure"/"setDtr"/"setRts", ...). R8 cannot see those native call sites,
+# so without these rules it DELETES the methods outright (no visible caller)
+# and every release-build serial download dies natively right after
+# "nativeDownloadRun begin" -- the failed GetMethodID leaves a pending
+# NoSuchMethodError and the next JNI call is undefined behavior (issue #318,
+# fourth root cause; found via R8's usage.txt listing the stripped methods).
+# Keeping the interfaces pins the method names on every implementation, the
+# same mechanism that already protected BleIoHandler implementers above; the
+# implements-wildcard is belt and braces for the concrete classes
+# (UsbSerialIoStream, BleIoStream, and any future handler). Class NAMES may
+# still be renamed harmlessly (JNI uses GetObjectClass, never FindClass), but
+# method names must survive verbatim. Guarded in CI by
+# scripts/check_proguard_serial_keep.py against the release mapping.txt.
+# DO NOT REMOVE.
+-keep interface com.submersion.libdivecomputer.IoHandler { *; }
+-keep interface com.submersion.libdivecomputer.SerialIoHandler { *; }
+-keep class * implements com.submersion.libdivecomputer.IoHandler { *; }
+
 # Keep the vendored usb-serial-for-android drivers (serial-over-USB dive
 # computer support, e.g. the Mares Puck Pro). These classes are discovered
 # purely by reflection, so R8 has no visible call site and would rename or

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -241,6 +241,8 @@ static void jni_on_progress(unsigned int current, unsigned int maximum, void *us
     if (method) {
         env->CallVoidMethod(ctx->callback, method,
             static_cast<jint>(current), static_cast<jint>(maximum));
+    } else {
+        env->ExceptionClear();
     }
 
     if (attached) ctx->jvm->DetachCurrentThread();
@@ -262,6 +264,8 @@ static void jni_on_dive(const libdc_parsed_dive_t *dive, void *userdata) {
         // Pass the dive pointer so Kotlin can read fields via additional JNI calls.
         env->CallVoidMethod(ctx->callback, method,
             reinterpret_cast<jlong>(dive));
+    } else {
+        env->ExceptionClear();
     }
 
     if (attached) ctx->jvm->DetachCurrentThread();
@@ -294,6 +298,7 @@ static int jni_io_read(void *userdata, void *data, size_t size, size_t *actual) 
     jmethodID method = env->GetMethodID(cls, "read", "(II)[B");
     env->DeleteLocalRef(cls);
     if (!method) {
+        env->ExceptionClear();
         if (attached) ctx->jvm->DetachCurrentThread();
         return LIBDC_STATUS_IO;
     }
@@ -345,6 +350,7 @@ static int jni_io_write(void *userdata, const void *data, size_t size, size_t *a
     jmethodID method = env->GetMethodID(cls, "write", "([BI)I");
     env->DeleteLocalRef(cls);
     if (!method) {
+        env->ExceptionClear();
         if (attached) ctx->jvm->DetachCurrentThread();
         return LIBDC_STATUS_IO;
     }
@@ -485,6 +491,12 @@ static int jni_io_ioctl(void *userdata, unsigned int request,
         jclass cls = env->GetObjectClass(ctx->ioHandler);
         jmethodID method = env->GetMethodID(cls, "onPinCodeRequired",
             "(Ljava/lang/String;)Ljava/lang/String;");
+        if (method == nullptr) {
+            env->ExceptionClear();
+            env->DeleteLocalRef(cls);
+            if (attached) ctx->jvm->DetachCurrentThread();
+            return LIBDC_STATUS_UNSUPPORTED;
+        }
 
         jstring jAddress = env->NewStringUTF(ctx->ble_name);
         jstring jPin = (jstring)env->CallObjectMethod(ctx->ioHandler, method, jAddress);
@@ -533,6 +545,13 @@ static int jni_io_ioctl(void *userdata, unsigned int request,
             // GET access code
             jmethodID method = env->GetMethodID(cls, "getAccessCode",
                 "(Ljava/lang/String;)[B");
+            if (method == nullptr) {
+                env->ExceptionClear();
+                env->DeleteLocalRef(jAddress);
+                env->DeleteLocalRef(cls);
+                if (attached) ctx->jvm->DetachCurrentThread();
+                return LIBDC_STATUS_UNSUPPORTED;
+            }
             jbyteArray jCode = (jbyteArray)env->CallObjectMethod(
                 ctx->ioHandler, method, jAddress);
 
@@ -552,12 +571,18 @@ static int jni_io_ioctl(void *userdata, unsigned int request,
             }
         } else {
             // SET access code
+            jmethodID method = env->GetMethodID(cls, "setAccessCode",
+                "(Ljava/lang/String;[B)V");
+            if (method == nullptr) {
+                env->ExceptionClear();
+                env->DeleteLocalRef(jAddress);
+                env->DeleteLocalRef(cls);
+                if (attached) ctx->jvm->DetachCurrentThread();
+                return LIBDC_STATUS_UNSUPPORTED;
+            }
             jbyteArray jCode = env->NewByteArray((jsize)size);
             env->SetByteArrayRegion(jCode, 0, (jsize)size,
                 reinterpret_cast<const jbyte *>(data));
-
-            jmethodID method = env->GetMethodID(cls, "setAccessCode",
-                "(Ljava/lang/String;[B)V");
             env->CallVoidMethod(ctx->ioHandler, method, jAddress, jCode);
             env->DeleteLocalRef(jCode);
             status = LIBDC_STATUS_SUCCESS;
@@ -588,6 +613,14 @@ static int jni_io_purge(void *userdata, unsigned int direction) {
     env->DeleteLocalRef(cls);
     if (method) {
         env->CallVoidMethod(ctx->ioHandler, method, static_cast<jint>(direction));
+    } else {
+        // A failed GetMethodID leaves a pending NoSuchMethodError; every
+        // JNI call made while an exception is pending is undefined behavior,
+        // so it MUST be cleared before this callback returns. Leaving it
+        // pending here crashed the whole download process when R8 stripped
+        // the handler methods (#318). Same rule applies to every failed
+        // GetMethodID in this file.
+        env->ExceptionClear();
     }
 
     if (attached) ctx->jvm->DetachCurrentThread();
@@ -608,6 +641,8 @@ static int jni_io_close(void *userdata) {
     env->DeleteLocalRef(cls);
     if (method) {
         env->CallVoidMethod(ctx->ioHandler, method);
+    } else {
+        env->ExceptionClear();
     }
 
     if (attached) ctx->jvm->DetachCurrentThread();

--- a/scripts/check_proguard_serial_keep.py
+++ b/scripts/check_proguard_serial_keep.py
@@ -17,16 +17,30 @@ keep rule R8 renames ``getSupportedDevices`` (and the driver class becomes e.g.
 failed unexpectedly (RuntimeException)". This was issue #318. The keep rule
 lives in the plugin's ``consumer-rules.pro``.
 
-Because the lookup is by method name on a runtime ``Class`` object, the precise
-thing that must survive is the *method name*, not the class name -- R8 may
-freely rename synthetic helper classes (e.g. ``$$ExternalSyntheticLambda``) in
-the same package without harm. This script reads the R8 ``mapping.txt`` from a
-release build and fails (exit code 1) if a reflectively-accessed driver method
-was renamed, or was stripped from an obfuscated mapping. A mapping showing no
-obfuscation at all only warns, since it cannot prove the drivers survived
-(Submersion's release builds always obfuscate, so CI never hits that case). It
-is the build-artifact counterpart to ``check_16kb_alignment`` and is
-dependency-free (pure stdlib).
+The plugin's own Kotlin I/O handlers are reflected the same way, from JNI
+rather than Java: ``libdc_jni.cpp`` resolves the handler passed to
+``nativeDownloadRun`` with ``GetMethodID(GetObjectClass(handler), "read", ...)``
+and friends. R8 cannot see those call sites either, so without keep rules it
+*deletes* the methods outright (there is no visible caller). That was the
+fourth #318 root cause: every release-build serial download died natively
+right after ``nativeDownloadRun begin`` because ``UsbSerialIoStream``'s
+``read/write/purge/close/configure/setDtr/setRts`` did not exist in the APK --
+the failed ``GetMethodID`` in ``jni_io_purge`` left a pending
+``NoSuchMethodError`` and the next JNI call was undefined behavior. The keep
+rules for the handler interfaces live in ``consumer-rules.pro`` next to the
+driver rules.
+
+Because both lookups are by method name on a runtime ``Class`` object, the
+precise thing that must survive is the *method name*, not the class name -- R8
+may freely rename the class (``GetObjectClass`` is name-agnostic) or synthetic
+helpers (e.g. ``$$ExternalSyntheticLambda``) without harm. This script reads
+the R8 ``mapping.txt`` from a release build and fails (exit code 1) if a
+reflectively-accessed driver method was renamed or stripped, or if a
+JNI-resolved handler method was renamed, stripped, or its class removed from
+an obfuscated mapping. A mapping showing no obfuscation at all only warns,
+since it cannot prove the members survived (Submersion's release builds always
+obfuscate, so CI never hits that case). It is the build-artifact counterpart
+to ``check_16kb_alignment`` and is dependency-free (pure stdlib).
 
 Usage:
     check_proguard_serial_keep.py <mapping.txt>
@@ -47,6 +61,21 @@ REFLECTED_METHODS = ("getSupportedDevices", "probe")
 # getSupportedDevices is declared by every concrete driver and is the canary:
 # if it survives, the keep rule is effective for the whole class.
 CANARY = "getSupportedDevices"
+
+# Kotlin I/O handlers whose methods libdc_jni.cpp resolves by name with
+# GetMethodID on the object passed to nativeDownloadRun. Each method must
+# survive R8 under its source name or the serial/BLE download breaks at
+# runtime (issue #318, fourth root cause). The class name itself may be
+# renamed: JNI uses GetObjectClass, never FindClass.
+JNI_HANDLERS = {
+    "com.submersion.libdivecomputer.UsbSerialIoStream": (
+        "read", "write", "purge", "close", "configure", "setDtr", "setRts",
+    ),
+    "com.submersion.libdivecomputer.BleIoStream": (
+        "read", "write", "purge", "close",
+        "onPinCodeRequired", "getAccessCode", "setAccessCode",
+    ),
+}
 
 
 def _method_name(left):
@@ -72,9 +101,14 @@ def analyze(text):
     renamed = []          # (class, method, obfuscated) -- a reflected method renamed
     kept = []             # (class, method) -- reflected method identity-mapped
     canary_classes = set()  # driver classes that declared getSupportedDevices
+    # handler class -> {method name -> set of obfuscated names seen}. A class
+    # key is present only if its mapping section exists at all; a missing key
+    # means R8 removed or merged the class away.
+    handler_methods = {}
 
     current_orig = None
     current_is_driver = False
+    current_handler = None
 
     for raw in text.splitlines():
         if not raw or raw.startswith("#") or " -> " not in raw:
@@ -87,6 +121,23 @@ def analyze(text):
             if right.rstrip(":").strip() != current_orig:
                 minify_ran = True
             current_is_driver = current_orig.startswith(DRIVER_PKG)
+            current_handler = (
+                current_orig if current_orig in JNI_HANDLERS else None
+            )
+            if current_handler is not None:
+                handler_methods.setdefault(current_handler, {})
+            continue
+
+        if current_handler is not None:
+            # Member line within a JNI handler class. Record every mapping of
+            # a JNI-resolved name; identity vs renamed is classified later so
+            # an inlined copy (e.g. "close():250 -> b") cannot mask the real
+            # identity-mapped method also present in the section.
+            left, right = raw.rsplit(" -> ", 1)
+            name = _method_name(left.strip())
+            if name in JNI_HANDLERS[current_handler]:
+                handler_methods[current_handler].setdefault(name, set()).add(
+                    right.strip())
             continue
 
         if not current_is_driver:
@@ -110,6 +161,7 @@ def analyze(text):
         "renamed": renamed,
         "kept": kept,
         "canary_classes": sorted(canary_classes),
+        "handler_methods": handler_methods,
     }
 
 
@@ -128,6 +180,39 @@ def check_mapping(path):
         ok = False
         lines.append(f"  FAIL  {cls}.{method}() renamed to '{obf}' "
                      "-- ProbeTable/UsbSerialProber reflect on this exact name")
+
+    # JNI-resolved handler methods (fourth #318 root cause). GetMethodID needs
+    # the exact source name to exist on the handler's runtime class; a method
+    # counts as kept only if at least one identity mapping survives (inlined
+    # copies under other names are just debug info for the inliner).
+    for cls, methods in sorted(JNI_HANDLERS.items()):
+        seen = report["handler_methods"].get(cls)
+        if seen is None:
+            if report["minify_ran"]:
+                ok = False
+                lines.append(f"  FAIL  {cls} has no mapping section -- R8 "
+                             "removed or merged the JNI handler class")
+            else:
+                lines.append(f"  WARN  {cls} not in a non-obfuscated mapping; "
+                             "cannot verify the JNI handler survived")
+            continue
+        bad = []
+        for method in methods:
+            obfs = seen.get(method, set())
+            if method in obfs:
+                continue
+            if obfs:
+                bad.append(f"{method}() renamed to {sorted(obfs)}")
+            else:
+                bad.append(f"{method}() stripped")
+        if bad:
+            ok = False
+            for b in bad:
+                lines.append(f"  FAIL  {cls}.{b} -- libdc_jni.cpp resolves "
+                             "this exact name via GetMethodID")
+        else:
+            lines.append(f"  ok    {cls.rsplit('.', 1)[-1]}: all "
+                         f"{len(methods)} JNI-resolved methods preserved")
 
     if report["canary_classes"]:
         if ok:
@@ -170,10 +255,12 @@ def main(argv):
         for line in lines:
             print(line)
         if ok:
-            print("  -> PASS: usb-serial-for-android drivers survive R8 obfuscation")
+            print("  -> PASS: reflected driver methods and JNI handler methods "
+                  "survive R8 obfuscation")
         else:
-            print("  -> FAIL: a reflectively-accessed serial driver method was "
-                  "obfuscated (serial-USB downloads will crash; see issue #318)")
+            print("  -> FAIL: a reflectively- or JNI-accessed method was "
+                  "obfuscated or stripped (dive computer downloads will "
+                  "crash; see issue #318)")
         all_ok = all_ok and ok
 
     return 0 if all_ok else 1

--- a/scripts/check_proguard_serial_keep_test.py
+++ b/scripts/check_proguard_serial_keep_test.py
@@ -26,6 +26,30 @@ guard = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(guard)
 
 
+# Healthy JNI handler sections: the class may be renamed (GetObjectClass is
+# name-agnostic) but every JNI-resolved method is identity-mapped. BleIoStream
+# also carries an inlined copy of close() under another name, which must not
+# mask the identity-mapped method.
+HANDLERS_GREEN = """\
+com.submersion.libdivecomputer.UsbSerialIoStream -> X5.U:
+    0:5:byte[] read(int,int) -> read
+    0:3:int write(byte[],int) -> write
+    0:2:void purge(int) -> purge
+    0:2:void close() -> close
+    0:9:int configure(int,int,int,int,int) -> configure
+    0:1:int setDtr(int) -> setDtr
+    0:1:int setRts(int) -> setRts
+com.submersion.libdivecomputer.BleIoStream -> X5.c:
+    0:5:byte[] read(int,int) -> read
+    0:3:int write(byte[],int) -> write
+    0:2:void purge(int) -> purge
+    0:2:void close() -> close
+    924:932:void close():250:250 -> b
+    0:4:java.lang.String onPinCodeRequired(java.lang.String) -> onPinCodeRequired
+    0:4:byte[] getAccessCode(java.lang.String) -> getAccessCode
+    0:4:void setAccessCode(java.lang.String,byte[]) -> setAccessCode
+"""
+
 # A driver class kept verbatim by `-keep class ...driver.** { *; }`: it maps to
 # itself and its reflected methods keep their names.
 GREEN = """\
@@ -35,7 +59,7 @@ com.hoho.android.usbserial.driver.ProlificSerialDriver -> com.hoho.android.usbse
     1:1:java.util.Map getSupportedDevices() -> getSupportedDevices
     2:2:boolean probe(android.hardware.usb.UsbDevice) -> probe
     3:5:void <init>(android.hardware.usb.UsbDevice) -> <init>
-"""
+""" + HANDLERS_GREEN
 
 # The issue #318 signature: no keep rule, so R8 renamed the class to P5.a and
 # getSupportedDevices/probe to short names.
@@ -45,7 +69,7 @@ com.example.app.MainActivity -> a.b.c:
 com.hoho.android.usbserial.driver.ProlificSerialDriver -> P5.a:
     1:1:java.util.Map getSupportedDevices() -> a
     2:2:boolean probe(android.hardware.usb.UsbDevice) -> b
-"""
+""" + HANDLERS_GREEN
 
 
 class AnalyzeTests(unittest.TestCase):
@@ -176,6 +200,92 @@ class CheckMappingTests(unittest.TestCase):
                               "    void onCreate(android.os.Bundle) -> a\n")
         self.assertFalse(ok)
         self.assertTrue(any("stripped" in line for line in lines))
+
+
+class JniHandlerTests(unittest.TestCase):
+    """The fourth #318 root cause: JNI GetMethodID-resolved handler methods."""
+
+    def _run(self, text):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(text)
+            path = fh.name
+        try:
+            return guard.check_mapping(path)
+        finally:
+            os.unlink(path)
+
+    # Driver section is healthy; only the handlers vary per test.
+    DRIVERS_OK = (
+        "com.example.app.MainActivity -> a.b.c:\n"
+        "    void onCreate(android.os.Bundle) -> a\n"
+        "com.hoho.android.usbserial.driver.ProlificSerialDriver -> "
+        "com.hoho.android.usbserial.driver.ProlificSerialDriver:\n"
+        "    1:1:java.util.Map getSupportedDevices() -> getSupportedDevices\n"
+        "    2:2:boolean probe(android.hardware.usb.UsbDevice) -> probe\n"
+    )
+
+    def test_removed_handler_class_fails(self):
+        # The real-world regression: R8 merged UsbSerialIoStream away and
+        # stripped its methods, so the class has no mapping section at all.
+        ok, lines = self._run(self.DRIVERS_OK)
+        self.assertFalse(ok)
+        self.assertTrue(any("UsbSerialIoStream has no mapping section" in line
+                            for line in lines))
+
+    def test_stripped_handler_method_fails(self):
+        # Section exists but configure() has no mapping line: R8 deleted the
+        # method (its only caller is native code).
+        broken = HANDLERS_GREEN.replace(
+            "    0:9:int configure(int,int,int,int,int) -> configure\n", "")
+        ok, lines = self._run(self.DRIVERS_OK + broken)
+        self.assertFalse(ok)
+        self.assertTrue(any("configure() stripped" in line for line in lines))
+
+    def test_renamed_handler_method_fails(self):
+        broken = HANDLERS_GREEN.replace(
+            "    0:5:byte[] read(int,int) -> read\n"
+            "    0:3:int write(byte[],int) -> write\n"
+            "    0:2:void purge(int) -> purge\n"
+            "    0:2:void close() -> close\n"
+            "    0:9:int configure(int,int,int,int,int) -> configure\n",
+            "    0:5:byte[] read(int,int) -> a\n"
+            "    0:3:int write(byte[],int) -> write\n"
+            "    0:2:void purge(int) -> purge\n"
+            "    0:2:void close() -> close\n"
+            "    0:9:int configure(int,int,int,int,int) -> configure\n",
+            1,
+        )
+        ok, lines = self._run(self.DRIVERS_OK + broken)
+        self.assertFalse(ok)
+        self.assertTrue(any("read() renamed" in line for line in lines))
+
+    def test_inlined_copy_does_not_mask_identity_mapping(self):
+        # BleIoStream in HANDLERS_GREEN carries "close():250:250 -> b" (an
+        # inlined copy) alongside "close() -> close"; the identity mapping
+        # must win and the mapping must pass.
+        r = guard.analyze(self.DRIVERS_OK + HANDLERS_GREEN)
+        ble = r["handler_methods"]["com.submersion.libdivecomputer.BleIoStream"]
+        self.assertEqual(ble["close"], {"close", "b"})
+        ok, _ = self._run(self.DRIVERS_OK + HANDLERS_GREEN)
+        self.assertTrue(ok)
+
+    def test_renamed_handler_class_name_is_allowed(self):
+        # HANDLERS_GREEN maps the classes to X5.U / X5.c. That must pass:
+        # JNI resolves the class via GetObjectClass, never by name.
+        ok, lines = self._run(self.DRIVERS_OK + HANDLERS_GREEN)
+        self.assertTrue(ok)
+        self.assertTrue(any("JNI-resolved methods preserved" in line
+                            for line in lines))
+
+    def test_missing_handlers_warn_when_not_obfuscated(self):
+        # Shrink-only mapping: cannot prove anything, warn rather than fail.
+        ok, lines = self._run(
+            "com.example.Foo -> com.example.Foo:\n    void bar() -> bar\n")
+        self.assertTrue(ok)
+        self.assertTrue(any("WARN" in line and "UsbSerialIoStream" in line
+                            for line in lines))
 
 
 class MainTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fourth root cause of #318, found from the 2026-07-06 log and **confirmed against build artifacts without hardware**: R8 deletes the serial I/O handler methods from every release build, because their only callers are native `GetMethodID` lookups it cannot see.

The v1.5.9 log proved the #445 process isolation works (six attempts, six reported `download_crashed`, app survives) and its breadcrumbs narrowed the crash to before the first JNI-to-Kotlin callback. A local release build then showed it in R8's own ledger: `usage.txt` lists `UsbSerialIoStream.read/write/purge/configure/setDtr/setRts` as **removed**, the `SerialIoHandler` interface deleted, and the class merged into `SerialDownloadRunner`. `BleIoStream` survived identity-mapped only because `BleIoHandler` was already kept — why BLE works and serial never has.

Crash mechanism: `jni_io_purge`'s failed `GetMethodID` left a pending `NoSuchMethodError`; the next JNI call ran with an exception pending — undefined behavior ART answers with native process death. Instant, silent, release-only, any serial dive computer, unaffected by the local-ref fix.

## Changes

- **consumer-rules.pro** — keep `IoHandler` + `SerialIoHandler` interfaces and `-keep class * implements IoHandler`, pinning the JNI-resolved method names (class renames stay harmless: JNI uses `GetObjectClass`, never `FindClass`).
- **libdc_jni.cpp** — defense in depth: `ExceptionClear()` on every failed `GetMethodID` (8 sites) and null-method guards in the BLE ioctl paths that called through a possibly-null `jmethodID`. A future rename now degrades to a clean I/O error instead of UB.
- **check_proguard_serial_keep.py (+ test)** — the CI guard now also verifies the 14 JNI-resolved handler methods (`UsbSerialIoStream` + `BleIoStream`) are identity-mapped in the release `mapping.txt`; inlined copies under other names don't mask, class renames are allowed. Runs in the existing Build Android mapping step — no CI changes needed.

## Verification

- Guard vs the **broken** mapping (pre-fix release build): FAIL — `UsbSerialIoStream has no mapping section`
- Guard vs the **fixed** mapping (rebuild with keep rules): PASS — all 7 methods preserved on both handlers, drivers still kept
- `check_proguard_serial_keep_test.py`: 25 tests pass (6 new for the JNI-handler contract)
- `check_jni_local_refs.py`: passes on the edited `libdc_jni.cpp`

Hardware verification on the reporter's Xiaomi 15T Pro + Puck Pro needs a beta release. Note this fix also un-blocks the serial path that has never actually executed in release (configure at 115200 8E1 was silently skipped), so a functional issue may surface next — but it will arrive as a logged error with NativeTrace breadcrumbs, not a crash.