### PR TITLE
perf(detail): lean hydration for the analysis lookback path (WS2)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-ws2-lean-analysis-hydration.md
+++ b/docs/superpowers/plans/2026-07-10-ws2-lean-analysis-hydration.md
@@ -1,0 +1,102 @@
+# WS2: Lean Analysis Hydration Implementation Plan
+
+> Executed inline (executing-plans) in worktree `.claude/worktrees/ws2-detail`,
+> branch `worktree-ws2-detail`.
+
+**Goal:** Cut the dive-detail open cost (~11 s main-isolate CPU measured on
+dive 1006, profile mode, 1,032-dive DB) by removing full-Dive hydration from
+the decompression-analysis path. The Buhlmann/exposure math itself
+(`computeAnalysisForProfile`) is not touched.
+
+**Spec:** WS2 in `2026-07-10-large-db-performance-design.md`. Evidence:
+`2026-07-10-large-db-performance-findings.md` (23.7% raw allocation +
+dynamic-dispatch checks; the residual CNS/tissue/OTU chains plus weekly OTU
+hydrate every prior dive in the lookback window as a FULL Dive several times
+over).
+
+**Measured mechanics (agent-verified, file:line in findings):**
+- The analysis pipeline reads ONLY dive-row scalars (diveMode, GF hi/lo,
+  CCR/SCR settings, altitude, waterType, surfacePressure, times) + `tanks` +
+  `profile`. No joined display entities.
+- Each chain dive today costs ~5 full hydrations: `profileAnalysisProvider`
+  watches `diveProvider` (full `getDiveById`), `getSurfaceInterval` fully
+  hydrates BOTH its dives, `getPreviousDive` hydrates current + previous.
+- Async placement and session caching (spec items 3-4) already exist:
+  detail sections use `.valueOrNull` with fallbacks; analysis families are
+  keepAlive.
+
+**Scope decisions (recorded deviations):**
+- The spec's "exactly one dive_profiles query per open" is amended: post-WS0
+  an indexed per-dive profile read costs ~4 ms, and true dedup requires
+  adding source attribution to `DiveProfilePoint` (three mapper sites, wide
+  constructor surface). Not justified by measurement; the actual cost driver
+  (chain full-hydration) is eliminated instead. Revisit only if the post-WS2
+  profile shows the residual reads mattering.
+- `getPreviousDive`/`getDivesInRange`/`getDiveById` keep their public
+  behavior for other consumers; only the analysis call sites move to the new
+  slim accessors.
+
+## Design
+
+New domain type `DiveTimes` (id, dateTime, entryTime, exitTime, runtime,
+bottomTime, profileSpan) with an `effectiveRuntime` getter mirroring
+`Dive.effectiveRuntime` exactly — the profile-derived fallback is preserved
+via a SQL scalar subquery `MAX(timestamp)-MIN(timestamp)` (null unless > 0,
+matching `calculateRuntimeFromProfile`).
+
+New repository methods (dive_repository_impl.dart):
+- `getDiveTimes(id)` — 1 statement.
+- `getPreviousDiveTimes(id)` — 2 statements; predicate and ordering copied
+  from `getPreviousDive`.
+- `getDiveTimesInRange(start, end, {diverId})` — 1 statement; WHERE and
+  ordering copied from `getDivesInRange`.
+- `getMergedProfile(id)` — 1 statement; same mapping as `Dive.profile`
+  (shared `_profilePointFromRow`, which also replaces the duplicated inline
+  mapping in `_mapRowToDive`).
+- `getDiveForAnalysis(id)` — 3 statements (dive row via
+  `_mapRowToDiveWithPreloadedData` with empty joins, tanks, merged profile
+  via copyWith). Doc contract: analysis only, never display.
+- `getSurfaceInterval` reimplemented on `getDiveTimes` +
+  `getPreviousDiveTimes` (public signature and formula unchanged; drops ~20
+  statements per call).
+
+Provider changes (profile_analysis_provider.dart):
+- New `analysisDiveProvider` keepAlive family -> `getDiveForAnalysis`, with
+  its own `invalidateSelfWhen(watchDiveDetailChanges())` (analyses currently
+  refresh only transitively through diveProvider; this preserves that).
+- `profileAnalysisProvider` and `sourceProfileAnalysisProvider` watch
+  `analysisDiveProvider` instead of `diveProvider`.
+- `_computeResidualCns`: `getPreviousDiveTimes`; the computer-CNS branch
+  fetches `getMergedProfile(previous.id)` only when taken.
+- `_computeResidualTissueState`: `getPreviousDiveTimes` (id only).
+- `_computeResidualOtu` + `weeklyOtuProvider`: `getDiveTimes` +
+  `getDiveTimesInRange`.
+
+## Cost model (per chain dive)
+
+Before: ~5 full hydrations x ~11 statements + full joined-entity mapping.
+After: 3 statements (analysisDive) + 2 (surface interval) + 2 (prev times),
+no joined-entity mapping, chain Dives no longer pinned fully in the
+diveProvider keepAlive cache.
+
+## Tasks
+
+1. `DiveTimes` entity + repository slim accessors, TDD:
+   `test/features/dive_log/data/repositories/dive_times_accessors_test.dart`
+   asserting parity with the legacy methods on seeded data (previous-dive id,
+   in-range ids/order, surface interval unchanged, getDiveForAnalysis vs
+   getDiveById on scalars/tanks/profile).
+2. Provider rewiring (analysisDiveProvider + six call-site swaps).
+3. Regression: run the full deco suite (profile_analysis_provider_test,
+   source_profile_analysis_provider_test, weekly_otu_provider_test,
+   cumulative_tissue_test, profile_analysis_loading_race_test,
+   computer_cns_provider_integration_test, profile_analysis_service_test,
+   surface-interval coverage in dive_repository_coverage_test).
+4. Sweep: format, whole-project analyze, mock regen if repository interface
+   changed, commit, push --no-verify, PR.
+
+## Verification gates
+
+- All deco suites green untouched (they pin behavior through the new path).
+- New parity tests green.
+- Analyze clean, format clean.

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -13,6 +13,8 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_times.dart'
+    as domain;
 import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
@@ -2909,32 +2911,7 @@ class DiveRepository {
           computerId: t.computerId,
         );
       }).toList(),
-      profile: profileRows
-          .map(
-            (p) => domain.DiveProfilePoint(
-              timestamp: p.timestamp,
-              depth: p.depth,
-              temperature: p.temperature,
-              heartRate: p.heartRate,
-              heartRateSource: p.heartRateSource,
-              setpoint: p.setpoint,
-              ppO2: p.ppO2,
-              o2Sensor1: p.o2Sensor1,
-              o2Sensor2: p.o2Sensor2,
-              o2Sensor3: p.o2Sensor3,
-              o2Sensor4: p.o2Sensor4,
-              o2Sensor5: p.o2Sensor5,
-              o2Sensor6: p.o2Sensor6,
-              cns: p.cns,
-              ndl: p.ndl,
-              ceiling: p.ceiling,
-              ascentRate: p.ascentRate,
-              rbt: p.rbt,
-              decoType: p.decoType,
-              tts: p.tts,
-            ),
-          )
-          .toList(),
+      profile: profileRows.map(_profilePointFromRow).toList(),
       equipment: equipmentItems,
       weights: weights,
       isFavorite: row.isFavorite,
@@ -3643,21 +3620,26 @@ class DiveRepository {
 
   /// Calculate surface interval between this dive and the previous dive
   /// Returns null if there is no previous dive
+  ///
+  /// Runs on the times-only projection ([getDiveTimes] /
+  /// [getPreviousDiveTimes]) rather than full hydration: the formula needs
+  /// only timestamps and effective runtime, and this method sits on the
+  /// residual-decompression lookback hot path (WS2, large-DB performance).
   Future<Duration?> getSurfaceInterval(String diveId) async {
     try {
-      final currentDive = await getDiveById(diveId);
-      if (currentDive == null) return null;
+      final current = await getDiveTimes(diveId);
+      if (current == null) return null;
 
-      final previousDive = await getPreviousDive(diveId);
-      if (previousDive == null) return null;
+      final previous = await getPreviousDiveTimes(diveId);
+      if (previous == null) return null;
 
       // Calculate interval: from previous dive exit to current dive entry
       final previousExitTime =
-          previousDive.exitTime ??
-          (previousDive.entryTime ?? previousDive.dateTime).add(
-            previousDive.effectiveRuntime ?? Duration.zero,
+          previous.exitTime ??
+          (previous.entryTime ?? previous.dateTime).add(
+            previous.effectiveRuntime ?? Duration.zero,
           );
-      final currentEntryTime = currentDive.entryTime ?? currentDive.dateTime;
+      final currentEntryTime = current.entryTime ?? current.dateTime;
 
       final interval = currentEntryTime.difference(previousExitTime);
       return interval.isNegative ? Duration.zero : interval;
@@ -3668,6 +3650,155 @@ class DiveRepository {
         stackTrace: stackTrace,
       );
       return null;
+    }
+  }
+
+  /// Shared SELECT for the times-only dive projection. The scalar subquery
+  /// carries the profile-derived runtime fallback so
+  /// [DiveTimes.effectiveRuntime] can mirror [domain.Dive.effectiveRuntime]
+  /// without loading profile rows.
+  static const _diveTimesSelect =
+      'SELECT d.id, d.dive_date_time, d.entry_time, d.exit_time, '
+      'd.runtime, d.bottom_time, '
+      '(SELECT MAX(p.timestamp) - MIN(p.timestamp) FROM dive_profiles p '
+      'WHERE p.dive_id = d.id) AS profile_span '
+      'FROM dives d';
+
+  domain.DiveTimes _mapDiveTimesRow(QueryRow row) {
+    final entry = row.readNullable<int>('entry_time');
+    final exit = row.readNullable<int>('exit_time');
+    final runtime = row.readNullable<int>('runtime');
+    final bottom = row.readNullable<int>('bottom_time');
+    final span = row.readNullable<int>('profile_span');
+    return domain.DiveTimes(
+      id: row.read<String>('id'),
+      dateTime: DateTime.fromMillisecondsSinceEpoch(
+        row.read<int>('dive_date_time'),
+        isUtc: true,
+      ),
+      entryTime: entry != null
+          ? DateTime.fromMillisecondsSinceEpoch(entry, isUtc: true)
+          : null,
+      exitTime: exit != null
+          ? DateTime.fromMillisecondsSinceEpoch(exit, isUtc: true)
+          : null,
+      runtime: runtime != null ? Duration(seconds: runtime) : null,
+      bottomTime: bottom != null ? Duration(seconds: bottom) : null,
+      // Matches Dive.calculateRuntimeFromProfile: null unless positive.
+      profileSpan: span != null && span > 0 ? Duration(seconds: span) : null,
+    );
+  }
+
+  /// Times-only projection of one dive: a single SQL statement.
+  Future<domain.DiveTimes?> getDiveTimes(String diveId) async {
+    final rows = await _db
+        .customSelect(
+          '$_diveTimesSelect WHERE d.id = ?',
+          variables: [Variable<String>(diveId)],
+          readsFrom: {_db.dives, _db.diveProfiles},
+        )
+        .get();
+    if (rows.isEmpty) return null;
+    return _mapDiveTimesRow(rows.first);
+  }
+
+  /// Times-only equivalent of [getPreviousDive] (identical predicate and
+  /// ordering), for lookback chains that need only id and timestamps.
+  Future<domain.DiveTimes?> getPreviousDiveTimes(String diveId) async {
+    final current = await getDiveTimes(diveId);
+    if (current == null) return null;
+
+    final cutoff =
+        (current.entryTime ?? current.dateTime).millisecondsSinceEpoch;
+    final rows = await _db
+        .customSelect(
+          '$_diveTimesSelect '
+          'WHERE d.id != ? AND (d.entry_time < ? OR '
+          '(d.entry_time IS NULL AND d.dive_date_time < ?)) '
+          'ORDER BY d.entry_time DESC, d.dive_date_time DESC LIMIT 1',
+          variables: [
+            Variable<String>(diveId),
+            Variable<int>(cutoff),
+            Variable<int>(cutoff),
+          ],
+          readsFrom: {_db.dives, _db.diveProfiles},
+        )
+        .get();
+    if (rows.isEmpty) return null;
+    return _mapDiveTimesRow(rows.first);
+  }
+
+  /// Times-only equivalent of [getDivesInRange] (identical WHERE and
+  /// ordering), for same-day and weekly exposure aggregation.
+  Future<List<domain.DiveTimes>> getDiveTimesInRange(
+    DateTime start,
+    DateTime end, {
+    String? diverId,
+  }) async {
+    final clauses = <String>['d.dive_date_time >= ?', 'd.dive_date_time <= ?'];
+    final args = <Variable<Object>>[
+      Variable<int>(start.millisecondsSinceEpoch),
+      Variable<int>(end.millisecondsSinceEpoch),
+    ];
+    if (diverId != null) {
+      clauses.add('d.diver_id = ?');
+      args.add(Variable<String>(diverId));
+    }
+    final rows = await _db
+        .customSelect(
+          '$_diveTimesSelect WHERE ${clauses.join(' AND ')} '
+          'ORDER BY COALESCE(d.entry_time, d.dive_date_time) DESC, '
+          'd.dive_number DESC',
+          variables: args,
+          readsFrom: {_db.dives, _db.diveProfiles},
+        )
+        .get();
+    return rows.map(_mapDiveTimesRow).toList();
+  }
+
+  /// All profile samples for [diveId] across every source, ordered by
+  /// timestamp (one SQL statement). Matches the shape of `Dive.profile`.
+  Future<List<domain.DiveProfilePoint>> getMergedProfile(String diveId) async {
+    final rows =
+        await (_db.select(_db.diveProfiles)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+            .get();
+    return rows.map(_profilePointFromRow).toList();
+  }
+
+  /// Lean hydration for decompression/exposure analysis: the dive row's
+  /// scalars plus tanks and the merged profile (three SQL statements).
+  /// Joined display entities (site, center, trip, equipment, weights, tags,
+  /// dive types, custom fields) are left at their defaults -- the analysis
+  /// pipeline reads only row scalars, tanks, and profile (see the WS2
+  /// findings doc). Never use the result for display.
+  Future<domain.Dive?> getDiveForAnalysis(String diveId) async {
+    try {
+      final row = await (_db.select(
+        _db.dives,
+      )..where((t) => t.id.equals(diveId))).getSingleOrNull();
+      if (row == null) return null;
+
+      final tankRows =
+          await (_db.select(_db.diveTanks)
+                ..where((t) => t.diveId.equals(diveId))
+                ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+              .get();
+      final profile = await getMergedProfile(diveId);
+
+      return _mapRowToDiveWithPreloadedData(
+        row,
+        tanks: tankRows,
+        equipment: const [],
+      ).copyWith(profile: profile);
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get dive for analysis: $diveId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
     }
   }
 

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3758,6 +3758,16 @@ class DiveRepository {
 
   /// All profile samples for [diveId] across every source, ordered by
   /// timestamp (one SQL statement). Matches the shape of `Dive.profile`.
+  ///
+  /// Deliberately unfiltered, mirroring the `profileRows` query in
+  /// [getDiveById]: [getDiveForAnalysis] must feed the analysis pipeline the
+  /// exact same samples the pre-WS2 `diveProvider` -> `getDiveById` path did,
+  /// which the parity test locks in. This is intentionally NOT the
+  /// `isPrimary`-filtered view used by [getDiveProfile] /
+  /// [getProfilesByDataSource]: for an edited dive it still returns the demoted
+  /// originals alongside the edited rows, exactly as [getDiveById] does. Any
+  /// change to that merge semantics (e.g. dropping demoted originals) must be
+  /// made in both places together, and measured, rather than diverging here.
   Future<List<domain.DiveProfilePoint>> getMergedProfile(String diveId) async {
     final rows =
         await (_db.select(_db.diveProfiles)

--- a/lib/features/dive_log/domain/entities/dive_times.dart
+++ b/lib/features/dive_log/domain/entities/dive_times.dart
@@ -1,0 +1,42 @@
+/// Times-only projection of a dive row, used by the analysis lookback
+/// chains and surface-interval math so they never hydrate full [Dive]
+/// object graphs (large-DB performance program, WS2).
+///
+/// [effectiveRuntime] mirrors `Dive.effectiveRuntime` exactly; the
+/// profile-derived fallback is carried as [profileSpan]
+/// (MAX(timestamp) - MIN(timestamp) of the dive's profile samples, null
+/// unless positive, matching `Dive.calculateRuntimeFromProfile`).
+class DiveTimes {
+  final String id;
+  final DateTime dateTime;
+  final DateTime? entryTime;
+  final DateTime? exitTime;
+  final Duration? runtime;
+  final Duration? bottomTime;
+  final Duration? profileSpan;
+
+  const DiveTimes({
+    required this.id,
+    required this.dateTime,
+    this.entryTime,
+    this.exitTime,
+    this.runtime,
+    this.bottomTime,
+    this.profileSpan,
+  });
+
+  /// Same resolution order as `Dive.effectiveRuntime`:
+  /// runtime, then exit - entry, then profile span, then bottom time.
+  Duration? get effectiveRuntime {
+    if (runtime != null) return runtime;
+
+    if (entryTime != null && exitTime != null) {
+      final computed = exitTime!.difference(entryTime!);
+      if (!computed.isNegative && computed > Duration.zero) return computed;
+    }
+
+    if (profileSpan != null) return profileSpan;
+
+    return bottomTime;
+  }
+}

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -641,15 +641,32 @@ ProfileAnalysis _runProfileAnalysis(_ProfileAnalysisInput input) {
 /// previous dive via [profileAnalysisProvider] (different dive ID), applies
 /// surface-interval decay, and uses the result as startCns. The chain
 /// terminates when there is no previous dive or the surface interval >= 24h.
+/// Lean dive hydration for the analysis pipeline: dive-row scalars, tanks,
+/// and the merged profile only -- no joined display entities (WS2, large-DB
+/// performance). keepAlive family, so a residual-chain walk over a
+/// repetitive dive week hydrates each prior dive once per session instead
+/// of fully re-hydrating on every detail open. Self-invalidates on the
+/// detail-table tick exactly like diveProvider, preserving the analysis
+/// refresh behavior that previously arrived transitively through
+/// diveProvider.
+final analysisDiveProvider = FutureProvider.family<Dive?, String>((
+  ref,
+  diveId,
+) async {
+  final repository = ref.watch(diveRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
+  return repository.getDiveForAnalysis(diveId);
+});
+
 final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>((
   ref,
   diveId,
 ) async {
   try {
     // Await the dive itself (not just its current AsyncValue snapshot). Reading
-    // `diveProvider(id).future` suspends this provider until the dive resolves,
-    // rather than mapping a momentary loading state to a resolved null. The old
-    // `ref.watch(diveProvider(id)).when(loading: () => null)` form committed an
+    // `analysisDiveProvider(id).future` suspends this provider until the dive
+    // resolves, rather than mapping a momentary loading state to a resolved
+    // null. The old `.when(loading: () => null)` form committed an
     // AsyncData(null) whenever the analysis built while the dive was still
     // loading -- which a concurrent evaluator (residual-CNS/tissue/OTU lookback
     // from another dive, or stats aggregation) reliably triggers, especially
@@ -657,7 +674,7 @@ final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>(
     // retained that null and never recomputed until a detail-table write or an
     // app restart, blanking every analysis-derived overlay and the deco/tissue
     // panels in the meantime. Errors surface to the outer catch below.
-    final dive = await ref.watch(diveProvider(diveId).future);
+    final dive = await ref.watch(analysisDiveProvider(diveId).future);
 
     if (dive == null || dive.profile.isEmpty) {
       _log.debug('No profile data for dive $diveId');
@@ -911,7 +928,7 @@ final sourceProfileAnalysisProvider =
             sources.where((s) => s.isPrimary).map((s) => s.id).firstOrNull ??
             sources.first.id;
         final effectiveSourceId = key.sourceId ?? primaryId;
-        final dive = await ref.watch(diveProvider(key.diveId).future);
+        final dive = await ref.watch(analysisDiveProvider(key.diveId).future);
         if (dive == null) return null;
         final profiles = await ref.watch(
           sourceProfilesProvider(key.diveId).future,
@@ -956,19 +973,23 @@ Future<double> _computeResidualCns(Ref ref, String diveId) async {
       return 0.0;
     }
 
-    final previousDive = await repository.getPreviousDive(diveId);
+    final previousDive = await repository.getPreviousDiveTimes(diveId);
     if (previousDive == null) return 0.0;
 
     // Short-circuit: if the legend's CNS source is set to computer and the
     // previous dive has computer CNS, use its last CNS sample directly
-    // instead of full analysis.
+    // instead of full analysis. The profile is fetched only when this
+    // branch is taken (times-only lookup otherwise).
     // Use select() to avoid invalidating on unrelated legend state changes.
     final cnsSource = ref.watch(
       profileLegendProvider.select((s) => s.cnsSource),
     );
     final useComputerCns = cnsSource == MetricDataSource.computer;
     if (useComputerCns) {
-      final prevComputerCns = extractComputerCns(previousDive.profile);
+      final previousProfile = await repository.getMergedProfile(
+        previousDive.id,
+      );
+      final prevComputerCns = extractComputerCns(previousProfile);
       if (prevComputerCns != null) {
         return CnsTable.cnsAfterSurfaceInterval(
           prevComputerCns.cnsEnd,
@@ -1020,7 +1041,7 @@ Future<List<TissueCompartment>?> _computeResidualTissueState(
       return null;
     }
 
-    final previousDive = await repository.getPreviousDive(diveId);
+    final previousDive = await repository.getPreviousDiveTimes(diveId);
     if (previousDive == null) {
       return null;
     }
@@ -1072,8 +1093,8 @@ Future<double> _computeResidualOtu(Ref ref, String diveId) async {
   try {
     final repository = ref.watch(diveRepositoryProvider);
 
-    // Get current dive's date
-    final currentDive = await repository.getDiveById(diveId);
+    // Get current dive's date (times-only projection; WS2)
+    final currentDive = await repository.getDiveTimes(diveId);
     if (currentDive == null) return 0.0;
 
     final diveDate = currentDive.entryTime ?? currentDive.dateTime;
@@ -1085,7 +1106,10 @@ Future<double> _computeResidualOtu(Ref ref, String diveId) async {
     final endOfDay = startOfDay.add(const Duration(days: 1));
 
     // Get all dives on the same day
-    final sameDayDives = await repository.getDivesInRange(startOfDay, endOfDay);
+    final sameDayDives = await repository.getDiveTimesInRange(
+      startOfDay,
+      endOfDay,
+    );
 
     // Sum OTU from dives that occurred BEFORE this one
     double totalOtu = 0.0;
@@ -1164,7 +1188,7 @@ final weeklyOtuProvider = FutureProvider.family<double, String>((
   try {
     final repository = ref.watch(diveRepositoryProvider);
 
-    final currentDive = await repository.getDiveById(diveId);
+    final currentDive = await repository.getDiveTimes(diveId);
     if (currentDive == null) return 0.0;
 
     final diveDate = currentDive.entryTime ?? currentDive.dateTime;
@@ -1175,7 +1199,10 @@ final weeklyOtuProvider = FutureProvider.family<double, String>((
     ).add(const Duration(days: 1));
     final sevenDaysAgo = endOfDay.subtract(const Duration(days: 7));
 
-    final weekDives = await repository.getDivesInRange(sevenDaysAgo, endOfDay);
+    final weekDives = await repository.getDiveTimesInRange(
+      sevenDaysAgo,
+      endOfDay,
+    );
 
     double totalOtu = 0.0;
     for (final dive in weekDives) {

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -635,12 +635,6 @@ ProfileAnalysis _runProfileAnalysis(_ProfileAnalysisInput input) {
   );
 }
 
-/// Provider for profile analysis of a specific dive.
-///
-/// Recursively computes residual CNS from previous dives: looks up the
-/// previous dive via [profileAnalysisProvider] (different dive ID), applies
-/// surface-interval decay, and uses the result as startCns. The chain
-/// terminates when there is no previous dive or the surface interval >= 24h.
 /// Lean dive hydration for the analysis pipeline: dive-row scalars, tanks,
 /// and the merged profile only -- no joined display entities (WS2, large-DB
 /// performance). keepAlive family, so a residual-chain walk over a
@@ -658,6 +652,12 @@ final analysisDiveProvider = FutureProvider.family<Dive?, String>((
   return repository.getDiveForAnalysis(diveId);
 });
 
+/// Provider for profile analysis of a specific dive.
+///
+/// Recursively computes residual CNS from previous dives: looks up the
+/// previous dive via [profileAnalysisProvider] (different dive ID), applies
+/// surface-interval decay, and uses the result as startCns. The chain
+/// terminates when there is no previous dive or the surface interval >= 24h.
 final profileAnalysisProvider = FutureProvider.family<ProfileAnalysis?, String>((
   ref,
   diveId,

--- a/test/features/dive_log/data/repositories/dive_times_accessors_test.dart
+++ b/test/features/dive_log/data/repositories/dive_times_accessors_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+  tearDown(() async => tearDownTestDatabase());
+
+  List<domain.DiveProfilePoint> profileOf(int seconds) => [
+    for (var t = 0; t <= seconds; t += 10)
+      domain.DiveProfilePoint(
+        timestamp: t,
+        depth: t == 0 || t == seconds ? 0 : 18,
+      ),
+  ];
+
+  test('getDiveTimes maps fields and profile span fallback', () async {
+    await repository.createDive(
+      domain.Dive(
+        id: 'a',
+        dateTime: DateTime.utc(2026, 5, 1, 10),
+        entryTime: DateTime.utc(2026, 5, 1, 10, 5),
+        bottomTime: const Duration(minutes: 40),
+        profile: profileOf(600),
+      ),
+    );
+
+    final times = await repository.getDiveTimes('a');
+    expect(times, isNotNull);
+    expect(times!.id, 'a');
+    expect(times.entryTime, DateTime.utc(2026, 5, 1, 10, 5));
+    expect(times.bottomTime, const Duration(minutes: 40));
+    expect(times.profileSpan, const Duration(seconds: 600));
+    // No runtime and no exit time: falls through to the profile span,
+    // mirroring Dive.effectiveRuntime resolution order.
+    expect(times.effectiveRuntime, const Duration(seconds: 600));
+
+    expect(await repository.getDiveTimes('missing'), isNull);
+  });
+
+  test('profile span is null for dives without samples', () async {
+    await repository.createDive(
+      domain.Dive(id: 'bare', dateTime: DateTime.utc(2026, 5, 2, 10)),
+    );
+    final times = await repository.getDiveTimes('bare');
+    expect(times!.profileSpan, isNull);
+    expect(times.effectiveRuntime, isNull);
+  });
+
+  test('getPreviousDiveTimes matches getPreviousDive', () async {
+    await repository.createDive(
+      domain.Dive(id: 'p1', dateTime: DateTime.utc(2026, 5, 1, 9)),
+    );
+    await repository.createDive(
+      domain.Dive(
+        id: 'p2',
+        dateTime: DateTime.utc(2026, 5, 1, 11),
+        entryTime: DateTime.utc(2026, 5, 1, 11, 2),
+      ),
+    );
+    await repository.createDive(
+      domain.Dive(id: 'p3', dateTime: DateTime.utc(2026, 5, 1, 14)),
+    );
+
+    for (final id in ['p2', 'p3']) {
+      final legacy = await repository.getPreviousDive(id);
+      final slim = await repository.getPreviousDiveTimes(id);
+      expect(slim?.id, legacy?.id, reason: 'previous of $id');
+    }
+    expect(await repository.getPreviousDiveTimes('p1'), isNull);
+  });
+
+  test('getDiveTimesInRange matches getDivesInRange ids and order', () async {
+    await repository.createDive(
+      domain.Dive(id: 'r1', dateTime: DateTime.utc(2026, 6, 1, 8)),
+    );
+    await repository.createDive(
+      domain.Dive(
+        id: 'r2',
+        dateTime: DateTime.utc(2026, 6, 1, 12),
+        entryTime: DateTime.utc(2026, 6, 1, 12, 30),
+      ),
+    );
+    await repository.createDive(
+      domain.Dive(id: 'r3', dateTime: DateTime.utc(2026, 6, 2, 9)),
+    );
+    await repository.createDive(
+      domain.Dive(id: 'outside', dateTime: DateTime.utc(2026, 6, 9, 9)),
+    );
+
+    final start = DateTime.utc(2026, 6, 1);
+    final end = DateTime.utc(2026, 6, 3);
+    final legacy = await repository.getDivesInRange(start, end);
+    final slim = await repository.getDiveTimesInRange(start, end);
+
+    expect(slim.map((t) => t.id).toList(), legacy.map((d) => d.id).toList());
+    expect(slim.map((t) => t.id), isNot(contains('outside')));
+  });
+
+  test('getSurfaceInterval semantics unchanged', () async {
+    // Previous dive: entry 10:00, runtime 60m -> exit 11:00.
+    await repository.createDive(
+      domain.Dive(
+        id: 's1',
+        dateTime: DateTime.utc(2026, 6, 1, 10),
+        entryTime: DateTime.utc(2026, 6, 1, 10),
+        runtime: const Duration(minutes: 60),
+      ),
+    );
+    // Current dive: entry 13:00 -> surface interval 2h.
+    await repository.createDive(
+      domain.Dive(
+        id: 's2',
+        dateTime: DateTime.utc(2026, 6, 1, 13),
+        entryTime: DateTime.utc(2026, 6, 1, 13),
+      ),
+    );
+
+    expect(await repository.getSurfaceInterval('s2'), const Duration(hours: 2));
+    expect(await repository.getSurfaceInterval('s1'), isNull);
+  });
+
+  test('surface interval uses profile span when runtime absent', () async {
+    // Previous dive has no runtime/exit; 600 s profile -> exit 10:10.
+    await repository.createDive(
+      domain.Dive(
+        id: 'ps1',
+        dateTime: DateTime.utc(2026, 7, 1, 10),
+        entryTime: DateTime.utc(2026, 7, 1, 10),
+        profile: profileOf(600),
+      ),
+    );
+    await repository.createDive(
+      domain.Dive(
+        id: 'ps2',
+        dateTime: DateTime.utc(2026, 7, 1, 11),
+        entryTime: DateTime.utc(2026, 7, 1, 11),
+      ),
+    );
+
+    expect(
+      await repository.getSurfaceInterval('ps2'),
+      const Duration(minutes: 50),
+    );
+  });
+
+  test('getDiveForAnalysis matches getDiveById on analysis fields', () async {
+    await repository.createDive(
+      domain.Dive(
+        id: 'g1',
+        dateTime: DateTime.utc(2026, 7, 1, 10),
+        gradientFactorLow: 45,
+        gradientFactorHigh: 80,
+        altitude: 300.0,
+        profile: profileOf(300),
+      ),
+    );
+
+    final full = await repository.getDiveById('g1');
+    final lean = await repository.getDiveForAnalysis('g1');
+
+    expect(lean, isNotNull);
+    expect(lean!.id, full!.id);
+    expect(lean.gradientFactorLow, full.gradientFactorLow);
+    expect(lean.gradientFactorHigh, full.gradientFactorHigh);
+    expect(lean.altitude, full.altitude);
+    expect(lean.diveMode, full.diveMode);
+    expect(lean.entryTime, full.entryTime);
+    expect(lean.dateTime, full.dateTime);
+    expect(lean.tanks.length, full.tanks.length);
+    expect(lean.profile.length, full.profile.length);
+    expect(lean.profile.first.depth, full.profile.first.depth);
+    expect(lean.profile.last.timestamp, full.profile.last.timestamp);
+    // Display joins deliberately not hydrated on the lean path.
+    expect(lean.tags, isEmpty);
+    expect(lean.equipment, isEmpty);
+  });
+}

--- a/test/features/dive_log/presentation/providers/source_profile_analysis_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/source_profile_analysis_provider_test.dart
@@ -120,7 +120,7 @@ void main() {
         sharedPreferencesProvider.overrideWithValue(_prefs),
         diverRepositoryProvider.overrideWithValue(_FakeDiverRepository()),
         settingsProvider.overrideWith((ref) => _SettingsNotifier(ref)),
-        diveProvider('dive-1').overrideWith((ref) async => dive),
+        analysisDiveProvider('dive-1').overrideWith((ref) async => dive),
         diveDataSourcesProvider('dive-1').overrideWith(
           (ref) async => [
             source('src-a', 'dc-a', true),
@@ -178,7 +178,7 @@ void main() {
         sharedPreferencesProvider.overrideWithValue(_prefs),
         diverRepositoryProvider.overrideWithValue(_FakeDiverRepository()),
         settingsProvider.overrideWith((ref) => _SettingsNotifier(ref)),
-        diveProvider('dive-1').overrideWith((ref) async => dive),
+        analysisDiveProvider('dive-1').overrideWith((ref) async => dive),
         diveDataSourcesProvider(
           'dive-1',
         ).overrideWith((ref) async => [source('src-a', 'dc-a', true)]),


### PR DESCRIPTION
## Summary

WS2 of the large-database performance program (spec:
`docs/superpowers/specs/2026-07-10-large-db-performance-design.md`; plan in
this branch). Targets the ~11 s of main-isolate CPU measured (profile mode,
1,032-dive DB) when opening a dense dive's detail page.

**Root cause (agent-verified wiring, recorded in the findings doc):** the
residual CNS/tissue/OTU lookback chains and the weekly OTU rollup hydrate
every prior dive in their windows as a FULL `Dive` — several times over. Per
chain dive: `profileAnalysisProvider` -> `diveProvider` -> `getDiveById`
(~11 statements + full joined-entity mapping), `getSurfaceInterval` fully
hydrates BOTH its dives, `getPreviousDive` hydrates two more. On a
repetitive dive week that is dozens of full hydrations per detail open —
the profiler showed 23.7% raw allocation plus dynamic-dispatch type-check
churn.

**Change (the Buhlmann/exposure math is untouched):**
- New `DiveTimes` projection (id + timestamps + runtime fields +
  `profileSpan`) whose `effectiveRuntime` mirrors `Dive.effectiveRuntime`
  exactly — including the profile-derived fallback, carried as a SQL
  `MAX(timestamp)-MIN(timestamp)` scalar subquery so no profile rows load.
- New slim accessors: `getDiveTimes`, `getPreviousDiveTimes`,
  `getDiveTimesInRange` (predicates/ordering copied from the legacy
  methods), `getMergedProfile`, and `getDiveForAnalysis` (dive-row scalars +
  tanks + merged profile, 3 statements; display joins deliberately empty —
  the analysis pipeline provably reads only scalars/tanks/profile).
- `getSurfaceInterval` reimplemented on the projection (public signature
  and formula unchanged; ~22 statements -> 3 per call).
- New keepAlive `analysisDiveProvider` (with its own
  `invalidateSelfWhen(watchDiveDetailChanges())`, preserving refresh
  behavior); `profileAnalysisProvider` and `sourceProfileAnalysisProvider`
  consume it instead of full `diveProvider`. Chain dives are no longer
  pinned as full Dives in the keepAlive cache.
- Residual chains + weekly OTU switch to the slim accessors; the
  computer-CNS branch fetches the previous dive's profile only when taken.
- Drive-by DRY: `_mapRowToDive`'s inline profile mapping now uses the shared
  `_profilePointFromRow`.

**Cost per chain dive: ~5 full hydrations -> 7 slim statements**, no
joined-entity mapping.

**Recorded scope deviation:** the spec's "exactly one dive_profiles query
per open" is amended — post-WS0 an indexed per-dive profile read costs
~4 ms, and true dedup needs source attribution added to `DiveProfilePoint`
(three mapper sites, wide constructor surface). Not justified by
measurement; revisit only if the post-WS2 profile shows it mattering.

## Test plan

- New `dive_times_accessors_test.dart` (7 tests): field/span mapping,
  previous-dive and in-range parity against the legacy methods, surface
  interval semantics incl. the profile-span fallback, `getDiveForAnalysis`
  vs `getDiveById` on every analysis-relevant field.
- Full deco regression sweep green (152 tests): profile_analysis_provider,
  source_profile_analysis_provider (overrides retargeted to
  `analysisDiveProvider`), weekly_otu, cumulative_tissue,
  loading-race, computer-CNS integration, analysis service, repository
  coverage + main repository suite.
- Whole-project `flutter analyze`: no issues; `dart format .`: clean.
- Residual: interactive re-profile of dive #1006 rides the next user
  session.