### PR TITLE
fix(profile): prevent NaN crash on dives with a flat tank pressure series

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -3626,6 +3626,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
     // Add some padding to the pressure range
     final pressureRange = globalMaxPressure - globalMinPressure;
+
+    // A zero span means every sample across every tank is identical -- in
+    // practice a computer that logged a pressure channel with no transmitter
+    // paired (all zeros). There is no pressure information to plot, and mapping
+    // a constant value through a zero-width range yields NaN spot coordinates
+    // that crash fl_chart's touch/tooltip painter (Offset NaN). Skip it.
+    if (pressureRange <= 0) return [];
+
     final minPressure = globalMinPressure - (pressureRange * 0.05);
     final maxPressure = globalMaxPressure + (pressureRange * 0.05);
 
@@ -3804,7 +3812,13 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     double minValue,
     double maxValue,
   ) {
-    final normalized = (value - minValue) / (maxValue - minValue);
+    // Guard a zero-width range: (value - min) / 0 is NaN, which propagates into
+    // FlSpot coordinates and crashes fl_chart's touch/tooltip painter with
+    // "Offset argument contained a NaN value". Collapse to the axis midpoint so
+    // a constant series renders as a finite flat line instead.
+    final span = maxValue - minValue;
+    if (span == 0) return maxDepth * 0.5;
+    final normalized = (value - minValue) / span;
     return maxDepth * (1 - normalized);
   }
 

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -307,6 +307,49 @@ void main() {
       );
     });
 
+    testWidgets(
+      'scrubbing over a flat (all-zero) tank pressure series does not throw',
+      (tester) async {
+        // Regression: a Shearwater logged a pressure channel with no
+        // transmitter paired, so every sample is 0.0. The pressure axis range
+        // collapses to zero width; mapping a constant value through it produced
+        // NaN FlSpot coordinates that crashed fl_chart's touch/tooltip painter
+        // with "Offset argument contained a NaN value" on hover (dive #835).
+        const tank = DiveTank(id: 't1', gasMix: GasMix(o2: 21), order: 0);
+        final profile = _makeProfile(points: 40);
+        final flatPressures = <TankPressurePoint>[
+          for (var i = 0; i < 40; i++)
+            TankPressurePoint(
+              id: 'p$i',
+              tankId: 't1',
+              timestamp: i * 30,
+              pressure: 0.0,
+            ),
+        ];
+
+        await tester.pumpWidget(
+          _buildChart(
+            profile: profile,
+            tanks: const [tank],
+            tankPressures: {'t1': flatPressures},
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final rect = tester.getRect(find.byType(LineChart));
+        final y = rect.center.dy;
+        final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await mouse.addPointer(location: Offset(rect.left + 2, y));
+        await tester.pump();
+        for (var i = 1; i <= 40; i++) {
+          await mouse.moveTo(Offset(rect.left + rect.width * (i / 40.0), y));
+          await tester.pump();
+          expect(tester.takeException(), isNull);
+        }
+        await mouse.removePointer();
+      },
+    );
+
     testWidgets('tooltip labels an estimated tank with the (est.) suffix', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

Fixes a `Offset argument contained a NaN value` crash (and a missing tooltip) when scrubbing the dive profile chart on dives whose dive computer logged a **tank-pressure channel with no transmitter paired** — i.e. an all-zero (all-equal) pressure series. This affects **~192 dives** in a real library (e.g. #835, #882).

### Root cause
In `_buildMultiTankPressureLines`, an all-equal pressure series collapses the pressure axis range to zero width (`globalMin == globalMax`). `_mapValueToDepth` then computes `(v - min) / (max - min) = 0 / 0 = NaN` for every `FlSpot`. fl_chart *skips* NaN spots when drawing the line (so the chart still renders), but crashes when drawing the touched-spot indicator / tooltip anchor **on hover**, aborting the tooltip paint (hence "no tooltip"). In the fullscreen playback view the aborted frame cascaded into a secondary framework `ancestor == this` assertion.

## Changes

- Skip the tank-pressure line when the pressure range across all tanks is zero — such a series carries no information and only ever rendered as broken NaN spots.
- Defense in depth: `_mapValueToDepth` returns the axis midpoint instead of dividing by a zero span, so no degenerate metric range can NaN-crash the chart.
- Add a regression test that hover-scrubs over an all-zero pressure series and asserts no exception.

## Test Plan

- [x] `flutter test` passes (dive_profile_chart_test.dart: 124/124, incl. new regression test)
- [x] `flutter analyze` passes (no issues)
- [x] Manual testing on: macOS (recommended — navigate to a dive with a no-transmitter pressure series and hover-scrub)