### PR TITLE
fix(dc): buffer Android USB serial reads at bulk-packet granularity

### DIFF
--- a/packages/libdivecomputer_plugin/android/build.gradle
+++ b/packages/libdivecomputer_plugin/android/build.gradle
@@ -69,6 +69,7 @@ android {
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
         androidTest.java.srcDirs += "src/androidTest/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
     }
 
     externalNativeBuild {
@@ -84,6 +85,10 @@ dependencies {
     // sources (android/third_party/usb-serial-for-android). Annotations-only
     // artifact; no runtime footprint of consequence.
     implementation "androidx.annotation:annotation:1.9.1"
+
+    // JVM unit tests for pure-Kotlin logic (e.g. SerialReadBuffer chunk
+    // reassembly); run via :libdivecomputer_plugin:testDebugUnitTest.
+    testImplementation "junit:junit:4.13.2"
 
     // Instrumented tests for the :dc IPC (marshaling round-trip, crash isolation).
     androidTestImplementation "androidx.test.ext:junit:1.1.5"

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialReadBuffer.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialReadBuffer.kt
@@ -1,0 +1,103 @@
+package com.submersion.libdivecomputer
+
+// Reassembles libdivecomputer's exact-length serial reads from raw USB bulk
+// chunk reads, restoring the tty byte-stream semantics its serial drivers
+// were written against.
+//
+// Raw USB bulk endpoints are packet-based: asking the kernel for fewer bytes
+// than the arriving packet contains fails the transfer with EOVERFLOW and
+// DISCARDS the packet, and usb-serial-for-android surfaces that as an
+// immediate 0-byte read -- indistinguishable from a silent device. That is
+// how the Mares Puck Pro handshake failed in issue #318: libdivecomputer
+// reads the 1-byte ACK header first, the device's whole response arrived in
+// one 64-byte bulk packet, and every retry threw the response away.
+//
+// Two invariants fix that:
+//  1. Never hand USB a buffer smaller than one bulk packet (minChunkSize =
+//     the endpoint's max packet size).
+//  2. Keep whatever a chunk returns beyond the requested size buffered for
+//     subsequent reads, since the next protocol bytes ride in the same packet.
+//
+// Pure Kotlin (no Android imports): the clock, the chunk reader, and tracing
+// are injected so the deadline and buffering logic is testable on the JVM.
+class SerialReadBuffer(
+    minChunkSize: Int,
+    private val nowNanos: () -> Long = System::nanoTime,
+    private val trace: (String) -> Unit = {},
+) {
+    private val minChunkSize = minChunkSize.coerceAtLeast(1)
+
+    // Surplus bytes from an earlier chunk, in arrival order.
+    private var pending = ByteArray(0)
+
+    // Returns exactly `size` bytes, or null on timeout (the JNI bridge maps
+    // null to LIBDC_STATUS_TIMEOUT and libdivecomputer retries). Timeout
+    // semantics follow libdivecomputer's serial contract: negative = block
+    // until data, zero = non-blocking single poll, positive = total deadline
+    // across however many chunk reads it takes.
+    //
+    // readChunk(dest, timeoutMs) performs one USB bulk read into dest and
+    // returns the byte count (0 = nothing this slice); usb-serial-for-android
+    // treats timeout 0 as "block until data". I/O errors propagate as
+    // exceptions.
+    fun read(
+        size: Int,
+        timeoutMs: Int,
+        readChunk: (ByteArray, Int) -> Int,
+    ): ByteArray? {
+        if (size <= 0) return ByteArray(0)
+        val result = ByteArray(size)
+        var received = 0
+
+        // Serve buffered surplus from earlier chunks first.
+        if (pending.isNotEmpty()) {
+            val n = minOf(pending.size, size)
+            System.arraycopy(pending, 0, result, 0, n)
+            pending = pending.copyOfRange(n, pending.size)
+            received = n
+        }
+
+        val deadlineNanos =
+            if (timeoutMs > 0) nowNanos() + timeoutMs.toLong() * 1_000_000L else 0L
+
+        while (received < size) {
+            val sliceTimeout: Int = when {
+                timeoutMs < 0 -> 0 // block until data arrives
+                timeoutMs == 0 -> 1 // non-blocking; smallest real slice
+                else -> {
+                    val remainingNanos = deadlineNanos - nowNanos()
+                    if (remainingNanos <= 0) break
+                    ((remainingNanos + 999_999L) / 1_000_000L).toInt().coerceAtLeast(1)
+                }
+            }
+            val chunk = ByteArray(maxOf(size - received, minChunkSize))
+            trace("usb read req=${chunk.size} sliceTimeout=$sliceTimeout received=$received")
+            val n = readChunk(chunk, sliceTimeout)
+            trace("usb read <- $n")
+            if (n <= 0) {
+                // Nothing this slice. A zero-length transfer must not fake a
+                // timeout while the deadline (or a blocking read) still
+                // stands; only the non-blocking mode gives up here.
+                if (timeoutMs == 0) break
+                continue
+            }
+            val take = minOf(n, size - received)
+            System.arraycopy(chunk, 0, result, received, take)
+            received += take
+            if (n > take) {
+                // Only the chunk that completes the read can overshoot, and
+                // pending was drained before the loop, so plain assignment.
+                pending = chunk.copyOfRange(take, n)
+            }
+        }
+
+        trace("read exit received=$received/$size buffered=${pending.size}")
+        return if (received == size) result else null
+    }
+
+    // Drops buffered surplus. Call when libdivecomputer purges the input
+    // direction, so stale bytes cannot leak into the next packet exchange.
+    fun clear() {
+        pending = ByteArray(0)
+    }
+}

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/UsbSerialIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/UsbSerialIoStream.kt
@@ -39,6 +39,7 @@ class UsbSerialIoStream(
 
     private var connection: UsbDeviceConnection? = null
     private var port: UsbSerialPort? = null
+    private var readBuffer: SerialReadBuffer? = null
 
     // Requests USB permission (if needed) and opens the first port on the
     // device. Blocks up to PERMISSION_TIMEOUT_SECONDS for the user's response.
@@ -81,7 +82,15 @@ class UsbSerialIoStream(
                 NativeTrace.d("opening port[$index]")
                 candidate.open(conn)
                 port = candidate
-                NativeTrace.d("opened port[$index]")
+                // Bulk reads must request at least one full USB packet or the
+                // kernel fails them with EOVERFLOW and drops the data (#318);
+                // SerialReadBuffer enforces that and buffers the surplus.
+                val maxPacketSize = candidate.readEndpoint?.maxPacketSize ?: 0
+                readBuffer = SerialReadBuffer(
+                    minChunkSize = if (maxPacketSize > 0) maxPacketSize else 64,
+                    trace = NativeTrace::d,
+                )
+                NativeTrace.d("opened port[$index] maxPacketSize=$maxPacketSize")
                 NativeLogger.i(TAG, "SER", "Opened USB serial port[$index] for ${device.deviceName}")
                 return true
             } catch (e: IOException) {
@@ -155,41 +164,24 @@ class UsbSerialIoStream(
 
     override fun read(size: Int, timeoutMs: Int): ByteArray? {
         val p = port ?: return null
+        val buffer = readBuffer ?: return null
         if (size <= 0) return ByteArray(0)
 
         NativeTrace.d("read enter size=$size timeoutMs=$timeoutMs")
         // libdivecomputer's read contract (see serial_posix.c dc_serial_read) is
-        // "return exactly `size` bytes or time out" -- every driver relies on it.
-        // A single UsbSerialPort.read() returns only the first ~64-byte USB bulk
-        // chunk, so a larger device response (e.g. the Mares Puck Pro 140-byte
-        // version block) came back truncated, desynced libdivecomputer's framing
-        // and failed every probe with rc=-8. Accumulate across chunks, re-reading
-        // on the remaining timeout, until the whole packet arrives (#334).
-        val result = ByteArray(size)
-        var received = 0
-        // Bound the TOTAL wait for a finite (positive) libdivecomputer timeout.
-        val deadlineNanos =
-            if (timeoutMs > 0) System.nanoTime() + timeoutMs.toLong() * 1_000_000L else 0L
-
-        while (received < size) {
-            val sliceTimeout: Int = when {
-                timeoutMs < 0 -> 0   // libdc infinite; usb-serial blocks on 0
-                timeoutMs == 0 -> 1  // libdc non-blocking; smallest real slice
-                else -> {
-                    val remainingNanos = deadlineNanos - System.nanoTime()
-                    if (remainingNanos <= 0) break
-                    ((remainingNanos + 999_999L) / 1_000_000L).toInt().coerceAtLeast(1)
-                }
-            }
-            val tmp = ByteArray(size - received)
-            // Written BEFORE the USB read: if the read crashes the process
-            // natively (no exception and no "<- n" follows), this is the last
-            // line on disk, naming the slice size + timeout that triggered it.
-            NativeTrace.d(
-                "usb read req=${tmp.size} sliceTimeout=$sliceTimeout received=$received"
-            )
-            val n = try {
-                p.read(tmp, sliceTimeout)
+        // "return exactly `size` bytes or time out" -- every driver relies on
+        // it. SerialReadBuffer reassembles that byte-stream contract from raw
+        // bulk chunk reads: accumulating chunks until the requested size or the
+        // deadline (#334), never requesting less than one USB packet, and
+        // keeping surplus bytes for the next read (#318). It returns exactly
+        // `size` bytes, or null so the JNI bridge reports LIBDC_STATUS_TIMEOUT
+        // and libdivecomputer retries, rather than accepting a truncated read.
+        return buffer.read(size, timeoutMs) { chunk, sliceTimeout ->
+            // The trace above is written BEFORE the USB read: if the read
+            // crashes the process natively (no exception and no "<- n"
+            // follows), the last line on disk names the slice that died.
+            try {
+                p.read(chunk, sliceTimeout)
             } catch (e: IOException) {
                 // A real I/O error (device unplugged, USB permission revoked) --
                 // not a timeout, which returns 0 rather than throwing. Propagate
@@ -204,17 +196,7 @@ class UsbSerialIoStream(
                 NativeTrace.e("usb read ${e.javaClass.simpleName}: ${e.message}")
                 throw e
             }
-            NativeTrace.d("usb read <- $n")
-            if (n <= 0) break // timeout / nothing available this slice
-            System.arraycopy(tmp, 0, result, received, n)
-            received += n
         }
-
-        // Exactly `size` -> success. A short read returns null so the JNI bridge
-        // reports LIBDC_STATUS_TIMEOUT and libdivecomputer retries, rather than
-        // accepting a truncated packet as a successful read.
-        NativeTrace.d("read exit received=$received/$size")
-        return if (received == size) result else null
     }
 
     override fun write(data: ByteArray, timeoutMs: Int): Int {
@@ -238,6 +220,11 @@ class UsbSerialIoStream(
         // libdivecomputer direction bits: 1 = input, 2 = output.
         val purgeRead = direction and 1 != 0
         val purgeWrite = direction and 2 != 0
+        if (purgeRead) {
+            // Stale surplus bytes must go with the hardware input buffer, or
+            // the next packet exchange starts mid-frame.
+            readBuffer?.clear()
+        }
         try {
             p.purgeHwBuffers(purgeWrite, purgeRead)
         } catch (e: Exception) {
@@ -248,6 +235,7 @@ class UsbSerialIoStream(
 
     override fun close() {
         NativeTrace.d("close")
+        readBuffer = null
         try {
             port?.close()
         } catch (e: Exception) {

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/SerialReadBufferTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/SerialReadBufferTest.kt
@@ -1,0 +1,213 @@
+package com.submersion.libdivecomputer
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+// JVM tests for the chunk-reassembly logic behind UsbSerialIoStream.read.
+//
+// The scenarios mirror the Mares Puck Pro handshake from issue #318: the
+// device answers a 2-byte command with ACK + payload + EOM in a single USB
+// bulk packet, while libdivecomputer reads it back in 1-byte and N-byte
+// slices and expects tty semantics (surplus bytes stay available).
+class SerialReadBufferTest {
+
+    private companion object {
+        const val CHUNK = 64
+    }
+
+    private fun bytes(range: IntRange) = range.map { it.toByte() }.toByteArray()
+
+    @Test
+    fun servesRequestFromSingleLargerChunkAndBuffersSurplus() {
+        val buffer = SerialReadBuffer(CHUNK)
+        var calls = 0
+        val payload = bytes(1..6)
+
+        val first = buffer.read(1, 3000) { dest, _ ->
+            calls++
+            System.arraycopy(payload, 0, dest, 0, payload.size)
+            payload.size
+        }
+
+        assertArrayEquals(byteArrayOf(1), first)
+        assertEquals(1, calls)
+
+        // The remaining 5 bytes must come from the buffer without touching USB.
+        val second = buffer.read(5, 3000) { _, _ ->
+            fail("must not issue a USB read while buffered bytes remain")
+            0
+        }
+        assertArrayEquals(bytes(2..6), second)
+    }
+
+    @Test
+    fun neverPassesBufferSmallerThanMinChunkSize() {
+        val buffer = SerialReadBuffer(CHUNK)
+
+        buffer.read(1, 3000) { dest, _ ->
+            // A bulk read with a buffer smaller than the endpoint packet size
+            // fails with EOVERFLOW and loses the packet (issue #318).
+            assertTrue(
+                "USB buffer was ${dest.size}, smaller than one bulk packet",
+                dest.size >= CHUNK,
+            )
+            dest[0] = 42
+            1
+        }
+    }
+
+    @Test
+    fun accumulatesAcrossMultipleChunks() {
+        val buffer = SerialReadBuffer(CHUNK)
+        val deliveries = listOf(bytes(1..4), bytes(5..8), bytes(9..10))
+        var call = 0
+
+        val result = buffer.read(10, 3000) { dest, _ ->
+            val chunk = deliveries[call++]
+            System.arraycopy(chunk, 0, dest, 0, chunk.size)
+            chunk.size
+        }
+
+        assertArrayEquals(bytes(1..10), result)
+        assertEquals(3, call)
+    }
+
+    @Test
+    fun emptySliceDoesNotAbortReadWithPositiveTimeout() {
+        val buffer = SerialReadBuffer(CHUNK)
+        var call = 0
+
+        val result = buffer.read(1, 3000) { dest, _ ->
+            when (call++) {
+                0 -> 0 // stray zero-length transfer must not fake a timeout
+                else -> {
+                    dest[0] = 7
+                    1
+                }
+            }
+        }
+
+        assertArrayEquals(byteArrayOf(7), result)
+        assertEquals(2, call)
+    }
+
+    @Test
+    fun returnsNullOnceDeadlinePasses() {
+        var nowMs = 0L
+        val buffer = SerialReadBuffer(CHUNK, nowNanos = { nowMs * 1_000_000L })
+        var calls = 0
+
+        val result = buffer.read(1, 3000) { _, _ ->
+            calls++
+            nowMs += 500
+            0
+        }
+
+        assertNull(result)
+        // Slices at t=0,500,...,2500; the deadline check stops the loop at 3000.
+        assertEquals(6, calls)
+    }
+
+    @Test
+    fun sliceTimeoutShrinksTowardDeadline() {
+        var nowMs = 0L
+        val buffer = SerialReadBuffer(CHUNK, nowNanos = { nowMs * 1_000_000L })
+        val slices = mutableListOf<Int>()
+
+        buffer.read(1, 3000) { _, slice ->
+            slices.add(slice)
+            nowMs += 1000
+            0
+        }
+
+        assertEquals(listOf(3000, 2000, 1000), slices)
+    }
+
+    @Test
+    fun nonBlockingReadStopsAtFirstEmptySlice() {
+        val buffer = SerialReadBuffer(CHUNK)
+        val slices = mutableListOf<Int>()
+
+        val result = buffer.read(1, 0) { _, slice ->
+            slices.add(slice)
+            0
+        }
+
+        assertNull(result)
+        // libdivecomputer's non-blocking read maps to a single minimal slice.
+        assertEquals(listOf(1), slices)
+    }
+
+    @Test
+    fun infiniteTimeoutUsesBlockingSliceAndRetriesEmptySlices() {
+        val buffer = SerialReadBuffer(CHUNK)
+        var call = 0
+        val slices = mutableListOf<Int>()
+
+        val result = buffer.read(1, -1) { dest, slice ->
+            slices.add(slice)
+            when (call++) {
+                0 -> 0
+                else -> {
+                    dest[0] = 9
+                    1
+                }
+            }
+        }
+
+        assertArrayEquals(byteArrayOf(9), result)
+        // usb-serial-for-android treats timeout 0 as "block until data".
+        assertEquals(listOf(0, 0), slices)
+    }
+
+    @Test
+    fun clearDropsBufferedSurplus() {
+        val buffer = SerialReadBuffer(CHUNK)
+        buffer.read(1, 3000) { dest, _ ->
+            System.arraycopy(bytes(1..6), 0, dest, 0, 6)
+            6
+        }
+
+        buffer.clear()
+
+        val result = buffer.read(1, 3000) { dest, _ ->
+            dest[0] = 99
+            1
+        }
+        assertArrayEquals(byteArrayOf(99), result)
+    }
+
+    @Test
+    fun zeroSizeReadReturnsEmptyWithoutUsbRead() {
+        val buffer = SerialReadBuffer(CHUNK)
+        val result = buffer.read(0, 3000) { _, _ ->
+            fail("zero-size read must not touch USB")
+            0
+        }
+        assertArrayEquals(ByteArray(0), result)
+    }
+
+    @Test
+    fun surplusFromFinalChunkOfMultiChunkReadIsPreserved() {
+        val buffer = SerialReadBuffer(CHUNK)
+        val deliveries = listOf(bytes(1..4), bytes(5..12))
+        var call = 0
+
+        val first = buffer.read(6, 3000) { dest, _ ->
+            val chunk = deliveries[call++]
+            System.arraycopy(chunk, 0, dest, 0, chunk.size)
+            chunk.size
+        }
+        assertArrayEquals(bytes(1..6), first)
+
+        val second = buffer.read(6, 3000) { _, _ ->
+            fail("must not issue a USB read while buffered bytes remain")
+            0
+        }
+        assertArrayEquals(bytes(7..12), second)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the remaining failure in #318: after the R8/16KB fixes, the Mares Puck Pro's CP210x port opened and configured correctly, but every download failed with `Failed to open device` (rc=-7, `DC_STATUS_TIMEOUT`).

The user's 2026-07-09 log shows the device **was** answering the handshake: each 1-byte ACK read returned 0 bytes after 1-12ms instead of blocking for its 3000ms timeout. Raw USB bulk endpoints are packet-based — asking the kernel for fewer bytes than the arriving packet contains fails the URB with `EOVERFLOW` and discards the packet, and usb-serial-for-android surfaces that as an immediate 0-byte read (its own comment: `nread == -1 can be: timeout, connection lost, buffer to small`). libdivecomputer reads the Mares handshake 1 byte at a time, so the whole response packet was thrown away on every retry.

## Changes

- New pure-Kotlin `SerialReadBuffer`: never hands USB a buffer smaller than the endpoint's max packet size, buffers surplus bytes for subsequent reads (the ACK byte and version block ride in the same bulk packet), and no longer lets a stray zero-length transfer fake a timeout before the deadline. Clock/chunk-reader/tracing injected for JVM testability.
- `UsbSerialIoStream` delegates `read()` to it, creates it at port-open with the endpoint's real max packet size (fallback 64), clears it on input purge (libdivecomputer purges between handshake retries) and on close. `[SER]` forensic trace lines preserved, plus a new `maxPacketSize=` breadcrumb.
- First JVM unit-test source set for the plugin (`src/test/kotlin` + JUnit 4): 11 tests covering the #318 scenario, chunk accumulation, deadline math with an injected clock, non-blocking/infinite timeout modes, and purge semantics.

Also incidentally protects FTDI adapters, whose driver throws on read buffers <= 2 bytes.

## Test Plan

- [x] `:libdivecomputer_plugin:testDebugUnitTest` passes (11/11)
- [x] `:libdivecomputer_plugin:compileDebugKotlin` passes
- [ ] Hardware verification: needs the issue reporter's Puck Pro + CP210x clip (cannot reproduce the USB babble path locally)