### PR TITLE
Backfill photo profile-marker enrichment for older dives (#511)

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -22,7 +22,11 @@ import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/core/services/maintenance/startup_maintenance_task.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_enrichment_backfill_service.dart';
 import 'package:submersion/main.dart' show SubmersionRestart;
 
 /// Callback signature for the service initializer used by [StartupWrapper].
@@ -306,6 +310,17 @@ class _StartupWrapperState extends State<StartupWrapper>
 
     final speciesRepository = SpeciesRepository();
     await speciesRepository.seedBuiltInSpecies();
+
+    // Run idempotent data-cleanup tasks after the DB is open. Each is safe to
+    // run on every launch and self-terminates once its work is done, so this
+    // also self-heals after a restore (which reopens an older DB in-app, past
+    // the migration path). Register future cleanup tasks by adding them here.
+    await StartupMaintenanceRunner([
+      MediaEnrichmentBackfillService(
+        mediaRepository: MediaRepository(),
+        diveRepository: DiveRepository(),
+      ),
+    ]).run();
   }
 
   Future<void> _runPreMigrationBackup({

--- a/lib/core/services/maintenance/startup_maintenance_task.dart
+++ b/lib/core/services/maintenance/startup_maintenance_task.dart
@@ -1,0 +1,51 @@
+import 'package:submersion/core/services/logger_service.dart';
+
+/// A cleanup/backfill task run once per launch, after the database is open.
+///
+/// Tasks exist to reconcile data that older app versions left in an incomplete
+/// state (e.g. backfilling values a feature now expects). They run on every
+/// launch rather than being gated to a single schema migration, so they also
+/// self-heal after a database restore — which reopens an older database in-app,
+/// past the migration path. That makes idempotency the core contract:
+///
+/// - [run] MUST be safe to invoke on every launch. Once its work is done it
+///   should become a cheap no-op (typically by scoping its own query to the
+///   rows that still need it, so a completed task finds nothing to do).
+/// - [run] MUST NOT assume it is the first time it has run.
+///
+/// The [StartupMaintenanceRunner] invokes tasks best-effort: a throwing task is
+/// logged and does not prevent the others (or app startup) from proceeding.
+abstract interface class StartupMaintenanceTask {
+  /// Stable, human-readable identifier used in logs.
+  String get name;
+
+  /// Perform the task. Must be idempotent (see class docs).
+  Future<void> run();
+}
+
+/// Runs a list of [StartupMaintenanceTask]s best-effort during startup.
+///
+/// Register new cleanup tasks by adding them to the list passed in at the
+/// composition root; no changes here are needed.
+class StartupMaintenanceRunner {
+  final List<StartupMaintenanceTask> _tasks;
+  final _log = LoggerService.forClass(StartupMaintenanceRunner);
+
+  StartupMaintenanceRunner(this._tasks);
+
+  /// Runs every task in order. Each is isolated: a failure is logged and the
+  /// remaining tasks still run.
+  Future<void> run() async {
+    for (final task in _tasks) {
+      try {
+        await task.run();
+      } catch (e, stackTrace) {
+        _log.error(
+          'Startup maintenance task "${task.name}" failed',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+  }
+}

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -603,6 +603,42 @@ class MediaRepository {
     }
   }
 
+  /// Dive ids that have at least one dive-linked media item missing its
+  /// [MediaEnrichment] row, where the dive also has primary profile points to
+  /// enrich against.
+  ///
+  /// Used by the enrichment backfill (issue #511): photos linked before the
+  /// profile-marker feature never had enrichment computed, so their markers
+  /// don't render. Restricting to profiled dives keeps the backfill
+  /// self-terminating — every candidate the enrichment service can process
+  /// gets a row and drops out of this query.
+  Future<List<String>> diveIdsNeedingEnrichmentBackfill() async {
+    try {
+      final rows = await _db.customSelect('''
+        SELECT DISTINCT m.dive_id AS dive_id
+        FROM media m
+        WHERE m.dive_id IS NOT NULL
+          AND m.taken_at IS NOT NULL
+          AND m.file_type != 'instructor_signature'
+          AND NOT EXISTS (
+            SELECT 1 FROM media_enrichment e WHERE e.media_id = m.id
+          )
+          AND EXISTS (
+            SELECT 1 FROM dive_profiles p
+            WHERE p.dive_id = m.dive_id AND p.is_primary = 1
+          )
+      ''').get();
+      return rows.map((row) => row.data['dive_id'] as String).toList();
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to list dives needing enrichment backfill',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Get the set of platformAssetIds already linked to a specific dive.
   ///
   /// Returns only non-null platformAssetIds for gallery photos.

--- a/lib/features/media/data/services/media_enrichment_backfill_service.dart
+++ b/lib/features/media/data/services/media_enrichment_backfill_service.dart
@@ -1,0 +1,106 @@
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/maintenance/startup_maintenance_task.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/enrichment_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+
+/// One-shot backfill for photo/video profile markers (issue #511).
+///
+/// Media linked to a dive before the profile-marker feature shipped never had
+/// their [MediaEnrichment] computed, so no marker renders on the dive profile
+/// chart — unlinking and relinking the media is currently the only way to make
+/// the marker appear. This service computes the missing enrichment for
+/// existing dive-linked media using the same [EnrichmentService] the
+/// import/link path uses, so backfilled markers match relinked ones exactly.
+///
+/// It is safe to run on every launch (see [StartupMaintenanceTask]): the
+/// candidate query only returns dives that still have unenriched media *and* a
+/// profile to enrich against, so each item enriched drops out of the set and
+/// the work naturally converges to zero.
+class MediaEnrichmentBackfillService implements StartupMaintenanceTask {
+  final MediaRepository _mediaRepository;
+  final DiveRepository _diveRepository;
+  final EnrichmentService _enrichmentService;
+  final _log = LoggerService.forClass(MediaEnrichmentBackfillService);
+
+  MediaEnrichmentBackfillService({
+    required MediaRepository mediaRepository,
+    required DiveRepository diveRepository,
+    EnrichmentService enrichmentService = const EnrichmentService(),
+  }) : _mediaRepository = mediaRepository,
+       _diveRepository = diveRepository,
+       _enrichmentService = enrichmentService;
+
+  @override
+  String get name => 'photo-enrichment-backfill';
+
+  /// Computes and saves enrichment for every dive-linked media item that lacks
+  /// it, on dives that have a profile. Best-effort per dive: an error on one
+  /// dive is logged and does not abort the rest. Returns the number of media
+  /// items enriched (the [StartupMaintenanceTask] contract ignores the value).
+  @override
+  Future<int> run() async {
+    final diveIds = await _mediaRepository.diveIdsNeedingEnrichmentBackfill();
+    if (diveIds.isEmpty) return 0;
+
+    var enriched = 0;
+    for (final diveId in diveIds) {
+      try {
+        enriched += await _backfillDive(diveId);
+      } catch (e, stackTrace) {
+        // One bad dive must not stop the rest; a later launch retries it.
+        _log.error(
+          'Enrichment backfill failed for dive $diveId',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
+    if (enriched > 0) {
+      _log.info('Backfilled enrichment for $enriched media item(s)');
+    }
+    return enriched;
+  }
+
+  Future<int> _backfillDive(String diveId) async {
+    final dive = await _diveRepository.getDiveById(diveId);
+    if (dive == null || dive.profile.isEmpty) return 0;
+
+    final media = await _mediaRepository.getMediaForDive(diveId);
+    var enriched = 0;
+    for (final item in media) {
+      if (item.enrichment != null) continue;
+      // Signatures are not dive-moment media and never get a marker.
+      if (item.mediaType == MediaType.instructorSignature) continue;
+
+      final result = _enrichmentService.calculateEnrichment(
+        profile: dive.profile,
+        diveStartTime: dive.effectiveEntryTime,
+        photoTime: item.takenAt,
+      );
+      // Mirror the import path: don't persist a row we couldn't position.
+      if (result.depthMeters == null &&
+          result.matchConfidence == MatchConfidence.noProfile) {
+        continue;
+      }
+
+      await _mediaRepository.saveEnrichment(
+        MediaEnrichment(
+          id: '',
+          mediaId: item.id,
+          diveId: diveId,
+          depthMeters: result.depthMeters,
+          temperatureCelsius: result.temperatureCelsius,
+          elapsedSeconds: result.elapsedSeconds,
+          matchConfidence: result.matchConfidence,
+          timestampOffsetSeconds: result.timestampOffsetSeconds,
+          createdAt: DateTime.now(),
+        ),
+      );
+      enriched++;
+    }
+    return enriched;
+  }
+}

--- a/lib/features/media/data/services/media_enrichment_backfill_service.dart
+++ b/lib/features/media/data/services/media_enrichment_backfill_service.dart
@@ -35,12 +35,16 @@ class MediaEnrichmentBackfillService implements StartupMaintenanceTask {
   @override
   String get name => 'photo-enrichment-backfill';
 
+  /// [StartupMaintenanceTask] entry point; delegates to [backfill], discarding
+  /// the count the runner has no use for.
+  @override
+  Future<void> run() => backfill();
+
   /// Computes and saves enrichment for every dive-linked media item that lacks
   /// it, on dives that have a profile. Best-effort per dive: an error on one
   /// dive is logged and does not abort the rest. Returns the number of media
-  /// items enriched (the [StartupMaintenanceTask] contract ignores the value).
-  @override
-  Future<int> run() async {
+  /// items enriched.
+  Future<int> backfill() async {
     final diveIds = await _mediaRepository.diveIdsNeedingEnrichmentBackfill();
     if (diveIds.isEmpty) return 0;
 

--- a/test/core/services/maintenance/startup_maintenance_runner_test.dart
+++ b/test/core/services/maintenance/startup_maintenance_runner_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/maintenance/startup_maintenance_task.dart';
+
+class _RecordingTask implements StartupMaintenanceTask {
+  _RecordingTask(this.name, this._log, {this.throws = false});
+
+  @override
+  final String name;
+  final List<String> _log;
+  final bool throws;
+
+  @override
+  Future<void> run() async {
+    _log.add(name);
+    if (throws) throw StateError('boom in $name');
+  }
+}
+
+void main() {
+  test('runs every task in order', () async {
+    final calls = <String>[];
+    await StartupMaintenanceRunner([
+      _RecordingTask('a', calls),
+      _RecordingTask('b', calls),
+      _RecordingTask('c', calls),
+    ]).run();
+    expect(calls, ['a', 'b', 'c']);
+  });
+
+  test('a throwing task is isolated: later tasks still run', () async {
+    final calls = <String>[];
+    await StartupMaintenanceRunner([
+      _RecordingTask('a', calls),
+      _RecordingTask('b', calls, throws: true),
+      _RecordingTask('c', calls),
+    ]).run();
+    // 'b' ran (and threw) but 'c' still ran; run() completed normally.
+    expect(calls, ['a', 'b', 'c']);
+  });
+
+  test('an empty task list is a no-op', () async {
+    await StartupMaintenanceRunner(const []).run();
+  });
+}

--- a/test/features/media/data/services/media_enrichment_backfill_service_test.dart
+++ b/test/features/media/data/services/media_enrichment_backfill_service_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_enrichment_backfill_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late MediaRepository mediaRepo;
+  late DiveRepository diveRepo;
+  late MediaEnrichmentBackfillService service;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    mediaRepo = MediaRepository();
+    diveRepo = DiveRepository();
+    service = MediaEnrichmentBackfillService(
+      mediaRepository: mediaRepo,
+      diveRepository: diveRepo,
+    );
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  // Dive starting at a fixed wall-clock time with a two-point profile:
+  // t=0s depth 0m/24C, t=120s depth 20m/18C.
+  //
+  // Dive entry time is stored/read as wall-clock-as-UTC; photo takenAt is
+  // stored/read as a LOCAL time and reinterpreted as wall-clock-UTC by the
+  // enrichment service. To make elapsed-seconds timezone-independent, express
+  // the dive start in UTC and photo times as LOCAL wall-clocks with the same
+  // clock face — mirroring a diver whose camera and computer share a timezone.
+  final diveStart = DateTime.utc(2025, 6, 1, 10, 0, 0);
+  DateTime photoAt(int secondsIn) =>
+      DateTime(2025, 6, 1, 10, 0, 0).add(Duration(seconds: secondsIn));
+
+  Future<Dive> createProfiledDive({String id = 'dive-1'}) {
+    return diveRepo.createDive(
+      Dive(
+        id: id,
+        diveNumber: 1,
+        dateTime: diveStart,
+        entryTime: diveStart,
+        profile: const [
+          DiveProfilePoint(timestamp: 0, depth: 0, temperature: 24),
+          DiveProfilePoint(timestamp: 120, depth: 20, temperature: 18),
+        ],
+      ),
+    );
+  }
+
+  Future<MediaItem> linkPhoto({
+    required String id,
+    required String diveId,
+    required DateTime takenAt,
+    MediaType mediaType = MediaType.photo,
+  }) {
+    final now = DateTime.now();
+    return mediaRepo.createMedia(
+      MediaItem(
+        id: id,
+        diveId: diveId,
+        filePath: '/photos/$id.jpg',
+        mediaType: mediaType,
+        takenAt: takenAt,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+  }
+
+  Future<MediaEnrichment?> enrichmentFor(String diveId, String mediaId) async {
+    final media = await mediaRepo.getMediaForDive(diveId);
+    return media.firstWhere((m) => m.id == mediaId).enrichment;
+  }
+
+  test('backfills enrichment for a linked photo that has none', () async {
+    await createProfiledDive();
+    // Photo taken 60s into the dive -> interpolated depth ~10m.
+    await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+
+    final count = await service.run();
+    expect(count, 1);
+
+    final enrichment = await enrichmentFor('dive-1', 'photo-1');
+    expect(enrichment, isNotNull);
+    expect(enrichment!.elapsedSeconds, 60);
+    expect(enrichment.depthMeters, closeTo(10.0, 1e-6));
+    expect(enrichment.matchConfidence, isNot(MatchConfidence.noProfile));
+  });
+
+  test('is idempotent: a second run enriches nothing', () async {
+    await createProfiledDive();
+    await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+
+    expect(await service.run(), 1);
+    expect(await service.run(), 0);
+  });
+
+  test('leaves an already-enriched photo untouched', () async {
+    await createProfiledDive();
+    await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+    await mediaRepo.saveEnrichment(
+      MediaEnrichment(
+        id: '',
+        mediaId: 'photo-1',
+        diveId: 'dive-1',
+        depthMeters: 99.0,
+        elapsedSeconds: 999,
+        matchConfidence: MatchConfidence.exact,
+        createdAt: DateTime.now(),
+      ),
+    );
+
+    expect(await service.run(), 0);
+    final enrichment = await enrichmentFor('dive-1', 'photo-1');
+    // Untouched: the pre-existing (sentinel) values survive.
+    expect(enrichment!.depthMeters, 99.0);
+    expect(enrichment.elapsedSeconds, 999);
+  });
+
+  test('skips media on a dive that has no profile', () async {
+    await diveRepo.createDive(
+      Dive(id: 'dive-noprofile', diveNumber: 2, dateTime: diveStart),
+    );
+    await linkPhoto(
+      id: 'photo-np',
+      diveId: 'dive-noprofile',
+      takenAt: photoAt(30),
+    );
+
+    expect(await service.run(), 0);
+    expect(await enrichmentFor('dive-noprofile', 'photo-np'), isNull);
+  });
+
+  test('backfills videos too', () async {
+    await createProfiledDive();
+    await linkPhoto(
+      id: 'clip-1',
+      diveId: 'dive-1',
+      takenAt: photoAt(90),
+      mediaType: MediaType.video,
+    );
+
+    expect(await service.run(), 1);
+    expect(await enrichmentFor('dive-1', 'clip-1'), isNotNull);
+  });
+
+  test('ignores instructor signatures and does not re-scan them', () async {
+    await createProfiledDive();
+    await linkPhoto(
+      id: 'sig-1',
+      diveId: 'dive-1',
+      takenAt: photoAt(45),
+      mediaType: MediaType.instructorSignature,
+    );
+
+    // Signature-only dive is never a candidate, so nothing is enriched and a
+    // second run still finds nothing (no perpetual re-scan).
+    expect(await service.run(), 0);
+    expect(await service.run(), 0);
+    expect(await enrichmentFor('dive-1', 'sig-1'), isNull);
+  });
+}

--- a/test/features/media/data/services/media_enrichment_backfill_service_test.dart
+++ b/test/features/media/data/services/media_enrichment_backfill_service_test.dart
@@ -81,7 +81,7 @@ void main() {
     // Photo taken 60s into the dive -> interpolated depth ~10m.
     await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
 
-    final count = await service.run();
+    final count = await service.backfill();
     expect(count, 1);
 
     final enrichment = await enrichmentFor('dive-1', 'photo-1');
@@ -91,12 +91,24 @@ void main() {
     expect(enrichment.matchConfidence, isNot(MatchConfidence.noProfile));
   });
 
+  test(
+    'run() (StartupMaintenanceTask entry point) performs the backfill',
+    () async {
+      await createProfiledDive();
+      await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+
+      await service.run();
+
+      expect(await enrichmentFor('dive-1', 'photo-1'), isNotNull);
+    },
+  );
+
   test('is idempotent: a second run enriches nothing', () async {
     await createProfiledDive();
     await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
 
-    expect(await service.run(), 1);
-    expect(await service.run(), 0);
+    expect(await service.backfill(), 1);
+    expect(await service.backfill(), 0);
   });
 
   test('leaves an already-enriched photo untouched', () async {
@@ -114,7 +126,7 @@ void main() {
       ),
     );
 
-    expect(await service.run(), 0);
+    expect(await service.backfill(), 0);
     final enrichment = await enrichmentFor('dive-1', 'photo-1');
     // Untouched: the pre-existing (sentinel) values survive.
     expect(enrichment!.depthMeters, 99.0);
@@ -131,7 +143,7 @@ void main() {
       takenAt: photoAt(30),
     );
 
-    expect(await service.run(), 0);
+    expect(await service.backfill(), 0);
     expect(await enrichmentFor('dive-noprofile', 'photo-np'), isNull);
   });
 
@@ -144,7 +156,7 @@ void main() {
       mediaType: MediaType.video,
     );
 
-    expect(await service.run(), 1);
+    expect(await service.backfill(), 1);
     expect(await enrichmentFor('dive-1', 'clip-1'), isNotNull);
   });
 
@@ -159,8 +171,8 @@ void main() {
 
     // Signature-only dive is never a candidate, so nothing is enriched and a
     // second run still finds nothing (no perpetual re-scan).
-    expect(await service.run(), 0);
-    expect(await service.run(), 0);
+    expect(await service.backfill(), 0);
+    expect(await service.backfill(), 0);
     expect(await enrichmentFor('dive-1', 'sig-1'), isNull);
   });
 }


### PR DESCRIPTION
## Summary

Fixes #511: photo tags on the dive profile chart don't appear for dives whose photos were linked before v1.5.9 — unlinking and relinking the photos makes them show up.

**Root cause:** the profile marker builder skips any media whose `MediaEnrichment` row is null (`photo_marker_layout.dart`). Enrichment — the photo's `elapsedSeconds` + interpolated `depthMeters`, which position the marker — is computed only at import/link time (`MediaImportService`). Media linked before that feature shipped never got a row, so no marker renders. Relinking re-runs `MediaImportService`, which is exactly why it fixes them.

## Approach

Add a generic **`StartupMaintenanceRunner`** that runs idempotent data-cleanup tasks after the database opens, and implement the enrichment backfill as its first task.

- The backfill reuses the existing `EnrichmentService`, so backfilled markers are identical to relinked ones (pure SQL can't reproduce its wall-clock normalization or profile interpolation).
- The candidate query is scoped to dives that have a profile and still have unenriched, dive-linked, non-signature media — so it self-terminates once done and is a cheap no-op thereafter.
- Running every launch (rather than gating to one schema migration) means it also **self-heals after a database restore**, which reopens an older DB in-app past the migration path.

## Changes

- **`core/services/maintenance/`** (new) — `StartupMaintenanceTask` interface + `StartupMaintenanceRunner` (best-effort: a throwing task is logged, the rest still run).
- **`MediaEnrichmentBackfillService`** (new) — implements `StartupMaintenanceTask`; computes missing enrichment per profiled dive.
- **`MediaRepository.diveIdsNeedingEnrichmentBackfill()`** — the self-terminating candidate query.
- **`startup_page.dart`** — invokes the runner after DB init; future cleanup tasks just get added to the list.

## Test Plan

- [x] Runner tests: runs all tasks in order, isolates a throwing task, no-ops on empty list
- [x] Backfill service tests (6): enriches unenriched linked media, idempotent, leaves existing enrichment untouched, skips profile-less dives, backfills videos, ignores signatures (no perpetual re-scan)
- [x] `flutter analyze` clean; `dart format .` a no-op
- [x] Regression suites pass: media (548), backup (229), database (124), startup (43)
- [x] Manual: on a device with a pre-v1.5.9 dive that has linked photos, confirm markers appear after launch without relinking