### PR TITLE
fix(shearwater): deliver dives oldest-first and preserve manifest records behind deleted dives

### DIFF
--- a/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
+++ b/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
@@ -17,6 +17,13 @@ class DownloadStepWidget extends ConsumerStatefulWidget {
   final VoidCallback onComplete;
   final void Function(String error) onError;
 
+  /// Invoked when the user chooses to import the dives that were delivered
+  /// before an interrupted (errored or cancelled) download. Null disables the
+  /// action. Because dives arrive oldest-first, the retained set is a
+  /// contiguous prefix of the oldest dives, so importing it and advancing the
+  /// fingerprint yields a correct resume point for the next download.
+  final VoidCallback? onImportPartial;
+
   /// When true, `newDivesOnly` is set to false after the notifier reset,
   /// causing the download to bypass the stored fingerprint and fetch every
   /// dive on the device. Used by the "Re-import all dives" flow.
@@ -28,6 +35,7 @@ class DownloadStepWidget extends ConsumerStatefulWidget {
     this.computer,
     required this.onComplete,
     required this.onError,
+    this.onImportPartial,
     this.forceFullDownload = false,
   });
 
@@ -214,32 +222,70 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
                 ),
               ),
               const SizedBox(height: 16),
-              FilledButton.icon(
-                onPressed: () {
-                  _hasStarted = false;
-                  _startDownload();
-                },
-                icon: const Icon(Icons.refresh),
-                label: Text(context.l10n.diveComputer_downloadStep_retry),
-              ),
+              ..._buildInterruptedActions(context, downloadState),
             ],
 
             // Cancelled state
             if (downloadState.isCancelled) ...[
               const SizedBox(height: 16),
-              FilledButton.icon(
-                onPressed: () {
-                  _hasStarted = false;
-                  _startDownload();
-                },
-                icon: const Icon(Icons.refresh),
-                label: Text(context.l10n.diveComputer_downloadStep_retry),
-              ),
+              ..._buildInterruptedActions(context, downloadState),
             ],
           ],
         ),
       ),
     );
+  }
+
+  /// Actions shown after an interrupted (errored or cancelled) download.
+  ///
+  /// When the download delivered some dives before stopping, offers to import
+  /// that partial set. Delivery is oldest-first, so the retained dives are a
+  /// contiguous prefix of the oldest dives; importing them advances the
+  /// fingerprint to a correct high-water mark and the next download resumes
+  /// with the newer dives. Retry is always available.
+  List<Widget> _buildInterruptedActions(
+    BuildContext context,
+    DownloadState state,
+  ) {
+    final retryButton = OutlinedButton.icon(
+      onPressed: () {
+        _hasStarted = false;
+        _startDownload();
+      },
+      icon: const Icon(Icons.refresh),
+      label: Text(context.l10n.diveComputer_downloadStep_retry),
+    );
+
+    final canImportPartial =
+        widget.onImportPartial != null && state.downloadedDives.isNotEmpty;
+    if (!canImportPartial) {
+      // No partial dives to keep: retry is the only, and therefore primary,
+      // action.
+      return [
+        FilledButton.icon(
+          onPressed: () {
+            _hasStarted = false;
+            _startDownload();
+          },
+          icon: const Icon(Icons.refresh),
+          label: Text(context.l10n.diveComputer_downloadStep_retry),
+        ),
+      ];
+    }
+
+    return [
+      FilledButton.icon(
+        onPressed: widget.onImportPartial,
+        icon: const Icon(Icons.download_done),
+        label: Text(
+          context.l10n.diveComputer_downloadStep_importPartialCount(
+            state.downloadedDives.length,
+          ),
+        ),
+      ),
+      const SizedBox(height: 8),
+      retryButton,
+    ];
   }
 
   Widget _buildProgressIndicator(DownloadState state, ColorScheme colorScheme) {

--- a/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
+++ b/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
@@ -19,9 +19,11 @@ class DownloadStepWidget extends ConsumerStatefulWidget {
 
   /// Invoked when the user chooses to import the dives that were delivered
   /// before an interrupted (errored or cancelled) download. Null disables the
-  /// action. Because dives arrive oldest-first, the retained set is a
-  /// contiguous prefix of the oldest dives, so importing it and advancing the
-  /// fingerprint yields a correct resume point for the next download.
+  /// action. When the native driver delivers dives oldest-first (as the
+  /// Shearwater driver does), the retained set is a contiguous prefix of the
+  /// oldest dives, so importing it and advancing the fingerprint yields a
+  /// correct resume point for the next download. This widget does not itself
+  /// enforce that ordering — it relies on the driver's delivery order.
   final VoidCallback? onImportPartial;
 
   /// When true, `newDivesOnly` is set to false after the notifier reset,
@@ -239,10 +241,12 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
   /// Actions shown after an interrupted (errored or cancelled) download.
   ///
   /// When the download delivered some dives before stopping, offers to import
-  /// that partial set. Delivery is oldest-first, so the retained dives are a
-  /// contiguous prefix of the oldest dives; importing them advances the
-  /// fingerprint to a correct high-water mark and the next download resumes
-  /// with the newer dives. Retry is always available.
+  /// that partial set. For drivers that deliver dives oldest-first (as
+  /// Shearwater does), the retained dives are a contiguous prefix of the
+  /// oldest dives; importing them advances the fingerprint to a correct
+  /// high-water mark and the next download resumes with the newer dives.
+  /// Ordering is the driver's responsibility, not this widget's. Retry is
+  /// always available.
   List<Widget> _buildInterruptedActions(
     BuildContext context,
     DownloadState state,

--- a/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
@@ -319,33 +319,7 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
     // from a previous session is ignored — only fresh transitions trigger.
     ref.listen<DownloadState>(downloadNotifierProvider, (previous, next) {
       if (!_captured && next.phase == DownloadPhase.complete) {
-        _captured = true;
-        widget.adapter.setDownloadedDives(next.downloadedDives);
-
-        // No new dives — show an informational message instead of advancing
-        // to an empty Review step.
-        if (next.downloadedDives.isEmpty) {
-          if (mounted) setState(() => _noDives = true);
-          return;
-        }
-
-        WidgetsBinding.instance.addPostFrameCallback((_) async {
-          if (!mounted) return;
-
-          final discoveryState = ref.read(discoveryNotifierProvider);
-          final device = discoveryState.selectedDevice;
-          if (device != null) {
-            await widget.adapter.ensureComputer(
-              device: device,
-              serialNumber: next.serialNumber,
-              firmwareVersion: next.firmwareVersion,
-            );
-          }
-
-          if (mounted) {
-            ref.read(dcAdapterDownloadCanAdvanceProvider.notifier).state = true;
-          }
-        });
+        _captureAndAdvance(next);
       }
     });
 
@@ -406,7 +380,48 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
       onError: (error) {
         // Download errors are shown by the DownloadStepWidget itself.
       },
+      onImportPartial: () {
+        // The user chose to keep the dives delivered before an interrupted
+        // download. Delivery is oldest-first, so this is a contiguous prefix
+        // of the oldest dives; capturing it advances the fingerprint to a
+        // correct resume point for the next download.
+        _captureAndAdvance(ref.read(downloadNotifierProvider));
+      },
     );
+  }
+
+  /// Captures the downloaded dives into the adapter and advances the wizard to
+  /// the Review step. Shared by the normal completion path and the
+  /// import-partial action for an interrupted download.
+  void _captureAndAdvance(DownloadState state) {
+    if (_captured) return;
+    _captured = true;
+    widget.adapter.setDownloadedDives(state.downloadedDives);
+
+    // No dives — show an informational message instead of advancing to an
+    // empty Review step.
+    if (state.downloadedDives.isEmpty) {
+      if (mounted) setState(() => _noDives = true);
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+
+      final discoveryState = ref.read(discoveryNotifierProvider);
+      final device = discoveryState.selectedDevice;
+      if (device != null) {
+        await widget.adapter.ensureComputer(
+          device: device,
+          serialNumber: state.serialNumber,
+          firmwareVersion: state.firmwareVersion,
+        );
+      }
+
+      if (mounted) {
+        ref.read(dcAdapterDownloadCanAdvanceProvider.notifier).state = true;
+      }
+    });
   }
 }
 

--- a/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
@@ -382,9 +382,10 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
       },
       onImportPartial: () {
         // The user chose to keep the dives delivered before an interrupted
-        // download. Delivery is oldest-first, so this is a contiguous prefix
-        // of the oldest dives; capturing it advances the fingerprint to a
-        // correct resume point for the next download.
+        // download. For drivers that deliver oldest-first (as Shearwater
+        // does), this is a contiguous prefix of the oldest dives, so capturing
+        // it advances the fingerprint to a correct resume point for the next
+        // download. Ordering depends on the native driver, not this code.
         _captureAndAdvance(ref.read(downloadNotifierProvider));
       },
     );

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -885,7 +885,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "تقدم التنزيل: {status}{percent}",
   "diveComputer_downloadStep_retry": "إعادة المحاولة",
-  "diveComputer_downloadStep_importPartialCount": "استيراد {count} غطسة تم تنزيلها",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{استيراد غطسة واحدة تم تنزيلها} other{استيراد {count} غطسات تم تنزيلها}}",
   "diveComputer_download_cancel": "إلغاء",
   "diveComputer_download_closeTooltip": "إغلاق",
   "diveComputer_download_computerNotFound": "لم يتم العثور على الكمبيوتر",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -885,6 +885,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "تقدم التنزيل: {status}{percent}",
   "diveComputer_downloadStep_retry": "إعادة المحاولة",
+  "diveComputer_downloadStep_importPartialCount": "استيراد {count} غطسة تم تنزيلها",
   "diveComputer_download_cancel": "إلغاء",
   "diveComputer_download_closeTooltip": "إغلاق",
   "diveComputer_download_computerNotFound": "لم يتم العثور على الكمبيوتر",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Download-Fortschritt: {status}{percent}",
   "diveComputer_downloadStep_retry": "Erneut versuchen",
+  "diveComputer_downloadStep_importPartialCount": "{count} heruntergeladene Tauchgänge importieren",
   "diveComputer_download_cancel": "Abbrechen",
   "diveComputer_download_closeTooltip": "Schließen",
   "diveComputer_download_computerNotFound": "Computer nicht gefunden",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Download-Fortschritt: {status}{percent}",
   "diveComputer_downloadStep_retry": "Erneut versuchen",
-  "diveComputer_downloadStep_importPartialCount": "{count} heruntergeladene Tauchgänge importieren",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{1 heruntergeladenen Tauchgang importieren} other{{count} heruntergeladene Tauchgänge importieren}}",
   "diveComputer_download_cancel": "Abbrechen",
   "diveComputer_download_closeTooltip": "Schließen",
   "diveComputer_download_computerNotFound": "Computer nicht gefunden",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9640,6 +9640,14 @@
     }
   },
   "diveComputer_downloadStep_retry": "Retry",
+  "diveComputer_downloadStep_importPartialCount": "Import {count} downloaded dives",
+  "@diveComputer_downloadStep_importPartialCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "diveComputer_download_cancel": "Cancel",
   "diveComputer_download_closeTooltip": "Close",
   "diveComputer_download_computerNotFound": "Computer not found",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9640,7 +9640,7 @@
     }
   },
   "diveComputer_downloadStep_retry": "Retry",
-  "diveComputer_downloadStep_importPartialCount": "Import {count} downloaded dives",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{Import 1 downloaded dive} other{Import {count} downloaded dives}}",
   "@diveComputer_downloadStep_importPartialCount": {
     "placeholders": {
       "count": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Progreso de descarga: {status}{percent}",
   "diveComputer_downloadStep_retry": "Reintentar",
-  "diveComputer_downloadStep_importPartialCount": "Importar {count} inmersiones descargadas",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{Importar 1 inmersión descargada} other{Importar {count} inmersiones descargadas}}",
   "diveComputer_download_cancel": "Cancelar",
   "diveComputer_download_closeTooltip": "Cerrar",
   "diveComputer_download_computerNotFound": "Ordenador no encontrado",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Progreso de descarga: {status}{percent}",
   "diveComputer_downloadStep_retry": "Reintentar",
+  "diveComputer_downloadStep_importPartialCount": "Importar {count} inmersiones descargadas",
   "diveComputer_download_cancel": "Cancelar",
   "diveComputer_download_closeTooltip": "Cerrar",
   "diveComputer_download_computerNotFound": "Ordenador no encontrado",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Progression du telechargement : {status}{percent}",
   "diveComputer_downloadStep_retry": "Reessayer",
+  "diveComputer_downloadStep_importPartialCount": "Importer {count} plongées téléchargées",
   "diveComputer_download_cancel": "Annuler",
   "diveComputer_download_closeTooltip": "Fermer",
   "diveComputer_download_computerNotFound": "Ordinateur introuvable",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Progression du telechargement : {status}{percent}",
   "diveComputer_downloadStep_retry": "Reessayer",
-  "diveComputer_downloadStep_importPartialCount": "Importer {count} plongées téléchargées",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{Importer 1 plongée téléchargée} other{Importer {count} plongées téléchargées}}",
   "diveComputer_download_cancel": "Annuler",
   "diveComputer_download_closeTooltip": "Fermer",
   "diveComputer_download_computerNotFound": "Ordinateur introuvable",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "התקדמות הורדה: {status}{percent}",
   "diveComputer_downloadStep_retry": "נסה שוב",
+  "diveComputer_downloadStep_importPartialCount": "ייבוא {count} צלילות שהורדו",
   "diveComputer_download_cancel": "ביטול",
   "diveComputer_download_closeTooltip": "סגירה",
   "diveComputer_download_computerNotFound": "המחשב לא נמצא",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "התקדמות הורדה: {status}{percent}",
   "diveComputer_downloadStep_retry": "נסה שוב",
-  "diveComputer_downloadStep_importPartialCount": "ייבוא {count} צלילות שהורדו",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{ייבוא צלילה אחת שהורדה} other{ייבוא {count} צלילות שהורדו}}",
   "diveComputer_download_cancel": "ביטול",
   "diveComputer_download_closeTooltip": "סגירה",
   "diveComputer_download_computerNotFound": "המחשב לא נמצא",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Letoltesi folyamat: {status}{percent}",
   "diveComputer_downloadStep_retry": "Ujraproba",
+  "diveComputer_downloadStep_importPartialCount": "{count} letöltött merülés importálása",
   "diveComputer_download_cancel": "Megse",
   "diveComputer_download_closeTooltip": "Bezaras",
   "diveComputer_download_computerNotFound": "A szamitogep nem talalhato",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Letoltesi folyamat: {status}{percent}",
   "diveComputer_downloadStep_retry": "Ujraproba",
-  "diveComputer_downloadStep_importPartialCount": "{count} letöltött merülés importálása",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{1 letöltött merülés importálása} other{{count} letöltött merülés importálása}}",
   "diveComputer_download_cancel": "Megse",
   "diveComputer_download_closeTooltip": "Bezaras",
   "diveComputer_download_computerNotFound": "A szamitogep nem talalhato",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Avanzamento download: {status}{percent}",
   "diveComputer_downloadStep_retry": "Riprova",
-  "diveComputer_downloadStep_importPartialCount": "Importa {count} immersioni scaricate",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{Importa 1 immersione scaricata} other{Importa {count} immersioni scaricate}}",
   "diveComputer_download_cancel": "Annulla",
   "diveComputer_download_closeTooltip": "Chiudi",
   "diveComputer_download_computerNotFound": "Computer non trovato",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Avanzamento download: {status}{percent}",
   "diveComputer_downloadStep_retry": "Riprova",
+  "diveComputer_downloadStep_importPartialCount": "Importa {count} immersioni scaricate",
   "diveComputer_download_cancel": "Annulla",
   "diveComputer_download_closeTooltip": "Chiudi",
   "diveComputer_download_computerNotFound": "Computer non trovato",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27116,6 +27116,12 @@ abstract class AppLocalizations {
   /// **'Retry'**
   String get diveComputer_downloadStep_retry;
 
+  /// No description provided for @diveComputer_downloadStep_importPartialCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Import {count} downloaded dives'**
+  String diveComputer_downloadStep_importPartialCount(int count);
+
   /// No description provided for @diveComputer_download_cancel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27119,7 +27119,7 @@ abstract class AppLocalizations {
   /// No description provided for @diveComputer_downloadStep_importPartialCount.
   ///
   /// In en, this message translates to:
-  /// **'Import {count} downloaded dives'**
+  /// **'{count, plural, =1{Import 1 downloaded dive} other{Import {count} downloaded dives}}'**
   String diveComputer_downloadStep_importPartialCount(int count);
 
   /// No description provided for @diveComputer_download_cancel.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15784,7 +15784,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'استيراد $count غطسة تم تنزيلها';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'استيراد $count غطسات تم تنزيلها',
+      one: 'استيراد غطسة واحدة تم تنزيلها',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -15783,6 +15783,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'إعادة المحاولة';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'استيراد $count غطسة تم تنزيلها';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'إلغاء';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16059,6 +16059,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Erneut versuchen';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return '$count heruntergeladene Tauchgänge importieren';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Abbrechen';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16060,7 +16060,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return '$count heruntergeladene Tauchgänge importieren';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count heruntergeladene Tauchgänge importieren',
+      one: '1 heruntergeladenen Tauchgang importieren',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15817,6 +15817,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Retry';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'Import $count downloaded dives';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Cancel';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -15818,7 +15818,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'Import $count downloaded dives';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Import $count downloaded dives',
+      one: 'Import 1 downloaded dive',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16094,6 +16094,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Reintentar';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'Importar $count inmersiones descargadas';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Cancelar';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16095,7 +16095,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'Importar $count inmersiones descargadas';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Importar $count inmersiones descargadas',
+      one: 'Importar 1 inmersión descargada',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16152,6 +16152,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Reessayer';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'Importer $count plongées téléchargées';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Annuler';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16153,7 +16153,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'Importer $count plongées téléchargées';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Importer $count plongées téléchargées',
+      one: 'Importer 1 plongée téléchargée',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15670,7 +15670,13 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'ייבוא $count צלילות שהורדו';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ייבוא $count צלילות שהורדו',
+      one: 'ייבוא צלילה אחת שהורדה',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -15669,6 +15669,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'נסה שוב';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'ייבוא $count צלילות שהורדו';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'ביטול';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16045,6 +16045,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Ujraproba';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return '$count letöltött merülés importálása';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Megse';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16046,7 +16046,13 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return '$count letöltött merülés importálása';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count letöltött merülés importálása',
+      one: '1 letöltött merülés importálása',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16089,6 +16089,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Riprova';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'Importa $count immersioni scaricate';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Annulla';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16090,7 +16090,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'Importa $count immersioni scaricate';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Importa $count immersioni scaricate',
+      one: 'Importa 1 immersione scaricata',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -15956,7 +15956,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return '$count gedownloade duiken importeren';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count gedownloade duiken importeren',
+      one: '1 gedownloade duik importeren',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -15955,6 +15955,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Opnieuw proberen';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return '$count gedownloade duiken importeren';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Annuleren';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16094,7 +16094,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return 'Importar $count mergulhos baixados';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Importar $count mergulhos baixados',
+      one: 'Importar 1 mergulho baixado',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16093,6 +16093,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveComputer_downloadStep_retry => 'Tentar Novamente';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return 'Importar $count mergulhos baixados';
+  }
+
+  @override
   String get diveComputer_download_cancel => 'Cancelar';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15304,7 +15304,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String diveComputer_downloadStep_importPartialCount(int count) {
-    return '导入 $count 次已下载的潜水';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '导入 $count 次已下载的潜水',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15303,6 +15303,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveComputer_downloadStep_retry => '重试';
 
   @override
+  String diveComputer_downloadStep_importPartialCount(int count) {
+    return '导入 $count 次已下载的潜水';
+  }
+
+  @override
   String get diveComputer_download_cancel => '取消';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Downloadvoortgang: {status}{percent}",
   "diveComputer_downloadStep_retry": "Opnieuw proberen",
-  "diveComputer_downloadStep_importPartialCount": "{count} gedownloade duiken importeren",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{1 gedownloade duik importeren} other{{count} gedownloade duiken importeren}}",
   "diveComputer_download_cancel": "Annuleren",
   "diveComputer_download_closeTooltip": "Sluiten",
   "diveComputer_download_computerNotFound": "Computer niet gevonden",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Downloadvoortgang: {status}{percent}",
   "diveComputer_downloadStep_retry": "Opnieuw proberen",
+  "diveComputer_downloadStep_importPartialCount": "{count} gedownloade duiken importeren",
   "diveComputer_download_cancel": "Annuleren",
   "diveComputer_download_closeTooltip": "Sluiten",
   "diveComputer_download_computerNotFound": "Computer niet gevonden",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -851,7 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Progresso do download: {status}{percent}",
   "diveComputer_downloadStep_retry": "Tentar Novamente",
-  "diveComputer_downloadStep_importPartialCount": "Importar {count} mergulhos baixados",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, =1{Importar 1 mergulho baixado} other{Importar {count} mergulhos baixados}}",
   "diveComputer_download_cancel": "Cancelar",
   "diveComputer_download_closeTooltip": "Fechar",
   "diveComputer_download_computerNotFound": "Computador nao encontrado",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -851,6 +851,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "Progresso do download: {status}{percent}",
   "diveComputer_downloadStep_retry": "Tentar Novamente",
+  "diveComputer_downloadStep_importPartialCount": "Importar {count} mergulhos baixados",
   "diveComputer_download_cancel": "Cancelar",
   "diveComputer_download_closeTooltip": "Fechar",
   "diveComputer_download_computerNotFound": "Computador nao encontrado",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -945,6 +945,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "下载进度：{status}{percent}",
   "diveComputer_downloadStep_retry": "重试",
+  "diveComputer_downloadStep_importPartialCount": "导入 {count} 次已下载的潜水",
   "diveComputer_download_cancel": "取消",
   "diveComputer_download_closeTooltip": "关闭",
   "diveComputer_download_computerNotFound": "未找到潜水电脑",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -945,7 +945,7 @@
   "diveComputer_downloadStep_progressPercent": "{percent}%",
   "diveComputer_downloadStep_progressSemanticLabel": "下载进度：{status}{percent}",
   "diveComputer_downloadStep_retry": "重试",
-  "diveComputer_downloadStep_importPartialCount": "导入 {count} 次已下载的潜水",
+  "diveComputer_downloadStep_importPartialCount": "{count, plural, other{导入 {count} 次已下载的潜水}}",
   "diveComputer_download_cancel": "取消",
   "diveComputer_download_closeTooltip": "关闭",
   "diveComputer_download_computerNotFound": "未找到潜水电脑",

--- a/packages/libdivecomputer_plugin/patches/0003-shearwater-oldest-first.patch
+++ b/packages/libdivecomputer_plugin/patches/0003-shearwater-oldest-first.patch
@@ -1,0 +1,34 @@
+diff --git a/src/shearwater_petrel.c b/src/shearwater_petrel.c
+index 56f90fe..2fbc314 100644
+--- a/src/shearwater_petrel.c
++++ b/src/shearwater_petrel.c
+@@ -314,11 +314,17 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 	unsigned char *data = dc_buffer_get_data (manifests);
+ 	unsigned int size = dc_buffer_get_size (manifests);
+ 
+-	unsigned int offset = 0;
+-	while (offset < size) {
++	// The manifest records are ordered newest to oldest. Walk them in
++	// reverse, so the dives are delivered oldest to newest. The download
++	// stops at the first failure, so a partial download always leaves a
++	// contiguous prefix of the oldest dives, and the newest delivered dive
++	// remains a correct fingerprint to resume from on the next attempt.
++	unsigned int nrecords = size / RECORD_SIZE;
++	for (unsigned int i = nrecords; i > 0; --i) {
++		unsigned int offset = (i - 1) * RECORD_SIZE;
++
+ 		// skip deleted dives
+ 		if (array_uint16_be(data + offset) == 0x5A23) {
+-			offset += RECORD_SIZE;
+ 			continue;
+ 		}
+ 		// Get the address of the dive.
+@@ -342,8 +348,6 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 		unsigned int len = dc_buffer_get_size (buffer);
+ 		if (callback && !callback (buf, len, buf + 12, sizeof (device->fingerprint), userdata))
+ 			break;
+-
+-		offset += RECORD_SIZE;
+ 	}
+ 
+ 	// Update and emit a progress event.

--- a/packages/libdivecomputer_plugin/patches/0004-shearwater-manifest-deleted-records.patch
+++ b/packages/libdivecomputer_plugin/patches/0004-shearwater-manifest-deleted-records.patch
@@ -1,0 +1,28 @@
+diff --git a/src/shearwater_petrel.c b/src/shearwater_petrel.c
+index 2fbc314..d8711e9 100644
+--- a/src/shearwater_petrel.c
++++ b/src/shearwater_petrel.c
+@@ -288,12 +288,18 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 			count++;
+ 		}
+ 
+-		// Update the progress state.
++		// Update the progress state. Deleted records are never
++		// downloaded, so they must not count towards the maximum.
+ 		current += 1;
+-		maximum -= RECORD_COUNT - count - deleted;
+-
+-		// Append the manifest records to the main buffer.
+-		if (!dc_buffer_append (manifests, data, count * RECORD_SIZE)) {
++		maximum -= RECORD_COUNT - count;
++
++		// Append all walked records to the main buffer, including the
++		// deleted ones. The walk advances past deleted records without
++		// counting them, so appending only a count-sized prefix would
++		// push any valid record behind a deleted one past the appended
++		// bytes, and its dive would silently never be downloaded. The
++		// dive download loop skips the deleted records.
++		if (!dc_buffer_append (manifests, data, offset)) {
+ 			ERROR (abstract->context, "Insufficient buffer space available.");
+ 			dc_buffer_free (buffer);
+ 			dc_buffer_free (manifests);

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -80,6 +80,27 @@ target_include_directories(test_hw_ostc3_read PRIVATE
     ${CONFIG_DIR}
 )
 
+# Regression test for issue #480: shearwater_petrel_device_foreach must
+# deliver dives oldest first (so the newest-fingerprint resume point works
+# after a partial BLE download), preserve manifest records behind deleted
+# (0x5A23) entries, and keep exact progress accounting. The test #includes
+# shearwater_petrel.c to reach the static foreach and mocks the whole
+# shearwater_common transport layer, so only leaf dependencies are linked.
+add_executable(test_shearwater_petrel_foreach
+    test_shearwater_petrel_foreach.c
+    ${LIBDC_DIR}/src/array.c
+    ${LIBDC_DIR}/src/buffer.c
+    ${LIBDC_DIR}/src/context.c
+    ${LIBDC_DIR}/src/common.c
+    ${LIBDC_DIR}/src/platform.c
+)
+target_include_directories(test_shearwater_petrel_foreach PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${CONFIG_DIR}
+)
+
 # test_parse_raw_dive requires the full libdivecomputer + wrapper linked in.
 # Use the Windows config on Windows, macOS config otherwise.
 if(WIN32)
@@ -122,6 +143,7 @@ add_test(NAME test_serial_callbacks COMMAND test_serial_callbacks)
 add_test(NAME test_descriptor_matcher COMMAND test_descriptor_matcher)
 add_test(NAME test_descriptor_match_integration COMMAND test_descriptor_match_integration)
 add_test(NAME test_hw_ostc3_read COMMAND test_hw_ostc3_read)
+add_test(NAME test_shearwater_petrel_foreach COMMAND test_shearwater_petrel_foreach)
 add_test(NAME test_parse_raw_dive COMMAND test_parse_raw_dive
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
+++ b/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
@@ -101,6 +101,7 @@ static void script_reset(void) {
 }
 
 static void script_add_dive(unsigned char id, int fail) {
+  assert(g_script.ndives < MAX_DIVES);  // fail fast on script overflow
   g_script.dives[g_script.ndives].id = id;
   g_script.dives[g_script.ndives].fail = fail;
   g_script.ndives++;
@@ -109,6 +110,8 @@ static void script_add_dive(unsigned char id, int fail) {
 // Writes one manifest record. deleted records get the 0x5A23 header and no
 // payload fields, matching what the device leaves behind after a delete.
 static void set_record(int page, int slot, int deleted, unsigned char id) {
+  assert(page >= 0 && page < MAX_PAGES);
+  assert(slot >= 0 && slot < (int)RECORD_COUNT);
   unsigned char *r = g_script.pages[page] + slot * RECORD_SIZE;
   memset(r, 0, RECORD_SIZE);
   if (deleted) {

--- a/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
+++ b/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
@@ -1,0 +1,457 @@
+// Regression test for issue #480: large Shearwater logbook downloads over BLE
+// time out and cannot resume, and dives behind deleted records are never
+// imported.
+//
+// Root causes, all in shearwater_petrel_device_foreach:
+//
+// 1. The profile-download loop walked the manifest front to back, i.e. newest
+//    dive first. Submersion persists the newest imported dive's fingerprint as
+//    the resume point, so after a partial (timed out or cancelled) run the
+//    next attempt's manifest stop-check matched at the newest dive and every
+//    older dive was stranded forever. Delivering the dives oldest first makes
+//    a partial run leave a contiguous oldest prefix, so the newest imported
+//    fingerprint is a correct high-water mark and resume works.
+// 2. The manifest phase appended only count * RECORD_SIZE bytes per page, but
+//    the record walk advances past deleted (0x5A23) records without counting
+//    them into count. A deleted dive interspersed among not-yet-downloaded
+//    dives pushed the trailing valid record(s) past the appended prefix; those
+//    dives were silently never downloaded.
+// 3. Deleted records were counted into the progress maximum but never credited
+//    to current, so progress never reached 100% on devices with deleted dives.
+//
+// shearwater_petrel_device_foreach is static, so this test #includes the
+// translation unit. The shearwater_common_* transport layer is mocked here
+// (shearwater_common.c is not linked): the mock serves scripted manifest pages
+// and dive payloads by address, and can fail a specific dive to simulate the
+// BLE timeouts from the issue.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libdivecomputer/common.h>
+#include <libdivecomputer/context.h>
+
+#include "shearwater_petrel.c"  // for the static foreach + device struct
+
+// ---------------------------------------------------------------------------
+// Stubs for the device.c symbols the #included TU references. device.c cannot
+// be linked (its dc_device_open switch-dispatches to every driver). The
+// progress stub records the most recent DC_EVENT_PROGRESS so the tests can
+// assert the final accounting.
+// ---------------------------------------------------------------------------
+
+static dc_event_progress_t g_last_progress;
+
+int dc_device_isinstance(dc_device_t *device, const dc_device_vtable_t *vtable) {
+  (void)device;
+  (void)vtable;
+  return 1;
+}
+dc_device_t *dc_device_allocate(dc_context_t *context,
+                                const dc_device_vtable_t *vtable) {
+  (void)context;
+  (void)vtable;
+  return NULL;
+}
+void dc_device_deallocate(dc_device_t *device) { (void)device; }
+void device_event_emit(dc_device_t *device, dc_event_type_t event,
+                       const void *data) {
+  (void)device;
+  if (event == DC_EVENT_PROGRESS)
+    g_last_progress = *(const dc_event_progress_t *)data;
+}
+
+// ---------------------------------------------------------------------------
+// Scripted mock of the shearwater_common transport layer.
+//
+// A manifest record is 32 bytes: header (0xA5C4 valid / 0x5A23 deleted) at
+// offset 0, the 4-byte fingerprint at offset 4, and the dive's storage address
+// at offset 20. Dives are identified by a one-byte id: the fingerprint is
+// {0xF0, 0, 0, id}, the storage address is id * 0x1000, and the served payload
+// carries the id at byte 0 and the fingerprint at bytes 12..15 (the foreach
+// callback contract points the fingerprint at buf + 12).
+// ---------------------------------------------------------------------------
+
+#define BASE_ADDR 0x80000000  // Petrel Native Format, reported via ID_LOGUPLOAD
+#define MAX_PAGES 3
+#define MAX_DIVES 64
+#define DIVE_PAYLOAD_SIZE 32
+
+typedef struct {
+  unsigned char pages[MAX_PAGES][MANIFEST_SIZE];
+  int npages;
+  int next_page;
+  struct {
+    unsigned char id;
+    int fail;  // serve DC_STATUS_TIMEOUT instead of the payload
+  } dives[MAX_DIVES];
+  int ndives;
+} script_t;
+
+static script_t g_script;
+
+static void script_reset(void) {
+  memset(&g_script, 0, sizeof(g_script));
+  // 0xFF-fill the pages: an 0xFFFF header is neither valid nor deleted, so an
+  // untouched slot terminates the manifest walk, like a real device's blank
+  // flash.
+  memset(g_script.pages, 0xFF, sizeof(g_script.pages));
+  memset(&g_last_progress, 0, sizeof(g_last_progress));
+}
+
+static void script_add_dive(unsigned char id, int fail) {
+  g_script.dives[g_script.ndives].id = id;
+  g_script.dives[g_script.ndives].fail = fail;
+  g_script.ndives++;
+}
+
+// Writes one manifest record. deleted records get the 0x5A23 header and no
+// payload fields, matching what the device leaves behind after a delete.
+static void set_record(int page, int slot, int deleted, unsigned char id) {
+  unsigned char *r = g_script.pages[page] + slot * RECORD_SIZE;
+  memset(r, 0, RECORD_SIZE);
+  if (deleted) {
+    r[0] = 0x5A;
+    r[1] = 0x23;
+    return;
+  }
+  r[0] = 0xA5;
+  r[1] = 0xC4;
+  r[4] = 0xF0;
+  r[7] = id;  // fingerprint {0xF0, 0, 0, id}
+  unsigned int address = (unsigned int)id * 0x1000;
+  r[20] = (address >> 24) & 0xFF;
+  r[21] = (address >> 16) & 0xFF;
+  r[22] = (address >> 8) & 0xFF;
+  r[23] = address & 0xFF;
+}
+
+dc_status_t shearwater_common_setup(shearwater_common_device_t *device,
+                                    dc_context_t *context,
+                                    dc_iostream_t *iostream) {
+  (void)device;
+  (void)context;
+  (void)iostream;
+  return DC_STATUS_SUCCESS;
+}
+
+dc_status_t shearwater_common_transfer(shearwater_common_device_t *device,
+                                       const unsigned char input[],
+                                       unsigned int isize,
+                                       unsigned char output[],
+                                       unsigned int osize,
+                                       unsigned int *actual) {
+  (void)device;
+  (void)input;
+  (void)isize;
+  (void)output;
+  (void)osize;
+  if (actual) *actual = 0;
+  return DC_STATUS_SUCCESS;
+}
+
+dc_status_t shearwater_common_rdbi(shearwater_common_device_t *device,
+                                   unsigned int id, unsigned char data[],
+                                   unsigned int size, unsigned int *actual) {
+  (void)device;
+  memset(data, 0, size);
+  switch (id) {
+    case ID_SERIAL:
+      memcpy(data, "0000ABCD", 8);  // hex string, converted by the driver
+      break;
+    case ID_FIRMWARE:
+      memcpy(data, "V37", 3);
+      if (actual) *actual = 3;
+      return DC_STATUS_SUCCESS;
+    case ID_MODEL:
+      data[0] = TERIC;
+      break;
+    case ID_LOGUPLOAD:
+      data[1] = (BASE_ADDR >> 24) & 0xFF;  // base address at bytes 1..4
+      break;
+    default:
+      break;
+  }
+  if (actual) *actual = size;
+  return DC_STATUS_SUCCESS;
+}
+
+dc_status_t shearwater_common_timesync_local(shearwater_common_device_t *device,
+                                             const dc_datetime_t *datetime) {
+  (void)device;
+  (void)datetime;
+  return DC_STATUS_SUCCESS;
+}
+
+dc_status_t shearwater_common_timesync_utc(shearwater_common_device_t *device,
+                                           const dc_datetime_t *datetime) {
+  (void)device;
+  (void)datetime;
+  return DC_STATUS_SUCCESS;
+}
+
+dc_status_t shearwater_common_download(shearwater_common_device_t *device,
+                                       dc_buffer_t *buffer,
+                                       unsigned int address, unsigned int size,
+                                       unsigned int compression,
+                                       dc_event_progress_t *progress) {
+  (void)device;
+  (void)size;
+  (void)compression;
+  (void)progress;
+  dc_buffer_clear(buffer);
+
+  if (address == MANIFEST_ADDR) {
+    if (g_script.next_page >= g_script.npages)
+      return DC_STATUS_IO;  // the driver asked for more pages than scripted
+    if (!dc_buffer_append(buffer, g_script.pages[g_script.next_page],
+                          MANIFEST_SIZE))
+      return DC_STATUS_NOMEMORY;
+    g_script.next_page++;
+    return DC_STATUS_SUCCESS;
+  }
+
+  for (int i = 0; i < g_script.ndives; i++) {
+    unsigned char id = g_script.dives[i].id;
+    if (BASE_ADDR + (unsigned int)id * 0x1000 != address) continue;
+    if (g_script.dives[i].fail) return DC_STATUS_TIMEOUT;
+    unsigned char payload[DIVE_PAYLOAD_SIZE];
+    memset(payload, 0xAB, sizeof(payload));
+    payload[0] = id;
+    payload[12] = 0xF0;
+    payload[13] = 0;
+    payload[14] = 0;
+    payload[15] = id;  // fingerprint {0xF0, 0, 0, id} at buf + 12
+    if (!dc_buffer_append(buffer, payload, sizeof(payload)))
+      return DC_STATUS_NOMEMORY;
+    return DC_STATUS_SUCCESS;
+  }
+
+  return DC_STATUS_IO;  // unknown address: the script has no such dive
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+typedef struct {
+  unsigned char order[MAX_DIVES];  // dive ids in delivery order
+  int n;
+  int contract_ok;  // fsize == 4, fingerprint == data + 12, value matches
+} cb_state_t;
+
+static int dive_cb(const unsigned char *data, unsigned int size,
+                   const unsigned char *fingerprint, unsigned int fsize,
+                   void *userdata) {
+  cb_state_t *s = (cb_state_t *)userdata;
+  (void)size;
+  if (fsize != 4 || fingerprint != data + 12 || fingerprint[0] != 0xF0 ||
+      fingerprint[3] != data[0])
+    s->contract_ok = 0;
+  if (s->n < MAX_DIVES) s->order[s->n] = data[0];
+  s->n++;
+  return 1;
+}
+
+// Runs foreach against the current script with an optional resume fingerprint.
+static dc_status_t run_foreach(const unsigned char *fingerprint,
+                               cb_state_t *state) {
+  dc_context_t *ctx = NULL;
+  assert(dc_context_new(&ctx) == DC_STATUS_SUCCESS);
+
+  shearwater_petrel_device_t dev;
+  memset(&dev, 0, sizeof(dev));
+  dev.base.base.context = ctx;
+  if (fingerprint) memcpy(dev.fingerprint, fingerprint, 4);
+
+  memset(state, 0, sizeof(*state));
+  state->contract_ok = 1;
+
+  dc_status_t rc =
+      shearwater_petrel_device_foreach(&dev.base.base, dive_cb, state);
+
+  dc_context_free(ctx);
+  return rc;
+}
+
+static int failures = 0;
+
+static void expect(int cond, const char *label) {
+  if (cond) {
+    printf("PASS: %s\n", label);
+  } else {
+    printf("FAIL: %s\n", label);
+    failures++;
+  }
+}
+
+static int order_is(const cb_state_t *s, const unsigned char *want, int n) {
+  if (s->n != n) return 0;
+  return memcmp(s->order, want, (size_t)n) == 0;
+}
+
+static void print_order(const cb_state_t *s) {
+  printf("  delivered %d dive(s):", s->n);
+  for (int i = 0; i < s->n && i < MAX_DIVES; i++) printf(" %u", s->order[i]);
+  printf("\n");
+}
+
+// The manifest lists dives newest first (slot 0 is the newest); delivery must
+// be oldest first so a partial run leaves a resumable oldest prefix.
+static void check_oldest_first(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 3);  // newest
+  set_record(0, 1, 0, 2);
+  set_record(0, 2, 0, 1);  // oldest
+  script_add_dive(1, 0);
+  script_add_dive(2, 0);
+  script_add_dive(3, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  const unsigned char want[] = {1, 2, 3};
+  expect(rc == DC_STATUS_SUCCESS, "a full download succeeds");
+  expect(order_is(&s, want, 3), "dives are delivered oldest first");
+  if (s.n != 3 || memcmp(s.order, want, 3) != 0) print_order(&s);
+  expect(s.contract_ok, "the fingerprint is buf + 12 of each dive's data");
+}
+
+// Valid records behind deleted (0x5A23) records must still be downloaded: the
+// manifest phase must preserve every walked record, not a count-sized prefix.
+static void check_deleted_records_preserved(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 4);  // newest
+  set_record(0, 1, 1, 0);  // deleted
+  set_record(0, 2, 0, 3);
+  set_record(0, 3, 1, 0);  // deleted
+  set_record(0, 4, 0, 2);
+  set_record(0, 5, 0, 1);  // oldest
+  script_add_dive(1, 0);
+  script_add_dive(2, 0);
+  script_add_dive(3, 0);
+  script_add_dive(4, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  const unsigned char want[] = {1, 2, 3, 4};
+  expect(rc == DC_STATUS_SUCCESS,
+         "a download with deleted records succeeds");
+  expect(order_is(&s, want, 4),
+         "dives behind deleted records are still delivered, oldest first");
+  if (s.n != 4 || memcmp(s.order, want, 4) != 0) print_order(&s);
+}
+
+// A failed dive download aborts the pass; everything delivered before it must
+// be a contiguous oldest prefix so the newest imported fingerprint resumes
+// correctly on the next attempt.
+static void check_stop_on_failure(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 3);  // newest
+  set_record(0, 1, 0, 2);  // this download fails (BLE timeout)
+  set_record(0, 2, 0, 1);  // oldest
+  script_add_dive(1, 0);
+  script_add_dive(2, 1);
+  script_add_dive(3, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  const unsigned char want[] = {1};
+  expect(rc == DC_STATUS_TIMEOUT, "the dive failure is propagated");
+  expect(order_is(&s, want, 1),
+         "a failed download leaves a contiguous oldest prefix");
+  if (s.n != 1 || s.order[0] != 1) print_order(&s);
+}
+
+// Resume: with the newest imported dive's fingerprint set, only newer dives
+// are downloaded, oldest first, even across interspersed deleted records.
+static void check_fingerprint_resume(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 4);  // newest
+  set_record(0, 1, 0, 3);
+  set_record(0, 2, 1, 0);  // deleted
+  set_record(0, 3, 0, 2);  // resume point: already imported
+  set_record(0, 4, 0, 1);
+  script_add_dive(3, 0);
+  script_add_dive(4, 0);
+
+  const unsigned char resume[4] = {0xF0, 0, 0, 2};
+  cb_state_t s;
+  dc_status_t rc = run_foreach(resume, &s);
+  const unsigned char want[] = {3, 4};
+  expect(rc == DC_STATUS_SUCCESS, "a resumed download succeeds");
+  expect(order_is(&s, want, 2),
+         "resume downloads only the dives newer than the fingerprint, oldest first");
+  if (s.n != 2 || memcmp(s.order, want, 2) != 0) print_order(&s);
+}
+
+// Deleted records must not be counted into the progress maximum: the final
+// progress event has to reach exactly 100%.
+static void check_progress_accounting(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 2);  // newest
+  set_record(0, 1, 1, 0);  // deleted
+  set_record(0, 2, 0, 1);  // oldest
+  script_add_dive(1, 0);
+  script_add_dive(2, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  expect(rc == DC_STATUS_SUCCESS, "a download with a deleted record succeeds");
+  expect(g_last_progress.maximum != 0, "a final progress event was emitted");
+  expect(g_last_progress.current == g_last_progress.maximum,
+         "final progress reaches 100% despite deleted records");
+  // 1 manifest page + 2 dives, NSTEPS each; the deleted record contributes
+  // nothing to either side.
+  expect(g_last_progress.maximum == 3 * NSTEPS,
+         "the progress maximum counts only the page and the real dives");
+  if (g_last_progress.current != g_last_progress.maximum ||
+      g_last_progress.maximum != 3 * NSTEPS)
+    printf("  final progress %u / %u\n", g_last_progress.current,
+           g_last_progress.maximum);
+}
+
+// A full first manifest page (48 valid records) makes the driver fetch a
+// second page; ordering must hold across the page boundary: the oldest dive
+// lives on the LAST page.
+static void check_multi_page(void) {
+  script_reset();
+  g_script.npages = 2;
+  for (int slot = 0; slot < (int)RECORD_COUNT; slot++) {
+    unsigned char id = (unsigned char)(49 - slot);  // page 0: ids 49..2
+    set_record(0, slot, 0, id);
+    script_add_dive(id, 0);
+  }
+  set_record(1, 0, 0, 1);  // page 1: the single oldest dive
+  script_add_dive(1, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  unsigned char want[49];
+  for (int i = 0; i < 49; i++) want[i] = (unsigned char)(i + 1);
+  expect(rc == DC_STATUS_SUCCESS, "a two-page download succeeds");
+  expect(order_is(&s, want, 49),
+         "oldest-first ordering holds across manifest pages");
+  if (s.n != 49 || memcmp(s.order, want, 49) != 0) print_order(&s);
+}
+
+int main(void) {
+  check_oldest_first();
+  check_deleted_records_preserved();
+  check_stop_on_failure();
+  check_fingerprint_resume();
+  check_progress_accounting();
+  check_multi_page();
+
+  if (failures == 0) {
+    printf("All shearwater_petrel_foreach tests passed.\n");
+    return 0;
+  }
+  printf("%d shearwater_petrel_foreach test(s) FAILED.\n", failures);
+  return 1;
+}

--- a/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
+++ b/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
@@ -144,6 +144,7 @@ Widget _buildWidget({
   DownloadState initialState = const DownloadState(),
   VoidCallback? onComplete,
   void Function(String)? onError,
+  VoidCallback? onImportPartial,
 }) {
   return ProviderScope(
     overrides: [
@@ -165,6 +166,7 @@ Widget _buildWidget({
           device: device ?? _testDevice,
           onComplete: onComplete ?? () {},
           onError: onError ?? (_) {},
+          onImportPartial: onImportPartial,
         ),
       ),
     ),
@@ -559,6 +561,99 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Cancel'), findsNothing);
+    });
+
+    // -----------------------------------------------------------------------
+    // Partial import: an interrupted download that already delivered dives
+    // (issue #480). Because dives are delivered oldest-first, the retained
+    // prefix is a contiguous run of the oldest dives, so importing it and
+    // advancing the fingerprint gives a correct resume point.
+    // -----------------------------------------------------------------------
+
+    testWidgets(
+      'shows import-partial button in error state when dives were delivered',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildWidget(
+            initialState: DownloadState(
+              phase: DownloadPhase.error,
+              errorMessage: 'Connection timed out',
+              downloadedDives: [_makeDive(diveNumber: 1), _makeDive()],
+            ),
+            onImportPartial: () {},
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The error is still shown, and an explicit action to keep the dives
+        // pulled before the failure is offered alongside Retry.
+        expect(find.text('Connection timed out'), findsOneWidget);
+        expect(find.text('Import 2 downloaded dives'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'does not show import-partial button in error state with no dives',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildWidget(
+            initialState: const DownloadState(
+              phase: DownloadPhase.error,
+              errorMessage: 'Connection timed out',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('downloaded dives'), findsNothing);
+        expect(find.text('Retry'), findsOneWidget);
+      },
+    );
+
+    testWidgets('import-partial button fires onImportPartial when tapped', (
+      tester,
+    ) async {
+      var importPartialCalled = false;
+
+      await tester.pumpWidget(
+        _buildWidget(
+          initialState: DownloadState(
+            phase: DownloadPhase.error,
+            errorMessage: 'Connection timed out',
+            downloadedDives: [_makeDive(diveNumber: 1)],
+          ),
+          onImportPartial: () => importPartialCalled = true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import 1 downloaded dives'));
+      await tester.pumpAndSettle();
+
+      expect(importPartialCalled, isTrue);
+    });
+
+    testWidgets('shows import-partial button in cancelled state with dives', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildWidget(
+          initialState: DownloadState(
+            phase: DownloadPhase.cancelled,
+            downloadedDives: [
+              _makeDive(diveNumber: 1),
+              _makeDive(),
+              _makeDive(),
+            ],
+          ),
+          onImportPartial: () {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import 3 downloaded dives'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
     });
 
     testWidgets('shows fallback error text when errorMessage is null', (

--- a/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
+++ b/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
@@ -628,10 +628,30 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Import 1 downloaded dives'));
+      // A single dive uses the grammatical singular form.
+      await tester.tap(find.text('Import 1 downloaded dive'));
       await tester.pumpAndSettle();
 
       expect(importPartialCalled, isTrue);
+    });
+
+    testWidgets('import-partial button uses singular label for one dive', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildWidget(
+          initialState: DownloadState(
+            phase: DownloadPhase.error,
+            errorMessage: 'Connection timed out',
+            downloadedDives: [_makeDive(diveNumber: 1)],
+          ),
+          onImportPartial: () {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import 1 downloaded dive'), findsOneWidget);
+      expect(find.text('Import 1 downloaded dives'), findsNothing);
     });
 
     testWidgets('shows import-partial button in cancelled state with dives', (

--- a/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
+++ b/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
@@ -654,6 +654,49 @@ void main() {
       expect(find.text('Import 1 downloaded dives'), findsNothing);
     });
 
+    testWidgets('tapping Retry with no partial dives restarts the download', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildWidget(
+          initialState: const DownloadState(
+            phase: DownloadPhase.error,
+            errorMessage: 'Connection timed out',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // No onImportPartial and no dives: Retry is the sole FilledButton.
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      // The stubbed notifier makes the restart a no-op; the widget survives.
+      expect(find.byType(DownloadStepWidget), findsOneWidget);
+    });
+
+    testWidgets(
+      'tapping Retry alongside import-partial restarts the download',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildWidget(
+            initialState: DownloadState(
+              phase: DownloadPhase.cancelled,
+              downloadedDives: [_makeDive(diveNumber: 1)],
+            ),
+            onImportPartial: () {},
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // With partial dives, Retry is the secondary OutlinedButton.
+        await tester.tap(find.text('Retry'));
+        await tester.pump();
+
+        expect(find.byType(DownloadStepWidget), findsOneWidget);
+      },
+    );
+
     testWidgets('shows import-partial button in cancelled state with dives', (
       tester,
     ) async {

--- a/test/features/import_wizard/presentation/widgets/dc_adapter_steps_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_adapter_steps_test.dart
@@ -8,6 +8,7 @@ import 'package:libdivecomputer_plugin/src/dive_computer_service.dart'
     show DownloadEvent;
 
 import 'package:submersion/features/dive_computer/domain/entities/device_model.dart';
+import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 import 'package:submersion/features/dive_computer/data/services/dive_import_service.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/discovery_providers.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/download_providers.dart';
@@ -532,5 +533,118 @@ void main() {
       // After resolution, the DownloadStepWidget is rendered.
       expect(find.byType(DownloadStepWidget), findsOneWidget);
     });
+
+    // -----------------------------------------------------------------------
+    // Capturing downloaded dives (_captureAndAdvance): the completion listener
+    // and the import-partial action both funnel here.
+    // -----------------------------------------------------------------------
+
+    testWidgets('a completed download captures dives and advances the wizard', (
+      tester,
+    ) async {
+      final computer = _makeComputer();
+      final adapter = _makeAdapter(knownComputer: computer);
+
+      await tester.pumpWidget(
+        _buildDownloadStep(
+          adapter: adapter,
+          knownComputer: computer,
+          discoveryState: DiscoveryState(selectedDevice: _testDevice),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DcAdapterDownloadStep)),
+      );
+      expect(container.read(dcAdapterDownloadCanAdvanceProvider), isFalse);
+
+      // Transition the download to complete with dives: the step's listener
+      // fires _captureAndAdvance, which (via a post-frame callback) flips the
+      // can-advance provider so the wizard can move to Review.
+      container.read(downloadNotifierProvider.notifier).state = DownloadState(
+        phase: DownloadPhase.complete,
+        downloadedDives: [_downloadedDive(), _downloadedDive()],
+      );
+      await tester.pumpAndSettle();
+
+      expect(container.read(dcAdapterDownloadCanAdvanceProvider), isTrue);
+    });
+
+    testWidgets('a completed download with no dives shows the no-dives view', (
+      tester,
+    ) async {
+      final computer = _makeComputer();
+      final adapter = _makeAdapter(knownComputer: computer);
+
+      await tester.pumpWidget(
+        _buildDownloadStep(
+          adapter: adapter,
+          knownComputer: computer,
+          discoveryState: DiscoveryState(selectedDevice: _testDevice),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DcAdapterDownloadStep)),
+      );
+      container
+          .read(downloadNotifierProvider.notifier)
+          .state = const DownloadState(
+        phase: DownloadPhase.complete,
+        downloadedDives: [],
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DcNoNewDivesView), findsOneWidget);
+      expect(container.read(dcAdapterDownloadCanAdvanceProvider), isFalse);
+    });
+
+    testWidgets(
+      'importing a partial download captures dives and advances the wizard',
+      (tester) async {
+        final computer = _makeComputer();
+        final adapter = _makeAdapter(knownComputer: computer);
+
+        await tester.pumpWidget(
+          _buildDownloadStep(
+            adapter: adapter,
+            knownComputer: computer,
+            discoveryState: DiscoveryState(selectedDevice: _testDevice),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(DcAdapterDownloadStep)),
+        );
+
+        // An interrupted download that already delivered dives: the download
+        // widget offers an import-partial action wired to _captureAndAdvance.
+        container.read(downloadNotifierProvider.notifier).state = DownloadState(
+          phase: DownloadPhase.error,
+          errorMessage: 'Connection timed out',
+          downloadedDives: [_downloadedDive(), _downloadedDive()],
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Import 2 downloaded dives'));
+        await tester.pumpAndSettle();
+
+        expect(container.read(dcAdapterDownloadCanAdvanceProvider), isTrue);
+      },
+    );
   });
 }
+
+DownloadedDive _downloadedDive() => DownloadedDive(
+  startTime: DateTime(2026, 3, 15, 10, 0),
+  durationSeconds: 40 * 60,
+  maxDepth: 20.0,
+  profile: const [],
+  tanks: const [],
+);


### PR DESCRIPTION
## Summary

Fixes #480: large Shearwater logbook downloads over BLE (Teric, and any `shearwater_petrel` backend device: Perdix, Petrel 2, Peregrine) time out partway through and can never resume, because dives were delivered newest-first while the resume point is the newest imported dive's fingerprint. Additionally, dives sitting behind deleted records in the device manifest were silently never imported, and progress never reached 100% on devices with deleted dives.

The native fixes are in the vendored libdivecomputer fork (`src/shearwater_petrel.c`), commits [`714a2e5`](https://github.com/submersion-app/libdivecomputer/commit/714a2e5) and [`7e8fd9a`](https://github.com/submersion-app/libdivecomputer/commit/7e8fd9a) on `submersion-patches`, mirrored as fork patches 0003/0004. The app-side change lets an interrupted download keep the dives it already pulled, which is what actually delivers resume.

## Changes

**libdivecomputer fork**
- Reverse the profile-download loop so dives are delivered oldest to newest. The loop stops on the first failed dive, so a partial run always leaves a contiguous oldest-first prefix, making the newest imported fingerprint (`selectNewestFingerprint`) a correct high-water mark. The manifest phase is unchanged (its newest-first walk is required by the fingerprint stop-check).
- Append all walked manifest bytes per page instead of a `count`-sized prefix, so valid records behind deleted (`0x5A23`) records are preserved; the dive-download loop already skips the deleted markers.
- Exclude deleted records from the progress `maximum` so the final progress event reaches exactly 100%.
- Fork patches `0003-shearwater-oldest-first.patch` and `0004-shearwater-manifest-deleted-records.patch`.
- Native regression test `test_shearwater_petrel_foreach.c` (mocks the `shearwater_common_*` transport): oldest-first delivery, deleted-record preservation, stop-on-first-failure contiguous oldest prefix, fingerprint resume, the `buf + 12` callback contract, exact final progress accounting, and cross-page ordering. Bounds-asserts its script buffers (review follow-up).

**App-side (makes resume actually reachable)**
- Previously the download step only advanced to review/store on `DownloadPhase.complete`; a timed-out (`DownloadErrorEvent`) or cancelled download discarded the dives delivered before the interruption, so the fingerprint never advanced. That left the native reorder correct but inert for the exact timeout case it targets.
- Add an "Import N downloaded dives" action to the download step's error and cancelled states, shown whenever a partial set was delivered. It routes those dives through the normal review/store path, which persists the newest imported fingerprint. Oldest-first delivery guarantees the retained set is a contiguous prefix of the oldest dives, so that fingerprint is a safe high-water mark and the next download resumes with the newer dives.
- Extract the capture-and-advance logic in `dc_adapter_steps` so the normal-completion path and the partial-import action share it. New localized string `diveComputer_downloadStep_importPartialCount` in all locales.

The rest of the Dart import path is order-agnostic (verified: `fingerprint_utils.dart` and dive numbering in `dive_computer_adapter.dart` both sort by `startTime`), so review, dive numbering, and fingerprint selection are unaffected by delivery order. Only visible behavior change beyond the partial-import button: the import wizard lists downloaded dives oldest-first, and a cancelled/failed partial download now offers to keep the oldest dives.

Out of scope: `src/shearwater_predator.c` (older Predator-format path, not used by the Teric) also delivers newest-first via ringbuffer ordering; a follow-up is only warranted if a predator-backend device shows the same failure.

## Test Plan

- [x] Native suite: 7/7 ctest targets pass locally, including `test_shearwater_petrel_foreach` (15/15 assertions), verified RED against the unpatched driver first
- [x] `download_step_widget_test` + `dc_adapter_steps_test` pass, including 4 new tests for the import-partial button (visibility gated on a delivered set + wired callback, tap routing, error and cancelled states); new tests verified RED before implementation
- [x] Localization parity test passes with the new string in all 11 locales
- [x] `flutter analyze` clean
- [ ] Hardware verify on a real Teric with a large logbook: cancel/timeout mid-download, tap "Import N downloaded dives", confirm the next download resumes with the newer dives rather than restarting