### PR TITLE
fix(home): Recent dives follows the dive list display settings (#506)

### DIFF
--- a/lib/features/dashboard/presentation/widgets/recent_dives_card.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_dives_card.dart
@@ -4,8 +4,9 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
-import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_list_item.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/add_dive_bottom_sheet.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -74,25 +75,19 @@ class RecentDivesCard extends ConsumerWidget {
               children: dives.asMap().entries.map((entry) {
                 final index = entry.key;
                 final dive = entry.value;
-                return DiveListTile(
-                  diveId: dive.id,
+                // Render through the shared DiveListItem so Recent dives honour
+                // the same view-mode and card configuration as the Dives tab
+                // (issue #506). The full Dive is passed for configurable extra
+                // fields; the summary drives title/date/stat slots.
+                return DiveListItem(
+                  summary: DiveSummary.fromDive(dive),
+                  fullDive: dive,
                   diveNumber: dive.diveNumber ?? index + 1,
-                  dateTime: dive.dateTime,
-                  siteName: dive.site?.name,
-                  siteLocation: dive.site?.locationString,
-                  maxDepth: dive.maxDepth,
-                  duration: dive.runtime ?? dive.bottomTime,
-                  waterTemp: dive.waterTemp,
-                  rating: dive.rating,
-                  isFavorite: dive.isFavorite,
-                  tags: dive.tags,
                   colorValue: getCardColorValueFromDive(dive, colorAttribute),
                   minValueInList: minValue,
                   maxValueInList: maxValue,
                   gradientStartColor: gradientColors.start,
                   gradientEndColor: gradientColors.end,
-                  siteLatitude: dive.site?.location?.latitude,
-                  siteLongitude: dive.site?.location?.longitude,
                   margin: const EdgeInsets.symmetric(vertical: 4),
                   onTap: () => context.push('/dives/${dive.id}'),
                 );

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -11,7 +11,7 @@ import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/compact_dive_list_tile.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_list_item.dart';
 import 'package:submersion/shared/widgets/list_view_mode_toggle.dart';
 import 'package:submersion/shared/widgets/master_detail/map_view_toggle_button.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -611,19 +611,6 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     if (ids.isEmpty) return;
     await context.pushNamed('bulkEditDives', extra: ids);
     if (mounted) _exitSelectionMode();
-  }
-
-  /// Returns the [DiveField] for [slotId] from [slots], or [defaultField] if
-  /// no matching slot is found.
-  DiveField _slotField(
-    List<CardSlotConfig> slots,
-    String slotId,
-    DiveField defaultField,
-  ) {
-    for (final slot in slots) {
-      if (slot.slotId == slotId) return slot.field;
-    }
-    return defaultField;
   }
 
   void _handleItemTap(DiveSummary dive) {
@@ -1255,131 +1242,31 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                 final isMasterSelected = widget.selectedId == dive.id;
                 final isHighlighted =
                     ref.watch(highlightedDiveIdProvider) == dive.id;
-                final viewMode = ref.watch(diveListViewModeProvider);
-                return switch (viewMode) {
-                  ListViewMode.detailed => DiveListTile(
-                    diveId: dive.id,
-                    diveNumber: dive.diveNumber ?? index + 1,
-                    dateTime: dive.dateTime,
-                    siteName: dive.siteName,
-                    siteLocation: dive.siteLocation,
-                    maxDepth: dive.maxDepth,
-                    duration: dive.runtime ?? dive.bottomTime,
-                    waterTemp: dive.waterTemp,
-                    rating: dive.rating,
-                    isFavorite: dive.isFavorite,
-                    tags: dive.tags,
-                    isSelectionMode: _isSelectionMode,
-                    isSelected: _isSelectionMode
-                        ? isSelected
-                        : (isSelected || isMasterSelected || isHighlighted),
-                    colorValue: getCardColorValue(dive, colorAttribute),
-                    minValueInList: minValue,
-                    maxValueInList: maxValue,
-                    gradientStartColor: gradientColors.start,
-                    gradientEndColor: gradientColors.end,
-                    siteLatitude: dive.siteLatitude,
-                    siteLongitude: dive.siteLongitude,
-                    onTap: () {
-                      if (_isSelectionMode && _isShiftPressed()) {
-                        _selectRangeTo(dive.id, dives);
-                      } else {
-                        _handleItemTap(dive);
-                      }
-                    },
-                    onLongPress: _isSelectionMode
-                        ? null
-                        : () => _enterSelectionMode(dive.id),
-                    summary: dive,
-                    fullDive: fullDiveLookup[dive.id],
-                  ),
-                  ListViewMode.compact => CompactDiveListTile(
-                    diveId: dive.id,
-                    diveNumber: dive.diveNumber ?? index + 1,
-                    dateTime: dive.dateTime,
-                    siteName: dive.siteName,
-                    maxDepth: dive.maxDepth,
-                    duration: dive.runtime ?? dive.bottomTime,
-                    isSelectionMode: _isSelectionMode,
-                    isSelected: _isSelectionMode
-                        ? isSelected
-                        : (isSelected || isMasterSelected || isHighlighted),
-                    colorValue: getCardColorValue(dive, colorAttribute),
-                    minValueInList: minValue,
-                    maxValueInList: maxValue,
-                    gradientStartColor: gradientColors.start,
-                    gradientEndColor: gradientColors.end,
-                    summary: dive,
-                    titleField: _slotField(
-                      ref.watch(compactCardConfigProvider).slots,
-                      'title',
-                      DiveField.siteName,
-                    ),
-                    dateField: _slotField(
-                      ref.watch(compactCardConfigProvider).slots,
-                      'date',
-                      DiveField.dateTime,
-                    ),
-                    stat1Field: _slotField(
-                      ref.watch(compactCardConfigProvider).slots,
-                      'stat1',
-                      DiveField.maxDepth,
-                    ),
-                    stat2Field: _slotField(
-                      ref.watch(compactCardConfigProvider).slots,
-                      'stat2',
-                      DiveField.bottomTime,
-                    ),
-                    onTap: () {
-                      if (_isSelectionMode && _isShiftPressed()) {
-                        _selectRangeTo(dive.id, dives);
-                      } else {
-                        _handleItemTap(dive);
-                      }
-                    },
-                    onLongPress: _isSelectionMode
-                        ? null
-                        : () => _enterSelectionMode(dive.id),
-                  ),
-                  // Dense is no longer a dive view option; table is handled
-                  // in _buildTableModeScaffold. Fall through to detailed.
-                  ListViewMode.dense || ListViewMode.table => DiveListTile(
-                    diveId: dive.id,
-                    diveNumber: dive.diveNumber ?? index + 1,
-                    dateTime: dive.dateTime,
-                    siteName: dive.siteName,
-                    siteLocation: dive.siteLocation,
-                    maxDepth: dive.maxDepth,
-                    duration: dive.runtime ?? dive.bottomTime,
-                    waterTemp: dive.waterTemp,
-                    rating: dive.rating,
-                    isFavorite: dive.isFavorite,
-                    tags: dive.tags,
-                    isSelectionMode: _isSelectionMode,
-                    isSelected: _isSelectionMode
-                        ? isSelected
-                        : (isSelected || isMasterSelected || isHighlighted),
-                    colorValue: getCardColorValue(dive, colorAttribute),
-                    minValueInList: minValue,
-                    maxValueInList: maxValue,
-                    gradientStartColor: gradientColors.start,
-                    gradientEndColor: gradientColors.end,
-                    siteLatitude: dive.siteLatitude,
-                    siteLongitude: dive.siteLongitude,
-                    onTap: () {
-                      if (_isSelectionMode && _isShiftPressed()) {
-                        _selectRangeTo(dive.id, dives);
-                      } else {
-                        _handleItemTap(dive);
-                      }
-                    },
-                    onLongPress: _isSelectionMode
-                        ? null
-                        : () => _enterSelectionMode(dive.id),
-                    summary: dive,
-                    fullDive: fullDiveLookup[dive.id],
-                  ),
-                };
+                // Shared renderer: honours the active view mode and card
+                // config, and keeps the home Recent dives list in sync (#506).
+                return DiveListItem(
+                  summary: dive,
+                  fullDive: fullDiveLookup[dive.id],
+                  diveNumber: dive.diveNumber ?? index + 1,
+                  colorValue: getCardColorValue(dive, colorAttribute),
+                  minValueInList: minValue,
+                  maxValueInList: maxValue,
+                  gradientStartColor: gradientColors.start,
+                  gradientEndColor: gradientColors.end,
+                  isSelectionMode: _isSelectionMode,
+                  isSelected: isSelected,
+                  isHighlighted: isMasterSelected || isHighlighted,
+                  onTap: () {
+                    if (_isSelectionMode && _isShiftPressed()) {
+                      _selectRangeTo(dive.id, dives);
+                    } else {
+                      _handleItemTap(dive);
+                    }
+                  },
+                  onLongPress: _isSelectionMode
+                      ? null
+                      : () => _enterSelectionMode(dive.id),
+                );
               },
             ),
           ),

--- a/lib/features/dive_log/presentation/widgets/dive_list_item.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_item.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart'
+    show DiveListTile;
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/compact_dive_list_tile.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Renders a single dive in a list according to the active [ListViewMode] and
+/// card configuration, so every dive list honours the same display settings.
+///
+/// This is the single source of truth for "how a dive row looks" — the Dives
+/// tab and the home screen's Recent dives both use it, which is what keeps the
+/// home list in sync with the list settings (issue #506).
+class DiveListItem extends ConsumerWidget {
+  /// Summary used for slot/field extraction (title, date, stats, extra fields).
+  final DiveSummary summary;
+
+  /// Full dive, when available, for fields not on [DiveSummary] (tanks, SAC,
+  /// buddy, weights). Enables the detailed card's configurable extra fields.
+  final Dive? fullDive;
+
+  /// Display number for the leading badge (caller resolves any fallback).
+  final int diveNumber;
+
+  /// Value/range for attribute-based card coloring.
+  final double? colorValue;
+  final double? minValueInList;
+  final double? maxValueInList;
+  final Color? gradientStartColor;
+  final Color? gradientEndColor;
+
+  /// Card margin override (detailed tile only).
+  final EdgeInsetsGeometry? margin;
+
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  /// Selection / highlight state (defaults suit read-only lists like Recent).
+  final bool isSelectionMode;
+  final bool isSelected;
+  final bool isHighlighted;
+
+  const DiveListItem({
+    super.key,
+    required this.summary,
+    required this.diveNumber,
+    this.fullDive,
+    this.colorValue,
+    this.minValueInList,
+    this.maxValueInList,
+    this.gradientStartColor,
+    this.gradientEndColor,
+    this.margin,
+    this.onTap,
+    this.onLongPress,
+    this.isSelectionMode = false,
+    this.isSelected = false,
+    this.isHighlighted = false,
+  });
+
+  static DiveField _slotField(
+    List<CardSlotConfig> slots,
+    String slotId,
+    DiveField defaultField,
+  ) {
+    for (final slot in slots) {
+      if (slot.slotId == slotId) return slot.field;
+    }
+    return defaultField;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewMode = ref.watch(diveListViewModeProvider);
+
+    // Outside selection mode a highlighted/master-selected row reads as
+    // selected, mirroring the Dives tab.
+    final resolvedSelected = isSelectionMode
+        ? isSelected
+        : (isSelected || isHighlighted);
+
+    final duration = summary.runtime ?? summary.bottomTime;
+
+    switch (viewMode) {
+      case ListViewMode.compact:
+        final slots = ref.watch(compactCardConfigProvider).slots;
+        return CompactDiveListTile(
+          diveId: summary.id,
+          diveNumber: diveNumber,
+          dateTime: summary.dateTime,
+          siteName: summary.siteName,
+          maxDepth: summary.maxDepth,
+          duration: duration,
+          isSelectionMode: isSelectionMode,
+          isSelected: resolvedSelected,
+          colorValue: colorValue,
+          minValueInList: minValueInList,
+          maxValueInList: maxValueInList,
+          gradientStartColor: gradientStartColor,
+          gradientEndColor: gradientEndColor,
+          summary: summary,
+          titleField: _slotField(slots, 'title', DiveField.siteName),
+          dateField: _slotField(slots, 'date', DiveField.dateTime),
+          stat1Field: _slotField(slots, 'stat1', DiveField.maxDepth),
+          stat2Field: _slotField(slots, 'stat2', DiveField.bottomTime),
+          onTap: onTap,
+          onLongPress: onLongPress,
+        );
+      case ListViewMode.detailed:
+      case ListViewMode.dense:
+      case ListViewMode.table:
+        return DiveListTile(
+          diveId: summary.id,
+          diveNumber: diveNumber,
+          dateTime: summary.dateTime,
+          siteName: summary.siteName,
+          siteLocation: summary.siteLocation,
+          maxDepth: summary.maxDepth,
+          duration: duration,
+          waterTemp: summary.waterTemp,
+          rating: summary.rating,
+          isFavorite: summary.isFavorite,
+          tags: summary.tags,
+          isSelectionMode: isSelectionMode,
+          isSelected: resolvedSelected,
+          colorValue: colorValue,
+          minValueInList: minValueInList,
+          maxValueInList: maxValueInList,
+          gradientStartColor: gradientStartColor,
+          gradientEndColor: gradientEndColor,
+          siteLatitude: summary.siteLatitude,
+          siteLongitude: summary.siteLongitude,
+          margin: margin,
+          onTap: onTap,
+          onLongPress: onLongPress,
+          summary: summary,
+          fullDive: fullDive,
+        );
+    }
+  }
+}

--- a/test/features/dashboard/presentation/widgets/recent_dives_card_test.dart
+++ b/test/features/dashboard/presentation/widgets/recent_dives_card_test.dart
@@ -1,12 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/recent_dives_card.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/compact_dive_list_tile.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
+
+GoRouter _cardRouter() => GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const Scaffold(body: RecentDivesCard()),
+    ),
+    GoRoute(path: '/dives', builder: (context, state) => const Scaffold()),
+    GoRoute(path: '/dives/:id', builder: (context, state) => const Scaffold()),
+    GoRoute(path: '/dives/new', builder: (context, state) => const Scaffold()),
+  ],
+);
 
 void main() {
   group('RecentDivesCard bottomTime coverage', () {
@@ -63,6 +80,59 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(RecentDivesCard), findsOneWidget);
+    });
+  });
+
+  group('RecentDivesCard follows the dive list view mode (#506)', () {
+    Future<void> pumpWithViewMode(
+      WidgetTester tester,
+      ListViewMode mode,
+    ) async {
+      final dives = [
+        createTestDiveWithBottomTime(
+          id: 'recent-1',
+          diveNumber: 1,
+          bottomTime: const Duration(minutes: 45),
+          runtime: const Duration(minutes: 50),
+          maxDepth: 25.0,
+          waterTemp: 22.0,
+        ),
+      ];
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            recentDivesProvider.overrideWith((ref) async => dives),
+            diveListViewModeProvider.overrideWith((ref) => mode),
+          ].cast(),
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: _cardRouter(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('renders the compact tile when view mode is compact', (
+      tester,
+    ) async {
+      await pumpWithViewMode(tester, ListViewMode.compact);
+
+      expect(find.byType(CompactDiveListTile), findsOneWidget);
+      expect(find.byType(DiveListTile), findsNothing);
+    });
+
+    testWidgets('renders the detailed tile when view mode is detailed', (
+      tester,
+    ) async {
+      await pumpWithViewMode(tester, ListViewMode.detailed);
+
+      expect(find.byType(DiveListTile), findsOneWidget);
+      expect(find.byType(CompactDiveListTile), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Fixes #506.

## Symptom

The home screen's **Recent dives** list did not follow the dive list display settings the way the Dives tab does (see the issue screenshots): it always rendered the full detailed card and ignored the list view mode (detailed vs compact) and the configurable card fields.

## Root cause

`RecentDivesCard` had its own copy of dive-row rendering — a bare `DiveListTile` constructed with no `summary`/`fullDive` and no awareness of `diveListViewModeProvider`. So it ignored:

- the **ListViewMode** setting (`diveListViewModeProvider`) — always detailed, never compact;
- the **card configuration** (title/date/stat slots and configurable extra fields), which only render when `summary`/`fullDive` are supplied.

The Dives tab (`dive_list_content.dart`) applies both via a `switch (viewMode)` that passes `summary: dive` and `fullDive:`. The home card was a divergent copy that had drifted from it.

## Fix

Extract the Dives tab's view-mode switch into a shared **`DiveListItem`** widget — the single source of truth for how one dive row renders per `diveListViewModeProvider` + the card config — and use it in **both** `dive_list_content.dart` (Dives tab) and `RecentDivesCard`. The divergent copy is deleted rather than patched, so the two lists can't fall out of sync again, and any future dive-list surface inherits the settings for free.

The home card converts its full `Dive` to a `DiveSummary` (via `DiveSummary.fromDive`, for slot/field extraction) and passes the full `Dive` (for configurable extra fields). The Dives-tab refactor is a faithful extraction — same params, same selection/highlight wiring — and its `_slotField` helper (now dead) is removed.

## Testing

- New tests assert the home card renders the **compact** tile in compact mode and the **detailed** tile in detailed mode (the compact case fails before this change, confirming the reproduction).
- Full `test/features/dive_log/presentation/widgets/` and `test/features/dashboard/` suites (680 tests) pass — the Dives tab's selection, highlight, and compact/detailed rendering are intact.
- Whole-project `flutter analyze` and `dart format` clean.

## Note

Verified at the widget-render level (both view modes exercised through the real path); not driven interactively in the running app.