### PR TITLE
fix(backup): route Android SAF pre-migration backup to the sandbox default (#505)

### DIFF
--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -727,7 +727,10 @@ class BackupService {
       return BackupDirLease(await resolveDefaultBackupsDirectory(), _noRelease);
     }
     if (!BackupBookmarkService.isSupported) {
-      // Desktop: bare custom filesystem paths persist and work without scoping.
+      // Non-Apple platforms (desktop Linux/Windows, and Android with a plain
+      // filesystem path -- SAF content:// locations were already handled
+      // above). Security-scoped bookmarks are an Apple-only concept, so a bare
+      // custom filesystem path here persists and works without scoping.
       return BackupDirLease(await _ensureDir(custom), _noRelease);
     }
     final port = bookmarks ?? const _DefaultBackupBookmarkPort();

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -714,8 +714,20 @@ class BackupService {
     if (custom == null) {
       return BackupDirLease(await resolveDefaultBackupsDirectory(), _noRelease);
     }
+    if (isSafRef(custom)) {
+      // An Android SAF location is a content:// URI, not a filesystem path.
+      // This leased directory is consumed by the pre-migration safety copy,
+      // which writes with dart:io -- and Directory('content://...').create
+      // treats the URI as a relative path and throws
+      // "FileSystemException: Creation failed, path = 'content:'" against the
+      // read-only app working directory, bricking startup on the "Database
+      // upgrade failed" screen (issue #505). Route the filesystem copy to the
+      // always-writable sandbox default. The SAF location is left intact and
+      // still used for normal backups via resolveBackupTargetLeased.
+      return BackupDirLease(await resolveDefaultBackupsDirectory(), _noRelease);
+    }
     if (!BackupBookmarkService.isSupported) {
-      // Desktop/Android: bare custom paths persist and work without scoping.
+      // Desktop: bare custom filesystem paths persist and work without scoping.
       return BackupDirLease(await _ensureDir(custom), _noRelease);
     }
     final port = bookmarks ?? const _DefaultBackupBookmarkPort();

--- a/test/features/backup/data/services/backup_service_leased_test.dart
+++ b/test/features/backup/data/services/backup_service_leased_test.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
 
 /// Fake of the narrow bookmark seam so the leased resolver can be tested
 /// without a native channel.
@@ -244,6 +245,45 @@ void main() {
 
         expect(lease.path, tmp.path);
         expect(port.resolveCalls, 0);
+      },
+    );
+
+    // Issue #505: an Android SAF custom location is a content:// URI, not a
+    // filesystem path. The pre-migration safety copy is written with dart:io,
+    // which cannot create a content:// URI: Directory('content://...').create
+    // treats it as a relative path and throws
+    // "FileSystemException: Creation failed, path = 'content:'" against the
+    // read-only app working directory, bricking startup on the "Database
+    // upgrade failed" screen. The filesystem copy must route to the sandbox
+    // default instead, without disturbing the SAF location (still used for
+    // normal backups).
+    test(
+      'Android SAF content:// location -> sandbox default, setting preserved',
+      () async {
+        const safUri =
+            'content://com.android.externalstorage.documents/tree/primary%3ABackups';
+        await preferences.setBackupLocation(safUri);
+        BackupBookmarkService.debugSupportedOverride = false; // Android
+        final port = _FakeBookmarkPort();
+
+        // Guard: the buggy code path creates a stray 'content:' dir under CWD.
+        addTearDown(() async {
+          final stray = Directory('content:');
+          if (await stray.exists()) await stray.delete(recursive: true);
+        });
+
+        final lease = await BackupService.resolveBackupsDirectoryLeased(
+          preferences,
+          bookmarks: port,
+        );
+
+        expect(lease.path, contains('Submersion'));
+        expect(lease.path, contains('Backups'));
+        expect(isSafRef(lease.path), isFalse);
+        // The user's SAF choice must remain for normal (SAF) backups.
+        expect(preferences.getSettings().backupLocation, safUri);
+        expect(port.resolveCalls, 0);
+        await lease.release(); // no-op; must not throw
       },
     );
   });


### PR DESCRIPTION
## Summary

Fixes #505: on Android, upgrading to a build with a pending schema migration showed a fatal **"Database upgrade failed — FileSystemException: Creation failed, path = 'content:' (OS Error: Read-only file system, errno = 30)"** screen and blocked startup.

The error is misleading — it did not come from the migration. It came from the **pre-migration safety backup** taken just before it. On Android a custom backup location is a SAF `content://` URI, not a filesystem path. `BackupService.resolveBackupsDirectoryLeased` (used by startup's `_runPreMigrationBackup`, which copies the DB with `dart:io`) fell through to its "bare path" branch — security-scoped bookmarks are iOS/macOS-only — and ran `Directory('content://…').create(recursive: true)`. `dart:io` treats the URI as a relative path and tries to create a directory literally named `content:` under the read-only app working directory → `FileSystemException` errno 30.

That raw `FileSystemException` is not a `BackupFailedException`, so it escaped the pre-migration backup's `on BackupFailedException` catch and surfaced through the generic startup handler as "Database upgrade failed", blocking the migration on every launch with (pending migration + SAF backup location). The backup service's own sandbox fallback never helped, because the throw happens earlier — during directory resolution, before that service is even constructed.

## Changes

- `resolveBackupsDirectoryLeased`: recognize a `content://` ref (`isSafRef`) and route the `dart:io` pre-migration safety copy to the always-writable sandbox default, placed **before** the bookmark/`isSupported` branch so a SAF URI can never reach `dart:io` on any platform. The user's SAF location is left intact and still used for normal backups via `resolveBackupTargetLeased` (which already handles SAF through the MethodChannel port).
- Regression test: `backup_service_leased_test.dart` → "Android SAF content:// location -> sandbox default, setting preserved" (verified RED against the old code, which returned the raw `content://` URI).

Out of scope: the sibling non-leased `resolveBackupsDirectory` has the same `Directory(custom).create` pattern, but it is only reachable via `getBackupsDirectory()`, which has zero production callers, so it is off the crash path.

## Test Plan

- [x] `flutter test test/features/backup/ test/core/presentation/pages/startup_page_test.dart test/core/presentation/pages/startup_page_backup_flow_test.dart` — 276 pass
- [x] New test verified RED before the fix, GREEN after
- [x] `flutter analyze` clean, formatted
- [ ] Hardware verify on Android: set a SAF (content://) custom backup folder, then upgrade across a schema migration and confirm startup migrates cleanly (pre-migration backup lands in the app sandbox) instead of showing "Database upgrade failed"