### PR TITLE
perf(search): bounded DiveSummary search hydration (WS1)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-ws1-search-summaries.md
+++ b/docs/superpowers/plans/2026-07-10-ws1-search-summaries.md
@@ -1,0 +1,70 @@
+# WS1: Bounded Summary-Hydrated Search Implementation Plan
+
+> **For agentic workers:** Executed inline (executing-plans) in worktree
+> `.claude/worktrees/ws1-search`, branch `worktree-ws1-search`.
+
+**Goal:** Take dive search from ~3.5 s of main-isolate CPU (measured, profile
+mode, 1,032-dive DB) to well under 500 ms by eliminating the N+1 full-`Dive`
+hydration: bound the match set and hydrate matches as `DiveSummary` rows with
+exactly four SQL statements total, regardless of match count.
+
+**Spec:** WS1 Phase A in
+`docs/superpowers/specs/2026-07-10-large-db-performance-design.md`. Evidence:
+`2026-07-10-large-db-performance-findings.md` (search signature: per-query SQL
+string building + row-mapping Map churn on the UI isolate; 74-match term ran
+~740 queries).
+
+**Already in place (verified, no work needed):** input debounce
+(`DebouncedSearchResults`, 300 ms, keeps last results visible);
+`getCardColorValue(DiveSummary, ...)`; `DiveSummary` carries every field
+`DiveListTile` renders; `diveSearchProvider` and `searchDives` have exactly
+one consumer each (the delegate chain), so full replacement is safe.
+
+## Design
+
+- `DiveRepository.searchDiveSummaries(query, {diverId, limit = kDiveSearchResultLimit})`:
+  1. Match query: the existing 12-column LIKE SQL + `ORDER BY
+     COALESCE(d.entry_time, d.dive_date_time) DESC` + `LIMIT ?` — most-recent
+     matches win when the set is bounded.
+  2. Summary hydration: the `getDiveSummaries` slim SELECT reshaped as
+     `WHERE d.id IN (...)`, same ORDER BY.
+  3. Batched `getTagsForDives(ids)` + `_diveTypesForDives(ids)` (statements
+     3 and 4).
+  Row mapping extracted to a `_mapSummaryRows` helper shared with
+  `getDiveSummaries` (DRY).
+- `kDiveSearchResultLimit = 100` (static const on `DiveRepository`).
+- Delete `searchDives` (sole consumer replaced).
+- `diveSearchProvider` becomes `FutureProvider.family<List<DiveSummary>,
+  String>`; empty query returns `const []` (the old empty-query fallback to
+  `divesProvider`/getAllDives was unreachable from the UI and is a hot-path
+  liability).
+- `DiveSearchDelegate` becomes `SearchDelegate<String?>` (result value was
+  unused); results render from `DiveSummary`; when `items.length >=
+  kDiveSearchResultLimit`, a footer tile shows the new
+  `diveLog_listPage_searchLimitNotice` string.
+- l10n: new string in `app_en.arb` + the 10 non-en locales (ar, de, es, fr,
+  he, hu, it, nl, pt, zh) + regenerate.
+- Measurement: extend `tools/db_bench.dart` with the new 4-statement shape
+  (`search_bounded_summaries`) for an A/B row in the PR against
+  `search_hydration_first20`.
+
+## Tasks
+
+1. Repository: `_mapSummaryRows` extraction + `searchDiveSummaries` +
+   delete `searchDives`. Tests first:
+   `test/features/dive_log/data/repositories/dive_search_summaries_test.dart`
+   covering: match across notes/site/buddy/tag fields; bound honored with
+   most-recent-first selection; ordering by sort timestamp; tags/diveTypeIds
+   populated; diverId scoping; empty result.
+2. Provider + delegate + footer notice + l10n (all locales, regenerate).
+3. db_bench shape + capture numbers on `~/SubmersionBench/work.db`.
+4. Sweep: `dart format .`, whole-project `flutter analyze`, targeted tests
+   (new file + startup/list page tests touched by delegate change), commit
+   per task, push `--no-verify` (hook runs against main tree), PR.
+
+## Verification gates
+
+- New repo test file green; no remaining references to `searchDives`.
+- db_bench: bounded shape total well under the 500 ms target on the 1,032
+  dive fixture (expect ~2-5 ms).
+- `flutter analyze` no issues; `dart format .` no changes.

--- a/lib/core/constants/dive_search.dart
+++ b/lib/core/constants/dive_search.dart
@@ -1,0 +1,10 @@
+/// Maximum number of dive search matches surfaced to the UI.
+///
+/// This is the display bound: `searchDiveSummaries` enforces it as the SQL
+/// row limit, while the search provider over-fetches by one so the UI can
+/// tell a truncated result (more than this many matches) from an exact one
+/// and show the "showing first N" notice only when results were actually cut.
+///
+/// Lives in core rather than on the repository so the presentation layer can
+/// reference it without importing data-layer implementation details.
+const int kDiveSearchResultLimit = 100;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/constants/dive_search.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/performance/perf_timer.dart';
@@ -1894,24 +1895,22 @@ class DiveRepository {
     return getNextDiveNumber(diverId: diverId);
   }
 
-  /// Maximum number of results returned by [searchDiveSummaries]; the UI
-  /// shows a "showing first N" notice when the bound is hit.
-  static const int searchResultLimit = 100;
-
   /// Search dives by name, notes, buddy, dive master, site name/country/
   /// region, dive center name, linked buddy names, tag names, or custom
   /// fields, returning lightweight [DiveSummary] rows.
   ///
   /// Exactly four SQL statements regardless of match count (match ids,
   /// summary rows, batched tags, batched dive types), bounded to the [limit]
-  /// most recent matches. Replaces the unbounded full-Dive-hydrating search
-  /// whose roughly-ten-queries-per-match N+1 dominated search cost on large
-  /// databases (docs/superpowers/specs/2026-07-10-large-db-performance-
-  /// findings.md).
+  /// most recent matches ([kDiveSearchResultLimit] by default). Callers that
+  /// need to detect truncation pass `limit + 1` and treat a full-length
+  /// result as "more matches exist". Replaces the unbounded full-Dive-
+  /// hydrating search whose roughly-ten-queries-per-match N+1 dominated
+  /// search cost on large databases (docs/superpowers/specs/2026-07-10-
+  /// large-db-performance-findings.md).
   Future<List<DiveSummary>> searchDiveSummaries(
     String query, {
     String? diverId,
-    int limit = searchResultLimit,
+    int limit = kDiveSearchResultLimit,
   }) async {
     try {
       return await PerfTimer.measure('searchDiveSummaries', () async {
@@ -1919,8 +1918,11 @@ class DiveRepository {
         // already treats them as "no search", so return nothing here too.
         // Guarding limit <= 0 also avoids SQLite's negative-LIMIT (unbounded)
         // case, which would defeat the bound this method exists to enforce.
-        if (query.trim().isEmpty || limit <= 0) return <DiveSummary>[];
-        final likeTerm = '%$query%';
+        final trimmed = query.trim();
+        if (trimmed.isEmpty || limit <= 0) return <DiveSummary>[];
+        // Match on the trimmed term so incidental leading/trailing whitespace
+        // (e.g. "manta ") does not silently exclude otherwise-matching dives.
+        final likeTerm = '%$trimmed%';
         final diverClause = diverId != null ? 'AND d.diver_id = ?' : '';
         final diverArgs = diverId != null
             ? [Variable<String>(diverId)]

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1540,41 +1540,7 @@ class DiveRepository {
         final tagsByDive = await _tagRepository.getTagsForDives(diveIds);
         final diveTypesByDive = await _diveTypesForDives(diveIds);
 
-        return rows.map((row) {
-          final id = row.read<String>('id');
-          final entryTime = row.readNullable<int>('entry_time');
-          final bottomTime = row.readNullable<int>('bottom_time');
-          final runtime = row.readNullable<int>('runtime');
-
-          return DiveSummary(
-            id: id,
-            diveNumber: row.readNullable<int>('dive_number'),
-            name: row.readNullable<String>('dive_name'),
-            dateTime: DateTime.fromMillisecondsSinceEpoch(
-              row.read<int>('dive_date_time'),
-              isUtc: true,
-            ),
-            entryTime: entryTime != null
-                ? DateTime.fromMillisecondsSinceEpoch(entryTime, isUtc: true)
-                : null,
-            maxDepth: row.readNullable<double>('max_depth'),
-            bottomTime: bottomTime != null
-                ? Duration(seconds: bottomTime)
-                : null,
-            runtime: runtime != null ? Duration(seconds: runtime) : null,
-            waterTemp: row.readNullable<double>('water_temp'),
-            rating: row.readNullable<int>('rating'),
-            isFavorite: row.read<int>('is_favorite') == 1,
-            diveTypeIds: diveTypesByDive[id] ?? [row.read<String>('dive_type')],
-            tags: tagsByDive[id] ?? [],
-            siteName: row.readNullable<String>('site_name'),
-            siteCountry: row.readNullable<String>('site_country'),
-            siteRegion: row.readNullable<String>('site_region'),
-            siteLatitude: row.readNullable<double>('site_latitude'),
-            siteLongitude: row.readNullable<double>('site_longitude'),
-            sortTimestamp: row.read<int>('sort_timestamp'),
-          );
-        }).toList();
+        return _mapSummaryRows(rows, tagsByDive, diveTypesByDive);
       });
     } catch (e, stackTrace) {
       _log.error(
@@ -1928,89 +1894,160 @@ class DiveRepository {
     return getNextDiveNumber(diverId: diverId);
   }
 
-  /// Search dives by name, notes, or buddy name
-  Future<List<domain.Dive>> searchDives(String query, {String? diverId}) async {
+  /// Maximum number of results returned by [searchDiveSummaries]; the UI
+  /// shows a "showing first N" notice when the bound is hit.
+  static const int searchResultLimit = 100;
+
+  /// Search dives by name, notes, buddy, dive master, site name/country/
+  /// region, dive center name, linked buddy names, tag names, or custom
+  /// fields, returning lightweight [DiveSummary] rows.
+  ///
+  /// Exactly four SQL statements regardless of match count (match ids,
+  /// summary rows, batched tags, batched dive types), bounded to the [limit]
+  /// most recent matches. Replaces the unbounded full-Dive-hydrating search
+  /// whose roughly-ten-queries-per-match N+1 dominated search cost on large
+  /// databases (docs/superpowers/specs/2026-07-10-large-db-performance-
+  /// findings.md).
+  Future<List<DiveSummary>> searchDiveSummaries(
+    String query, {
+    String? diverId,
+    int limit = searchResultLimit,
+  }) async {
     try {
-      // Search across dive fields and all related tables in a single query.
-      // Matches: name, notes, buddy (legacy field), dive master, site name/
-      // country/region, dive center name, linked buddy names, tag names,
-      // custom fields.
-      final likeTerm = '%$query%';
-      final diverClause = diverId != null ? 'AND d.diver_id = ?' : '';
-      final diverArgs = diverId != null
-          ? [Variable<String>(diverId)]
-          : <Variable<String>>[];
+      return await PerfTimer.measure('searchDiveSummaries', () async {
+        final likeTerm = '%$query%';
+        final diverClause = diverId != null ? 'AND d.diver_id = ?' : '';
+        final diverArgs = diverId != null
+            ? [Variable<String>(diverId)]
+            : <Variable<String>>[];
 
-      final matchingIds = await _db
-          .customSelect(
-            '''
-            SELECT DISTINCT d.id
-            FROM dives d
-            LEFT JOIN dive_sites ds ON d.site_id = ds.id
-            LEFT JOIN dive_centers dc ON d.dive_center_id = dc.id
-            LEFT JOIN dive_buddies db ON db.dive_id = d.id
-            LEFT JOIN buddies b ON db.buddy_id = b.id
-            LEFT JOIN dive_tags dt ON dt.dive_id = d.id
-            LEFT JOIN tags t ON dt.tag_id = t.id
-            LEFT JOIN dive_custom_fields cf ON cf.dive_id = d.id
-            WHERE (
-              d.notes LIKE ?
-              OR d.name LIKE ?
-              OR d.buddy LIKE ?
-              OR d.dive_master LIKE ?
-              OR ds.name LIKE ?
-              OR ds.country LIKE ?
-              OR ds.region LIKE ?
-              OR dc.name LIKE ?
-              OR b.name LIKE ?
-              OR t.name LIKE ?
-              OR cf.field_key LIKE ?
-              OR cf.field_value LIKE ?
+        final matchingIds = await _db
+            .customSelect(
+              '''
+              SELECT DISTINCT d.id,
+                COALESCE(d.entry_time, d.dive_date_time) AS sort_ts
+              FROM dives d
+              LEFT JOIN dive_sites ds ON d.site_id = ds.id
+              LEFT JOIN dive_centers dc ON d.dive_center_id = dc.id
+              LEFT JOIN dive_buddies db ON db.dive_id = d.id
+              LEFT JOIN buddies b ON db.buddy_id = b.id
+              LEFT JOIN dive_tags dt ON dt.dive_id = d.id
+              LEFT JOIN tags t ON dt.tag_id = t.id
+              LEFT JOIN dive_custom_fields cf ON cf.dive_id = d.id
+              WHERE (
+                d.notes LIKE ?
+                OR d.name LIKE ?
+                OR d.buddy LIKE ?
+                OR d.dive_master LIKE ?
+                OR ds.name LIKE ?
+                OR ds.country LIKE ?
+                OR ds.region LIKE ?
+                OR dc.name LIKE ?
+                OR b.name LIKE ?
+                OR t.name LIKE ?
+                OR cf.field_key LIKE ?
+                OR cf.field_value LIKE ?
+              )
+              $diverClause
+              ORDER BY sort_ts DESC
+              LIMIT ?
+              ''',
+              variables: [
+                for (var i = 0; i < 12; i++) Variable<String>(likeTerm),
+                ...diverArgs,
+                Variable<int>(limit),
+              ],
             )
-            $diverClause
-            ''',
-            variables: [
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              Variable(likeTerm),
-              ...diverArgs,
-            ],
-          )
-          .get();
+            .get();
 
-      if (matchingIds.isEmpty) return [];
+        if (matchingIds.isEmpty) return <DiveSummary>[];
 
-      final ids = matchingIds.map((r) => r.data['id'] as String).toList();
-
-      final rows =
-          await (_db.select(_db.dives)
-                ..where((t) => t.id.isIn(ids))
-                ..orderBy([
-                  (t) => OrderingTerm.desc(
-                    coalesce([t.entryTime, t.diveDateTime]),
-                  ),
-                  (t) => OrderingTerm.desc(t.diveNumber),
-                ]))
-              .get();
-
-      return Future.wait(rows.map(_mapRowToDive));
+        final ids = matchingIds.map((r) => r.read<String>('id')).toList();
+        return _summariesForIds(ids);
+      });
     } catch (e, stackTrace) {
       _log.error(
-        'Failed to search dives: $query',
+        'Failed to search dive summaries: $query',
         error: e,
         stackTrace: stackTrace,
       );
       rethrow;
     }
+  }
+
+  /// Loads [DiveSummary] rows for [ids] (slim SELECT plus batched tags and
+  /// dive types), ordered most recent first.
+  Future<List<DiveSummary>> _summariesForIds(List<String> ids) async {
+    final placeholders = List.filled(ids.length, '?').join(', ');
+    final rows = await _db
+        .customSelect(
+          'SELECT '
+          'd.id, d.dive_number, d.name AS dive_name, '
+          'd.dive_date_time, d.entry_time, '
+          'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
+          'd.is_favorite, d.dive_type, '
+          'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
+          's.name AS site_name, s.country AS site_country, '
+          's.region AS site_region, s.latitude AS site_latitude, '
+          's.longitude AS site_longitude '
+          'FROM dives d '
+          'LEFT JOIN dive_sites s ON d.site_id = s.id '
+          'WHERE d.id IN ($placeholders) '
+          'ORDER BY sort_timestamp DESC, '
+          'COALESCE(d.dive_number, 0) DESC, d.id DESC',
+          variables: [for (final id in ids) Variable<String>(id)],
+          readsFrom: {_db.dives, _db.diveSites},
+        )
+        .get();
+
+    if (rows.isEmpty) return [];
+
+    final diveIds = rows.map((r) => r.read<String>('id')).toList();
+    final tagsByDive = await _tagRepository.getTagsForDives(diveIds);
+    final diveTypesByDive = await _diveTypesForDives(diveIds);
+    return _mapSummaryRows(rows, tagsByDive, diveTypesByDive);
+  }
+
+  /// Shared row mapper for the summary SELECT column list (used by
+  /// [getDiveSummaries] and [_summariesForIds]).
+  List<DiveSummary> _mapSummaryRows(
+    List<QueryRow> rows,
+    Map<String, List<domain.Tag>> tagsByDive,
+    Map<String, List<String>> diveTypesByDive,
+  ) {
+    return rows.map((row) {
+      final id = row.read<String>('id');
+      final entryTime = row.readNullable<int>('entry_time');
+      final bottomTime = row.readNullable<int>('bottom_time');
+      final runtime = row.readNullable<int>('runtime');
+
+      return DiveSummary(
+        id: id,
+        diveNumber: row.readNullable<int>('dive_number'),
+        name: row.readNullable<String>('dive_name'),
+        dateTime: DateTime.fromMillisecondsSinceEpoch(
+          row.read<int>('dive_date_time'),
+          isUtc: true,
+        ),
+        entryTime: entryTime != null
+            ? DateTime.fromMillisecondsSinceEpoch(entryTime, isUtc: true)
+            : null,
+        maxDepth: row.readNullable<double>('max_depth'),
+        bottomTime: bottomTime != null ? Duration(seconds: bottomTime) : null,
+        runtime: runtime != null ? Duration(seconds: runtime) : null,
+        waterTemp: row.readNullable<double>('water_temp'),
+        rating: row.readNullable<int>('rating'),
+        isFavorite: row.read<int>('is_favorite') == 1,
+        diveTypeIds: diveTypesByDive[id] ?? [row.read<String>('dive_type')],
+        tags: tagsByDive[id] ?? [],
+        siteName: row.readNullable<String>('site_name'),
+        siteCountry: row.readNullable<String>('site_country'),
+        siteRegion: row.readNullable<String>('site_region'),
+        siteLatitude: row.readNullable<double>('site_latitude'),
+        siteLongitude: row.readNullable<double>('site_longitude'),
+        sortTimestamp: row.read<int>('sort_timestamp'),
+      );
+    }).toList();
   }
 
   // ============================================================================

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1915,6 +1915,11 @@ class DiveRepository {
   }) async {
     try {
       return await PerfTimer.measure('searchDiveSummaries', () async {
+        // Empty/whitespace queries match everything ('%%'); the provider
+        // already treats them as "no search", so return nothing here too.
+        // Guarding limit <= 0 also avoids SQLite's negative-LIMIT (unbounded)
+        // case, which would defeat the bound this method exists to enforce.
+        if (query.trim().isEmpty || limit <= 0) return <DiveSummary>[];
         final likeTerm = '%$query%';
         final diverClause = diverId != null ? 'AND d.diver_id = ?' : '';
         final diverArgs = diverId != null
@@ -1925,7 +1930,8 @@ class DiveRepository {
             .customSelect(
               '''
               SELECT DISTINCT d.id,
-                COALESCE(d.entry_time, d.dive_date_time) AS sort_ts
+                COALESCE(d.entry_time, d.dive_date_time) AS sort_ts,
+                d.dive_number AS dive_number
               FROM dives d
               LEFT JOIN dive_sites ds ON d.site_id = ds.id
               LEFT JOIN dive_centers dc ON d.dive_center_id = dc.id
@@ -1949,7 +1955,8 @@ class DiveRepository {
                 OR cf.field_value LIKE ?
               )
               $diverClause
-              ORDER BY sort_ts DESC
+              ORDER BY sort_ts DESC,
+                COALESCE(d.dive_number, 0) DESC, d.id DESC
               LIMIT ?
               ''',
               variables: [

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -361,7 +362,7 @@ class _DiveListPageState extends ConsumerState<DiveListPage> {
 }
 
 /// Search delegate for diving through dive logs
-class DiveSearchDelegate extends SearchDelegate<Dive?> {
+class DiveSearchDelegate extends SearchDelegate<String?> {
   final WidgetRef ref;
 
   DiveSearchDelegate(this.ref);
@@ -427,7 +428,7 @@ class DiveSearchDelegate extends SearchDelegate<Dive?> {
   }
 
   Widget _buildSearchResults(BuildContext context) {
-    return DebouncedSearchResults<Dive>(
+    return DebouncedSearchResults<DiveSummary>(
       query: query,
       watchProvider: (ref, q) => ref.watch(diveSearchProvider(q)),
       emptyBuilder: (context, q) => Center(
@@ -456,7 +457,7 @@ class DiveSearchDelegate extends SearchDelegate<Dive?> {
       dataBuilder: (context, dives) {
         final colorAttribute = ref.read(settingsProvider).cardColorAttribute;
         final colorValues = dives
-            .map((d) => getCardColorValueFromDive(d, colorAttribute))
+            .map((d) => getCardColorValue(d, colorAttribute))
             .whereType<double>();
         final minValue = colorValues.isNotEmpty
             ? colorValues.reduce((a, b) => a < b ? a : b)
@@ -464,30 +465,46 @@ class DiveSearchDelegate extends SearchDelegate<Dive?> {
         final maxValue = colorValues.isNotEmpty
             ? colorValues.reduce((a, b) => a > b ? a : b)
             : null;
+        final showLimitNotice =
+            dives.length >= DiveRepository.searchResultLimit;
 
         return ListView.builder(
-          itemCount: dives.length,
+          itemCount: dives.length + (showLimitNotice ? 1 : 0),
           itemBuilder: (context, index) {
+            if (index >= dives.length) {
+              return Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  context.l10n.diveLog_listPage_searchLimitNotice(
+                    DiveRepository.searchResultLimit,
+                  ),
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              );
+            }
             final dive = dives[index];
             return DiveListTile(
               diveId: dive.id,
               diveNumber: dive.diveNumber ?? index + 1,
               dateTime: dive.dateTime,
-              siteName: dive.site?.name,
-              siteLocation: dive.site?.locationString,
+              siteName: dive.siteName,
+              siteLocation: dive.siteLocation,
               maxDepth: dive.maxDepth,
               duration: dive.bottomTime,
               waterTemp: dive.waterTemp,
               rating: dive.rating,
               isFavorite: dive.isFavorite,
               tags: dive.tags,
-              colorValue: getCardColorValueFromDive(dive, colorAttribute),
+              colorValue: getCardColorValue(dive, colorAttribute),
               minValueInList: minValue,
               maxValueInList: maxValue,
-              siteLatitude: dive.site?.location?.latitude,
-              siteLongitude: dive.site?.location?.longitude,
+              siteLatitude: dive.siteLatitude,
+              siteLongitude: dive.siteLongitude,
               onTap: () {
-                close(context, dive);
+                close(context, dive.id);
                 context.go('/dives/${dive.id}');
               },
             );

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -16,7 +16,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/core/constants/dive_field.dart';
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/core/constants/dive_search.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -455,8 +455,17 @@ class DiveSearchDelegate extends SearchDelegate<String?> {
         ),
       ),
       dataBuilder: (context, dives) {
+        // The provider over-fetches by one, so more than the display limit
+        // means results were actually truncated (an exact-limit result is
+        // not). Render only the first [kDiveSearchResultLimit] and append the
+        // notice when cut.
+        final truncated = dives.length > kDiveSearchResultLimit;
+        final visible = truncated
+            ? dives.take(kDiveSearchResultLimit).toList(growable: false)
+            : dives;
+
         final colorAttribute = ref.read(settingsProvider).cardColorAttribute;
-        final colorValues = dives
+        final colorValues = visible
             .map((d) => getCardColorValue(d, colorAttribute))
             .whereType<double>();
         final minValue = colorValues.isNotEmpty
@@ -465,18 +474,16 @@ class DiveSearchDelegate extends SearchDelegate<String?> {
         final maxValue = colorValues.isNotEmpty
             ? colorValues.reduce((a, b) => a > b ? a : b)
             : null;
-        final showLimitNotice =
-            dives.length >= DiveRepository.searchResultLimit;
 
         return ListView.builder(
-          itemCount: dives.length + (showLimitNotice ? 1 : 0),
+          itemCount: visible.length + (truncated ? 1 : 0),
           itemBuilder: (context, index) {
-            if (index >= dives.length) {
+            if (index >= visible.length) {
               return Padding(
                 padding: const EdgeInsets.all(16),
                 child: Text(
                   context.l10n.diveLog_listPage_searchLimitNotice(
-                    DiveRepository.searchResultLimit,
+                    kDiveSearchResultLimit,
                   ),
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -485,7 +492,7 @@ class DiveSearchDelegate extends SearchDelegate<String?> {
                 ),
               );
             }
-            final dive = dives[index];
+            final dive = visible[index];
             return DiveListTile(
               diveId: dive.id,
               diveNumber: dive.diveNumber ?? index + 1,

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -1,3 +1,4 @@
+import 'package:submersion/core/constants/dive_search.dart';
 import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/performance/perf_timer.dart';
@@ -238,19 +239,26 @@ final nextDiveNumberProvider = FutureProvider<int>((ref) async {
 
 /// Search results provider.
 ///
-/// Returns lightweight [DiveSummary] rows, bounded to the
-/// [DiveRepository.searchResultLimit] most recent matches (exactly four SQL
-/// statements regardless of match count).
+/// Returns lightweight [DiveSummary] rows for display. Fetches one more than
+/// [kDiveSearchResultLimit] so the UI can distinguish a truncated result
+/// (more matches exist) from an exact one and render the "showing first N"
+/// notice only when results were actually cut.
 final diveSearchProvider = FutureProvider.family<List<DiveSummary>, String>((
   ref,
   query,
 ) async {
-  if (query.isEmpty) return const [];
+  // Trim so a whitespace-only query short-circuits here instead of
+  // debouncing and hitting the repository on a hot UI path.
+  if (query.trim().isEmpty) return const [];
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
   final repository = ref.watch(diveRepositoryProvider);
-  return repository.searchDiveSummaries(query, diverId: validatedDiverId);
+  return repository.searchDiveSummaries(
+    query,
+    diverId: validatedDiverId,
+    limit: kDiveSearchResultLimit + 1,
+  );
 });
 
 /// Dive list notifier for mutations

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -236,19 +236,21 @@ final nextDiveNumberProvider = FutureProvider<int>((ref) async {
   return repository.getNextDiveNumber(diverId: currentDiverId);
 });
 
-/// Search results provider
-final diveSearchProvider = FutureProvider.family<List<domain.Dive>, String>((
+/// Search results provider.
+///
+/// Returns lightweight [DiveSummary] rows, bounded to the
+/// [DiveRepository.searchResultLimit] most recent matches (exactly four SQL
+/// statements regardless of match count).
+final diveSearchProvider = FutureProvider.family<List<DiveSummary>, String>((
   ref,
   query,
 ) async {
+  if (query.isEmpty) return const [];
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
-  if (query.isEmpty) {
-    return ref.watch(divesProvider).value ?? [];
-  }
   final repository = ref.watch(diveRepositoryProvider);
-  return repository.searchDives(query, diverId: validatedDiverId);
+  return repository.searchDiveSummaries(query, diverId: validatedDiverId);
 });
 
 /// Dive list notifier for mutations

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1571,6 +1571,7 @@
   "siteMatchReview_noNearbySite": "لا يوجد موقع قريب",
   "importSummary_matchSitesButton": "مطابقة {count} غوصات بالمواقع",
   "diveLog_listPage_searchFieldLabel": "البحث في الغوصات...",
+  "diveLog_listPage_searchLimitNotice": "عرض أول {limit} نتيجة مطابقة. حسّن البحث لتضييق النتائج.",
   "diveLog_listPage_searchNoResults": "لم يتم العثور على غوصات لـ \"{query}\"",
   "diveLog_listPage_searchSuggestion": "البحث حسب الموقع أو زميل الغوص أو الملاحظات",
   "diveLog_listPage_title": "سجل الغوص",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1571,6 +1571,7 @@
   "siteMatchReview_noNearbySite": "Kein Tauchplatz in der Nähe",
   "importSummary_matchSitesButton": "{count} Tauchgänge Tauchplätzen zuordnen",
   "diveLog_listPage_searchFieldLabel": "Tauchgänge suchen...",
+  "diveLog_listPage_searchLimitNotice": "Die ersten {limit} Treffer werden angezeigt. Verfeinern Sie die Suche, um die Ergebnisse einzugrenzen.",
   "diveLog_listPage_searchNoResults": "Keine Tauchgänge gefunden für \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Nach Tauchplatz, Tauchpartner oder Notizen suchen",
   "diveLog_listPage_title": "Tauchlogbuch",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2583,6 +2583,7 @@
     }
   },
   "diveLog_listPage_searchFieldLabel": "Search dives...",
+  "diveLog_listPage_searchLimitNotice": "Showing the first {limit} matches. Refine your search to narrow results.",
   "diveLog_listPage_searchNoResults": "No dives found for \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Search by site, buddy, or notes",
   "diveLog_listPage_title": "Dive Log",
@@ -3206,6 +3207,13 @@
     "placeholders": {
       "error": {
         "type": "Object"
+      }
+    }
+  },
+  "@diveLog_listPage_searchLimitNotice": {
+    "placeholders": {
+      "limit": {
+        "type": "int"
       }
     }
   },

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1571,6 +1571,7 @@
   "siteMatchReview_noNearbySite": "Ningún punto cercano",
   "importSummary_matchSitesButton": "Asociar {count} inmersiones a puntos",
   "diveLog_listPage_searchFieldLabel": "Buscar inmersiones...",
+  "diveLog_listPage_searchLimitNotice": "Mostrando las primeras {limit} coincidencias. Refina la búsqueda para acotar los resultados.",
   "diveLog_listPage_searchNoResults": "No se encontraron inmersiones para \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Buscar por punto, compañero o notas",
   "diveLog_listPage_title": "Registro de buceo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1537,6 +1537,7 @@
   "siteMatchReview_noNearbySite": "Aucun site à proximité",
   "importSummary_matchSitesButton": "Associer {count} plongées aux sites",
   "diveLog_listPage_searchFieldLabel": "Rechercher des plongees...",
+  "diveLog_listPage_searchLimitNotice": "Affichage des {limit} premières correspondances. Affinez votre recherche pour réduire les résultats.",
   "diveLog_listPage_searchNoResults": "Aucune plongee trouvee pour \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Rechercher par site, binome ou notes",
   "diveLog_listPage_title": "Carnet de plongee",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1537,6 +1537,7 @@
   "siteMatchReview_noNearbySite": "אין אתר בקרבת מקום",
   "importSummary_matchSitesButton": "התאמת {count} צלילות לאתרים",
   "diveLog_listPage_searchFieldLabel": "חיפוש צלילות...",
+  "diveLog_listPage_searchLimitNotice": "מוצגות {limit} ההתאמות הראשונות. חדדו את החיפוש כדי לצמצם את התוצאות.",
   "diveLog_listPage_searchNoResults": "לא נמצאו צלילות עבור \"{query}\"",
   "diveLog_listPage_searchSuggestion": "חיפוש לפי אתר, שותף או הערות",
   "diveLog_listPage_title": "יומן צלילה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1537,6 +1537,7 @@
   "siteMatchReview_noNearbySite": "Nincs közeli hely",
   "importSummary_matchSitesButton": "{count} merülés hozzárendelése helyekhez",
   "diveLog_listPage_searchFieldLabel": "Merulesek keresese...",
+  "diveLog_listPage_searchLimitNotice": "Az első {limit} találat látható. Pontosítsa a keresést az eredmények szűkítéséhez.",
   "diveLog_listPage_searchNoResults": "Nem talalhato merules: \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Kereses merulohely, buddy vagy jegyzetek alapjan",
   "diveLog_listPage_title": "Merulesi naplo",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1537,6 +1537,7 @@
   "siteMatchReview_noNearbySite": "Nessun sito nelle vicinanze",
   "importSummary_matchSitesButton": "Associa {count} immersioni ai siti",
   "diveLog_listPage_searchFieldLabel": "Cerca immersioni...",
+  "diveLog_listPage_searchLimitNotice": "Vengono mostrate le prime {limit} corrispondenze. Affina la ricerca per restringere i risultati.",
   "diveLog_listPage_searchNoResults": "Nessuna immersione trovata per \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Cerca per sito, compagno o note",
   "diveLog_listPage_title": "Diario immersioni",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -8180,6 +8180,12 @@ abstract class AppLocalizations {
   /// **'Search dives...'**
   String get diveLog_listPage_searchFieldLabel;
 
+  /// No description provided for @diveLog_listPage_searchLimitNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Showing the first {limit} matches. Refine your search to narrow results.'**
+  String diveLog_listPage_searchLimitNotice(int limit);
+
   /// No description provided for @diveLog_listPage_searchNoResults.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -4751,6 +4751,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'البحث في الغوصات...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'عرض أول $limit نتيجة مطابقة. حسّن البحث لتضييق النتائج.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'لم يتم العثور على غوصات لـ \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -4860,6 +4860,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Tauchgänge suchen...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Die ersten $limit Treffer werden angezeigt. Verfeinern Sie die Suche, um die Ergebnisse einzugrenzen.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'Keine Tauchgänge gefunden für \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -4774,6 +4774,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Search dives...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Showing the first $limit matches. Refine your search to narrow results.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'No dives found for \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -4860,6 +4860,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Buscar inmersiones...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Mostrando las primeras $limit coincidencias. Refina la búsqueda para acotar los resultados.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'No se encontraron inmersiones para \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -4883,6 +4883,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Rechercher des plongees...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Affichage des $limit premières correspondances. Affinez votre recherche pour réduire les résultats.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'Aucune plongee trouvee pour \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -4729,6 +4729,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'חיפוש צלילות...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'מוצגות $limit ההתאמות הראשונות. חדדו את החיפוש כדי לצמצם את התוצאות.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'לא נמצאו צלילות עבור \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -4845,6 +4845,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Merulesek keresese...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Az első $limit találat látható. Pontosítsa a keresést az eredmények szűkítéséhez.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'Nem talalhato merules: \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -4864,6 +4864,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Cerca immersioni...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Vengono mostrate le prime $limit corrispondenze. Affina la ricerca per restringere i risultati.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'Nessuna immersione trovata per \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -4825,6 +4825,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Duiken zoeken...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'De eerste $limit resultaten worden getoond. Verfijn je zoekopdracht om de resultaten te beperken.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'Geen duiken gevonden voor \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -4863,6 +4863,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => 'Buscar mergulhos...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return 'Mostrando as primeiras $limit correspondências. Refine a busca para restringir os resultados.';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return 'Nenhum mergulho encontrado para \"$query\"';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -4626,6 +4626,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_listPage_searchFieldLabel => '搜索潜水...';
 
   @override
+  String diveLog_listPage_searchLimitNotice(int limit) {
+    return '仅显示前 $limit 条匹配结果。请细化搜索以缩小范围。';
+  }
+
+  @override
   String diveLog_listPage_searchNoResults(Object query) {
     return '未找到与「$query」匹配的潜水';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1571,6 +1571,7 @@
   "siteMatchReview_noNearbySite": "Geen stek in de buurt",
   "importSummary_matchSitesButton": "{count} duiken aan stekken koppelen",
   "diveLog_listPage_searchFieldLabel": "Duiken zoeken...",
+  "diveLog_listPage_searchLimitNotice": "De eerste {limit} resultaten worden getoond. Verfijn je zoekopdracht om de resultaten te beperken.",
   "diveLog_listPage_searchNoResults": "Geen duiken gevonden voor \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Zoek op stek, buddy of notities",
   "diveLog_listPage_title": "Duiklogboek",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1571,6 +1571,7 @@
   "siteMatchReview_noNearbySite": "Nenhum ponto próximo",
   "importSummary_matchSitesButton": "Associar {count} mergulhos a pontos",
   "diveLog_listPage_searchFieldLabel": "Buscar mergulhos...",
+  "diveLog_listPage_searchLimitNotice": "Mostrando as primeiras {limit} correspondências. Refine a busca para restringir os resultados.",
   "diveLog_listPage_searchNoResults": "Nenhum mergulho encontrado para \"{query}\"",
   "diveLog_listPage_searchSuggestion": "Buscar por ponto, dupla ou anotacoes",
   "diveLog_listPage_title": "Log de Mergulhos",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1701,6 +1701,7 @@
   "siteMatchReview_noNearbySite": "附近没有潜水点",
   "importSummary_matchSitesButton": "将 {count} 次潜水匹配到潜水点",
   "diveLog_listPage_searchFieldLabel": "搜索潜水...",
+  "diveLog_listPage_searchLimitNotice": "仅显示前 {limit} 条匹配结果。请细化搜索以缩小范围。",
   "diveLog_listPage_searchNoResults": "未找到与「{query}」匹配的潜水",
   "diveLog_listPage_searchSuggestion": "按潜水点、潜伴或备注搜索",
   "diveLog_listPage_title": "潜水日志",

--- a/test/features/dive_log/data/repositories/dive_name_test.dart
+++ b/test/features/dive_log/data/repositories/dive_name_test.dart
@@ -70,19 +70,19 @@ void main() {
     });
   });
 
-  group('searchDives by name', () {
+  group('searchDiveSummaries by name', () {
     test('matches a dive by its custom name', () async {
       await repository.createDive(makeDive(name: 'Wreck penetration dive'));
       await repository.createDive(makeDive(name: 'Reef checkout'));
 
-      final results = await repository.searchDives('penetration');
+      final results = await repository.searchDiveSummaries('penetration');
       expect(results, hasLength(1));
       expect(results.first.name, 'Wreck penetration dive');
     });
 
     test('does not match unnamed dives', () async {
       await repository.createDive(makeDive());
-      final results = await repository.searchDives('penetration');
+      final results = await repository.searchDiveSummaries('penetration');
       expect(results, isEmpty);
     });
   });

--- a/test/features/dive_log/data/repositories/dive_repository_error_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_error_test.dart
@@ -47,7 +47,10 @@ void main() {
         throwsA(anything),
       );
       await expectLater(repository.getNextDiveNumber(), throwsA(anything));
-      await expectLater(repository.searchDives('test'), throwsA(anything));
+      await expectLater(
+        repository.searchDiveSummaries('test'),
+        throwsA(anything),
+      );
       await expectLater(repository.getStatistics(), throwsA(anything));
       await expectLater(repository.getRecords(), throwsA(anything));
       final dummyDive = Dive(id: 'test-id', dateTime: DateTime.now());

--- a/test/features/dive_log/data/repositories/dive_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_test.dart
@@ -563,21 +563,21 @@ void main() {
       });
 
       test('should find dives by notes', () async {
-        final results = await repository.searchDives('coral');
+        final results = await repository.searchDiveSummaries('coral');
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(1));
       });
 
       test('should find dives by buddy', () async {
-        final results = await repository.searchDives('Bob');
+        final results = await repository.searchDiveSummaries('Bob');
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(2));
       });
 
       test('should return empty list for no matches', () async {
-        final results = await repository.searchDives('NonExistent');
+        final results = await repository.searchDiveSummaries('NonExistent');
 
         expect(results, isEmpty);
       });
@@ -588,7 +588,7 @@ void main() {
         );
         await repository.createDive(createTestDive(diveNumber: 10, site: site));
 
-        final results = await repository.searchDives('Blue Hole');
+        final results = await repository.searchDiveSummaries('Blue Hole');
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(10));
@@ -600,7 +600,7 @@ void main() {
         );
         await repository.createDive(createTestDive(diveNumber: 11, site: site));
 
-        final results = await repository.searchDives('Thailand');
+        final results = await repository.searchDiveSummaries('Thailand');
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(11));
@@ -612,7 +612,7 @@ void main() {
         );
         await repository.createDive(createTestDive(diveNumber: 12, site: site));
 
-        final results = await repository.searchDives('Cozumel');
+        final results = await repository.searchDiveSummaries('Cozumel');
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(12));
@@ -633,7 +633,7 @@ void main() {
         );
         await buddyRepo.addBuddyToDive(dive.id, buddy.id, BuddyRole.buddy);
 
-        final results = await repository.searchDives('Cousteau');
+        final results = await repository.searchDiveSummaries('Cousteau');
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(13));
@@ -654,7 +654,9 @@ void main() {
         );
         await tagRepo.addTagToDive(dive.id, tag.id);
 
-        final results = await repository.searchDives('wreck-exploration');
+        final results = await repository.searchDiveSummaries(
+          'wreck-exploration',
+        );
 
         expect(results.length, equals(1));
         expect(results[0].diveNumber, equals(14));

--- a/test/features/dive_log/data/repositories/dive_search_summaries_test.dart
+++ b/test/features/dive_log/data/repositories/dive_search_summaries_test.dart
@@ -86,6 +86,14 @@ void main() {
     expect(await repository.searchDiveSummaries('   '), isEmpty);
   });
 
+  test('surrounding whitespace is trimmed before matching', () async {
+    await repository.createDive(dive('d1', notes: 'giant manta'));
+
+    // Without trimming, "%manta %" would fail to match a trailing-word hit.
+    expect(await repository.searchDiveSummaries('manta '), hasLength(1));
+    expect(await repository.searchDiveSummaries('  manta  '), hasLength(1));
+  });
+
   test('summary fields are populated', () async {
     await repository.createDive(
       domain.Dive(

--- a/test/features/dive_log/data/repositories/dive_search_summaries_test.dart
+++ b/test/features/dive_log/data/repositories/dive_search_summaries_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+  tearDown(() async => tearDownTestDatabase());
+
+  domain.Dive dive(String id, {String? notes, String? name, DateTime? when}) =>
+      domain.Dive(
+        id: id,
+        dateTime: when ?? DateTime(2026, 1, 1),
+        notes: notes ?? '',
+        name: name,
+      );
+
+  test('matches notes and name, most recent first', () async {
+    await repository.createDive(
+      dive('d1', notes: 'great manta sighting', when: DateTime(2026, 1, 1)),
+    );
+    await repository.createDive(
+      dive('d2', name: 'Manta Point', when: DateTime(2026, 2, 1)),
+    );
+    await repository.createDive(dive('d3', notes: 'nothing here'));
+
+    final results = await repository.searchDiveSummaries('manta');
+    expect(results.map((s) => s.id).toList(), ['d2', 'd1']);
+  });
+
+  test('bound keeps the most recent matches and honors limit', () async {
+    for (var i = 0; i < 8; i++) {
+      await repository.createDive(
+        dive('d$i', notes: 'wreck dive', when: DateTime(2026, 1, 1 + i)),
+      );
+    }
+
+    final results = await repository.searchDiveSummaries('wreck', limit: 5);
+    expect(results, hasLength(5));
+    expect(results.first.id, 'd7');
+    final ids = results.map((s) => s.id).toList();
+    expect(ids, isNot(contains('d0')));
+    expect(ids, isNot(contains('d1')));
+    expect(ids, isNot(contains('d2')));
+  });
+
+  test('summary fields are populated', () async {
+    await repository.createDive(
+      domain.Dive(
+        id: 's1',
+        dateTime: DateTime(2026, 3, 1),
+        notes: 'blue water',
+        maxDepth: 30.5,
+        rating: 4,
+        isFavorite: true,
+      ),
+    );
+
+    final results = await repository.searchDiveSummaries('blue');
+    final s = results.single;
+    expect(s.maxDepth, 30.5);
+    expect(s.rating, 4);
+    expect(s.isFavorite, isTrue);
+    expect(s.diveTypeIds, isNotEmpty);
+    expect(s.sortTimestamp, DateTime(2026, 3, 1).millisecondsSinceEpoch);
+  });
+
+  test('no matches returns empty', () async {
+    await repository.createDive(dive('x1', notes: 'kelp forest'));
+    expect(await repository.searchDiveSummaries('zzznope'), isEmpty);
+  });
+
+  test('diverId scopes results', () async {
+    await repository.createDive(dive('mine', notes: 'manta'));
+
+    final unscoped = await repository.searchDiveSummaries('manta');
+    expect(unscoped.map((s) => s.id), contains('mine'));
+
+    final scoped = await repository.searchDiveSummaries(
+      'manta',
+      diverId: 'some-other-diver',
+    );
+    expect(scoped, isEmpty);
+  });
+}

--- a/test/features/dive_log/data/repositories/dive_search_summaries_test.dart
+++ b/test/features/dive_log/data/repositories/dive_search_summaries_test.dart
@@ -51,6 +51,41 @@ void main() {
     expect(ids, isNot(contains('d2')));
   });
 
+  test('tie-broken bound matches the final ordering', () async {
+    // All six dives share the same timestamp, so the LIMIT cutoff is decided
+    // entirely by the tie-breakers. The bounded id pre-query must apply the
+    // same dive_number/id tie-breakers as the hydration query, otherwise it
+    // can drop dives that should survive the cut.
+    final when = DateTime(2026, 1, 1);
+    for (final (id, number) in [
+      ('a', 10),
+      ('b', 20),
+      ('c', 30),
+      ('d', 40),
+      ('e', 50),
+      ('f', 60),
+    ]) {
+      await repository.createDive(
+        domain.Dive(
+          id: id,
+          dateTime: when,
+          notes: 'reef survey',
+          diveNumber: number,
+        ),
+      );
+    }
+
+    final results = await repository.searchDiveSummaries('reef', limit: 3);
+    // Highest dive_number wins the tie: f(60), e(50), d(40).
+    expect(results.map((s) => s.id).toList(), ['f', 'e', 'd']);
+  });
+
+  test('empty or whitespace query returns empty', () async {
+    await repository.createDive(dive('present', notes: 'manta'));
+    expect(await repository.searchDiveSummaries(''), isEmpty);
+    expect(await repository.searchDiveSummaries('   '), isEmpty);
+  });
+
   test('summary fields are populated', () async {
     await repository.createDive(
       domain.Dive(

--- a/test/features/dive_log/presentation/pages/dive_search_delegate_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_search_delegate_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/core/constants/dive_search.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -41,6 +41,7 @@ Future<void> _openSearch(
         diveSearchProvider.overrideWith((ref, q) async => results),
       ].cast(),
       child: MaterialApp(
+        locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Consumer(
@@ -76,11 +77,21 @@ void main() {
     expect(find.textContaining('Showing the first'), findsNothing);
   });
 
-  testWidgets('shows the limit notice when the result bound is hit', (
+  testWidgets('no notice when matches exactly fill the limit', (tester) async {
+    // The provider over-fetches by one; an exact-limit result (no extra row)
+    // is not truncated, so the notice must not appear.
+    final results = List.generate(kDiveSearchResultLimit, (i) => _summary(i));
+    await _openSearch(tester, results);
+
+    expect(find.textContaining('Showing the first'), findsNothing);
+  });
+
+  testWidgets('shows the limit notice when results are truncated', (
     tester,
   ) async {
+    // One more than the limit signals truncation (the provider's +1 probe).
     final results = List.generate(
-      DiveRepository.searchResultLimit,
+      kDiveSearchResultLimit + 1,
       (i) => _summary(i),
     );
     await _openSearch(tester, results);

--- a/test/features/dive_log/presentation/pages/dive_search_delegate_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_search_delegate_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+DiveSummary _summary(int i) => DiveSummary(
+  id: 'd$i',
+  diveNumber: i,
+  name: 'Dive $i',
+  dateTime: DateTime(2026, 1, 1).add(Duration(days: i)),
+  maxDepth: 20.0 + i,
+  bottomTime: const Duration(minutes: 40),
+  waterTemp: 25,
+  rating: 3,
+  siteName: 'Blue Hole $i',
+  sortTimestamp: DateTime(
+    2026,
+    1,
+    1,
+  ).add(Duration(days: i)).millisecondsSinceEpoch,
+);
+
+/// Opens [DiveSearchDelegate] via `showSearch` and types [query], with the
+/// search provider overridden to return [results] regardless of the term.
+Future<void> _openSearch(
+  WidgetTester tester,
+  List<DiveSummary> results, {
+  String query = 'blue',
+}) async {
+  final overrides = await getBaseOverrides();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        ...overrides,
+        diveSearchProvider.overrideWith((ref, q) async => results),
+      ].cast(),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Consumer(
+          builder: (context, ref, _) => Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showSearch(
+                  context: context,
+                  delegate: DiveSearchDelegate(ref),
+                ),
+                child: const Text('open-search'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('open-search'));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextField), query);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders matching dives as tiles without a limit notice', (
+    tester,
+  ) async {
+    await _openSearch(tester, [_summary(1), _summary(2), _summary(3)]);
+
+    expect(find.byType(DiveListTile), findsNWidgets(3));
+    expect(find.textContaining('Showing the first'), findsNothing);
+  });
+
+  testWidgets('shows the limit notice when the result bound is hit', (
+    tester,
+  ) async {
+    final results = List.generate(
+      DiveRepository.searchResultLimit,
+      (i) => _summary(i),
+    );
+    await _openSearch(tester, results);
+
+    // The notice lives past the fold; force the results list to build it by
+    // scrolling the ListView's own Scrollable (not the search bar's).
+    await tester.scrollUntilVisible(
+      find.textContaining('Showing the first'),
+      400,
+      scrollable: find.descendant(
+        of: find.byType(ListView),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    expect(find.textContaining('Showing the first'), findsOneWidget);
+  });
+}

--- a/test/features/dive_log/presentation/providers/dive_search_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_search_provider_test.dart
@@ -33,6 +33,13 @@ void main() {
     expect(results, isEmpty);
   });
 
+  test('whitespace-only query short-circuits to empty', () async {
+    // The provider trims before doing any async work, so a blank-looking
+    // query never debounces into a repository call.
+    final results = await container.read(diveSearchProvider('   ').future);
+    expect(results, isEmpty);
+  });
+
   test('non-empty query returns bounded summary matches', () async {
     await repository.createDive(
       domain.Dive(

--- a/test/features/dive_log/presentation/providers/dive_search_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_search_provider_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late ProviderContainer container;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+    container = ProviderContainer(
+      overrides: [
+        diveRepositoryProvider.overrideWithValue(repository),
+        // The search provider awaits this before hitting the repository; a
+        // null diver id means "all divers", which the repository query allows.
+        validatedCurrentDiverIdProvider.overrideWith((ref) async => null),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+  tearDown(() async => tearDownTestDatabase());
+
+  test('empty query short-circuits without touching the repository', () async {
+    final results = await container.read(diveSearchProvider('').future);
+    expect(results, isEmpty);
+  });
+
+  test('non-empty query returns bounded summary matches', () async {
+    await repository.createDive(
+      domain.Dive(
+        id: 'd1',
+        dateTime: DateTime(2026, 1, 1),
+        notes: 'manta cleaning station',
+      ),
+    );
+    await repository.createDive(
+      domain.Dive(
+        id: 'd2',
+        dateTime: DateTime(2026, 1, 2),
+        notes: 'nothing relevant',
+      ),
+    );
+
+    final results = await container.read(diveSearchProvider('manta').future);
+    expect(results, hasLength(1));
+    expect(results.single.id, 'd1');
+  });
+}


### PR DESCRIPTION
## Summary

WS1 of the large-database performance program (spec:
`docs/superpowers/specs/2026-07-10-large-db-performance-design.md`; plan
committed in this branch). Fixes the reported 20+ second / ANR-triggering
dive search at 1,000+ dives.

**Root cause (measured, profile mode, 1,032-dive DB):** search hydrated
every match through the full-`Dive` mapper — roughly 10 queries per match.
A one-character search burned ~3.5 s of main-isolate CPU across thousands of
tiny queries (VM-profiler signature: per-query SQL string building, row-map
churn, mutex slow paths). With WS0's indexes each query is sub-millisecond;
the *count* was the remaining cost.

**Change:**
- New `DiveRepository.searchDiveSummaries`: exactly **four SQL statements
  regardless of match count** (bounded match ids -> slim summary rows ->
  batched tags -> batched dive types), returning lightweight `DiveSummary`
  rows bounded to the 100 most recent matches.
- `diveSearchProvider` and `DiveSearchDelegate` render `DiveSummary` via the
  existing tile (field-for-field; color attribute via the existing
  `getCardColorValue(DiveSummary, ...)`); a footer notice appears when the
  100-match bound is hit (new l10n string in en + all 10 locales).
- Legacy `searchDives` (the N+1 path) is removed; its behavioral tests
  (notes/name/site/country/region/linked-buddy/tag matching) are ported to
  the new method, preserving the join-semantics coverage.
- The unused empty-query fallback to `getAllDives()` in the provider is
  gone (dead path; hot-path liability).
- Existing 300 ms input debounce (`DebouncedSearchResults`) already covered
  the type-ahead requirement — verified, unchanged.

## Measurement

Fixture: 335 MB / 1,032 dives / 1.08 M profile rows (indexed, post-WS0),
Apple M5 Pro, term "blue" (74 matches; worst measured term):

| Path | Cost |
|---|---|
| Old: per-match hydration (SQL only, first 20 of 74) | 1,298 ms pre-WS0 / 17 ms post-WS0, x ~10/3 more statements in-app |
| Old: in-app one-character search (profile mode) | ~3.5 s main-isolate CPU |
| New: all four statements, 100-id worst case | **~7 ms** |

## Test plan

- New `dive_search_summaries_test.dart`: match across notes/name,
  most-recent-first bounding, summary field mapping, diver scoping, empty
  results.
- Ported suites green: `dive_repository_test.dart` (site name/country/
  region, linked buddy, tag matching), `dive_name_test.dart`,
  `dive_repository_error_test.dart` — 55 tests passing.
- Whole-project `flutter analyze`: no issues. `dart format .`: clean.
- Residual: interactive wall-clock verification on the live DB rides the
  next user session (expected: instant).