### PR TITLE
Fix missing SAC stats from MacDive imports (tank volume key mismatch) (#517)

### DIFF
--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -334,11 +334,16 @@ class MacDiveDiveMapper {
         if (tank?.name != null) entry['name'] = tank!.name;
         if (tank?.size != null) {
           final volumeL = c.tankSizeLiters(tank!.size, tank.workingPressure);
-          if (volumeL != null) entry['volumeL'] = volumeL;
+          // Key must be `volume` (not `volumeL`) — the shared UDDF importer's
+          // _buildTanks reads `t['volume']`. A mismatched key silently drops
+          // tank volume, which zeroes out volume-based SAC statistics (#517).
+          if (volumeL != null) entry['volume'] = volumeL;
         }
         if (tank?.workingPressure != null) {
           final wp = c.pressureToBar(tank!.workingPressure);
-          if (wp != null) entry['workingPressureBar'] = wp;
+          // Key must be `workingPressure` (not `workingPressureBar`) for the
+          // same reason as `volume` above.
+          if (wp != null) entry['workingPressure'] = wp;
         }
         final startPressure = c.pressureToBar(t.airStart);
         if (startPressure != null) entry['startPressure'] = startPressure;

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -85,6 +85,18 @@ void main() {
       // unit-converter tests in M2 did that.
       expect(tank['startPressure'], 3000);
       expect(tank['endPressure'], 1000);
+      // #517: volume and working pressure must use the same payload keys the
+      // shared UddfEntityImporter._buildTanks reads (`volume` /
+      // `workingPressure`), NOT `volumeL` / `workingPressureBar`. A mismatched
+      // key silently drops the value, which zeroes out volume-based SAC
+      // statistics even though the per-dive SAC (which has a volume fallback)
+      // still renders.
+      expect(tank['volume'], isNotNull);
+      expect(tank['volume'] as num, greaterThan(0));
+      expect(tank['workingPressure'], isNotNull);
+      expect(tank['workingPressure'] as num, greaterThan(0));
+      expect(tank.containsKey('volumeL'), isFalse);
+      expect(tank.containsKey('workingPressureBar'), isFalse);
       // gasMix must be a `GasMix` object, not a Map — UddfEntityImporter does
       // `t['gasMix'] as GasMix?` and a Map cast would throw at runtime.
       // MacDive stores oxygen as a fraction (0.32); GasMix.o2 is a percent.


### PR DESCRIPTION
## Summary

Fixes #517: after importing a MacDive library, tank data and per-dive SAC are present but the aggregate SAC statistics (SAC Rate Trend, SAC Records, SAC by Tank Role) show "No data".

**Root cause:** the MacDive **SQLite/.db** mapper (`macdive_dive_mapper.dart`) wrote tank volume and working pressure under the keys `volumeL` / `workingPressureBar`, but the shared `UddfEntityImporter._buildTanks` reads `volume` / `workingPressure`. The import payload is an untyped `Map`, so the mismatch failed silently — MacDive-imported tanks persisted with **null volume**. Volume-based SAC statistics query `WHERE t.volume > 0`, so they matched zero rows.

Gas Mix Distribution kept working because `gasMix` used the correct key, and per-dive SAC still rendered because it has a volume fallback the aggregate query doesn't — which is exactly the confusing symptom in the report. The MacDive **XML** parser already carries a comment warning to use `volume`/`workingPressure` "not `volumeL`/`workingPressureBar`"; the SQLite mapper just hadn't followed it.

## Changes

- **`macdive_dive_mapper.dart`** — write tank volume under `volume` and working pressure under `workingPressure`, matching the importer's contract (comment references #517).
- **`macdive_dive_mapper_test.dart`** — the tank test asserted pressures and gas mix but never volume/working pressure, which is how this slipped through. It now asserts both are present and positive under the correct keys, and that the old `volumeL`/`workingPressureBar` keys are absent. The test fails without the fix.

## Note

This corrects **future** MacDive imports. Dives already imported with the bug have null tank volume in the database; they need re-importing (or a per-tank volume edit) to get volume-based SAC stats.

## Test Plan

- [x] MacDive mapper + XML parser suites pass (32)
- [x] Full `universal_import` suite passes (1305, 5 skipped)
- [x] `flutter analyze` clean; `dart format .` a no-op
- [x] Manual: import a MacDive `.db`, confirm SAC Rate Trend / Records / by-Tank-Role populate