### PR TITLE
feat: anchor dive-edit site picker on the dive's GPS + seed New Dive Site

### DIFF
--- a/docs/superpowers/plans/2026-07-08-dive-gps-site-picker.md
+++ b/docs/superpowers/plans/2026-07-08-dive-gps-site-picker.md
@@ -1,0 +1,890 @@
+# Dive-GPS-anchored Site Picker + Seeded New-Site Creation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the dive edit form, anchor the site picker's distance/sort on the edited dive's own GPS (entry, else exit) and seed the "New Dive Site" form with those coordinates + a best-effort reverse-geocode — while GPS-less dives behave exactly as today.
+
+**Architecture:** Most machinery already exists in `SitePickerSheet` (distance, sort, header, "New Dive Site" button), keyed on a single nullable anchor. We (1) add an auto-scaling, unit-aware distance formatter, (2) add two localized strings, (3) re-point the picker's anchor to a new `diveLocation` param, (4) let `SiteEditPage` accept + seed an `initialLocation` (with geocode) reachable through the `/sites/new` route's `extra`, and (5) wire the dive edit page to feed both. No DB/schema change.
+
+**Tech Stack:** Flutter, Riverpod (StateNotifierProvider), go_router, Drift (unchanged here), Flutter gen-l10n (ARB).
+
+## Global Constraints
+
+- Displayed distances MUST respect the diver's unit settings (metric/imperial derived from `settings.depthUnit`). (CLAUDE.md units rule.)
+- New user-facing strings go into `app_en.arb` **and all 10 non-English locales** (`ar, de, es, fr, he, hu, it, nl, pt, zh`), then regenerate with `flutter gen-l10n`.
+- No emojis in code/comments. Immutability preserved. Proper error handling.
+- `dart format .` must leave the whole repo unchanged before any commit.
+- TDD: failing test first, minimal implementation, green, commit.
+- Metric distance output MUST stay byte-identical to today (see Task 1 note); only imperial is additive.
+- Anchor resolution is always `diveLocation ?? currentLocation` so a GPS-less dive passes today's device value through untouched.
+
+---
+
+### Task 1: Auto-scaling, unit-aware geo-distance formatter
+
+**Files:**
+- Modify: `lib/core/utils/unit_formatter.dart` (add method after `formatDistance`, ~`:44`)
+- Test: `test/core/utils/unit_formatter_distance_test.dart` (append)
+
+**Interfaces:**
+- Produces: `String UnitFormatter.formatGeoDistance(double meters)` — returns value + latin unit (`"556 m"`, `"5.6 km"`, `"394 ft"`, `"2.0 mi"`), scaling by magnitude and metric/imperial preference. Consumed by Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `main()` of `test/core/utils/unit_formatter_distance_test.dart`:
+
+```dart
+  group('formatGeoDistance', () {
+    const metric = UnitFormatter(AppSettings(depthUnit: DepthUnit.meters));
+    const imperial = UnitFormatter(AppSettings(depthUnit: DepthUnit.feet));
+
+    test('metric scales meters to km', () {
+      expect(metric.formatGeoDistance(120), '120 m');
+      expect(metric.formatGeoDistance(999), '999 m');
+      expect(metric.formatGeoDistance(1000), '1.0 km');
+      expect(metric.formatGeoDistance(5560), '5.6 km');
+      expect(metric.formatGeoDistance(23400), '23 km');
+    });
+
+    test('imperial scales feet to miles', () {
+      expect(imperial.formatGeoDistance(120), '394 ft');
+      expect(imperial.formatGeoDistance(1000), '3281 ft');
+      expect(imperial.formatGeoDistance(3218.688), '2.0 mi');
+      expect(imperial.formatGeoDistance(160934), '100 mi');
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/core/utils/unit_formatter_distance_test.dart`
+Expected: FAIL — `formatGeoDistance` is not defined.
+
+- [ ] **Step 3: Add the implementation**
+
+In `lib/core/utils/unit_formatter.dart`, immediately after the existing `formatDistance` method (closing brace at ~`:44`), add:
+
+```dart
+  /// Format a geographic distance (meters) for site lists and pickers.
+  ///
+  /// Unlike [formatDistance] (depth-unit m/ft, for short surface drift), this
+  /// auto-scales across the full range of site distances and respects the
+  /// diver's metric/imperial preference (derived from depth unit): metric -> m
+  /// under 1 km else km; imperial -> ft under 1 mile else mi. Unit symbols are
+  /// latin (m/km/ft/mi), consistent with [formatDepth].
+  String formatGeoDistance(double meters) {
+    final isMetric = settings.depthUnit == DepthUnit.meters;
+    if (isMetric) {
+      if (meters < 1000) return '${meters.round()} m';
+      final km = meters / 1000;
+      final text = km < 10 ? km.toStringAsFixed(1) : km.round().toString();
+      return '$text km';
+    }
+    final feet = meters * 3.28084;
+    const feetPerMile = 5280.0;
+    if (feet < feetPerMile) return '${feet.round()} ft';
+    final miles = feet / feetPerMile;
+    final text = miles < 10 ? miles.toStringAsFixed(1) : miles.round().toString();
+    return '$text mi';
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/core/utils/unit_formatter_distance_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+dart format lib/core/utils/unit_formatter.dart test/core/utils/unit_formatter_distance_test.dart
+git add lib/core/utils/unit_formatter.dart test/core/utils/unit_formatter_distance_test.dart
+git commit -m "feat(units): add auto-scaling unit-aware formatGeoDistance"
+```
+
+---
+
+### Task 2: Localized strings (header + distance wrapper)
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` (add 2 keys + metadata)
+- Modify: `lib/l10n/arb/app_{ar,de,es,fr,he,hu,it,nl,pt,zh}.arb` (add 2 keys each, value-only)
+- Generated: `lib/l10n/arb/app_localizations*.dart` via `flutter gen-l10n`
+
+**Interfaces:**
+- Produces: `context.l10n.diveLog_sitePicker_sortedByDiveDistance` (no args) and `context.l10n.diveLog_sitePicker_distanceAway(String distance)`. Consumed by Task 3.
+
+- [ ] **Step 1: Add English keys + metadata**
+
+In `lib/l10n/arb/app_en.arb`, add the value keys next to the existing `diveLog_sitePicker_*` entries (alphabetical block around `:2746`):
+
+```json
+  "diveLog_sitePicker_distanceAway": "{distance} away",
+  "diveLog_sitePicker_sortedByDiveDistance": "Sorted by distance from this dive",
+```
+
+And add metadata next to the existing `@diveLog_sitePicker_*` block (around `:3328`):
+
+```json
+  "@diveLog_sitePicker_distanceAway": {
+    "description": "A site's distance from the reference point; {distance} already includes the unit, e.g. '1.2 km' or '800 ft'",
+    "placeholders": {
+      "distance": { "type": "String", "example": "1.2 km" }
+    }
+  },
+  "@diveLog_sitePicker_sortedByDiveDistance": {
+    "description": "Site picker header shown when sites are sorted by distance from the edited dive's GPS position"
+  },
+```
+
+- [ ] **Step 2: Add translations to all non-English locales (value-only)**
+
+Add these two keys to each locale ARB. Values mirror each locale's existing `diveLog_sitePicker_distanceKm` / `diveLog_sitePicker_sortedByDistance` phrasing (`{distance}` now carries the unit, so drop the hard-coded "km"). Native review welcome before merge:
+
+| locale | `diveLog_sitePicker_distanceAway` | `diveLog_sitePicker_sortedByDiveDistance` |
+|---|---|---|
+| ar | `"{distance} بعيداً"` | `"مرتبة حسب المسافة من هذه الغطسة"` |
+| de | `"{distance} entfernt"` | `"Nach Entfernung zu diesem Tauchgang sortiert"` |
+| es | `"a {distance}"` | `"Ordenados por distancia a esta inmersión"` |
+| fr | `"à {distance}"` | `"Trié par distance à cette plongée"` |
+| he | `"{distance} משם"` | `"ממוין לפי מרחק מהצלילה הזו"` |
+| hu | `"{distance} távolságra"` | `"Távolság szerint rendezve ettől a merüléstől"` |
+| it | `"{distance} di distanza"` | `"Ordinati per distanza da questa immersione"` |
+| nl | `"{distance} afstand"` | `"Gesorteerd op afstand tot deze duik"` |
+| pt | `"{distance} de distância"` | `"Ordenado por distância deste mergulho"` |
+| zh | `"距离 {distance}"` | `"按与本次潜水的距离排序"` |
+
+- [ ] **Step 3: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: no errors; `app_localizations.dart` now declares `diveLog_sitePicker_sortedByDiveDistance` and `diveLog_sitePicker_distanceAway(String distance)`.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `flutter analyze lib/l10n`
+Expected: no new issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/arb/
+git commit -m "i18n(site-picker): add dive-distance header + distance-away strings"
+```
+
+---
+
+### Task 3: Anchor the picker on the dive's GPS (unit-aware, dive-labelled)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart`
+- Test: `test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart`
+
+**Interfaces:**
+- Consumes: `UnitFormatter.formatGeoDistance` (Task 1); `diveLog_sitePicker_sortedByDiveDistance` / `diveLog_sitePicker_distanceAway` (Task 2); `distanceMeters(GeoPoint, GeoPoint)` from `lib/core/utils/geo_math.dart:10`.
+- Produces: `SitePickerSheet(... GeoPoint? diveLocation)` — new optional param. Consumed by Task 5.
+
+- [ ] **Step 1: Update the test harness + write failing tests**
+
+In `site_picker_sheet_test.dart`, add imports at top:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+```
+
+Add a test settings notifier (mirrors `test/l10n/localization_test.dart:326`; note the explicit `super(initial)` — `StateNotifier`'s positional param is private, so a `super.` parameter will not compile) above `_pump`:
+
+```dart
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(AppSettings initial) : super(initial);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+```
+
+Replace the `_pump` helper to add `diveLocation` + a settings override:
+
+```dart
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<DiveSite> sites,
+  LocationResult? currentLocation,
+  GeoPoint? diveLocation,
+  AppSettings settings = const AppSettings(),
+  String? selectedSiteId,
+  void Function(DiveSite)? onSiteSelected,
+  VoidCallback? onCreateNewSite,
+}) async {
+  tester.view.physicalSize = const Size(900, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sitesProvider.overrideWith((ref) async => sites),
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SitePickerSheet(
+            scrollController: ScrollController(),
+            selectedSiteId: selectedSiteId,
+            currentLocation: currentLocation,
+            diveLocation: diveLocation,
+            onSiteSelected: onSiteSelected ?? (_) {},
+            onCreateNewSite: onCreateNewSite ?? () {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+```
+
+Add new tests inside `main()`:
+
+```dart
+  testWidgets('sorts by diveLocation when provided', (tester) async {
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite, _midSite],
+      diveLocation: const GeoPoint(10.0, 10.0),
+    );
+    expect(_tileTitles(tester), ['House Reef', 'Channel', 'Blue Hole']);
+    expect(find.text('Sorted by distance from this dive'), findsOneWidget);
+  });
+
+  testWidgets('falls back to currentLocation when diveLocation is null',
+      (tester) async {
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite, _midSite],
+      currentLocation: _here,
+    );
+    expect(_tileTitles(tester), ['House Reef', 'Channel', 'Blue Hole']);
+    expect(find.text('Sorted by distance'), findsOneWidget);
+    expect(find.text('Sorted by distance from this dive'), findsNothing);
+  });
+
+  testWidgets('distance readout respects imperial units', (tester) async {
+    await _pump(
+      tester,
+      sites: const [_farSite],
+      diveLocation: const GeoPoint(10.0, 10.0),
+      settings: const AppSettings(depthUnit: DepthUnit.feet),
+    );
+    expect(find.textContaining('mi'), findsWidgets);
+    expect(find.textContaining('km'), findsNothing);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart`
+Expected: FAIL — `diveLocation` is not a parameter of `SitePickerSheet`.
+
+- [ ] **Step 3: Add the `diveLocation` param + imports**
+
+In `site_picker_sheet.dart`, add imports (keep `location_service.dart` for `LocationResult`):
+
+```dart
+import 'package:submersion/core/utils/geo_math.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+```
+
+Add the field + constructor param (after `currentLocation`, `:16`/`:24`):
+
+```dart
+  final LocationResult? currentLocation;
+  final GeoPoint? diveLocation;
+```
+```dart
+    this.currentLocation,
+    this.diveLocation,
+```
+
+- [ ] **Step 4: Resolve the anchor + switch distance to meters via geo_math**
+
+Replace `_distanceToSite` (`:43-53`) with a resolved-anchor version returning **meters**:
+
+```dart
+  /// The point distances are measured from: the dive's GPS if present,
+  /// otherwise the device location (today's behavior).
+  GeoPoint? get _anchor {
+    if (widget.diveLocation != null) return widget.diveLocation;
+    final cl = widget.currentLocation;
+    return cl == null ? null : GeoPoint(cl.latitude, cl.longitude);
+  }
+
+  /// Distance from the resolved anchor to a site, in meters.
+  double? _distanceToSite(DiveSite site) {
+    final anchor = _anchor;
+    if (anchor == null || site.location == null) return null;
+    return distanceMeters(anchor, site.location!);
+  }
+```
+
+- [ ] **Step 5: Replace `_formatDistance` with the unit-aware wrapper**
+
+Replace `_formatDistance` (`:55-64`) with:
+
+```dart
+  /// Format a site distance (meters) for display, unit-aware.
+  String _formatDistance(BuildContext context, UnitFormatter units, double m) {
+    return context.l10n.diveLog_sitePicker_distanceAway(
+      units.formatGeoDistance(m),
+    );
+  }
+```
+
+- [ ] **Step 6: Update `build` — units, header, sort, list, nearby**
+
+After `final sitesAsync = ref.watch(sitesProvider);` add:
+
+```dart
+    final units = UnitFormatter(ref.watch(settingsProvider));
+```
+
+Change the header condition (`:86`) from `if (widget.currentLocation != null)` to a dive-aware block:
+
+```dart
+                  if (_anchor != null)
+                    Row(
+                      children: [
+                        Icon(
+                          widget.diveLocation != null
+                              ? Icons.place
+                              : Icons.my_location,
+                          size: 14,
+                          color: colorScheme.primary,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          widget.diveLocation != null
+                              ? context.l10n.diveLog_sitePicker_sortedByDiveDistance
+                              : context.l10n.diveLog_sitePicker_sortedByDistance,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(color: colorScheme.primary),
+                        ),
+                      ],
+                    ),
+```
+
+Change the sort gate (`:189`) from `if (widget.currentLocation != null)` to `if (_anchor != null)` (inner sort logic and `_SiteWithDistance` unchanged — `distance` now holds meters).
+
+Change `isNearby` (`:236`) to meters:
+
+```dart
+                  final isNearby =
+                      distance != null && distance < 50000; // within 50 km
+```
+
+Change the distance subtitle (`:260-270`) to the unit-aware formatter:
+
+```dart
+                        if (distance != null)
+                          Text(
+                            _formatDistance(context, units, distance),
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
+                                  color: isNearby
+                                      ? colorScheme.tertiary
+                                      : colorScheme.onSurfaceVariant,
+                                  fontWeight: isNearby ? FontWeight.w600 : null,
+                                ),
+                          ),
+```
+
+`LocationService.instance` is no longer called; the `location_service.dart` import stays for `LocationResult`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart`
+Expected: PASS (new tests + all pre-existing tests, whose metric strings are byte-identical).
+
+- [ ] **Step 8: Format + commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
+git add lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
+git commit -m "feat(site-picker): anchor distance/sort on dive GPS, unit-aware readout"
+```
+
+---
+
+### Task 4: Seed `SiteEditPage` from `initialLocation` (+ router `extra`)
+
+**Files:**
+- Modify: `lib/features/dive_sites/presentation/pages/site_edit_page.dart`
+- Modify: `lib/core/router/app_router.dart:379`
+- Test: `test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `GeoPoint`; `locationServiceProvider` → `reverseGeocode` (`lib/core/services/location_service.dart:188`).
+- Produces: `SiteEditPage(... GeoPoint? initialLocation)`; the `/sites/new` route maps a `GeoPoint` `state.extra` into it. Consumed by Task 5.
+
+**Testing note:** the Location `FormSection` is collapsed by default for new sites (`_siteSectionExpanded('location') == false`, `site_edit_page.dart:524`). Its collapsed summary renders exactly `"{lat}, {lng}"` (`_locationSummary`, `:573-579`), which is the stable assertion target — do not assert on the individual (unbuilt) lat/lng fields.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/location_service_provider.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Records the coordinates it was asked to reverse-geocode and returns a fixed
+/// placemark, so tests can prove the seed path fires geocoding. (The
+/// fill-only-empty write of country/region is already covered by the existing
+/// site_edit_page_test.dart geocode tests.)
+class _RecordingLocationService implements LocationService {
+  ({double lat, double lng})? geocodedWith;
+
+  @override
+  Future<({String? country, String? region, String? locality})> reverseGeocode(
+    double latitude,
+    double longitude,
+  ) async {
+    geocodedWith = (lat: latitude, lng: longitude);
+    return (country: 'Testland', region: 'Test Region', locality: null);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+List<Diver> _divers() => [
+      Diver(
+        id: 'd1',
+        name: 'Me',
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    ];
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  testWidgets('seeds coordinates and fires geocoding from initialLocation',
+      (tester) async {
+    tester.view.physicalSize = const Size(1000, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final geocoder = _RecordingLocationService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          allDiversProvider.overrideWith((_) async => _divers()),
+          shareByDefaultProvider.overrideWith((_) async => false),
+          locationServiceProvider.overrideWithValue(geocoder),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SiteEditPage(initialLocation: GeoPoint(34.0182, -118.4965)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Location section is collapsed by default; its summary is "{lat}, {lng}".
+    expect(find.text('34.018200, -118.496500'), findsOneWidget);
+    // Seeding fired a reverse-geocode for exactly those coordinates.
+    expect(geocoder.geocodedWith, isNotNull);
+    expect(geocoder.geocodedWith!.lat, closeTo(34.0182, 1e-9));
+    expect(geocoder.geocodedWith!.lng, closeTo(-118.4965, 1e-9));
+  });
+
+  testWidgets('/sites/new maps a GeoPoint extra into initialLocation',
+      (tester) async {
+    tester.view.physicalSize = const Size(1000, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final router = GoRouter(
+      initialLocation: '/start',
+      routes: [
+        GoRoute(
+          path: '/start',
+          builder: (context, state) => Scaffold(
+            body: Center(
+              child: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => context.push(
+                    '/sites/new',
+                    extra: const GeoPoint(1.5, 2.5),
+                  ),
+                  child: const Text('go'),
+                ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sites/new',
+          builder: (context, state) => SiteEditPage(
+            initialLocation:
+                state.extra is GeoPoint ? state.extra as GeoPoint : null,
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          allDiversProvider.overrideWith((_) async => _divers()),
+          shareByDefaultProvider.overrideWith((_) async => false),
+          locationServiceProvider.overrideWithValue(_RecordingLocationService()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.500000, 2.500000'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart`
+Expected: FAIL — `initialLocation` is not a parameter of `SiteEditPage`.
+
+- [ ] **Step 3: Add the `initialLocation` constructor param**
+
+In `site_edit_page.dart`, add the field and constructor arg (near `siteId`, `:33`/`:40`) and a second assert:
+
+```dart
+  final String? siteId;
+  final List<String>? mergeSiteIds;
+  final bool embedded;
+  final void Function(String savedId)? onSaved;
+  final VoidCallback? onCancel;
+  final GeoPoint? initialLocation;
+
+  const SiteEditPage({
+    super.key,
+    this.siteId,
+    this.mergeSiteIds,
+    this.embedded = false,
+    this.onSaved,
+    this.onCancel,
+    this.initialLocation,
+  }) : assert(
+         siteId == null || mergeSiteIds == null,
+         'siteId and mergeSiteIds are mutually exclusive',
+       ),
+       assert(
+         initialLocation == null || (siteId == null && mergeSiteIds == null),
+         'initialLocation is only valid when creating a new site',
+       );
+```
+
+- [ ] **Step 4: Seed on the new-site init path**
+
+Replace the new-site init block in `build` (`:511-513`):
+
+```dart
+    if (!_isInitialized) {
+      _isInitialized = true;
+    }
+    return _buildForm(context, units);
+```
+
+with:
+
+```dart
+    if (!_isInitialized) {
+      _isInitialized = true;
+      _seedInitialLocation();
+    }
+    return _buildForm(context, units);
+```
+
+Add these methods near `_initializeFromSite`:
+
+```dart
+  /// Seed a brand-new site form from [SiteEditPage.initialLocation]: fill the
+  /// coordinate fields immediately (as non-dirtying initial values), then
+  /// best-effort reverse-geocode country/region into the empty fields.
+  void _seedInitialLocation() {
+    final loc = widget.initialLocation;
+    if (loc == null) return;
+
+    _isApplyingInitialValues = true;
+    _latitudeController.text = loc.latitude.toStringAsFixed(6);
+    _longitudeController.text = loc.longitude.toStringAsFixed(6);
+    _isApplyingInitialValues = false;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => _geocodeSeed(loc));
+  }
+
+  Future<void> _geocodeSeed(GeoPoint loc) async {
+    final result = await ref
+        .read(locationServiceProvider)
+        .reverseGeocode(loc.latitude, loc.longitude);
+    if (!mounted) return;
+    setState(() {
+      _isApplyingInitialValues = true;
+      if (_countryController.text.isEmpty && result.country != null) {
+        _countryController.text = result.country!;
+      }
+      if (_regionController.text.isEmpty && result.region != null) {
+        _regionController.text = result.region!;
+      }
+      _isApplyingInitialValues = false;
+    });
+  }
+```
+
+(`locationServiceProvider` is already imported — used by `_useMyLocation`.)
+
+- [ ] **Step 5: Wire the `/sites/new` route to read `extra`**
+
+In `lib/core/router/app_router.dart`, add the import if absent:
+
+```dart
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+```
+
+Replace `:379`:
+
+```dart
+                builder: (context, state) => const SiteEditPage(),
+```
+
+with:
+
+```dart
+                builder: (context, state) => SiteEditPage(
+                  initialLocation:
+                      state.extra is GeoPoint ? state.extra as GeoPoint : null,
+                ),
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart`
+Expected: PASS (both the seed test and the router-mapping test).
+
+- [ ] **Step 7: Format + commit**
+
+```bash
+dart format lib/features/dive_sites/presentation/pages/site_edit_page.dart lib/core/router/app_router.dart test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
+git add lib/features/dive_sites/presentation/pages/site_edit_page.dart lib/core/router/app_router.dart test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
+git commit -m "feat(site-edit): seed new-site form from initialLocation + geocode; wire /sites/new extra"
+```
+
+---
+
+### Task 5: Wire the dive edit page to feed the dive's GPS
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (`_showSitePicker`, `:1927-1963`)
+- Test: `test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `SitePickerSheet.diveLocation` (Task 3); `/sites/new` `extra` → `initialLocation` (Task 4). `GeoPoint` already imported via `dive_site.dart` (`dive_edit_page.dart:18`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart` (harness copied from `dive_edit_page_test.dart`):
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  testWidgets('site picker is anchored on the dive GPS', (tester) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final dive = Dive(
+      id: 'dive-gps',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 3, 28, 10, 0),
+      entryTime: DateTime(2026, 3, 28, 10, 5),
+      bottomTime: const Duration(minutes: 40),
+      maxDepth: 20.0,
+      entryLocation: const GeoPoint(34.0182, -118.4965),
+      tanks: const [],
+      profile: const [],
+      equipment: const [],
+      notes: '',
+      photoIds: const [],
+      sightings: const [],
+      weights: const [],
+      tags: const [],
+    );
+    final created = await repository.createDive(dive);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveEditPage(diveId: created.id, embedded: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Open the site picker via the "Add site" FormRow.picker placeholder.
+    await tester.ensureVisible(find.text('Add site'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add site'));
+    await tester.pumpAndSettle();
+
+    // Dive has entry GPS -> the picker is anchored on it.
+    expect(find.text('Sorted by distance from this dive'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart`
+Expected: FAIL — header text absent (picker still anchored on `_currentLocation`, which is null here).
+
+- [ ] **Step 3: Feed the dive anchor + seed the create route**
+
+In `dive_edit_page.dart` `_showSitePicker` (`:1927`), add before `showModalBottomSheet`:
+
+```dart
+    final anchor =
+        _existingDive?.entryLocation ?? _existingDive?.exitLocation;
+```
+
+Pass it to the sheet (after `currentLocation: _currentLocation,`, `:1939`):
+
+```dart
+          currentLocation: _currentLocation,
+          diveLocation: anchor,
+```
+
+Change the create-new push (`:1953`) to carry the coordinates (null is safe — the route ignores non-`GeoPoint` extras):
+
+```dart
+      final siteId = await context.push<String>('/sites/new', extra: anchor);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Full analyze + targeted regression run**
+
+Run:
+```bash
+flutter analyze lib/features/dive_log/presentation/pages/dive_edit_page.dart lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart lib/features/dive_sites/presentation/pages/site_edit_page.dart lib/core/router/app_router.dart
+flutter test test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart test/features/dive_sites/presentation/pages/site_edit_page_test.dart test/features/dive_log/presentation/pages/dive_edit_page_test.dart
+```
+Expected: no analyzer issues; all listed suites PASS (proves existing site-edit and dive-edit behavior is unregressed).
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+dart format lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart
+git add lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart
+git commit -m "feat(dive-edit): anchor site picker on dive GPS and seed New Dive Site coords"
+```
+
+---
+
+## Manual verification (after all tasks)
+
+1. Open a downloaded dive that has entry GPS → Edit → tap the site field ("Add site").
+   - Existing sites are sorted nearest-first, each showing distance in your unit
+     setting; header reads "Sorted by distance from this dive".
+2. Tap "New Dive Site" → the editor opens with latitude/longitude pre-filled and,
+   after a moment, country/region populated (online). Save the site, then save the
+   dive edit → the dive is associated to the new site.
+3. Switch units (Settings → depth m/ft) and reopen → distances render in km/mi vs
+   m/ft accordingly.
+4. Open a **manually created** dive with no GPS → Edit → site picker behaves exactly
+   as before (device-location sort if available; "New Dive Site" opens a blank editor).
+
+## Self-review coverage map
+
+- Behavior contract (dive-anchored sort/distance) → Tasks 1, 3, 5.
+- "New Dive Site" pre-fill + geocode → Task 4; fed by Task 5.
+- Unit-aware distance (project rule) → Task 1; consumed Task 3.
+- GPS-less dives unchanged → anchor `?? currentLocation` (Task 3), metric strings byte-identical (Task 1), null `extra` ignored (Task 4 router), manual step 4.
+- l10n all-locales → Task 2.
+- No DB/schema change → confirmed (no migration task).
+- Open items resolved: (1) DivePrefill has no GPS → `_existingDive` sole source (Task 5); (2) distance shape → `formatGeoDistance` + `distanceAway` wrapper (Tasks 1-2); (3) header icon → `Icons.place` (Task 3).
+```

--- a/docs/superpowers/specs/2026-07-08-dive-gps-site-picker-design.md
+++ b/docs/superpowers/specs/2026-07-08-dive-gps-site-picker-design.md
@@ -1,0 +1,204 @@
+# Dive-GPS-anchored site picker + seeded new-site creation
+
+- **Date:** 2026-07-08
+- **Status:** Approved design, pending implementation plan
+- **Scope decision:** "Approach 3" — core re-anchor + seeded new-site + unit-aware distance + reverse-geocode on seed
+
+## Problem
+
+When a dive is downloaded (or matched to a phone GPS track), it carries entry/exit
+GPS fixes. In the **dive edit form**, the site picker that lets a diver choose or
+create a site does not use those coordinates:
+
+- The picker sorts/labels site distances from the **device's** current location
+  (`_currentLocation`), which is meaningless for a dive logged elsewhere days ago.
+- The **"New Dive Site"** button opens the site editor with **no** coordinates, so
+  the diver must re-enter GPS that the dive already knows.
+
+We want the picker to anchor on the **dive's own GPS** when it has one, and to seed
+the new-site form with those coordinates — while leaving GPS-less dives behaving
+exactly as they do today.
+
+## What already exists (reused, not rebuilt)
+
+Most of the machinery is already present; the change is re-pointing it.
+
+- `SitePickerSheet` — `lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart`
+  - Already computes per-site distance (`_distanceToSite`, `:44-53`), sorts
+    nearest-first with GPS-less sites last (`:189-199`), shows a "Sorted by
+    distance" header (`:86-101`), renders per-site distance with a <50 km "nearby"
+    highlight (`:236`, `:260-270`), and hosts the "New Dive Site" button
+    (`:104-108`, and the empty-state variant `:176-181`).
+  - All of that is gated on a single nullable anchor (`currentLocation`). Only
+    referenced from `dive_edit_page.dart`.
+- `dive_edit_page.dart` — `lib/features/dive_log/presentation/pages/dive_edit_page.dart`
+  - `_existingDive` (declared `:227`, assigned `:510`) holds the loaded dive, so
+    `entryLocation`/`exitLocation` are in hand — no new query.
+  - `_currentLocation` (device GPS, `:230`/`:675`) is what the picker uses today
+    (`:1939`).
+  - `_showSitePicker` (`:1927-1963`) opens the sheet, and on the
+    `_createNewSiteSentinel` (`:90`) result pushes `context.push<String>('/sites/new')`
+    (`:1953`), then loads the returned id and selects it (`:1956-1959`).
+- `SiteEditPage` — `lib/features/dive_sites/presentation/pages/site_edit_page.dart`
+  - Has lat/lng fields and a `_isApplyingInitialValues` seam (`:84`, `:126-129`)
+    that suppresses dirty-marking while fields are seeded (`:159`-`:187`).
+  - Fills **only-empty** country/region from reverse-geocode in "Use my location"
+    (`:1419-1487`, fill `:1460-1465`) and "Pick from map" (`:1489-1526`, fill
+    `:1510-1515`); `_saveSite` deliberately does **not** geocode (`:2035-2040`).
+  - Returns the saved id via `context.pop(savedId)` (`:2143-2147`).
+  - Reverse-geocode is reached through `locationServiceProvider`
+    (`lib/core/providers/location_service_provider.dart:9`).
+- Distance/geocode primitives:
+  - `distanceMeters(GeoPoint, GeoPoint)` — Haversine, `lib/core/utils/geo_math.dart:10-20`.
+  - `LocationService.reverseGeocode(lat, lng)` → `({country, region, locality})`,
+    `lib/core/services/location_service.dart:188-224`.
+  - `GeoPoint` — `lib/features/dive_sites/domain/entities/dive_site.dart:203-215`.
+- Router: `/sites/new` at `lib/core/router/app_router.dart:379`
+  (`builder: (context, state) => const SiteEditPage()`).
+
+## Behavior contract
+
+**Dive being edited has GPS** (`entryLocation`, else `exitLocation`):
+
+1. Existing sites in the picker show distance from that point and are sorted
+   nearest-first; GPS-less sites sink to the bottom (existing sort rule).
+2. The picker header reads "Sorted by distance from this dive" (new string) with a
+   dive-appropriate icon.
+3. "New Dive Site" opens the site editor pre-filled with the dive's lat/lng, and
+   best-effort reverse-geocodes country/region into the (empty) fields.
+4. Selecting or creating a site associates it to the dive via the normal dive-edit
+   save path (unchanged).
+
+**Dive being edited has no GPS:** identical to today. Guaranteed structurally — the
+anchor resolves to `diveGps ?? _currentLocation`, so a null dive-GPS passes today's
+device-location value through unchanged, and "New Dive Site" pushes `/sites/new`
+with no `extra`.
+
+**Coordinate selection:** entry wins when both entry and exit exist; exit is used
+only when entry is absent (`entryLocation ?? exitLocation`).
+
+## Design
+
+### A. Anchor the picker on the dive's GPS
+
+`SitePickerSheet`:
+
+- Add `final GeoPoint? diveLocation;`. Resolve `anchor = diveLocation ?? currentLocation`
+  (convert `currentLocation` to a `GeoPoint` for a single code path) and key all
+  distance/sort logic off `anchor`.
+- Replace the `LocationService.instance.distanceBetween` call with the pure
+  `distanceMeters(GeoPoint, GeoPoint)` from `geo_math.dart` — drops a singleton
+  dependency and makes the sheet unit-testable.
+- Header: when `diveLocation != null`, show the new
+  `diveLog_sitePicker_sortedByDiveDistance` string ("Sorted by distance from this
+  dive") with a dive/place icon; otherwise keep the existing
+  `diveLog_sitePicker_sortedByDistance` + `my_location`.
+- Keep the existing "nearby" highlight rule (threshold unchanged), recomputed against
+  the resolved anchor in meters.
+
+`dive_edit_page._showSitePicker`:
+
+- Compute `final anchor = _existingDive?.entryLocation ?? _existingDive?.exitLocation;`
+  (see Open item 1 on prefill dives).
+- Pass `diveLocation: anchor` to `SitePickerSheet` (continue passing
+  `currentLocation: _currentLocation` for the fallback).
+- On the create-new branch: `context.push<String>('/sites/new', extra: anchor)` when
+  `anchor != null`, else the existing no-`extra` push.
+
+### B. Unit-aware, auto-scaling distance readout
+
+`UnitFormatter.formatDistance` (`lib/core/utils/unit_formatter.dart:41-44`) converts
+into the diver's **depth** unit (m/ft) with no km/mi scaling — a 50 km site would
+render "50000m"/"164042ft". It is unsuitable for site distances.
+
+- Add a new `UnitFormatter.formatGeoDistance(double meters)` that respects the
+  metric/imperial preference (derived from `settings.depthUnit`) and auto-scales:
+  metric → `m` under 1 km, else `km`; imperial → `ft` under 1 mi (5280 ft), else `mi`.
+  Decimal rules mirror today's picker (major unit `<10` → one decimal, else rounded;
+  minor unit rounded to whole m/ft).
+- The picker uses `formatGeoDistance` (via `ref.watch(settingsProvider)` →
+  `UnitFormatter`) in place of the hardcoded-km/m `_formatDistance` (`:56-64`).
+- Output format should embed the unit symbol to avoid a combinatorial set of
+  per-unit "away" l10n keys (see Open item 2).
+
+### C. Seed the new-site form
+
+`SiteEditPage`:
+
+- Add `final GeoPoint? initialLocation;` to the constructor; ignored when editing or
+  merging (assert / guard against `siteId`/`mergeSiteIds`).
+- On init, when creating and `initialLocation != null`:
+  1. Seed `_latitudeController`/`_longitudeController` inside `_isApplyingInitialValues`
+     so the pre-filled form is **not** marked dirty (a diver who backs out is not
+     nagged).
+  2. Fire a best-effort `reverseGeocode(initialLocation)` via `locationServiceProvider`;
+     when it returns and the widget is still mounted, fill **only-empty**
+     country/region (non-clobbering), matching the "Pick from map" convention. Do not
+     hold `_isApplyingInitialValues` across the await; set it only around the
+     synchronous controller writes.
+
+Router `/sites/new` (`app_router.dart:379`):
+
+- `SiteEditPage(initialLocation: state.extra is GeoPoint ? state.extra as GeoPoint : null)`.
+  The defensive cast keeps the other three `/sites/new` callers (`site_map_page.dart:125`,
+  `site_list_page.dart:72`, `site_list_content.dart:920`), which pass no `extra`,
+  byte-identical.
+
+## Edge cases
+
+- Both entry & exit present → entry. Only exit → exit. Neither → device fallback
+  (today's behavior).
+- Geocode fails / offline → coords still seeded; country/region stay empty.
+- Diver types into country/region before the geocode returns → only-empty fill never
+  overwrites their input.
+- Other `/sites/new` callers → unaffected (defensive `extra` cast).
+
+## Testing (TDD)
+
+- **Unit — `formatGeoDistance`:** metric vs imperial selection from `depthUnit`;
+  m↔km and ft↔mi thresholds; decimal rules; boundary values (999 m, 1 km, ~1 mi).
+- **Unit — sort:** given an anchor and a mix of sited/unsited candidates, ordering is
+  nearest-first with unsited last (exercise the resolved-anchor path).
+- **Widget — picker:** with `diveLocation` set, sites sort by the dive anchor and the
+  dive header string shows; with `diveLocation == null` and `currentLocation` set,
+  falls back to device sorting and the original header.
+- **Widget — `SiteEditPage` seed:** `initialLocation` seeds lat/lng without setting
+  `_hasChanges`; an overridden `locationServiceProvider` returns a placemark and only
+  the empty country/region get filled (pre-typed values survive). No live network.
+- **Widget — router:** `/sites/new` with a `GeoPoint` `extra` yields
+  `initialLocation`; with no `extra`, `initialLocation` is null.
+- **Widget — `_showSitePicker`:** a GPS dive passes the anchor to the sheet and
+  `extra` to the push; a GPS-less dive passes neither.
+- Follow project conventions: SettingsNotifier mocks kept in sync; geocode overridden
+  via provider; Drift/fakeasync awaits wrapped where needed.
+
+## Localization
+
+- New string `diveLog_sitePicker_sortedByDiveDistance` ("Sorted by distance from this
+  dive") added to `app_en.arb` and all non-English locales
+  (`ar, de, es, fr, he, hu, it, nl, pt, zh`), then regenerate localizations.
+- Any additional distance-unit strings introduced by `formatGeoDistance` follow the
+  same all-locales rule (minimized per Open item 2).
+
+## Non-goals (YAGNI)
+
+- No DB/schema change, no migration.
+- No changes to the post-download **site-match review** flow or the **dive-detail**
+  Surface GPS section.
+- No new distance surfaces beyond this picker.
+- The 50 km "nearby" highlight threshold is unchanged.
+- Seeding does not populate depth/difficulty/etc. — only coordinates and (best-effort)
+  country/region.
+
+## Open items (resolve during planning)
+
+1. **Prefill dives:** confirm whether `DivePrefill` (`dive_edit_page.dart:112`) exposes
+   entry/exit GPS. If it does, extend the anchor to
+   `_existingDive?.entry ?? _existingDive?.exit ?? prefill?.entry ?? prefill?.exit`;
+   if not, `_existingDive` is the sole source and new/manual dives use the device
+   fallback (acceptable).
+2. **`formatGeoDistance` output shape:** decide symbol-embedded string vs l10n
+   `{value} away` phrasing, to minimize new localized keys while keeping the existing
+   "away" tone. Prefer the shape that adds the fewest new strings.
+3. **Header icon:** pick the dive-anchored header icon (e.g. `Icons.place` /
+   `Icons.scuba_diving`) for the `diveLocation != null` case.

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -44,6 +44,7 @@ import 'package:submersion/features/dive_log/presentation/pages/profile_editor_p
 import 'package:submersion/features/dive_log/presentation/providers/profile_editor_provider.dart';
 import 'package:submersion/features/maps/presentation/pages/dive_activity_map_page.dart';
 import 'package:submersion/features/maps/presentation/pages/offline_maps_page.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/pages/site_list_page.dart';
 import 'package:submersion/features/dive_sites/presentation/pages/site_detail_page.dart';
 import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
@@ -376,7 +377,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: 'new',
                 name: 'newSite',
-                builder: (context, state) => const SiteEditPage(),
+                builder: (context, state) => SiteEditPage(
+                  initialLocation: state.extra is GeoPoint
+                      ? state.extra as GeoPoint
+                      : null,
+                ),
               ),
               GoRoute(
                 path: 'merge',

--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -43,6 +43,31 @@ class UnitFormatter {
     return '${converted.toStringAsFixed(decimals)}${settings.depthUnit.symbol}';
   }
 
+  /// Format a geographic distance (meters) for site lists and pickers.
+  ///
+  /// Unlike [formatDistance] (depth-unit m/ft, for short surface drift), this
+  /// auto-scales across the full range of site distances and respects the
+  /// diver's metric/imperial preference (derived from depth unit): metric -> m
+  /// under 1 km else km; imperial -> ft under 1 mile else mi. Unit symbols are
+  /// latin (m/km/ft/mi), consistent with [formatDepth].
+  String formatGeoDistance(double meters) {
+    final isMetric = settings.depthUnit == DepthUnit.meters;
+    if (isMetric) {
+      if (meters < 1000) return '${meters.round()} m';
+      final km = meters / 1000;
+      final text = km < 10 ? km.toStringAsFixed(1) : km.round().toString();
+      return '$text km';
+    }
+    final feet = meters * 3.28084;
+    const feetPerMile = 5280.0;
+    if (feet < feetPerMile) return '${feet.round()} ft';
+    final miles = feet / feetPerMile;
+    final text = miles < 10
+        ? miles.toStringAsFixed(1)
+        : miles.round().toString();
+    return '$text mi';
+  }
+
   // ============================================================================
   // Temperature
   // ============================================================================

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1925,6 +1925,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   }
 
   Future<void> _showSitePicker() async {
+    final anchor = _existingDive?.entryLocation ?? _existingDive?.exitLocation;
     final result = await showModalBottomSheet<String>(
       context: context,
       isScrollControlled: true,
@@ -1937,6 +1938,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           scrollController: scrollController,
           selectedSiteId: _selectedSite?.id,
           currentLocation: _currentLocation,
+          diveLocation: anchor,
           onSiteSelected: (site) {
             _markDirty();
             setState(() => _selectedSite = site);
@@ -1950,7 +1952,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     );
 
     if (result == _createNewSiteSentinel && mounted) {
-      final siteId = await context.push<String>('/sites/new');
+      final siteId = await context.push<String>('/sites/new', extra: anchor);
       if (siteId != null && mounted) {
         final repo = ref.read(siteRepositoryProvider);
         final site = await repo.getSiteById(siteId);

--- a/lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart
@@ -81,38 +81,42 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    context.l10n.diveLog_sitePicker_title,
-                    style: Theme.of(context).textTheme.titleLarge,
-                  ),
-                  if (_anchor != null)
-                    Row(
-                      children: [
-                        Icon(
-                          widget.diveLocation != null
-                              ? Icons.place
-                              : Icons.my_location,
-                          size: 14,
-                          color: colorScheme.primary,
-                        ),
-                        const SizedBox(width: 4),
-                        Text(
-                          widget.diveLocation != null
-                              ? context
-                                    .l10n
-                                    .diveLog_sitePicker_sortedByDiveDistance
-                              : context
-                                    .l10n
-                                    .diveLog_sitePicker_sortedByDistance,
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(color: colorScheme.primary),
-                        ),
-                      ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      context.l10n.diveLog_sitePicker_title,
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
-                ],
+                    if (_anchor != null)
+                      Row(
+                        children: [
+                          Icon(
+                            widget.diveLocation != null
+                                ? Icons.place
+                                : Icons.my_location,
+                            size: 14,
+                            color: colorScheme.primary,
+                          ),
+                          const SizedBox(width: 4),
+                          Flexible(
+                            child: Text(
+                              widget.diveLocation != null
+                                  ? context
+                                        .l10n
+                                        .diveLog_sitePicker_sortedByDiveDistance
+                                  : context
+                                        .l10n
+                                        .diveLog_sitePicker_sortedByDistance,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: colorScheme.primary),
+                            ),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
               ),
               TextButton.icon(
                 onPressed: widget.onCreateNewSite,

--- a/lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart
@@ -3,10 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/location_service.dart';
 import 'package:submersion/core/text/fuzzy_match.dart';
+import 'package:submersion/core/utils/geo_math.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/utils/site_picker_search.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/dive_sites/presentation/widgets/similar_value_hint.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Site picker bottom sheet with nearby site suggestions
@@ -14,6 +17,7 @@ class SitePickerSheet extends ConsumerStatefulWidget {
   final ScrollController scrollController;
   final String? selectedSiteId;
   final LocationResult? currentLocation;
+  final GeoPoint? diveLocation;
   final void Function(DiveSite) onSiteSelected;
   final VoidCallback onCreateNewSite;
 
@@ -22,6 +26,7 @@ class SitePickerSheet extends ConsumerStatefulWidget {
     required this.scrollController,
     required this.selectedSiteId,
     this.currentLocation,
+    this.diveLocation,
     required this.onSiteSelected,
     required this.onCreateNewSite,
   });
@@ -40,32 +45,32 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
     super.dispose();
   }
 
-  /// Calculate distance from current location to a site in km
-  double? _distanceToSite(DiveSite site) {
-    if (widget.currentLocation == null || site.location == null) return null;
-    final distanceMeters = LocationService.instance.distanceBetween(
-      widget.currentLocation!.latitude,
-      widget.currentLocation!.longitude,
-      site.location!.latitude,
-      site.location!.longitude,
-    );
-    return distanceMeters / 1000; // Convert to km
+  /// The point distances are measured from: the dive's GPS if present,
+  /// otherwise the device location (today's behavior).
+  GeoPoint? get _anchor {
+    if (widget.diveLocation != null) return widget.diveLocation;
+    final cl = widget.currentLocation;
+    return cl == null ? null : GeoPoint(cl.latitude, cl.longitude);
   }
 
-  /// Format distance for display
-  String _formatDistance(BuildContext context, double km) {
-    if (km < 1) {
-      return context.l10n.diveLog_sitePicker_distanceMeters(
-        (km * 1000).round().toString(),
-      );
-    }
-    final text = km < 10 ? km.toStringAsFixed(1) : km.round().toString();
-    return context.l10n.diveLog_sitePicker_distanceKm(text);
+  /// Distance from the resolved anchor to a site, in meters.
+  double? _distanceToSite(DiveSite site) {
+    final anchor = _anchor;
+    if (anchor == null || site.location == null) return null;
+    return distanceMeters(anchor, site.location!);
+  }
+
+  /// Format a site distance (meters) for display, unit-aware.
+  String _formatDistance(BuildContext context, UnitFormatter units, double m) {
+    return context.l10n.diveLog_sitePicker_distanceAway(
+      units.formatGeoDistance(m),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final sitesAsync = ref.watch(sitesProvider);
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final colorScheme = Theme.of(context).colorScheme;
     final normalizedQuery = _searchQuery.trim().toLowerCase();
 
@@ -83,17 +88,25 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
                     context.l10n.diveLog_sitePicker_title,
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
-                  if (widget.currentLocation != null)
+                  if (_anchor != null)
                     Row(
                       children: [
                         Icon(
-                          Icons.my_location,
+                          widget.diveLocation != null
+                              ? Icons.place
+                              : Icons.my_location,
                           size: 14,
                           color: colorScheme.primary,
                         ),
                         const SizedBox(width: 4),
                         Text(
-                          context.l10n.diveLog_sitePicker_sortedByDistance,
+                          widget.diveLocation != null
+                              ? context
+                                    .l10n
+                                    .diveLog_sitePicker_sortedByDiveDistance
+                              : context
+                                    .l10n
+                                    .diveLog_sitePicker_sortedByDistance,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.primary),
                         ),
@@ -184,9 +197,9 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
                 );
               }
 
-              // Sort sites by distance if we have current location
+              // Sort sites by distance from the resolved anchor when present.
               List<_SiteWithDistance> sortedSites;
-              if (widget.currentLocation != null) {
+              if (_anchor != null) {
                 sortedSites = sites.map((site) {
                   return _SiteWithDistance(site, _distanceToSite(site));
                 }).toList();
@@ -233,7 +246,7 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
                   final distance = siteWithDist.distance;
                   final isSelected = site.id == widget.selectedSiteId;
                   final isNearby =
-                      distance != null && distance < 50; // Within 50km
+                      distance != null && distance < 50000; // within 50 km
 
                   return ListTile(
                     leading: CircleAvatar(
@@ -259,7 +272,7 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
                           Text(site.locationString),
                         if (distance != null)
                           Text(
-                            _formatDistance(context, distance),
+                            _formatDistance(context, units, distance),
                             style: Theme.of(context).textTheme.bodySmall
                                 ?.copyWith(
                                   color: isNearby

--- a/lib/features/dive_sites/presentation/pages/site_edit_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_edit_page.dart
@@ -35,6 +35,7 @@ class SiteEditPage extends ConsumerStatefulWidget {
   final bool embedded;
   final void Function(String savedId)? onSaved;
   final VoidCallback? onCancel;
+  final GeoPoint? initialLocation;
 
   const SiteEditPage({
     super.key,
@@ -43,9 +44,14 @@ class SiteEditPage extends ConsumerStatefulWidget {
     this.embedded = false,
     this.onSaved,
     this.onCancel,
+    this.initialLocation,
   }) : assert(
          siteId == null || mergeSiteIds == null,
          'siteId and mergeSiteIds are mutually exclusive',
+       ),
+       assert(
+         initialLocation == null || (siteId == null && mergeSiteIds == null),
+         'initialLocation is only valid when creating a new site',
        );
 
   bool get isEditing => siteId != null;
@@ -128,6 +134,38 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     if (!_hasChanges && _isInitialized) {
       setState(() => _hasChanges = true);
     }
+  }
+
+  /// Seed a brand-new site form from [SiteEditPage.initialLocation]: fill the
+  /// coordinate fields immediately (as non-dirtying initial values), then
+  /// best-effort reverse-geocode country/region into the empty fields.
+  void _seedInitialLocation() {
+    final loc = widget.initialLocation;
+    if (loc == null) return;
+
+    _isApplyingInitialValues = true;
+    _latitudeController.text = loc.latitude.toStringAsFixed(6);
+    _longitudeController.text = loc.longitude.toStringAsFixed(6);
+    _isApplyingInitialValues = false;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => _geocodeSeed(loc));
+  }
+
+  Future<void> _geocodeSeed(GeoPoint loc) async {
+    final result = await ref
+        .read(locationServiceProvider)
+        .reverseGeocode(loc.latitude, loc.longitude);
+    if (!mounted) return;
+    setState(() {
+      _isApplyingInitialValues = true;
+      if (_countryController.text.isEmpty && result.country != null) {
+        _countryController.text = result.country!;
+      }
+      if (_regionController.text.isEmpty && result.region != null) {
+        _regionController.text = result.region!;
+      }
+      _isApplyingInitialValues = false;
+    });
   }
 
   @override
@@ -510,6 +548,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     // For new sites, mark as initialized immediately
     if (!_isInitialized) {
       _isInitialized = true;
+      _seedInitialLocation();
     }
 
     return _buildForm(context, units);

--- a/lib/features/dive_sites/presentation/pages/site_edit_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_edit_page.dart
@@ -152,6 +152,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
   }
 
   Future<void> _geocodeSeed(GeoPoint loc) async {
+    if (!mounted) return;
     final result = await ref
         .read(locationServiceProvider)
         .reverseGeocode(loc.latitude, loc.longitude);

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1732,6 +1732,8 @@
   "diveLog_sighting_notesOptional": "ملاحظات (اختياري)",
   "diveLog_sitePicker_addDiveSite": "إضافة موقع غوص",
   "diveLog_sitePicker_distanceKm": "{distance} km بعيداً",
+  "diveLog_sitePicker_distanceAway": "{distance} بعيداً",
+  "diveLog_sitePicker_sortedByDiveDistance": "مرتبة حسب المسافة من هذه الغطسة",
   "diveLog_sitePicker_distanceMeters": "{distance} m بعيداً",
   "diveLog_sitePicker_errorLoading": "خطأ في تحميل المواقع: {error}",
   "diveLog_sitePicker_newDiveSite": "موقع غوص جديد",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1732,6 +1732,8 @@
   "diveLog_sighting_notesOptional": "Notizen (optional)",
   "diveLog_sitePicker_addDiveSite": "Tauchplatz hinzufügen",
   "diveLog_sitePicker_distanceKm": "{distance} km entfernt",
+  "diveLog_sitePicker_distanceAway": "{distance} entfernt",
+  "diveLog_sitePicker_sortedByDiveDistance": "Nach Entfernung zu diesem Tauchgang sortiert",
   "diveLog_sitePicker_distanceMeters": "{distance} m entfernt",
   "diveLog_sitePicker_errorLoading": "Fehler beim Laden der Plätze: {error}",
   "diveLog_sitePicker_newDiveSite": "Neuer Tauchplatz",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2744,6 +2744,8 @@
   "diveLog_sighting_notesOptional": "Notes (optional)",
   "diveLog_sitePicker_addDiveSite": "Add Dive Site",
   "diveLog_sitePicker_distanceKm": "{distance} km away",
+  "diveLog_sitePicker_distanceAway": "{distance} away",
+  "diveLog_sitePicker_sortedByDiveDistance": "Sorted by distance from this dive",
   "diveLog_sitePicker_distanceMeters": "{distance} m away",
   "diveLog_sitePicker_errorLoading": "Error loading sites: {error}",
   "diveLog_sitePicker_newDiveSite": "New Dive Site",
@@ -3324,6 +3326,15 @@
         "type": "Object"
       }
     }
+  },
+  "@diveLog_sitePicker_distanceAway": {
+    "description": "A site's distance from the reference point; {distance} already includes the unit, e.g. '1.2 km' or '800 ft'",
+    "placeholders": {
+      "distance": { "type": "String", "example": "1.2 km" }
+    }
+  },
+  "@diveLog_sitePicker_sortedByDiveDistance": {
+    "description": "Site picker header shown when sites are sorted by distance from the edited dive's GPS position"
   },
   "@diveLog_sitePicker_distanceKm": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1732,6 +1732,8 @@
   "diveLog_sighting_notesOptional": "Notas (opcional)",
   "diveLog_sitePicker_addDiveSite": "Agregar punto de buceo",
   "diveLog_sitePicker_distanceKm": "a {distance} km",
+  "diveLog_sitePicker_distanceAway": "a {distance}",
+  "diveLog_sitePicker_sortedByDiveDistance": "Ordenados por distancia a esta inmersión",
   "diveLog_sitePicker_distanceMeters": "a {distance} m",
   "diveLog_sitePicker_errorLoading": "Error al cargar los sitios: {error}",
   "diveLog_sitePicker_newDiveSite": "Nuevo punto de buceo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1698,6 +1698,8 @@
   "diveLog_sighting_notesOptional": "Notes (optionnel)",
   "diveLog_sitePicker_addDiveSite": "Ajouter un site de plongee",
   "diveLog_sitePicker_distanceKm": "{distance} km",
+  "diveLog_sitePicker_distanceAway": "à {distance}",
+  "diveLog_sitePicker_sortedByDiveDistance": "Trié par distance à cette plongée",
   "diveLog_sitePicker_distanceMeters": "{distance} m",
   "diveLog_sitePicker_errorLoading": "Erreur de chargement des sites : {error}",
   "diveLog_sitePicker_newDiveSite": "Nouveau site de plongee",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1698,6 +1698,8 @@
   "diveLog_sighting_notesOptional": "הערות (אופציונלי)",
   "diveLog_sitePicker_addDiveSite": "הוסף אתר צלילה",
   "diveLog_sitePicker_distanceKm": "{distance} km משם",
+  "diveLog_sitePicker_distanceAway": "{distance} משם",
+  "diveLog_sitePicker_sortedByDiveDistance": "ממוין לפי מרחק מהצלילה הזו",
   "diveLog_sitePicker_distanceMeters": "{distance} m משם",
   "diveLog_sitePicker_errorLoading": "שגיאה בטעינת אתרים: {error}",
   "diveLog_sitePicker_newDiveSite": "אתר צלילה חדש",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1698,6 +1698,8 @@
   "diveLog_sighting_notesOptional": "Megjegyzesek (opcionalis)",
   "diveLog_sitePicker_addDiveSite": "Merulohely hozzaadasa",
   "diveLog_sitePicker_distanceKm": "{distance} km tavolsagra",
+  "diveLog_sitePicker_distanceAway": "{distance} távolságra",
+  "diveLog_sitePicker_sortedByDiveDistance": "Távolság szerint rendezve ettől a merüléstől",
   "diveLog_sitePicker_distanceMeters": "{distance} m tavolsagra",
   "diveLog_sitePicker_errorLoading": "Hiba a helyszinek betoltesekor: {error}",
   "diveLog_sitePicker_newDiveSite": "Uj merulohely",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1698,6 +1698,8 @@
   "diveLog_sighting_notesOptional": "Note (opzionale)",
   "diveLog_sitePicker_addDiveSite": "Aggiungi sito di immersione",
   "diveLog_sitePicker_distanceKm": "{distance} km di distanza",
+  "diveLog_sitePicker_distanceAway": "{distance} di distanza",
+  "diveLog_sitePicker_sortedByDiveDistance": "Ordinati per distanza da questa immersione",
   "diveLog_sitePicker_distanceMeters": "{distance} m di distanza",
   "diveLog_sitePicker_errorLoading": "Errore nel caricamento dei siti: {error}",
   "diveLog_sitePicker_newDiveSite": "Nuovo sito di immersione",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -9146,6 +9146,18 @@ abstract class AppLocalizations {
   /// **'{distance} km away'**
   String diveLog_sitePicker_distanceKm(Object distance);
 
+  /// A site's distance from the reference point; {distance} already includes the unit, e.g. '1.2 km' or '800 ft'
+  ///
+  /// In en, this message translates to:
+  /// **'{distance} away'**
+  String diveLog_sitePicker_distanceAway(String distance);
+
+  /// Site picker header shown when sites are sorted by distance from the edited dive's GPS position
+  ///
+  /// In en, this message translates to:
+  /// **'Sorted by distance from this dive'**
+  String get diveLog_sitePicker_sortedByDiveDistance;
+
   /// No description provided for @diveLog_sitePicker_distanceMeters.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -5286,6 +5286,15 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance بعيداً';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'مرتبة حسب المسافة من هذه الغطسة';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m بعيداً';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -5401,6 +5401,15 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance entfernt';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Nach Entfernung zu diesem Tauchgang sortiert';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m entfernt';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -5308,6 +5308,15 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance away';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Sorted by distance from this dive';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m away';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -5404,6 +5404,15 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return 'a $distance';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Ordenados por distancia a esta inmersión';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return 'a $distance m';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -5430,6 +5430,15 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return 'à $distance';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Trié par distance à cette plongée';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -5260,6 +5260,15 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance משם';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'ממוין לפי מרחק מהצלילה הזו';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m משם';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -5389,6 +5389,15 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance távolságra';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Távolság szerint rendezve ettől a merüléstől';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m tavolsagra';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -5410,6 +5410,15 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance di distanza';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Ordinati per distanza da questa immersione';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m di distanza';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -5364,6 +5364,15 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance afstand';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Gesorteerd op afstand tot deze duik';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m afstand';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -5408,6 +5408,15 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '$distance de distância';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance =>
+      'Ordenado por distância deste mergulho';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '$distance m de distancia';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -5150,6 +5150,14 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String diveLog_sitePicker_distanceAway(String distance) {
+    return '距离 $distance';
+  }
+
+  @override
+  String get diveLog_sitePicker_sortedByDiveDistance => '按与本次潜水的距离排序';
+
+  @override
   String diveLog_sitePicker_distanceMeters(Object distance) {
     return '距离 $distance 米';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1732,6 +1732,8 @@
   "diveLog_sighting_notesOptional": "Notities (optioneel)",
   "diveLog_sitePicker_addDiveSite": "Duikstek toevoegen",
   "diveLog_sitePicker_distanceKm": "{distance} km afstand",
+  "diveLog_sitePicker_distanceAway": "{distance} afstand",
+  "diveLog_sitePicker_sortedByDiveDistance": "Gesorteerd op afstand tot deze duik",
   "diveLog_sitePicker_distanceMeters": "{distance} m afstand",
   "diveLog_sitePicker_errorLoading": "Fout bij laden van stekken: {error}",
   "diveLog_sitePicker_newDiveSite": "Nieuwe duikstek",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1732,6 +1732,8 @@
   "diveLog_sighting_notesOptional": "Observacoes (opcional)",
   "diveLog_sitePicker_addDiveSite": "Adicionar Ponto de Mergulho",
   "diveLog_sitePicker_distanceKm": "{distance} km de distancia",
+  "diveLog_sitePicker_distanceAway": "{distance} de distância",
+  "diveLog_sitePicker_sortedByDiveDistance": "Ordenado por distância deste mergulho",
   "diveLog_sitePicker_distanceMeters": "{distance} m de distancia",
   "diveLog_sitePicker_errorLoading": "Erro ao carregar pontos: {error}",
   "diveLog_sitePicker_newDiveSite": "Novo Ponto de Mergulho",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1862,6 +1862,8 @@
   "diveLog_sighting_notesOptional": "备注（可选）",
   "diveLog_sitePicker_addDiveSite": "添加潜水点",
   "diveLog_sitePicker_distanceKm": "距离 {distance} 公里",
+  "diveLog_sitePicker_distanceAway": "距离 {distance}",
+  "diveLog_sitePicker_sortedByDiveDistance": "按与本次潜水的距离排序",
   "diveLog_sitePicker_distanceMeters": "距离 {distance} 米",
   "diveLog_sitePicker_errorLoading": "加载潜水点出错：{error}",
   "diveLog_sitePicker_newDiveSite": "新潜水点",

--- a/test/core/utils/unit_formatter_distance_test.dart
+++ b/test/core/utils/unit_formatter_distance_test.dart
@@ -11,4 +11,24 @@ void main() {
     const imperial = UnitFormatter(AppSettings(depthUnit: DepthUnit.feet));
     expect(imperial.formatDistance(120), '394ft');
   });
+
+  group('formatGeoDistance', () {
+    const metric = UnitFormatter(AppSettings(depthUnit: DepthUnit.meters));
+    const imperial = UnitFormatter(AppSettings(depthUnit: DepthUnit.feet));
+
+    test('metric scales meters to km', () {
+      expect(metric.formatGeoDistance(120), '120 m');
+      expect(metric.formatGeoDistance(999), '999 m');
+      expect(metric.formatGeoDistance(1000), '1.0 km');
+      expect(metric.formatGeoDistance(5560), '5.6 km');
+      expect(metric.formatGeoDistance(23400), '23 km');
+    });
+
+    test('imperial scales feet to miles', () {
+      expect(imperial.formatGeoDistance(120), '394 ft');
+      expect(imperial.formatGeoDistance(1000), '3281 ft');
+      expect(imperial.formatGeoDistance(3218.688), '2.0 mi');
+      expect(imperial.formatGeoDistance(160934), '100 mi');
+    });
+  });
 }

--- a/test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_site_gps_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  testWidgets('site picker is anchored on the dive GPS', (tester) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final dive = Dive(
+      id: 'dive-gps',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 3, 28, 10, 0),
+      entryTime: DateTime(2026, 3, 28, 10, 5),
+      bottomTime: const Duration(minutes: 40),
+      maxDepth: 20.0,
+      entryLocation: const GeoPoint(34.0182, -118.4965),
+      tanks: const [],
+      profile: const [],
+      equipment: const [],
+      notes: '',
+      photoIds: const [],
+      sightings: const [],
+      weights: const [],
+      tags: const [],
+    );
+    final created = await repository.createDive(dive);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveEditPage(diveId: created.id, embedded: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Open the site picker via the "Add site" FormRow.picker placeholder.
+    await tester.ensureVisible(find.text('Add site'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add site'));
+    await tester.pumpAndSettle();
+
+    // Dive has entry GPS -> the picker is anchored on it.
+    expect(find.text('Sorted by distance from this dive'), findsOneWidget);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
+++ b/test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/location_service.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 const _nearSite = DiveSite(
@@ -26,10 +28,19 @@ const _noGpsSite = DiveSite(id: 'nogps', name: 'Mystery Lake');
 
 const _here = LocationResult(latitude: 10.0, longitude: 10.0);
 
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(super.state);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 Future<void> _pump(
   WidgetTester tester, {
   required List<DiveSite> sites,
   LocationResult? currentLocation,
+  GeoPoint? diveLocation,
+  AppSettings settings = const AppSettings(),
   String? selectedSiteId,
   void Function(DiveSite)? onSiteSelected,
   VoidCallback? onCreateNewSite,
@@ -39,7 +50,10 @@ Future<void> _pump(
   addTearDown(tester.view.reset);
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [sitesProvider.overrideWith((ref) async => sites)],
+      overrides: [
+        sitesProvider.overrideWith((ref) async => sites),
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
+      ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -48,6 +62,7 @@ Future<void> _pump(
             scrollController: ScrollController(),
             selectedSiteId: selectedSiteId,
             currentLocation: currentLocation,
+            diveLocation: diveLocation,
             onSiteSelected: onSiteSelected ?? (_) {},
             onCreateNewSite: onCreateNewSite ?? () {},
           ),
@@ -125,5 +140,39 @@ void main() {
     expect(find.text('No dive sites yet'), findsOneWidget);
     await tester.tap(find.text('Add Dive Site'));
     expect(created, 1);
+  });
+
+  testWidgets('sorts by diveLocation when provided', (tester) async {
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite, _midSite],
+      diveLocation: const GeoPoint(10.0, 10.0),
+    );
+    expect(_tileTitles(tester), ['House Reef', 'Channel', 'Blue Hole']);
+    expect(find.text('Sorted by distance from this dive'), findsOneWidget);
+  });
+
+  testWidgets('falls back to currentLocation when diveLocation is null', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite, _midSite],
+      currentLocation: _here,
+    );
+    expect(_tileTitles(tester), ['House Reef', 'Channel', 'Blue Hole']);
+    expect(find.text('Sorted by distance'), findsOneWidget);
+    expect(find.text('Sorted by distance from this dive'), findsNothing);
+  });
+
+  testWidgets('distance readout respects imperial units', (tester) async {
+    await _pump(
+      tester,
+      sites: const [_farSite],
+      diveLocation: const GeoPoint(10.0, 10.0),
+      settings: const AppSettings(depthUnit: DepthUnit.feet),
+    );
+    expect(find.textContaining('mi'), findsWidgets);
+    expect(find.textContaining('km'), findsNothing);
   });
 }

--- a/test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/location_service_provider.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Records the coordinates it was asked to reverse-geocode and returns a fixed
+/// placemark, so tests can prove the seed path fires geocoding. (The
+/// fill-only-empty write of country/region is already covered by the existing
+/// site_edit_page_test.dart geocode tests.)
+class _RecordingLocationService implements LocationService {
+  ({double lat, double lng})? geocodedWith;
+
+  @override
+  Future<({String? country, String? region, String? locality})> reverseGeocode(
+    double latitude,
+    double longitude,
+  ) async {
+    geocodedWith = (lat: latitude, lng: longitude);
+    return (country: 'Testland', region: 'Test Region', locality: null);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+List<Diver> _divers() => [
+  Diver(
+    id: 'd1',
+    name: 'Me',
+    createdAt: DateTime(2024),
+    updatedAt: DateTime(2024),
+  ),
+];
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  testWidgets('seeds coordinates and fires geocoding from initialLocation', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final geocoder = _RecordingLocationService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          allDiversProvider.overrideWith((_) async => _divers()),
+          shareByDefaultProvider.overrideWith((_) async => false),
+          locationServiceProvider.overrideWithValue(geocoder),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SiteEditPage(initialLocation: GeoPoint(34.0182, -118.4965)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Location section is collapsed by default; its summary is "{lat}, {lng}".
+    expect(find.text('34.018200, -118.496500'), findsOneWidget);
+    // Seeding fired a reverse-geocode for exactly those coordinates.
+    expect(geocoder.geocodedWith, isNotNull);
+    expect(geocoder.geocodedWith!.lat, closeTo(34.0182, 1e-9));
+    expect(geocoder.geocodedWith!.lng, closeTo(-118.4965, 1e-9));
+  });
+
+  testWidgets('/sites/new maps a GeoPoint extra into initialLocation', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final router = GoRouter(
+      initialLocation: '/start',
+      routes: [
+        GoRoute(
+          path: '/start',
+          builder: (context, state) => Scaffold(
+            body: Center(
+              child: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => context.push(
+                    '/sites/new',
+                    extra: const GeoPoint(1.5, 2.5),
+                  ),
+                  child: const Text('go'),
+                ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sites/new',
+          builder: (context, state) => SiteEditPage(
+            initialLocation: state.extra is GeoPoint
+                ? state.extra as GeoPoint
+                : null,
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          allDiversProvider.overrideWith((_) async => _divers()),
+          shareByDefaultProvider.overrideWith((_) async => false),
+          locationServiceProvider.overrideWithValue(
+            _RecordingLocationService(),
+          ),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.500000, 2.500000'), findsOneWidget);
+  });
+}

--- a/test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/test_database.dart';

--- a/test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_seed_location_test.dart
@@ -9,7 +9,6 @@ import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
-import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/test_database.dart';


### PR DESCRIPTION
## What

When editing a dive that has GPS coordinates (entry, or exit if entry is absent), the dive-edit site picker now:

- **Sorts existing sites by distance from the dive's GPS** (nearest first), showing each site's distance in the diver's unit system (m/km or ft/mi).
- **Seeds "New Dive Site"** with the dive's coordinates and best-effort reverse-geocodes country/region into the form.

Dives without GPS behave exactly as before (device-location fallback for sorting; blank new-site form).

## How

- `UnitFormatter.formatGeoDistance` — auto-scaling, unit-aware distance formatter (metric m↔km, imperial ft↔mi), consistent with `formatDepth`'s latin unit symbols.
- `SitePickerSheet` gains a `diveLocation` anchor; distance/sort/header key off `diveLocation ?? currentLocation` via `geo_math.distanceMeters`. Metric output is byte-identical to before, so imperial support is purely additive.
- `SiteEditPage.initialLocation` seeds lat/lng as non-dirtying initial values, then fires a fill-only-empty reverse-geocode; reached through the `/sites/new` route's `extra` (defensive cast keeps the other three callers unchanged).
- `dive_edit_page._showSitePicker` feeds the dive anchor (`_existingDive.entryLocation ?? exitLocation`) and carries it as the route `extra`.
- Two localized strings (`diveLog_sitePicker_sortedByDiveDistance`, `diveLog_sitePicker_distanceAway`) added across all 11 locales.
- Header layout hardened with `Expanded`/`Flexible` so the longer label doesn't overflow on narrow widths (caught by the wiring test).

## Testing

- **New:** `formatGeoDistance` unit tests (metric/imperial scaling); picker anchor/fallback/imperial widget tests; `SiteEditPage` seed + `/sites/new` extra-mapping tests; dive-edit anchor wiring test.
- **Regression:** 83 tests across router/formatter/picker/site-edit/dive-edit suites + 42 l10n tests, all green. `flutter analyze` clean on all changed files.

Design spec + implementation plan are included under `docs/superpowers/`.