### PR TITLE
fix(dc): round Android USB serial bulk reads up to whole packets (#318)

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialReadBuffer.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialReadBuffer.kt
@@ -13,8 +13,10 @@ package com.submersion.libdivecomputer
 // one 64-byte bulk packet, and every retry threw the response away.
 //
 // Two invariants fix that:
-//  1. Never hand USB a buffer smaller than one bulk packet (minChunkSize =
-//     the endpoint's max packet size).
+//  1. Only hand USB buffers sized to a whole number of bulk packets
+//     (minChunkSize = the endpoint's max packet size). "At least one packet"
+//     is not enough: a request ending mid-packet still babbles when the
+//     response runs one packet past it (issue #318, Puck Pro version block).
 //  2. Keep whatever a chunk returns beyond the requested size buffered for
 //     subsequent reads, since the next protocol bytes ride in the same packet.
 //
@@ -70,7 +72,12 @@ class SerialReadBuffer(
                     ((remainingNanos + 999_999L) / 1_000_000L).toInt().coerceAtLeast(1)
                 }
             }
-            val chunk = ByteArray(maxOf(size - received, minChunkSize))
+            // Request a whole number of bulk packets (invariant 1): a request
+            // ending mid-packet babbles (EOVERFLOW) when the response runs
+            // past it, and the kernel discards the transfer. Overshoot lands
+            // in `pending`.
+            val packets = (size - received + minChunkSize - 1) / minChunkSize
+            val chunk = ByteArray(packets * minChunkSize)
             trace("usb read req=${chunk.size} sliceTimeout=$sliceTimeout received=$received")
             val n = readChunk(chunk, sliceTimeout)
             trace("usb read <- $n")

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/UsbSerialIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/UsbSerialIoStream.kt
@@ -82,9 +82,10 @@ class UsbSerialIoStream(
                 NativeTrace.d("opening port[$index]")
                 candidate.open(conn)
                 port = candidate
-                // Bulk reads must request at least one full USB packet or the
-                // kernel fails them with EOVERFLOW and drops the data (#318);
-                // SerialReadBuffer enforces that and buffers the surplus.
+                // Bulk reads must request whole multiples of the USB packet
+                // size or the kernel fails them with EOVERFLOW and drops the
+                // data (#318); SerialReadBuffer enforces that and buffers the
+                // surplus.
                 val maxPacketSize = candidate.readEndpoint?.maxPacketSize ?: 0
                 readBuffer = SerialReadBuffer(
                     minChunkSize = if (maxPacketSize > 0) maxPacketSize else 64,
@@ -172,7 +173,7 @@ class UsbSerialIoStream(
         // "return exactly `size` bytes or time out" -- every driver relies on
         // it. SerialReadBuffer reassembles that byte-stream contract from raw
         // bulk chunk reads: accumulating chunks until the requested size or the
-        // deadline (#334), never requesting less than one USB packet, and
+        // deadline (#334), requesting whole USB packets only, and
         // keeping surplus bytes for the next read (#318). It returns exactly
         // `size` bytes, or null so the JNI bridge reports LIBDC_STATUS_TIMEOUT
         // and libdivecomputer retries, rather than accepting a truncated read.

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/SerialReadBufferTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/SerialReadBufferTest.kt
@@ -61,6 +61,87 @@ class SerialReadBufferTest {
     }
 
     @Test
+    fun chunkRequestsAreWholeMultiplesOfMinChunkSize() {
+        val buffer = SerialReadBuffer(CHUNK)
+
+        // ACK-style read: one 64-byte packet arrives, 63 bytes stay buffered.
+        buffer.read(1, 3000) { dest, _ ->
+            System.arraycopy(ByteArray(CHUNK) { it.toByte() }, 0, dest, 0, CHUNK)
+            CHUNK
+        }
+
+        // Version-block read: 77 bytes are still needed. Requesting exactly 77
+        // babbles when the tail arrives as a 64-byte packet followed by a
+        // 14-byte packet (the second packet exceeds the 13 bytes of remaining
+        // buffer space), so the kernel fails the transfer with EOVERFLOW and
+        // the tail is lost (issue #318). The request must be rounded up to a
+        // whole number of bulk packets: 128, never 77.
+        buffer.read(140, 3000) { dest, _ ->
+            assertEquals(
+                "USB buffer must be a whole multiple of the packet size",
+                0,
+                dest.size % CHUNK,
+            )
+            System.arraycopy(ByteArray(78), 0, dest, 0, 78)
+            78
+        }
+    }
+
+    @Test
+    fun puckProVersionResponseSurvivesPacketSplitTail() {
+        // The exact issue #318 round-6 failure: after the 1-byte ACK read
+        // consumes the head of the first 64-byte packet, the remaining 141
+        // bytes of ACK + version(140) + EOM arrive as a 64-byte packet plus a
+        // 14-byte packet. The fake reader below enforces real bulk-endpoint
+        // semantics: a packet larger than the space left in the request fails
+        // the whole transfer (EOVERFLOW -> 0 bytes, data discarded); a packet
+        // shorter than the packet size terminates the transfer.
+        val buffer = SerialReadBuffer(CHUNK)
+        val packets = ArrayDeque(
+            listOf(
+                ByteArray(CHUNK) { (it + 1).toByte() }, // ACK + version[0..62]
+                ByteArray(CHUNK) { (65 + it).toByte() }, // version[63..126]
+                ByteArray(14) { (129 + it).toByte() }, // version[127..139] + EOM
+            ),
+        )
+        val readChunk = { dest: ByteArray, _: Int ->
+            var copied = 0
+            while (packets.isNotEmpty()) {
+                val space = dest.size - copied
+                if (space == 0) break // request filled: transfer complete
+                val packet = packets.removeFirst()
+                if (packet.size > space) {
+                    // Babble: the transfer errors out, bytes already copied
+                    // into it are lost with it, and so is the packet.
+                    copied = 0
+                    break
+                }
+                System.arraycopy(packet, 0, dest, copied, packet.size)
+                copied += packet.size
+                if (packet.size < CHUNK) break // short packet terminates
+            }
+            copied
+        }
+
+        val ack = buffer.read(1, 3000, readChunk)
+        assertArrayEquals(byteArrayOf(1), ack)
+
+        val version = buffer.read(140, 3000, readChunk)
+        assertArrayEquals(
+            "version block must survive the 64+14 packet split",
+            ByteArray(140) { (it + 2).toByte() },
+            version,
+        )
+
+        // The EOM trailer rode in the last packet and must still be buffered.
+        val trailer = buffer.read(1, 3000) { _, _ ->
+            fail("trailer must be served from the buffer")
+            0
+        }
+        assertArrayEquals(byteArrayOf(142.toByte()), trailer)
+    }
+
+    @Test
     fun accumulatesAcrossMultipleChunks() {
         val buffer = SerialReadBuffer(CHUNK)
         val deliveries = listOf(bytes(1..4), bytes(5..8), bytes(9..10))


### PR DESCRIPTION
## Summary

Round 6 of #318. The 2026-07-10 log from the reporter proves the #531 `SerialReadBuffer` works (packets buffered and drained, device answering CMD_VERSION in ~10ms), but the handshake still fails: the 140-byte version-block read requests the **77 bytes** it still needs (`maxOf(size - received, minChunkSize)` — at least one packet, but **not a whole multiple of 64**). The 142-byte response (`ACK + 140 + END`) arrives as 64+64+14-byte bulk packets: the 64 fits the 77-byte request, the 14-byte packet exceeds the remaining 13 bytes, and the kernel fails the transfer with EOVERFLOW (babble) and discards it — the instant `usb read req=77 ... <- 0` in the log, followed by silence and a 63/140 short read on every attempt.

Retries then alternate between a fresh-but-truncated response and 78 bytes of stale tail chewed one byte at a time — the byte-wise reads in the log are `mares_iconhd_packet_fixed`'s `while(1)` ACK-hunt loop scanning the previous response's remainder.

The fix mirrors Subsurface's `AndroidSerial.java` ("use blocks of 64 for reading"): round every USB chunk request up to a whole number of bulk packets, sized from the endpoint's actual `wMaxPacketSize` (also correct for 512-byte high-speed endpoints). Surplus bytes land in the existing `pending` buffer — the END trailer rides along and serves the follow-up 1-byte trailer read from the buffer.

After the version handshake, every Mares memory read (256-byte packets) is a 64-multiple by construction, so this failure mode cannot recur later in the download.

## Test Plan

- [x] `:libdivecomputer_plugin:testDebugUnitTest` passes (13/13; two new TDD'd tests: chunk-alignment invariant + full Puck Pro 64/64/14 handshake repro with a babble-faithful fake, both watched fail before the fix)
- [x] `dart format .` clean (no Dart changes)
- [ ] Hardware verification: needs the issue reporter's Puck Pro + CP210x clip (the babble path cannot be reproduced locally)