### PR TITLE
fix(startup): converge maintenance backfill + progress bar (#524)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -245,6 +245,24 @@ class GpsTrackPointsLocal extends Table {
   // coverage:ignore-end
 }
 
+/// Device-local idempotency ledger for [StartupMaintenanceTask]s.
+///
+/// A maintenance task records the entities it has handled here (keyed by an
+/// opaque [taskName]), so its `pendingWork()` can exclude already-processed
+/// items and converge to zero. Task identity lives in the data, not the schema,
+/// so new maintenance tasks reuse this table with no further migration.
+///
+/// Never synced (not in `_hlcTables`): it is per-device bookkeeping, like a
+/// cache.
+class MaintenanceProcessed extends Table {
+  TextColumn get taskName => text()();
+  TextColumn get entityId => text()();
+  IntColumn get attemptedAt => integer()(); // epoch millis
+
+  @override
+  Set<Column> get primaryKey => {taskName, entityId};
+}
+
 /// Saved dive plans (dive planner redesign, Phase 2)
 class DivePlans extends Table {
   // coverage:ignore-start
@@ -2007,6 +2025,8 @@ class FieldPresets extends Table {
     // GPS surface track logging (discussion #289)
     GpsTracks,
     GpsTrackPointsLocal,
+    // Generic device-local maintenance ledger (issue #524)
+    MaintenanceProcessed,
     // Saved dive plans (planner redesign Phase 2)
     DivePlans,
     DivePlanTanks,
@@ -2030,7 +2050,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 102;
+  static const int currentSchemaVersion = 103;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -2136,6 +2156,7 @@ class AppDatabase extends _$AppDatabase {
     100,
     101,
     102,
+    103,
   ];
 
   /// Tables that carry a per-row Hybrid Logical Clock for cross-device conflict
@@ -4979,6 +5000,20 @@ class AppDatabase extends _$AppDatabase {
           await _relinkStrandedTankPressures();
         }
         if (from < 102) await reportProgress();
+        if (from < 103) {
+          // Generic device-local maintenance ledger (issue #524). Raw
+          // idempotent DDL (v98 checklist idiom); the beforeOpen backstop
+          // re-asserts it against schema-version collisions. Never synced.
+          await customStatement('''
+            CREATE TABLE IF NOT EXISTS maintenance_processed (
+              task_name TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              attempted_at INTEGER NOT NULL,
+              PRIMARY KEY (task_name, entity_id)
+            )
+          ''');
+        }
+        if (from < 103) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -5018,6 +5053,10 @@ class AppDatabase extends _$AppDatabase {
           CREATE INDEX IF NOT EXISTS idx_dive_plan_segments_plan_id
           ON dive_plan_segments(plan_id)
         ''');
+
+        // v103 backstop: re-assert the maintenance ledger (collision-safe,
+        // idempotent).
+        await createMigrator().createTable(maintenanceProcessed);
       },
     );
   }

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -36,6 +36,7 @@ import 'package:submersion/main.dart' show SubmersionRestart;
 typedef ServiceInitializer =
     Future<void> Function(
       void Function(int currentStep, int totalSteps) onMigrationProgress,
+      MaintenanceProgressReporter onMaintenanceProgress,
     );
 
 /// Callback signature for the schema-version probe used by [StartupWrapper]
@@ -47,6 +48,7 @@ enum _StartupState {
   initializing,
   backingUp,
   migrating,
+  optimizing,
   backupFailed,
   recoveryRequired,
   recovering,
@@ -102,6 +104,9 @@ class _StartupWrapperState extends State<StartupWrapper>
     currentStep: 0,
     totalSteps: 0,
   );
+
+  /// User-facing label for the current maintenance task (optimizing state).
+  String _maintenanceLabel = '';
   String _errorMessage = '';
   bool _isVersionMismatch = false;
   int _dbVersion = 0;
@@ -288,8 +293,24 @@ class _StartupWrapperState extends State<StartupWrapper>
       }
     }
 
+    // Maintenance tasks report (label, completed, total). Flipping to the
+    // optimizing state only happens when a task actually reports work, so a
+    // caught-up launch never shows this UI (no flicker).
+    void onMaintenance(String label, int completed, int total) {
+      if (mounted) {
+        setState(() {
+          _state = _StartupState.optimizing;
+          _maintenanceLabel = label;
+          _progress = MigrationProgress(
+            currentStep: completed,
+            totalSteps: total,
+          );
+        });
+      }
+    }
+
     if (widget.initializerOverride != null) {
-      await widget.initializerOverride!(onProgress);
+      await widget.initializerOverride!(onProgress, onMaintenance);
       return;
     }
 
@@ -320,7 +341,7 @@ class _StartupWrapperState extends State<StartupWrapper>
         mediaRepository: MediaRepository(),
         diveRepository: DiveRepository(),
       ),
-    ]).run();
+    ]).run(onProgress: onMaintenance);
   }
 
   Future<void> _runPreMigrationBackup({
@@ -549,12 +570,14 @@ class _StartupWrapperState extends State<StartupWrapper>
             width: 240,
             child: AnimatedSize(
               duration: const Duration(milliseconds: 200),
-              child: _state == _StartupState.migrating
+              child:
+                  (_state == _StartupState.migrating ||
+                      _state == _StartupState.optimizing)
                   ? Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         LinearProgressIndicator(
-                          value: _progress.fraction,
+                          value: _progress.fraction.clamp(0.0, 1.0).toDouble(),
                           backgroundColor: Colors.white.withValues(alpha: 0.2),
                           valueColor: const AlwaysStoppedAnimation<Color>(
                             Colors.white,
@@ -562,8 +585,11 @@ class _StartupWrapperState extends State<StartupWrapper>
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Upgrading database... '
-                          'step ${_progress.currentStep} of ${_progress.totalSteps}',
+                          _state == _StartupState.migrating
+                              ? 'Upgrading database... '
+                                    'step ${_progress.currentStep} of ${_progress.totalSteps}'
+                              : '$_maintenanceLabel... '
+                                    '${_progress.currentStep} of ${_progress.totalSteps}',
                           style: TextStyle(
                             fontSize: 13,
                             color: Colors.white.withValues(alpha: 0.8),

--- a/lib/core/services/maintenance/maintenance_ledger_repository.dart
+++ b/lib/core/services/maintenance/maintenance_ledger_repository.dart
@@ -50,15 +50,28 @@ class MaintenanceLedgerRepository {
     final ids = entityIds.toList();
     if (ids.isEmpty) return;
     final millis = (at ?? DateTime.now()).millisecondsSinceEpoch;
+
+    MaintenanceProcessedCompanion row(String id) =>
+        MaintenanceProcessedCompanion.insert(
+          taskName: taskName,
+          entityId: id,
+          attemptedAt: millis,
+        );
+
+    // Common case (the backfill marks one item at a time): a single insert
+    // avoids the batch/transaction wrapper.
+    if (ids.length == 1) {
+      await _db
+          .into(_db.maintenanceProcessed)
+          .insert(row(ids.first), mode: InsertMode.insertOrIgnore);
+      return;
+    }
+
     await _db.batch((batch) {
       for (final id in ids) {
         batch.insert(
           _db.maintenanceProcessed,
-          MaintenanceProcessedCompanion.insert(
-            taskName: taskName,
-            entityId: id,
-            attemptedAt: millis,
-          ),
+          row(id),
           mode: InsertMode.insertOrIgnore,
         );
       }

--- a/lib/core/services/maintenance/maintenance_ledger_repository.dart
+++ b/lib/core/services/maintenance/maintenance_ledger_repository.dart
@@ -1,0 +1,67 @@
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+/// Device-local idempotency ledger for [StartupMaintenanceTask]s.
+///
+/// A task records the entity ids it has handled (namespaced by an opaque
+/// task name); its `pendingWork()` excludes ledgered ids so the backlog
+/// converges to zero. Reused by every maintenance task with no schema change.
+class MaintenanceLedgerRepository {
+  final AppDatabase? _injected;
+
+  /// [db] is injected in tests; production defaults to the live singleton so a
+  /// restore that swaps the database is picked up (mirrors [MediaRepository]).
+  MaintenanceLedgerRepository([AppDatabase? db]) : _injected = db;
+
+  AppDatabase get _db => _injected ?? DatabaseService.instance.database;
+
+  /// Number of entities recorded for [taskName].
+  Future<int> countProcessed(String taskName) async {
+    final row = await _db
+        .customSelect(
+          'SELECT COUNT(*) AS c FROM maintenance_processed '
+          'WHERE task_name = ?',
+          variables: [Variable.withString(taskName)],
+        )
+        .getSingle();
+    return row.read<int>('c');
+  }
+
+  /// Entity ids recorded for [taskName].
+  Future<Set<String>> processedEntityIds(String taskName) async {
+    final rows = await _db
+        .customSelect(
+          'SELECT entity_id FROM maintenance_processed WHERE task_name = ?',
+          variables: [Variable.withString(taskName)],
+        )
+        .get();
+    return rows.map((r) => r.read<String>('entity_id')).toSet();
+  }
+
+  /// Records that [taskName] has handled each id in [entityIds]. Idempotent on
+  /// the (task_name, entity_id) primary key.
+  Future<void> markProcessed(
+    String taskName,
+    Iterable<String> entityIds, {
+    DateTime? at,
+  }) async {
+    final ids = entityIds.toList();
+    if (ids.isEmpty) return;
+    final millis = (at ?? DateTime.now()).millisecondsSinceEpoch;
+    await _db.batch((batch) {
+      for (final id in ids) {
+        batch.insert(
+          _db.maintenanceProcessed,
+          MaintenanceProcessedCompanion.insert(
+            taskName: taskName,
+            entityId: id,
+            attemptedAt: millis,
+          ),
+          mode: InsertMode.insertOrIgnore,
+        );
+      }
+    });
+  }
+}

--- a/lib/core/services/maintenance/startup_maintenance_task.dart
+++ b/lib/core/services/maintenance/startup_maintenance_task.dart
@@ -62,13 +62,14 @@ class StartupMaintenanceRunner {
         );
 
         // Convergence safety net: if the backlog did not shrink, the task is
-        // stuck (likely a persistent per-item failure). Log loudly instead of
-        // silently repeating a startup hang on every future launch.
+        // stuck (likely a persistent per-item failure) or growing. Log loudly
+        // instead of silently repeating a startup hang on every future launch.
         final remaining = await task.pendingWork();
         if (remaining >= total) {
           _log.warning(
-            'Startup maintenance task "${task.name}" made no progress '
-            '($remaining of $total still pending) - check earlier error logs.',
+            'Startup maintenance task "${task.name}" did not reduce its '
+            'backlog ($remaining of $total pending after run) - check earlier '
+            'error logs.',
           );
         }
       } catch (e, stackTrace) {

--- a/lib/core/services/maintenance/startup_maintenance_task.dart
+++ b/lib/core/services/maintenance/startup_maintenance_task.dart
@@ -1,17 +1,24 @@
 import 'package:submersion/core/services/logger_service.dart';
 
+/// Reports incremental progress within a task: [completed] work units done.
+typedef MaintenanceProgressCallback = void Function(int completed);
+
+/// Reports a task's progress to the UI: its [label], [completed] of [total].
+typedef MaintenanceProgressReporter =
+    void Function(String label, int completed, int total);
+
 /// A cleanup/backfill task run once per launch, after the database is open.
 ///
-/// Tasks exist to reconcile data that older app versions left in an incomplete
-/// state (e.g. backfilling values a feature now expects). They run on every
-/// launch rather than being gated to a single schema migration, so they also
-/// self-heal after a database restore — which reopens an older database in-app,
-/// past the migration path. That makes idempotency the core contract:
+/// Tasks reconcile data older app versions left incomplete. They run on every
+/// launch (so they also self-heal after a database restore, which reopens an
+/// older database in-app past the migration path), which makes idempotency the
+/// core contract:
 ///
-/// - [run] MUST be safe to invoke on every launch. Once its work is done it
-///   should become a cheap no-op (typically by scoping its own query to the
-///   rows that still need it, so a completed task finds nothing to do).
-/// - [run] MUST NOT assume it is the first time it has run.
+/// - [pendingWork] MUST be a cheap, indexed count of remaining units. It is
+///   called on every launch; the runner only invokes [run] when it is > 0.
+/// - [run] MUST be idempotent and drive [pendingWork] strictly toward 0 (record
+///   handled entities durably - e.g. via MaintenanceLedgerRepository - so
+///   items that cannot produce their normal artifact still drop out).
 ///
 /// The [StartupMaintenanceRunner] invokes tasks best-effort: a throwing task is
 /// logged and does not prevent the others (or app startup) from proceeding.
@@ -19,8 +26,15 @@ abstract interface class StartupMaintenanceTask {
   /// Stable, human-readable identifier used in logs.
   String get name;
 
-  /// Perform the task. Must be idempotent (see class docs).
-  Future<void> run();
+  /// User-facing label shown on the startup progress bar.
+  String get progressLabel;
+
+  /// Cheap, indexed count of remaining work units (0 => nothing to do).
+  Future<int> pendingWork();
+
+  /// Perform the work. Only called when [pendingWork] > 0. [onProgress] is
+  /// ticked with the running completed-count as each unit finishes.
+  Future<void> run({MaintenanceProgressCallback? onProgress});
 }
 
 /// Runs a list of [StartupMaintenanceTask]s best-effort during startup.
@@ -34,11 +48,29 @@ class StartupMaintenanceRunner {
   StartupMaintenanceRunner(this._tasks);
 
   /// Runs every task in order. Each is isolated: a failure is logged and the
-  /// remaining tasks still run.
-  Future<void> run() async {
+  /// remaining tasks still run. Tasks with no pending work are skipped cheaply.
+  Future<void> run({MaintenanceProgressReporter? onProgress}) async {
     for (final task in _tasks) {
       try {
-        await task.run();
+        final total = await task.pendingWork();
+        if (total == 0) continue; // cheap gate: skip the heavy path entirely
+
+        onProgress?.call(task.progressLabel, 0, total);
+        await task.run(
+          onProgress: (done) =>
+              onProgress?.call(task.progressLabel, done, total),
+        );
+
+        // Convergence safety net: if the backlog did not shrink, the task is
+        // stuck (likely a persistent per-item failure). Log loudly instead of
+        // silently repeating a startup hang on every future launch.
+        final remaining = await task.pendingWork();
+        if (remaining >= total) {
+          _log.warning(
+            'Startup maintenance task "${task.name}" made no progress '
+            '($remaining of $total still pending) - check earlier error logs.',
+          );
+        }
       } catch (e, stackTrace) {
         _log.error(
           'Startup maintenance task "${task.name}" failed',

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -603,32 +603,73 @@ class MediaRepository {
     }
   }
 
-  /// Dive ids that have at least one dive-linked media item missing its
-  /// [MediaEnrichment] row, where the dive also has primary profile points to
-  /// enrich against.
+  /// Ledger namespace for the photo-enrichment backfill (issues #511, #524).
+  static const String _enrichmentTaskName = 'photo-enrichment-backfill';
+
+  /// Shared WHERE predicate for enrichment-backfill candidate media.
   ///
-  /// Used by the enrichment backfill (issue #511): photos linked before the
-  /// profile-marker feature never had enrichment computed, so their markers
-  /// don't render. Restricting to profiled dives keeps the backfill
-  /// self-terminating — every candidate the enrichment service can process
-  /// gets a row and drops out of this query.
-  Future<List<String>> diveIdsNeedingEnrichmentBackfill() async {
+  /// Media that is dive-linked, timestamped, not an instructor signature, has
+  /// no enrichment row, sits on a dive with a primary profile, and has not been
+  /// recorded in the maintenance ledger for this task. Restricting to these
+  /// keeps the backfill self-terminating: every candidate either gets an
+  /// enrichment row or is marked in the ledger, so it drops out.
+  static const String _enrichmentCandidateWhere = '''
+      m.dive_id IS NOT NULL
+      AND m.taken_at IS NOT NULL
+      AND m.file_type != 'instructor_signature'
+      AND NOT EXISTS (
+        SELECT 1 FROM media_enrichment e WHERE e.media_id = m.id
+      )
+      AND EXISTS (
+        SELECT 1 FROM dive_profiles p
+        WHERE p.dive_id = m.dive_id AND p.is_primary = 1
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM maintenance_processed mp
+        WHERE mp.task_name = 'photo-enrichment-backfill'
+          AND mp.entity_id = m.id
+      )
+  ''';
+
+  /// Cheap count of remaining enrichment-backfill candidate media (issue #524).
+  Future<int> countEnrichmentBackfillCandidates() async {
+    try {
+      final row = await _db
+          .customSelect(
+            'SELECT COUNT(*) AS c FROM media m WHERE $_enrichmentCandidateWhere',
+          )
+          .getSingle();
+      return row.read<int>('c');
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to count enrichment backfill candidates',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  /// Distinct dives that have enrichment-backfill candidate media, each with
+  /// its effective start time (entry time, else dive date-time) in epoch ms.
+  Future<List<({String diveId, int diveStartMs})>>
+  divesNeedingEnrichmentBackfill() async {
     try {
       final rows = await _db.customSelect('''
-        SELECT DISTINCT m.dive_id AS dive_id
+        SELECT DISTINCT m.dive_id AS dive_id,
+               COALESCE(d.entry_time, d.dive_date_time) AS start_ms
         FROM media m
-        WHERE m.dive_id IS NOT NULL
-          AND m.taken_at IS NOT NULL
-          AND m.file_type != 'instructor_signature'
-          AND NOT EXISTS (
-            SELECT 1 FROM media_enrichment e WHERE e.media_id = m.id
-          )
-          AND EXISTS (
-            SELECT 1 FROM dive_profiles p
-            WHERE p.dive_id = m.dive_id AND p.is_primary = 1
-          )
+        JOIN dives d ON d.id = m.dive_id
+        WHERE $_enrichmentCandidateWhere
       ''').get();
-      return rows.map((row) => row.data['dive_id'] as String).toList();
+      return rows
+          .map(
+            (r) => (
+              diveId: r.read<String>('dive_id'),
+              diveStartMs: r.read<int>('start_ms'),
+            ),
+          )
+          .toList();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to list dives needing enrichment backfill',
@@ -637,6 +678,55 @@ class MediaRepository {
       );
       rethrow;
     }
+  }
+
+  /// Candidate media on a single dive, mapped like [getMediaForDive] so
+  /// [domain.MediaItem.takenAt] keeps its wall-clock semantics. Excludes media
+  /// already recorded in the maintenance ledger for this task.
+  Future<List<domain.MediaItem>> candidateEnrichmentMediaForDive(
+    String diveId,
+  ) async {
+    try {
+      final query =
+          _db.select(_db.media).join([
+              leftOuterJoin(
+                _db.mediaEnrichment,
+                _db.mediaEnrichment.mediaId.equalsExp(_db.media.id),
+              ),
+            ])
+            ..where(_db.media.diveId.equals(diveId))
+            ..where(_db.media.takenAt.isNotNull())
+            ..where(_db.media.fileType.isNotValue('instructor_signature'))
+            ..where(_db.mediaEnrichment.id.isNull()) // no enrichment row yet
+            ..orderBy([OrderingTerm.asc(_db.media.takenAt)]);
+
+      final rows = await query.get();
+      final ledgered = await _ledgeredMediaIds();
+      final result = <domain.MediaItem>[];
+      for (final row in rows) {
+        final mediaRow = row.readTable(_db.media);
+        if (ledgered.contains(mediaRow.id)) continue;
+        result.add(_mapRowToMediaItem(mediaRow, null));
+      }
+      return result;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to load candidate enrichment media for dive: $diveId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  Future<Set<String>> _ledgeredMediaIds() async {
+    final rows = await _db
+        .customSelect(
+          'SELECT entity_id FROM maintenance_processed WHERE task_name = ?',
+          variables: [Variable.withString(_enrichmentTaskName)],
+        )
+        .get();
+    return rows.map((r) => r.read<String>('entity_id')).toSet();
   }
 
   /// Get the set of platformAssetIds already linked to a specific dive.

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -604,7 +604,12 @@ class MediaRepository {
   }
 
   /// Ledger namespace for the photo-enrichment backfill (issues #511, #524).
-  static const String _enrichmentTaskName = 'photo-enrichment-backfill';
+  ///
+  /// Single source of truth: `MediaEnrichmentBackfillService.name` references
+  /// this so the ledger `task_name` written by the task always matches the
+  /// `task_name` the candidate queries exclude on. Renaming one alone would
+  /// regress the task to non-convergence.
+  static const String enrichmentBackfillTaskName = 'photo-enrichment-backfill';
 
   /// Shared WHERE predicate for enrichment-backfill candidate media.
   ///
@@ -627,7 +632,7 @@ class MediaRepository {
       )
       AND NOT EXISTS (
         SELECT 1 FROM maintenance_processed mp
-        WHERE mp.task_name = '$_enrichmentTaskName'
+        WHERE mp.task_name = '$enrichmentBackfillTaskName'
           AND mp.entity_id = m.id
       )
   ''';
@@ -704,7 +709,7 @@ class MediaRepository {
             ..where(
               const CustomExpression<bool>(
                 "NOT EXISTS (SELECT 1 FROM maintenance_processed mp "
-                "WHERE mp.task_name = '$_enrichmentTaskName' "
+                "WHERE mp.task_name = '$enrichmentBackfillTaskName' "
                 "AND mp.entity_id = media.id)",
               ),
             )

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -613,7 +613,8 @@ class MediaRepository {
   /// recorded in the maintenance ledger for this task. Restricting to these
   /// keeps the backfill self-terminating: every candidate either gets an
   /// enrichment row or is marked in the ledger, so it drops out.
-  static const String _enrichmentCandidateWhere = '''
+  static const String _enrichmentCandidateWhere =
+      '''
       m.dive_id IS NOT NULL
       AND m.taken_at IS NOT NULL
       AND m.file_type != 'instructor_signature'
@@ -626,7 +627,7 @@ class MediaRepository {
       )
       AND NOT EXISTS (
         SELECT 1 FROM maintenance_processed mp
-        WHERE mp.task_name = 'photo-enrichment-backfill'
+        WHERE mp.task_name = '$_enrichmentTaskName'
           AND mp.entity_id = m.id
       )
   ''';
@@ -698,17 +699,21 @@ class MediaRepository {
             ..where(_db.media.takenAt.isNotNull())
             ..where(_db.media.fileType.isNotValue('instructor_signature'))
             ..where(_db.mediaEnrichment.id.isNull()) // no enrichment row yet
+            // Exclude ledgered media in SQL (indexed PK lookup) rather than
+            // fetching the whole ledger and filtering in memory per dive.
+            ..where(
+              const CustomExpression<bool>(
+                "NOT EXISTS (SELECT 1 FROM maintenance_processed mp "
+                "WHERE mp.task_name = '$_enrichmentTaskName' "
+                "AND mp.entity_id = media.id)",
+              ),
+            )
             ..orderBy([OrderingTerm.asc(_db.media.takenAt)]);
 
       final rows = await query.get();
-      final ledgered = await _ledgeredMediaIds();
-      final result = <domain.MediaItem>[];
-      for (final row in rows) {
-        final mediaRow = row.readTable(_db.media);
-        if (ledgered.contains(mediaRow.id)) continue;
-        result.add(_mapRowToMediaItem(mediaRow, null));
-      }
-      return result;
+      return rows
+          .map((row) => _mapRowToMediaItem(row.readTable(_db.media), null))
+          .toList();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to load candidate enrichment media for dive: $diveId',
@@ -717,16 +722,6 @@ class MediaRepository {
       );
       rethrow;
     }
-  }
-
-  Future<Set<String>> _ledgeredMediaIds() async {
-    final rows = await _db
-        .customSelect(
-          'SELECT entity_id FROM maintenance_processed WHERE task_name = ?',
-          variables: [Variable.withString(_enrichmentTaskName)],
-        )
-        .get();
-    return rows.map((r) => r.read<String>('entity_id')).toSet();
   }
 
   /// Get the set of platformAssetIds already linked to a specific dive.

--- a/lib/features/media/data/services/media_enrichment_backfill_service.dart
+++ b/lib/features/media/data/services/media_enrichment_backfill_service.dart
@@ -36,8 +36,10 @@ class MediaEnrichmentBackfillService implements StartupMaintenanceTask {
        _ledger = ledger ?? MaintenanceLedgerRepository(),
        _enrichmentService = enrichmentService;
 
+  // Single source of truth shared with the candidate queries, so the ledger
+  // task_name written here always matches the one the queries exclude on.
   @override
-  String get name => 'photo-enrichment-backfill';
+  String get name => MediaRepository.enrichmentBackfillTaskName;
 
   @override
   String get progressLabel => 'Optimizing dive data';

--- a/lib/features/media/data/services/media_enrichment_backfill_service.dart
+++ b/lib/features/media/data/services/media_enrichment_backfill_service.dart
@@ -1,109 +1,126 @@
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/maintenance/maintenance_ledger_repository.dart';
 import 'package:submersion/core/services/maintenance/startup_maintenance_task.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/services/enrichment_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 
-/// One-shot backfill for photo/video profile markers (issue #511).
+/// One-shot backfill for photo/video profile markers (issues #511, #524).
 ///
 /// Media linked to a dive before the profile-marker feature shipped never had
 /// their [MediaEnrichment] computed, so no marker renders on the dive profile
-/// chart — unlinking and relinking the media is currently the only way to make
-/// the marker appear. This service computes the missing enrichment for
-/// existing dive-linked media using the same [EnrichmentService] the
-/// import/link path uses, so backfilled markers match relinked ones exactly.
+/// chart. This task computes the missing enrichment using the same
+/// [EnrichmentService] the import/link path uses, so backfilled markers match
+/// relinked ones exactly.
 ///
-/// It is safe to run on every launch (see [StartupMaintenanceTask]): the
-/// candidate query only returns dives that still have unenriched media *and* a
-/// profile to enrich against, so each item enriched drops out of the set and
-/// the work naturally converges to zero.
+/// Convergence (issue #524): every candidate media item it visits is recorded
+/// in the maintenance ledger (whether it was enriched or the attempt failed
+/// deterministically), so it drops out of [pendingWork] and the backlog reaches
+/// zero. Combined with the runner's cheap [pendingWork] gate, a caught-up launch
+/// does no per-dive work at all - only a single indexed COUNT.
 class MediaEnrichmentBackfillService implements StartupMaintenanceTask {
   final MediaRepository _mediaRepository;
   final DiveRepository _diveRepository;
+  final MaintenanceLedgerRepository _ledger;
   final EnrichmentService _enrichmentService;
   final _log = LoggerService.forClass(MediaEnrichmentBackfillService);
 
   MediaEnrichmentBackfillService({
     required MediaRepository mediaRepository,
     required DiveRepository diveRepository,
+    MaintenanceLedgerRepository? ledger,
     EnrichmentService enrichmentService = const EnrichmentService(),
   }) : _mediaRepository = mediaRepository,
        _diveRepository = diveRepository,
+       _ledger = ledger ?? MaintenanceLedgerRepository(),
        _enrichmentService = enrichmentService;
 
   @override
   String get name => 'photo-enrichment-backfill';
 
-  /// [StartupMaintenanceTask] entry point; delegates to [backfill], discarding
-  /// the count the runner has no use for.
   @override
-  Future<void> run() => backfill();
+  String get progressLabel => 'Optimizing dive data';
 
-  /// Computes and saves enrichment for every dive-linked media item that lacks
-  /// it, on dives that have a profile. Best-effort per dive: an error on one
-  /// dive is logged and does not abort the rest. Returns the number of media
-  /// items enriched.
-  Future<int> backfill() async {
-    final diveIds = await _mediaRepository.diveIdsNeedingEnrichmentBackfill();
-    if (diveIds.isEmpty) return 0;
+  @override
+  Future<int> pendingWork() =>
+      _mediaRepository.countEnrichmentBackfillCandidates();
+
+  @override
+  Future<void> run({MaintenanceProgressCallback? onProgress}) =>
+      backfill(onProgress: onProgress);
+
+  /// Enriches every candidate media item. Best-effort per item: a failure is
+  /// logged, the item is still recorded in the ledger (a deterministic failure
+  /// must not re-qualify forever), and the rest proceed. Returns the number of
+  /// items for which enrichment was persisted.
+  Future<int> backfill({MaintenanceProgressCallback? onProgress}) async {
+    final dives = await _mediaRepository.divesNeedingEnrichmentBackfill();
+    if (dives.isEmpty) return 0;
 
     var enriched = 0;
-    for (final diveId in diveIds) {
-      try {
-        enriched += await _backfillDive(diveId);
-      } catch (e, stackTrace) {
-        // One bad dive must not stop the rest; a later launch retries it.
-        _log.error(
-          'Enrichment backfill failed for dive $diveId',
-          error: e,
-          stackTrace: stackTrace,
-        );
+    var processed = 0;
+    for (final d in dives) {
+      // Profile-only load (not the full dive graph): enrichment needs just the
+      // primary profile points and the effective entry time.
+      final profile = await _diveRepository.getDiveProfile(d.diveId);
+      if (profile.isEmpty) continue; // defensive; candidates have a profile
+      final start = DateTime.fromMillisecondsSinceEpoch(
+        d.diveStartMs,
+        isUtc: true,
+      );
+      final media = await _mediaRepository.candidateEnrichmentMediaForDive(
+        d.diveId,
+      );
+      for (final item in media) {
+        try {
+          final result = _enrichmentService.calculateEnrichment(
+            profile: profile,
+            diveStartTime: start,
+            photoTime: item.takenAt,
+          );
+          // Mirror the import path: don't persist a row we couldn't position.
+          final unpositioned =
+              result.depthMeters == null &&
+              result.matchConfidence == MatchConfidence.noProfile;
+          if (!unpositioned) {
+            await _mediaRepository.saveEnrichment(
+              MediaEnrichment(
+                id: '',
+                mediaId: item.id,
+                diveId: d.diveId,
+                depthMeters: result.depthMeters,
+                temperatureCelsius: result.temperatureCelsius,
+                elapsedSeconds: result.elapsedSeconds,
+                matchConfidence: result.matchConfidence,
+                timestampOffsetSeconds: result.timestampOffsetSeconds,
+                createdAt: DateTime.now(),
+              ),
+            );
+            enriched++;
+          }
+          // Terminal: recorded whether enriched or unpositioned, so it drops
+          // out of pendingWork on the next launch.
+          await _ledger.markProcessed(name, [item.id]);
+        } catch (e, stackTrace) {
+          // A deterministic failure (e.g. a constraint) would otherwise re-run
+          // every launch (issue #524). Record it so the backlog still
+          // converges; the loud log surfaces the data-quality issue.
+          _log.error(
+            'Enrichment failed for media ${item.id} on dive ${d.diveId}; '
+            'recording as processed to avoid a launch-time re-scan loop',
+            error: e,
+            stackTrace: stackTrace,
+          );
+          await _ledger.markProcessed(name, [item.id]);
+        }
+        processed++;
+        onProgress?.call(processed);
       }
     }
 
     if (enriched > 0) {
       _log.info('Backfilled enrichment for $enriched media item(s)');
-    }
-    return enriched;
-  }
-
-  Future<int> _backfillDive(String diveId) async {
-    final dive = await _diveRepository.getDiveById(diveId);
-    if (dive == null || dive.profile.isEmpty) return 0;
-
-    final media = await _mediaRepository.getMediaForDive(diveId);
-    var enriched = 0;
-    for (final item in media) {
-      if (item.enrichment != null) continue;
-      // Signatures are not dive-moment media and never get a marker.
-      if (item.mediaType == MediaType.instructorSignature) continue;
-
-      final result = _enrichmentService.calculateEnrichment(
-        profile: dive.profile,
-        diveStartTime: dive.effectiveEntryTime,
-        photoTime: item.takenAt,
-      );
-      // Mirror the import path: don't persist a row we couldn't position.
-      if (result.depthMeters == null &&
-          result.matchConfidence == MatchConfidence.noProfile) {
-        continue;
-      }
-
-      await _mediaRepository.saveEnrichment(
-        MediaEnrichment(
-          id: '',
-          mediaId: item.id,
-          diveId: diveId,
-          depthMeters: result.depthMeters,
-          temperatureCelsius: result.temperatureCelsius,
-          elapsedSeconds: result.elapsedSeconds,
-          matchConfidence: result.matchConfidence,
-          timestampOffsetSeconds: result.timestampOffsetSeconds,
-          createdAt: DateTime.now(),
-        ),
-      );
-      enriched++;
     }
     return enriched;
   }

--- a/test/core/database/maintenance_processed_migration_test.dart
+++ b/test/core/database/maintenance_processed_migration_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+import '../../helpers/test_database.dart';
+
+void main() {
+  setUp(setUpTestDatabase);
+  tearDown(tearDownTestDatabase);
+
+  test(
+    'fresh database has maintenance_processed with a composite PK',
+    () async {
+      final db = DatabaseService.instance.database;
+
+      // Force schema creation.
+      await db.customSelect('SELECT 1').get();
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('maintenance_processed')")
+          .get();
+      final names = cols.map((r) => r.read<String>('name')).toSet();
+      expect(
+        names,
+        containsAll(<String>{'task_name', 'entity_id', 'attempted_at'}),
+      );
+
+      // Composite primary key: task_name + entity_id.
+      final pkCols = cols
+          .where((r) => r.read<int>('pk') > 0)
+          .map((r) => r.read<String>('name'))
+          .toSet();
+      expect(pkCols, {'task_name', 'entity_id'});
+    },
+  );
+
+  test('currentSchemaVersion is 103', () {
+    expect(AppDatabase.currentSchemaVersion, 103);
+  });
+}

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -10,6 +10,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/domain/entities/migration_progress.dart';
 import 'package:submersion/core/presentation/pages/startup_page.dart';
+import 'package:submersion/core/services/maintenance/startup_maintenance_task.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
@@ -585,7 +586,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) => Completer<void>().future,
+          initializerOverride: (_, _) => Completer<void>().future,
         ),
       );
 
@@ -616,7 +617,7 @@ void main() {
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 5),
           preMigrationBackupFactory: _noOpBackupFactory,
-          initializerOverride: (onProgress) {
+          initializerOverride: (onProgress, _) {
             capturedCallback = onProgress;
             // Never completes -- we stay on the migration screen
             return Completer<void>().future;
@@ -659,7 +660,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw const DatabaseVersionMismatchException(
               databaseVersion: 99,
               appVersion: 63,
@@ -690,7 +691,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw Exception('Disk is full');
           },
         ),
@@ -719,7 +720,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw Exception('Something broke');
           },
           closeAppOverride: () => closeCalled = true,
@@ -748,7 +749,7 @@ void main() {
             locationService: locationService,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               throw const DatabaseVersionMismatchException(
                 databaseVersion: 70,
                 appVersion: 63,
@@ -778,7 +779,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) => Completer<void>().future,
+          initializerOverride: (_, _) => Completer<void>().future,
         ),
       );
 
@@ -804,7 +805,7 @@ void main() {
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 10),
           preMigrationBackupFactory: _noOpBackupFactory,
-          initializerOverride: (onProgress) {
+          initializerOverride: (onProgress, _) {
             progressCallback = onProgress;
             return Completer<void>().future;
           },
@@ -841,6 +842,47 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
     });
 
+    testWidgets(
+      'shows the optimizing progress bar when maintenance reports work',
+      (tester) async {
+        late MaintenanceProgressReporter maintenanceCallback;
+
+        await tester.pumpWidget(
+          _buildStartupWrapper(
+            prefs: prefs,
+            logFileService: logFileService,
+            locationService: locationService,
+            schemaVersionProbeOverride: (_) =>
+                (needsMigration: false, totalSteps: 0),
+            initializerOverride: (_, onMaintenance) {
+              maintenanceCallback = onMaintenance;
+              return Completer<void>().future; // stay on the splash
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // No progress UI until a task reports work.
+        expect(find.byType(LinearProgressIndicator), findsNothing);
+        expect(find.textContaining('Optimizing dive data'), findsNothing);
+
+        // A maintenance task reports 3 of 10 -> optimizing bar appears.
+        maintenanceCallback('Optimizing dive data', 3, 10);
+        await tester.pump();
+
+        expect(find.text('Optimizing dive data... 3 of 10'), findsOneWidget);
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+        final indicator = tester.widget<LinearProgressIndicator>(
+          find.byType(LinearProgressIndicator),
+        );
+        expect(indicator.value, closeTo(0.3, 1e-9));
+
+        // Drain the 1-second splash delay timer
+        await tester.pump(const Duration(seconds: 2));
+      },
+    );
+
     testWidgets('splash scaffold key is used during init', (tester) async {
       await tester.pumpWidget(
         _buildStartupWrapper(
@@ -849,7 +891,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) => Completer<void>().future,
+          initializerOverride: (_, _) => Completer<void>().future,
         ),
       );
 
@@ -873,7 +915,7 @@ void main() {
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 3),
           preMigrationBackupFactory: _noOpBackupFactory,
-          initializerOverride: (_) => Completer<void>().future,
+          initializerOverride: (_, _) => Completer<void>().future,
         ),
       );
 
@@ -893,7 +935,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw Exception('Test error');
           },
         ),
@@ -914,7 +956,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw Exception('Corrupt database header');
           },
         ),
@@ -937,7 +979,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw const DatabaseVersionMismatchException(
               databaseVersion: 100,
               appVersion: 50,
@@ -995,7 +1037,7 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: true, totalSteps: 5),
             preMigrationBackupFactory: failingFactory,
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               // Should never be called: backup failure blocks migration.
               throw StateError('initializer must not run on backup failure');
             },
@@ -1048,7 +1090,7 @@ void main() {
             preMigrationBackupFactory: flakyFactory,
             // Never completes so retry path stops at the "migrating" state,
             // avoiding go_router redirect that would need DatabaseService.
-            initializerOverride: (_) => Completer<void>().future,
+            initializerOverride: (_, _) => Completer<void>().future,
           ),
         );
 
@@ -1099,7 +1141,7 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: true, totalSteps: 1),
             preMigrationBackupFactory: alwaysFailingFactory,
-            initializerOverride: (_) async {},
+            initializerOverride: (_, _) async {},
           ),
         );
 
@@ -1150,7 +1192,7 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: true, totalSteps: 1),
             preMigrationBackupFactory: factory,
-            initializerOverride: (_) async {},
+            initializerOverride: (_, _) async {},
           ),
         );
 
@@ -1196,7 +1238,7 @@ void main() {
           schemaVersionProbeOverride: (_) =>
               (needsMigration: true, totalSteps: 1),
           preMigrationBackupFactory: factory,
-          initializerOverride: (_) async {},
+          initializerOverride: (_, _) async {},
           closeAppOverride: () => quitCalled++,
         ),
       );
@@ -1267,7 +1309,7 @@ void main() {
             locationService: locationService,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               throw sqlite3.SqliteException(
                 776,
                 'attempt to write a readonly database',
@@ -1305,7 +1347,7 @@ void main() {
             locationService: locationService,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               throw sqlite3.SqliteException(776, 'readonly');
             },
           ),
@@ -1328,7 +1370,7 @@ void main() {
             locationService: locationService,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               // SQLITE_BUSY — primary code 5; not in the READONLY family.
               throw sqlite3.SqliteException(5, 'database is locked');
             },
@@ -1355,7 +1397,7 @@ void main() {
             locationService: locationService,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               throw sqlite3.SqliteException(776, 'readonly');
             },
             closeAppOverride: () => closeCalled++,
@@ -1394,7 +1436,7 @@ void main() {
             locationService: locationService,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               throw sqlite3.SqliteException(776, 'readonly');
             },
           ),
@@ -1438,7 +1480,7 @@ void main() {
             locationService: flaky,
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
-            initializerOverride: (_) async {
+            initializerOverride: (_, _) async {
               throw sqlite3.SqliteException(776, 'readonly');
             },
           ),
@@ -1485,7 +1527,7 @@ void main() {
           locationService: flaky,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw sqlite3.SqliteException(776, 'readonly');
           },
         ),
@@ -1529,7 +1571,7 @@ void main() {
           locationService: flaky,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             throw sqlite3.SqliteException(776, 'readonly');
           },
           closeAppOverride: () => closeCalled++,
@@ -1565,7 +1607,7 @@ void main() {
           locationService: locationService,
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
-          initializerOverride: (_) async {
+          initializerOverride: (_, _) async {
             calls++;
             if (calls == 1) {
               throw sqlite3.SqliteException(776, 'readonly');

--- a/test/core/services/maintenance/maintenance_ledger_repository_test.dart
+++ b/test/core/services/maintenance/maintenance_ledger_repository_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/maintenance/maintenance_ledger_repository.dart';
+
+import '../../../helpers/test_database.dart';
+
+void main() {
+  late MaintenanceLedgerRepository ledger;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    ledger = MaintenanceLedgerRepository(DatabaseService.instance.database);
+  });
+  tearDown(tearDownTestDatabase);
+
+  test('records and counts processed entities per task', () async {
+    expect(await ledger.countProcessed('task-a'), 0);
+
+    await ledger.markProcessed('task-a', ['e1', 'e2']);
+    expect(await ledger.countProcessed('task-a'), 2);
+    expect(await ledger.processedEntityIds('task-a'), {'e1', 'e2'});
+  });
+
+  test('is idempotent on (taskName, entityId)', () async {
+    await ledger.markProcessed('task-a', ['e1']);
+    await ledger.markProcessed('task-a', ['e1']); // no throw, no duplicate
+    expect(await ledger.countProcessed('task-a'), 1);
+  });
+
+  test('task namespaces are independent', () async {
+    await ledger.markProcessed('task-a', ['e1']);
+    await ledger.markProcessed('task-b', ['e1', 'e2']);
+    expect(await ledger.countProcessed('task-a'), 1);
+    expect(await ledger.countProcessed('task-b'), 2);
+    expect(await ledger.processedEntityIds('task-a'), {'e1'});
+  });
+
+  test('markProcessed with an empty id list is a no-op', () async {
+    await ledger.markProcessed('task-a', const []);
+    expect(await ledger.countProcessed('task-a'), 0);
+  });
+}

--- a/test/core/services/maintenance/startup_maintenance_runner_test.dart
+++ b/test/core/services/maintenance/startup_maintenance_runner_test.dart
@@ -1,42 +1,81 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/maintenance/startup_maintenance_task.dart';
 
-class _RecordingTask implements StartupMaintenanceTask {
-  _RecordingTask(this.name, this._log, {this.throws = false});
+class _FakeTask implements StartupMaintenanceTask {
+  _FakeTask(
+    this.name, {
+    required int pending,
+    this.throwsOnRun = false,
+    this.convergesTo = 0,
+    List<String>? runLog,
+  }) : _pending = pending,
+       _runLog = runLog;
 
   @override
   final String name;
-  final List<String> _log;
-  final bool throws;
+  @override
+  String get progressLabel => 'Doing $name';
+
+  int _pending;
+  final int convergesTo;
+  final bool throwsOnRun;
+  final List<String>? _runLog;
 
   @override
-  Future<void> run() async {
-    _log.add(name);
-    if (throws) throw StateError('boom in $name');
+  Future<int> pendingWork() async => _pending;
+
+  @override
+  Future<void> run({MaintenanceProgressCallback? onProgress}) async {
+    _runLog?.add(name);
+    if (throwsOnRun) throw StateError('boom in $name');
+    for (var i = 1; i <= _pending; i++) {
+      onProgress?.call(i);
+    }
+    _pending = convergesTo; // simulate work reducing the backlog
   }
 }
 
 void main() {
-  test('runs every task in order', () async {
-    final calls = <String>[];
+  test('skips a task whose pendingWork is 0 (never calls run)', () async {
+    final runLog = <String>[];
     await StartupMaintenanceRunner([
-      _RecordingTask('a', calls),
-      _RecordingTask('b', calls),
-      _RecordingTask('c', calls),
+      _FakeTask('idle', pending: 0, runLog: runLog),
     ]).run();
-    expect(calls, ['a', 'b', 'c']);
+    expect(runLog, isEmpty);
+  });
+
+  test('runs a task with work and reports progress with its label', () async {
+    final events = <String>[];
+    await StartupMaintenanceRunner([_FakeTask('backfill', pending: 3)]).run(
+      onProgress: (label, done, total) => events.add('$label $done/$total'),
+    );
+    expect(events, [
+      'Doing backfill 0/3',
+      'Doing backfill 1/3',
+      'Doing backfill 2/3',
+      'Doing backfill 3/3',
+    ]);
   });
 
   test('a throwing task is isolated: later tasks still run', () async {
-    final calls = <String>[];
+    final runLog = <String>[];
     await StartupMaintenanceRunner([
-      _RecordingTask('a', calls),
-      _RecordingTask('b', calls, throws: true),
-      _RecordingTask('c', calls),
+      _FakeTask('a', pending: 1, runLog: runLog),
+      _FakeTask('b', pending: 1, throwsOnRun: true, runLog: runLog),
+      _FakeTask('c', pending: 1, runLog: runLog),
     ]).run();
-    // 'b' ran (and threw) but 'c' still ran; run() completed normally.
-    expect(calls, ['a', 'b', 'c']);
+    expect(runLog, ['a', 'b', 'c']);
   });
+
+  test(
+    'a task that does not converge does not throw (logged, not fatal)',
+    () async {
+      // pending stays at 2 after run(): the runner must complete normally.
+      await StartupMaintenanceRunner([
+        _FakeTask('stuck', pending: 2, convergesTo: 2),
+      ]).run();
+    },
+  );
 
   test('an empty task list is a no-op', () async {
     await StartupMaintenanceRunner(const []).run();

--- a/test/features/media/data/repositories/media_repository_enrichment_candidates_test.dart
+++ b/test/features/media/data/repositories/media_repository_enrichment_candidates_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/maintenance/maintenance_ledger_repository.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late MediaRepository media;
+  late DiveRepository dives;
+  late MaintenanceLedgerRepository ledger;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    media = MediaRepository();
+    dives = DiveRepository();
+    ledger = MaintenanceLedgerRepository(DatabaseService.instance.database);
+  });
+  tearDown(tearDownTestDatabase);
+
+  final diveStart = DateTime.utc(2025, 6, 1, 10, 0, 0);
+
+  Future<void> profiledDive(String id) => dives.createDive(
+    Dive(
+      id: id,
+      diveNumber: 1,
+      dateTime: diveStart,
+      entryTime: diveStart,
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0, temperature: 24),
+        DiveProfilePoint(timestamp: 120, depth: 20, temperature: 18),
+      ],
+    ),
+  );
+
+  Future<void> photo(String id, String diveId) {
+    final now = DateTime.now();
+    return media.createMedia(
+      MediaItem(
+        id: id,
+        diveId: diveId,
+        filePath: '/p/$id.jpg',
+        mediaType: MediaType.photo,
+        takenAt: DateTime(2025, 6, 1, 10, 1, 0),
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+  }
+
+  test('counts unenriched candidate media on profiled dives', () async {
+    await profiledDive('d1');
+    await photo('m1', 'd1');
+    await photo('m2', 'd1');
+    expect(await media.countEnrichmentBackfillCandidates(), 2);
+
+    final divesList = await media.divesNeedingEnrichmentBackfill();
+    expect(divesList.map((d) => d.diveId), ['d1']);
+    expect(divesList.single.diveStartMs, diveStart.millisecondsSinceEpoch);
+
+    final perDive = await media.candidateEnrichmentMediaForDive('d1');
+    expect(perDive.map((m) => m.id).toSet(), {'m1', 'm2'});
+  });
+
+  test('ledgered media are excluded from candidates', () async {
+    await profiledDive('d1');
+    await photo('m1', 'd1');
+    await photo('m2', 'd1');
+    await ledger.markProcessed('photo-enrichment-backfill', ['m1']);
+
+    expect(await media.countEnrichmentBackfillCandidates(), 1);
+    expect(
+      (await media.candidateEnrichmentMediaForDive('d1')).map((m) => m.id),
+      ['m2'],
+    );
+  });
+
+  test('a dive with no profile is not a candidate', () async {
+    await dives.createDive(
+      Dive(id: 'noprof', diveNumber: 2, dateTime: diveStart),
+    );
+    await photo('m1', 'noprof');
+    expect(await media.countEnrichmentBackfillCandidates(), 0);
+    expect(await media.divesNeedingEnrichmentBackfill(), isEmpty);
+  });
+}

--- a/test/features/media/data/repositories/media_repository_enrichment_candidates_test.dart
+++ b/test/features/media/data/repositories/media_repository_enrichment_candidates_test.dart
@@ -69,7 +69,9 @@ void main() {
     await profiledDive('d1');
     await photo('m1', 'd1');
     await photo('m2', 'd1');
-    await ledger.markProcessed('photo-enrichment-backfill', ['m1']);
+    await ledger.markProcessed(MediaRepository.enrichmentBackfillTaskName, [
+      'm1',
+    ]);
 
     expect(await media.countEnrichmentBackfillCandidates(), 1);
     expect(

--- a/test/features/media/data/services/media_enrichment_backfill_service_test.dart
+++ b/test/features/media/data/services/media_enrichment_backfill_service_test.dart
@@ -9,6 +9,15 @@ import 'package:submersion/features/media/domain/entities/media_item.dart';
 
 import '../../../../helpers/test_database.dart';
 
+/// A MediaRepository whose saveEnrichment always throws, to exercise the
+/// terminal-failure path: the item must still be ledger-marked so it converges.
+class _ThrowingSaveMediaRepository extends MediaRepository {
+  @override
+  Future<void> saveEnrichment(MediaEnrichment enrichment) async {
+    throw StateError('simulated save failure');
+  }
+}
+
 void main() {
   late MediaRepository mediaRepo;
   late DiveRepository diveRepo;
@@ -183,4 +192,29 @@ void main() {
     expect(await service.pendingWork(), 0);
     expect(await enrichmentFor('dive-1', 'sig-1'), isNull);
   });
+
+  test(
+    'an item whose save fails is still ledger-marked and does not re-qualify',
+    () async {
+      await createProfiledDive();
+      await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+
+      final throwingService = MediaEnrichmentBackfillService(
+        mediaRepository: _ThrowingSaveMediaRepository(),
+        diveRepository: diveRepo,
+        ledger: ledger,
+      );
+
+      // The save throws, is caught, and the item is marked processed so the
+      // backlog converges instead of re-scanning every launch (issue #524).
+      await throwingService.run();
+
+      expect(await throwingService.pendingWork(), 0);
+      expect(await enrichmentFor('dive-1', 'photo-1'), isNull);
+      expect(
+        await ledger.countProcessed(MediaRepository.enrichmentBackfillTaskName),
+        1,
+      );
+    },
+  );
 }

--- a/test/features/media/data/services/media_enrichment_backfill_service_test.dart
+++ b/test/features/media/data/services/media_enrichment_backfill_service_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/maintenance/maintenance_ledger_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
@@ -10,46 +12,41 @@ import '../../../../helpers/test_database.dart';
 void main() {
   late MediaRepository mediaRepo;
   late DiveRepository diveRepo;
+  late MaintenanceLedgerRepository ledger;
   late MediaEnrichmentBackfillService service;
 
   setUp(() async {
     await setUpTestDatabase();
     mediaRepo = MediaRepository();
     diveRepo = DiveRepository();
+    ledger = MaintenanceLedgerRepository(DatabaseService.instance.database);
     service = MediaEnrichmentBackfillService(
       mediaRepository: mediaRepo,
       diveRepository: diveRepo,
+      ledger: ledger,
     );
   });
-
   tearDown(tearDownTestDatabase);
 
   // Dive starting at a fixed wall-clock time with a two-point profile:
   // t=0s depth 0m/24C, t=120s depth 20m/18C.
-  //
-  // Dive entry time is stored/read as wall-clock-as-UTC; photo takenAt is
-  // stored/read as a LOCAL time and reinterpreted as wall-clock-UTC by the
-  // enrichment service. To make elapsed-seconds timezone-independent, express
-  // the dive start in UTC and photo times as LOCAL wall-clocks with the same
-  // clock face — mirroring a diver whose camera and computer share a timezone.
   final diveStart = DateTime.utc(2025, 6, 1, 10, 0, 0);
   DateTime photoAt(int secondsIn) =>
       DateTime(2025, 6, 1, 10, 0, 0).add(Duration(seconds: secondsIn));
 
-  Future<Dive> createProfiledDive({String id = 'dive-1'}) {
-    return diveRepo.createDive(
-      Dive(
-        id: id,
-        diveNumber: 1,
-        dateTime: diveStart,
-        entryTime: diveStart,
-        profile: const [
-          DiveProfilePoint(timestamp: 0, depth: 0, temperature: 24),
-          DiveProfilePoint(timestamp: 120, depth: 20, temperature: 18),
-        ],
-      ),
-    );
-  }
+  Future<Dive> createProfiledDive({String id = 'dive-1'}) =>
+      diveRepo.createDive(
+        Dive(
+          id: id,
+          diveNumber: 1,
+          dateTime: diveStart,
+          entryTime: diveStart,
+          profile: const [
+            DiveProfilePoint(timestamp: 0, depth: 0, temperature: 24),
+            DiveProfilePoint(timestamp: 120, depth: 20, temperature: 18),
+          ],
+        ),
+      );
 
   Future<MediaItem> linkPhoto({
     required String id,
@@ -72,8 +69,8 @@ void main() {
   }
 
   Future<MediaEnrichment?> enrichmentFor(String diveId, String mediaId) async {
-    final media = await mediaRepo.getMediaForDive(diveId);
-    return media.firstWhere((m) => m.id == mediaId).enrichment;
+    final all = await mediaRepo.getMediaForDive(diveId);
+    return all.firstWhere((m) => m.id == mediaId).enrichment;
   }
 
   test('backfills enrichment for a linked photo that has none', () async {
@@ -81,8 +78,7 @@ void main() {
     // Photo taken 60s into the dive -> interpolated depth ~10m.
     await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
 
-    final count = await service.backfill();
-    expect(count, 1);
+    expect(await service.backfill(), 1);
 
     final enrichment = await enrichmentFor('dive-1', 'photo-1');
     expect(enrichment, isNotNull);
@@ -96,19 +92,38 @@ void main() {
     () async {
       await createProfiledDive();
       await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
-
       await service.run();
-
       expect(await enrichmentFor('dive-1', 'photo-1'), isNotNull);
     },
   );
 
+  test('pendingWork reflects the backlog and reaches 0 after run', () async {
+    await createProfiledDive();
+    await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+    await linkPhoto(id: 'photo-2', diveId: 'dive-1', takenAt: photoAt(90));
+
+    expect(await service.pendingWork(), 2);
+    await service.run();
+    expect(await service.pendingWork(), 0);
+  });
+
+  test('run ticks progress up to the total', () async {
+    await createProfiledDive();
+    await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
+    await linkPhoto(id: 'photo-2', diveId: 'dive-1', takenAt: photoAt(90));
+
+    final ticks = <int>[];
+    await service.run(onProgress: ticks.add);
+    expect(ticks.last, 2);
+    expect(ticks, [1, 2]);
+  });
+
   test('is idempotent: a second run enriches nothing', () async {
     await createProfiledDive();
     await linkPhoto(id: 'photo-1', diveId: 'dive-1', takenAt: photoAt(60));
-
     expect(await service.backfill(), 1);
     expect(await service.backfill(), 0);
+    expect(await service.pendingWork(), 0);
   });
 
   test('leaves an already-enriched photo untouched', () async {
@@ -125,10 +140,8 @@ void main() {
         createdAt: DateTime.now(),
       ),
     );
-
     expect(await service.backfill(), 0);
     final enrichment = await enrichmentFor('dive-1', 'photo-1');
-    // Untouched: the pre-existing (sentinel) values survive.
     expect(enrichment!.depthMeters, 99.0);
     expect(enrichment.elapsedSeconds, 999);
   });
@@ -142,7 +155,6 @@ void main() {
       diveId: 'dive-noprofile',
       takenAt: photoAt(30),
     );
-
     expect(await service.backfill(), 0);
     expect(await enrichmentFor('dive-noprofile', 'photo-np'), isNull);
   });
@@ -155,7 +167,6 @@ void main() {
       takenAt: photoAt(90),
       mediaType: MediaType.video,
     );
-
     expect(await service.backfill(), 1);
     expect(await enrichmentFor('dive-1', 'clip-1'), isNotNull);
   });
@@ -168,11 +179,8 @@ void main() {
       takenAt: photoAt(45),
       mediaType: MediaType.instructorSignature,
     );
-
-    // Signature-only dive is never a candidate, so nothing is enriched and a
-    // second run still finds nothing (no perpetual re-scan).
     expect(await service.backfill(), 0);
-    expect(await service.backfill(), 0);
+    expect(await service.pendingWork(), 0);
     expect(await enrichmentFor('dive-1', 'sig-1'), isNull);
   });
 }


### PR DESCRIPTION
Fixes #524.

## Problem

On a large database (~1000 dives) the app hung on the splash for ~20 seconds **on every launch**, with no feedback. The issue was filed as "add a progress notification," but investigation showed the progress bar alone would only mask the symptom. Two compounding defects plus a latent framework hazard were at play:

1. **Non-convergence** — `MediaEnrichmentBackfillService` re-processed the same dives every launch. If the candidate set actually emptied, there would be no loop and no hang; a 20s cost *every* launch proves some media never got its enrichment row (a `saveEnrichment` failure swallowed by the per-dive `catch`).
2. **Cost multiplier** — each candidate dive was loaded via `getDiveById` → `_mapRowToDive` (~8 sub-queries) when enrichment needs only the profile points + entry time.
3. **Framework hazard** — the `StartupMaintenanceTask` contract (`name` + `run()`) had no cheap "is there work?" probe and no progress channel, so any future task could reintroduce the same hang.

## Fix

Make the runner a place where it's hard to write a task that hangs startup:

- **`pendingWork()` on the contract** — the runner skips zero-work tasks with a single indexed COUNT, drives the progress bar from the probe total, and **logs when a task fails to converge** (the check that would have caught this on day one).
- **Generic device-local ledger (`maintenance_processed`, schema v103)** — an open-for-extension `(task_name, entity_id, attempted_at)` table any task uses to mark handled entities. Task identity lives in the data, so it's the **last** migration the framework needs — future tasks are code-only. Not synced (per-device bookkeeping).
- **Enrichment backfill rewritten** — probe-driven, profile-only per-dive load (`getDiveProfile`), and every visited item recorded in the ledger (enriched *or* deterministically failed) so the backlog converges to zero.
- **Determinate splash progress** — a new `optimizing` state shows "Optimizing dive data… X of Y", appearing only when a task actually reports work (a caught-up launch shows nothing).

Net effect: steady-state launches do ~zero maintenance work (one cheap COUNT); the genuine one-time pass shows a progress bar and cannot recur.

## Commits

1. `feat(db)` — device-local `maintenance_processed` ledger (schema v103)
2. `feat(maintenance)` — `MaintenanceLedgerRepository`
3. `feat(maintenance)` — `pendingWork` probe + progress + convergence safety net; enrichment rewrite
4. `feat(startup)` — determinate progress while maintenance runs

## Testing

- New/updated unit tests: ledger repo, runner (skip/progress/convergence/isolation), ledger-aware candidate queries, enrichment convergence + progress, startup `optimizing` widget test.
- Full affected suite: **614 pass, 2 skipped** (Apple-only). `dart format` + `flutter analyze` clean.

## Follow-ups

- **Diagnose the underlying `saveEnrichment` throw** on the affected device (Task 0): the ledger guarantees no-hang regardless, and any residual failure now logs loudly — but confirming the root cause would let those items actually enrich rather than just drop out.
- **macOS smoke on a real large DB** to visually confirm the one-time bar + instant subsequent launches.