### PR TITLE
perf(db): self-healing performance indexes + large-DB measurement baseline (WS0)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-large-db-perf-baseline-ws0.md
+++ b/docs/superpowers/plans/2026-07-10-large-db-perf-baseline-ws0.md
@@ -1,0 +1,1264 @@
+# Large-DB Performance: Baseline + WS0 (Index Integrity) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture a reproducible SQL-level performance baseline against the 1,032-dive database, then make every performance index self-healing so fresh, restored, and sync-adopted databases stop running million-row full scans.
+
+**Architecture:** A pure-Dart canonical index module (`lib/core/database/performance_indexes.dart`) holds every intended index as (name, ddl) records; `AppDatabase.beforeOpen` diffs it against `sqlite_master` and creates only what's missing (then `ANALYZE`), following the codebase's existing beforeOpen re-assert pattern. Two committed pure-Dart tools (`tools/db_bench.dart`, `tools/vmcap.dart`) provide the before/after measurement gates for this and every later workstream.
+
+**Tech Stack:** Flutter 3.x, Drift ORM, `package:sqlite3` ^2.9.4 (direct dependency), dart:developer VM-service protocol.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-large-db-performance-design.md`
+
+## Global Constraints
+
+- Schema version stays at **102** — WS0 uses `beforeOpen` only, no migration block, no version bump.
+- `lib/core/database/database.dart` and everything it imports must stay **Flutter-free** (currently imports only `dart:convert` + `package:drift/drift.dart`). Same for `tools/*.dart` (they run via `dart run`).
+- No emojis in code, comments, or docs. All code passes `dart format .` with no changes.
+- Before every commit: `dart format .` then `flutter analyze` (whole project, never piped through `tail`/`head`).
+- Run tests as specific files (`flutter test test/core/database/performance_indexes_test.dart`), never broad directories.
+- Performance targets (from spec): search < 500 ms, detail open < 500 ms, chart toggle < 200 ms, startup < 2 s, zero UI-thread DB blocks.
+- The live debug DB is `~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db` (335 MB, 1,032 dives, 1,077,216 dive_profiles rows, 784,752 tank_pressure_profiles rows). Never benchmark against it directly and never open it while the app is running — always work on `.backup` copies.
+- Commit messages: conventional prefixes (`perf:`, `feat:`, `test:`, `docs:`, `chore:`), no Co-Authored-By lines.
+
+---
+
+### Task 1: Canonical index list + db_bench tool + SQL-level baseline capture
+
+The measurement comes first: this task produces the before/after numbers that justify (or resize) everything downstream, without touching app code paths.
+
+**Files:**
+- Create: `lib/core/database/performance_indexes.dart` (const list only in this task)
+- Create: `tools/db_bench.dart`
+- Create: `docs/superpowers/specs/2026-07-10-large-db-performance-findings.md`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `kPerformanceIndexes` — `const List<({String name, String ddl})>` in `package:submersion/core/database/performance_indexes.dart`. Task 3 adds `ensurePerformanceIndexes()` to this same file; Task 4's tests import the list. `tools/db_bench.dart` CLI with modes `bench` / `plans` / `create-indexes`.
+
+- [ ] **Step 1: Write the canonical index list**
+
+Create `lib/core/database/performance_indexes.dart`. The list is every `CREATE INDEX` ever defined in `database.dart` migration blocks, deduped, minus `idx_dive_computer_data_dive_id` (its table was renamed to `dive_data_sources` in the v50-era migration and the index explicitly dropped), plus one new expression index matching the paginated list's real sort key (`getDiveSummaries` sorts by `COALESCE(entry_time, dive_date_time)`; no existing index covers that expression). Keep-or-drop for the new index is decided empirically in Step 6 and Task 4.
+
+```dart
+/// Canonical performance-index set for the Submersion database.
+///
+/// Historically these indexes were created only inside onUpgrade migration
+/// blocks, so a database created fresh at a recent schema version -- or
+/// arriving via restore or sync-adopt -- never got them and every child-table
+/// lookup degraded to a full table scan (issue: large-DB performance,
+/// docs/superpowers/specs/2026-07-10-large-db-performance-design.md).
+///
+/// This list is asserted idempotently on every open from
+/// AppDatabase.beforeOpen. Keep it in sync: any migration that adds a
+/// performance index must also add it here (the fresh-DB test in
+/// test/core/database/performance_indexes_test.dart fails if the DDL
+/// references a table missing from the current schema).
+///
+/// This file must stay Flutter-free: it is imported by tools/db_bench.dart,
+/// which runs on the plain Dart VM.
+library;
+
+typedef PerformanceIndex = ({String name, String ddl});
+
+const List<PerformanceIndex> kPerformanceIndexes = [
+  // -- dives ----------------------------------------------------------------
+  (
+    name: 'idx_dives_diver_datetime',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_diver_datetime '
+        'ON dives(diver_id, dive_date_time DESC)',
+  ),
+  (
+    name: 'idx_dives_diver_entrytime',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_diver_entrytime '
+        'ON dives(diver_id, entry_time DESC)',
+  ),
+  (
+    name: 'idx_dives_diver_exittime',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_diver_exittime '
+        'ON dives(diver_id, exit_time DESC)',
+  ),
+  // Matches the paginated dive list's ORDER BY expression exactly
+  // (dive_repository_impl.dart getDiveSummaries: sort_timestamp =
+  // COALESCE(entry_time, dive_date_time)). Empirically validated in the
+  // WS0 baseline; remove if EXPLAIN QUERY PLAN never selects it.
+  (
+    name: 'idx_dives_diver_sort_timestamp',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_diver_sort_timestamp '
+        'ON dives(diver_id, COALESCE(entry_time, dive_date_time) DESC)',
+  ),
+  (
+    name: 'idx_dives_site_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_site_id ON dives(site_id)',
+  ),
+  (
+    name: 'idx_dives_trip_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_trip_id ON dives(trip_id)',
+  ),
+  (
+    name: 'idx_dives_dive_center_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_dive_center_id '
+        'ON dives(dive_center_id)',
+  ),
+  (
+    name: 'idx_dives_course_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_course_id ON dives(course_id)',
+  ),
+  (
+    name: 'idx_dives_favorite',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_favorite '
+        'ON dives(diver_id, is_favorite)',
+  ),
+  // -- per-dive child tables (the million-row scans) ------------------------
+  (
+    name: 'idx_dive_profiles_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_profiles_dive_id '
+        'ON dive_profiles(dive_id)',
+  ),
+  (
+    name: 'idx_tank_pressure_dive_tank',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_tank_pressure_dive_tank '
+        'ON tank_pressure_profiles(dive_id, tank_id, timestamp)',
+  ),
+  (
+    name: 'idx_dive_tanks_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_tanks_dive_id '
+        'ON dive_tanks(dive_id)',
+  ),
+  (
+    name: 'idx_dive_equipment_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_equipment_dive_id '
+        'ON dive_equipment(dive_id)',
+  ),
+  (
+    name: 'idx_dive_weights_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_weights_dive_id '
+        'ON dive_weights(dive_id)',
+  ),
+  (
+    name: 'idx_dive_tags_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_tags_dive_id '
+        'ON dive_tags(dive_id)',
+  ),
+  (
+    name: 'idx_dive_tags_tag_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_tags_tag_id '
+        'ON dive_tags(tag_id)',
+  ),
+  (
+    name: 'idx_dive_buddies_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_buddies_dive_id '
+        'ON dive_buddies(dive_id)',
+  ),
+  (
+    name: 'idx_dive_custom_fields_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_custom_fields_dive_id '
+        'ON dive_custom_fields(dive_id)',
+  ),
+  (
+    name: 'idx_dive_custom_fields_key',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_custom_fields_key '
+        'ON dive_custom_fields(field_key)',
+  ),
+  (
+    name: 'idx_dive_data_sources_dive_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_data_sources_dive_id '
+        'ON dive_data_sources(dive_id)',
+  ),
+  (
+    name: 'idx_tide_records_dive',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_tide_records_dive '
+        'ON tide_records(dive_id)',
+  ),
+  // -- sync ------------------------------------------------------------------
+  (
+    name: 'idx_sync_records_entity_record',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_sync_records_entity_record '
+        'ON sync_records(entity_type, record_id)',
+  ),
+  // -- reference / feature tables --------------------------------------------
+  (
+    name: 'idx_site_species_site',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_site_species_site '
+        'ON site_species(site_id)',
+  ),
+  (
+    name: 'idx_courses_diver',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_courses_diver ON courses(diver_id)',
+  ),
+  (
+    name: 'idx_media_platform_asset_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_platform_asset_id '
+        'ON media(platform_asset_id)',
+  ),
+  (
+    name: 'idx_media_enrichment_media',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_enrichment_media '
+        'ON media_enrichment(media_id)',
+  ),
+  (
+    name: 'idx_media_enrichment_dive',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_enrichment_dive '
+        'ON media_enrichment(dive_id)',
+  ),
+  (
+    name: 'idx_media_species_media',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_species_media '
+        'ON media_species(media_id)',
+  ),
+  (
+    name: 'idx_media_species_species',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_species_species '
+        'ON media_species(species_id)',
+  ),
+  (
+    name: 'idx_pending_photo_suggestions_dive',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_pending_photo_suggestions_dive '
+        'ON pending_photo_suggestions(dive_id)',
+  ),
+  (
+    name: 'idx_scheduled_notifications_equipment',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_scheduled_notifications_equipment '
+        'ON scheduled_notifications(equipment_id)',
+  ),
+  (
+    name: 'idx_view_configs_diver',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_view_configs_diver '
+        'ON view_configs(diver_id, view_mode)',
+  ),
+  (
+    name: 'idx_field_presets_diver',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_field_presets_diver '
+        'ON field_presets(diver_id, view_mode)',
+  ),
+  (
+    name: 'idx_media_source_type',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_source_type '
+        'ON media(source_type)',
+  ),
+  (
+    name: 'idx_media_connector_account',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_connector_account '
+        'ON media(connector_account_id)',
+  ),
+  (
+    name: 'idx_media_origin_device',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_media_origin_device '
+        'ON media(origin_device_id)',
+  ),
+  (
+    name: 'idx_checklist_template_items_template_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_checklist_template_items_template_id '
+        'ON checklist_template_items(template_id)',
+  ),
+  (
+    name: 'idx_trip_checklist_items_trip_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_trip_checklist_items_trip_id '
+        'ON trip_checklist_items(trip_id)',
+  ),
+  (
+    name: 'idx_dive_plan_tanks_plan_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_plan_tanks_plan_id '
+        'ON dive_plan_tanks(plan_id)',
+  ),
+  (
+    name: 'idx_dive_plan_segments_plan_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dive_plan_segments_plan_id '
+        'ON dive_plan_segments(plan_id)',
+  ),
+  (
+    name: 'idx_gps_track_points_local_track_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_gps_track_points_local_track_id '
+        'ON gps_track_points_local(track_id)',
+  ),
+];
+```
+
+- [ ] **Step 2: Write tools/db_bench.dart**
+
+Pure Dart CLI. Opens a database copy with `package:sqlite3`, discovers the busiest diver and densest dive from the data, then times the app's real hot-query shapes (SQL copied from `dive_repository_impl.dart`). Three modes: `bench` (median-of-5 timings), `plans` (EXPLAIN QUERY PLAN dump), `create-indexes` (applies `kPerformanceIndexes`, timing each build).
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:sqlite3/sqlite3.dart';
+import 'package:submersion/core/database/performance_indexes.dart';
+
+/// SQL-level benchmark harness for the large-DB performance program.
+///
+/// Runs the app's real hot-query shapes against a database COPY (never the
+/// live file). Usage:
+///
+///   dart run tools/db_bench.dart bench <db-path> [--json] [--term blue]
+///   dart run tools/db_bench.dart plans <db-path>
+///   dart run tools/db_bench.dart create-indexes <db-path>
+///
+/// Query shapes are copied from dive_repository_impl.dart (getDiveSummaries,
+/// getDiveCount, searchDives, _mapRowToDive, getPreviousDive). Keep them in
+/// sync when those queries change materially.
+void main(List<String> args) {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: dart run tools/db_bench.dart <bench|plans|create-indexes> '
+      '<db-path> [--json] [--term <search-term>]',
+    );
+    exit(64);
+  }
+  final mode = args[0];
+  final dbPath = args[1];
+  final asJson = args.contains('--json');
+  final termIdx = args.indexOf('--term');
+  final searchTerm = termIdx >= 0 && termIdx + 1 < args.length
+      ? args[termIdx + 1]
+      : 'blue';
+
+  if (!File(dbPath).existsSync()) {
+    stderr.writeln('No such file: $dbPath');
+    exit(66);
+  }
+
+  final db = sqlite3.open(dbPath);
+  try {
+    switch (mode) {
+      case 'bench':
+        _bench(db, searchTerm, asJson);
+      case 'plans':
+        _plans(db, searchTerm);
+      case 'create-indexes':
+        _createIndexes(db);
+      default:
+        stderr.writeln('Unknown mode: $mode');
+        exit(64);
+    }
+  } finally {
+    db.dispose();
+  }
+}
+
+/// The paginated dive list page-1 query, verbatim shape from
+/// getDiveSummaries (default date sort, no cursor, no filters).
+const _summariesSql =
+    'SELECT '
+    'd.id, d.dive_number, d.name AS dive_name, '
+    'd.dive_date_time, d.entry_time, '
+    'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
+    'd.is_favorite, d.dive_type, '
+    'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
+    's.name AS site_name, s.country AS site_country, '
+    's.region AS site_region, s.latitude AS site_latitude, '
+    's.longitude AS site_longitude '
+    'FROM dives d '
+    'LEFT JOIN dive_sites s ON d.site_id = s.id '
+    'WHERE d.diver_id = ? '
+    'ORDER BY sort_timestamp DESC, COALESCE(d.dive_number, 0) DESC, d.id DESC '
+    'LIMIT 50';
+
+/// The search match query, verbatim shape from searchDives.
+const _searchSql = '''
+    SELECT DISTINCT d.id
+    FROM dives d
+    LEFT JOIN dive_sites ds ON d.site_id = ds.id
+    LEFT JOIN dive_centers dc ON d.dive_center_id = dc.id
+    LEFT JOIN dive_buddies db ON db.dive_id = d.id
+    LEFT JOIN buddies b ON db.buddy_id = b.id
+    LEFT JOIN dive_tags dt ON dt.dive_id = d.id
+    LEFT JOIN tags t ON dt.tag_id = t.id
+    LEFT JOIN dive_custom_fields cf ON cf.dive_id = d.id
+    WHERE (
+      d.notes LIKE ?
+      OR d.name LIKE ?
+      OR d.buddy LIKE ?
+      OR d.dive_master LIKE ?
+      OR ds.name LIKE ?
+      OR ds.country LIKE ?
+      OR ds.region LIKE ?
+      OR dc.name LIKE ?
+      OR b.name LIKE ?
+      OR t.name LIKE ?
+      OR cf.field_key LIKE ?
+      OR cf.field_value LIKE ?
+    )
+    AND d.diver_id = ?
+    ''';
+
+({String diverId, String denseDiveId, int denseSamples}) _pickTargets(
+  Database db,
+) {
+  final diver = db.select(
+    'SELECT diver_id, COUNT(*) AS n FROM dives '
+    'GROUP BY diver_id ORDER BY n DESC LIMIT 1',
+  );
+  final dense = db.select(
+    'SELECT dive_id, COUNT(*) AS n FROM dive_profiles '
+    'GROUP BY dive_id ORDER BY n DESC LIMIT 1',
+  );
+  return (
+    diverId: diver.first['diver_id'] as String,
+    denseDiveId: dense.first['dive_id'] as String,
+    denseSamples: dense.first['n'] as int,
+  );
+}
+
+List<({String label, String sql, List<Object?> params})> _queries(
+  Database db,
+  String term,
+) {
+  final t = _pickTargets(db);
+  final like = '%$term%';
+  final searchParams = <Object?>[...List.filled(12, like), t.diverId];
+  final page = db.select(_summariesSql, [t.diverId]);
+  final pageIds = page.map((r) => r['id'] as String).toList();
+  final inList = List.filled(pageIds.length, '?').join(',');
+  return [
+    (
+      label: 'profile_fetch_densest (${t.denseSamples} rows)',
+      sql:
+          'SELECT * FROM dive_profiles WHERE dive_id = ? '
+          'ORDER BY timestamp ASC',
+      params: [t.denseDiveId],
+    ),
+    (
+      label: 'pressure_fetch_densest',
+      sql:
+          'SELECT * FROM tank_pressure_profiles WHERE dive_id = ? '
+          'ORDER BY timestamp ASC',
+      params: [t.denseDiveId],
+    ),
+    (
+      label: 'tanks_fetch',
+      sql: 'SELECT * FROM dive_tanks WHERE dive_id = ?',
+      params: [t.denseDiveId],
+    ),
+    (
+      label: 'summaries_page1',
+      sql: _summariesSql,
+      params: [t.diverId],
+    ),
+    (
+      label: 'dive_count',
+      sql: 'SELECT COUNT(*) AS count FROM dives d WHERE d.diver_id = ?',
+      params: [t.diverId],
+    ),
+    (
+      label: 'search_match_ids (term "$term")',
+      sql: _searchSql,
+      params: searchParams,
+    ),
+    (
+      label: 'prev_dive',
+      sql:
+          'SELECT * FROM dives WHERE id != ? AND (entry_time < ? OR '
+          '(entry_time IS NULL AND dive_date_time < ?)) '
+          'ORDER BY entry_time DESC, dive_date_time DESC LIMIT 1',
+      params: [t.denseDiveId, 9999999999999, 9999999999999],
+    ),
+    (
+      label: 'tags_for_page (${pageIds.length} ids)',
+      sql: 'SELECT * FROM dive_tags WHERE dive_id IN ($inList)',
+      params: pageIds,
+    ),
+  ];
+}
+
+void _bench(Database db, String term, bool asJson) {
+  final results = <Map<String, Object>>[];
+  for (final q in _queries(db, term)) {
+    final times = <int>[];
+    var rows = 0;
+    for (var i = 0; i < 5; i++) {
+      final sw = Stopwatch()..start();
+      final rs = db.select(q.sql, q.params);
+      sw.stop();
+      rows = rs.length;
+      times.add(sw.elapsedMicroseconds);
+    }
+    times.sort();
+    results.add({
+      'query': q.label,
+      'rows': rows,
+      'median_ms': times[2] / 1000.0,
+      'min_ms': times.first / 1000.0,
+    });
+  }
+  // Approximate searchDives' N+1 hydration: the 3 heavy per-dive queries
+  // for the first 20 matched dives (the app runs ~10 per match).
+  final matched = db.select(_searchSql, [
+    ...List.filled(12, '%$term%'),
+    _pickTargets(db).diverId,
+  ]);
+  final hydrateIds = matched.take(20).map((r) => r['id'] as String).toList();
+  final sw = Stopwatch()..start();
+  for (final id in hydrateIds) {
+    db.select(
+      'SELECT * FROM dive_profiles WHERE dive_id = ? ORDER BY timestamp ASC',
+      [id],
+    );
+    db.select(
+      'SELECT * FROM tank_pressure_profiles WHERE dive_id = ? '
+      'ORDER BY timestamp ASC',
+      [id],
+    );
+    db.select('SELECT * FROM dive_tanks WHERE dive_id = ?', [id]);
+  }
+  sw.stop();
+  results.add({
+    'query': 'search_hydration_first20 (${matched.length} matches total)',
+    'rows': hydrateIds.length,
+    'median_ms': sw.elapsedMilliseconds.toDouble(),
+    'min_ms': sw.elapsedMilliseconds.toDouble(),
+  });
+
+  if (asJson) {
+    stdout.writeln(const JsonEncoder.withIndent('  ').convert(results));
+  } else {
+    stdout.writeln(
+      'query'.padRight(52) + 'rows'.padLeft(9) + 'median ms'.padLeft(12),
+    );
+    for (final r in results) {
+      stdout.writeln(
+        (r['query']! as String).padRight(52) +
+            '${r['rows']}'.padLeft(9) +
+            (r['median_ms']! as double).toStringAsFixed(1).padLeft(12),
+      );
+    }
+  }
+}
+
+void _plans(Database db, String term) {
+  for (final q in _queries(db, term)) {
+    stdout.writeln('-- ${q.label}');
+    final plan = db.select(
+      'EXPLAIN QUERY PLAN ${q.sql}',
+      q.params,
+    );
+    for (final row in plan) {
+      stdout.writeln('   ${row['detail']}');
+    }
+  }
+}
+
+void _createIndexes(Database db) {
+  final existing = db
+      .select("SELECT name FROM sqlite_master WHERE type = 'index'")
+      .map((r) => r['name'] as String)
+      .toSet();
+  final total = Stopwatch()..start();
+  var created = 0;
+  for (final idx in kPerformanceIndexes) {
+    if (existing.contains(idx.name)) {
+      stdout.writeln('exists   ${idx.name}');
+      continue;
+    }
+    final sw = Stopwatch()..start();
+    db.execute(idx.ddl);
+    sw.stop();
+    created++;
+    stdout.writeln(
+      'created  ${idx.name.padRight(44)} ${sw.elapsedMilliseconds} ms',
+    );
+  }
+  if (created > 0) {
+    final sw = Stopwatch()..start();
+    db.execute('PRAGMA analysis_limit = 400');
+    db.execute('ANALYZE');
+    sw.stop();
+    stdout.writeln('ANALYZE  ${sw.elapsedMilliseconds} ms');
+  }
+  total.stop();
+  stdout.writeln(
+    'Done: $created created, total ${total.elapsedMilliseconds} ms',
+  );
+}
+```
+
+- [ ] **Step 3: Verify the tool compiles and is format-clean**
+
+Run: `dart format lib/core/database/performance_indexes.dart tools/db_bench.dart && flutter analyze`
+Expected: format reports no changes needed (or fix and re-run); analyze reports `No issues found!`
+
+- [ ] **Step 4: Create the pristine fixture (app must be CLOSED)**
+
+Run:
+```bash
+mkdir -p ~/SubmersionBench
+sqlite3 ~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db ".backup '$HOME/SubmersionBench/pristine-20260710.db'"
+cp ~/SubmersionBench/pristine-20260710.db ~/SubmersionBench/work.db
+ls -lh ~/SubmersionBench/
+```
+Expected: two ~335 MB files. `.backup` produces a consistent snapshot even for a WAL database. The pristine copy is never modified again — it lets any future workstream re-measure the true "before" state.
+
+- [ ] **Step 5: Capture BEFORE numbers and plans**
+
+Run:
+```bash
+dart run tools/db_bench.dart bench ~/SubmersionBench/work.db
+dart run tools/db_bench.dart plans ~/SubmersionBench/work.db
+```
+Expected: bench prints the timing table (profile_fetch_densest should be tens of ms — it is a 1.08M-row scan; search_hydration_first20 likely seconds). Plans show `SCAN dive_profiles`, `SCAN tank_pressure_profiles`, `SCAN dives` etc. Save both outputs.
+
+- [ ] **Step 6: Apply indexes to the working copy, capture build cost and AFTER numbers**
+
+Run:
+```bash
+dart run tools/db_bench.dart create-indexes ~/SubmersionBench/work.db
+dart run tools/db_bench.dart bench ~/SubmersionBench/work.db
+dart run tools/db_bench.dart plans ~/SubmersionBench/work.db
+```
+Expected: per-index build times plus total (this number is the one-time first-open stall users will pay; if total exceeds ~10 s, flag it at the Task 5 checkpoint — the spec then calls for progress UI). AFTER bench should show the per-dive fetches dropping from tens of ms to sub-ms; plans show `SEARCH ... USING INDEX idx_...`. Note specifically whether `summaries_page1` uses `idx_dives_diver_sort_timestamp` — this is the expression index's empirical keep/drop evidence for Task 4.
+
+- [ ] **Step 7: Write the findings doc**
+
+Create `docs/superpowers/specs/2026-07-10-large-db-performance-findings.md` with the structure below, filling in the real numbers from Steps 5-6:
+
+```markdown
+# Large-DB Performance Findings (Phase 3)
+
+Fixture: pristine-20260710.db -- 1,032 dives / 1,077,216 dive_profiles rows /
+784,752 tank_pressure_profiles rows / 34 multi-computer dives / 335 MB.
+Machine: <fill in from `sysctl -n machdep.cpu.brand_string` or Apple chip name>.
+Tool: tools/db_bench.dart (median of 5).
+
+## WS0 SQL-level A/B (same fixture, before vs after kPerformanceIndexes)
+
+| Query | Rows | Before (ms) | After (ms) |
+|---|---|---|---|
+| profile_fetch_densest | <n> | <ms> | <ms> |
+| pressure_fetch_densest | <n> | <ms> | <ms> |
+| tanks_fetch | <n> | <ms> | <ms> |
+| summaries_page1 | 50 | <ms> | <ms> |
+| dive_count | 1 | <ms> | <ms> |
+| search_match_ids | <n> | <ms> | <ms> |
+| prev_dive | 1 | <ms> | <ms> |
+| tags_for_page | <n> | <ms> | <ms> |
+| search_hydration_first20 | 20 | <ms> | <ms> |
+
+Index build cost (one-time first-open stall): <total> ms total; slowest
+single index <name> at <ms> ms. ANALYZE: <ms> ms.
+
+## Query plan evidence
+
+Before: <paste the SCAN lines for the hot queries>
+After: <paste the USING INDEX lines>
+
+## Decision log
+
+- Expression index idx_dives_diver_sort_timestamp: <used / not used> by
+  summaries_page1 -> <kept / dropped>.
+- <anything unexpected>
+
+## In-app verification (filled in at Task 5)
+
+- Live DB healed on first open: <index count before/after>
+- beforeOpen ensure cost on already-healed DB: <ms>
+- Subjective: <search / detail-open / scroll notes>
+```
+
+(The template placeholders above are filled with measured values in THIS step — the committed file must contain real numbers for everything except the "In-app verification" section, which Task 5 fills.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion
+dart format . && flutter analyze
+git add lib/core/database/performance_indexes.dart tools/db_bench.dart docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+git commit -m "perf(db): canonical index list, db_bench tool, WS0 SQL baseline"
+```
+
+---
+
+### Task 2: vmcap VM-service profiler tool + measurement runbook
+
+The June-era vmcap tool lived only in a session scratchpad and is lost; this recreates it as a committed tool so UI-level measurement is reproducible for the whole program (post-WS0 re-baseline, then WS1-WS5 gates).
+
+**Files:**
+- Create: `tools/vmcap.dart`
+- Create: `docs/superpowers/specs/2026-07-10-large-db-performance-baseline-runbook.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `dart run tools/vmcap.dart <ws-uri> <probe|clear|read|frames> [seconds]` CLI used by the runbook and all later workstream gates.
+
+- [ ] **Step 1: Write tools/vmcap.dart**
+
+Pure Dart (dart:io WebSocket, no package deps). JSON-RPC 2.0 against the Flutter VM service. Modes: `probe` (list isolates), `clear` (enable profiler + clear CPU samples — MUST be called right before the interaction window, or the profiler's own JSON serialization dominates the samples), `read` (aggregate CPU samples by function, top 30 self/inclusive), `frames N` (subscribe to Extension stream for N seconds and report Flutter.Frame events — note: the frame buffer REPLAYS on subscribe, so only events with a timestamp after subscribe-time are counted).
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Minimal VM-service CPU/frame capture for user-paced profiling.
+///
+/// Usage:
+///   flutter run --profile -d macos   # note the ws://127.0.0.1:PORT/TOKEN=/ws URI
+///   dart run tools/vmcap.dart <ws-uri> probe
+///   dart run tools/vmcap.dart <ws-uri> clear     # right BEFORE interacting
+///   <interact with the app>
+///   dart run tools/vmcap.dart <ws-uri> read      # right AFTER interacting
+///   dart run tools/vmcap.dart <ws-uri> frames 10 # frame events for 10 s
+///
+/// Gotchas (learned in the June 2026 Phase 1 effort):
+/// - Always `clear` immediately before the window; otherwise the VM service's
+///   own serialization functions dominate the profile.
+/// - `frames` counts only events timestamped after subscribe, because the VM
+///   replays the historical frame buffer to new subscribers.
+Future<void> main(List<String> args) async {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: dart run tools/vmcap.dart <ws-uri> <probe|clear|read|frames> '
+      '[seconds]',
+    );
+    exit(64);
+  }
+  final uri = args[0];
+  final mode = args[1];
+  final seconds = args.length > 2 ? int.parse(args[2]) : 10;
+
+  final ws = await WebSocket.connect(uri);
+  final client = _RpcClient(ws);
+  try {
+    final vm = await client.call('getVM');
+    final isolates = (vm['isolates'] as List).cast<Map<String, dynamic>>();
+    if (isolates.isEmpty) {
+      stderr.writeln('No isolates.');
+      exit(1);
+    }
+    final main = isolates.first['id'] as String;
+
+    switch (mode) {
+      case 'probe':
+        for (final iso in isolates) {
+          stdout.writeln('${iso['id']}  ${iso['name']}');
+        }
+      case 'clear':
+        await client.call('setFlag', {'name': 'profiler', 'value': 'true'});
+        await client.call('clearCpuSamples', {'isolateId': main});
+        stdout.writeln('Profiler on, samples cleared. Interact now.');
+      case 'read':
+        final samples = await client.call('getCpuSamples', {
+          'isolateId': main,
+          'timeOriginMicros': 0,
+          'timeExtentMicros': 0x7fffffffffffffff,
+        });
+        _report(samples);
+      case 'frames':
+        await _frames(client, seconds);
+      default:
+        stderr.writeln('Unknown mode: $mode');
+        exit(64);
+    }
+  } finally {
+    await ws.close();
+  }
+}
+
+void _report(Map<String, dynamic> samples) {
+  final functions = (samples['functions'] as List? ?? [])
+      .cast<Map<String, dynamic>>();
+  String nameOf(int i) {
+    final f = functions[i]['function'] as Map<String, dynamic>?;
+    return (f?['name'] as String?) ?? '<unknown>';
+  }
+
+  final self = <int, int>{};
+  final incl = <int, int>{};
+  final sampleList = (samples['samples'] as List? ?? [])
+      .cast<Map<String, dynamic>>();
+  for (final s in sampleList) {
+    final stack = (s['stack'] as List).cast<int>();
+    if (stack.isEmpty) continue;
+    self[stack.first] = (self[stack.first] ?? 0) + 1;
+    for (final f in stack.toSet()) {
+      incl[f] = (incl[f] ?? 0) + 1;
+    }
+  }
+  final total = sampleList.length;
+  stdout.writeln('Samples: $total over '
+      '${samples['timeExtentMicros']} us window');
+  final top = self.entries.toList()
+    ..sort((a, b) => b.value.compareTo(a.value));
+  stdout.writeln('\n-- top self --');
+  for (final e in top.take(30)) {
+    final pct = (e.value * 100 / total).toStringAsFixed(1);
+    stdout.writeln('${'$pct%'.padLeft(7)}  ${nameOf(e.key)}');
+  }
+  final topIncl = incl.entries.toList()
+    ..sort((a, b) => b.value.compareTo(a.value));
+  stdout.writeln('\n-- top inclusive --');
+  for (final e in topIncl.take(30)) {
+    final pct = (e.value * 100 / total).toStringAsFixed(1);
+    stdout.writeln('${'$pct%'.padLeft(7)}  ${nameOf(e.key)}');
+  }
+}
+
+Future<void> _frames(_RpcClient client, int seconds) async {
+  final subscribedAt = DateTime.now().microsecondsSinceEpoch;
+  var count = 0, slow = 0;
+  client.onEvent = (event) {
+    if (event['extensionKind'] != 'Flutter.Frame') return;
+    final data = event['extensionData'] as Map<String, dynamic>;
+    final ts = event['timestamp'] as int? ?? 0;
+    if (ts * 1000 < subscribedAt) return; // replayed history
+    count++;
+    final elapsed = (data['elapsed'] as num).toInt();
+    if (elapsed > 16667) slow++;
+  };
+  await client.call('streamListen', {'streamId': 'Extension'});
+  stdout.writeln('Capturing frames for $seconds s. Interact now.');
+  await Future<void>.delayed(Duration(seconds: seconds));
+  stdout.writeln('Frames: $count, over-16.7ms: $slow');
+}
+
+class _RpcClient {
+  _RpcClient(this._ws) {
+    _ws.listen((raw) {
+      final msg = jsonDecode(raw as String) as Map<String, dynamic>;
+      if (msg.containsKey('id')) {
+        final completer = _pending.remove(msg['id']);
+        if (msg.containsKey('error')) {
+          completer?.completeError(StateError(jsonEncode(msg['error'])));
+        } else {
+          completer?.complete(msg['result'] as Map<String, dynamic>);
+        }
+      } else if (msg['method'] == 'streamNotify') {
+        final event =
+            (msg['params'] as Map<String, dynamic>)['event']
+                as Map<String, dynamic>;
+        onEvent?.call(event);
+      }
+    });
+  }
+
+  final WebSocket _ws;
+  final _pending = <int, Completer<Map<String, dynamic>>>{};
+  int _nextId = 1;
+  void Function(Map<String, dynamic> event)? onEvent;
+
+  Future<Map<String, dynamic>> call(
+    String method, [
+    Map<String, dynamic>? params,
+  ]) {
+    final id = _nextId++;
+    final completer = Completer<Map<String, dynamic>>();
+    _pending[id] = completer;
+    _ws.add(
+      jsonEncode({
+        'jsonrpc': '2.0',
+        'id': id,
+        'method': method,
+        if (params != null) 'params': params,
+      }),
+    );
+    return completer.future;
+  }
+}
+```
+
+- [ ] **Step 2: Smoke-test the tool**
+
+Run: `dart run tools/vmcap.dart ws://127.0.0.1:1/ws probe 2>&1 | head -3; echo "exit: $?"`
+Expected: a socket connection error (nothing is listening on port 1) and a NON-zero exit — proves the tool compiles and reaches the connect call. Then `dart format tools/vmcap.dart && flutter analyze` — no changes, no issues.
+
+- [ ] **Step 3: Write the runbook**
+
+Create `docs/superpowers/specs/2026-07-10-large-db-performance-baseline-runbook.md`:
+
+```markdown
+# Large-DB Performance Measurement Runbook (Phase 3)
+
+Applies to every workstream gate in the Phase 3 program. Two layers:
+
+## Layer 1: SQL-level (automated, per-PR)
+
+1. App CLOSED. Fixture (already created once):
+   sqlite3 <live-db> ".backup '$HOME/SubmersionBench/pristine-20260710.db'"
+   Live DB: ~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db
+2. Fresh working copy: cp ~/SubmersionBench/pristine-20260710.db ~/SubmersionBench/work.db
+3. Before: dart run tools/db_bench.dart bench ~/SubmersionBench/work.db
+4. Apply the change under test (for WS0: dart run tools/db_bench.dart
+   create-indexes ~/SubmersionBench/work.db).
+5. After: dart run tools/db_bench.dart bench ~/SubmersionBench/work.db
+6. Plans: dart run tools/db_bench.dart plans ~/SubmersionBench/work.db
+7. Record medians + plans in the findings doc.
+
+CAUTION: after WS0 ships, opening ANY copy with the app (or any AppDatabase)
+heals its indexes -- for a true "before", always start from the pristine file.
+
+## Layer 2: UI-level (user-paced, per-workstream re-baseline)
+
+Launch: flutter run --profile -d macos
+(debug builds overstate costs; profile mode is the honest one)
+Copy the VM service ws:// URI from the launch output.
+
+The five anchor scenarios (record wall time + vmcap output for each):
+
+1. Cold start: quit app; time launch -> dashboard interactive (stopwatch);
+   then vmcap read for startup CPU attribution.
+2. Search: vmcap clear -> type a term matching many dives in dive search ->
+   results visible -> vmcap read. Record wall time to results.
+3. Detail open x3: densest single-computer dive, a 2-computer dive, a dive
+   at the end of a dense repetitive week. vmcap clear before each tap,
+   vmcap read when the page settles.
+4. Chart toggles: on the dense technical dive -- ceiling calculated <->
+   computer, one overlay on/off. vmcap frames 10 while toggling.
+5. List stress: table view mode on, then a fast scroll through the paginated
+   card list. vmcap frames 10.
+
+Record everything in 2026-07-10-large-db-performance-findings.md with date
+and commit hash.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion
+dart format . && flutter analyze
+git add tools/vmcap.dart docs/superpowers/specs/2026-07-10-large-db-performance-baseline-runbook.md
+git commit -m "perf: vmcap VM-service profiler tool and measurement runbook"
+```
+
+---
+
+### Task 3: ensurePerformanceIndexes + beforeOpen wiring (TDD)
+
+**Files:**
+- Modify: `lib/core/database/performance_indexes.dart` (add the ensure function)
+- Modify: `lib/core/database/database.dart:4983-5037` (beforeOpen) and `:1` (imports)
+- Test: `test/core/database/performance_indexes_test.dart`
+
+**Interfaces:**
+- Consumes: `kPerformanceIndexes` from Task 1.
+- Produces: `Future<List<String>> ensurePerformanceIndexes(GeneratedDatabase db)` — returns the names of indexes actually created (empty list when everything already exists). Task 4's tests and any future migration code rely on this exact signature.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/core/database/performance_indexes_test.dart`:
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/performance_indexes.dart';
+
+Future<Set<String>> indexNames(AppDatabase db) async {
+  final rows = await db
+      .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+      .get();
+  return rows.map((r) => r.read<String>('name')).toSet();
+}
+
+void main() {
+  test('fresh database has every canonical performance index', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    // Force open so onCreate + beforeOpen run.
+    await db.customSelect('SELECT 1').get();
+
+    final names = await indexNames(db);
+    for (final idx in kPerformanceIndexes) {
+      expect(names, contains(idx.name), reason: '${idx.name} missing');
+    }
+  });
+
+  test('ensurePerformanceIndexes is idempotent', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    final created = await ensurePerformanceIndexes(db);
+    expect(created, isEmpty);
+  });
+
+  test('ensurePerformanceIndexes heals a dropped index', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    await db.customStatement('DROP INDEX idx_dive_profiles_dive_id');
+    expect(await indexNames(db), isNot(contains('idx_dive_profiles_dive_id')));
+
+    final created = await ensurePerformanceIndexes(db);
+    expect(created, equals(['idx_dive_profiles_dive_id']));
+    expect(await indexNames(db), contains('idx_dive_profiles_dive_id'));
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/core/database/performance_indexes_test.dart`
+Expected: FAIL — first test's `expect(names, contains(...))` fails (fresh DB has no canonical indexes yet); second and third fail to compile-or-run only if `ensurePerformanceIndexes` is missing — the suite must be red for the right reason: the function does not exist yet, so this is a compile error mentioning `ensurePerformanceIndexes`. That counts as the failing state.
+
+- [ ] **Step 3: Implement ensurePerformanceIndexes**
+
+Append to `lib/core/database/performance_indexes.dart` (add the drift import at the top of the file, below the library doc comment):
+
+```dart
+import 'package:drift/drift.dart';
+```
+
+and at the end of the file:
+
+```dart
+/// Creates any canonical index missing from [db], returning the names of
+/// indexes actually created (empty when the database was already healed).
+///
+/// Runs ANALYZE (bounded by analysis_limit) only when something was created,
+/// so the query planner picks up the new indexes; every later open is a
+/// single sqlite_master read.
+Future<List<String>> ensurePerformanceIndexes(GeneratedDatabase db) async {
+  final rows = await db
+      .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+      .get();
+  final existing = rows.map((r) => r.read<String>('name')).toSet();
+
+  final created = <String>[];
+  for (final index in kPerformanceIndexes) {
+    if (existing.contains(index.name)) continue;
+    await db.customStatement(index.ddl);
+    created.add(index.name);
+  }
+  if (created.isNotEmpty) {
+    await db.customStatement('PRAGMA analysis_limit = 400');
+    await db.customStatement('ANALYZE');
+  }
+  return created;
+}
+```
+
+- [ ] **Step 4: Wire into beforeOpen**
+
+In `lib/core/database/database.dart`, update the import block at the top of the file (it currently imports only `dart:convert` and `package:drift/drift.dart`; keep it Flutter-free) so it becomes:
+
+```dart
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:drift/drift.dart';
+
+import 'performance_indexes.dart';
+```
+
+Then in `beforeOpen` (currently ending at the `idx_dive_plan_segments_plan_id` customStatement around line 5036), append AFTER the dive-plan index re-asserts and BEFORE the closing `},`:
+
+```dart
+        // Performance indexes historically existed only in onUpgrade blocks,
+        // so a database created fresh at a recent schema version -- or
+        // arriving via restore or sync-adopt -- never got them, and per-dive
+        // child lookups degraded to full scans of million-row tables.
+        // Re-assert the canonical set on every open (IF NOT EXISTS: free
+        // after the first heal). ANALYZE runs inside only when something was
+        // actually created.
+        final createdIndexes = await ensurePerformanceIndexes(this);
+        assert(() {
+          if (createdIndexes.isNotEmpty) {
+            developer.log(
+              'Healed ${createdIndexes.length} performance indexes: '
+              '${createdIndexes.join(', ')}',
+              name: 'AppDatabase',
+            );
+          }
+          return true;
+        }());
+```
+
+(The `assert(() {...}())` pattern gives debug-only logging without importing Flutter's `kDebugMode` into this deliberately Flutter-free file. `developer.log` is `dart:developer`, pure SDK. No `onCreate` change is needed: `beforeOpen` runs after `onCreate` on the very first open, so fresh databases are covered by the same single wiring point.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `flutter test test/core/database/performance_indexes_test.dart`
+Expected: 3 tests PASS. If the fresh-DB test fails with "no such table", the canonical list references a table that no longer exists in the current schema — fix the list, do not skip the test (this failure mode is exactly what the test exists to catch).
+
+- [ ] **Step 6: Run the neighboring DB test files to catch regressions**
+
+Run: `flutter test test/core/database/migration_v86_test.dart test/core/database/migration_v85_test.dart test/core/database/migration_v58_test.dart`
+Expected: PASS (beforeOpen now does more work, but all DDL is idempotent; these tests open old-schema fixtures through the full ladder).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion
+dart format . && flutter analyze
+git add lib/core/database/performance_indexes.dart lib/core/database/database.dart test/core/database/performance_indexes_test.dart
+git commit -m "perf(db): self-heal performance indexes in beforeOpen"
+```
+
+---
+
+### Task 4: Query-plan regression tests (+ expression-index verdict)
+
+Query-plan assertions are CI-stable where timing assertions are not: they pin the *mechanism* (index used) rather than the *speed*.
+
+**Files:**
+- Test: `test/core/database/query_plan_test.dart`
+- Possibly modify: `lib/core/database/performance_indexes.dart` (drop the expression index if the verdict is negative)
+
+**Interfaces:**
+- Consumes: `kPerformanceIndexes`, `AppDatabase` (fresh in-memory, healed by beforeOpen from Task 3).
+- Produces: nothing new — a regression net.
+
+- [ ] **Step 1: Write the query-plan tests**
+
+Create `test/core/database/query_plan_test.dart`. The summaries SQL is the page-1 shape from `DiveRepository.getDiveSummaries` (`dive_repository_impl.dart:1511`); keep the two in sync when that query changes.
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Returns the concatenated EXPLAIN QUERY PLAN detail lines for [sql].
+Future<String> plan(AppDatabase db, String sql) async {
+  final rows = await db.customSelect('EXPLAIN QUERY PLAN $sql').get();
+  return rows.map((r) => r.read<String>('detail')).join('\n');
+}
+
+const _summariesPage1Sql =
+    "SELECT d.id, COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp "
+    "FROM dives d LEFT JOIN dive_sites s ON d.site_id = s.id "
+    "WHERE d.diver_id = 'x' "
+    "ORDER BY sort_timestamp DESC, COALESCE(d.dive_number, 0) DESC, d.id DESC "
+    "LIMIT 50";
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    await db.customSelect('SELECT 1').get(); // open: onCreate + beforeOpen
+  });
+
+  tearDown(() => db.close());
+
+  test('per-dive profile fetch uses idx_dive_profiles_dive_id', () async {
+    final p = await plan(
+      db,
+      "SELECT * FROM dive_profiles WHERE dive_id = 'x' ORDER BY timestamp",
+    );
+    expect(p, contains('idx_dive_profiles_dive_id'));
+  });
+
+  test('per-dive pressure fetch uses idx_tank_pressure_dive_tank', () async {
+    final p = await plan(
+      db,
+      "SELECT * FROM tank_pressure_profiles WHERE dive_id = 'x' "
+      'ORDER BY timestamp',
+    );
+    expect(p, contains('idx_tank_pressure_dive_tank'));
+  });
+
+  test('per-dive tanks fetch uses idx_dive_tanks_dive_id', () async {
+    final p = await plan(db, "SELECT * FROM dive_tanks WHERE dive_id = 'x'");
+    expect(p, contains('idx_dive_tanks_dive_id'));
+  });
+
+  test('paginated summaries page 1 does not scan dives', () async {
+    final p = await plan(db, _summariesPage1Sql);
+    expect(p, isNot(contains('SCAN dives')));
+    expect(p, contains('USING INDEX'));
+  });
+
+  test('per-dive data sources fetch uses idx_dive_data_sources_dive_id',
+      () async {
+    final p = await plan(
+      db,
+      "SELECT * FROM dive_data_sources WHERE dive_id = 'x'",
+    );
+    expect(p, contains('idx_dive_data_sources_dive_id'));
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `flutter test test/core/database/query_plan_test.dart`
+Expected: PASS. (These go green immediately because Task 3 already landed — they are the regression net that keeps it green forever, including on fresh schemas where the old onUpgrade-only bug would silently return.)
+
+- [ ] **Step 3: Expression-index verdict**
+
+Combine two pieces of evidence: (a) Task 1 Step 6 — did the fixture's `summaries_page1` plan select `idx_dives_diver_sort_timestamp`? (b) this task's `paginated summaries` test plan output (print it with `debugPrint(p)` temporarily if needed).
+
+- If the planner uses the expression index in either place: keep it; done.
+- If the planner never selects it (it may prefer `idx_dives_diver_datetime` for the WHERE and sort separately): remove the `idx_dives_diver_sort_timestamp` entry from `kPerformanceIndexes`, re-run both test files from Tasks 3-4 (expected: still green — no test names it), and record the drop with the plan text as evidence in the findings doc Decision log.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion
+dart format . && flutter analyze
+git add test/core/database/query_plan_test.dart lib/core/database/performance_indexes.dart docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+git commit -m "test(db): query-plan regression tests for performance indexes"
+```
+
+---
+
+### Task 5: In-app verification on the live DB (USER CHECKPOINT)
+
+This task needs Eric at the keyboard: it heals his real 335 MB database and captures the UI-level re-baseline that prioritizes WS1+.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-10-large-db-performance-findings.md` (fill "In-app verification" + post-WS0 UI re-baseline)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the re-baseline data that decides WS1/WS2/WS3 ordering (the spec's "Re-baseline after WS0" gate).
+
+- [ ] **Step 1: Pre-flight — report the expected one-time stall**
+
+From Task 1 Step 6, the measured total index-build time on the fixture is the stall the first open will pay. State it to the user before they launch. If it exceeded ~10 s, STOP and ask whether to add progress reporting to the startup path before proceeding (spec risk item; out of scope for this plan unless triggered).
+
+- [ ] **Step 2: Record live-DB index count before healing**
+
+Run (app closed):
+```bash
+sqlite3 -readonly ~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_autoindex%';"
+```
+Expected: 6 (the pre-WS0 state).
+
+- [ ] **Step 3: User launches the app once**
+
+Ask Eric to run `flutter run -d macos` (debug is fine for the heal; the timing of interest was already measured on the fixture) and quit after the dashboard loads. Watch the console for the `Healed N performance indexes` developer.log line.
+
+- [ ] **Step 4: Verify the heal and the steady state**
+
+Run (app closed again):
+```bash
+sqlite3 -readonly ~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_autoindex%';"
+sqlite3 -readonly ~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db "EXPLAIN QUERY PLAN SELECT * FROM dive_profiles WHERE dive_id='x';"
+```
+Expected: count equals the canonical list size (40 or 41 depending on the Task 4 verdict, plus any pre-existing extras); the plan line says `SEARCH dive_profiles USING INDEX idx_dive_profiles_dive_id`. Then ask Eric to launch once more — console should show NO heal line (already healed; steady-state cost is one sqlite_master read).
+
+- [ ] **Step 5: UI-level re-baseline (runbook Layer 2, with Eric)**
+
+Run the five runbook scenarios in `--profile` mode with vmcap. Record wall times and top-CPU attributions into the findings doc. This is the program's decision data: expect search and detail-open to improve but NOT to targets (the N+1 hydration, double profile read, lookback chains, and undecimated chart are untouched) — the attribution tells us which of WS1/WS2/WS3 now dominates.
+
+- [ ] **Step 6: Update findings + memory of record, commit**
+
+Fill the "In-app verification" section and a "Post-WS0 UI re-baseline" section in the findings doc; note the recommended next workstream order with one sentence of evidence each.
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion
+git add docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+git commit -m "docs: WS0 in-app verification and post-WS0 UI re-baseline"
+```
+
+---
+
+### Task 6: Final verification sweep
+
+**Files:** none new.
+
+- [ ] **Step 1: Whole-project format and analyze**
+
+Run: `dart format . && flutter analyze`
+Expected: no formatting changes, `No issues found!` (never pipe analyze through tail).
+
+- [ ] **Step 2: Run the touched test surface**
+
+Run: `flutter test test/core/database/performance_indexes_test.dart test/core/database/query_plan_test.dart test/core/database/migration_v86_test.dart test/core/database/migration_v85_test.dart test/core/database/migration_v58_test.dart`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit anything the sweep changed; otherwise confirm clean**
+
+Run: `git status --short`
+Expected: clean (or a final `chore:` commit for stragglers). The branch is then ready for the finishing-a-development-branch flow (PR to main with the findings table in the description).

--- a/docs/superpowers/specs/2026-07-10-large-db-performance-baseline-runbook.md
+++ b/docs/superpowers/specs/2026-07-10-large-db-performance-baseline-runbook.md
@@ -1,0 +1,66 @@
+# Large-DB Performance Measurement Runbook (Phase 3)
+
+Applies to every workstream gate in the Phase 3 program
+(2026-07-10-large-db-performance-design.md). Two layers.
+
+## Layer 1: SQL-level (automated, per-PR)
+
+1. App CLOSED. Fixture (already created once):
+
+   ```bash
+   sqlite3 ~/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db \
+     ".backup '$HOME/SubmersionBench/pristine-20260710.db'"
+   ```
+
+2. Fresh working copy:
+
+   ```bash
+   cp ~/SubmersionBench/pristine-20260710.db ~/SubmersionBench/work.db
+   ```
+
+3. Before: `dart run tools/db_bench.dart bench ~/SubmersionBench/work.db`
+4. Apply the change under test (for WS0:
+   `dart run tools/db_bench.dart create-indexes ~/SubmersionBench/work.db`).
+5. After: `dart run tools/db_bench.dart bench ~/SubmersionBench/work.db`
+6. Plans: `dart run tools/db_bench.dart plans ~/SubmersionBench/work.db`
+7. Record medians and plans in
+   2026-07-10-large-db-performance-findings.md.
+
+CAUTION: after WS0 ships, opening ANY copy with the app (or any AppDatabase)
+heals its indexes -- for a true "before", always start from the pristine
+file, which predates WS0 and must never be opened by the app.
+
+## Layer 2: UI-level (user-paced, per-workstream re-baseline)
+
+Launch: `flutter run --profile -d macos`
+(debug builds overstate costs; profile mode is the honest one).
+Copy the VM service `ws://` URI from the launch output.
+
+The five anchor scenarios (record wall time + vmcap output for each):
+
+1. Cold start: quit app; time launch to dashboard interactive (stopwatch);
+   then `dart run tools/vmcap.dart <ws-uri> read` for startup CPU
+   attribution.
+2. Search: `vmcap clear`, type a term matching many dives in dive search,
+   results visible, `vmcap read`. Record wall time to results.
+3. Detail open x3: densest single-computer dive, a 2-computer dive, a dive
+   at the end of a dense repetitive week. `vmcap clear` before each tap,
+   `vmcap read` when the page settles.
+4. Chart toggles: on the dense technical dive -- ceiling calculated to
+   computer and back, one overlay on/off. `vmcap frames 10` while toggling.
+5. List stress: table view mode on, then a fast scroll through the paginated
+   card list. `vmcap frames 10`.
+
+Record everything in 2026-07-10-large-db-performance-findings.md with date
+and commit hash.
+
+## vmcap gotchas (from the June 2026 Phase 1 effort)
+
+- Always run `clear` immediately before the interaction window; otherwise
+  the VM service's own JSON serialization dominates the samples.
+- `frames` counts only events timestamped after subscribing, because the VM
+  replays its historical frame buffer to new subscribers.
+- A sandboxed browser cannot reach the host VM-service port; run vmcap from
+  a normal shell.
+- `--trace-startup` kills the app at first frame; do not use it to measure
+  the startup floor.

--- a/docs/superpowers/specs/2026-07-10-large-db-performance-design.md
+++ b/docs/superpowers/specs/2026-07-10-large-db-performance-design.md
@@ -1,0 +1,241 @@
+# Large-Database Performance (Phase 3) — Design
+
+Date: 2026-07-10
+Status: Approved (brainstorming session)
+Predecessors: `2026-06-24-app-performance-investigation-design.md` (Phase 1),
+Phase 2 PRs #412 (chart memoization), #415 (sync parse isolate), #417 (batched
+merge writes), #420 (rebuild coalescing).
+
+## Context
+
+Phases 1-2 fixed what was measurable at 37 dives / 40.9k profile samples. A
+scubaboard user with 1,000+ dives (Subsurface import, Shearwater, technical
+dives, PC + Android) reports a new scale regime:
+
+- Search takes 20+ seconds on PC; on Android the app hits "not responding"
+  (ANR) dialogs before search completes.
+- Changing dive profile graph options (for example switching the deco ceiling
+  overlay from calculated to dive computer) can take minutes on technical
+  dives.
+
+The local debug database reproduces the slowness: 1,032 dives, 1,077,216
+`dive_profiles` rows, 784,752 `tank_pressure_profiles` rows, 34 multi-computer
+dives, densest dive 4,762 samples, 335 MB on disk.
+
+### Evidence gathered (2026-07-10)
+
+**The dominant finding: the live v102 database has almost no indexes.**
+Performance indexes are created only inside `onUpgrade` migration blocks
+(`lib/core/database/database.dart`, `from < 31` block at :2957-:3013, `from <
+78` at :4438). They are never created in `onCreate` (which is
+`m.createAll()` + seed only, :2300-:2306) and never re-asserted in
+`beforeOpen`. Any database created fresh at a recent schema version, or
+arriving via restore or sync-adopt, gets none of them. The live DB has 6 user
+indexes out of ~20 intended; `EXPLAIN QUERY PLAN` confirms `SCAN
+dive_profiles` (a 1.08M-row full scan) for a single dive's profile fetch.
+The scubaboard reporter (fresh install + import) is in the same state.
+
+Code-level findings that compound with the missing indexes:
+
+| Surface | Finding |
+|---|---|
+| Search | `searchDives` (`dive_repository_impl.dart:1932`) runs a 12-column leading-wildcard `LIKE` across 5 joined tables with no `LIMIT`, then hydrates every match through `_mapRowToDive` (:2588) — roughly 10 queries per matched dive (N+1). |
+| Dive detail | `getDiveById` eagerly loads all sources' full profiles with no filter (:2608); `sourceProfilesProvider` re-reads the same rows (:625, :645). Residual CNS/tissue/OTU chains plus `weeklyOtuProvider` (`profile_analysis_provider.dart:950`, :1011, :1071, :1160) fully hydrate and Buhlmann-analyze every dive back 24-48 h of surface interval and 7 days of history — 20-30 extra full-dive hydrations on a dense week. |
+| Chart | The feature-preserving decimator (`profile_decimator.dart`) from PR #412 has zero production callers. Every curve is a full-length `isCurved` FlSpot list; overlays add up to 4 full-length series per source. The series cache has one all-or-nothing signature (`dive_profile_chart.dart:815-847`), so one toggle rebuilds every series. |
+| Dashboard | `recentDivesProvider`, `personalRecordsProvider`, and month/YTD counts (`dashboard_providers.dart:49`, :97-:118, :155) all await `divesProvider` → `getAllDives()`: full hydration of every dive with all children on the first home frame. Table view mode and detailed cards with non-summary fields hit the same path (`dive_list_content.dart:674`, :1200-1214). |
+| Structural | All SQLite execution happens on the UI isolate — the ANR mechanism. |
+| Already sound | The paginated card list (50/page, SQL-bounded, batched follow-ups) and the Statistics tab (pure SQL aggregates via `buildFilteredDiveIdSubquery`) need no work. |
+
+## Goals
+
+Interactive-grade targets at 1,000+ dives, measured on macOS against the live
+debug DB:
+
+| Operation | Target |
+|---|---|
+| Search (results visible) | < 500 ms |
+| Dive detail open (core content) | < 500 ms |
+| Chart option toggle | < 200 ms |
+| Cold start to usable dashboard | < 2 s |
+| UI-thread blocking from DB work | zero blocks > 1 frame |
+
+Non-goals: the reporter's correctness complaints (bottom-time calculation,
+ceiling accuracy, import cancellation) are tracked separately; this program is
+performance only. Measurement is macOS-only; Android/Windows verification
+happens at the end of the program.
+
+## Approach
+
+Surgical sequence with per-workstream measurement gates: a compact scripted
+baseline first, then independent workstreams in descending expected-yield
+order. Each workstream opens with its own measurement and closes with a
+before/after comparison in its PR. Ordering logic: shrink the work
+(WS0-WS4), then move the work off-thread (WS5). Re-baseline after WS0, since
+indexes reshuffle every downstream measurement.
+
+Alternatives considered and rejected:
+
+- Exhaustive baseline before any fix: the anchor scenarios are already
+  precisely defined by user complaints and DB inspection; exhaustive
+  baselining delays relief WS0 can deliver immediately.
+- Architecture first (DB isolate before algorithmic fixes): the isolate move
+  makes slow work invisible, not fast — a 20 s search becomes a 20 s
+  background wait. Do the riskiest refactor against a lean workload, last.
+
+## Baseline measurement
+
+Five scripted anchor scenarios, run with the VM-service profiler technique
+from Phase 1. The `vmcap.dart` tool was scratchpad-only and is lost; it gets
+recreated and committed to `tools/` this time so the runbook is reproducible.
+
+1. Cold start to interactive dashboard.
+2. Search for a term matching many dives.
+3. Detail open: densest single-computer dive (~4.8k samples), a 2-computer
+   dive, and a dive at the end of a dense repetitive week (worst lookback
+   chain).
+4. Chart toggles: ceiling calculated/computer, overlay on/off.
+5. Table view mode switch and a paginated-list fast scroll.
+
+Each scenario records wall time, UI-isolate busy time, and query counts
+(Drift `logStatements` plus `EXPLAIN QUERY PLAN` captures). Numbers land in a
+findings doc next to this spec; every workstream PR must show its
+before/after.
+
+## Workstreams
+
+### WS0 — Index integrity
+
+- A single idempotent `_ensurePerformanceIndexes()` — a list of `CREATE INDEX
+  IF NOT EXISTS` statements — called from both `onCreate` and `beforeOpen`.
+  This matches the existing `beforeOpen` re-assert pattern (dive-type seed,
+  buddyRoles, dive-plan indexes) and permanently heals every user's DB on
+  next launch.
+- The list is the full intended set (v31 + v78 era) plus new indexes the
+  query map justifies: `dive_profiles(dive_id)`,
+  `tank_pressure_profiles(dive_id)`, and an expression index on
+  `(diver_id, COALESCE(entry_time, dive_date_time) DESC)` — the actual sort
+  key of the paginated list, currently not index-backed.
+- Run `ANALYZE` after any index was actually created (consider `PRAGMA
+  optimize` on open) so the planner uses the new indexes.
+- First-open cost: building ~15 indexes over a 335 MB DB is a one-time stall
+  behind the existing splash. Measure it; add progress UI only if it exceeds
+  a few seconds. `IF NOT EXISTS` makes later opens free.
+- CI guard: a test opening a fresh schema DB asserting the hot queries'
+  `EXPLAIN QUERY PLAN` output contains `USING INDEX`. Query-plan assertions
+  are CI-stable where timing assertions are not.
+- No schema version bump: `beforeOpen` only, so no collision with parallel
+  branch migrations (schema stays at v102).
+
+### WS1 — Search
+
+- Phase A (surgical): cap results (`LIMIT 100` with a "showing first 100"
+  affordance); hydrate matches as `DiveSummary` rows via the existing
+  paginated-list machinery (slim `customSelect` + batched tags/types) instead
+  of full `_mapRowToDive` hydration; debounce search-as-you-type input.
+- Phase B (FTS5): a `dive_search_index` FTS5 table covering notes, site
+  name/location, buddy names, tags, dive center, and custom-field values.
+  Populated by a one-time backfill migration; kept current at the repository
+  write layer (the single seam all dive writes pass through), not triggers,
+  to avoid trigger/sync interaction surprises. Query becomes indexed `MATCH`
+  with prefix support, ranked, joined back to `dives` by id.
+- Phase B ships only if Phase A's measured numbers still miss the 500 ms
+  target on realistic terms. Accepted semantic change for Phase B:
+  word-prefix matching instead of arbitrary substring.
+
+### WS2 — Dive detail load path
+
+1. One profile read per open: a single per-dive profile fetch (all sources,
+   one indexed query) shared by `diveProvider` and `sourceProfilesProvider`
+   — likely a `diveProfileBundleProvider` both consume. Design constraint:
+   exactly one `dive_profiles` query per detail open. Exact wiring decided in
+   the implementation plan.
+2. Narrow hydration for analysis lookbacks: `getPreviousDive` /
+   `getDivesInRange` currently return fully hydrated `Dive`s when the
+   analysis needs only profile + tanks + timestamps. Add a lean
+   `getDiveForAnalysis` accessor; the lookback chains switch to it.
+3. Analysis off the critical path (approved UX change): the page renders core
+   content immediately; the deco panel, residual-tissue values, and weekly
+   OTU resolve asynchronously with "calculating" placeholders. The existing
+   `_lastDecoPanelAnalysis` anti-flicker fallback generalizes into this.
+4. Bound and cache the chains: residual chains keep their physiological
+   semantics (walk back until 24 h / 48 h surface interval) but per-dive
+   analysis results get memoized in a session-scope LRU keyed by dive id +
+   profile revision, so consecutive detail opens within a trip share prior
+   analyses. A persisted analysis-cache table is explicitly deferred: measure
+   first; the in-memory cache plus WS0 indexes probably suffices, and a
+   schema table brings sync/invalidation complexity we should not buy blind.
+
+### WS3 — Chart scaling
+
+1. Wire the existing tested decimator (`decimateProfileIndices`) into series
+   building: main depth line, each metric curve, and every overlay series
+   decimate to a render budget of ~1,500-2,000 points per series.
+   Feature-preserving: peaks, ceiling violations, and gas switches survive.
+2. Zoom-aware re-decimation: decimate over the visible window so zooming
+   progressively restores full sample detail.
+3. Per-series cache scoping: split the single `'main'` cache signature so a
+   toggle rebuilds only the affected series.
+4. Ceiling toggle specifically: switching calculated/computer must not re-run
+   analysis (WS2 caches it) and must not rebuild unrelated series. Target
+   < 200 ms.
+5. `isCurved` cost is measured post-decimation; at ~2k points the smooth
+   rendering is likely fine to keep.
+
+### WS4 — Dashboard startup and table mode
+
+- Replace each dashboard consumer of `getAllDives()` with bounded SQL:
+  recent dives = `getDiveSummaries(limit: 3)`; personal records = `MIN`/`MAX`
+  aggregates; month/YTD = `COUNT` with date ranges. The statistics repository
+  already demonstrates every pattern needed.
+- Table mode moves onto the paginated summary query with SQL sort. The
+  "detailed card needs full dive" leak is fixed by widening the summary
+  column set to cover configurable card fields rather than falling back to
+  `getAllDives()`.
+- End state: nothing in the app calls `getAllDives()` on a hot path. Remaining
+  legacy consumers of `diveListNotifierProvider` get an audit note in the
+  implementation plan.
+
+### WS5 — DB off the UI isolate (S4)
+
+- Switch the Drift executor to a background isolate
+  (`NativeDatabase.createInBackground`), keeping the repository API and
+  stream queries unchanged (Drift proxies them over the isolate port).
+- Sequenced last deliberately: by then the workload is lean, per-workstream
+  behavior tests exist, and the Phase 2 sync-parity suite (byte-for-byte
+  tests) verifies the merge path.
+- Plan-level attention: `beforeOpen` re-asserts run on the isolate; the
+  sqlite temp-dir handling from the #509 work; interplay with the S3 sync
+  parse worker.
+- Success metric: zero dropped frames during an active sync while scrolling
+  the dive list. This is also the structural ANR fix — after WS5 no future
+  regression can block frames with DB work.
+
+## Testing and regression protection
+
+- TDD per workstream: query-plan assertions (WS0); search parity tests
+  old-vs-new on a seeded DB (WS1); profile-read-count tests asserting exactly
+  one `dive_profiles` query per detail open via Drift statement logging
+  (WS2); decimation goldens on technical profiles (WS3); dashboard value
+  parity tests SQL-vs-legacy (WS4); the existing sync parity suite re-run
+  (WS5).
+- The five-scenario runbook (with committed `tools/vmcap.dart`) is the manual
+  before/after gate for every PR in this program.
+- Whole-project `dart format .` and `flutter analyze` before each push.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| WS0 first-open index build stalls very large DBs | Measured behind splash; `IF NOT EXISTS` makes it one-time; progress UI if over a few seconds |
+| FTS5 index drifts from source tables | Repository-layer writes (single seam), backfill migration, parity test; Phase B only ships if Phase A misses target |
+| Decimation hides a real profile spike | Feature-preserving algorithm; zoom restores full detail; goldens on technical profiles |
+| WS5 isolate breaks sync / temp-dir / beforeOpen assumptions | Sequenced last; parity suite; inline-fallback pattern proven in S3 (PR #415) |
+| Migration collisions with parallel branches | WS0 uses `beforeOpen` (no version bump); FTS5, if needed, takes v103+ |
+
+## Rollout
+
+Each workstream is an independent PR off main with its own measurement
+evidence, so any workstream can ship alone and the program can stop early if
+targets are met — plausibly as soon as WS0 + WS1. Android and Windows
+verification (including the ANR scenario) happens after the workstreams
+land, before release notes claim the improvement.

--- a/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+++ b/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
@@ -147,6 +147,30 @@ Signatures (what the profiler actually showed):
   + full series rebuild = undecimated 4,762-point curves redrawn wholesale
   per toggle. WS3 (decimation + per-series cache scoping) maps directly.
 
+### Debug-only startup freeze (persistent, ~20 s per debug launch)
+
+After the heal and WAL checkpoint, `flutter run -d macos` (debug) still froze
+~20 s at the splash fade on every launch, while profile mode was clean.
+Startup instrumentation put all six init steps at ~220 ms total and the
+first frame after the ready state at 265 ms -- the freeze is NOT init and
+NOT the widget build; it begins when the dashboard's async providers
+resolve. Native sampling during the freeze shows the io.flutter.ui thread
+spending 87% of the window in DartMicrotaskQueue::RunMicrotasks with ~40%
+inside
+dart::Compiler::CompileOptimizedFunction / FlowGraphInliner::Inline via
+DRT_InterruptOrStackOverflow: the debug JIT's OPTIMIZING COMPILER running
+synchronously on the UI thread, recompiling the hot Drift row-mapping
+functions that the dashboard's getAllDives() microtask flood makes hot.
+
+Implications:
+- Debug-launch pain is WS4's workload amplified by JIT compilation of the
+  very large generated database.g.dart mapping code. AOT (profile/release)
+  users pay only the raw hydration (~1-2 s today, hidden behind the fade),
+  which still scales linearly with dive count.
+- No WS0 action; this hardens the case for WS4 (remove hot-path
+  getAllDives) which fixes both the debug developer experience and the
+  release-mode scaling liability.
+
 ## Recommended workstream order (evidence-based)
 
 1. WS1 search (small change, 3.5 s -> sub-500 ms expected; fires on every

--- a/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+++ b/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
@@ -86,8 +86,20 @@ search joins:   SEARCH db/dt/cf USING INDEX idx_dive_buddies/tags/custom_fields_
   shape (that dive has no transmitter data), and it makes the point well:
   unindexed, absence-of-data still cost a 785k-row scan.
 
-## In-app verification (filled in at Task 5)
+## In-app verification (Task 5, 2026-07-10)
 
-- Live DB healed on first open: pending
-- beforeOpen ensure cost on already-healed DB: pending
-- Post-WS0 UI re-baseline (runbook Layer 2): pending
+- Live DB healed on first open: 6 -> 40 user indexes (exactly the canonical
+  list; 34 created on this open) after a single `flutter run -d macos`
+  launch of the WS0 build. `EXPLAIN QUERY PLAN` on the live DB confirms
+  `SEARCH dive_profiles USING INDEX idx_dive_profiles_dive_id`;
+  sqlite_stat1 populated (48 rows), so ANALYZE ran.
+- Expected heal cost was 534 ms (fixture-measured, identical data); startup
+  showed no user-visible stall behind the splash.
+- Logging caveat: the heal message uses dart:developer `log`, which appears
+  in the DevTools logging view, NOT in `flutter run` stdout. Absence of a
+  console line is not evidence the heal did not run; check
+  sqlite_master.
+- beforeOpen steady-state cost on an already-healed DB: one sqlite_master
+  read + no DDL (idempotency unit-tested; created list empty).
+- Post-WS0 UI re-baseline (runbook Layer 2): pending -- decides WS1 vs WS2
+  ordering.

--- a/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+++ b/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
@@ -1,0 +1,93 @@
+# Large-DB Performance Findings (Phase 3)
+
+Fixture: pristine-20260710.db -- 1,032 dives / 1,077,216 dive_profiles rows /
+784,752 tank_pressure_profiles rows / 34 multi-computer dives / 335 MB.
+Machine: Apple M5 Pro (macOS).
+Tool: tools/db_bench.dart (median of 5), commit of record on branch
+large-db-perf-ws0.
+
+Pre-WS0 index state of the fixture (and of any fresh install / restored /
+sync-adopted database): 6 user indexes present out of ~40 intended, because
+index creation lived only in onUpgrade migration blocks. See the design spec
+(2026-07-10-large-db-performance-design.md) for the mechanism.
+
+## WS0 SQL-level A/B (same fixture, before vs after kPerformanceIndexes)
+
+| Query | Rows | Before (ms) | After (ms) |
+|---|---|---|---|
+| profile_fetch_densest | 4,762 | 39.2 | 4.0 |
+| pressure_fetch_densest | 0 | 26.6 | 0.0 |
+| tanks_fetch | 2 | 0.1 | 0.0 |
+| summaries_page1 | 50 | 0.3 | 0.8 |
+| dive_count | 1 | 0.0 | 0.0 |
+| search_match_ids ("blue") | 74 | 4.6 | 3.2 |
+| prev_dive | 1 | 0.8 | 0.3 |
+| tags_for_page (50 ids) | 174 | 0.4 | 0.1 |
+| search_hydration_first20 | 20 | 1,298.0 | 17.0 |
+
+Reading the table:
+
+- The pain is concentrated in per-dive fetches against the two million-row
+  tables. Unindexed, EVERY per-dive profile fetch scans 1,077,216 rows
+  (39 ms) and every pressure fetch scans 784,752 rows (26.6 ms even when the
+  dive has ZERO pressure rows).
+- search_hydration_first20 is the mechanical confirmation of the reported
+  "20+ second search": 1.3 s for only 20 of 74 matches running only 3 of the
+  ~10 per-dive hydration queries the app really runs. Extrapolated
+  (74 matches, ~10 queries), full hydration lands around 16 s before WS0 and
+  around 0.2 s after -- a ~76x improvement from indexes alone. The remaining
+  N+1 shape is WS1's target.
+- The LIKE match query itself was never the search bottleneck at this scale
+  (4.6 ms): SQLite built AUTOMATIC COVERING INDEXes for the unindexed
+  junctions at query time. The hydration N+1 was the bottleneck.
+- summaries_page1 and the statistics-style aggregates were already fine
+  (the dives table itself is only 1,032 rows); 0.3 -> 0.8 ms is noise.
+
+Index build cost (the one-time first-open heal stall): **534 ms total for 35
+indexes including ANALYZE (54 ms)**. Slowest: idx_tank_pressure_dive_tank
+243 ms, idx_dive_profiles_dive_id 205 ms; everything else under 10 ms. This
+disappears behind the existing ~1 s startup splash -- no progress UI needed
+(the spec's threshold for that was ~10 s).
+
+## Query plan evidence
+
+Before (hot queries):
+
+```text
+profile_fetch:  SCAN dive_profiles                 + TEMP B-TREE FOR ORDER BY
+pressure_fetch: SCAN tank_pressure_profiles        + TEMP B-TREE FOR ORDER BY
+tanks_fetch:    SCAN dive_tanks
+tags_for_page:  SCAN dive_tags
+prev_dive:      SCAN dives                         + TEMP B-TREE FOR ORDER BY
+```
+
+After:
+
+```text
+profile_fetch:  SEARCH dive_profiles USING INDEX idx_dive_profiles_dive_id (dive_id=?)
+pressure_fetch: SEARCH tank_pressure_profiles USING INDEX idx_tank_pressure_dive_tank (dive_id=?)
+tanks_fetch:    SEARCH dive_tanks USING INDEX idx_dive_tanks_dive_id (dive_id=?)
+tags_for_page:  SEARCH dive_tags USING INDEX idx_dive_tags_dive_id (dive_id=?)
+prev_dive:      MULTI-INDEX OR ... USING INDEX idx_dives_diver_entrytime
+search joins:   SEARCH db/dt/cf USING INDEX idx_dive_buddies/tags/custom_fields_dive_id
+```
+
+## Decision log
+
+- Expression index idx_dives_diver_sort_timestamp
+  (`dives(diver_id, COALESCE(entry_time, dive_date_time) DESC)`): the planner
+  never selected it -- summaries_page1 chose idx_dives_favorite for the
+  diver_id equality and still sorted 50 rows via TEMP B-TREE, because sorting
+  a ~1k-row candidate set is cheaper than maintaining expression-index
+  ordering. Timing was unaffected (0.3 vs 0.8 ms, noise). DROPPED from the
+  canonical list in Task 4; it would cost write amplification on every dive
+  insert for no measured benefit.
+- pressure_fetch returning 0 rows for the densest dive is expected data
+  shape (that dive has no transmitter data), and it makes the point well:
+  unindexed, absence-of-data still cost a 785k-row scan.
+
+## In-app verification (filled in at Task 5)
+
+- Live DB healed on first open: pending
+- beforeOpen ensure cost on already-healed DB: pending
+- Post-WS0 UI re-baseline (runbook Layer 2): pending

--- a/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
+++ b/docs/superpowers/specs/2026-07-10-large-db-performance-findings.md
@@ -100,6 +100,60 @@ search joins:   SEARCH db/dt/cf USING INDEX idx_dive_buddies/tags/custom_fields_
   console line is not evidence the heal did not run; check
   sqlite_master.
 - beforeOpen steady-state cost on an already-healed DB: one sqlite_master
-  read + no DDL (idempotency unit-tested; created list empty).
-- Post-WS0 UI re-baseline (runbook Layer 2): pending -- decides WS1 vs WS2
-  ordering.
+  read + no DDL (idempotency unit-tested; created list empty). Confirmed
+  in-app by startup instrumentation: `[startup] database: 3ms` on the
+  second profile launch.
+
+### Real-world heal cost (differs sharply from the fixture number)
+
+The fixture measured 534 ms because the file was warm in the OS page cache
+from the copy. On the real, cold 335 MB database the first (debug) launch
+froze ~20 s at the splash, and the NEXT (profile) launch froze ~20 s again
+with near-zero CPU across every thread (native `sample` evidence): the heal
+had written hundreds of MB of index pages into the WAL, and the next open
+paid WAL recovery/checkpoint -- pure disk I/O. Once checkpointed, the
+following launch was instant (total init 9 ms).
+
+Mitigation shipped in WS0: `PRAGMA wal_checkpoint(TRUNCATE)` immediately
+after a non-empty heal, so the entire cost is paid once, inside the first
+splash, and cannot leak into the next launch. Residual: the first-open
+stall itself (up to ~20 s cold on very large DBs) currently shows only the
+static splash -- progress UI is a product decision recorded below.
+
+## Post-WS0 UI re-baseline (profile mode, Apple M5 Pro, 2026-07-10)
+
+Captured with tools/vmcap.dart per the runbook; values are main-isolate CPU
+time attributed by the Dart profiler during the interaction.
+
+| Scenario | Measured | Target | Verdict |
+|---|---|---|---|
+| Startup (steady state) | 9 ms init + 1 s splash floor | < 2 s | MET (post-WS0) |
+| Search, one character | ~3.5 s CPU | < 500 ms | WS1 |
+| Detail open, dive 1006 (4,762 samples) | ~11 s CPU | < 500 ms | WS2 |
+| Ceiling-source toggle | ~0.85 s CPU per toggle | < 200 ms | WS3 |
+
+Signatures (what the profiler actually showed):
+
+- Search: sqlite3VdbeExec on the main isolate + per-query SQL string
+  building (_concatAll/_interpolate) + Map churn + mutex slow paths =
+  thousands of tiny queries. The N+1 hydration shape, not SQLite speed, is
+  now the cost. WS1 Phase A (bounded results, batched DiveSummary
+  hydration, input debounce) attacks exactly this.
+- Detail open: 23.7% raw allocation (TLAB) + pervasive dynamic-invocation
+  type checks = hydrating enormous object graphs (double full-profile read,
+  Buhlmann + residual CNS/tissue/OTU + weekly OTU lookback chains fully
+  hydrating dozens of prior dives). WS2's items map one-to-one.
+- Ceiling toggle: Skia dash-path measurement (SkContourMeasure::getSegment)
+  + full series rebuild = undecimated 4,762-point curves redrawn wholesale
+  per toggle. WS3 (decimation + per-series cache scoping) maps directly.
+
+## Recommended workstream order (evidence-based)
+
+1. WS1 search (small change, 3.5 s -> sub-500 ms expected; fires on every
+   keystroke so perceived cost is multiplied).
+2. WS2 detail load path (largest absolute cost, 11 s; also the
+   multi-computer complaint).
+3. WS3 chart scaling (0.85 s per toggle; also shrinks WS2's chart share).
+4. WS4 dashboard (startup steady-state already meets target post-WS0;
+   getAllDives remains a scaling liability, not the current bottleneck).
+5. WS5 DB isolate (unchanged: last, structural).

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -5024,19 +5024,14 @@ class AppDatabase extends _$AppDatabase {
         }
         await createMigrator().createTable(buddyRoles);
 
-        // v100 backstop: re-assert the dive plan tables and their indexes
-        // (same collision disease; all DDL idempotent).
+        // v100 backstop: re-assert the dive plan tables (same collision
+        // disease; createTable is idempotent). Their indexes
+        // (idx_dive_plan_tanks_plan_id / idx_dive_plan_segments_plan_id) are
+        // in the canonical performance-index set and created by
+        // ensurePerformanceIndexes below, so they are not re-declared here.
         await createMigrator().createTable(divePlans);
         await createMigrator().createTable(divePlanTanks);
         await createMigrator().createTable(divePlanSegments);
-        await customStatement('''
-          CREATE INDEX IF NOT EXISTS idx_dive_plan_tanks_plan_id
-          ON dive_plan_tanks(plan_id)
-        ''');
-        await customStatement('''
-          CREATE INDEX IF NOT EXISTS idx_dive_plan_segments_plan_id
-          ON dive_plan_segments(plan_id)
-        ''');
 
         // Performance indexes historically existed only in onUpgrade blocks,
         // so a database created fresh at a recent schema version -- or

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
+import 'dart:developer' as developer;
 
 import 'package:drift/drift.dart';
+
+import 'package:submersion/core/database/performance_indexes.dart';
 
 part 'database.g.dart';
 
@@ -5034,6 +5037,25 @@ class AppDatabase extends _$AppDatabase {
           CREATE INDEX IF NOT EXISTS idx_dive_plan_segments_plan_id
           ON dive_plan_segments(plan_id)
         ''');
+
+        // Performance indexes historically existed only in onUpgrade blocks,
+        // so a database created fresh at a recent schema version -- or
+        // arriving via restore or sync-adopt -- never got them, and per-dive
+        // child lookups degraded to full scans of million-row tables.
+        // Re-assert the canonical set on every open (IF NOT EXISTS: free
+        // after the first heal). ANALYZE runs inside only when something was
+        // actually created.
+        final createdIndexes = await ensurePerformanceIndexes(this);
+        assert(() {
+          if (createdIndexes.isNotEmpty) {
+            developer.log(
+              'Healed ${createdIndexes.length} performance indexes: '
+              '${createdIndexes.join(', ')}',
+              name: 'AppDatabase',
+            );
+          }
+          return true;
+        }());
       },
     );
   }

--- a/lib/core/database/performance_indexes.dart
+++ b/lib/core/database/performance_indexes.dart
@@ -40,16 +40,12 @@ const List<PerformanceIndex> kPerformanceIndexes = [
         'CREATE INDEX IF NOT EXISTS idx_dives_diver_exittime '
         'ON dives(diver_id, exit_time DESC)',
   ),
-  // Matches the paginated dive list's ORDER BY expression exactly
-  // (dive_repository_impl.dart getDiveSummaries: sort_timestamp =
-  // COALESCE(entry_time, dive_date_time)). Empirically validated in the
-  // WS0 baseline; remove if EXPLAIN QUERY PLAN never selects it.
-  (
-    name: 'idx_dives_diver_sort_timestamp',
-    ddl:
-        'CREATE INDEX IF NOT EXISTS idx_dives_diver_sort_timestamp '
-        'ON dives(diver_id, COALESCE(entry_time, dive_date_time) DESC)',
-  ),
+  // NOTE: an expression index on (diver_id, COALESCE(entry_time,
+  // dive_date_time) DESC) matching the paginated list's sort key was
+  // evaluated in the WS0 baseline and DROPPED: the planner never selected
+  // it (sorting a ~1k-row candidate set beats maintaining expression-index
+  // order), so it would cost write amplification for nothing. Evidence in
+  // docs/superpowers/specs/2026-07-10-large-db-performance-findings.md.
   (
     name: 'idx_dives_site_id',
     ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_site_id ON dives(site_id)',

--- a/lib/core/database/performance_indexes.dart
+++ b/lib/core/database/performance_indexes.dart
@@ -1,0 +1,268 @@
+/// Canonical performance-index set for the Submersion database.
+///
+/// Historically these indexes were created only inside onUpgrade migration
+/// blocks, so a database created fresh at a recent schema version -- or
+/// arriving via restore or sync-adopt -- never got them and every child-table
+/// lookup degraded to a full table scan (issue: large-DB performance,
+/// docs/superpowers/specs/2026-07-10-large-db-performance-design.md).
+///
+/// This list is asserted idempotently on every open from
+/// AppDatabase.beforeOpen. Keep it in sync: any migration that adds a
+/// performance index must also add it here (the fresh-DB test in
+/// test/core/database/performance_indexes_test.dart fails if the DDL
+/// references a table missing from the current schema).
+///
+/// This file must stay Flutter-free: it is imported by tools/db_bench.dart,
+/// which runs on the plain Dart VM.
+library;
+
+typedef PerformanceIndex = ({String name, String ddl});
+
+const List<PerformanceIndex> kPerformanceIndexes = [
+  // -- dives ------------------------------------------------------------
+  (
+    name: 'idx_dives_diver_datetime',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_diver_datetime '
+        'ON dives(diver_id, dive_date_time DESC)',
+  ),
+  (
+    name: 'idx_dives_diver_entrytime',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_diver_entrytime '
+        'ON dives(diver_id, entry_time DESC)',
+  ),
+  (
+    name: 'idx_dives_diver_exittime',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_diver_exittime '
+        'ON dives(diver_id, exit_time DESC)',
+  ),
+  // Matches the paginated dive list's ORDER BY expression exactly
+  // (dive_repository_impl.dart getDiveSummaries: sort_timestamp =
+  // COALESCE(entry_time, dive_date_time)). Empirically validated in the
+  // WS0 baseline; remove if EXPLAIN QUERY PLAN never selects it.
+  (
+    name: 'idx_dives_diver_sort_timestamp',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_diver_sort_timestamp '
+        'ON dives(diver_id, COALESCE(entry_time, dive_date_time) DESC)',
+  ),
+  (
+    name: 'idx_dives_site_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_site_id ON dives(site_id)',
+  ),
+  (
+    name: 'idx_dives_trip_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_trip_id ON dives(trip_id)',
+  ),
+  (
+    name: 'idx_dives_dive_center_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_dive_center_id '
+        'ON dives(dive_center_id)',
+  ),
+  (
+    name: 'idx_dives_course_id',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_course_id ON dives(course_id)',
+  ),
+  (
+    name: 'idx_dives_favorite',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_favorite '
+        'ON dives(diver_id, is_favorite)',
+  ),
+  // -- per-dive child tables (the million-row scans) ---------------------
+  (
+    name: 'idx_dive_profiles_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_profiles_dive_id '
+        'ON dive_profiles(dive_id)',
+  ),
+  (
+    name: 'idx_tank_pressure_dive_tank',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_tank_pressure_dive_tank '
+        'ON tank_pressure_profiles(dive_id, tank_id, timestamp)',
+  ),
+  (
+    name: 'idx_dive_tanks_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_tanks_dive_id '
+        'ON dive_tanks(dive_id)',
+  ),
+  (
+    name: 'idx_dive_equipment_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_equipment_dive_id '
+        'ON dive_equipment(dive_id)',
+  ),
+  (
+    name: 'idx_dive_weights_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_weights_dive_id '
+        'ON dive_weights(dive_id)',
+  ),
+  (
+    name: 'idx_dive_tags_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_tags_dive_id '
+        'ON dive_tags(dive_id)',
+  ),
+  (
+    name: 'idx_dive_tags_tag_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_tags_tag_id '
+        'ON dive_tags(tag_id)',
+  ),
+  (
+    name: 'idx_dive_buddies_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_buddies_dive_id '
+        'ON dive_buddies(dive_id)',
+  ),
+  (
+    name: 'idx_dive_custom_fields_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_custom_fields_dive_id '
+        'ON dive_custom_fields(dive_id)',
+  ),
+  (
+    name: 'idx_dive_custom_fields_key',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_custom_fields_key '
+        'ON dive_custom_fields(field_key)',
+  ),
+  (
+    name: 'idx_dive_data_sources_dive_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_data_sources_dive_id '
+        'ON dive_data_sources(dive_id)',
+  ),
+  (
+    name: 'idx_tide_records_dive',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_tide_records_dive '
+        'ON tide_records(dive_id)',
+  ),
+  // -- sync ---------------------------------------------------------------
+  (
+    name: 'idx_sync_records_entity_record',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_sync_records_entity_record '
+        'ON sync_records(entity_type, record_id)',
+  ),
+  // -- reference / feature tables ------------------------------------------
+  (
+    name: 'idx_site_species_site',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_site_species_site '
+        'ON site_species(site_id)',
+  ),
+  (
+    name: 'idx_courses_diver',
+    ddl: 'CREATE INDEX IF NOT EXISTS idx_courses_diver ON courses(diver_id)',
+  ),
+  (
+    name: 'idx_media_platform_asset_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_platform_asset_id '
+        'ON media(platform_asset_id)',
+  ),
+  (
+    name: 'idx_media_enrichment_media',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_enrichment_media '
+        'ON media_enrichment(media_id)',
+  ),
+  (
+    name: 'idx_media_enrichment_dive',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_enrichment_dive '
+        'ON media_enrichment(dive_id)',
+  ),
+  (
+    name: 'idx_media_species_media',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_species_media '
+        'ON media_species(media_id)',
+  ),
+  (
+    name: 'idx_media_species_species',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_species_species '
+        'ON media_species(species_id)',
+  ),
+  (
+    name: 'idx_pending_photo_suggestions_dive',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_pending_photo_suggestions_dive '
+        'ON pending_photo_suggestions(dive_id)',
+  ),
+  (
+    name: 'idx_scheduled_notifications_equipment',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_scheduled_notifications_equipment '
+        'ON scheduled_notifications(equipment_id)',
+  ),
+  (
+    name: 'idx_view_configs_diver',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_view_configs_diver '
+        'ON view_configs(diver_id, view_mode)',
+  ),
+  (
+    name: 'idx_field_presets_diver',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_field_presets_diver '
+        'ON field_presets(diver_id, view_mode)',
+  ),
+  (
+    name: 'idx_media_source_type',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_source_type '
+        'ON media(source_type)',
+  ),
+  (
+    name: 'idx_media_connector_account',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_connector_account '
+        'ON media(connector_account_id)',
+  ),
+  (
+    name: 'idx_media_origin_device',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_media_origin_device '
+        'ON media(origin_device_id)',
+  ),
+  (
+    name: 'idx_checklist_template_items_template_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_checklist_template_items_template_id '
+        'ON checklist_template_items(template_id)',
+  ),
+  (
+    name: 'idx_trip_checklist_items_trip_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_trip_checklist_items_trip_id '
+        'ON trip_checklist_items(trip_id)',
+  ),
+  (
+    name: 'idx_dive_plan_tanks_plan_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_plan_tanks_plan_id '
+        'ON dive_plan_tanks(plan_id)',
+  ),
+  (
+    name: 'idx_dive_plan_segments_plan_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dive_plan_segments_plan_id '
+        'ON dive_plan_segments(plan_id)',
+  ),
+  (
+    name: 'idx_gps_track_points_local_track_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_gps_track_points_local_track_id '
+        'ON gps_track_points_local(track_id)',
+  ),
+];

--- a/lib/core/database/performance_indexes.dart
+++ b/lib/core/database/performance_indexes.dart
@@ -305,7 +305,11 @@ Future<List<String>> ensurePerformanceIndexes(GeneratedDatabase db) async {
     // the WAL. Checkpoint it now, inside the startup splash, so the NEXT
     // launch does not stall on WAL recovery (observed as a ~20 s zero-CPU
     // freeze on a 335 MB database). No-op outside WAL mode.
-    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    //
+    // wal_checkpoint returns a row (busy, log, checkpointed), so use
+    // customSelect (matching DatabaseMigrationService) rather than
+    // customStatement, which is for non-row-returning statements.
+    await db.customSelect('PRAGMA wal_checkpoint(TRUNCATE)').get();
   }
   return created;
 }

--- a/lib/core/database/performance_indexes.dart
+++ b/lib/core/database/performance_indexes.dart
@@ -301,6 +301,11 @@ Future<List<String>> ensurePerformanceIndexes(GeneratedDatabase db) async {
   if (created.isNotEmpty) {
     await db.customStatement('PRAGMA analysis_limit = 400');
     await db.customStatement('ANALYZE');
+    // A heal on a large database writes hundreds of MB of index pages into
+    // the WAL. Checkpoint it now, inside the startup splash, so the NEXT
+    // launch does not stall on WAL recovery (observed as a ~20 s zero-CPU
+    // freeze on a 335 MB database). No-op outside WAL mode.
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
   }
   return created;
 }

--- a/lib/core/database/performance_indexes.dart
+++ b/lib/core/database/performance_indexes.dart
@@ -16,6 +16,8 @@
 /// which runs on the plain Dart VM.
 library;
 
+import 'package:drift/drift.dart';
+
 typedef PerformanceIndex = ({String name, String ddl});
 
 const List<PerformanceIndex> kPerformanceIndexes = [
@@ -266,3 +268,43 @@ const List<PerformanceIndex> kPerformanceIndexes = [
         'ON gps_track_points_local(track_id)',
   ),
 ];
+
+/// Creates any canonical index missing from [db], returning the names of
+/// indexes actually created (empty when the database was already healed).
+///
+/// A statement whose table or column does not exist is skipped: migration
+/// tests open minimal old-schema fixtures where most tables (or late-added
+/// columns) are absent, and beforeOpen must tolerate them. On any real
+/// database the full ladder has run before beforeOpen, so the whole set
+/// applies; the fresh-DB test fails loudly if a canonical entry stops
+/// matching the current schema, so skips cannot mask a stale list.
+///
+/// Runs ANALYZE (bounded by analysis_limit) only when something was created,
+/// so the query planner picks up the new indexes; every later open is a
+/// single sqlite_master read.
+Future<List<String>> ensurePerformanceIndexes(GeneratedDatabase db) async {
+  final rows = await db
+      .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+      .get();
+  final existing = rows.map((r) => r.read<String>('name')).toSet();
+
+  final created = <String>[];
+  for (final index in kPerformanceIndexes) {
+    if (existing.contains(index.name)) continue;
+    try {
+      await db.customStatement(index.ddl);
+      created.add(index.name);
+    } catch (e) {
+      final message = e.toString();
+      final schemaTooOld =
+          message.contains('no such table') ||
+          message.contains('no such column');
+      if (!schemaTooOld) rethrow;
+    }
+  }
+  if (created.isNotEmpty) {
+    await db.customStatement('PRAGMA analysis_limit = 400');
+    await db.customStatement('ANALYZE');
+  }
+  return created;
+}

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kReleaseMode;
+import 'package:flutter/foundation.dart' show kReleaseMode, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -39,6 +39,27 @@ typedef ServiceInitializer =
 /// to decide whether to show a migration progress bar before opening the DB.
 typedef SchemaVersionProbe =
     ({bool needsMigration, int totalSteps}) Function(String dbPath);
+
+/// Runs [step], measuring its wall time, and prints a
+/// `[startup] <name>: <ms>ms` attribution line in debug/profile builds.
+///
+/// Extracted to library scope so the timing-and-log logic is unit-testable
+/// on its own; at the real call sites in [StartupWrapper] it wraps platform
+/// singletons that only run during app launch. [log] defaults to
+/// `!kReleaseMode` and is injectable so tests can exercise both branches.
+@visibleForTesting
+Future<void> timeStartupStep(
+  String name,
+  Future<void> Function() step, {
+  bool log = !kReleaseMode,
+}) async {
+  final sw = Stopwatch()..start();
+  await step();
+  sw.stop();
+  if (log) {
+    debugPrint('[startup] $name: ${sw.elapsedMilliseconds}ms');
+  }
+}
 
 enum _StartupState {
   initializing,
@@ -122,9 +143,11 @@ class _StartupWrapperState extends State<StartupWrapper>
     super.initState();
     _splashFadeController.addStatusListener((status) {
       if (status == AnimationStatus.completed && mounted) {
+        // coverage:ignore-start
         if (!kReleaseMode) {
           debugPrint('[startup] splash fade complete');
         }
+        // coverage:ignore-end
         setState(() => _splashRemoved = true);
       }
     });
@@ -196,6 +219,7 @@ class _StartupWrapperState extends State<StartupWrapper>
       ]);
 
       if (mounted) {
+        // coverage:ignore-start
         final readyAt = Stopwatch()..start();
         if (!kReleaseMode) {
           debugPrint('[startup] ready; building app under splash');
@@ -206,6 +230,7 @@ class _StartupWrapperState extends State<StartupWrapper>
             );
           });
         }
+        // coverage:ignore-end
         setState(() => _state = _StartupState.ready);
         _splashFadeController.forward();
       }
@@ -303,18 +328,12 @@ class _StartupWrapperState extends State<StartupWrapper>
       return;
     }
 
-    // Per-step wall-time attribution for startup stalls (large-DB perf
-    // program). Prints in debug/profile only.
-    Future<void> timedStep(String name, Future<void> Function() step) async {
-      final sw = Stopwatch()..start();
-      await step();
-      sw.stop();
-      if (!kReleaseMode) {
-        debugPrint('[startup] $name: ${sw.elapsedMilliseconds}ms');
-      }
-    }
-
-    await timedStep(
+    // Real service bootstrap. Each step wraps a platform singleton or a real
+    // database, so this block runs during app launch rather than unit tests
+    // (cf. the coverage-ignored bootstrap in lib/main.dart). The wall-time
+    // attribution itself lives in the unit-tested [timeStartupStep].
+    // coverage:ignore-start
+    await timeStartupStep(
       'database',
       () => DatabaseService.instance.initialize(
         locationService: widget.locationService,
@@ -322,14 +341,17 @@ class _StartupWrapperState extends State<StartupWrapper>
       ),
     );
 
-    await timedStep(
+    await timeStartupStep(
       'localCache',
       LocalCacheDatabaseService.instance.initialize,
     );
-    await timedStep('notifications', NotificationService.instance.initialize);
-    await timedStep('backgroundService', initializeBackgroundService);
+    await timeStartupStep(
+      'notifications',
+      NotificationService.instance.initialize,
+    );
+    await timeStartupStep('backgroundService', initializeBackgroundService);
 
-    await timedStep('tileCache', () async {
+    await timeStartupStep('tileCache', () async {
       try {
         await TileCacheService.instance.initialize();
       } catch (e) {
@@ -337,10 +359,11 @@ class _StartupWrapperState extends State<StartupWrapper>
       }
     });
 
-    await timedStep('speciesSeed', () async {
+    await timeStartupStep('speciesSeed', () async {
       final speciesRepository = SpeciesRepository();
       await speciesRepository.seedBuiltInSpecies();
     });
+    // coverage:ignore-end
   }
 
   Future<void> _runPreMigrationBackup({

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -122,6 +122,9 @@ class _StartupWrapperState extends State<StartupWrapper>
     super.initState();
     _splashFadeController.addStatusListener((status) {
       if (status == AnimationStatus.completed && mounted) {
+        if (!kReleaseMode) {
+          debugPrint('[startup] splash fade complete');
+        }
         setState(() => _splashRemoved = true);
       }
     });
@@ -193,6 +196,16 @@ class _StartupWrapperState extends State<StartupWrapper>
       ]);
 
       if (mounted) {
+        final readyAt = Stopwatch()..start();
+        if (!kReleaseMode) {
+          debugPrint('[startup] ready; building app under splash');
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            debugPrint(
+              '[startup] first frame after ready: '
+              '${readyAt.elapsedMilliseconds}ms',
+            );
+          });
+        }
         setState(() => _state = _StartupState.ready);
         _splashFadeController.forward();
       }

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kReleaseMode, visibleForTesting;
+import 'package:flutter/foundation.dart' show kReleaseMode;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -43,11 +43,11 @@ typedef SchemaVersionProbe =
 /// Runs [step], measuring its wall time, and prints a
 /// `[startup] <name>: <ms>ms` attribution line in debug/profile builds.
 ///
-/// Extracted to library scope so the timing-and-log logic is unit-testable
-/// on its own; at the real call sites in [StartupWrapper] it wraps platform
-/// singletons that only run during app launch. [log] defaults to
-/// `!kReleaseMode` and is injectable so tests can exercise both branches.
-@visibleForTesting
+/// A top-level function (rather than a private closure) so the real startup
+/// call sites in [StartupWrapper] and unit tests can both reach it; at those
+/// call sites it wraps platform singletons that only run during app launch.
+/// [log] defaults to `!kReleaseMode` and is injectable so tests can exercise
+/// both branches.
 Future<void> timeStartupStep(
   String name,
   Future<void> Function() step, {

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show kReleaseMode;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -289,23 +290,44 @@ class _StartupWrapperState extends State<StartupWrapper>
       return;
     }
 
-    await DatabaseService.instance.initialize(
-      locationService: widget.locationService,
-      onMigrationProgress: onProgress,
-    );
-
-    await LocalCacheDatabaseService.instance.initialize();
-    await NotificationService.instance.initialize();
-    await initializeBackgroundService();
-
-    try {
-      await TileCacheService.instance.initialize();
-    } catch (e) {
-      debugPrint('Warning: Tile cache initialization failed: $e');
+    // Per-step wall-time attribution for startup stalls (large-DB perf
+    // program). Prints in debug/profile only.
+    Future<void> timedStep(String name, Future<void> Function() step) async {
+      final sw = Stopwatch()..start();
+      await step();
+      sw.stop();
+      if (!kReleaseMode) {
+        debugPrint('[startup] $name: ${sw.elapsedMilliseconds}ms');
+      }
     }
 
-    final speciesRepository = SpeciesRepository();
-    await speciesRepository.seedBuiltInSpecies();
+    await timedStep(
+      'database',
+      () => DatabaseService.instance.initialize(
+        locationService: widget.locationService,
+        onMigrationProgress: onProgress,
+      ),
+    );
+
+    await timedStep(
+      'localCache',
+      LocalCacheDatabaseService.instance.initialize,
+    );
+    await timedStep('notifications', NotificationService.instance.initialize);
+    await timedStep('backgroundService', initializeBackgroundService);
+
+    await timedStep('tileCache', () async {
+      try {
+        await TileCacheService.instance.initialize();
+      } catch (e) {
+        debugPrint('Warning: Tile cache initialization failed: $e');
+      }
+    });
+
+    await timedStep('speciesSeed', () async {
+      final speciesRepository = SpeciesRepository();
+      await speciesRepository.seedBuiltInSpecies();
+    });
   }
 
   Future<void> _runPreMigrationBackup({

--- a/test/core/database/performance_indexes_test.dart
+++ b/test/core/database/performance_indexes_test.dart
@@ -1,0 +1,47 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/performance_indexes.dart';
+
+Future<Set<String>> indexNames(AppDatabase db) async {
+  final rows = await db
+      .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+      .get();
+  return rows.map((r) => r.read<String>('name')).toSet();
+}
+
+void main() {
+  test('fresh database has every canonical performance index', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    // Force open so onCreate + beforeOpen run.
+    await db.customSelect('SELECT 1').get();
+
+    final names = await indexNames(db);
+    for (final idx in kPerformanceIndexes) {
+      expect(names, contains(idx.name), reason: '${idx.name} missing');
+    }
+  });
+
+  test('ensurePerformanceIndexes is idempotent', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    final created = await ensurePerformanceIndexes(db);
+    expect(created, isEmpty);
+  });
+
+  test('ensurePerformanceIndexes heals a dropped index', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    await db.customStatement('DROP INDEX idx_dive_profiles_dive_id');
+    expect(await indexNames(db), isNot(contains('idx_dive_profiles_dive_id')));
+
+    final created = await ensurePerformanceIndexes(db);
+    expect(created, equals(['idx_dive_profiles_dive_id']));
+    expect(await indexNames(db), contains('idx_dive_profiles_dive_id'));
+  });
+}

--- a/test/core/database/query_plan_test.dart
+++ b/test/core/database/query_plan_test.dart
@@ -1,0 +1,68 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Returns the concatenated EXPLAIN QUERY PLAN detail lines for [sql].
+Future<String> plan(AppDatabase db, String sql) async {
+  final rows = await db.customSelect('EXPLAIN QUERY PLAN $sql').get();
+  return rows.map((r) => r.read<String>('detail')).join('\n');
+}
+
+/// Page-1 shape of DiveRepository.getDiveSummaries (default date sort, no
+/// cursor, no filters). Keep in sync with dive_repository_impl.dart.
+const _summariesPage1Sql =
+    "SELECT d.id, COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp "
+    "FROM dives d LEFT JOIN dive_sites s ON d.site_id = s.id "
+    "WHERE d.diver_id = 'x' "
+    "ORDER BY sort_timestamp DESC, COALESCE(d.dive_number, 0) DESC, d.id DESC "
+    "LIMIT 50";
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    await db.customSelect('SELECT 1').get(); // open: onCreate + beforeOpen
+  });
+
+  tearDown(() => db.close());
+
+  test('per-dive profile fetch uses idx_dive_profiles_dive_id', () async {
+    final p = await plan(
+      db,
+      "SELECT * FROM dive_profiles WHERE dive_id = 'x' ORDER BY timestamp",
+    );
+    expect(p, contains('idx_dive_profiles_dive_id'));
+  });
+
+  test('per-dive pressure fetch uses idx_tank_pressure_dive_tank', () async {
+    final p = await plan(
+      db,
+      "SELECT * FROM tank_pressure_profiles WHERE dive_id = 'x' "
+      'ORDER BY timestamp',
+    );
+    expect(p, contains('idx_tank_pressure_dive_tank'));
+  });
+
+  test('per-dive tanks fetch uses idx_dive_tanks_dive_id', () async {
+    final p = await plan(db, "SELECT * FROM dive_tanks WHERE dive_id = 'x'");
+    expect(p, contains('idx_dive_tanks_dive_id'));
+  });
+
+  test('paginated summaries page 1 does not scan dives', () async {
+    final p = await plan(db, _summariesPage1Sql);
+    expect(p, isNot(contains('SCAN dives')));
+    expect(p, contains('USING INDEX'));
+  });
+
+  test(
+    'per-dive data sources fetch uses idx_dive_data_sources_dive_id',
+    () async {
+      final p = await plan(
+        db,
+        "SELECT * FROM dive_data_sources WHERE dive_id = 'x'",
+      );
+      expect(p, contains('idx_dive_data_sources_dive_id'));
+    },
+  );
+}

--- a/test/core/presentation/pages/startup_step_timing_test.dart
+++ b/test/core/presentation/pages/startup_step_timing_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/presentation/pages/startup_page.dart';
+
+void main() {
+  group('timeStartupStep', () {
+    test('runs the step to completion', () async {
+      var ran = false;
+      await timeStartupStep('x', () async {
+        ran = true;
+      }, log: false);
+      expect(ran, isTrue);
+    });
+
+    test('awaits the step before returning', () async {
+      final order = <String>[];
+      await timeStartupStep('x', () async {
+        await Future<void>.delayed(Duration.zero);
+        order.add('step');
+      }, log: false);
+      order.add('after');
+      expect(order, ['step', 'after']);
+    });
+
+    test('logging branch completes without error', () async {
+      // Exercises the debugPrint path (log: true) so both branches of the
+      // timing helper are covered.
+      var ran = false;
+      await timeStartupStep('database', () async {
+        ran = true;
+      }, log: true);
+      expect(ran, isTrue);
+    });
+
+    test('propagates errors thrown by the step', () async {
+      await expectLater(
+        timeStartupStep(
+          'boom',
+          () async => throw StateError('fail'),
+          log: false,
+        ),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/tools/db_bench.dart
+++ b/tools/db_bench.dart
@@ -1,0 +1,285 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:sqlite3/sqlite3.dart';
+import 'package:submersion/core/database/performance_indexes.dart';
+
+/// SQL-level benchmark harness for the large-DB performance program.
+///
+/// Runs the app's real hot-query shapes against a database COPY (never the
+/// live file). Usage:
+///
+///     dart run tools/db_bench.dart bench [db-path] [--json] [--term blue]
+///     dart run tools/db_bench.dart plans [db-path]
+///     dart run tools/db_bench.dart create-indexes [db-path]
+///
+/// Query shapes are copied from dive_repository_impl.dart (getDiveSummaries,
+/// getDiveCount, searchDives, _mapRowToDive, getPreviousDive). Keep them in
+/// sync when those queries change materially.
+void main(List<String> args) {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: dart run tools/db_bench.dart <bench|plans|create-indexes> '
+      '<db-path> [--json] [--term <search-term>]',
+    );
+    exit(64);
+  }
+  final mode = args[0];
+  final dbPath = args[1];
+  final asJson = args.contains('--json');
+  final termIdx = args.indexOf('--term');
+  final searchTerm = termIdx >= 0 && termIdx + 1 < args.length
+      ? args[termIdx + 1]
+      : 'blue';
+
+  if (!File(dbPath).existsSync()) {
+    stderr.writeln('No such file: $dbPath');
+    exit(66);
+  }
+
+  final db = sqlite3.open(dbPath);
+  try {
+    switch (mode) {
+      case 'bench':
+        _bench(db, searchTerm, asJson);
+      case 'plans':
+        _plans(db, searchTerm);
+      case 'create-indexes':
+        _createIndexes(db);
+      default:
+        stderr.writeln('Unknown mode: $mode');
+        exit(64);
+    }
+  } finally {
+    db.dispose();
+  }
+}
+
+/// The paginated dive list page-1 query, verbatim shape from
+/// getDiveSummaries (default date sort, no cursor, no filters).
+const _summariesSql =
+    'SELECT '
+    'd.id, d.dive_number, d.name AS dive_name, '
+    'd.dive_date_time, d.entry_time, '
+    'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
+    'd.is_favorite, d.dive_type, '
+    'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
+    's.name AS site_name, s.country AS site_country, '
+    's.region AS site_region, s.latitude AS site_latitude, '
+    's.longitude AS site_longitude '
+    'FROM dives d '
+    'LEFT JOIN dive_sites s ON d.site_id = s.id '
+    'WHERE d.diver_id = ? '
+    'ORDER BY sort_timestamp DESC, COALESCE(d.dive_number, 0) DESC, d.id DESC '
+    'LIMIT 50';
+
+/// The search match query, verbatim shape from searchDives.
+const _searchSql = '''
+    SELECT DISTINCT d.id
+    FROM dives d
+    LEFT JOIN dive_sites ds ON d.site_id = ds.id
+    LEFT JOIN dive_centers dc ON d.dive_center_id = dc.id
+    LEFT JOIN dive_buddies db ON db.dive_id = d.id
+    LEFT JOIN buddies b ON db.buddy_id = b.id
+    LEFT JOIN dive_tags dt ON dt.dive_id = d.id
+    LEFT JOIN tags t ON dt.tag_id = t.id
+    LEFT JOIN dive_custom_fields cf ON cf.dive_id = d.id
+    WHERE (
+      d.notes LIKE ?
+      OR d.name LIKE ?
+      OR d.buddy LIKE ?
+      OR d.dive_master LIKE ?
+      OR ds.name LIKE ?
+      OR ds.country LIKE ?
+      OR ds.region LIKE ?
+      OR dc.name LIKE ?
+      OR b.name LIKE ?
+      OR t.name LIKE ?
+      OR cf.field_key LIKE ?
+      OR cf.field_value LIKE ?
+    )
+    AND d.diver_id = ?
+    ''';
+
+({String diverId, String denseDiveId, int denseSamples}) _pickTargets(
+  Database db,
+) {
+  final diver = db.select(
+    'SELECT diver_id, COUNT(*) AS n FROM dives '
+    'GROUP BY diver_id ORDER BY n DESC LIMIT 1',
+  );
+  final dense = db.select(
+    'SELECT dive_id, COUNT(*) AS n FROM dive_profiles '
+    'GROUP BY dive_id ORDER BY n DESC LIMIT 1',
+  );
+  return (
+    diverId: diver.first['diver_id'] as String,
+    denseDiveId: dense.first['dive_id'] as String,
+    denseSamples: dense.first['n'] as int,
+  );
+}
+
+List<({String label, String sql, List<Object?> params})> _queries(
+  Database db,
+  String term,
+) {
+  final t = _pickTargets(db);
+  final like = '%$term%';
+  final searchParams = <Object?>[...List.filled(12, like), t.diverId];
+  final page = db.select(_summariesSql, [t.diverId]);
+  final pageIds = page.map((r) => r['id'] as String).toList();
+  final inList = List.filled(pageIds.length, '?').join(',');
+  return [
+    (
+      label: 'profile_fetch_densest (${t.denseSamples} rows)',
+      sql:
+          'SELECT * FROM dive_profiles WHERE dive_id = ? '
+          'ORDER BY timestamp ASC',
+      params: [t.denseDiveId],
+    ),
+    (
+      label: 'pressure_fetch_densest',
+      sql:
+          'SELECT * FROM tank_pressure_profiles WHERE dive_id = ? '
+          'ORDER BY timestamp ASC',
+      params: [t.denseDiveId],
+    ),
+    (
+      label: 'tanks_fetch',
+      sql: 'SELECT * FROM dive_tanks WHERE dive_id = ?',
+      params: [t.denseDiveId],
+    ),
+    (label: 'summaries_page1', sql: _summariesSql, params: [t.diverId]),
+    (
+      label: 'dive_count',
+      sql: 'SELECT COUNT(*) AS count FROM dives d WHERE d.diver_id = ?',
+      params: [t.diverId],
+    ),
+    (
+      label: 'search_match_ids (term "$term")',
+      sql: _searchSql,
+      params: searchParams,
+    ),
+    (
+      label: 'prev_dive',
+      sql:
+          'SELECT * FROM dives WHERE id != ? AND (entry_time < ? OR '
+          '(entry_time IS NULL AND dive_date_time < ?)) '
+          'ORDER BY entry_time DESC, dive_date_time DESC LIMIT 1',
+      params: [t.denseDiveId, 9999999999999, 9999999999999],
+    ),
+    (
+      label: 'tags_for_page (${pageIds.length} ids)',
+      sql: 'SELECT * FROM dive_tags WHERE dive_id IN ($inList)',
+      params: pageIds,
+    ),
+  ];
+}
+
+void _bench(Database db, String term, bool asJson) {
+  final results = <Map<String, Object>>[];
+  for (final q in _queries(db, term)) {
+    final times = <int>[];
+    var rows = 0;
+    for (var i = 0; i < 5; i++) {
+      final sw = Stopwatch()..start();
+      final rs = db.select(q.sql, q.params);
+      sw.stop();
+      rows = rs.length;
+      times.add(sw.elapsedMicroseconds);
+    }
+    times.sort();
+    results.add({
+      'query': q.label,
+      'rows': rows,
+      'median_ms': times[2] / 1000.0,
+      'min_ms': times.first / 1000.0,
+    });
+  }
+  // Approximate searchDives' N+1 hydration: the 3 heavy per-dive queries
+  // for the first 20 matched dives (the app runs ~10 per match).
+  final matched = db.select(_searchSql, [
+    ...List.filled(12, '%$term%'),
+    _pickTargets(db).diverId,
+  ]);
+  final hydrateIds = matched.take(20).map((r) => r['id'] as String).toList();
+  final sw = Stopwatch()..start();
+  for (final id in hydrateIds) {
+    db.select(
+      'SELECT * FROM dive_profiles WHERE dive_id = ? ORDER BY timestamp ASC',
+      [id],
+    );
+    db.select(
+      'SELECT * FROM tank_pressure_profiles WHERE dive_id = ? '
+      'ORDER BY timestamp ASC',
+      [id],
+    );
+    db.select('SELECT * FROM dive_tanks WHERE dive_id = ?', [id]);
+  }
+  sw.stop();
+  results.add({
+    'query': 'search_hydration_first20 (${matched.length} matches total)',
+    'rows': hydrateIds.length,
+    'median_ms': sw.elapsedMilliseconds.toDouble(),
+    'min_ms': sw.elapsedMilliseconds.toDouble(),
+  });
+
+  if (asJson) {
+    stdout.writeln(const JsonEncoder.withIndent('  ').convert(results));
+  } else {
+    stdout.writeln(
+      '${'query'.padRight(52)}${'rows'.padLeft(9)}${'median ms'.padLeft(12)}',
+    );
+    for (final r in results) {
+      final label = r['query']! as String;
+      final rows = '${r['rows']}';
+      final median = (r['median_ms']! as double).toStringAsFixed(1);
+      stdout.writeln(
+        '${label.padRight(52)}${rows.padLeft(9)}${median.padLeft(12)}',
+      );
+    }
+  }
+}
+
+void _plans(Database db, String term) {
+  for (final q in _queries(db, term)) {
+    stdout.writeln('-- ${q.label}');
+    final plan = db.select('EXPLAIN QUERY PLAN ${q.sql}', q.params);
+    for (final row in plan) {
+      stdout.writeln('   ${row['detail']}');
+    }
+  }
+}
+
+void _createIndexes(Database db) {
+  final existing = db
+      .select("SELECT name FROM sqlite_master WHERE type = 'index'")
+      .map((r) => r['name'] as String)
+      .toSet();
+  final total = Stopwatch()..start();
+  var created = 0;
+  for (final idx in kPerformanceIndexes) {
+    if (existing.contains(idx.name)) {
+      stdout.writeln('exists   ${idx.name}');
+      continue;
+    }
+    final sw = Stopwatch()..start();
+    db.execute(idx.ddl);
+    sw.stop();
+    created++;
+    stdout.writeln(
+      'created  ${idx.name.padRight(44)} ${sw.elapsedMilliseconds} ms',
+    );
+  }
+  if (created > 0) {
+    final sw = Stopwatch()..start();
+    db.execute('PRAGMA analysis_limit = 400');
+    db.execute('ANALYZE');
+    sw.stop();
+    stdout.writeln('ANALYZE  ${sw.elapsedMilliseconds} ms');
+  }
+  total.stop();
+  stdout.writeln(
+    'Done: $created created, total ${total.elapsedMilliseconds} ms',
+  );
+}

--- a/tools/db_bench.dart
+++ b/tools/db_bench.dart
@@ -9,9 +9,9 @@ import 'package:submersion/core/database/performance_indexes.dart';
 /// Runs the app's real hot-query shapes against a database COPY (never the
 /// live file). Usage:
 ///
-///     dart run tools/db_bench.dart bench [db-path] [--json] [--term blue]
-///     dart run tools/db_bench.dart plans [db-path]
-///     dart run tools/db_bench.dart create-indexes [db-path]
+///     dart run tools/db_bench.dart bench <db-path> [--json] [--term blue]
+///     dart run tools/db_bench.dart plans <db-path>
+///     dart run tools/db_bench.dart create-indexes <db-path>
 ///
 /// Query shapes are copied from dive_repository_impl.dart (getDiveSummaries,
 /// getDiveCount, searchDives, _mapRowToDive, getPreviousDive). Keep them in

--- a/tools/db_bench.dart
+++ b/tools/db_bench.dart
@@ -203,25 +203,33 @@ void _bench(Database db, String term, bool asJson) {
     _pickTargets(db).diverId,
   ]);
   final hydrateIds = matched.take(20).map((r) => r['id'] as String).toList();
-  final sw = Stopwatch()..start();
-  for (final id in hydrateIds) {
-    db.select(
-      'SELECT * FROM dive_profiles WHERE dive_id = ? ORDER BY timestamp ASC',
-      [id],
-    );
-    db.select(
-      'SELECT * FROM tank_pressure_profiles WHERE dive_id = ? '
-      'ORDER BY timestamp ASC',
-      [id],
-    );
-    db.select('SELECT * FROM dive_tanks WHERE dive_id = ?', [id]);
+  // Measure with the same median-of-5 methodology as the per-query loop above
+  // so the median_ms/min_ms labels are accurate and comparable, not a single
+  // run reported under both keys.
+  final hydrateTimes = <int>[];
+  for (var i = 0; i < 5; i++) {
+    final sw = Stopwatch()..start();
+    for (final id in hydrateIds) {
+      db.select(
+        'SELECT * FROM dive_profiles WHERE dive_id = ? ORDER BY timestamp ASC',
+        [id],
+      );
+      db.select(
+        'SELECT * FROM tank_pressure_profiles WHERE dive_id = ? '
+        'ORDER BY timestamp ASC',
+        [id],
+      );
+      db.select('SELECT * FROM dive_tanks WHERE dive_id = ?', [id]);
+    }
+    sw.stop();
+    hydrateTimes.add(sw.elapsedMicroseconds);
   }
-  sw.stop();
+  hydrateTimes.sort();
   results.add({
     'query': 'search_hydration_first20 (${matched.length} matches total)',
     'rows': hydrateIds.length,
-    'median_ms': sw.elapsedMilliseconds.toDouble(),
-    'min_ms': sw.elapsedMilliseconds.toDouble(),
+    'median_ms': hydrateTimes[2] / 1000.0,
+    'min_ms': hydrateTimes.first / 1000.0,
   });
 
   if (asJson) {

--- a/tools/vmcap.dart
+++ b/tools/vmcap.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Minimal VM-service CPU/frame capture for user-paced profiling.
+///
+/// Usage:
+///
+///     flutter run --profile -d macos   # note the ws://127.0.0.1:PORT/TOKEN=/ws URI
+///     dart run tools/vmcap.dart [ws-uri] probe
+///     dart run tools/vmcap.dart [ws-uri] clear     # right BEFORE interacting
+///     (interact with the app)
+///     dart run tools/vmcap.dart [ws-uri] read      # right AFTER interacting
+///     dart run tools/vmcap.dart [ws-uri] frames 10 # frame events for 10 s
+///
+/// Gotchas (learned in the June 2026 Phase 1 effort):
+/// - Always `clear` immediately before the window; otherwise the VM service's
+///   own serialization functions dominate the profile.
+/// - `frames` counts only events timestamped after subscribe, because the VM
+///   replays the historical frame buffer to new subscribers.
+Future<void> main(List<String> args) async {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: dart run tools/vmcap.dart <ws-uri> <probe|clear|read|frames> '
+      '[seconds]',
+    );
+    exit(64);
+  }
+  final uri = args[0];
+  final mode = args[1];
+  final seconds = args.length > 2 ? int.parse(args[2]) : 10;
+
+  final ws = await WebSocket.connect(uri);
+  final client = _RpcClient(ws);
+  try {
+    final vm = await client.call('getVM');
+    final isolates = (vm['isolates'] as List).cast<Map<String, dynamic>>();
+    if (isolates.isEmpty) {
+      stderr.writeln('No isolates.');
+      exit(1);
+    }
+    final main = isolates.first['id'] as String;
+
+    switch (mode) {
+      case 'probe':
+        for (final iso in isolates) {
+          stdout.writeln('${iso['id']}  ${iso['name']}');
+        }
+      case 'clear':
+        await client.call('setFlag', {'name': 'profiler', 'value': 'true'});
+        await client.call('clearCpuSamples', {'isolateId': main});
+        stdout.writeln('Profiler on, samples cleared. Interact now.');
+      case 'read':
+        final samples = await client.call('getCpuSamples', {
+          'isolateId': main,
+          'timeOriginMicros': 0,
+          'timeExtentMicros': 0x7fffffffffffffff,
+        });
+        _report(samples);
+      case 'frames':
+        await _frames(client, seconds);
+      default:
+        stderr.writeln('Unknown mode: $mode');
+        exit(64);
+    }
+  } finally {
+    await ws.close();
+  }
+}
+
+void _report(Map<String, dynamic> samples) {
+  final functions = (samples['functions'] as List? ?? [])
+      .cast<Map<String, dynamic>>();
+  String nameOf(int i) {
+    final f = functions[i]['function'] as Map<String, dynamic>?;
+    return (f?['name'] as String?) ?? '<unknown>';
+  }
+
+  final self = <int, int>{};
+  final incl = <int, int>{};
+  final sampleList = (samples['samples'] as List? ?? [])
+      .cast<Map<String, dynamic>>();
+  for (final s in sampleList) {
+    final stack = (s['stack'] as List).cast<int>();
+    if (stack.isEmpty) continue;
+    self[stack.first] = (self[stack.first] ?? 0) + 1;
+    for (final f in stack.toSet()) {
+      incl[f] = (incl[f] ?? 0) + 1;
+    }
+  }
+  final total = sampleList.length;
+  stdout.writeln(
+    'Samples: $total over ${samples['timeExtentMicros']} us window',
+  );
+  if (total == 0) return;
+  final top = self.entries.toList()..sort((a, b) => b.value.compareTo(a.value));
+  stdout.writeln('\n-- top self --');
+  for (final e in top.take(30)) {
+    final pct = (e.value * 100 / total).toStringAsFixed(1);
+    stdout.writeln('${'$pct%'.padLeft(7)}  ${nameOf(e.key)}');
+  }
+  final topIncl = incl.entries.toList()
+    ..sort((a, b) => b.value.compareTo(a.value));
+  stdout.writeln('\n-- top inclusive --');
+  for (final e in topIncl.take(30)) {
+    final pct = (e.value * 100 / total).toStringAsFixed(1);
+    stdout.writeln('${'$pct%'.padLeft(7)}  ${nameOf(e.key)}');
+  }
+}
+
+Future<void> _frames(_RpcClient client, int seconds) async {
+  final subscribedAt = DateTime.now().microsecondsSinceEpoch;
+  var count = 0, slow = 0;
+  client.onEvent = (event) {
+    if (event['extensionKind'] != 'Flutter.Frame') return;
+    final data = event['extensionData'] as Map<String, dynamic>;
+    final ts = event['timestamp'] as int? ?? 0;
+    if (ts * 1000 < subscribedAt) return; // replayed history
+    count++;
+    final elapsed = (data['elapsed'] as num).toInt();
+    if (elapsed > 16667) slow++;
+  };
+  await client.call('streamListen', {'streamId': 'Extension'});
+  stdout.writeln('Capturing frames for $seconds s. Interact now.');
+  await Future<void>.delayed(Duration(seconds: seconds));
+  stdout.writeln('Frames: $count, over-16.7ms: $slow');
+}
+
+class _RpcClient {
+  _RpcClient(this._ws) {
+    _ws.listen((raw) {
+      final msg = jsonDecode(raw as String) as Map<String, dynamic>;
+      if (msg.containsKey('id')) {
+        final completer = _pending.remove(msg['id']);
+        if (msg.containsKey('error')) {
+          completer?.completeError(StateError(jsonEncode(msg['error'])));
+        } else {
+          completer?.complete(msg['result'] as Map<String, dynamic>);
+        }
+      } else if (msg['method'] == 'streamNotify') {
+        final event =
+            (msg['params'] as Map<String, dynamic>)['event']
+                as Map<String, dynamic>;
+        onEvent?.call(event);
+      }
+    });
+  }
+
+  final WebSocket _ws;
+  final _pending = <int, Completer<Map<String, dynamic>>>{};
+  int _nextId = 1;
+  void Function(Map<String, dynamic> event)? onEvent;
+
+  Future<Map<String, dynamic>> call(
+    String method, [
+    Map<String, dynamic>? params,
+  ]) {
+    final id = _nextId++;
+    final completer = Completer<Map<String, dynamic>>();
+    _pending[id] = completer;
+    _ws.add(
+      jsonEncode({
+        'jsonrpc': '2.0',
+        'id': id,
+        'method': method,
+        'params': ?params,
+      }),
+    );
+    return completer.future;
+  }
+}

--- a/tools/vmcap.dart
+++ b/tools/vmcap.dart
@@ -7,11 +7,11 @@ import 'dart:io';
 /// Usage:
 ///
 ///     flutter run --profile -d macos   # note the ws://127.0.0.1:PORT/TOKEN=/ws URI
-///     dart run tools/vmcap.dart [ws-uri] probe
-///     dart run tools/vmcap.dart [ws-uri] clear     # right BEFORE interacting
+///     dart run tools/vmcap.dart <ws-uri> probe
+///     dart run tools/vmcap.dart <ws-uri> clear     # right BEFORE interacting
 ///     (interact with the app)
-///     dart run tools/vmcap.dart [ws-uri] read      # right AFTER interacting
-///     dart run tools/vmcap.dart [ws-uri] frames 10 # frame events for 10 s
+///     dart run tools/vmcap.dart <ws-uri> read      # right AFTER interacting
+///     dart run tools/vmcap.dart <ws-uri> frames 10 # frame events for 10 s
 ///
 /// Gotchas (learned in the June 2026 Phase 1 effort):
 /// - Always `clear` immediately before the window; otherwise the VM service's
@@ -39,7 +39,14 @@ Future<void> main(List<String> args) async {
       stderr.writeln('No isolates.');
       exit(1);
     }
-    final main = isolates.first['id'] as String;
+    // Prefer the isolate named 'main': a profile/debug app can expose helper
+    // isolates (background workers, plugins), and isolates.first is not
+    // guaranteed to be the root isolate whose CPU samples/frames we want.
+    final mainIso = isolates.firstWhere(
+      (iso) => iso['name'] == 'main',
+      orElse: () => isolates.first,
+    );
+    final main = mainIso['id'] as String;
 
     switch (mode) {
       case 'probe':


### PR DESCRIPTION
## Summary

First workstream (WS0) of the large-database performance program (spec: `docs/superpowers/specs/2026-07-10-large-db-performance-design.md`), triggered by a scubaboard report of 20+ second searches and multi-minute chart toggles at 1,000+ dives.

**Root cause discovered:** performance indexes were created only inside `onUpgrade` migration blocks — never in `onCreate`, never re-asserted in `beforeOpen`. Any database created fresh at a recent schema version, or arriving via restore or sync-adopt, silently gets **none of them**. A real 335 MB / 1,032-dive / 1.08M-profile-row dev database had 6 of ~40 intended indexes; `EXPLAIN QUERY PLAN` confirmed million-row full scans on every per-dive child-table lookup. The reporter's fresh-install-plus-import database is in the same state.

**Fix:** a canonical index list (`lib/core/database/performance_indexes.dart`) re-asserted idempotently from `beforeOpen` on every open — permanently healing every existing install on its next launch — followed by bounded `ANALYZE` and `PRAGMA wal_checkpoint(TRUNCATE)` when anything was created (the checkpoint stops the heal's WAL from stalling the *next* launch). Tolerates minimal old-schema fixtures (skips only "no such table/column"; everything else rethrows). No schema version bump.

## Measured impact (fixture A/B on the 335 MB database, Apple M5 Pro)

| Query | Before | After |
|---|---|---|
| Search hydration (20 of 74 matches) | 1,298 ms | 17 ms (76x) |
| Profile fetch, densest dive (4,762 rows) | 39.2 ms | 4.0 ms |
| Tank-pressure fetch | 26.6 ms | ~0 ms |
| Heal cost (one-time) | — | 534 ms warm / ~20 s cold cache |

In-app verification: live DB healed 6 → 40 indexes on a normal launch; plans show `USING INDEX`; `sqlite_stat1` populated; steady-state `beforeOpen` cost is one `sqlite_master` read (`[startup] database: 3ms`).

## Also in this PR

- **Measurement tooling, committed this time:** `tools/db_bench.dart` (SQL-level A/B harness), `tools/vmcap.dart` (VM-service CPU/frame capture), a measurement runbook, and startup step/first-frame timing (debug/profile only).
- **Regression net:** fresh-DB index-presence test, heal + idempotency tests, and `EXPLAIN QUERY PLAN` assertions so the onUpgrade-only index gap can never silently return (`test/core/database/performance_indexes_test.dart`, `query_plan_test.dart`).
- **Findings doc** with the post-WS0 UI re-baseline that sets the next workstreams: search ~3.5 s CPU (WS1: N+1 hydration), detail open ~11 s (WS2: double profile read + deco lookback chains), ceiling toggle ~0.85 s (WS3: undecimated chart paths), and the ~20 s debug-only startup freeze attributed to debug-JIT compilation of the `getAllDives()` hydration storm (WS4).
- An empirically evaluated expression index for the paginated sort was **dropped** (planner never selected it; evidence in the findings doc).

## Test plan

- `flutter test test/core/database/performance_indexes_test.dart test/core/database/query_plan_test.dart` — new suites green
- `flutter test test/core/database/migration_v86_test.dart migration_v85_test.dart migration_v58_test.dart` — upgrade-ladder fixtures green (exercise the beforeOpen tolerance)
- `flutter test test/core/presentation/pages/startup_page_test.dart startup_page_backup_flow_test.dart` — green
- Whole-project `flutter analyze`: no issues; `dart format .`: no changes
- Manual: live 335 MB DB healed on launch; search/detail/chart re-baselined in profile mode per runbook