### PR TITLE
fix(sync): preserve built-in reference data across replace-adopt

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -4984,6 +4984,22 @@ class AppDatabase extends _$AppDatabase {
         // Enable foreign keys
         await customStatement('PRAGMA foreign_keys = ON');
 
+        // Built-in dive types are reference data: identical on every device and
+        // undeletable through DiveTypeRepository. Nothing else restores them --
+        // the seed runs only in onCreate and the one-shot v93 step -- yet a
+        // replace-adopt clears dive_types and refills from a payload that omits
+        // built-ins, and a library copied from an already-empty device carries
+        // the hole with it. Re-assert on every open, mirroring the built-in
+        // species seed. INSERT OR IGNORE is idempotent, and the stable slug ids
+        // are exactly what dive_dive_types references, so orphaned junction
+        // rows resolve again.
+        final diveTypesTable = await customSelect(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='dive_types'",
+        ).get();
+        if (diveTypesTable.isNotEmpty) {
+          await customStatement(kSeedBuiltInDiveTypesSql);
+        }
+
         // Backstop for schema-version collisions (issue #395; same disease
         // as the v77/v82/v83 sync-branch incidents): a parallel branch build
         // that claims the same schema version can advance user_version past

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2613,12 +2613,33 @@ class SyncDataSerializer {
   /// `active_diver_id`) are preserved: they are never part of a synced or
   /// replaced library, so an adopt must not wipe them (they are also excluded
   /// from the base by [_exportSettings], so re-insert would not restore them).
+  ///
+  /// Built-in reference rows are preserved for the same reason:
+  /// [_exportDiveTypes], [_exportSpecies] and [_exportFieldPresets] all omit
+  /// `isBuiltIn` rows, so the refill that follows this clear cannot put them
+  /// back. Deleting them would leave the catalog permanently empty.
   Future<void> deleteAllRecords(String entityType) async {
-    if (entityType == 'settings') {
-      await (_db.delete(
-        _db.settings,
-      )..where((t) => t.key.isNotIn(_deviceLocalSettingsKeys.toList()))).go();
-      return;
+    switch (entityType) {
+      case 'settings':
+        await (_db.delete(
+          _db.settings,
+        )..where((t) => t.key.isNotIn(_deviceLocalSettingsKeys.toList()))).go();
+        return;
+      case 'diveTypes':
+        await (_db.delete(
+          _db.diveTypes,
+        )..where((t) => t.isBuiltIn.equals(false))).go();
+        return;
+      case 'species':
+        await (_db.delete(
+          _db.species,
+        )..where((t) => t.isBuiltIn.equals(false))).go();
+        return;
+      case 'fieldPresets':
+        await (_db.delete(
+          _db.fieldPresets,
+        )..where((t) => t.isBuiltIn.equals(false))).go();
+        return;
     }
     await _db.delete(_syncTableFor(entityType)).go();
   }

--- a/test/core/services/sync/sync_adopt_builtin_dive_types_test.dart
+++ b/test/core/services/sync/sync_adopt_builtin_dive_types_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Built-in dive types are reference data: seeded identically on every device,
+/// and rejected by [DiveTypeRepository.deleteDiveType]. Nothing may remove
+/// them.
+///
+/// A replace-adopt clears every synced table and refills from the cloud, but
+/// `_exportDiveTypes` deliberately omits built-ins from the payload -- so the
+/// refill cannot restore what the clear removed. Since the seed only runs in
+/// `onCreate` and the one-shot `from < 93` migration, a device past v93 that
+/// loses its built-ins never gets them back: the dive-type picker and
+/// Settings > Manage > Dive Types both go permanently empty, and the surviving
+/// `dive_dive_types` rows dangle against a missing catalog.
+///
+/// The adopt parity test cannot catch this: it compares both adopt paths via
+/// `exportData()`, which excludes built-ins by definition.
+SyncService _svc() => SyncService(
+  syncRepository: SyncRepository(),
+  serializer: SyncDataSerializer(),
+);
+
+Future<List<String>> _builtInIds() async {
+  final db = DatabaseService.instance.database;
+  final rows = await (db.select(
+    db.diveTypes,
+  )..where((t) => t.isBuiltIn.equals(true))).get();
+  return rows.map((r) => r.id).toList()..sort();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('adopt preserves built-in dive types', () async {
+    // The cloud library is published by a peer whose export, like every
+    // export, carries only custom dive types.
+    final base = await SyncDataSerializer().exportData(
+      deviceId: 'peer',
+      deletions: const [],
+    );
+    expect(
+      base.data.diveTypes,
+      isEmpty,
+      reason: 'exports never carry built-in dive types',
+    );
+
+    final seeded = await _builtInIds();
+    expect(seeded, hasLength(15), reason: 'onCreate seeds the built-ins');
+
+    final tmpDir = await Directory.systemTemp.createTemp('adopt_builtin');
+    final tmp = File('${tmpDir.path}/base.json');
+    await tmp.writeAsBytes(
+      utf8.encode(SyncDataSerializer().serializePayload(base)),
+    );
+    await _svc().debugAdoptStreaming([tmp.path], [base.exportedAt], const []);
+    await tmpDir.delete(recursive: true);
+
+    expect(
+      await _builtInIds(),
+      seeded,
+      reason: 'adopt must not delete rows its refill cannot restore',
+    );
+  });
+
+  test(
+    'reopening a database with no built-in dive types re-seeds them',
+    () async {
+      // Databases already stranded with an empty catalog -- by an adopt predating
+      // the guard above, or by restoring a library copied from such a device --
+      // are past v93, so no migration will ever repair them. beforeOpen must.
+      final dir = await Directory.systemTemp.createTemp('reseed_backstop');
+      final file = File('${dir.path}/submersion.db');
+
+      var db = AppDatabase(NativeDatabase(file));
+      await db.customStatement('DELETE FROM dive_types');
+      final emptied = await db
+          .customSelect('SELECT count(*) AS c FROM dive_types')
+          .getSingle();
+      expect(emptied.read<int>('c'), 0);
+      await db.close();
+
+      db = AppDatabase(NativeDatabase(file));
+      final restored = await (db.select(
+        db.diveTypes,
+      )..where((t) => t.isBuiltIn.equals(true))).get();
+      await db.close();
+      await dir.delete(recursive: true);
+
+      expect(
+        restored,
+        hasLength(15),
+        reason: 'beforeOpen re-seeds the built-ins',
+      );
+      expect(
+        restored.map((r) => r.id),
+        contains('wreck'),
+        reason: 'stable slug ids are what dive_dive_types references',
+      );
+    },
+  );
+}

--- a/test/core/services/sync/sync_adopt_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_adopt_streaming_parity_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
@@ -31,12 +32,24 @@ String _canonical(Map<String, dynamic> dataJson) {
   return jsonEncode(out);
 }
 
+/// `exportData` omits built-in reference rows, so a snapshot built only from it
+/// is blind to precisely the rows an adopt's table-clear destroys: the two paths
+/// once diverged there (streaming wiped built-in dive types, in-memory kept
+/// them) while this comparison stayed green. Fold them in explicitly.
 Future<String> _dump() async {
   final export = await SyncDataSerializer().exportData(
     deviceId: 'snapshot',
     deletions: const [],
   );
-  return _canonical(export.data.toJson());
+  final json = export.data.toJson();
+  final db = DatabaseService.instance.database;
+  final builtIns = await (db.select(
+    db.diveTypes,
+  )..where((t) => t.isBuiltIn.equals(true))).get();
+  json['builtInDiveTypes'] = [
+    for (final t in builtIns) {'id': t.id, 'name': t.name},
+  ];
+  return _canonical(json);
 }
 
 SyncService _svc() => SyncService(

--- a/test/core/services/sync/sync_builtin_reference_data_test.dart
+++ b/test/core/services/sync/sync_builtin_reference_data_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Replace-adopt clears each synced table via [SyncDataSerializer.deleteAllRecords]
+/// and refills it from the cloud payload. Every exporter that filters
+/// `isBuiltIn` rows out of that payload therefore makes its table unrestorable
+/// by the refill: whatever the clear removes is gone for good.
+///
+/// This asserts the contract for all such tables at once, and fails when a new
+/// one appears -- the fourth `isBuiltIn` table must make the same choice
+/// deliberately rather than inherit the bug.
+///
+/// Recovery differs per table and none of it runs during an adopt: species are
+/// re-seeded at app startup, field presets lazily on read, dive types only in
+/// `beforeOpen`. The clear must not depend on any of them.
+const _entityForTable = {
+  'dive_types': 'diveTypes',
+  'species': 'species',
+  'field_presets': 'fieldPresets',
+};
+
+const _diverId = 'diver-1';
+
+/// Minimal rows: every NOT NULL column without a default, plus is_built_in.
+String _insert(String table, {required String id, required bool builtIn}) {
+  final b = builtIn ? 1 : 0;
+  switch (table) {
+    case 'dive_types':
+      return "INSERT INTO dive_types (id, name, created_at, updated_at, "
+          "is_built_in) VALUES ('$id', '$id', 0, 0, $b)";
+    case 'species':
+      return "INSERT INTO species (id, common_name, category, is_built_in) "
+          "VALUES ('$id', '$id', 'fish', $b)";
+    case 'field_presets':
+      return "INSERT INTO field_presets (id, diver_id, view_mode, name, "
+          "config_json, created_at, is_built_in) VALUES ('$id', '$_diverId', "
+          "'table', '$id', '{}', 0, $b)";
+    default:
+      throw ArgumentError('no insert template for $table');
+  }
+}
+
+Future<int> _count(String table, {required bool builtIn}) async {
+  final row = await DatabaseService.instance.database
+      .customSelect(
+        'SELECT count(*) AS c FROM $table WHERE is_built_in = ${builtIn ? 1 : 0}',
+      )
+      .getSingle();
+  return row.read<int>('c');
+}
+
+/// Every table in the schema carrying an `is_built_in` column.
+Future<Set<String>> _tablesWithBuiltInColumn() async {
+  final db = DatabaseService.instance.database;
+  final tables = await db
+      .customSelect(
+        "SELECT name FROM sqlite_master WHERE type = 'table' "
+        "AND name NOT LIKE 'sqlite_%'",
+      )
+      .get();
+  final found = <String>{};
+  for (final t in tables) {
+    final name = t.read<String>('name');
+    final cols = await db.customSelect("PRAGMA table_info('$name')").get();
+    if (cols.any((c) => c.read<String>('name') == 'is_built_in')) {
+      found.add(name);
+    }
+  }
+  return found;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await setUpTestDatabase();
+    await DatabaseService.instance.database.customStatement(
+      "INSERT INTO divers (id, name, created_at, updated_at) "
+      "VALUES ('$_diverId', 'Test', 0, 0)",
+    );
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  test('every isBuiltIn table is covered by this contract', () async {
+    expect(
+      await _tablesWithBuiltInColumn(),
+      _entityForTable.keys.toSet(),
+      reason:
+          'a new isBuiltIn table must decide whether deleteAllRecords may '
+          'clear it, and whether anything re-seeds it',
+    );
+  });
+
+  test('exports omit built-in rows, so a refill cannot restore them', () async {
+    final data = (await SyncDataSerializer().exportData(
+      deviceId: 'peer',
+      deletions: const [],
+    )).data;
+    expect(data.diveTypes, isEmpty);
+    expect(data.species, isEmpty);
+    expect(data.fieldPresets, isEmpty);
+  });
+
+  for (final entry in _entityForTable.entries) {
+    final table = entry.key;
+    final entity = entry.value;
+
+    test(
+      'deleteAllRecords($entity) clears custom rows but keeps built-ins',
+      () async {
+        final db = DatabaseService.instance.database;
+        await db.customStatement('DELETE FROM $table');
+        await db.customStatement(_insert(table, id: 'b1', builtIn: true));
+        await db.customStatement(_insert(table, id: 'c1', builtIn: false));
+
+        await SyncDataSerializer().deleteAllRecords(entity);
+
+        expect(
+          await _count(table, builtIn: true),
+          1,
+          reason: '$table built-in rows are absent from every export',
+        );
+        expect(
+          await _count(table, builtIn: false),
+          0,
+          reason:
+              '$table custom rows are exported, so the refill restores them',
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Problem

The dive-type picker and **Settings > Manage > Dive Types** were empty on affected databases, while dives kept their type assignments in `dive_dive_types`.

Replace-adopt (`_adoptApplyStreaming`) clears every synced table, then refills from the cloud payload. But `_exportDiveTypes`, `_exportSpecies` and `_exportFieldPresets` all filter `isBuiltIn` rows *out* of that payload — so the refill cannot restore what the clear removed. The wipe deletes 15 built-in dive types; the refill restores 0.

Nothing puts them back. `kSeedBuiltInDiveTypesSql` runs only in `onCreate` and the one-shot `if (from < 93)` migration, so any database past v93 that loses its built-ins is **permanently broken**. Because `dive_dive_types.diveTypeId` is not a declared foreign key, SQLite never blocked the delete, leaving junction rows dangling against a missing catalog.

`_exportDiveTypes` justifies the exclusion with an invariant that was never implemented:

> Built-in dive types are re-seeded identically on every device at first launch

Species survives the identical wipe only because `seedBuiltInSpecies()` runs at app startup; field presets because `ensureBuiltInPresets()` runs on every read. Dive types had no equivalent.

## Fix

- **`deleteAllRecords`** now spares `isBuiltIn` rows for `diveTypes`, `species` and `fieldPresets`. This mirrors the pre-existing `settings` case, which skips `_deviceLocalSettingsKeys` for exactly this reason: *"they are also excluded from the base by `_exportSettings`, so re-insert would not restore them."*
- **`beforeOpen`** re-asserts the built-in dive-type seed on every open, `sqlite_master`-guarded — the same backstop pattern this file already uses for the v99 objects (#395). This heals **already-stranded installs on next launch**, with no schema bump and no user action.

The heal is lossless: built-in ids are stable slugs (`recreational`, `wreck`), not UUIDs, so re-inserting them restores exactly the identities orphaned junction rows already reference. No dive loses its types.

## Why not just sync the built-ins?

Considered and rejected. It would not remove the need for the local seed (sync is optional), so it creates a second source of truth for the same 15 rows. Worse, under latest-export-wins the winner is whichever device synced most recently — not the one running the newest app — so a stale peer could overwrite constants a new release ships, and updating the app could not reliably correct it. Built-in types are code-owned constants versioned with the binary. Derive constants; transport variables.

## Tests

- **`sync_adopt_builtin_dive_types_test.dart`** (new) — adopt must not delete rows its refill cannot restore; reopening an emptied database re-seeds it. Failed before the fix (expected 15 slugs, got `[]`).
- **`sync_builtin_reference_data_test.dart`** (new) — asserts the contract for *every* table carrying an `is_built_in` column, **discovered from the schema at runtime**, so a fourth such table cannot inherit this bug silently. Verified by mutation: all three cases fail with the guard removed.
- **`sync_adopt_streaming_parity_test.dart`** — `_dump()` now includes built-in dive types. It compared both adopt paths via `exportData()`, which excludes built-ins *by definition*, and so stayed green while the paths genuinely diverged there (streaming wiped them, in-memory kept them). Verified by mutation: it now fails with the guard removed, where before it passed.

`flutter analyze` clean; 196 tests pass across the sync, database-migration, dive-types and view-config suites.