### PR TITLE
Populate dive name from Garmin FIT source filename (#507)

### DIFF
--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1146,9 +1146,11 @@ class UddfEntityImporter {
             )
           : null;
 
+      final diveName = (diveData['name'] as String?)?.trim();
       var dive = Dive(
         id: diveId,
         diverId: diverId,
+        name: diveName != null && diveName.isNotEmpty ? diveName : null,
         diveNumber: nextDiveNumber != null
             ? nextDiveNumber++
             : diveData['diveNumber'] as int?,

--- a/lib/features/universal_import/data/models/import_options.dart
+++ b/lib/features/universal_import/data/models/import_options.dart
@@ -10,8 +10,16 @@ class ImportOptions extends Equatable {
   /// The detected/confirmed format.
   final ImportFormat format;
 
-  const ImportOptions({required this.sourceApp, required this.format});
+  /// The source file's name, when known. Used by formats that carry no
+  /// in-file dive name (e.g. Garmin FIT) to seed the dive name from the file.
+  final String? fileName;
+
+  const ImportOptions({
+    required this.sourceApp,
+    required this.format,
+    this.fileName,
+  });
 
   @override
-  List<Object?> get props => [sourceApp, format];
+  List<Object?> get props => [sourceApp, format, fileName];
 }

--- a/lib/features/universal_import/data/parsers/fit_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/fit_import_parser.dart
@@ -47,7 +47,13 @@ class FitImportParser implements ImportParser {
 
     final sourceUuid = dive.sourceUuid ?? dive.sourceId;
 
+    // FIT files carry no user-facing dive name (the sport message only holds
+    // the sport profile, e.g. "Multi-Gas"). Garmin Connect encodes the dive
+    // name in the exported filename, so seed the dive name from there.
+    final nameFromFile = _diveNameFromFileName(options?.fileName);
+
     final diveData = <String, dynamic>{
+      'name': ?nameFromFile,
       'dateTime': dive.startTime,
       'maxDepth': dive.maxDepth,
       'avgDepth': dive.avgDepth,
@@ -158,5 +164,24 @@ class FitImportParser implements ImportParser {
         'sourceUuid': sourceUuid,
       },
     );
+  }
+
+  /// Derives a dive name from the source [fileName]: drops the extension and
+  /// a leading Garmin dive-number prefix (`22 `, `#7 `), which is redundant
+  /// with the separately stored dive number. Returns null when nothing
+  /// name-like remains (e.g. the stem is only a number or the file is
+  /// unnamed), so the dive is simply left unnamed rather than labelled with a
+  /// bare number.
+  ///
+  /// The prefix must be followed by whitespace, so a date-led name such as
+  /// `2024-10-13 Night Dive` is preserved intact.
+  static String? _diveNameFromFileName(String? fileName) {
+    if (fileName == null) return null;
+    var stem = fileName.trim();
+    final dot = stem.lastIndexOf('.');
+    if (dot > 0) stem = stem.substring(0, dot);
+    stem = stem.replaceFirst(RegExp(r'^#?\d{1,4}\s+'), '').trim();
+    if (stem.isEmpty || RegExp(r'^\d+$').hasMatch(stem)) return null;
+    return stem;
   }
 }

--- a/lib/features/universal_import/presentation/providers/universal_import_providers.dart
+++ b/lib/features/universal_import/presentation/providers/universal_import_providers.dart
@@ -240,7 +240,11 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
     final sourceApp =
         effectiveOverride ?? detection.sourceApp ?? SourceApp.generic;
 
-    final options = ImportOptions(sourceApp: sourceApp, format: format);
+    final options = ImportOptions(
+      sourceApp: sourceApp,
+      format: format,
+      fileName: state.fileName,
+    );
 
     // For CSV files, run pipeline detection to check for multi-file presets.
     if (format == ImportFormat.csv && state.fileBytes != null) {

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -255,6 +255,53 @@ void main() {
       expect(dive.profile.any((p) => p.ceiling == 6.0), isTrue);
       expect(dive.profile.any((p) => p.tts == 480), isTrue);
     });
+
+    test('maps the dive name from the payload (FIT filename seed)', () async {
+      final data = UddfImportResult(
+        dives: [
+          {
+            'name': 'Dos Ojos Cenote Dive (Barbie Line)',
+            'dateTime': DateTime.utc(2025, 10, 13, 11, 24, 0),
+            'maxDepth': 29.5,
+            'duration': const Duration(seconds: 3263),
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final dive =
+          verify(mockDiveRepo.createDive(captureAny)).captured.single as Dive;
+      expect(dive.name, 'Dos Ojos Cenote Dive (Barbie Line)');
+    });
+
+    test('leaves the dive unnamed when the payload has no name', () async {
+      final data = UddfImportResult(
+        dives: [
+          {
+            'dateTime': DateTime.utc(2025, 10, 13, 11, 24, 0),
+            'maxDepth': 29.5,
+            'duration': const Duration(seconds: 3263),
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final dive =
+          verify(mockDiveRepo.createDive(captureAny)).captured.single as Dive;
+      expect(dive.name, isNull);
+    });
   });
 
   group('Import equipment', () {

--- a/test/features/universal_import/data/parsers/fit_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/fit_import_parser_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     show GasMix;
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/models/import_options.dart';
 import 'package:submersion/features/universal_import/data/parsers/fit_import_parser.dart';
 
 /// A rich dive FIT file (deco records, gas, settings, summary, GPS) built with
@@ -217,4 +218,54 @@ void main() {
       expect(reading['pressure'], closeTo(220.0, 1e-6));
     },
   );
+
+  group('dive name from source filename', () {
+    ImportOptions optsWithFile(String name) => ImportOptions(
+      sourceApp: SourceApp.garminConnect,
+      format: ImportFormat.fit,
+      fileName: name,
+    );
+
+    Future<Map<String, dynamic>> parseWith(String fileName) async {
+      final payload = await const FitImportParser().parse(
+        _richFitBytes(),
+        options: optsWithFile(fileName),
+      );
+      return payload.entities[ImportEntityType.dives]!.single;
+    }
+
+    test('uses the filename stem as the dive name', () async {
+      final d = await parseWith('Dos Ojos Cenote Dive (Barbie Line).fit');
+      expect(d['name'], 'Dos Ojos Cenote Dive (Barbie Line)');
+    });
+
+    test('strips a leading Garmin dive-number prefix', () async {
+      final d = await parseWith('22 Dos Ojos Cenote Dive (Barbie Line).fit');
+      expect(d['name'], 'Dos Ojos Cenote Dive (Barbie Line)');
+    });
+
+    test('strips a leading #-number prefix', () async {
+      final d = await parseWith('#7 Blue Hole.FIT');
+      expect(d['name'], 'Blue Hole');
+    });
+
+    test(
+      'keeps a date-like prefix intact (no space after the digits)',
+      () async {
+        final d = await parseWith('2024-10-13 Night Dive.fit');
+        expect(d['name'], '2024-10-13 Night Dive');
+      },
+    );
+
+    test('emits no name when the stem is only a dive number', () async {
+      final d = await parseWith('22.fit');
+      expect(d.containsKey('name'), isFalse);
+    });
+
+    test('emits no name when no filename is supplied', () async {
+      final payload = await const FitImportParser().parse(_richFitBytes());
+      final d = payload.entities[ImportEntityType.dives]!.single;
+      expect(d.containsKey('name'), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #507: after importing a Garmin `.FIT` file, the dive name was not populating — it only survived as an import-provenance tag (e.g. `22 Dos Ojos Cenote Dive (Barbie Line).fit Import 2026-07-06`), leaving the dive itself unnamed.

**Root cause:** FIT files carry no user-facing dive name — the sport message holds only the sport *profile* (e.g. `Multi-Gas`). Garmin encodes the dive name in the exported filename, but nothing read it onto the dive: `FitImportParser` emitted no name and `UddfEntityImporter` never mapped one, even though `Dive` and the `dives` table both have a nullable name column.

## Changes

- **`ImportOptions`** — add an optional `fileName` so parsers can see the source filename.
- **`universal_import_providers`** — pass `state.fileName` into the options.
- **`FitImportParser`** — derive the dive name from the filename: drop the extension and a leading Garmin dive-number prefix (`22 `, `#7 `). Leaves the dive unnamed rather than labelling it with a bare number, and preserves date-led names like `2024-10-13 Night Dive` (the prefix strip requires whitespace after the digits).
- **`UddfEntityImporter`** — map `diveData['name']` onto the persisted `Dive`.

So `22 Dos Ojos Cenote Dive (Barbie Line).fit` now imports with the dive **name** "Dos Ojos Cenote Dive (Barbie Line)". The provenance tag is unchanged (separate, intentional feature). FIT-only: other formats (UDDF/Subsurface/MacDive) carry real in-file names and are untouched.

## Test Plan

- [x] 6 new `FitImportParser` tests (filename stem, number-prefix strip, `#`-prefix, date-prefix preserved, number-only stem → no name, no filename → no name)
- [x] 2 new `UddfEntityImporter` tests (name mapped onto dive; unnamed when absent)
- [x] `flutter analyze` clean; `dart format .` a no-op
- [x] Regression suites pass: `universal_import` (1311), `dive_import` (184), `import_wizard` (617)
- [x] Manual: import a real Garmin `.FIT` and confirm the dive name populates