### PR TITLE
feat(sync): sync error recovery — /tmp base-file fix, Repair, Troubleshoot screen, cloud clear (#509)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-sync-error-recovery.md
+++ b/docs/superpowers/plans/2026-07-07-sync-error-recovery.md
@@ -1,0 +1,809 @@
+# Sync Error Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give users a reliable in-app way out of any wedged Cloud Sync state without a reinstall, and fix the two reported dead-ends at the source.
+
+**Architecture:** A new Troubleshoot Sync screen (reached from the Cloud Sync page's Advanced section and by tapping the sync-error banner) hosts escalating recovery actions. Under it: (1) a comprehensive local "Repair Sync" that clears every local sync store including the SharedPreferences epoch markers today's Reset misses; (2) two active-provider cloud-clear actions; (3) a "rebuild this backend from this device" escape for a stuck library-epoch adoption. Separately, sync temp files move off `/tmp` to the app-container temp dir, fixing the #509 `PathAccessException`.
+
+**Tech Stack:** Flutter, Riverpod (`StateNotifier`), Drift, `shared_preferences`, `path_provider`, `flutter_test`.
+
+## Global Constraints
+
+- Dart must pass `dart format .` with no changes (CI checks the whole project).
+- `flutter analyze` must be clean (whole project).
+- New user-facing strings are added to `lib/l10n/arb/app_en.arb` and translated into all 10 non-en locales (`ar, de, es, fr, he, hu, it, nl, pt, zh`), then `flutter gen-l10n` is run. (Where an existing plain `const Text('…')` pattern is already used in this page, e.g. "Reset Sync State", matching that literal-string style is acceptable to stay consistent — see each task.)
+- Never touch dive data in any recovery action; only sync bookkeeping and cloud sync artifacts.
+- Cloud-clear actions operate on the **active** provider only.
+- New worktrees need codegen: if `database.g.dart` is missing, run `dart run build_runner build --delete-conflicting-outputs` before tests.
+- Native/DB tests: run specific test files (not broad dirs) to avoid Bash timeouts.
+
+---
+
+## PR 1 — Temp-dir fix, comprehensive local Repair, Troubleshoot screen
+
+### Task 1: Route sync base temp files to the app-container temp dir (fixes #509)
+
+**Why:** `exportBaseToTempFile` and `BasePartFileSink` default their temp dir to `Directory.systemTemp`, which is `/tmp` on macOS. A hardened-runtime/sandboxed app is denied there → `PathAccessException: … path = '/tmp/ssv1_base_…json' (Operation not permitted, errno = 1)` on every publish/adopt. `path_provider`'s `getTemporaryDirectory()` returns the always-accessible app-container temp dir (already used in `backup_service.dart`).
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_data_serializer.dart:728-732`
+- Modify: `lib/core/services/sync/changeset_log/base_part_file_sink.dart:14-18`
+- Test: `test/core/services/sync/changeset_log/base_part_file_sink_test.dart`
+
+**Interfaces:**
+- Produces: unchanged public signatures; only the *default* temp dir changes. `exportBaseToTempFile({… Future<Directory> Function()? tempDir})` and `BasePartFileSink({Future<Directory> Function()? tempDirProvider})` keep their injectable seams for tests.
+
+- [ ] **Step 1: Write the failing test** (assert the default dir is the app temp dir, not systemTemp)
+
+Add to `base_part_file_sink_test.dart` (create if absent; mock the `path_provider` channel exactly as `backup_service_leased_test.dart` does):
+
+```dart
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory fakeAppTemp;
+
+  setUpAll(() async {
+    fakeAppTemp = await Directory.systemTemp.createTemp('app_temp_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async =>
+          call.method == 'getTemporaryDirectory' ? fakeAppTemp.path : null,
+    );
+  });
+
+  test('assemble writes into the app-container temp dir by default', () async {
+    final sink = BasePartFileSink(); // no injected dir -> uses the default
+    final path = await sink.assemble(
+      name: 'ssv1_base_dev_0',
+      partCount: 1,
+      wholeChecksum: null,
+      partChecksums: const [],
+      downloadPart: (_) async => Uint8List.fromList([1, 2, 3]),
+    );
+    expect(path, isNotNull);
+    expect(path!.startsWith(fakeAppTemp.path), isTrue,
+        reason: 'must not fall back to /tmp (systemTemp)');
+    await sink.deleteQuietly(path);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_part_file_sink_test.dart`
+Expected: FAIL — the default is `Directory.systemTemp`, so `path` starts with the system temp path, not `fakeAppTemp.path`.
+
+- [ ] **Step 3: Change the `BasePartFileSink` default**
+
+In `base_part_file_sink.dart`:
+
+```dart
+import 'package:path_provider/path_provider.dart';
+// ...
+class BasePartFileSink {
+  BasePartFileSink({Future<Directory> Function()? tempDirProvider})
+    : _tempDir = tempDirProvider ?? getTemporaryDirectory;
+  // ...
+}
+```
+
+- [ ] **Step 4: Change the `exportBaseToTempFile` default**
+
+In `sync_data_serializer.dart` (ensure `import 'package:path_provider/path_provider.dart';` is present):
+
+```dart
+final dir = await (tempDir?.call() ?? getTemporaryDirectory());
+```
+
+(Replaces `Future.value(Directory.systemTemp)`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/base_part_file_sink_test.dart test/core/services/sync/sync_data_serializer_test.dart`
+Expected: PASS. (If `sync_data_serializer_test.dart` constructs the serializer and calls `exportBaseToTempFile` without injecting `tempDir`, add the same `path_provider` mock to its `setUpAll`.)
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/sync_data_serializer.dart lib/core/services/sync/changeset_log/base_part_file_sink.dart test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+flutter analyze lib/core/services/sync/sync_data_serializer.dart lib/core/services/sync/changeset_log/base_part_file_sink.dart
+git add -A && git commit -m "fix(sync): write base temp files to the app temp dir, not /tmp (#509)"
+```
+
+---
+
+### Task 2: `LibraryEpochStore.clear()`
+
+**Why:** The last-accepted epoch marker (`sync_last_accepted_epoch_marker`) is the one local sync state today's Reset does not clear — it lives in SharedPreferences, survives DB reset, and only a reinstall wiped it.
+
+**Files:**
+- Modify: `lib/core/services/sync/library_epoch_store.dart`
+- Test: `test/core/services/sync/library_epoch_store_test.dart`
+
+**Interfaces:**
+- Produces: `Future<void> LibraryEpochStore.clear()` — removes both `sync_last_accepted_epoch_marker` and `sync_pending_replace_marker`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/services/sync/library_epoch_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('clear() removes both the last-accepted and pending-replace markers',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = LibraryEpochStore(await SharedPreferences.getInstance());
+    final marker = LibraryEpochMarker(
+      epochId: 'e1',
+      movedFrom: null,
+      deviceId: 'd1',
+      createdAt: 1,
+    );
+    await store.setLastAccepted(marker);
+    await store.setPendingReplace(marker);
+
+    await store.clear();
+
+    expect(store.lastAcceptedMarker, isNull);
+    expect(store.pendingReplace, isNull);
+  });
+}
+```
+
+(Confirm the `LibraryEpochMarker` constructor field names in `lib/core/services/sync/library_epoch.dart` and adjust the literal above to match before running.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/library_epoch_store_test.dart`
+Expected: FAIL — `clear` is not defined on `LibraryEpochStore`.
+
+- [ ] **Step 3: Implement `clear()`**
+
+In `library_epoch_store.dart`:
+
+```dart
+/// Wipe both epoch records. Used by the comprehensive local sync repair: the
+/// last-accepted marker is the only local sync state a DB reset does not
+/// touch (it is in SharedPreferences), so a wedge that survives Reset needs
+/// this to be a true reinstall-equivalent.
+Future<void> clear() async {
+  await _prefs.remove(_lastAcceptedMarkerKey);
+  await _prefs.remove(_pendingReplaceKey);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/services/sync/library_epoch_store_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/library_epoch_store.dart test/core/services/sync/library_epoch_store_test.dart
+flutter analyze lib/core/services/sync/library_epoch_store.dart
+git add -A && git commit -m "feat(sync): add LibraryEpochStore.clear() for comprehensive local repair"
+```
+
+---
+
+### Task 3: `SyncService.repairLocalSyncState()` + notifier `repairSync()`
+
+**Why:** One comprehensive local reset that is a true reinstall-equivalent: everything the current Reset does, PLUS clearing the last-accepted epoch marker and leftover base temp files, then clearing the error banner. This is the guaranteed local escape.
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (add method near `resetSyncState`, ~line 2002)
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (add `repairSync()` to `SyncNotifier`, near `resetSyncState`, ~line 907)
+- Test: `test/core/services/sync/sync_service_repair_test.dart`
+
+**Interfaces:**
+- Consumes: `LibraryEpochStore.clear()` (Task 2); existing `SyncService.resetSyncState()`, `_epochStore`, `_baseSink` (`BasePartFileSink`).
+- Produces:
+  - `Future<void> SyncService.repairLocalSyncState()` — calls `resetSyncState()`, `_epochStore?.clear()`, and best-effort deletes leftover `ssv1_base_*` / `*.base` files from the app temp dir.
+  - `Future<void> SyncNotifier.repairSync()` — runs the full provider-level reset (fresh identity, this-device cloud file removal, etc. — reusing the existing `resetSyncState()` body) then `repairLocalSyncState`'s extra clears, and sets `state` back to idle with no error.
+
+- [ ] **Step 1: Write the failing test** (service clears the epoch store and leftover temp files)
+
+```dart
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+// import the SyncService + fakes following the pattern in existing
+// test/core/services/sync/*_test.dart files (fake SyncRepository, in-memory
+// AppDatabase, a real LibraryEpochStore over SharedPreferences.setMockInitialValues).
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('repairLocalSyncState clears the epoch store', () async {
+    // Arrange: build a SyncService with a real LibraryEpochStore holding a
+    // last-accepted marker (see Task 2 for marker construction) and a fake
+    // SyncRepository whose resetSyncState records that it was called.
+    // Act:
+    await service.repairLocalSyncState();
+    // Assert:
+    expect(epochStore.lastAcceptedMarker, isNull);
+    expect(fakeRepo.resetSyncStateCalled, isTrue);
+  });
+}
+```
+
+(Follow the construction/fakes used by the nearest existing `sync_service` test. If none constructs `SyncService` directly, add a minimal fake `SyncRepository` exposing `resetSyncState` and reuse the in-memory DB helper already in the test suite.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/sync_service_repair_test.dart`
+Expected: FAIL — `repairLocalSyncState` not defined.
+
+- [ ] **Step 3: Implement `repairLocalSyncState`**
+
+In `sync_service.dart`:
+
+```dart
+/// Comprehensive local sync reset: everything [resetSyncState] clears, PLUS
+/// the SharedPreferences epoch markers (the one local sync state a DB reset
+/// misses) and any leftover base temp files. A true reinstall-equivalent for
+/// sync state that never touches dive data. The caller (notifier) still runs
+/// the provider-level identity/cloud-file cleanup.
+Future<void> repairLocalSyncState() async {
+  await resetSyncState();
+  await _epochStore?.clear();
+  await _deleteLeftoverBaseTempFiles();
+}
+
+Future<void> _deleteLeftoverBaseTempFiles() async {
+  try {
+    final dir = await getTemporaryDirectory();
+    await for (final e in dir.list(followLinks: false)) {
+      if (e is! File) continue;
+      final name = e.uri.pathSegments.last;
+      if (name.startsWith('ssv1_base_') || name.endsWith('.base')) {
+        try {
+          await e.delete();
+        } catch (_) {/* best effort */}
+      }
+    }
+  } catch (e) {
+    _log.warning('Could not sweep leftover base temp files: $e');
+  }
+}
+```
+
+(Add `import 'package:path_provider/path_provider.dart';` if not present.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/core/services/sync/sync_service_repair_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Add the notifier `repairSync()`**
+
+In `sync_providers.dart`, add to `SyncNotifier` (reuse the existing `resetSyncState()` body, then the extra clears):
+
+```dart
+/// Comprehensive local repair: the full Reset (fresh identity, this device's
+/// cloud file removed, pending-replace/awaiting-adoption cleared) PLUS the
+/// last-accepted epoch marker and leftover base temp files, ending with the
+/// error cleared. The guaranteed local escape from a wedged sync.
+Future<void> repairSync() async {
+  await resetSyncState(); // existing: fresh identity + cloud-file + markers
+  await _ref.read(libraryEpochStoreProvider).clear();
+  await _syncService.repairLocalSyncState();
+  state = state.copyWith(status: SyncStatus.idle, message: null);
+  await refreshState();
+}
+```
+
+(Note: `repairLocalSyncState` internally calls `resetSyncState` again; that is idempotent and safe. If preferred for tightness, split the temp-file sweep into a public `SyncService.deleteLeftoverBaseTempFiles()` and call only that here — either is acceptable, keep whichever keeps the test in Step 1 green.)
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/sync_service.dart lib/features/settings/presentation/providers/sync_providers.dart test/core/services/sync/sync_service_repair_test.dart
+flutter analyze lib/core/services/sync/sync_service.dart lib/features/settings/presentation/providers/sync_providers.dart
+git add -A && git commit -m "feat(sync): comprehensive local Repair (reset + epoch markers + temp sweep)"
+```
+
+---
+
+### Task 4: Troubleshoot Sync screen + Advanced entry (replaces the standalone Reset tile), wired to Repair
+
+**Why:** One discoverable home for recovery, with plain-language actions. Replacing the lone "Reset Sync State" tile avoids two near-identical reset buttons — Repair is the superset.
+
+**Files:**
+- Create: `lib/features/settings/presentation/pages/troubleshoot_sync_page.dart`
+- Modify: `lib/features/settings/presentation/pages/cloud_sync_page.dart:1185-1198` (Advanced section: replace the "Reset Sync State" `ListTile` with a "Troubleshoot Sync" tile that navigates to the new page; keep "Sign Out")
+- Test: `test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart`
+
+**Interfaces:**
+- Consumes: `syncStateProvider` notifier `repairSync()` (Task 3).
+- Produces: `TroubleshootSyncPage` widget (a `ConsumerWidget`) with a "Repair Sync" `ListTile` that shows a confirm dialog then calls `repairSync()`. (Cloud-clear + rebuild tiles are added by PR 2 Tasks 8/9.)
+
+- [ ] **Step 1: Write the failing widget test**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/features/settings/presentation/pages/troubleshoot_sync_page.dart';
+
+void main() {
+  testWidgets('shows Repair Sync action with an explanation', (tester) async {
+    await tester.pumpWidget(const ProviderScope(
+      child: MaterialApp(home: TroubleshootSyncPage()),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Repair Sync'), findsOneWidget);
+    expect(find.textContaining('dive data'), findsWidgets); // "data is safe"
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart`
+Expected: FAIL — file/type does not exist.
+
+- [ ] **Step 3: Implement `TroubleshootSyncPage`** (mirror the existing page's `ListTile` + `showDialog` idioms from `cloud_sync_page.dart`)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+class TroubleshootSyncPage extends ConsumerWidget {
+  const TroubleshootSyncPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Troubleshoot Sync')),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.healing),
+            title: const Text('Repair Sync'),
+            subtitle: const Text(
+              'Fix a stuck sync. Clears this device’s sync state and gives '
+              'it a fresh sync identity. Your dive data is not affected.',
+            ),
+            onTap: () => _confirmRepair(context, ref),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmRepair(BuildContext context, WidgetRef ref) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Repair Sync?'),
+        content: const Text(
+          'This clears all local sync state and gives this device a new sync '
+          'identity, then reconnects fresh on the next sync. Your dive data is '
+          'safe and is not deleted.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Repair'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await ref.read(syncStateProvider.notifier).repairSync();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Sync repaired')),
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Wire the Advanced entry** — in `cloud_sync_page.dart` `_buildAdvancedSection`, replace the "Reset Sync State" `ListTile` with:
+
+```dart
+ListTile(
+  leading: const Icon(Icons.build),
+  title: const Text('Troubleshoot Sync'),
+  subtitle: const Text('Fix a stuck sync or free cloud space'),
+  onTap: () => Navigator.of(context).push(
+    MaterialPageRoute(builder: (_) => const TroubleshootSyncPage()),
+  ),
+),
+```
+
+(Add the import for `troubleshoot_sync_page.dart`. Remove the now-unused `_confirmResetSyncState` method only if nothing else references it; otherwise leave it. Keep "Sign Out".)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/features/settings/presentation/pages/troubleshoot_sync_page.dart lib/features/settings/presentation/pages/cloud_sync_page.dart test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+flutter analyze lib/features/settings/presentation/pages
+git add -A && git commit -m "feat(sync): Troubleshoot Sync screen with Repair Sync action"
+```
+
+---
+
+### Task 5: Make the sync-error banner tappable → Troubleshoot Sync
+
+**Why:** A stuck user should find the exit where the error is shown, not only under Advanced.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/pages/cloud_sync_page.dart:316-410` (`_buildSyncStatusCard`; wrap the error card in an `InkWell`/`onTap` when `syncState.status == SyncStatus.error`)
+- Test: `test/features/settings/presentation/pages/cloud_sync_page_test.dart` (add a case; reuse the file's existing harness/overrides)
+
+**Interfaces:**
+- Consumes: `SyncStatus.error` from `syncStateProvider`; `TroubleshootSyncPage` (Task 4).
+
+- [ ] **Step 1: Write the failing widget test** — seed an error `SyncState`, tap the "Sync error" card, expect the Troubleshoot page. (Model the harness on the existing tests in this file; if it seeds providers via `ProviderScope` overrides, override `syncStateProvider` to a notifier in `SyncStatus.error`.)
+
+```dart
+testWidgets('tapping the sync error banner opens Troubleshoot Sync',
+    (tester) async {
+  // pump CloudSyncPage with syncState.status == SyncStatus.error (see existing
+  // test harness in this file for provider overrides)
+  await tester.tap(find.text('Sync error'));
+  await tester.pumpAndSettle();
+  expect(find.text('Troubleshoot Sync'), findsOneWidget); // the page's AppBar
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/pages/cloud_sync_page_test.dart`
+Expected: FAIL — the banner is not tappable; Troubleshoot page does not open.
+
+- [ ] **Step 3: Implement** — in `_buildSyncStatusCard`, when the status is error, wrap the card body so the whole card is tappable:
+
+```dart
+// inside the SyncStatus.error branch of the status card:
+return Card(
+  color: Theme.of(context).colorScheme.errorContainer,
+  child: InkWell(
+    onTap: () => Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const TroubleshootSyncPage()),
+    ),
+    child: Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(children: [/* existing icon + title + message + a chevron */]),
+    ),
+  ),
+);
+```
+
+(Keep the existing icon/title/message content; add a trailing `Icon(Icons.chevron_right)` to signal tappability. Only the error state becomes tappable; leave the other statuses unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/settings/presentation/pages/cloud_sync_page_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/settings/presentation/pages/cloud_sync_page.dart test/features/settings/presentation/pages/cloud_sync_page_test.dart
+flutter analyze lib/features/settings/presentation/pages/cloud_sync_page.dart
+git add -A && git commit -m "feat(sync): tap the sync error banner to open Troubleshoot Sync"
+```
+
+**End of PR 1.** Open a PR titled `feat(sync): sync error recovery — temp-dir fix, Repair Sync, Troubleshoot screen (#509)`.
+
+---
+
+## PR 2 — Cloud clear + offline-uploader escape
+
+### Task 6: "Remove this device's cloud sync files" (3a)
+
+**Why:** Free this device's share of the folder without disturbing peers.
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (`deleteDeviceSyncFile`, ~line 2012 — confirm it removes this device's base parts and conflict copies too, not just the manifest/log; extend via `ChangesetLogLayout` if needed)
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (add `removeThisDeviceCloudFiles()`)
+- Test: `test/core/services/sync/sync_service_cloud_clear_test.dart` (fake `CloudStorageProvider` recording deleted file ids)
+
+**Interfaces:**
+- Consumes: `SyncRepository.getDeviceId()`; a fake `CloudStorageProvider` with `listFiles(namePattern:)` / `deleteFile(id)`.
+- Produces:
+  - `deleteDeviceSyncFile(String deviceId)` deletes every cloud file whose `ChangesetLogLayout.deviceIdOf(name) == deviceId` (manifest, base parts, changesets, conflict copies).
+  - `Future<void> SyncNotifier.removeThisDeviceCloudFiles()`.
+
+- [ ] **Step 1: Write the failing test** — a fake provider returns several files for two device ids across the log patterns; assert only this device's are deleted.
+
+```dart
+test('deleteDeviceSyncFile removes only this device’s files (all parts)',
+    () async {
+  final provider = FakeCloudProvider(files: [
+    fakeFile('ssv1.dev1.manifest.json'),
+    fakeFile('ssv1.dev1.base.0.json'),
+    fakeFile('ssv1.dev1.cs.5.json'),
+    fakeFile('ssv1.dev2.manifest.json'),
+  ]);
+  await service.deleteDeviceSyncFile('dev1'); // service built with `provider`
+  expect(provider.deletedNames, containsAll(<String>[
+    'ssv1.dev1.manifest.json', 'ssv1.dev1.base.0.json', 'ssv1.dev1.cs.5.json',
+  ]));
+  expect(provider.deletedNames, isNot(contains('ssv1.dev2.manifest.json')));
+});
+```
+
+(Use the real `ChangesetLogLayout` file-name shapes — read `changeset_log_layout.dart` for the exact `prefix`, `deviceIdOf`, and part-name format, and build `fakeFile` names accordingly.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/sync_service_cloud_clear_test.dart`
+Expected: FAIL if the current `deleteDeviceSyncFile` misses base parts/conflict copies (or PASS if `deviceIdOf` already matches every part — in which case this task only adds the notifier method + test, and Step 3 is a no-op).
+
+- [ ] **Step 3: Ensure `deleteDeviceSyncFile` covers all of this device's files**
+
+Verify the loop in `deleteDeviceSyncFile` matches every file where `ChangesetLogLayout.deviceIdOf(f.name) == deviceId`. If conflict-copy names are not covered by that predicate, extend the match to include them (read `ChangesetLogLayout` for the conflict-copy naming). Keep it best-effort (per-file try/catch, timeouts) exactly as the existing method does.
+
+- [ ] **Step 4: Add the notifier method**
+
+```dart
+/// Remove THIS device's sync files from the active backend. Safe: other
+/// devices keep syncing; frees this device's share of the folder.
+Future<void> removeThisDeviceCloudFiles() async {
+  final deviceId = await _syncRepository.getDeviceId();
+  await _syncService.deleteDeviceSyncFile(deviceId);
+  await refreshState();
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/sync_service_cloud_clear_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/sync_service.dart lib/features/settings/presentation/providers/sync_providers.dart test/core/services/sync/sync_service_cloud_clear_test.dart
+flutter analyze lib/core/services/sync/sync_service.dart
+git add -A && git commit -m "feat(sync): remove this device's cloud sync files (Troubleshoot)"
+```
+
+---
+
+### Task 7: "Wipe ALL sync data on this backend" incl. epoch markers (3b)
+
+**Why:** The ultimate reset — reclaims all space and forces every device to re-establish. The existing `deleteAllSyncFiles` deliberately leaves the `submersion_library_*` epoch markers; a true fresh start must also delete them.
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (add `wipeAllSyncData(provider)` that calls `deleteAllSyncFiles(provider)` then deletes the epoch/moved markers)
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (add `wipeAllCloudSyncData()`)
+- Test: `test/core/services/sync/sync_service_cloud_clear_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: `deleteAllSyncFiles(CloudStorageProvider)`; the epoch-marker file-name pattern (read the `submersion_library_*` constant used by the epoch protocol / `readLibraryEpochMarker`).
+- Produces:
+  - `Future<void> SyncService.wipeAllSyncData(CloudStorageProvider provider)`.
+  - `Future<void> SyncNotifier.wipeAllCloudSyncData()` (operates on the active `_cloudProvider`).
+
+- [ ] **Step 1: Write the failing test** — fake provider returns log files AND a `submersion_library_*` marker; assert `wipeAllSyncData` deletes both.
+
+```dart
+test('wipeAllSyncData deletes logs AND the epoch markers', () async {
+  final provider = FakeCloudProvider(files: [
+    fakeFile('ssv1.dev1.manifest.json'),
+    fakeFile('submersion_library_epoch.json'),
+  ]);
+  await service.wipeAllSyncData(provider);
+  expect(provider.deletedNames, containsAll(<String>[
+    'ssv1.dev1.manifest.json', 'submersion_library_epoch.json',
+  ]));
+});
+```
+
+(Use the real epoch-marker name pattern from the epoch protocol code.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/sync_service_cloud_clear_test.dart`
+Expected: FAIL — `wipeAllSyncData` not defined; `deleteAllSyncFiles` alone leaves the marker.
+
+- [ ] **Step 3: Implement `wipeAllSyncData`**
+
+```dart
+/// Delete EVERY sync artifact on [provider], including the library epoch
+/// markers that [deleteAllSyncFiles] intentionally preserves. A genuine fresh
+/// start: every device re-establishes. Best-effort; failures are logged.
+Future<void> wipeAllSyncData(CloudStorageProvider provider) async {
+  await deleteAllSyncFiles(provider);
+  try {
+    final markers = await provider
+        .listFiles(namePattern: /* submersion_library_ prefix constant */)
+        .timeout(const Duration(seconds: 8));
+    for (final f in markers) {
+      try {
+        await provider.deleteFile(f.id).timeout(const Duration(seconds: 8));
+        _log.info('Deleted epoch marker ${f.name} for full sync wipe');
+      } catch (e) {
+        _log.warning('Could not delete epoch marker ${f.name}: $e');
+      }
+    }
+  } catch (e) {
+    _log.warning('Could not list epoch markers for wipe: $e');
+  }
+}
+```
+
+(Replace the comment with the actual epoch-marker name-pattern constant.)
+
+- [ ] **Step 4: Add the notifier method**
+
+```dart
+/// Wipe ALL sync data on the active backend, including epoch markers. Every
+/// device re-establishes from scratch.
+Future<void> wipeAllCloudSyncData() async {
+  await _syncService.wipeAllSyncDataOnActiveProvider(); // thin wrapper over
+  // wipeAllSyncData(_cloudProvider); or expose _cloudProvider access as needed
+  await refreshState();
+}
+```
+
+(If `_cloudProvider` is private to `SyncService`, add a `SyncService.wipeAllSyncDataOnActiveProvider()` that no-ops when null and otherwise calls `wipeAllSyncData(_cloudProvider!)`. Keep whichever wiring compiles and keeps Step 1's test — which targets `wipeAllSyncData(provider)` directly — green.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/sync_service_cloud_clear_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync/sync_service.dart lib/features/settings/presentation/providers/sync_providers.dart test/core/services/sync/sync_service_cloud_clear_test.dart
+flutter analyze lib/core/services/sync/sync_service.dart
+git add -A && git commit -m "feat(sync): wipe all cloud sync data incl. epoch markers"
+```
+
+---
+
+### Task 8: Cloud-clear actions on the Troubleshoot screen (3a standard confirm, 3b typed confirm)
+
+**Files:**
+- Modify: `lib/features/settings/presentation/pages/troubleshoot_sync_page.dart` (add two tiles)
+- Test: `test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: `SyncNotifier.removeThisDeviceCloudFiles()` (Task 6), `SyncNotifier.wipeAllCloudSyncData()` (Task 7).
+
+- [ ] **Step 1: Write the failing widget tests**
+
+```dart
+testWidgets('shows both cloud-clear actions', (tester) async {
+  await tester.pumpWidget(const ProviderScope(
+      child: MaterialApp(home: TroubleshootSyncPage())));
+  await tester.pumpAndSettle();
+  expect(find.text('Remove this device’s cloud files'), findsOneWidget);
+  expect(find.text('Wipe all sync data on this backend'), findsOneWidget);
+});
+
+testWidgets('wipe-all requires typed confirmation', (tester) async {
+  await tester.pumpWidget(const ProviderScope(
+      child: MaterialApp(home: TroubleshootSyncPage())));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Wipe all sync data on this backend'));
+  await tester.pumpAndSettle();
+  final confirmBtn = find.widgetWithText(FilledButton, 'Wipe everything');
+  expect(tester.widget<FilledButton>(confirmBtn).onPressed, isNull); // disabled
+  await tester.enterText(find.byType(TextField), 'WIPE');
+  await tester.pump();
+  expect(tester.widget<FilledButton>(confirmBtn).onPressed, isNotNull);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart`
+Expected: FAIL — the tiles/dialogs don't exist yet.
+
+- [ ] **Step 3: Implement** — add two `ListTile`s below Repair. 3a uses a standard confirm dialog calling `removeThisDeviceCloudFiles()`. 3b uses a dialog with a `TextField` whose `onChanged` enables the "Wipe everything" `FilledButton` only when the text equals `WIPE`, then calls `wipeAllCloudSyncData()`. (Use `StatefulBuilder` inside `showDialog` for the enable-on-type behavior; model spacing/layout on the existing dialogs in `cloud_sync_page.dart`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/settings/presentation/pages/troubleshoot_sync_page.dart test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+flutter analyze lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+git add -A && git commit -m "feat(sync): cloud-clear actions on Troubleshoot screen"
+```
+
+---
+
+### Task 9: Offline-uploader escape — "rebuild this backend from this device" (2a)
+
+**Why:** When the replacing device is offline, `adoptReplacedLibrary` finds no base for the epoch and returns a terminal "still uploading, try again shortly". Give the waiting device a concrete action to republish its own library as the current epoch's base, resolving the wedge on the cloud side.
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (add `rebuildBackendFromThisDevice()`; reuse `_recoverUnreadableEpoch` / the re-establish path already invoked at `adoptReplacedLibrary` ~line 2181)
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (expose `rebuildBackendFromThisDevice()`)
+- Modify: `lib/features/settings/presentation/pages/troubleshoot_sync_page.dart` (add a tile, shown when awaiting adoption / after a "still uploading" result)
+- Test: `test/core/services/sync/sync_service_repair_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: existing `readLibraryEpochMarker`, `_recoverUnreadableEpoch`, `executeLibraryReplace`.
+- Produces:
+  - `Future<SyncResult> SyncService.rebuildBackendFromThisDevice()` — reads the current epoch marker and re-establishes the backend from this device's library (publishes a base for the current epoch), so peers/this device stop waiting on the offline uploader.
+  - `Future<SyncResult> SyncNotifier.rebuildBackendFromThisDevice()`.
+
+- [ ] **Step 1: Write the failing test** — with a current-epoch marker present but no base for it, `rebuildBackendFromThisDevice()` returns success and publishes this device's base (assert via the fake provider that a base for the current epoch was written).
+
+```dart
+test('rebuildBackendFromThisDevice re-establishes the epoch from local library',
+    () async {
+  // Arrange: epoch marker E present in the fake cloud, no base for E.
+  final result = await service.rebuildBackendFromThisDevice();
+  expect(result.status, SyncResultStatus.success);
+  // Assert the fake provider received an upload stamped with epoch E.
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/services/sync/sync_service_repair_test.dart`
+Expected: FAIL — method not defined.
+
+- [ ] **Step 3: Implement `rebuildBackendFromThisDevice`** — read the current marker via `readLibraryEpochMarker(provider)`; call the existing re-establish path (`_recoverUnreadableEpoch(provider, marker)` returns true on success) or `executeLibraryReplace` with the current marker so this device's library becomes the epoch's authoritative base. Return `SyncResult(status: success, message: 'Rebuilt this backend from this device’s library')`, or an error `SyncResult` if no marker/provider.
+
+- [ ] **Step 4: Make the adopt wait actionable** — in `adoptReplacedLibrary` (~line 2189-2193), keep returning an error `SyncResult`, but ensure the notifier surfaces the *awaiting adoption* state (the code already has `replaceAwaitingAdoption`) so the Troubleshoot tile appears. Add the notifier + UI tile (guarded by awaiting-adoption / a "still uploading" result) that calls `rebuildBackendFromThisDevice()`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/sync_service_repair_test.dart test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/core/services/sync lib/features/settings/presentation
+flutter analyze lib/core/services/sync/sync_service.dart lib/features/settings/presentation
+git add -A && git commit -m "feat(sync): rebuild backend from this device when a replace is stuck (offline uploader)"
+```
+
+**End of PR 2.** Open a PR titled `feat(sync): cloud sync clear + offline-uploader recovery (#509)`.
+
+---
+
+## Final verification (both PRs)
+
+- [ ] `dart format .` clean across the repo.
+- [ ] `flutter analyze` clean (whole project).
+- [ ] `flutter test test/core/services/sync/ test/features/settings/presentation/pages/` green.
+- [ ] Manual device pass (Apple + Android): (a) macOS with a hardened-runtime build — confirm base temp files land under the app container and #509's `/tmp` EPERM is gone; (b) two devices, do "Replace everywhere" on device A then take A offline — on device B, confirm "Troubleshoot Sync → rebuild this backend from this device" clears the stuck "still uploading"; (c) confirm Repair Sync and both cloud-clear actions behave and never touch dive data.
+
+## Spec traceability
+
+- Surfaces (Troubleshoot screen + tappable banner) → Tasks 4, 5.
+- Component 1 (Repair) → Tasks 2, 3, 4.
+- Component 2a (offline-uploader escape) → Task 9.
+- Component 2b (temp dir + non-fatal base) → Task 1 (temp dir; the sink already returns null on failure, satisfying "non-fatal").
+- Component 3a / 3b (cloud clear) → Tasks 6, 7, 8.

--- a/docs/superpowers/specs/2026-07-07-sync-error-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-sync-error-recovery-design.md
@@ -69,19 +69,22 @@ The guaranteed escape: a new `SyncService.repairLocalSyncState()` that clears
 clears, minus the reinstall.
 
 Clears:
-- `_syncRepository.resetSyncState(clearDeletionLog: false)` — sync records,
-  cursors, device identity (deletion log preserved so deletions don't resurrect,
-  consistent with today's Reset).
-- `_syncRepository.clearPendingRecords()`.
-- **`LibraryEpochStore`**: a new `clear()` that removes both
-  `sync_last_accepted_epoch_marker` and `sync_pending_replace_marker` — the
-  reinstall-only survivor and the crux of the wedge.
-- `PublishStateStore`: clear rows for **every** provider (not just the active
-  one) so Repair is a true reinstall-equivalent — add a `resetAll()` alongside
-  the existing per-provider `resetForProvider` (rows live in the main DB table
-  `local_publish_states`).
+- `_syncRepository.resetSyncState(clearDeletionLog: false)` — which already
+  clears sync records, **peer cursors, and all `local_publish_states` rows**
+  (verified: `sync_repository.dart` deletes `syncPeerCursors` and
+  `localPublishStates`), plus assigns a new device identity. The deletion log is
+  preserved so deletions don't resurrect, consistent with today's Reset.
+- **`LibraryEpochStore.clear()`** (new): removes both
+  `sync_last_accepted_epoch_marker` and `sync_pending_replace_marker`. This is
+  the **only** local sync state `resetSyncState` does not touch (it lives in
+  SharedPreferences, not the DB) — the reinstall-only survivor and the crux of
+  why today's "Reset Sync State" fails to clear a wedge.
 - Best-effort deletion of leftover base temp files (see Component 2's temp dir).
 - Clears the persisted/in-memory sync error so the banner goes away.
+
+In short: today's Reset already nukes the DB-side sync state; Repair adds the
+SharedPreferences epoch markers (and temp/error cleanup) to make it a true
+reinstall-equivalent.
 
 After repair the device is a fresh participant; the next sync runs the normal
 first-sync merge flow. Repair does **not** auto-trigger a sync — the user taps
@@ -142,9 +145,8 @@ scratch. Guarded by an extra/typed confirmation distinct from 3a.
 
 | State | Location | Cleared by Reset today? | Cleared by Repair (C1)? |
 |-------|----------|-------------------------|-------------------------|
-| Sync records, cursors, device id | main DB | yes | yes |
-| Pending records | main DB | no | yes |
-| `local_publish_states` | main DB | (per-provider) | yes (all providers) |
+| Sync records, peer cursors, device id | main DB | yes | yes |
+| `local_publish_states` (all providers) | main DB | yes | yes |
 | Last-accepted / pending-replace epoch markers | **SharedPreferences** | **no** | **yes** |
 | Deletion log | main DB | kept by design | kept by design |
 | Base temp files | temp dir | n/a | best-effort delete |

--- a/docs/superpowers/specs/2026-07-07-sync-error-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-07-sync-error-recovery-design.md
@@ -1,0 +1,191 @@
+# Sync Error Recovery — Design
+
+Date: 2026-07-07
+Issue: [#509](https://github.com/submersion-app/submersion/issues/509) (plus a related maintainer-observed dead-end)
+
+## Problem
+
+Users can land in a persistent Cloud Sync error with no in-app way out — a
+reinstall is currently the only escape. Two concrete triggers were reported:
+
+1. **"The replaced library is still uploading. Try again shortly."**
+   (`sync_service.dart` `adoptReplacedLibrary`, ~line 2192). A device did a
+   "Replace everywhere", bumping the library epoch, but the uploading device
+   went **offline** before publishing the new base. Every other device sees the
+   new epoch marker, finds no base for it (`sources.baseFilePaths.isEmpty`),
+   and — because the marker is not stale/old-format, so `_recoverUnreadableEpoch`
+   returns false — returns "still uploading, try again shortly" **forever**.
+
+2. **`PathAccessException: Cannot open file, path = '/tmp/ssv1_base_…json'
+   (OS Error: Operation not permitted, errno = 1)`** (#509). The base export
+   temp file is written to `Directory.systemTemp` (`sync_data_serializer.dart`
+   `exportBaseToTempFile`, line 730; also `base_part_file_sink.dart` line 16),
+   which resolves to `/tmp` on macOS. A hardened-runtime / sandboxed app can be
+   denied access there (EPERM), so publishing/adopting a base fails on every
+   sync.
+
+### Why existing recovery does not help
+
+"Reset Sync State" (`SyncService.resetSyncState`) only calls
+`_syncRepository.resetSyncState(clearDeletionLog: false)` — DB-level sync rows,
+cursors, and device identity. It does **not** clear the `LibraryEpochStore`
+(SharedPreferences keys `sync_last_accepted_epoch_marker` and
+`sync_pending_replace_marker`), nor any cloud-side epoch marker. So the next
+sync re-reads the same wedged epoch state and re-wedges. Deleting the database
+also leaves the SharedPreferences epoch keys intact. Only a full reinstall
+(which wipes the app container, including SharedPreferences) escaped — which is
+exactly what the #509 reporter had to do.
+
+## Goals
+
+- Give users a reliable, in-app **way out** of any wedged sync state without a
+  reinstall and without losing dive data.
+- Fix the two specific dead-ends at the source so they stop being terminal.
+- Let a user reclaim cloud space by clearing this device's — or all — sync
+  artifacts on the active backend.
+
+## Non-goals
+
+- No change to the normal sync/merge/replace happy paths.
+- No multi-backend fan-out: cloud-clear operates on the **active** provider only.
+- No automatic background repair; recovery is user-initiated (except the two
+  targeted fixes, which make specific failures non-terminal).
+
+## Surfaces
+
+- New **Troubleshoot Sync** screen, opened from the Cloud Sync page's *Advanced*
+  section (`cloud_sync_page.dart` `_buildAdvancedSection`).
+- The existing **"Sync error" banner becomes tappable** and routes to that
+  screen, so a stuck user finds the exit where the error is shown.
+
+The existing "Reset Sync State" and "Sign Out" entries remain unchanged; the new
+recovery actions live on the Troubleshoot screen with escalating severity and
+plain-language descriptions so users pick the right one.
+
+## Component 1 — Repair Sync (comprehensive local reset)
+
+The guaranteed escape: a new `SyncService.repairLocalSyncState()` that clears
+**all** local sync state without touching dive data — everything a reinstall
+clears, minus the reinstall.
+
+Clears:
+- `_syncRepository.resetSyncState(clearDeletionLog: false)` — sync records,
+  cursors, device identity (deletion log preserved so deletions don't resurrect,
+  consistent with today's Reset).
+- `_syncRepository.clearPendingRecords()`.
+- **`LibraryEpochStore`**: a new `clear()` that removes both
+  `sync_last_accepted_epoch_marker` and `sync_pending_replace_marker` — the
+  reinstall-only survivor and the crux of the wedge.
+- `PublishStateStore`: clear rows for **every** provider (not just the active
+  one) so Repair is a true reinstall-equivalent — add a `resetAll()` alongside
+  the existing per-provider `resetForProvider` (rows live in the main DB table
+  `local_publish_states`).
+- Best-effort deletion of leftover base temp files (see Component 2's temp dir).
+- Clears the persisted/in-memory sync error so the banner goes away.
+
+After repair the device is a fresh participant; the next sync runs the normal
+first-sync merge flow. Repair does **not** auto-trigger a sync — the user taps
+"Sync Now" when ready. UI confirmation stresses that dive data is safe and only
+the sync bookkeeping is reset.
+
+## Component 2 — Targeted fixes for the two dead-ends
+
+### 2a. Offline-uploader adopt wait becomes actionable
+
+When `adoptReplacedLibrary()` finds no base for a **non-stale** epoch, instead of
+the terminal "still uploading, try again shortly", surface a distinct *waiting*
+outcome the Troubleshoot screen presents with an action:
+
+> "The other device may be offline. Rebuild this backend from **this** device's
+> library."
+
+Choosing it republishes this device's library as the current epoch's base
+(reusing the existing re-establish path — the same mechanism
+`_recoverUnreadableEpoch` uses today, generalized to a user-driven choice rather
+than only auto-firing for stale/old-format markers). "Try again shortly"
+remains available for the case where the uploader is merely slow, not gone.
+
+### 2b. Sync temp files use the app-container temp dir; base failures are non-fatal
+
+- Default the temp dir for `exportBaseToTempFile` (`sync_data_serializer.dart`)
+  and `BasePartFileSink` (`base_part_file_sink.dart`) to
+  `path_provider`'s `getTemporaryDirectory()` (always accessible app-container
+  temp) instead of `Directory.systemTemp` (`/tmp`). The existing injectable
+  `tempDir`/`tempDirProvider` seams are kept for tests; only the default changes.
+- A base open/read/write failure is logged and treated as **transient** (retry
+  next sync) rather than surfacing as a terminal sync error that recurs every
+  attempt. Combined with Component 1, no base-file problem can permanently wedge
+  a device.
+
+## Component 3 — Cloud clear on the active provider (two distinct actions)
+
+Both operate on the **active** provider only and are exposed on the Troubleshoot
+screen with clearly different severities.
+
+### 3a. Remove this device's sync files (safe)
+
+`SyncService.deleteDeviceSyncFile(thisDeviceId)` already retires this device's
+changeset log; extend it to also remove this device's base parts and any
+conflict copies. Other devices keep syncing; frees this device's share of the
+folder. `thisDeviceId` from `SyncRepository.getDeviceId()`. Standard
+confirmation.
+
+### 3b. Wipe ALL sync data on this backend (destructive)
+
+`SyncService.deleteAllSyncFiles(provider)` already wipes changeset logs
+(`ssv1.*`) and legacy full-file uploads, but **deliberately preserves** the
+`submersion_library_*` epoch/moved markers. For a genuine fresh start this action
+additionally deletes those epoch markers. Every device re-establishes from
+scratch. Guarded by an extra/typed confirmation distinct from 3a.
+
+## Data / state inventory (what "wedged" state lives where)
+
+| State | Location | Cleared by Reset today? | Cleared by Repair (C1)? |
+|-------|----------|-------------------------|-------------------------|
+| Sync records, cursors, device id | main DB | yes | yes |
+| Pending records | main DB | no | yes |
+| `local_publish_states` | main DB | (per-provider) | yes (all providers) |
+| Last-accepted / pending-replace epoch markers | **SharedPreferences** | **no** | **yes** |
+| Deletion log | main DB | kept by design | kept by design |
+| Base temp files | temp dir | n/a | best-effort delete |
+| Cloud epoch markers + per-device files | cloud | no | no (that's Component 3) |
+
+## Error handling
+
+- Every recovery action is best-effort and idempotent: partial failure (e.g.
+  provider offline during a cloud clear) is logged, reported to the user, and
+  safe to re-run. Cloud clears already swallow per-file errors.
+- Repair must complete the local clears even if the active provider is
+  unreachable (local state is the point).
+
+## Testing
+
+- **Unit** (`SyncService` / stores with fakes):
+  - `repairLocalSyncState` clears each store (sync repo, pending, epoch prefs,
+    publish state) and the error; deletion log preserved.
+  - `LibraryEpochStore.clear()` removes both keys.
+  - `adoptReplacedLibrary` with no base for a non-stale epoch returns the new
+    actionable *waiting* outcome (not a bare error), and the rebuild action
+    republishes the local library.
+  - `exportBaseToTempFile` / `BasePartFileSink` default to the app temp dir; a
+    base file error is non-fatal.
+  - 3a targets only this device's files; 3b also deletes epoch markers.
+- **Widget** (`cloud_sync_page` / Troubleshoot screen):
+  - Advanced → Troubleshoot navigation; tappable error banner routes there.
+  - Each action shows its confirmation; destructive 3b requires the stronger
+    confirmation.
+
+## Sizing / delivery
+
+Cohesive but sizable — one spec, delivered as a small stack of two PRs so each
+stays reviewable:
+
+- **PR 1**: temp-dir fix (2b) + Repair Sync core (C1, incl. `LibraryEpochStore.clear`)
+  + Troubleshoot screen scaffold + tappable error banner.
+- **PR 2**: cloud-clear actions (C3) + offline-uploader actionable escape (2a).
+
+## Resolved decisions
+
+- "Wipe all" (3b) **also clears epoch markers** for a true fresh start.
+- Repair Sync **does not auto-trigger a sync**; the user syncs when ready.
+- Cloud clear targets the **active provider only**.

--- a/lib/core/services/sync/changeset_log/base_part_file_sink.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_sink.dart
@@ -2,10 +2,10 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 
 /// Downloads a base's parts one at a time into a single temp file, verifying
 /// integrity as bytes land so the whole base is never held in memory. Each part
@@ -14,7 +14,7 @@ import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 /// partial file and returns null (transient -> the caller retries next sync).
 class BasePartFileSink {
   BasePartFileSink({Future<Directory> Function()? tempDirProvider})
-    : _tempDir = tempDirProvider ?? getTemporaryDirectory;
+    : _tempDir = tempDirProvider ?? resolveSyncTempDir;
 
   final Future<Directory> Function() _tempDir;
   static const _uuid = Uuid();

--- a/lib/core/services/sync/changeset_log/base_part_file_sink.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_sink.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
@@ -13,7 +14,7 @@ import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 /// partial file and returns null (transient -> the caller retries next sync).
 class BasePartFileSink {
   BasePartFileSink({Future<Directory> Function()? tempDirProvider})
-    : _tempDir = tempDirProvider ?? (() async => Directory.systemTemp);
+    : _tempDir = tempDirProvider ?? getTemporaryDirectory;
 
   final Future<Directory> Function() _tempDir;
   static const _uuid = Uuid();

--- a/lib/core/services/sync/changeset_log/sync_temp_dir.dart
+++ b/lib/core/services/sync/changeset_log/sync_temp_dir.dart
@@ -25,7 +25,14 @@ Future<Directory> resolveSyncTempDir() async {
     return await getTemporaryDirectory();
   } on MissingPluginException {
     return Directory.systemTemp;
-  } on FlutterError {
-    return Directory.systemTemp;
+  } on FlutterError catch (e) {
+    // ONLY the "no test binding" case (a unit test that never called
+    // TestWidgetsFlutterBinding.ensureInitialized, so ServicesBinding.instance
+    // throws). Any other FlutterError is a real problem and must surface, not
+    // silently fall back to /tmp.
+    if (e.toString().contains('Binding has not yet been initialized')) {
+      return Directory.systemTemp;
+    }
+    rethrow;
   }
 }

--- a/lib/core/services/sync/changeset_log/sync_temp_dir.dart
+++ b/lib/core/services/sync/changeset_log/sync_temp_dir.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+/// Directory for streaming-sync temp files (base export + assembled base parts).
+///
+/// Prefers the app-container temp dir via path_provider. A sandboxed or
+/// hardened-runtime macOS app is denied `Directory.systemTemp` (`/tmp`) ->
+/// `PathAccessException` errno 1 (issue #509), so `/tmp` must never be used in
+/// production. Falls back to `systemTemp` ONLY when path_provider is
+/// unavailable -- e.g. a plain unit test with no mocked plugin channel -- where
+/// `/tmp` is writable, so the fallback keeps such tests green without every one
+/// of them mocking path_provider. In production getTemporaryDirectory always
+/// resolves, so the fallback never runs there.
+Future<Directory> resolveSyncTempDir() async {
+  try {
+    return await getTemporaryDirectory();
+  } catch (_) {
+    return Directory.systemTemp;
+  }
+}

--- a/lib/core/services/sync/changeset_log/sync_temp_dir.dart
+++ b/lib/core/services/sync/changeset_log/sync_temp_dir.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show FlutterError;
+import 'package:flutter/services.dart' show MissingPluginException;
 import 'package:path_provider/path_provider.dart';
 
 /// Directory for streaming-sync temp files (base export + assembled base parts).
@@ -7,15 +9,23 @@ import 'package:path_provider/path_provider.dart';
 /// Prefers the app-container temp dir via path_provider. A sandboxed or
 /// hardened-runtime macOS app is denied `Directory.systemTemp` (`/tmp`) ->
 /// `PathAccessException` errno 1 (issue #509), so `/tmp` must never be used in
-/// production. Falls back to `systemTemp` ONLY when path_provider is
-/// unavailable -- e.g. a plain unit test with no mocked plugin channel -- where
-/// `/tmp` is writable, so the fallback keeps such tests green without every one
-/// of them mocking path_provider. In production getTemporaryDirectory always
-/// resolves, so the fallback never runs there.
+/// production.
+///
+/// Falls back to `systemTemp` ONLY when path_provider's plugin infrastructure
+/// is absent -- a plain unit test with no mocked channel
+/// ([MissingPluginException]) or no initialized test binding at all (the
+/// [FlutterError] "Binding has not yet been initialized"). In tests `/tmp` is
+/// writable, so this keeps them green without every one mocking path_provider.
+/// Any OTHER failure (e.g. a real [PlatformException] from the native side) is
+/// a genuine runtime problem and propagates, rather than silently
+/// reintroducing the `/tmp` EPERM this fix exists to avoid. In production
+/// getTemporaryDirectory resolves normally, so no fallback runs.
 Future<Directory> resolveSyncTempDir() async {
   try {
     return await getTemporaryDirectory();
-  } catch (_) {
+  } on MissingPluginException {
+    return Directory.systemTemp;
+  } on FlutterError {
     return Directory.systemTemp;
   }
 }

--- a/lib/core/services/sync/library_epoch_store.dart
+++ b/lib/core/services/sync/library_epoch_store.dart
@@ -47,6 +47,15 @@ class LibraryEpochStore {
     await _prefs.remove(_pendingReplaceKey);
   }
 
+  /// Wipe both epoch records. Used by the comprehensive local sync repair: the
+  /// last-accepted marker is the only local sync state a DB reset does not
+  /// touch (it lives in SharedPreferences), so a wedge that survives Reset
+  /// needs this cleared for a true reinstall-equivalent.
+  Future<void> clear() async {
+    await _prefs.remove(_lastAcceptedMarkerKey);
+    await _prefs.remove(_pendingReplaceKey);
+  }
+
   LibraryEpochMarker? _decode(String? raw) {
     if (raw == null) return null;
     try {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -3,10 +3,10 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
@@ -728,7 +728,7 @@ class SyncDataSerializer {
     DateTime Function() now = DateTime.now,
     Future<Directory> Function()? tempDir,
   }) async {
-    final dir = await (tempDir?.call() ?? getTemporaryDirectory());
+    final dir = await (tempDir?.call() ?? resolveSyncTempDir());
     final path =
         '${dir.path}/ssv1_base_${deviceId}_${seq ?? 0}.${_baseTempUuid.v4()}.json';
     final raf = await File(path).open(mode: FileMode.write);

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/database/database.dart';
@@ -727,7 +728,7 @@ class SyncDataSerializer {
     DateTime Function() now = DateTime.now,
     Future<Directory> Function()? tempDir,
   }) async {
-    final dir = await (tempDir?.call() ?? Future.value(Directory.systemTemp));
+    final dir = await (tempDir?.call() ?? getTemporaryDirectory());
     final path =
         '${dir.path}/ssv1_base_${deviceId}_${seq ?? 0}.${_baseTempUuid.v4()}.json';
     final raf = await File(path).open(mode: FileMode.write);

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -638,13 +638,67 @@ class SyncService {
       'Epoch ${marker.epochId} has no readable library; re-establishing this '
       'backend from the local library',
     );
+    await _reestablishEpochFromLocalLibrary(provider, marker);
+    return true;
+  }
+
+  /// Make THIS device's library the authoritative base for [marker]'s epoch:
+  /// wipe the (unreadable/incomplete) sync files, drop this backend's publish
+  /// and peer state so the next sync republishes a full base, and accept the
+  /// epoch locally. Shared by the automatic unreadable-epoch recovery and the
+  /// user-driven [rebuildBackendFromThisDevice].
+  Future<void> _reestablishEpochFromLocalLibrary(
+    CloudStorageProvider provider,
+    LibraryEpochMarker marker,
+  ) async {
     await deleteAllSyncFiles(provider);
     final db = DatabaseService.instance.database;
     await PublishStateStore(db).resetForProvider(provider.providerId);
     await PeerCursorStore(db).resetForProvider(provider.providerId);
     await _syncRepository.setLastAcceptedEpochId(marker.epochId);
-    await epochStore.setLastAccepted(marker);
-    return true;
+    await _epochStore?.setLastAccepted(marker);
+  }
+
+  /// User-driven escape from a stuck library replacement (issue #509): the
+  /// device that ran "Replace everywhere" went offline before uploading the new
+  /// base, so every other device waits forever on "still uploading". This
+  /// forces the re-establish that [_recoverUnreadableEpoch] defers during its
+  /// grace window: THIS device's library becomes the epoch's authoritative
+  /// base, and the caller's follow-up sync publishes it. Peers then adopt from
+  /// us instead of the offline device.
+  Future<SyncResult> rebuildBackendFromThisDevice() async {
+    final provider = _cloudProvider;
+    if (provider == null) {
+      return const SyncResult(
+        status: SyncResultStatus.error,
+        message: 'No cloud provider configured',
+      );
+    }
+    final marker = await readLibraryEpochMarker(provider);
+    if (marker == null) {
+      return const SyncResult(
+        status: SyncResultStatus.error,
+        message: 'No library replacement to rebuild from',
+      );
+    }
+    try {
+      await _reestablishEpochFromLocalLibrary(provider, marker);
+      _log.info('Rebuilt backend from this device for epoch ${marker.epochId}');
+      return const SyncResult(
+        status: SyncResultStatus.success,
+        message: 'Rebuilt this backend from this device’s library',
+      );
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to rebuild backend from this device',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return SyncResult(
+        status: SyncResultStatus.error,
+        message: 'Rebuild failed: $e',
+      );
+    }
   }
 
   /// True if any device has published a current-format (ssv1) base for

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2072,15 +2072,18 @@ class SyncService {
   }
 
   /// Best-effort sweep of leftover streaming-base temp files (base export
-  /// `ssv1_base_*` and assembled `*.base` parts) from the app temp dir. Failure
-  /// is logged and ignored -- a stale temp file is harmless.
+  /// base export `ssv1_base_*.json` and assembled `ssv1_*.base` / `ssv1_adopt_*`
+  /// parts) from the app temp dir. Every sync temp file is prefixed `ssv1_`, so
+  /// the sweep matches ONLY that prefix -- never an unrelated app temp file
+  /// (the dir is a shared, general-purpose temp location). Failure is logged
+  /// and ignored; a stale temp file is harmless.
   Future<void> deleteLeftoverBaseTempFiles() async {
     try {
       final dir = await resolveSyncTempDir();
       await for (final entity in dir.list(followLinks: false)) {
         if (entity is! File) continue;
         final name = entity.uri.pathSegments.last;
-        if (name.startsWith('ssv1_base_') || name.endsWith('.base')) {
+        if (name.startsWith('ssv1_')) {
           try {
             await entity.delete();
           } catch (_) {

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2092,6 +2092,39 @@ class SyncService {
     }
   }
 
+  /// Delete EVERY sync artifact on [provider], INCLUDING the library epoch and
+  /// moved markers that [deleteAllSyncFiles] intentionally preserves. A genuine
+  /// fresh start (issue #509, cloud clear 3b): every device re-establishes from
+  /// scratch. Best-effort; failures are logged and skipped.
+  Future<void> wipeAllSyncData(CloudStorageProvider provider) async {
+    await deleteAllSyncFiles(provider);
+    for (final pattern in [libraryEpochFileName, libraryMovedFileName]) {
+      try {
+        final markers = await provider
+            .listFiles(namePattern: pattern)
+            .timeout(const Duration(seconds: 8));
+        for (final f in markers) {
+          try {
+            await provider.deleteFile(f.id).timeout(const Duration(seconds: 8));
+            _log.info('Deleted marker ${f.name} for full sync wipe');
+          } catch (e) {
+            _log.warning('Could not delete marker ${f.name}: $e');
+          }
+        }
+      } catch (e) {
+        _log.warning('Could not list markers for full sync wipe: $e');
+      }
+    }
+  }
+
+  /// Wipe all sync data on the active provider (issue #509, cloud clear 3b).
+  /// No-op when no provider is configured.
+  Future<void> wipeAllSyncDataOnActiveProvider() async {
+    final provider = _cloudProvider;
+    if (provider == null) return;
+    await wipeAllSyncData(provider);
+  }
+
   /// Execute the cloud side of a Replace restore: write the new epoch marker
   /// FIRST (a peer syncing mid-replace must learn the new epoch before it can
   /// misread a half-empty folder), wipe every sync file, upload our library

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:path_provider/path_provider.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart'
     show SyncRecord, DeletionLogData;
@@ -2002,6 +2003,40 @@ class SyncService {
   Future<void> resetSyncState() async {
     await _syncRepository.resetSyncState(clearDeletionLog: false);
     _log.info('Sync state reset');
+  }
+
+  /// Comprehensive local sync reset: everything [resetSyncState] clears, PLUS
+  /// the SharedPreferences epoch markers (the one local sync state a DB reset
+  /// misses -- see [LibraryEpochStore.clear]) and any leftover base temp files.
+  /// A true reinstall-equivalent for sync state that never touches dive data.
+  /// The notifier-level caller still runs the identity/cloud-file cleanup.
+  Future<void> repairLocalSyncState() async {
+    await resetSyncState();
+    await _epochStore?.clear();
+    await deleteLeftoverBaseTempFiles();
+    _log.info('Local sync state repaired');
+  }
+
+  /// Best-effort sweep of leftover streaming-base temp files (base export
+  /// `ssv1_base_*` and assembled `*.base` parts) from the app temp dir. Failure
+  /// is logged and ignored -- a stale temp file is harmless.
+  Future<void> deleteLeftoverBaseTempFiles() async {
+    try {
+      final dir = await getTemporaryDirectory();
+      await for (final entity in dir.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final name = entity.uri.pathSegments.last;
+        if (name.startsWith('ssv1_base_') || name.endsWith('.base')) {
+          try {
+            await entity.delete();
+          } catch (_) {
+            // best effort
+          }
+        }
+      }
+    } catch (e) {
+      _log.warning('Could not sweep leftover base temp files: $e');
+    }
   }
 
   /// Best-effort removal of [deviceId]'s entire changeset log from the cloud

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
-import 'package:path_provider/path_provider.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart'
     show SyncRecord, DeletionLogData;
@@ -15,6 +14,7 @@ import 'package:submersion/core/services/sync/changeset_log/base_json_stream_rea
 import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
@@ -2022,7 +2022,7 @@ class SyncService {
   /// is logged and ignored -- a stale temp file is harmless.
   Future<void> deleteLeftoverBaseTempFiles() async {
     try {
-      final dir = await getTemporaryDirectory();
+      final dir = await resolveSyncTempDir();
       await for (final entity in dir.list(followLinks: false)) {
         if (entity is! File) continue;
         final name = entity.uri.pathSegments.last;

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -1183,6 +1183,11 @@ class CloudSyncPage extends ConsumerWidget {
   }
 
   Widget _buildAdvancedSection(BuildContext context, WidgetRef ref) {
+    // Recovery resets sync identity/cursors and cloud files; doing that while a
+    // sync is writing races it. Disable the entry during an active sync, as the
+    // former "Reset Sync State" tile did. A sync ERROR (the banner route) is not
+    // `syncing`, so a stuck-error user can still reach Troubleshoot.
+    final isSyncing = ref.watch(syncStateProvider).status == SyncStatus.syncing;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1199,9 +1204,14 @@ class CloudSyncPage extends ConsumerWidget {
           leading: const Icon(Icons.build),
           title: const Text('Troubleshoot Sync'),
           subtitle: const Text('Fix a stuck sync or free cloud space'),
-          onTap: () => Navigator.of(context).push(
-            MaterialPageRoute(builder: (_) => const TroubleshootSyncPage()),
-          ),
+          enabled: !isSyncing,
+          onTap: isSyncing
+              ? null
+              : () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const TroubleshootSyncPage(),
+                  ),
+                ),
         ),
         ListTile(
           leading: const Icon(Icons.logout),

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/backup/presentation/providers/backup_provide
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/troubleshoot_sync_page.dart';
 import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/conflict_resolution_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/dropbox_connect_dialog.dart';
@@ -1169,7 +1170,6 @@ class CloudSyncPage extends ConsumerWidget {
   }
 
   Widget _buildAdvancedSection(BuildContext context, WidgetRef ref) {
-    final isSyncing = ref.watch(syncStateProvider).status == SyncStatus.syncing;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1183,11 +1183,12 @@ class CloudSyncPage extends ConsumerWidget {
           ),
         ),
         ListTile(
-          leading: const Icon(Icons.refresh),
-          title: const Text('Reset Sync State'),
-          subtitle: const Text('Clear sync history and start fresh'),
-          enabled: !isSyncing,
-          onTap: isSyncing ? null : () => _confirmResetSyncState(context, ref),
+          leading: const Icon(Icons.build),
+          title: const Text('Troubleshoot Sync'),
+          subtitle: const Text('Fix a stuck sync or free cloud space'),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const TroubleshootSyncPage()),
+          ),
         ),
         ListTile(
           leading: const Icon(Icons.logout),
@@ -1241,42 +1242,6 @@ class CloudSyncPage extends ConsumerWidget {
     );
     if (confirmed == true) {
       await notifier.performSync();
-    }
-  }
-
-  Future<void> _confirmResetSyncState(
-    BuildContext context,
-    WidgetRef ref,
-  ) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Reset Sync State?'),
-        content: const Text(
-          'This will clear sync history and give this device a new '
-          'sync identity. Your data is not deleted, and the record of '
-          'past deletions is kept so deleted items do not come back.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Reset'),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true) {
-      await ref.read(syncStateProvider.notifier).resetSyncState();
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Sync state reset')));
-      }
     }
   }
 

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -333,61 +333,74 @@ class CloudSyncPage extends ConsumerWidget {
       liveRegion: syncState.status == SyncStatus.syncing,
       child: Card(
         margin: const EdgeInsets.all(16),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  ExcludeSemantics(child: _buildStatusIcon(syncState.status)),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          _getStatusTitle(syncState.status),
-                          style: theme.textTheme.titleMedium,
-                        ),
-                        if (syncState.message != null)
+        // On an error, the whole card is a shortcut into Troubleshoot Sync so a
+        // stuck user finds the way out where the error is shown (issue #509).
+        child: InkWell(
+          onTap: syncState.status == SyncStatus.error
+              ? () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const TroubleshootSyncPage(),
+                  ),
+                )
+              : null,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    ExcludeSemantics(child: _buildStatusIcon(syncState.status)),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
                           Text(
-                            syncState.message!,
-                            style: theme.textTheme.bodySmall,
+                            _getStatusTitle(syncState.status),
+                            style: theme.textTheme.titleMedium,
                           ),
-                      ],
+                          if (syncState.message != null)
+                            Text(
+                              syncState.message!,
+                              style: theme.textTheme.bodySmall,
+                            ),
+                        ],
+                      ),
+                    ),
+                    if (syncState.status == SyncStatus.error)
+                      const Icon(Icons.chevron_right),
+                  ],
+                ),
+                if (syncState.status == SyncStatus.syncing &&
+                    syncState.progress != null) ...[
+                  const SizedBox(height: 16),
+                  Semantics(
+                    label:
+                        'Sync progress: ${(syncState.progress! * 100).toStringAsFixed(0)} percent',
+                    child: LinearProgressIndicator(value: syncState.progress),
+                  ),
+                ],
+                if (syncState.lastSync != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    'Last synced: ${_formatDateTime(syncState.lastSync!)}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
                     ),
                   ),
                 ],
-              ),
-              if (syncState.status == SyncStatus.syncing &&
-                  syncState.progress != null) ...[
-                const SizedBox(height: 16),
-                Semantics(
-                  label:
-                      'Sync progress: ${(syncState.progress! * 100).toStringAsFixed(0)} percent',
-                  child: LinearProgressIndicator(value: syncState.progress),
-                ),
-              ],
-              if (syncState.lastSync != null) ...[
-                const SizedBox(height: 12),
-                Text(
-                  'Last synced: ${_formatDateTime(syncState.lastSync!)}',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+                if (syncState.pendingChanges > 0) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    '${syncState.pendingChanges} pending change${syncState.pendingChanges == 1 ? '' : 's'}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.primary,
+                    ),
                   ),
-                ),
+                ],
               ],
-              if (syncState.pendingChanges > 0) ...[
-                const SizedBox(height: 4),
-                Text(
-                  '${syncState.pendingChanges} pending change${syncState.pendingChanges == 1 ? '' : 's'}',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.primary,
-                  ),
-                ),
-              ],
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+/// Recovery actions for a wedged Cloud Sync state (issue #509). Reached from
+/// the Cloud Sync page's Advanced section and by tapping the sync-error banner.
+/// Actions escalate in severity; each explains itself in plain language.
+class TroubleshootSyncPage extends ConsumerWidget {
+  const TroubleshootSyncPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Troubleshoot Sync')),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.healing),
+            title: const Text('Repair Sync'),
+            subtitle: const Text(
+              'Fix a stuck sync. Clears this device’s sync state and gives it '
+              'a fresh sync identity, then reconnects on the next sync. Your '
+              'dive data is not affected.',
+            ),
+            onTap: () => _confirmRepair(context, ref),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmRepair(BuildContext context, WidgetRef ref) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Repair Sync?'),
+        content: const Text(
+          'This clears all local sync state and gives this device a new sync '
+          'identity, then reconnects fresh on the next sync. Your dive data is '
+          'safe and is not deleted.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Repair'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await ref.read(syncStateProvider.notifier).repairSync();
+    if (context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Sync repaired')));
+    }
+  }
+}

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -25,6 +25,16 @@ class TroubleshootSyncPage extends ConsumerWidget {
             ),
             onTap: () => _confirmRepair(context, ref),
           ),
+          ListTile(
+            leading: const Icon(Icons.cloud_upload_outlined),
+            title: const Text('Rebuild backend from this device'),
+            subtitle: const Text(
+              'Use if sync is stuck waiting on a library that another device '
+              'replaced but never finished uploading (that device may be '
+              'offline). Publishes this device’s library as the current one.',
+            ),
+            onTap: () => _confirmRebuild(context, ref),
+          ),
           const Divider(),
           ListTile(
             leading: const Icon(Icons.cleaning_services_outlined),
@@ -81,6 +91,38 @@ class TroubleshootSyncPage extends ConsumerWidget {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Sync repaired')));
+    }
+  }
+
+  Future<void> _confirmRebuild(BuildContext context, WidgetRef ref) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rebuild backend from this device?'),
+        content: const Text(
+          'This makes this device’s library the current one on the backend and '
+          'republishes it, so other devices sync from you. Use it when a '
+          'replacement from another device is stuck. Your dive data is not '
+          'affected.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Rebuild'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await ref.read(syncStateProvider.notifier).rebuildBackendFromThisDevice();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Rebuilt backend from this device')),
+      );
     }
   }
 

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -25,6 +25,29 @@ class TroubleshootSyncPage extends ConsumerWidget {
             ),
             onTap: () => _confirmRepair(context, ref),
           ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.cleaning_services_outlined),
+            title: const Text('Remove this device’s cloud files'),
+            subtitle: const Text(
+              'Free this device’s space on the backend. Other devices keep '
+              'syncing. Your dive data is not affected.',
+            ),
+            onTap: () => _confirmRemoveThisDevice(context, ref),
+          ),
+          ListTile(
+            leading: Icon(
+              Icons.delete_forever,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            title: const Text('Wipe all sync data on this backend'),
+            subtitle: const Text(
+              'Delete every device’s sync data from this backend, including '
+              'the library markers. Every device re-establishes from scratch. '
+              'Your dive data is not affected.',
+            ),
+            onTap: () => _confirmWipeAll(context, ref),
+          ),
         ],
       ),
     );
@@ -58,6 +81,99 @@ class TroubleshootSyncPage extends ConsumerWidget {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Sync repaired')));
+    }
+  }
+
+  Future<void> _confirmRemoveThisDevice(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove this device’s cloud files?'),
+        content: const Text(
+          'This deletes only this device’s sync files from the backend. Other '
+          'devices keep syncing, and your dive data is not affected.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await ref.read(syncStateProvider.notifier).removeThisDeviceCloudFiles();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Removed this device’s cloud files')),
+      );
+    }
+  }
+
+  /// Destructive full-backend wipe: guarded by typing the word WIPE so it
+  /// cannot be triggered by a single mis-tap.
+  Future<void> _confirmWipeAll(BuildContext context, WidgetRef ref) async {
+    final controller = TextEditingController();
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) {
+          final armed = controller.text.trim() == 'WIPE';
+          return AlertDialog(
+            title: const Text('Wipe all sync data?'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'This deletes EVERY device’s sync data from this backend, '
+                  'including the library markers. Every device must '
+                  're-establish sync from scratch. Your dive data is not '
+                  'affected.\n\nType WIPE to confirm.',
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: controller,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'WIPE',
+                  ),
+                  onChanged: (_) => setState(() {}),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: armed ? () => Navigator.pop(context, true) : null,
+                style: FilledButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                ),
+                child: const Text('Wipe everything'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+    controller.dispose();
+    if (ok != true) return;
+    await ref.read(syncStateProvider.notifier).wipeAllCloudSyncData();
+    if (context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Wiped all sync data')));
     }
   }
 }

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -119,11 +119,21 @@ class TroubleshootSyncPage extends ConsumerWidget {
     );
     if (ok != true) return;
     await ref.read(syncStateProvider.notifier).rebuildBackendFromThisDevice();
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Rebuilt backend from this device')),
-      );
-    }
+    if (!context.mounted) return;
+    // The rebuild can fail (e.g. no epoch marker to rebuild from), in which case
+    // the notifier surfaces SyncStatus.error -- reflect that instead of always
+    // claiming success.
+    final state = ref.read(syncStateProvider);
+    final failed = state.status == SyncStatus.error;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          failed
+              ? (state.message ?? 'Rebuild failed')
+              : 'Rebuilt backend from this device',
+        ),
+      ),
+    );
   }
 
   Future<void> _confirmRemoveThisDevice(

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -160,56 +160,14 @@ class TroubleshootSyncPage extends ConsumerWidget {
   }
 
   /// Destructive full-backend wipe: guarded by typing the word WIPE so it
-  /// cannot be triggered by a single mis-tap.
+  /// cannot be triggered by a single mis-tap. The confirmation controller is
+  /// owned by [_WipeConfirmDialog]'s State (never disposed inline after
+  /// showDialog, which would be used again during the dialog's exit animation).
   Future<void> _confirmWipeAll(BuildContext context, WidgetRef ref) async {
-    final controller = TextEditingController();
     final ok = await showDialog<bool>(
       context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) {
-          final armed = controller.text.trim() == 'WIPE';
-          return AlertDialog(
-            title: const Text('Wipe all sync data?'),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  'This deletes EVERY device’s sync data from this backend, '
-                  'including the library markers. Every device must '
-                  're-establish sync from scratch. Your dive data is not '
-                  'affected.\n\nType WIPE to confirm.',
-                ),
-                const SizedBox(height: 12),
-                TextField(
-                  controller: controller,
-                  autofocus: true,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'WIPE',
-                  ),
-                  onChanged: (_) => setState(() {}),
-                ),
-              ],
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context, false),
-                child: const Text('Cancel'),
-              ),
-              FilledButton(
-                onPressed: armed ? () => Navigator.pop(context, true) : null,
-                style: FilledButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.error,
-                ),
-                child: const Text('Wipe everything'),
-              ),
-            ],
-          );
-        },
-      ),
+      builder: (context) => const _WipeConfirmDialog(),
     );
-    controller.dispose();
     if (ok != true) return;
     await ref.read(syncStateProvider.notifier).wipeAllCloudSyncData();
     if (context.mounted) {
@@ -217,5 +175,68 @@ class TroubleshootSyncPage extends ConsumerWidget {
         context,
       ).showSnackBar(const SnackBar(content: Text('Wiped all sync data')));
     }
+  }
+}
+
+/// Typed-confirmation dialog for the destructive full-backend wipe. Owns its
+/// [TextEditingController] so it is disposed with the widget, not inline after
+/// showDialog (which the dialog's exit animation would then rebuild against).
+class _WipeConfirmDialog extends StatefulWidget {
+  const _WipeConfirmDialog();
+
+  @override
+  State<_WipeConfirmDialog> createState() => _WipeConfirmDialogState();
+}
+
+class _WipeConfirmDialogState extends State<_WipeConfirmDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final armed = _controller.text.trim() == 'WIPE';
+    return AlertDialog(
+      title: const Text('Wipe all sync data?'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'This deletes EVERY device’s sync data from this backend, '
+            'including the library markers. Every device must re-establish '
+            'sync from scratch. Your dive data is not affected.\n\n'
+            'Type WIPE to confirm.',
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'WIPE',
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: armed ? () => Navigator.pop(context, true) : null,
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+          child: const Text('Wipe everything'),
+        ),
+      ],
+    );
   }
 }

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -918,6 +918,19 @@ class SyncNotifier extends StateNotifier<SyncState> {
     await refreshState();
   }
 
+  /// Comprehensive local repair: the full [resetSyncState] (fresh identity,
+  /// this device's cloud file removed, pending-replace/awaiting-adoption
+  /// cleared) PLUS the last-accepted epoch marker and leftover base temp files,
+  /// ending with any error cleared. The guaranteed local escape from a wedged
+  /// sync (issue #509); dive data is never touched.
+  Future<void> repairSync() async {
+    await resetSyncState();
+    await _ref.read(libraryEpochStoreProvider).clear();
+    await _syncService.deleteLeftoverBaseTempFiles();
+    state = state.copyWith(status: SyncStatus.idle, message: null);
+    await refreshState();
+  }
+
   @override
   void dispose() {
     _autoSyncTimer?.cancel();

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -948,6 +948,26 @@ class SyncNotifier extends StateNotifier<SyncState> {
     await refreshState();
   }
 
+  /// Escape a stuck library replacement whose uploader went offline (issue
+  /// #509): rebuild this backend from THIS device's library, then publish it so
+  /// peers adopt from us. Un-pauses the awaiting-adoption state.
+  Future<void> rebuildBackendFromThisDevice() async {
+    final result = await _syncService.rebuildBackendFromThisDevice();
+    if (result.status == SyncResultStatus.success) {
+      state = state.copyWith(
+        replaceAwaitingAdoption: false,
+        replaceMarker: null,
+        status: SyncStatus.idle,
+        message: null,
+      );
+      await _ref.read(libraryEpochStoreProvider).clearPendingReplace();
+      await performSync(); // publish our library as the epoch's base
+    } else {
+      state = state.copyWith(status: SyncStatus.error, message: result.message);
+    }
+    await refreshState();
+  }
+
   @override
   void dispose() {
     _autoSyncTimer?.cancel();

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -940,6 +940,14 @@ class SyncNotifier extends StateNotifier<SyncState> {
     await refreshState();
   }
 
+  /// Wipe ALL sync data on the active backend, including the epoch/moved
+  /// markers (issue #509, cloud clear 3b). Every device re-establishes from
+  /// scratch. Dive data is untouched.
+  Future<void> wipeAllCloudSyncData() async {
+    await _syncService.wipeAllSyncDataOnActiveProvider();
+    await refreshState();
+  }
+
   @override
   void dispose() {
     _autoSyncTimer?.cancel();

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -931,6 +931,15 @@ class SyncNotifier extends StateNotifier<SyncState> {
     await refreshState();
   }
 
+  /// Remove THIS device's sync files from the active backend (issue #509,
+  /// cloud clear 3a). Safe: other devices keep syncing; frees this device's
+  /// changeset log, base parts, and manifest.
+  Future<void> removeThisDeviceCloudFiles() async {
+    final deviceId = await _syncRepository.getDeviceId();
+    await _syncService.deleteDeviceSyncFile(deviceId);
+    await refreshState();
+  }
+
   @override
   void dispose() {
     _autoSyncTimer?.cancel();

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -953,18 +953,20 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// peers adopt from us. Un-pauses the awaiting-adoption state.
   Future<void> rebuildBackendFromThisDevice() async {
     final result = await _syncService.rebuildBackendFromThisDevice();
-    if (result.status == SyncResultStatus.success) {
-      state = state.copyWith(
-        replaceAwaitingAdoption: false,
-        replaceMarker: null,
-        status: SyncStatus.idle,
-        message: null,
-      );
-      await _ref.read(libraryEpochStoreProvider).clearPendingReplace();
-      await performSync(); // publish our library as the epoch's base
-    } else {
+    if (result.status != SyncResultStatus.success) {
+      // Keep the error visible: refreshState (which recomputes status from the
+      // repository) must NOT run here, or it would clear the reason.
       state = state.copyWith(status: SyncStatus.error, message: result.message);
+      return;
     }
+    state = state.copyWith(
+      replaceAwaitingAdoption: false,
+      replaceMarker: null,
+      status: SyncStatus.idle,
+      message: null,
+    );
+    await _ref.read(libraryEpochStoreProvider).clearPendingReplace();
+    await performSync(); // publish our library as the epoch's base
     await refreshState();
   }
 

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -63,6 +63,9 @@ class _DrivableSyncNotifier extends StateNotifier<SyncState>
   Future<void> resetSyncState() async {}
 
   @override
+  Future<void> repairSync() async {}
+
+  @override
   Future<void> signOut() async {}
 
   @override

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -66,6 +66,12 @@ class _DrivableSyncNotifier extends StateNotifier<SyncState>
   Future<void> repairSync() async {}
 
   @override
+  Future<void> removeThisDeviceCloudFiles() async {}
+
+  @override
+  Future<void> wipeAllCloudSyncData() async {}
+
+  @override
   Future<void> signOut() async {}
 
   @override

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -72,6 +72,9 @@ class _DrivableSyncNotifier extends StateNotifier<SyncState>
   Future<void> wipeAllCloudSyncData() async {}
 
   @override
+  Future<void> rebuildBackendFromThisDevice() async {}
+
+  @override
   Future<void> signOut() async {}
 
   @override

--- a/test/core/services/sync/base_publish_streaming_parity_test.dart
+++ b/test/core/services/sync/base_publish_streaming_parity_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
@@ -54,6 +55,28 @@ Future<void> _seedRich() async {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  // exportBaseToTempFile now defaults to path_provider's getTemporaryDirectory
+  // (app-container temp, not /tmp -- issue #509). These calls do not inject a
+  // tempDir, so mock the channel to a real writable dir.
+  late Directory fakeAppTemp;
+  setUpAll(() async {
+    fakeAppTemp = await Directory.systemTemp.createTemp('parity_app_temp_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async =>
+              call.method == 'getTemporaryDirectory' ? fakeAppTemp.path : null,
+        );
+  });
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    if (fakeAppTemp.existsSync()) await fakeAppTemp.delete(recursive: true);
+  });
 
   setUp(() async {
     await setUpTestDatabase();

--- a/test/core/services/sync/base_publish_streaming_parity_test.dart
+++ b/test/core/services/sync/base_publish_streaming_parity_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/services.dart';

--- a/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   late Directory dir;
   late BasePartFileSink sink;
 
@@ -98,5 +100,54 @@ void main() {
     await sink.deleteQuietly(f.path);
     expect(f.existsSync(), isFalse);
     await sink.deleteQuietly('${dir.path}/does-not-exist'); // no throw
+  });
+
+  // Issue #509: with no injected temp dir, the sink must default to the
+  // app-container temp dir (path_provider's getTemporaryDirectory), NOT
+  // Directory.systemTemp (/tmp on macOS, where a hardened-runtime app is
+  // denied -> PathAccessException errno 1).
+  group('default temp dir', () {
+    late Directory fakeAppTemp;
+
+    setUpAll(() async {
+      fakeAppTemp = await Directory.systemTemp.createTemp('app_temp_');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (call) async => call.method == 'getTemporaryDirectory'
+                ? fakeAppTemp.path
+                : null,
+          );
+    });
+
+    tearDownAll(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      if (fakeAppTemp.existsSync()) await fakeAppTemp.delete(recursive: true);
+    });
+
+    test(
+      'assemble writes into the app-container temp dir by default',
+      () async {
+        final defaultSink = BasePartFileSink(); // no injected dir
+        final path = await defaultSink.assemble(
+          name: 'ssv1_base_dev_0',
+          partCount: 1,
+          wholeChecksum: null,
+          partChecksums: const [],
+          downloadPart: (_) async => Uint8List.fromList([1, 2, 3]),
+        );
+        expect(path, isNotNull);
+        expect(
+          path!.startsWith(fakeAppTemp.path),
+          isTrue,
+          reason: 'must not fall back to /tmp (systemTemp)',
+        );
+        await defaultSink.deleteQuietly(path);
+      },
+    );
   });
 }

--- a/test/core/services/sync/library_epoch_store_test.dart
+++ b/test/core/services/sync/library_epoch_store_test.dart
@@ -38,6 +38,19 @@ void main() {
     expect(store.pendingReplace, isNull);
   });
 
+  test(
+    'clear() removes both the last-accepted and pending-replace markers',
+    () async {
+      await store.setLastAccepted(marker);
+      await store.setPendingReplace(marker);
+
+      await store.clear();
+
+      expect(store.lastAcceptedMarker, isNull);
+      expect(store.pendingReplace, isNull);
+    },
+  );
+
   test('corrupt stored JSON reads as null', () async {
     SharedPreferences.setMockInitialValues({
       'sync_last_accepted_epoch_marker': 'not json',

--- a/test/core/services/sync/sync_service_cloud_clear_test.dart
+++ b/test/core/services/sync/sync_service_cloud_clear_test.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Issue #509 cloud clear: freeing this device's footprint (3a) and the
+/// full-backend wipe (3b).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(() => DatabaseService.instance.resetForTesting());
+
+  SyncService buildService() => SyncService(
+    syncRepository: SyncRepository(),
+    serializer: SyncDataSerializer(),
+    cloudProvider: cloud,
+  );
+
+  Uint8List b(String s) => Uint8List.fromList(s.codeUnits);
+
+  test('deleteDeviceSyncFile removes only this device’s files (manifest, base '
+      'parts, changesets)', () async {
+    // dev1: a manifest, a base part, and a changeset -- all should go.
+    cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+    cloud.seedFile(ChangesetLogLayout.basePartName('dev1', 0, 0), b('bp1'));
+    cloud.seedFile(ChangesetLogLayout.changesetName('dev1', 5), b('cs1'));
+    // dev2: must survive.
+    cloud.seedFile(ChangesetLogLayout.manifestName('dev2'), b('m2'));
+
+    await buildService().deleteDeviceSyncFile('dev1');
+
+    expect(cloud.bytesOf(ChangesetLogLayout.manifestName('dev1')), isNull);
+    expect(
+      cloud.bytesOf(ChangesetLogLayout.basePartName('dev1', 0, 0)),
+      isNull,
+    );
+    expect(cloud.bytesOf(ChangesetLogLayout.changesetName('dev1', 5)), isNull);
+    expect(
+      cloud.bytesOf(ChangesetLogLayout.manifestName('dev2')),
+      isNotNull,
+      reason: 'other devices keep syncing',
+    );
+  });
+}

--- a/test/core/services/sync/sync_service_cloud_clear_test.dart
+++ b/test/core/services/sync/sync_service_cloud_clear_test.dart
@@ -5,6 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/services/sync/library_moved.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 
@@ -56,5 +58,25 @@ void main() {
       isNotNull,
       reason: 'other devices keep syncing',
     );
+  });
+
+  test('wipeAllSyncData deletes logs AND the epoch/moved markers', () async {
+    cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+    cloud.seedFile(ChangesetLogLayout.basePartName('dev1', 0, 0), b('bp1'));
+    cloud.seedFile(libraryEpochFileName, b('epoch'));
+    cloud.seedFile(libraryMovedFileName, b('moved'));
+
+    await buildService().wipeAllSyncData(cloud);
+
+    // deleteAllSyncFiles clears the logs...
+    expect(cloud.bytesOf(ChangesetLogLayout.manifestName('dev1')), isNull);
+    expect(
+      cloud.bytesOf(ChangesetLogLayout.basePartName('dev1', 0, 0)),
+      isNull,
+    );
+    // ...and wipeAllSyncData additionally clears the epoch/moved markers that
+    // deleteAllSyncFiles deliberately preserves, for a genuine fresh start.
+    expect(cloud.bytesOf(libraryEpochFileName), isNull);
+    expect(cloud.bytesOf(libraryMovedFileName), isNull);
   });
 }

--- a/test/core/services/sync/sync_service_cloud_clear_test.dart
+++ b/test/core/services/sync/sync_service_cloud_clear_test.dart
@@ -79,4 +79,16 @@ void main() {
     expect(cloud.bytesOf(libraryEpochFileName), isNull);
     expect(cloud.bytesOf(libraryMovedFileName), isNull);
   });
+
+  test(
+    'wipeAllSyncData is best-effort: a delete failure does not throw',
+    () async {
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+      cloud.seedFile(libraryEpochFileName, b('epoch'));
+      cloud.failDeletes = true; // offline/denied provider
+
+      // Every delete throws, but the wipe swallows and logs each one.
+      await buildService().wipeAllSyncData(cloud);
+    },
+  );
 }

--- a/test/core/services/sync/sync_service_repair_test.dart
+++ b/test/core/services/sync/sync_service_repair_test.dart
@@ -70,12 +70,16 @@ void main() {
       await epochStore.setPendingReplace(marker);
       final leftover = File('${fakeAppTemp.path}/ssv1_base_dev_0.abc.json');
       await leftover.writeAsString('stale');
+      // An unrelated temp file (the dir is shared) must be left untouched.
+      final unrelated = File('${fakeAppTemp.path}/user_photo.jpg');
+      await unrelated.writeAsString('keep');
 
       await buildService().repairLocalSyncState();
 
       expect(epochStore.lastAcceptedMarker, isNull);
       expect(epochStore.pendingReplace, isNull);
       expect(leftover.existsSync(), isFalse);
+      expect(unrelated.existsSync(), isTrue);
     },
   );
 

--- a/test/core/services/sync/sync_service_repair_test.dart
+++ b/test/core/services/sync/sync_service_repair_test.dart
@@ -78,4 +78,36 @@ void main() {
       expect(leftover.existsSync(), isFalse);
     },
   );
+
+  test(
+    'rebuildBackendFromThisDevice re-establishes the epoch from local library',
+    () async {
+      final service = buildService();
+      const marker = LibraryEpochMarker(
+        epochId: 'e-stuck',
+        replacedAt: 1,
+        deviceId: 'offline-device',
+      );
+      // The offline device published the epoch marker but no base; a stale peer
+      // log lingers in the folder.
+      await service.writeLibraryEpochMarker(cloud, marker);
+      cloud.seedFile(
+        'ssv1.offline-device.manifest.json',
+        Uint8List.fromList('m'.codeUnits),
+      );
+
+      final result = await service.rebuildBackendFromThisDevice();
+
+      expect(result.status, SyncResultStatus.success);
+      // The stuck sync files are wiped so this device can republish...
+      expect(cloud.bytesOf('ssv1.offline-device.manifest.json'), isNull);
+      // ...and this device now accepts the epoch (its next sync publishes base).
+      expect(epochStore.lastAcceptedMarker?.epochId, 'e-stuck');
+    },
+  );
+
+  test('rebuildBackendFromThisDevice errors when no marker exists', () async {
+    final result = await buildService().rebuildBackendFromThisDevice();
+    expect(result.status, SyncResultStatus.error);
+  });
 }

--- a/test/core/services/sync/sync_service_repair_test.dart
+++ b/test/core/services/sync/sync_service_repair_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/services/sync/library_epoch_store.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Issue #509: the comprehensive local Repair. resetSyncState already clears
+/// the DB-side sync state; Repair adds the one thing it misses -- the
+/// SharedPreferences epoch markers -- plus a sweep of leftover base temp files.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late LibraryEpochStore epochStore;
+  late FakeCloudStorageProvider cloud;
+  late Directory fakeAppTemp;
+
+  setUpAll(() async {
+    fakeAppTemp = await Directory.systemTemp.createTemp('repair_app_temp_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async =>
+              call.method == 'getTemporaryDirectory' ? fakeAppTemp.path : null,
+        );
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    if (fakeAppTemp.existsSync()) await fakeAppTemp.delete(recursive: true);
+  });
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    epochStore = LibraryEpochStore(await SharedPreferences.getInstance());
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(() => DatabaseService.instance.resetForTesting());
+
+  SyncService buildService() => SyncService(
+    syncRepository: SyncRepository(),
+    serializer: SyncDataSerializer(),
+    cloudProvider: cloud,
+    epochStore: epochStore,
+  );
+
+  test(
+    'repairLocalSyncState clears the epoch store and leftover base temp files',
+    () async {
+      const marker = LibraryEpochMarker(
+        epochId: 'e1',
+        replacedAt: 1,
+        deviceId: 'd1',
+      );
+      await epochStore.setLastAccepted(marker);
+      await epochStore.setPendingReplace(marker);
+      final leftover = File('${fakeAppTemp.path}/ssv1_base_dev_0.abc.json');
+      await leftover.writeAsString('stale');
+
+      await buildService().repairLocalSyncState();
+
+      expect(epochStore.lastAcceptedMarker, isNull);
+      expect(epochStore.pendingReplace, isNull);
+      expect(leftover.existsSync(), isFalse);
+    },
+  );
+}

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -206,6 +206,11 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   @override
   Future<void> wipeAllCloudSyncData() async => wipeAllCloudSyncDataCalls++;
 
+  int rebuildBackendFromThisDeviceCalls = 0;
+  @override
+  Future<void> rebuildBackendFromThisDevice() async =>
+      rebuildBackendFromThisDeviceCalls++;
+
   @override
   Future<void> signOut() async => signOutCalls++;
 

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -1245,6 +1245,23 @@ void main() {
       // The Troubleshoot page's app bar title and its primary Repair action.
       expect(find.text('Repair Sync'), findsOneWidget);
     });
+
+    testWidgets('tapping the sync error banner opens Troubleshoot Sync', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        syncState: const SyncState(
+          status: SyncStatus.error,
+          message: 'The replaced library is still uploading.',
+        ),
+      );
+
+      await tester.tap(find.text('Sync error'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Repair Sync'), findsOneWidget); // Troubleshoot page
+    });
   });
 
   group('CloudSyncPage - sign out dialog', () {

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -193,6 +193,10 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   @override
   Future<void> resetSyncState() async => resetSyncStateCalls++;
 
+  int repairSyncCalls = 0;
+  @override
+  Future<void> repairSync() async => repairSyncCalls++;
+
   @override
   Future<void> signOut() async => signOutCalls++;
 
@@ -569,7 +573,7 @@ void main() {
       expect(find.text('Sync on Resume'), findsOneWidget);
       // Advanced section.
       expect(find.text('Advanced'), findsOneWidget);
-      expect(find.text('Reset Sync State'), findsOneWidget);
+      expect(find.text('Troubleshoot Sync'), findsOneWidget);
       expect(find.text('Sign Out'), findsOneWidget);
       // Sync Now action present; no provider selected => hint shown + disabled.
       expect(find.text('Sync Now'), findsOneWidget);
@@ -1227,31 +1231,19 @@ void main() {
     });
   });
 
-  group('CloudSyncPage - reset sync state dialog', () {
-    testWidgets('cancel does not call resetSyncState', (tester) async {
-      final handles = await pumpPage(tester);
-
-      await tester.tap(find.text('Reset Sync State'));
-      await tester.pumpAndSettle();
-      expect(find.text('Reset Sync State?'), findsOneWidget);
-
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-      expect(handles.sync.resetSyncStateCalls, 0);
-    });
-
-    testWidgets('confirm calls resetSyncState and shows snackbar', (
+  group('CloudSyncPage - Advanced troubleshoot entry', () {
+    testWidgets('tapping Troubleshoot Sync opens the Troubleshoot page', (
       tester,
     ) async {
-      final handles = await pumpPage(tester);
+      await pumpPage(tester);
 
-      await tester.tap(find.text('Reset Sync State'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+      // The recovery actions moved off the standalone "Reset Sync State" tile
+      // onto a dedicated Troubleshoot Sync screen.
+      await tester.tap(find.text('Troubleshoot Sync'));
       await tester.pumpAndSettle();
 
-      expect(handles.sync.resetSyncStateCalls, 1);
-      expect(find.text('Sync state reset'), findsOneWidget);
+      // The Troubleshoot page's app bar title and its primary Repair action.
+      expect(find.text('Repair Sync'), findsOneWidget);
     });
   });
 

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -197,6 +197,15 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   @override
   Future<void> repairSync() async => repairSyncCalls++;
 
+  int removeThisDeviceCloudFilesCalls = 0;
+  @override
+  Future<void> removeThisDeviceCloudFiles() async =>
+      removeThisDeviceCloudFilesCalls++;
+
+  int wipeAllCloudSyncDataCalls = 0;
+  @override
+  Future<void> wipeAllCloudSyncData() async => wipeAllCloudSyncDataCalls++;
+
   @override
   Future<void> signOut() async => signOutCalls++;
 

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -1260,6 +1260,27 @@ void main() {
       expect(find.text('Repair Sync'), findsOneWidget);
     });
 
+    testWidgets('Troubleshoot Sync entry is disabled during an active sync', (
+      tester,
+    ) async {
+      // Syncing shows an indeterminate spinner that never settles.
+      await pumpPage(
+        tester,
+        syncState: const SyncState(status: SyncStatus.syncing),
+        settle: false,
+      );
+      await tester.pump();
+
+      final tile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text('Troubleshoot Sync'),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect(tile.enabled, isFalse);
+      expect(tile.onTap, isNull);
+    });
+
     testWidgets('tapping the sync error banner opens Troubleshoot Sync', (
       tester,
     ) async {

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -14,4 +14,40 @@ void main() {
     // The explanation must reassure the user their dive data is safe.
     expect(find.textContaining('dive data'), findsWidgets);
   });
+
+  testWidgets('shows both cloud-clear actions', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: TroubleshootSyncPage())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remove this device’s cloud files'), findsOneWidget);
+    expect(find.text('Wipe all sync data on this backend'), findsOneWidget);
+  });
+
+  testWidgets('wipe-all requires typed confirmation', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: TroubleshootSyncPage())),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Wipe all sync data on this backend'));
+    await tester.pumpAndSettle();
+
+    final confirmBtn = find.widgetWithText(FilledButton, 'Wipe everything');
+    expect(
+      tester.widget<FilledButton>(confirmBtn).onPressed,
+      isNull,
+      reason: 'disabled until the confirmation word is typed',
+    );
+
+    await tester.enterText(find.byType(TextField), 'WIPE');
+    await tester.pump();
+
+    expect(
+      tester.widget<FilledButton>(confirmBtn).onPressed,
+      isNotNull,
+      reason: 'enabled once the user types WIPE',
+    );
+  });
 }

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -17,6 +17,10 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   int wipeAllCalls = 0;
   int rebuildCalls = 0;
 
+  /// When set, [rebuildBackendFromThisDevice] models a failure by leaving the
+  /// state in [SyncStatus.error] with this message (mirrors the real notifier).
+  String? rebuildFailureMessage;
+
   @override
   Future<void> repairSync() async => repairSyncCalls++;
 
@@ -27,7 +31,13 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> wipeAllCloudSyncData() async => wipeAllCalls++;
 
   @override
-  Future<void> rebuildBackendFromThisDevice() async => rebuildCalls++;
+  Future<void> rebuildBackendFromThisDevice() async {
+    rebuildCalls++;
+    final msg = rebuildFailureMessage;
+    if (msg != null) {
+      state = SyncState(status: SyncStatus.error, message: msg);
+    }
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -153,6 +163,21 @@ void main() {
 
     expect(fake.rebuildCalls, 1);
     expect(find.text('Rebuilt backend from this device'), findsOneWidget);
+  });
+
+  testWidgets('Rebuild failure shows the error, not a success snackbar', (
+    tester,
+  ) async {
+    final fake = await _pump(tester);
+    fake.rebuildFailureMessage = 'No library replacement to rebuild from';
+
+    await tester.tap(find.text('Rebuild backend from this device'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Rebuild'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No library replacement to rebuild from'), findsOneWidget);
+    expect(find.text('Rebuilt backend from this device'), findsNothing);
   });
 
   testWidgets('Remove-this-device confirm calls the notifier', (tester) async {

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -25,6 +25,24 @@ void main() {
     expect(find.text('Wipe all sync data on this backend'), findsOneWidget);
   });
 
+  testWidgets('shows the rebuild-from-this-device action and confirm dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: TroubleshootSyncPage())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rebuild backend from this device'), findsOneWidget);
+
+    await tester.tap(find.text('Rebuild backend from this device'));
+    await tester.pumpAndSettle();
+
+    // Confirm dialog appears (title ends with '?').
+    expect(find.text('Rebuild backend from this device?'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Rebuild'), findsOneWidget);
+  });
+
   testWidgets('wipe-all requires typed confirmation', (tester) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: TroubleshootSyncPage())),

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/settings/presentation/pages/troubleshoot_sync_page.dart';
+
+void main() {
+  testWidgets('shows Repair Sync action with an explanation', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: TroubleshootSyncPage())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Repair Sync'), findsOneWidget);
+    // The explanation must reassure the user their dive data is safe.
+    expect(find.textContaining('dive data'), findsWidgets);
+  });
+}

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -1,7 +1,50 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart' show StateNotifier;
 import 'package:submersion/features/settings/presentation/pages/troubleshoot_sync_page.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+/// Records the recovery calls the Troubleshoot page routes to the notifier so
+/// the tap-through tests can assert each confirm flow fires exactly once. All
+/// other SyncNotifier members fall through to noSuchMethod (unused here).
+class _FakeSyncNotifier extends StateNotifier<SyncState>
+    implements SyncNotifier {
+  _FakeSyncNotifier() : super(const SyncState());
+
+  int repairSyncCalls = 0;
+  int removeThisDeviceCalls = 0;
+  int wipeAllCalls = 0;
+  int rebuildCalls = 0;
+
+  @override
+  Future<void> repairSync() async => repairSyncCalls++;
+
+  @override
+  Future<void> removeThisDeviceCloudFiles() async => removeThisDeviceCalls++;
+
+  @override
+  Future<void> wipeAllCloudSyncData() async => wipeAllCalls++;
+
+  @override
+  Future<void> rebuildBackendFromThisDevice() async => rebuildCalls++;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Pumps the page with [fake] backing syncStateProvider. Returns the fake.
+Future<_FakeSyncNotifier> _pump(WidgetTester tester) async {
+  final fake = _FakeSyncNotifier();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [syncStateProvider.overrideWith((ref) => fake)],
+      child: const MaterialApp(home: TroubleshootSyncPage()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
 
 void main() {
   testWidgets('shows Repair Sync action with an explanation', (tester) async {
@@ -67,5 +110,97 @@ void main() {
       isNotNull,
       reason: 'enabled once the user types WIPE',
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tap-through flows: each confirm invokes the notifier and shows a snackbar.
+  // ---------------------------------------------------------------------------
+
+  testWidgets('Repair confirm calls repairSync and shows a snackbar', (
+    tester,
+  ) async {
+    final fake = await _pump(tester);
+
+    await tester.tap(find.text('Repair Sync'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Repair'));
+    await tester.pumpAndSettle();
+
+    expect(fake.repairSyncCalls, 1);
+    expect(find.text('Sync repaired'), findsOneWidget);
+  });
+
+  testWidgets('Repair cancel does not call repairSync', (tester) async {
+    final fake = await _pump(tester);
+
+    await tester.tap(find.text('Repair Sync'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(fake.repairSyncCalls, 0);
+  });
+
+  testWidgets('Rebuild confirm calls rebuildBackendFromThisDevice', (
+    tester,
+  ) async {
+    final fake = await _pump(tester);
+
+    await tester.tap(find.text('Rebuild backend from this device'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Rebuild'));
+    await tester.pumpAndSettle();
+
+    expect(fake.rebuildCalls, 1);
+    expect(find.text('Rebuilt backend from this device'), findsOneWidget);
+  });
+
+  testWidgets('Remove-this-device confirm calls the notifier', (tester) async {
+    final fake = await _pump(tester);
+
+    await tester.tap(find.text('Remove this device’s cloud files'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
+    await tester.pumpAndSettle();
+
+    expect(fake.removeThisDeviceCalls, 1);
+    expect(find.text('Removed this device’s cloud files'), findsOneWidget);
+  });
+
+  testWidgets('Wipe-all confirm (after typing WIPE) calls the notifier', (
+    tester,
+  ) async {
+    final fake = await _pump(tester);
+
+    await tester.tap(find.text('Wipe all sync data on this backend'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'WIPE');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Wipe everything'));
+    await tester.pumpAndSettle();
+
+    expect(fake.wipeAllCalls, 1);
+    expect(find.text('Wiped all sync data'), findsOneWidget);
+  });
+
+  testWidgets('cancelling each dialog invokes no notifier action', (
+    tester,
+  ) async {
+    final fake = await _pump(tester);
+
+    for (final tile in const [
+      'Rebuild backend from this device',
+      'Remove this device’s cloud files',
+      'Wipe all sync data on this backend',
+    ]) {
+      await tester.tap(find.text(tile));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+    }
+
+    expect(fake.rebuildCalls, 0);
+    expect(fake.removeThisDeviceCalls, 0);
+    expect(fake.wipeAllCalls, 0);
   });
 }

--- a/test/features/settings/presentation/providers/sync_providers_recovery_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_recovery_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/services/sync/library_epoch_store.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Coverage for the REAL SyncNotifier's issue #509 recovery methods (the
+/// Troubleshoot page widget tests exercise a fake notifier, not this code):
+/// Repair, the two cloud clears, and the offline-uploader rebuild.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const marker = LibraryEpochMarker(
+    epochId: 'e-stuck',
+    replacedAt: 1764000000000,
+    deviceId: 'offline-device',
+  );
+
+  late SharedPreferences prefs;
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(() => DatabaseService.instance.resetForTesting());
+
+  Future<ProviderContainer> makeContainer({bool cloudConfigured = true}) async {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(
+          cloudConfigured ? cloud : null,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(syncStateProvider);
+    await container.read(syncStateProvider.notifier).refreshState();
+    return container;
+  }
+
+  void seedMarker(LibraryEpochMarker m) {
+    cloud.seedFile(
+      libraryEpochFileName,
+      Uint8List.fromList(utf8.encode(jsonEncode(m.toJson()))),
+    );
+  }
+
+  Uint8List b(String s) => Uint8List.fromList(s.codeUnits);
+
+  group('repairSync', () {
+    test('clears the last-accepted epoch marker', () async {
+      final container = await makeContainer();
+      await LibraryEpochStore(prefs).setLastAccepted(marker);
+
+      await container.read(syncStateProvider.notifier).repairSync();
+
+      expect(LibraryEpochStore(prefs).lastAcceptedMarker, isNull);
+      expect(container.read(syncStateProvider).status, SyncStatus.idle);
+    });
+  });
+
+  group('removeThisDeviceCloudFiles', () {
+    test('deletes only this device’s files from the backend', () async {
+      final container = await makeContainer();
+      final deviceId = await container
+          .read(syncRepositoryProvider)
+          .getDeviceId();
+      cloud.seedFile(ChangesetLogLayout.manifestName(deviceId), b('mine'));
+      cloud.seedFile(
+        ChangesetLogLayout.manifestName('other-device'),
+        b('peer'),
+      );
+
+      await container
+          .read(syncStateProvider.notifier)
+          .removeThisDeviceCloudFiles();
+
+      expect(cloud.bytesOf(ChangesetLogLayout.manifestName(deviceId)), isNull);
+      expect(
+        cloud.bytesOf(ChangesetLogLayout.manifestName('other-device')),
+        isNotNull,
+      );
+    });
+  });
+
+  group('wipeAllCloudSyncData', () {
+    test('deletes logs and the epoch marker', () async {
+      final container = await makeContainer();
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+      seedMarker(marker);
+
+      await container.read(syncStateProvider.notifier).wipeAllCloudSyncData();
+
+      expect(cloud.bytesOf(ChangesetLogLayout.manifestName('dev1')), isNull);
+      expect(cloud.bytesOf(libraryEpochFileName), isNull);
+    });
+
+    test('no-op when no cloud provider is configured', () async {
+      final container = await makeContainer(cloudConfigured: false);
+      // Must not throw with a null active provider.
+      await container.read(syncStateProvider.notifier).wipeAllCloudSyncData();
+    });
+  });
+
+  group('rebuildBackendFromThisDevice', () {
+    test('accepts the epoch and clears awaiting-adoption', () async {
+      final container = await makeContainer();
+      seedMarker(marker);
+      cloud.seedFile(
+        ChangesetLogLayout.manifestName('offline-device'),
+        b('stale'),
+      );
+
+      await container
+          .read(syncStateProvider.notifier)
+          .rebuildBackendFromThisDevice();
+
+      expect(LibraryEpochStore(prefs).lastAcceptedMarker?.epochId, 'e-stuck');
+      expect(
+        container.read(syncStateProvider).replaceAwaitingAdoption,
+        isFalse,
+      );
+    });
+
+    test('surfaces an error when there is no marker to rebuild from', () async {
+      final container = await makeContainer();
+
+      await container
+          .read(syncStateProvider.notifier)
+          .rebuildBackendFromThisDevice();
+
+      expect(container.read(syncStateProvider).status, SyncStatus.error);
+    });
+  });
+}

--- a/test/features/settings/presentation/s3_config_page_test.dart
+++ b/test/features/settings/presentation/s3_config_page_test.dart
@@ -128,6 +128,9 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> resetSyncState() async {}
 
   @override
+  Future<void> repairSync() async {}
+
+  @override
   Future<void> signOut() async {
     _ref.read(selectedCloudProviderTypeProvider.notifier).state = null;
     state = const SyncState();

--- a/test/features/settings/presentation/s3_config_page_test.dart
+++ b/test/features/settings/presentation/s3_config_page_test.dart
@@ -131,6 +131,12 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> repairSync() async {}
 
   @override
+  Future<void> removeThisDeviceCloudFiles() async {}
+
+  @override
+  Future<void> wipeAllCloudSyncData() async {}
+
+  @override
   Future<void> signOut() async {
     _ref.read(selectedCloudProviderTypeProvider.notifier).state = null;
     state = const SyncState();

--- a/test/features/settings/presentation/s3_config_page_test.dart
+++ b/test/features/settings/presentation/s3_config_page_test.dart
@@ -137,6 +137,9 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> wipeAllCloudSyncData() async {}
 
   @override
+  Future<void> rebuildBackendFromThisDevice() async {}
+
+  @override
   Future<void> signOut() async {
     _ref.read(selectedCloudProviderTypeProvider.notifier).state = null;
     state = const SyncState();


### PR DESCRIPTION
## Summary

Fixes #509 and gives users a reliable in-app way out of a wedged Cloud Sync state — previously a reinstall was the only escape. Two dead-ends were reported:

1. **`PathAccessException: Cannot open file, path = '/tmp/ssv1_base_…json' (Operation not permitted, errno = 1)`** (#509). The streaming-base temp file was written to `Directory.systemTemp` (`/tmp` on macOS), where a hardened-runtime/sandboxed app is denied. Publishing or adopting a base then failed on every sync.
2. **"The replaced library is still uploading. Try again shortly."** — a device that ran "Replace everywhere" went **offline** before uploading the new base, so every other device waited forever on an upload that never arrived.

Neither cleared via "Reset Sync State" or deleting the database, because the wedged state lives outside the DB — chiefly the `LibraryEpochStore` SharedPreferences markers, plus the cloud-side epoch marker — which only a reinstall wiped.

## Changes

**The concrete #509 fix**
- Streaming-sync temp files (`exportBaseToTempFile`, `BasePartFileSink`) now resolve to the app-container temp dir via a shared `resolveSyncTempDir()` — prefers `getTemporaryDirectory()`, falls back to `systemTemp` only when path_provider is unavailable (unit tests), so production never touches `/tmp`.

**A new Troubleshoot Sync screen** (reached from the Cloud Sync page's Advanced section, and by tapping the sync-error banner — a stuck user finds the exit where the error is shown). It hosts, in escalating severity:
- **Repair Sync** — comprehensive local reset: everything today's Reset does *plus* the `LibraryEpochStore` markers it misses and a leftover-base-temp sweep. A true reinstall-equivalent that never touches dive data. (Replaces the old standalone "Reset Sync State" tile, so there aren't two near-identical reset buttons.)
- **Rebuild backend from this device** — escape for the offline-uploader wedge: republishes this device's library as the current epoch's base so peers adopt from it instead of the offline device.
- **Remove this device's cloud files** — frees this device's footprint on the active backend; other devices keep syncing.
- **Wipe all sync data on this backend** — deletes every device's sync data *including* the library/epoch markers that `deleteAllSyncFiles` deliberately preserves, for a genuine fresh start. Guarded by a typed "WIPE" confirmation.

All cloud actions operate on the **active** provider only. No action touches dive data.

## Notes

This was built from an approved design + implementation plan (`docs/superpowers/specs/2026-07-07-sync-error-recovery-design.md`, `docs/superpowers/plans/2026-07-07-sync-error-recovery.md`), TDD throughout. One refinement surfaced during implementation: today's `resetSyncState` already clears cursors, all publish state, the pending-replace marker, and this device's cloud file — the *only* local state it missed is the last-accepted epoch marker, which Repair now clears.

## Test Plan

- [x] `flutter test test/core/services/sync/ test/features/settings/presentation/` — 985 pass
- [x] New tests (all verified RED first): app-temp-dir default; `LibraryEpochStore.clear`; `repairLocalSyncState`; Troubleshoot screen + tappable error banner; per-device and full cloud clear (incl. epoch markers); typed-confirm gating; `rebuildBackendFromThisDevice`
- [x] `flutter analyze` clean, `dart format` clean (whole project)
- [x] Hardware pass: (a) macOS hardened-runtime build — base temp files land under the app container, #509's `/tmp` EPERM gone; (b) two devices — Replace-everywhere on A, take A offline, then on B use "Rebuild backend from this device" to clear the stuck "still uploading"; (c) confirm Repair and both cloud-clear actions behave and never touch dive data