### PR TITLE
fix(gas): show SAC by cylinder on re-keyed and profileless dives (#510)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2263,10 +2263,16 @@ class AppDatabase extends _$AppDatabase {
           });
       if (orphans.isEmpty) continue;
 
-      final unmatchedTanks = [
-        for (final t in tanks)
-          if (!matchedIds.contains(t.id)) t,
-      ]..sort((a, b) => a.order.compareTo(b.order));
+      final unmatchedTanks =
+          [
+            for (final t in tanks)
+              if (!matchedIds.contains(t.id)) t,
+          ]..sort((a, b) {
+            // id tie-break so tanks sharing the default order (0) pair
+            // deterministically -- Dart's sort is not stable.
+            final byOrder = a.order.compareTo(b.order);
+            return byOrder != 0 ? byOrder : a.id.compareTo(b.id);
+          });
       if (unmatchedTanks.isEmpty) continue;
 
       final count = orphans.length < unmatchedTanks.length

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2030,7 +2030,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 101;
+  static const int currentSchemaVersion = 102;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -2135,6 +2135,7 @@ class AppDatabase extends _$AppDatabase {
     99,
     100,
     101,
+    102,
   ];
 
   /// Tables that carry a per-row Hybrid Logical Clock for cross-device conflict
@@ -2181,6 +2182,105 @@ class AppDatabase extends _$AppDatabase {
 
   @override
   int get schemaVersion => currentSchemaVersion;
+
+  /// Re-link tank pressure series stranded under a stale tank id (issue #510).
+  ///
+  /// A reparse, re-import, or multi-computer consolidation can regenerate a
+  /// dive's tanks with fresh UUIDs while its `tank_pressure_profiles` rows keep
+  /// the old tank id. The per-cylinder SAC calculation looked those up by exact
+  /// tank id and missed them, so SAC by cylinder went blank even though the
+  /// pressure data was present (the runtime fix now tolerates this at read
+  /// time; this migration heals the stored data once so the exact-id path works
+  /// for every future consumer too).
+  ///
+  /// Mirrors the runtime resolver (`GasAnalysisService`): exact id matches are
+  /// left alone; each orphaned series (keyed to an id that is no longer one of
+  /// the dive's tanks) is adopted by a still-unmatched current tank, in tank
+  /// order. Every reassignment targets a current tank of the same dive, so it
+  /// is foreign-key safe. Idempotent: a second run finds no orphans.
+  Future<void> _relinkStrandedTankPressures() async {
+    // Defensive: both tables predate v102 in any real database, but migration
+    // tests (and any partial DB) may reach this block without them. A missing
+    // table would make the query below throw and abort the whole upgrade.
+    Future<bool> tableExists(String name) async {
+      final rows = await customSelect(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        variables: [Variable<String>(name)],
+      ).get();
+      return rows.isNotEmpty;
+    }
+
+    if (!await tableExists('dive_tanks') ||
+        !await tableExists('tank_pressure_profiles')) {
+      return;
+    }
+
+    // Current tanks per dive (id + order for deterministic assignment).
+    final tankRows = await customSelect(
+      'SELECT dive_id, id, tank_order FROM dive_tanks',
+    ).get();
+    final tanksByDive = <String, List<({String id, int order})>>{};
+    for (final r in tankRows) {
+      (tanksByDive[r.read<String>('dive_id')] ??= []).add((
+        id: r.read<String>('id'),
+        order: r.read<int>('tank_order'),
+      ));
+    }
+    if (tanksByDive.isEmpty) return;
+
+    // One entry per (dive, pressure tank id), with the earliest sample time so
+    // orphans are ordered the same way the runtime resolver iterates them.
+    final pressureKeyRows = await customSelect(
+      'SELECT dive_id, tank_id, MIN(timestamp) AS first_ts '
+      'FROM tank_pressure_profiles GROUP BY dive_id, tank_id',
+    ).get();
+    final pressureKeysByDive = <String, List<({String tankId, int firstTs})>>{};
+    for (final r in pressureKeyRows) {
+      (pressureKeysByDive[r.read<String>('dive_id')] ??= []).add((
+        tankId: r.read<String>('tank_id'),
+        firstTs: r.read<int>('first_ts'),
+      ));
+    }
+
+    for (final entry in pressureKeysByDive.entries) {
+      final diveId = entry.key;
+      final tanks = tanksByDive[diveId];
+      if (tanks == null || tanks.isEmpty) continue;
+
+      final currentIds = {for (final t in tanks) t.id};
+      final matchedIds = {
+        for (final k in entry.value)
+          if (currentIds.contains(k.tankId)) k.tankId,
+      };
+
+      final orphans =
+          [
+            for (final k in entry.value)
+              if (!currentIds.contains(k.tankId)) k,
+          ]..sort((a, b) {
+            final byTime = a.firstTs.compareTo(b.firstTs);
+            return byTime != 0 ? byTime : a.tankId.compareTo(b.tankId);
+          });
+      if (orphans.isEmpty) continue;
+
+      final unmatchedTanks = [
+        for (final t in tanks)
+          if (!matchedIds.contains(t.id)) t,
+      ]..sort((a, b) => a.order.compareTo(b.order));
+      if (unmatchedTanks.isEmpty) continue;
+
+      final count = orphans.length < unmatchedTanks.length
+          ? orphans.length
+          : unmatchedTanks.length;
+      for (var i = 0; i < count; i++) {
+        await customStatement(
+          'UPDATE tank_pressure_profiles SET tank_id = ? '
+          'WHERE dive_id = ? AND tank_id = ?',
+          [unmatchedTanks[i].id, diveId, orphans[i].tankId],
+        );
+      }
+    }
+  }
 
   @override
   MigrationStrategy get migration {
@@ -4863,6 +4963,10 @@ class AppDatabase extends _$AppDatabase {
           ''');
         }
         if (from < 101) await reportProgress();
+        if (from < 102) {
+          await _relinkStrandedTankPressures();
+        }
+        if (from < 102) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2183,6 +2183,12 @@ class AppDatabase extends _$AppDatabase {
   @override
   int get schemaVersion => currentSchemaVersion;
 
+  /// Test hook: run the v102 stranded-pressure repair on demand so tests can
+  /// assert it is idempotent (a second run over already-healed data is a
+  /// no-op). Not used in production; the migration invokes the private method.
+  Future<void> relinkStrandedTankPressuresForTest() =>
+      _relinkStrandedTankPressures();
+
   /// Re-link tank pressure series stranded under a stale tank id (issue #510).
   ///
   /// A reparse, re-import, or multi-computer consolidation can regenerate a

--- a/lib/features/dive_log/data/services/gas_analysis_service.dart
+++ b/lib/features/dive_log/data/services/gas_analysis_service.dart
@@ -365,9 +365,15 @@ class GasAnalysisService {
   /// it does not silently go blank on those dives (issue #510).
   ///
   /// Exact id matches win. Any remaining series whose key matches no current
-  /// tank ("orphaned") is adopted by a still-unmatched tank, in tank order, so
-  /// the single-transmitter case (one tank, one orphaned series) is always
+  /// tank ("orphaned") is adopted by a still-unmatched tank so the
+  /// single-transmitter case (one tank, one orphaned series) is always
   /// resolved and multi-tank is a stable best effort.
+  ///
+  /// Both sides are sorted with a full tie-breaker so the pairing is
+  /// deterministic regardless of map insertion order or tanks sharing the same
+  /// [DiveTank.order] (the default is 0): orphaned series by earliest sample
+  /// then key; unmatched tanks by order then id. This mirrors the v102 data
+  /// migration exactly, so the runtime result and the healed data agree.
   static Map<String, List<TankPressurePoint>> _resolveTankPressureSeries(
     List<DiveTank> tanks,
     Map<String, List<TankPressurePoint>>? tankPressures,
@@ -382,19 +388,33 @@ class GasAnalysisService {
       if (series != null) resolved[tank.id] = series;
     }
 
-    final orphanSeries = [
-      for (final entry in tankPressures.entries)
-        if (!tankIds.contains(entry.key)) entry.value,
-    ];
-    if (orphanSeries.isEmpty) return resolved;
+    final orphanEntries =
+        [
+          for (final entry in tankPressures.entries)
+            if (!tankIds.contains(entry.key)) entry,
+        ]..sort((a, b) {
+          final aFirst = a.value.isEmpty ? 0 : a.value.first.timestamp;
+          final bFirst = b.value.isEmpty ? 0 : b.value.first.timestamp;
+          final byTime = aFirst.compareTo(bFirst);
+          return byTime != 0 ? byTime : a.key.compareTo(b.key);
+        });
+    if (orphanEntries.isEmpty) return resolved;
 
-    final unmatchedTanks = [
-      for (final tank in tanks)
-        if (!resolved.containsKey(tank.id)) tank,
-    ]..sort((a, b) => a.order.compareTo(b.order));
+    final unmatchedTanks =
+        [
+          for (final tank in tanks)
+            if (!resolved.containsKey(tank.id)) tank,
+        ]..sort((a, b) {
+          final byOrder = a.order.compareTo(b.order);
+          return byOrder != 0 ? byOrder : a.id.compareTo(b.id);
+        });
 
-    for (var i = 0; i < unmatchedTanks.length && i < orphanSeries.length; i++) {
-      resolved[unmatchedTanks[i].id] = orphanSeries[i];
+    for (
+      var i = 0;
+      i < unmatchedTanks.length && i < orphanEntries.length;
+      i++
+    ) {
+      resolved[unmatchedTanks[i].id] = orphanEntries[i].value;
     }
 
     return resolved;

--- a/lib/features/dive_log/data/services/gas_analysis_service.dart
+++ b/lib/features/dive_log/data/services/gas_analysis_service.dart
@@ -37,6 +37,7 @@ class GasAnalysisService {
   }) {
     if (profile.isEmpty || gasSwitches.isEmpty) return null;
 
+    final resolvedPressures = _resolveTankPressureSeries(tanks, tankPressures);
     final segments = <SacSegment>[];
     final diveEndTimestamp = profile.last.timestamp;
 
@@ -77,7 +78,7 @@ class GasAnalysisService {
       final sacRate = _calculateSegmentSac(
         profile: segmentProfile,
         tank: tank,
-        tankPressures: tankPressures?[tank.id],
+        tankPressures: resolvedPressures[tank.id],
         startTime: startTime,
         endTime: endTime,
       );
@@ -122,6 +123,8 @@ class GasAnalysisService {
     List<GasSwitchWithTank>? gasSwitches,
   }) {
     if (profile.length < 10) return null;
+
+    final resolvedPressures = _resolveTankPressureSeries(tanks, tankPressures);
 
     // Find max depth
     final maxDepth = profile.map((p) => p.depth).reduce(math.max);
@@ -190,7 +193,7 @@ class GasAnalysisService {
       final sacRate = _calculateSegmentSac(
         profile: segmentProfile,
         tank: tank,
-        tankPressures: tankPressures?[tank.id],
+        tankPressures: resolvedPressures[tank.id],
         startTime: seg.start,
         endTime: seg.end,
       );
@@ -234,6 +237,13 @@ class GasAnalysisService {
   }) {
     final results = <CylinderSac>[];
 
+    // Resolve each tank's time-series pressure, tolerating series that were
+    // re-keyed under a stale tank id (see [_resolveTankPressureSeries]).
+    final resolvedPressures = _resolveTankPressureSeries(
+      dive.tanks,
+      tankPressures,
+    );
+
     for (final tank in dive.tanks) {
       // Determine when this tank was in use
       final usageRange = _getTankUsageRange(
@@ -266,14 +276,15 @@ class GasAnalysisService {
             usageProfile.length;
       }
 
-      // Check if we have time-series pressure data for this tank
-      final hasTsData = tankPressures?.containsKey(tank.id) ?? false;
-      final tsPressures = tankPressures?[tank.id];
+      // Check if we have time-series pressure data for this tank (matched by
+      // id, or adopted from a re-keyed/orphaned series).
+      final tsPressures = resolvedPressures[tank.id];
+      final hasTsData = tsPressures != null;
 
       // Calculate SAC rate
       double? sacRate;
 
-      if (hasTsData && tsPressures != null && tsPressures.length >= 2) {
+      if (tsPressures != null && tsPressures.length >= 2) {
         // Enhanced calculation using time-series data
         sacRate = _calculateSacFromTimeSeries(
           pressurePoints: tsPressures,
@@ -285,13 +296,20 @@ class GasAnalysisService {
         );
       } else if (tank.startPressure != null &&
           tank.endPressure != null &&
-          avgDepthDuringUse != null) {
-        // Basic calculation from start/end pressures with Z-factor correction
+          (avgDepthDuringUse ?? dive.avgDepth) != null) {
+        // Basic calculation from start/end pressures with Z-factor correction.
+        //
+        // Fall back to the dive's average depth when there are no profile
+        // samples in the usage window (older or manually-logged dives store a
+        // summary avgDepth but no depth profile). Without this the ambient
+        // pressure correction below could not run and SAC by cylinder would be
+        // blank for every profileless dive (issue #510).
+        final effectiveAvgDepth = avgDepthDuringUse ?? dive.avgDepth!;
         final pressureUsed = tank.startPressure! - tank.endPressure!;
         if (pressureUsed > 0) {
           final durationMin = (usageRange.end - usageRange.start) / 60.0;
           if (durationMin > 0) {
-            final ambientPressureAtm = (avgDepthDuringUse / 10.0) + 1.0;
+            final ambientPressureAtm = (effectiveAvgDepth / 10.0) + 1.0;
             if (tank.volume != null) {
               sacRate = _zCorrectedSacRate(
                 tankVolume: tank.volume!,
@@ -336,6 +354,51 @@ class GasAnalysisService {
   // ─────────────────────────────────────────────────────────────────────────
   // Private Helper Methods
   // ─────────────────────────────────────────────────────────────────────────
+
+  /// Map each tank to its time-series pressure, tolerating a re-keyed series.
+  ///
+  /// A dive's transmitter pressure is stored in `tank_pressure_profiles` keyed
+  /// by tank id. A reparse, re-import, or multi-computer consolidation can
+  /// regenerate the dive's tanks with fresh UUIDs while the pressure rows keep
+  /// the old tank id (issue #276). The overall SAC curve already tolerates this
+  /// (`combineMultiTankPressures`); this does the same for per-cylinder SAC so
+  /// it does not silently go blank on those dives (issue #510).
+  ///
+  /// Exact id matches win. Any remaining series whose key matches no current
+  /// tank ("orphaned") is adopted by a still-unmatched tank, in tank order, so
+  /// the single-transmitter case (one tank, one orphaned series) is always
+  /// resolved and multi-tank is a stable best effort.
+  static Map<String, List<TankPressurePoint>> _resolveTankPressureSeries(
+    List<DiveTank> tanks,
+    Map<String, List<TankPressurePoint>>? tankPressures,
+  ) {
+    final resolved = <String, List<TankPressurePoint>>{};
+    if (tankPressures == null || tankPressures.isEmpty) return resolved;
+
+    final tankIds = {for (final t in tanks) t.id};
+
+    for (final tank in tanks) {
+      final series = tankPressures[tank.id];
+      if (series != null) resolved[tank.id] = series;
+    }
+
+    final orphanSeries = [
+      for (final entry in tankPressures.entries)
+        if (!tankIds.contains(entry.key)) entry.value,
+    ];
+    if (orphanSeries.isEmpty) return resolved;
+
+    final unmatchedTanks = [
+      for (final tank in tanks)
+        if (!resolved.containsKey(tank.id)) tank,
+    ]..sort((a, b) => a.order.compareTo(b.order));
+
+    for (var i = 0; i < unmatchedTanks.length && i < orphanSeries.length; i++) {
+      resolved[unmatchedTanks[i].id] = orphanSeries[i];
+    }
+
+    return resolved;
+  }
 
   /// Compute SAC rate using Z-factor corrected gas volumes.
   ///

--- a/test/core/database/migration_v102_tank_pressure_relink_test.dart
+++ b/test/core/database/migration_v102_tank_pressure_relink_test.dart
@@ -132,22 +132,36 @@ void main() {
     },
   );
 
-  test('is idempotent when nothing is stranded', () async {
+  test('a second repair run over healed data is a no-op', () async {
+    // Seed an orphaned series so the migration re-links it on open, then run
+    // the repair AGAIN and confirm nothing else moves and no rows are lost.
     final db = AppDatabase(
       makeDb((rawDb) {
         rawDb.execute("INSERT INTO dives VALUES ('d4', 1, 1, 1)");
         rawDb.execute("INSERT INTO dive_tanks VALUES ('tank-x', 'd4', 0)");
         rawDb.execute(
           "INSERT INTO tank_pressure_profiles VALUES "
-          "('p1', 'd4', 'tank-x', 0, 200.0)",
+          "('p1', 'd4', 'tank-old', 0, 200.0), "
+          "('p2', 'd4', 'tank-old', 60, 150.0)",
         );
       }),
     );
     addTearDown(() => db.close());
 
-    // Run the repair a second time directly; it must be a no-op.
-    await db.customSelect('SELECT 1').get();
+    // First pass ran during the migration on open.
     expect(await pressureTankIds(db, 'd4'), ['tank-x']);
+    final countBefore = await db
+        .customSelect('SELECT COUNT(*) AS n FROM tank_pressure_profiles')
+        .getSingle();
+
+    // Explicit second pass must change nothing.
+    await db.relinkStrandedTankPressuresForTest();
+
+    expect(await pressureTankIds(db, 'd4'), ['tank-x']);
+    final countAfter = await db
+        .customSelect('SELECT COUNT(*) AS n FROM tank_pressure_profiles')
+        .getSingle();
+    expect(countAfter.read<int>('n'), countBefore.read<int>('n'));
   });
 
   test('v102 is registered in the migration ladder', () {

--- a/test/core/database/migration_v102_tank_pressure_relink_test.dart
+++ b/test/core/database/migration_v102_tank_pressure_relink_test.dart
@@ -1,0 +1,157 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// v102 re-links tank_pressure_profiles rows that were stranded under a stale
+/// tank id (issue #510). See `AppDatabase._relinkStrandedTankPressures`.
+void main() {
+  // Minimal pre-v102 shape for the three tables the migration touches. No FK
+  // constraints so the test can insert an orphaned pressure row directly (the
+  // real DB reaches this state via reparse/consolidation with FKs relaxed).
+  NativeDatabase makeDb(void Function(dynamic rawDb) seed) {
+    return NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 101');
+        rawDb.execute('''
+          CREATE TABLE dives (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_date_time INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE dive_tanks (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            tank_order INTEGER NOT NULL DEFAULT 0
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE tank_pressure_profiles (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            tank_id TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            pressure REAL NOT NULL
+          )
+        ''');
+        seed(rawDb);
+      },
+    );
+  }
+
+  Future<List<String>> pressureTankIds(AppDatabase db, String diveId) async {
+    final rows = await db
+        .customSelect(
+          'SELECT DISTINCT tank_id FROM tank_pressure_profiles '
+          "WHERE dive_id = '$diveId' ORDER BY tank_id",
+        )
+        .get();
+    return rows.map((r) => r.read<String>('tank_id')).toList();
+  }
+
+  test(
+    're-links an orphaned single-tank pressure series to the current tank',
+    () async {
+      final db = AppDatabase(
+        makeDb((rawDb) {
+          rawDb.execute("INSERT INTO dives VALUES ('d1', 1, 1, 1)");
+          // Current tank has a fresh UUID; pressure rows still carry the old id.
+          rawDb.execute("INSERT INTO dive_tanks VALUES ('tank-new', 'd1', 0)");
+          rawDb.execute(
+            "INSERT INTO tank_pressure_profiles VALUES "
+            "('p1', 'd1', 'tank-old', 0, 200.0), "
+            "('p2', 'd1', 'tank-old', 60, 150.0)",
+          );
+        }),
+      );
+      addTearDown(() => db.close());
+
+      // Touch the DB to run the migration.
+      expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(102));
+
+      expect(await pressureTankIds(db, 'd1'), ['tank-new']);
+    },
+  );
+
+  test('leaves correctly-keyed pressure untouched', () async {
+    final db = AppDatabase(
+      makeDb((rawDb) {
+        rawDb.execute("INSERT INTO dives VALUES ('d2', 1, 1, 1)");
+        rawDb.execute("INSERT INTO dive_tanks VALUES ('tank-a', 'd2', 0)");
+        rawDb.execute(
+          "INSERT INTO tank_pressure_profiles VALUES "
+          "('p1', 'd2', 'tank-a', 0, 210.0), "
+          "('p2', 'd2', 'tank-a', 60, 160.0)",
+        );
+      }),
+    );
+    addTearDown(() => db.close());
+
+    expect(await pressureTankIds(db, 'd2'), ['tank-a']);
+  });
+
+  test(
+    'assigns multiple orphaned series to unmatched tanks by tank order',
+    () async {
+      final db = AppDatabase(
+        makeDb((rawDb) {
+          rawDb.execute("INSERT INTO dives VALUES ('d3', 1, 1, 1)");
+          // Two current tanks, ordered.
+          rawDb.execute("INSERT INTO dive_tanks VALUES ('tank-1', 'd3', 0)");
+          rawDb.execute("INSERT INTO dive_tanks VALUES ('tank-2', 'd3', 1)");
+          // Two orphaned series; 'old-early' starts first, so it maps to the
+          // lowest-order unmatched tank (tank-1).
+          rawDb.execute(
+            "INSERT INTO tank_pressure_profiles VALUES "
+            "('a1', 'd3', 'old-late', 100, 200.0), "
+            "('a2', 'd3', 'old-late', 160, 150.0), "
+            "('b1', 'd3', 'old-early', 0, 190.0), "
+            "('b2', 'd3', 'old-early', 60, 140.0)",
+          );
+        }),
+      );
+      addTearDown(() => db.close());
+
+      final earlyTarget = await db
+          .customSelect(
+            "SELECT DISTINCT tank_id FROM tank_pressure_profiles "
+            "WHERE dive_id = 'd3' AND id IN ('b1', 'b2')",
+          )
+          .getSingle();
+      final lateTarget = await db
+          .customSelect(
+            "SELECT DISTINCT tank_id FROM tank_pressure_profiles "
+            "WHERE dive_id = 'd3' AND id IN ('a1', 'a2')",
+          )
+          .getSingle();
+
+      expect(earlyTarget.read<String>('tank_id'), 'tank-1');
+      expect(lateTarget.read<String>('tank_id'), 'tank-2');
+    },
+  );
+
+  test('is idempotent when nothing is stranded', () async {
+    final db = AppDatabase(
+      makeDb((rawDb) {
+        rawDb.execute("INSERT INTO dives VALUES ('d4', 1, 1, 1)");
+        rawDb.execute("INSERT INTO dive_tanks VALUES ('tank-x', 'd4', 0)");
+        rawDb.execute(
+          "INSERT INTO tank_pressure_profiles VALUES "
+          "('p1', 'd4', 'tank-x', 0, 200.0)",
+        );
+      }),
+    );
+    addTearDown(() => db.close());
+
+    // Run the repair a second time directly; it must be a no-op.
+    await db.customSelect('SELECT 1').get();
+    expect(await pressureTankIds(db, 'd4'), ['tank-x']);
+  });
+
+  test('v102 is registered in the migration ladder', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(102));
+    expect(AppDatabase.migrationVersions, contains(102));
+  });
+}

--- a/test/features/dive_log/data/services/gas_analysis_service_sac_test.dart
+++ b/test/features/dive_log/data/services/gas_analysis_service_sac_test.dart
@@ -298,6 +298,63 @@ void main() {
       expect(results.first.hasValidSac, isTrue);
     });
 
+    test(
+      'orphan-to-tank pairing is deterministic when tanks share an order',
+      () {
+        // Two current tanks with the DEFAULT order (0) and two orphaned
+        // series. The pairing must be stable regardless of Dart's unstable
+        // sort: orphans by earliest sample then key, tanks by order then id.
+        // Expected: tank-a (id-first) <- early series, tank-b <- late series.
+        const tankA = DiveTank(
+          id: 'tank-a',
+          volume: 11.1,
+          gasMix: GasMix(o2: 21, he: 0),
+        );
+        const tankB = DiveTank(
+          id: 'tank-b',
+          volume: 11.1,
+          gasMix: GasMix(o2: 21, he: 0),
+        );
+        final dive = makeDive(
+          runtime: const Duration(minutes: 40),
+          avgDepth: 18.0,
+          tanks: const [tankB, tankA], // list order deliberately reversed
+          profile: makeProfile(40 * 60),
+        );
+
+        List<TankPressurePoint> series(String key, int firstTs, double drain) {
+          return [
+            for (var t = firstTs; t <= 40 * 60; t += 60)
+              TankPressurePoint(
+                id: '$key-$t',
+                tankId: key,
+                timestamp: t,
+                pressure: 200 - drain * (t - firstTs) / (40 * 60 - firstTs),
+              ),
+          ];
+        }
+
+        // Iteration order reversed vs. the expected time order to prove the
+        // sort (not map order) decides the pairing.
+        final pressures = <String, List<TankPressurePoint>>{
+          'z-late': series('z-late', 600, 20), // small drain -> low SAC
+          'y-early': series('y-early', 0, 150), // big drain -> high SAC
+        };
+
+        final results = service.calculateCylinderSac(
+          dive: dive,
+          profile: dive.profile,
+          tankPressures: pressures,
+        );
+
+        final byId = {for (final r in results) r.tankId: r};
+        expect(byId['tank-a']!.hasValidSac, isTrue);
+        expect(byId['tank-b']!.hasValidSac, isTrue);
+        // tank-a adopted the early, big-drain series -> higher SAC than tank-b.
+        expect(byId['tank-a']!.sacRate!, greaterThan(byId['tank-b']!.sacRate!));
+      },
+    );
+
     test('returns empty list for dive with no tanks', () {
       final dive = makeDive(
         runtime: const Duration(minutes: 42),

--- a/test/features/dive_log/data/services/gas_analysis_service_sac_test.dart
+++ b/test/features/dive_log/data/services/gas_analysis_service_sac_test.dart
@@ -137,17 +137,67 @@ void main() {
         profile: const [],
       );
 
-      // With empty profile, calculateCylinderSac should still work
-      // using effectiveRuntime fallback chain (bottomTime as last resort)
+      // With empty profile, calculateCylinderSac still runs using the
+      // effectiveRuntime fallback chain (bottomTime as last resort).
       final results = service.calculateCylinderSac(
         dive: dive,
         profile: dive.profile,
       );
 
-      // Empty profile means no usage profile points, so SAC can't be
-      // calculated with depth data - but the method should still run
-      expect(results, isA<List>());
+      expect(results, hasLength(1));
     });
+
+    test('computes SAC from start/end pressures when the dive has no profile '
+        '(older/manually-logged dives) using the dive average depth', () {
+      // Regression for #510: SAC by cylinder must show on profileless dives
+      // that still carry an average depth and tank start/end pressures.
+      final dive = makeDive(
+        runtime: const Duration(minutes: 40),
+        bottomTime: const Duration(minutes: 40),
+        avgDepth: 18.0,
+        tanks: [makeTank(startPressure: 200, endPressure: 50, volume: 11.1)],
+        profile: const [], // no depth samples, as in older manual entries
+      );
+
+      final results = service.calculateCylinderSac(
+        dive: dive,
+        profile: dive.profile,
+      );
+
+      expect(results, hasLength(1));
+      expect(
+        results.first.sacRate,
+        isNotNull,
+        reason: 'basic SAC branch must fall back to dive.avgDepth',
+      );
+      expect(results.first.sacRate!, greaterThan(0));
+      expect(results.first.hasValidSac, isTrue);
+      // Depth data was inferred from the dive, not per-sample.
+      expect(results.first.hasTimeSeriesData, isFalse);
+    });
+
+    test(
+      'still yields no SAC when a profileless dive also lacks an average depth',
+      () {
+        // Without any depth reference the ambient-pressure correction is
+        // undefined, so SAC stays null (the cylinder row is still returned).
+        final dive = makeDive(
+          runtime: const Duration(minutes: 40),
+          bottomTime: const Duration(minutes: 40),
+          tanks: [makeTank(startPressure: 200, endPressure: 50, volume: 11.1)],
+          profile: const [],
+        );
+
+        final results = service.calculateCylinderSac(
+          dive: dive,
+          profile: dive.profile,
+        );
+
+        expect(results, hasLength(1));
+        expect(results.first.sacRate, isNull);
+        expect(results.first.hasValidSac, isFalse);
+      },
+    );
 
     test('computes SAC rate from start/end pressures', () {
       final dive = makeDive(
@@ -167,6 +217,85 @@ void main() {
       expect(results.first.sacRate!, greaterThan(0));
       expect(results.first.startPressure, 200);
       expect(results.first.endPressure, 30);
+    });
+
+    test(
+      'uses transmitter pressure keyed under an orphaned tank id (#510)',
+      () {
+        // Regression for #510. Air-integration dives re-keyed by a reparse /
+        // consolidation (issue #276) store their pressure series under a tank
+        // id that no longer matches the current dive tank. The overall SAC
+        // curve tolerates this; per-cylinder SAC must too, instead of coming
+        // out blank. The tank has NO start/end pressure, so the ONLY way to a
+        // SAC value is via the (mis-keyed) time-series data.
+        final dive = makeDive(
+          runtime: const Duration(minutes: 40),
+          avgDepth: 18.0,
+          tanks: [makeTank(id: 'current-tank', volume: 11.1)],
+          profile: makeProfile(40 * 60),
+        );
+
+        // Pressure series keyed under an id that is NOT dive.tanks[0].id.
+        final orphanPressures = <String, List<TankPressurePoint>>{
+          'stale-uuid': [
+            for (var t = 0; t <= 40 * 60; t += 60)
+              TankPressurePoint(
+                id: 'p$t',
+                tankId: 'stale-uuid',
+                timestamp: t,
+                // Linear drain 200 -> 60 bar over the dive.
+                pressure: 200 - (140 * t / (40 * 60)),
+              ),
+          ],
+        };
+
+        final results = service.calculateCylinderSac(
+          dive: dive,
+          profile: dive.profile,
+          tankPressures: orphanPressures,
+        );
+
+        expect(results, hasLength(1));
+        expect(
+          results.first.sacRate,
+          isNotNull,
+          reason: 'orphaned time-series pressure must still drive SAC',
+        );
+        expect(results.first.sacRate!, greaterThan(0));
+        expect(results.first.hasValidSac, isTrue);
+        expect(results.first.hasTimeSeriesData, isTrue);
+      },
+    );
+
+    test('still prefers an exact tank-id match over orphaned series', () {
+      // When the pressure series IS correctly keyed, nothing changes.
+      final dive = makeDive(
+        runtime: const Duration(minutes: 40),
+        avgDepth: 18.0,
+        tanks: [makeTank(id: 'tank-A', volume: 11.1)],
+        profile: makeProfile(40 * 60),
+      );
+
+      final pressures = <String, List<TankPressurePoint>>{
+        'tank-A': [
+          for (var t = 0; t <= 40 * 60; t += 60)
+            TankPressurePoint(
+              id: 'a$t',
+              tankId: 'tank-A',
+              timestamp: t,
+              pressure: 210 - (150 * t / (40 * 60)),
+            ),
+        ],
+      };
+
+      final results = service.calculateCylinderSac(
+        dive: dive,
+        profile: dive.profile,
+        tankPressures: pressures,
+      );
+
+      expect(results.first.hasTimeSeriesData, isTrue);
+      expect(results.first.hasValidSac, isTrue);
     });
 
     test('returns empty list for dive with no tanks', () {

--- a/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
+++ b/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
@@ -203,6 +203,51 @@ void main() {
         expect(seg.sacRate, greaterThan(0));
       }
     });
+
+    test(
+      'uses transmitter pressure keyed under an orphaned tank id (#510)',
+      () {
+        // Same re-keyed-pressure condition as the per-cylinder path: the tank
+        // carries no start/end pressure, so segment SAC can only come from the
+        // time-series, which is stored under a stale tank id.
+        const tank = DiveTank(
+          id: 'current-tank',
+          volume: 11.1,
+          gasMix: GasMix(o2: 21, he: 0),
+        );
+        final profile = <DiveProfilePoint>[];
+        for (int t = 0; t <= 120; t += 10) {
+          profile.add(DiveProfilePoint(timestamp: t, depth: t / 120 * 25));
+        }
+        for (int t = 130; t <= 2220; t += 10) {
+          profile.add(DiveProfilePoint(timestamp: t, depth: 25.0));
+        }
+        for (int t = 2230; t <= 2520; t += 10) {
+          profile.add(
+            DiveProfilePoint(
+              timestamp: t,
+              depth: 25.0 * (1 - (t - 2220) / 300),
+            ),
+          );
+        }
+
+        final tankPressures = {
+          'stale-uuid': linearPressure('stale-uuid', 200, 80, 2520),
+        };
+
+        final segments = service.calculatePhaseSegments(
+          profile: profile,
+          tanks: [tank],
+          tankPressures: tankPressures,
+        );
+
+        expect(segments, isNotNull);
+        expect(segments!, isNotEmpty);
+        for (final seg in segments) {
+          expect(seg.sacRate, greaterThan(0));
+        }
+      },
+    );
   });
 
   group('_calculateSacFromTimeSeries (via calculateCylinderSac)', () {


### PR DESCRIPTION
Fixes #510.

## Symptom

"SAC by cylinder" was blank on many existing dives, while the overall/average SAC still displayed for the same dives. Confirmed with the reporter: the affected dives have depth profiles and an air-integration pressure curve, and it happened regardless of cylinder count.

## Root cause

A dive's transmitter pressure is stored in `tank_pressure_profiles` keyed by tank id. A reparse, re-import, or multi-computer consolidation (the v94+ multi-source work, #466/#482) can regenerate the dive's tanks with fresh UUIDs while the pressure rows keep the **old** tank id.

`GasAnalysisService.calculateCylinderSac` — and the two SAC-segment methods — looked up pressure with an exact `tankPressures[tank.id]` match, so on those re-keyed dives the time-series data was invisible and per-cylinder / per-segment SAC came out blank. The **overall** SAC curve was immune because `combineMultiTankPressures` was already hardened to tolerate this exact mismatch back in #276. That asymmetry is precisely why overall SAC showed but per-cylinder didn't.

The "before v1.5.9" framing in the issue is a red herring: the per-cylinder code path has existed since v1.5.4; v1.5.9's unified Cylinders card (#492) merely made per-cylinder SAC prominent enough to notice.

## Fix — two commits

**1. Runtime fix (`fix(gas):`)** — tolerate the mismatch at read time so existing installs recover immediately.
- `_resolveTankPressureSeries(tanks, tankPressures)`: exact tank-id matches first, then any orphaned series (key matches no current tank) is adopted by a still-unmatched tank in tank order. Single-transmitter (one tank, one orphaned series) always resolves; multi-tank is a stable best effort. Applied to `calculateCylinderSac`, `calculateGasSwitchSegments`, and `calculatePhaseSegments`.
- Also gives the basic start/end-pressure SAC branch the same `dive.avgDepth` fallback the time-series branch already had, so profileless dives with a stored average depth (older manual entries) get per-cylinder SAC too.

**2. Data migration (`feat(db):` schema v102)** — heal the stored data once so the exact-id lookup works for every consumer, not only the ones taught to tolerate the mismatch.
- For each dive, `tank_pressure_profiles` rows keyed under a tank id that is no longer one of the dive's tanks are re-linked to a current tank, mirroring the runtime resolver (exact matches stay; orphans adopt an unmatched tank in tank order, ordered by earliest sample for determinism).
- Every reassignment targets a current tank of the same dive → foreign-key safe. Idempotent (a second run finds no orphans). Guarded by a `sqlite_master` table-existence check so partial DBs / minimal migration-test schemas are skipped rather than aborting the upgrade.

## Testing

- Runtime: new regression tests reproduce the orphaned-tank-id case for the per-cylinder and per-segment paths (fail before, pass after), plus the profileless-with-avgDepth case, the no-depth case (SAC stays null), and an exact-match-still-wins case.
- Migration: v102 test covers single-tank re-link, correctly-keyed left untouched, multi-orphan assignment by tank order, idempotency, and ladder registration. All 129 `test/core/database` tests pass.
- Whole-project `flutter analyze` and `dart format` clean.

## Notes / limitations

- Multi-tank re-keyed dives where **no** series match by id: orphan→tank assignment is positional (by tank order) and could in principle pair a series with the wrong cylinder — but only when the id linkage is already lost, and best-effort SAC beats a blank one. The common single-transmitter case is always exact.
- Schema bump lands on **v102**; if another in-flight PR claims 102 first, this one should be renumbered on merge (the usual ladder-collision dance).