### PR TITLE
perf(chart): decimate analysis curves and scope the series cache (WS3)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-ws3-chart-decimation.md
+++ b/docs/superpowers/plans/2026-07-10-ws3-chart-decimation.md
@@ -1,0 +1,69 @@
+# WS3: Chart Decimation + Scoped Series Cache Implementation Plan
+
+> Executed inline (executing-plans) in worktree `.claude/worktrees/ws3-chart`,
+> branch `worktree-ws3-chart`.
+
+**Goal:** Ceiling-source toggles measured at ~0.85 s main-isolate CPU each
+(profile mode, dive 1006, 4,762 samples; Skia dash-path measurement +
+full series rebuild). Target < 200 ms by (a) rendering decimated series
+(~2,000 points budget) everywhere the full profile is drawn today, and
+(b) scoping the series cache so an analysis-curve change no longer rebuilds
+the base depth/temperature/pressure series.
+
+**Spec:** WS3 in `2026-07-10-large-db-performance-design.md`; evidence in
+the findings doc (SkContourMeasure::getSegment + series-rebuild allocation).
+
+## Design
+
+1. **Shared decimation projection.** `decimateProfileIndices` (existing,
+   tested, feature-preserving: depth envelope, max-depth spike, ascent-band
+   crossings, decoType transitions) produces the kept ORIGINAL indices for
+   the active profile. All parallel per-sample arrays (the 14 analysis
+   curves, ascentRates) are projected through the same indices, so every
+   series stays index-aligned. State fields `_dProfile`, `_dAscentRates`,
+   `_dCeilingCurve`, ... hold the projections; series builders read them
+   instead of `widget.*`. Tooltip/touch code keeps reading the ORIGINAL
+   `widget.profile` (it already remaps touched spots by timestamp, which is
+   decimation-compatible).
+2. **Zoom-aware, quantized.** The projection covers the visible X window
+   expanded by half a window on each side, at the full point budget. The
+   viewport enters the cache signatures as a BUCKET (half-octave zoom steps,
+   quarter-window pan steps): within a bucket, zoom/pan stays a pure cache
+   hit exactly as today; crossing a bucket re-decimates (~ms at 2k points).
+   Unzoomed charts use the whole range ('full' bucket). Deep zoom therefore
+   converges to original resolution (window shrinks, budget constant).
+3. **Scoped cache.** `ChartSeriesCache` gains per-key signatures
+   (`series(key, signature, build)`); the single `'main'` assembly splits
+   into four order-preserving groups:
+   - `base`: depth (gas/velocity variants), gas-switch markers,
+     temperature, tank pressures, heart rate, SAC, ascent-rate line.
+   - `analysis`: ceiling, NDL, ppO2/ppN2/ppHe, MOD, density, GF, surface
+     GF, mean depth, TTS, CNS, OTU (everything fed by analysis curves).
+   - `markers`: profile marker lines.
+   - `overlays`: comparison-source overlays (kept LAST, preserving the
+     depth-bar leading-index invariant).
+   A ceiling-source toggle re-emits analysis curves -> only `analysis`
+   (and nothing else) rebuilds, over decimated points.
+4. **Overlays decimated** per overlay source with the same helper (depth /
+   temperature / ceiling / NDL series per overlay).
+5. Tank-pressure series are NOT decimated (independent sparse timestamps,
+   NaN-guard logic untouched; not implicated by measurement).
+
+## Tasks
+
+1. `ChartSeriesCache` per-key signatures + unit tests (extend existing
+   test file if present, else create).
+2. `DecimatedProfileView` helper (slice by visible fraction + decimate +
+   project parallel arrays) + unit tests (budget respected, max-depth kept,
+   slice covers expanded window, identity when under budget).
+3. Chart surgery: projection state fields, four-group cache assembly with
+   per-group signatures (viewport bucket included), builder bodies swapped
+   to `_d*` fields.
+4. Regression: chart-related test files + whole-project analyze/format.
+5. Commit, push --no-verify, PR.
+
+## Verification gates
+
+- Existing chart/velocity/tooltip tests green.
+- New cache + decimation tests green.
+- Analyze/format clean.

--- a/lib/features/dive_log/presentation/widgets/chart_series_cache.dart
+++ b/lib/features/dive_log/presentation/widgets/chart_series_cache.dart
@@ -1,22 +1,22 @@
-/// Memoizes a chart's series lists by key. The whole cache is dropped whenever
-/// the data signature changes (data, units, visibility, or theme); within one
-/// signature, rebuilds driven purely by interaction state (playback ticks,
-/// hover, zoom) are pure cache hits and never reconstruct the series. A
-/// visibility (legend) or theme change is part of the signature and so does
-/// rebuild.
+/// Memoizes a chart's series lists by key, with a per-key data signature.
+///
+/// Within one signature a key's rebuilds -- driven purely by interaction
+/// state (playback ticks, hover, zoom inside the same decimation bucket) --
+/// are pure cache hits and never reconstruct the series. When a key's
+/// signature changes (its data, units, visibility, viewport bucket, or
+/// theme), ONLY that key rebuilds: an analysis-curve re-emission (for
+/// example a ceiling-source toggle) leaves the depth/temperature/pressure
+/// series untouched (WS3, large-DB performance).
 class ChartSeriesCache<T> {
-  final Map<String, List<T>> _cache = {};
-  String? _signature;
+  final Map<String, ({String signature, List<T> series})> _cache = {};
 
-  /// Drops all cached series if [dataSignature] differs from the last one.
-  void invalidate(String dataSignature) {
-    if (dataSignature != _signature) {
-      _cache.clear();
-      _signature = dataSignature;
-    }
+  /// Returns the cached series for [key] when [signature] matches the last
+  /// build; otherwise builds once via [build] and caches the result.
+  List<T> series(String key, String signature, List<T> Function() build) {
+    final hit = _cache[key];
+    if (hit != null && hit.signature == signature) return hit.series;
+    final built = build();
+    _cache[key] = (signature: signature, series: built);
+    return built;
   }
-
-  /// Returns the cached series for [key], building once via [build] on a miss.
-  List<T> series(String key, List<T> Function() build) =>
-      _cache[key] ??= build();
 }

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/dive_log/domain/entities/profile_event.dart'
 import 'package:submersion/features/dive_log/presentation/providers/profile_legend_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/chart_series_cache.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_legend.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_decimator.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_colors.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
@@ -805,46 +806,118 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   final ChartSeriesCache<LineChartBarData> _barsCache =
       ChartSeriesCache<LineChartBarData>();
 
-  /// Identity of everything the assembled bars depend on. Excludes playback,
-  /// viewport, highlight, and tooltip state -- those drive separate overlays and
-  /// never change the bars. [legendState] is taken as [Object] since only its
-  /// identity (changed on any visibility toggle) matters here. [colorScheme] is
-  /// hashed by value (not just its [Brightness]) so switching between two
-  /// presets of the same brightness -- which recolours series such as the
-  /// tertiary temperature line -- still invalidates the cached bars.
-  String _barsSignature(
-    UnitFormatter units,
-    Object legendState,
-    ColorScheme colorScheme,
-  ) => [
-    identityHashCode(widget.profile),
-    identityHashCode(widget.ascentRates),
-    identityHashCode(widget.ceilingCurve),
-    identityHashCode(widget.ndlCurve),
-    identityHashCode(widget.sacCurve),
-    identityHashCode(widget.ppO2Curve),
-    identityHashCode(widget.ppN2Curve),
-    identityHashCode(widget.ppHeCurve),
-    identityHashCode(widget.modCurve),
-    identityHashCode(widget.densityCurve),
-    identityHashCode(widget.gfCurve),
-    identityHashCode(widget.surfaceGfCurve),
-    identityHashCode(widget.meanDepthCurve),
-    identityHashCode(widget.ttsCurve),
-    identityHashCode(widget.cnsCurve),
-    identityHashCode(widget.otuCurve),
-    identityHashCode(widget.tankPressures),
-    identityHashCode(widget.overlays),
-    identityHashCode(widget.gasSwitches),
-    identityHashCode(widget.tanks),
-    identityHashCode(widget.markers),
-    identityHashCode(legendState),
-    units.depthSymbol,
-    units.temperatureSymbol,
-    units.pressureSymbol,
-    units.sacSymbol,
-    colorScheme.hashCode,
-  ].join('|');
+  // Per-group cache signatures, computed once per build in the legend-sync
+  // pass and consumed by the chart assembly (see _barsCache).
+  String _baseSig = '';
+  String _sacSig = '';
+  String _ascentSig = '';
+  String _analysisSig = '';
+  String _markersSig = '';
+  String _overlaysSig = '';
+
+  /// Joins signature parts for [_barsCache] group keys. Each group's
+  /// signature covers exactly the inputs its series read, so changing one
+  /// group's data (analysis curves, overlays) leaves the others cached.
+  /// [ColorScheme.hashCode] is by value (not just [Brightness]) so switching
+  /// between two presets of the same brightness still invalidates. Playback,
+  /// highlight, and tooltip state are deliberately excluded.
+  String _sigOf(List<Object?> parts) => parts.join('|');
+
+  /// Fixed point budget per analysis-curve series (WS3, large-DB
+  /// performance). Depth/touch series are never decimated: tooltips,
+  /// scrubbing, and velocity-band suppression all key off the depth bars at
+  /// full resolution.
+  static const int _curvePointBudget = 2000;
+
+  /// Decimation bucket for the current viewport. Within one bucket, zoomed
+  /// pans/zooms stay pure cache hits (as unzoomed interaction always has
+  /// been); crossing a half-octave zoom step or a quarter-window pan
+  /// re-decimates the analysis curves over the newly visible window, so
+  /// deep zoom converges back to full sample resolution.
+  String _viewportDecimationBucket() {
+    if (!_viewport.isZoomed) return 'full';
+    final zoomBucket = (math.log(_viewport.zoom) / math.ln2 * 2).round();
+    final panBucket = (_viewport.offsetX * _viewport.zoom * 4).round();
+    return 'z$zoomBucket-p$panBucket';
+  }
+
+  /// Indices of [values] (parallel to [widget.profile]) to render: clipped
+  /// to the visible window expanded by half a window on each side, then
+  /// decimated to [_curvePointBudget] preserving the value envelope
+  /// (min/max per bucket, global extreme, endpoints).
+  List<int> _decimatedCurveIndices(List<num> values) {
+    final n = math.min(widget.profile.length, values.length);
+    if (n == 0) return const [];
+    var start = 0;
+    var end = n;
+    if (_viewport.isZoomed) {
+      final t0 = widget.profile.first.timestamp;
+      final span = (widget.profile[n - 1].timestamp - t0).toDouble();
+      if (span > 0) {
+        final w = _viewport.visibleWidth;
+        final loT = t0 + span * (_viewport.offsetX - w / 2);
+        final hiT = t0 + span * (_viewport.offsetX + w * 1.5);
+        start = _firstProfileIndexAtOrAfter(loT, n);
+        end = _lastProfileIndexAtOrBefore(hiT, n) + 1;
+        if (end - start < 2) {
+          start = 0;
+          end = n;
+        }
+      }
+    }
+    final kept = decimateSeriesIndices([
+      for (var i = start; i < end; i++) values[i].toDouble(),
+    ], targetPoints: _curvePointBudget);
+    if (start == 0) return kept;
+    return [for (final k in kept) k + start];
+  }
+
+  int _firstProfileIndexAtOrAfter(double t, int n) {
+    var lo = 0;
+    var hi = n - 1;
+    var ans = 0;
+    while (lo <= hi) {
+      final mid = (lo + hi) >> 1;
+      if (widget.profile[mid].timestamp >= t) {
+        ans = mid;
+        hi = mid - 1;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return ans;
+  }
+
+  int _lastProfileIndexAtOrBefore(double t, int n) {
+    var lo = 0;
+    var hi = n - 1;
+    var ans = n - 1;
+    while (lo <= hi) {
+      final mid = (lo + hi) >> 1;
+      if (widget.profile[mid].timestamp <= t) {
+        ans = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return ans;
+  }
+
+  /// Overlay variant of [_decimatedCurveIndices]: indices into [points]
+  /// selected by the envelope of [value]. Overlay series are decimated by
+  /// budget only (their timestamps live on their own domain).
+  List<int> _decimatedOverlayIndices(
+    List<DiveProfilePoint> points,
+    double Function(DiveProfilePoint) value,
+  ) {
+    if (points.length <= _curvePointBudget) {
+      return List<int>.generate(points.length, (i) => i);
+    }
+    return decimateSeriesIndices([
+      for (final p in points) value(p),
+    ], targetPoints: _curvePointBudget);
+  }
 
   @override
   void initState() {
@@ -1446,9 +1519,52 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       _showTankPressure[entry.key] = entry.value;
     }
 
-    // Drop the memoized bars only when their inputs change; playback / hover /
-    // zoom rebuilds keep the same signature and reuse the assembled series.
-    _barsCache.invalidate(_barsSignature(units, legendState, colorScheme));
+    // Per-group signatures for the memoized bars (see _barsCache): playback /
+    // hover / zoom rebuilds inside one decimation bucket reuse every group;
+    // an analysis-curve re-emission (e.g. a ceiling-source toggle) rebuilds
+    // only the analysis group over decimated points.
+    final vpBucket = _viewportDecimationBucket();
+    final commonSig = _sigOf([
+      identityHashCode(widget.profile),
+      identityHashCode(legendState),
+      units.depthSymbol,
+      units.temperatureSymbol,
+      units.pressureSymbol,
+      units.sacSymbol,
+      colorScheme.hashCode,
+    ]);
+    _baseSig = _sigOf([
+      commonSig,
+      identityHashCode(widget.ascentRates),
+      identityHashCode(widget.gasSwitches),
+      identityHashCode(widget.tanks),
+      identityHashCode(widget.tankPressures),
+    ]);
+    _sacSig = _sigOf([commonSig, identityHashCode(widget.sacCurve), vpBucket]);
+    _ascentSig = _sigOf([commonSig, identityHashCode(widget.ascentRates)]);
+    _analysisSig = _sigOf([
+      commonSig,
+      identityHashCode(widget.ceilingCurve),
+      identityHashCode(widget.ndlCurve),
+      identityHashCode(widget.ppO2Curve),
+      identityHashCode(widget.ppN2Curve),
+      identityHashCode(widget.ppHeCurve),
+      identityHashCode(widget.modCurve),
+      identityHashCode(widget.densityCurve),
+      identityHashCode(widget.gfCurve),
+      identityHashCode(widget.surfaceGfCurve),
+      identityHashCode(widget.meanDepthCurve),
+      identityHashCode(widget.ttsCurve),
+      identityHashCode(widget.cnsCurve),
+      identityHashCode(widget.otuCurve),
+      vpBucket,
+    ]);
+    _markersSig = _sigOf([
+      commonSig,
+      identityHashCode(widget.markers),
+      identityHashCode(widget.tankPressures),
+    ]);
+    _overlaysSig = _sigOf([commonSig, identityHashCode(widget.overlays)]);
 
     // Check data availability for advanced curves
     final hasNdlData = widget.ndlCurve != null && widget.ndlCurve!.isNotEmpty;
@@ -2123,119 +2239,174 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               show: true,
               border: Border.all(color: colorScheme.outlineVariant),
             ),
+            // Bar order is invariant: depth bars first (velocity suppression
+            // and tooltip resolution key off the leading barIndex range),
+            // overlays last (see _depthBarCount). The groups scope cache
+            // invalidation; the combined key memoizes the concatenation so a
+            // playback-only rebuild returns the identical outer list (fl_chart
+            // listEquals short-circuits on identity).
             lineBarsData: _barsCache.series(
-              'main',
+              'combined',
+              _sigOf([
+                _baseSig,
+                _sacSig,
+                _ascentSig,
+                _analysisSig,
+                _markersSig,
+                _overlaysSig,
+              ]),
               () => [
-                // Depth line segments (colored by active gas if gas switches exist)
-                ..._buildGasColoredDepthLines(colorScheme, units),
+                ..._barsCache.series(
+                  'base',
+                  _baseSig,
+                  () => [
+                    // Depth line segments (colored by active gas if present)
+                    ..._buildGasColoredDepthLines(colorScheme, units),
 
-                // Gas switch markers (if showing and data available)
-                if (_showGasSwitchMarkers) ..._buildGasSwitchMarkers(units),
+                    // Gas switch markers (if showing and data available)
+                    if (_showGasSwitchMarkers) ..._buildGasSwitchMarkers(units),
 
-                // Temperature line(s) (if showing) — one per visible computer
-                // when multi-computer profiles are present, else a single
-                // curve from the primary profile.
-                if (_showTemperature &&
-                    hasTemperatureData &&
-                    minTemp != null &&
-                    maxTemp != null)
-                  ..._buildTemperatureLines(
-                    colorScheme,
-                    totalMaxDepth,
-                    minTemp,
-                    maxTemp,
-                    units,
-                  ),
+                    // Temperature line(s) (if showing) — one per visible
+                    // computer when multi-computer profiles are present, else
+                    // a single curve from the primary profile.
+                    if (_showTemperature &&
+                        hasTemperatureData &&
+                        minTemp != null &&
+                        maxTemp != null)
+                      ..._buildTemperatureLines(
+                        colorScheme,
+                        totalMaxDepth,
+                        minTemp,
+                        maxTemp,
+                        units,
+                      ),
 
-                // Multi-tank pressure lines (per-tank visibility controlled
-                // inside _buildMultiTankPressureLines via _showTankPressure)
-                if (_hasMultiTankPressure)
-                  ..._buildMultiTankPressureLines(totalMaxDepth),
+                    // Multi-tank pressure lines (per-tank visibility controlled
+                    // inside _buildMultiTankPressureLines via _showTankPressure)
+                    if (_hasMultiTankPressure)
+                      ..._buildMultiTankPressureLines(totalMaxDepth),
 
-                // Heart rate line (if showing)
-                if (_showHeartRate &&
-                    hasHeartRateData &&
-                    minHR != null &&
-                    maxHR != null)
-                  _buildHeartRateLine(
-                    heartRateColor,
-                    totalMaxDepth,
-                    minHR,
-                    maxHR,
-                  ),
-
-                // SAC curve line (if showing)
-                if (_showSac && hasSacData && minSac != null && maxSac != null)
-                  _buildSacLine(totalMaxDepth, minSac, maxSac),
-
-                // Ascent-rate magnitude line (separate overlay; signed m/min)
-                if (_showAscentRateLine && widget.ascentRates != null)
-                  _buildAscentRateLine(totalMaxDepth),
-
-                // Ceiling line (if showing and data available)
-                if (_showCeiling && widget.ceilingCurve != null)
-                  _buildCeilingLine(units),
-
-                // NDL line (if showing)
-                if (_showNdl && widget.ndlCurve != null)
-                  _buildNdlLine(totalMaxDepth),
-
-                // ppO2 line (if showing)
-                if (_showPpO2 && widget.ppO2Curve != null)
-                  _buildPpO2Line(totalMaxDepth),
-
-                // ppN2 line (if showing)
-                if (_showPpN2 && widget.ppN2Curve != null)
-                  _buildPpN2Line(totalMaxDepth),
-
-                // ppHe line (if showing and has helium data)
-                if (_showPpHe &&
-                    widget.ppHeCurve != null &&
-                    widget.ppHeCurve!.any((v) => v > 0.001))
-                  _buildPpHeLine(totalMaxDepth),
-
-                // MOD line (if showing)
-                if (_showMod && widget.modCurve != null) _buildModLine(units),
-
-                // Gas density line (if showing)
-                if (_showDensity && widget.densityCurve != null)
-                  _buildDensityLine(totalMaxDepth),
-
-                // GF% line (if showing)
-                if (_showGf && widget.gfCurve != null)
-                  _buildGfLine(totalMaxDepth),
-
-                // Surface GF line (if showing)
-                if (_showSurfaceGf && widget.surfaceGfCurve != null)
-                  _buildSurfaceGfLine(totalMaxDepth),
-
-                // Mean depth line (if showing)
-                if (_showMeanDepth && widget.meanDepthCurve != null)
-                  _buildMeanDepthLine(units),
-
-                // TTS line (if showing)
-                if (_showTts && widget.ttsCurve != null)
-                  _buildTtsLine(totalMaxDepth),
-
-                // CNS% curve (if showing)
-                if (_showCns && widget.cnsCurve != null)
-                  _buildCnsLine(totalMaxDepth),
-
-                // OTU curve (if showing)
-                if (_showOtu && widget.otuCurve != null)
-                  _buildOtuLine(totalMaxDepth),
-
-                // Profile markers (max depth, pressure thresholds)
-                ..._buildMarkerLines(
-                  units,
-                  totalMaxDepth,
-                  minPressure: minPressure,
-                  maxPressure: maxPressure,
+                    // Heart rate line (if showing)
+                    if (_showHeartRate &&
+                        hasHeartRateData &&
+                        minHR != null &&
+                        maxHR != null)
+                      _buildHeartRateLine(
+                        heartRateColor,
+                        totalMaxDepth,
+                        minHR,
+                        maxHR,
+                      ),
+                  ],
                 ),
+                ..._barsCache.series(
+                  'sac',
+                  _sacSig,
+                  () => [
+                    // SAC curve line (if showing)
+                    if (_showSac &&
+                        hasSacData &&
+                        minSac != null &&
+                        maxSac != null)
+                      _buildSacLine(totalMaxDepth, minSac, maxSac),
+                  ],
+                ),
+                ..._barsCache.series(
+                  'ascent',
+                  _ascentSig,
+                  () => [
+                    // Ascent-rate magnitude line (separate overlay; signed
+                    // m/min)
+                    if (_showAscentRateLine && widget.ascentRates != null)
+                      _buildAscentRateLine(totalMaxDepth),
+                  ],
+                ),
+                ..._barsCache.series(
+                  'analysis',
+                  _analysisSig,
+                  () => [
+                    // Ceiling line (if showing and data available)
+                    if (_showCeiling && widget.ceilingCurve != null)
+                      _buildCeilingLine(units),
 
-                // Overlaid comparison sources — LAST, so depth bars keep
-                // occupying the leading barIndex range (see _depthBarCount).
-                ..._buildOverlayLines(units, totalMaxDepth, minTemp, maxTemp),
+                    // NDL line (if showing)
+                    if (_showNdl && widget.ndlCurve != null)
+                      _buildNdlLine(totalMaxDepth),
+
+                    // ppO2 line (if showing)
+                    if (_showPpO2 && widget.ppO2Curve != null)
+                      _buildPpO2Line(totalMaxDepth),
+
+                    // ppN2 line (if showing)
+                    if (_showPpN2 && widget.ppN2Curve != null)
+                      _buildPpN2Line(totalMaxDepth),
+
+                    // ppHe line (if showing and has helium data)
+                    if (_showPpHe &&
+                        widget.ppHeCurve != null &&
+                        widget.ppHeCurve!.any((v) => v > 0.001))
+                      _buildPpHeLine(totalMaxDepth),
+
+                    // MOD line (if showing)
+                    if (_showMod && widget.modCurve != null)
+                      _buildModLine(units),
+
+                    // Gas density line (if showing)
+                    if (_showDensity && widget.densityCurve != null)
+                      _buildDensityLine(totalMaxDepth),
+
+                    // GF% line (if showing)
+                    if (_showGf && widget.gfCurve != null)
+                      _buildGfLine(totalMaxDepth),
+
+                    // Surface GF line (if showing)
+                    if (_showSurfaceGf && widget.surfaceGfCurve != null)
+                      _buildSurfaceGfLine(totalMaxDepth),
+
+                    // Mean depth line (if showing)
+                    if (_showMeanDepth && widget.meanDepthCurve != null)
+                      _buildMeanDepthLine(units),
+
+                    // TTS line (if showing)
+                    if (_showTts && widget.ttsCurve != null)
+                      _buildTtsLine(totalMaxDepth),
+
+                    // CNS% curve (if showing)
+                    if (_showCns && widget.cnsCurve != null)
+                      _buildCnsLine(totalMaxDepth),
+
+                    // OTU curve (if showing)
+                    if (_showOtu && widget.otuCurve != null)
+                      _buildOtuLine(totalMaxDepth),
+                  ],
+                ),
+                ..._barsCache.series(
+                  'markers',
+                  _markersSig,
+                  () => [
+                    // Profile markers (max depth, pressure thresholds)
+                    ..._buildMarkerLines(
+                      units,
+                      totalMaxDepth,
+                      minPressure: minPressure,
+                      maxPressure: maxPressure,
+                    ),
+                  ],
+                ),
+                ..._barsCache.series(
+                  'overlays',
+                  _overlaysSig,
+                  () => [
+                    // Overlaid comparison sources — LAST, so depth bars keep
+                    // occupying the leading barIndex range (_depthBarCount).
+                    ..._buildOverlayLines(
+                      units,
+                      totalMaxDepth,
+                      minTemp,
+                      maxTemp,
+                    ),
+                  ],
+                ),
               ],
             ),
             extraLinesData: ExtraLinesData(
@@ -3352,12 +3523,19 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     for (final overlay in overlays) {
       if (overlay.points.isEmpty) continue;
 
-      // Depth: dashed, no fill.
+      // Depth: dashed, no fill. Decimated on the depth envelope (WS3).
+      final depthKeep = _decimatedOverlayIndices(
+        overlay.points,
+        (p) => p.depth,
+      );
       lines.add(
         LineChartBarData(
           spots: [
-            for (final p in overlay.points)
-              FlSpot(p.timestamp.toDouble(), -units.convertDepth(p.depth)),
+            for (final i in depthKeep)
+              FlSpot(
+                overlay.points[i].timestamp.toDouble(),
+                -units.convertDepth(overlay.points[i].depth),
+              ),
           ],
           isCurved: true,
           curveSmoothness: 0.2,
@@ -3376,14 +3554,18 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             .where((p) => p.temperature != null)
             .toList();
         if (tempPoints.isNotEmpty) {
+          final tempKeep = _decimatedOverlayIndices(
+            tempPoints,
+            (p) => p.temperature!,
+          );
           lines.add(
             LineChartBarData(
               spots: [
-                for (final p in tempPoints)
+                for (final i in tempKeep)
                   FlSpot(
-                    p.timestamp.toDouble(),
+                    tempPoints[i].timestamp.toDouble(),
                     -_mapTempToDepth(
-                      units.convertTemperature(p.temperature!),
+                      units.convertTemperature(tempPoints[i].temperature!),
                       chartMaxDepth,
                       minTemp,
                       maxTemp,
@@ -3404,15 +3586,23 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
       // Computer-reported ceiling, mapped like the active ceiling line.
       if (_showCeiling) {
-        final ceilingSpots = [
-          for (final p in overlay.points)
-            if (p.ceiling != null && p.ceiling! > 0)
-              FlSpot(p.timestamp.toDouble(), -units.convertDepth(p.ceiling!)),
-        ];
-        if (ceilingSpots.isNotEmpty) {
+        final ceilingPoints = overlay.points
+            .where((p) => p.ceiling != null && p.ceiling! > 0)
+            .toList();
+        if (ceilingPoints.isNotEmpty) {
+          final ceilingKeep = _decimatedOverlayIndices(
+            ceilingPoints,
+            (p) => p.ceiling!,
+          );
           lines.add(
             LineChartBarData(
-              spots: ceilingSpots,
+              spots: [
+                for (final i in ceilingKeep)
+                  FlSpot(
+                    ceilingPoints[i].timestamp.toDouble(),
+                    -units.convertDepth(ceilingPoints[i].ceiling!),
+                  ),
+              ],
               isCurved: true,
               curveSmoothness: 0.2,
               color: overlay.color.withValues(alpha: 0.45),
@@ -3429,19 +3619,24 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // NDL line (see _buildNdlLine).
       if (_showNdl) {
         const maxNdlSeconds = 3600.0;
-        final ndlSpots = <FlSpot>[];
-        for (final p in overlay.points) {
-          final ndl = p.ndl;
-          if (ndl == null) continue;
-          final clamped = ndl.clamp(0, maxNdlSeconds.toInt()).toDouble();
-          ndlSpots.add(
-            FlSpot(
-              p.timestamp.toDouble(),
-              -(chartMaxDepth * (1 - clamped / maxNdlSeconds)),
-            ),
+        final ndlPoints = overlay.points.where((p) => p.ndl != null).toList();
+        if (ndlPoints.isNotEmpty) {
+          final ndlKeep = _decimatedOverlayIndices(
+            ndlPoints,
+            (p) => p.ndl!.clamp(0, maxNdlSeconds.toInt()).toDouble(),
           );
-        }
-        if (ndlSpots.isNotEmpty) {
+          final ndlSpots = <FlSpot>[
+            for (final i in ndlKeep)
+              FlSpot(
+                ndlPoints[i].timestamp.toDouble(),
+                -(chartMaxDepth *
+                    (1 -
+                        ndlPoints[i].ndl!
+                                .clamp(0, maxNdlSeconds.toInt())
+                                .toDouble() /
+                            maxNdlSeconds)),
+              ),
+          ];
           lines.add(
             LineChartBarData(
               spots: ndlSpots,
@@ -3735,7 +3930,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
     // Build spots for each profile point that has SAC data
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < sacCurve.length; i++) {
+    for (final i in _decimatedCurveIndices(sacCurve)) {
       final sac = sacCurve[i];
       if (sac > 0) {
         spots.add(
@@ -3846,7 +4041,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
     // Build spots only where ceiling > 0
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < ceilingData.length; i++) {
+    for (final i in _decimatedCurveIndices(ceilingData)) {
       final ceiling = ceilingData[i];
       if (ceiling > 0) {
         spots.add(
@@ -3888,7 +4083,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxNdlSeconds = 3600.0; // 60 minutes as max display
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < ndlData.length; i++) {
+    for (final i in _decimatedCurveIndices(ndlData)) {
       // Clamp NDL to display range to avoid gaps that cause Bezier artifacts.
       // Negative values (in deco) clamp to 0; values > 60 min clamp to 60 min.
       final ndl = ndlData[i].clamp(0, maxNdlSeconds.toInt()).toDouble();
@@ -3921,7 +4116,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxPpO2 = 2.0;
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < ppO2Data.length; i++) {
+    for (final i in _decimatedCurveIndices(ppO2Data)) {
       final ppO2 = ppO2Data[i].clamp(minPpO2, maxPpO2);
       final yValue = _mapValueToDepth(ppO2, chartMaxDepth, minPpO2, maxPpO2);
       spots.add(FlSpot(widget.profile[i].timestamp.toDouble(), -yValue));
@@ -3949,7 +4144,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxPpN2 = 5.0;
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < ppN2Data.length; i++) {
+    for (final i in _decimatedCurveIndices(ppN2Data)) {
       final ppN2 = ppN2Data[i].clamp(minPpN2, maxPpN2);
       final yValue = _mapValueToDepth(ppN2, chartMaxDepth, minPpN2, maxPpN2);
       spots.add(FlSpot(widget.profile[i].timestamp.toDouble(), -yValue));
@@ -3977,7 +4172,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxPpHe = 3.0;
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < ppHeData.length; i++) {
+    for (final i in _decimatedCurveIndices(ppHeData)) {
       final ppHe = ppHeData[i];
       if (ppHe > 0.001) {
         final clamped = ppHe.clamp(minPpHe, maxPpHe);
@@ -4011,7 +4206,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
     // MOD is typically constant for a given gas
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < modData.length; i++) {
+    for (final i in _decimatedCurveIndices(modData)) {
       final mod = modData[i];
       if (mod > 0 && mod < 200) {
         spots.add(
@@ -4045,7 +4240,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxDensity = 8.0;
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < densityData.length; i++) {
+    for (final i in _decimatedCurveIndices(densityData)) {
       final density = densityData[i].clamp(minDensity, maxDensity);
       final yValue = _mapValueToDepth(
         density,
@@ -4079,7 +4274,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxGf = 120.0;
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < gfData.length; i++) {
+    for (final i in _decimatedCurveIndices(gfData)) {
       final gf = gfData[i].clamp(minGf, maxGf);
       final yValue = _mapValueToDepth(gf, chartMaxDepth, minGf, maxGf);
       spots.add(FlSpot(widget.profile[i].timestamp.toDouble(), -yValue));
@@ -4108,11 +4303,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxGf = 150.0;
 
     final spots = <FlSpot>[];
-    for (
-      int i = 0;
-      i < widget.profile.length && i < surfaceGfData.length;
-      i++
-    ) {
+    for (final i in _decimatedCurveIndices(surfaceGfData)) {
       final gf = surfaceGfData[i].clamp(minGf, maxGf);
       final yValue = _mapValueToDepth(gf, chartMaxDepth, minGf, maxGf);
       spots.add(FlSpot(widget.profile[i].timestamp.toDouble(), -yValue));
@@ -4136,11 +4327,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const meanDepthColor = Colors.blueGrey;
 
     final spots = <FlSpot>[];
-    for (
-      int i = 0;
-      i < widget.profile.length && i < meanDepthData.length;
-      i++
-    ) {
+    for (final i in _decimatedCurveIndices(meanDepthData)) {
       spots.add(
         FlSpot(
           widget.profile[i].timestamp.toDouble(),
@@ -4173,7 +4360,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     const maxTtsSeconds = 3600.0;
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < ttsData.length; i++) {
+    for (final i in _decimatedCurveIndices(ttsData)) {
       final tts = ttsData[i].toDouble().clamp(0, maxTtsSeconds);
       final normalized = tts / maxTtsSeconds;
       final yValue = chartMaxDepth * (1 - normalized);
@@ -4215,7 +4402,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     final maxCns = _getCnsMaxScale();
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < cnsData.length; i++) {
+    for (final i in _decimatedCurveIndices(cnsData)) {
       final cns = cnsData[i].clamp(minCns, maxCns);
       final yValue = _mapValueToDepth(cns, chartMaxDepth, minCns, maxCns);
       spots.add(FlSpot(widget.profile[i].timestamp.toDouble(), -yValue));
@@ -4242,7 +4429,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     final maxOtu = _getOtuMaxScale();
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < widget.profile.length && i < otuData.length; i++) {
+    for (final i in _decimatedCurveIndices(otuData)) {
       final otu = otuData[i].clamp(minOtu, maxOtu);
       final yValue = _mapValueToDepth(otu, chartMaxDepth, minOtu, maxOtu);
       spots.add(FlSpot(widget.profile[i].timestamp.toDouble(), -yValue));

--- a/lib/features/dive_log/presentation/widgets/profile_decimator.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_decimator.dart
@@ -13,6 +13,28 @@
 /// span a band boundary, so the velocity recomputed on the decimated series
 /// stays in the same band as the original -- a brief rapid-ascent excursion can
 /// never be averaged into a safer-looking band.
+/// Returns the ascending indices to keep when rendering a dense analysis
+/// curve (ceiling, NDL, ppO2, ...): endpoints, the global extreme, and the
+/// min/max envelope per time bucket. Identity when already under budget.
+///
+/// This is [decimateProfileIndices] without the safety force-keeps, which
+/// only apply to the depth trace (ascent-rate bands, decoType transitions).
+List<int> decimateSeriesIndices(
+  List<double> values, {
+  int targetPoints = 2000,
+}) {
+  final n = values.length;
+  if (n <= targetPoints) {
+    return List<int>.generate(n, (i) => i);
+  }
+  return decimateProfileIndices(
+    depths: values,
+    bands: List<int>.filled(n, 0),
+    decoTypes: List<int>.filled(n, -1),
+    targetPoints: targetPoints,
+  );
+}
+
 List<int> decimateProfileIndices({
   required List<double> depths,
   required List<int> bands,

--- a/test/features/dive_log/presentation/widgets/chart_series_cache_test.dart
+++ b/test/features/dive_log/presentation/widgets/chart_series_cache_test.dart
@@ -11,39 +11,61 @@ void main() {
       return [const FlSpot(0, 0)];
     }
 
-    final a = cache.series('depth', build);
-    final b = cache.series('depth', build);
+    final a = cache.series('depth', 'sigA', build);
+    final b = cache.series('depth', 'sigA', build);
     expect(identical(a, b), isTrue);
     expect(builds, 1);
   });
 
-  test(
-    'invalidate(newSignature) forces a rebuild; same signature does not',
-    () {
-      final cache = ChartSeriesCache<FlSpot>();
-      var builds = 0;
-      List<FlSpot> build() {
-        builds++;
-        return [const FlSpot(0, 0)];
-      }
+  test('a changed signature rebuilds; an unchanged one does not', () {
+    final cache = ChartSeriesCache<FlSpot>();
+    var builds = 0;
+    List<FlSpot> build() {
+      builds++;
+      return [const FlSpot(0, 0)];
+    }
 
-      cache.invalidate('sigA');
-      cache.series('depth', build);
-      cache.invalidate('sigA'); // unchanged -> keep cache
-      cache.series('depth', build);
-      expect(builds, 1);
+    cache.series('depth', 'sigA', build);
+    cache.series('depth', 'sigA', build);
+    expect(builds, 1);
 
-      cache.invalidate('sigB'); // changed -> drop cache
-      cache.series('depth', build);
-      expect(builds, 2);
-    },
-  );
+    cache.series('depth', 'sigB', build);
+    expect(builds, 2);
+  });
+
+  test('signature changes are scoped per key', () {
+    final cache = ChartSeriesCache<FlSpot>();
+    var depthBuilds = 0;
+    var analysisBuilds = 0;
+
+    List<FlSpot> buildDepth() {
+      depthBuilds++;
+      return [const FlSpot(0, 0)];
+    }
+
+    List<FlSpot> buildAnalysis() {
+      analysisBuilds++;
+      return [const FlSpot(1, 1)];
+    }
+
+    final depth = cache.series('depth', 'base-sig', buildDepth);
+    cache.series('analysis', 'curves-v1', buildAnalysis);
+
+    // The analysis curves re-emit (e.g. ceiling-source toggle): only the
+    // analysis key rebuilds; depth stays the identical cached instance.
+    cache.series('analysis', 'curves-v2', buildAnalysis);
+    final depthAgain = cache.series('depth', 'base-sig', buildDepth);
+
+    expect(analysisBuilds, 2);
+    expect(depthBuilds, 1);
+    expect(identical(depth, depthAgain), isTrue);
+  });
 
   test('distinct keys are cached independently', () {
     final cache = ChartSeriesCache<FlSpot>();
-    final depth = cache.series('depth', () => [const FlSpot(0, 0)]);
-    final temp = cache.series('temp', () => [const FlSpot(1, 1)]);
-    expect(identical(cache.series('depth', () => []), depth), isTrue);
-    expect(identical(cache.series('temp', () => []), temp), isTrue);
+    final depth = cache.series('depth', 's', () => [const FlSpot(0, 0)]);
+    final temp = cache.series('temp', 's', () => [const FlSpot(1, 1)]);
+    expect(identical(cache.series('depth', 's', () => []), depth), isTrue);
+    expect(identical(cache.series('temp', 's', () => []), temp), isTrue);
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -3448,6 +3448,189 @@ void main() {
         }
       },
     );
+
+    testWidgets('zooming a dense profile decimates analysis curves through the '
+        'viewport-clipped path', (tester) async {
+      // Exercises the _viewport.isZoomed branch of _decimatedCurveIndices:
+      // the visible window is clipped (binary search for the first/last
+      // in-range sample) before decimation, and kept indices are offset
+      // back by the window start.
+      const samples = 5000;
+      final profile = _makeProfile(points: samples);
+      final ceiling = List<double>.generate(
+        samples,
+        (i) => 3.0 + (i % 7) * 0.5,
+      );
+
+      await tester.pumpWidget(
+        _buildChart(profile: profile, ceilingCurve: ceiling),
+      );
+      await tester.pumpAndSettle();
+
+      final chart = find.byType(LineChart).first;
+      final fullWindow = tester.widget<LineChart>(chart).data;
+      final fullSpan = fullWindow.maxX - fullWindow.minX;
+
+      // Zoom in deeply (several wheel steps) so the visible window becomes a
+      // strict interior subset: > 2x zoom clips the decimation window off
+      // both ends, exercising the start offset and both binary searches.
+      final topLeft = tester.getTopLeft(chart);
+      final size = tester.getSize(chart);
+      final cursor = topLeft + Offset(size.width * 0.5, size.height * 0.5);
+      for (var step = 0; step < 14; step++) {
+        await tester.sendEventToBinding(
+          PointerScrollEvent(
+            position: cursor,
+            scrollDelta: const Offset(0, -100),
+          ),
+        );
+        await tester.pump();
+      }
+
+      final zoomed = tester.widget<LineChart>(chart).data;
+      expect(
+        zoomed.maxX - zoomed.minX,
+        lessThan(fullSpan / 2),
+        reason: 'the wheel steps must zoom past 2x',
+      );
+      expect(
+        zoomed.minX,
+        greaterThan(fullWindow.minX),
+        reason: 'the visible window no longer starts at the first sample',
+      );
+      expect(
+        zoomed.maxX,
+        lessThan(fullWindow.maxX),
+        reason: 'the visible window no longer ends at the last sample',
+      );
+
+      // The ceiling curve still decimates within the visible window.
+      final ceilingBars = zoomed.lineBarsData.where(
+        (b) =>
+            b.dashArray != null &&
+            b.dashArray!.length == 2 &&
+            b.dashArray!.first == 4 &&
+            b.dashArray!.last == 4 &&
+            b.spots.isNotEmpty,
+      );
+      expect(ceilingBars, isNotEmpty);
+      for (final bar in ceilingBars) {
+        expect(bar.spots.length, lessThanOrEqualTo(2008));
+      }
+    });
+
+    testWidgets(
+      'a dense source overlay decimates its depth, temperature, ceiling and '
+      'NDL series to the point budget',
+      (tester) async {
+        // Exercises _decimatedOverlayIndices' over-budget branch and all four
+        // overlay series builders (depth / temp / ceiling / NDL), whose
+        // envelope closures only execute when the overlay exceeds the budget.
+        const n = 5000;
+        final overlayPoints = List<DiveProfilePoint>.generate(
+          n,
+          (i) => DiveProfilePoint(
+            timestamp: i * 10,
+            depth: 10.0 + (i % 11) * 1.0,
+            temperature: 20.0 + (i % 5) * 0.5,
+            ceiling: 1.0 + (i % 7) * 0.5,
+            ndl: (i % 9) * 60,
+          ),
+        );
+        // Active source small; its temperature seeds the shared temp scale.
+        final active = List<DiveProfilePoint>.generate(
+          8,
+          (i) => DiveProfilePoint(
+            timestamp: i * 30,
+            depth: i * 2.0,
+            temperature: 21.0,
+          ),
+        );
+
+        await tester.pumpWidget(
+          _buildChart(
+            profile: active,
+            activeComputerId: 'comp-a',
+            overlays: [
+              ChartSourceOverlay(
+                sourceId: 'src-b',
+                name: 'Dense',
+                color: Colors.orange,
+                computerId: 'comp-b',
+                points: overlayPoints,
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // NDL is off by default; enable it so the overlay NDL series builds.
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(DiveProfileChart)),
+        );
+        container.read(profileLegendProvider.notifier).toggleNdl();
+        await tester.pumpAndSettle();
+
+        final bars = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data
+            .lineBarsData;
+
+        // Depth, temperature and ceiling overlay series (NDL too) each derive
+        // from the 5,000-point overlay and must decimate toward the budget.
+        final denseBars = bars.where((b) => b.spots.length > 1000).toList();
+        expect(
+          denseBars.length,
+          greaterThanOrEqualTo(3),
+          reason: 'overlay depth/temp/ceiling/NDL each decimate to ~budget',
+        );
+        for (final b in bars) {
+          expect(
+            b.spots.length,
+            lessThanOrEqualTo(2008),
+            reason: 'no overlay series emits all 5,000 samples',
+          );
+        }
+      },
+    );
+
+    testWidgets('enabling MOD builds the decimated MOD line for a dense '
+        'profile', (tester) async {
+      // The MOD line is gated on the legend showMod toggle (default off), so
+      // _buildModLine and its inclusion in the analysis group are otherwise
+      // never reached.
+      const samples = 5000;
+      final profile = _makeProfile(points: samples);
+      final mod = List<double>.generate(samples, (i) => 30.0 + (i % 5));
+
+      await tester.pumpWidget(_buildChart(profile: profile, modCurve: mod));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveProfileChart)),
+      );
+      container.read(profileLegendProvider.notifier).toggleMod();
+      await tester.pumpAndSettle();
+
+      // MOD is the deepOrange [8, 4] dashed line.
+      final modBars = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineBarsData
+          .where(
+            (b) =>
+                b.color == Colors.deepOrange &&
+                b.dashArray != null &&
+                b.dashArray!.length == 2 &&
+                b.dashArray!.first == 8 &&
+                b.dashArray!.last == 4,
+          );
+      expect(modBars, isNotEmpty);
+      for (final b in modBars) {
+        expect(b.spots, isNotEmpty);
+        expect(b.spots.length, lessThanOrEqualTo(2008));
+      }
+    });
   });
 }
 

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -3398,6 +3398,57 @@ void main() {
       expect(find.byType(PhotoMarkerOverlay), findsNothing);
     });
   });
+
+  group('analysis-curve decimation (WS3)', () {
+    testWidgets(
+      'a dense ceiling curve renders decimated while the depth trace keeps '
+      'full resolution',
+      (tester) async {
+        const samples = 5000;
+        final profile = _makeProfile(points: samples);
+        // A ceiling that is positive everywhere so every sample would emit
+        // a spot without decimation.
+        final ceiling = List<double>.generate(
+          samples,
+          (i) => 3.0 + (i % 7) * 0.5,
+        );
+
+        await tester.pumpWidget(
+          _buildChart(profile: profile, ceilingCurve: ceiling),
+        );
+
+        final bars = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data
+            .lineBarsData;
+
+        final depthBars = bars.where((b) => b.spots.length == samples);
+        expect(
+          depthBars,
+          isNotEmpty,
+          reason: 'the depth trace must stay at full resolution',
+        );
+
+        // The ceiling line is the dashed [4, 4] bar; it must be decimated
+        // to the point budget instead of emitting all 5,000 spots.
+        final ceilingBars = bars.where(
+          (b) =>
+              b.dashArray != null &&
+              b.dashArray!.length == 2 &&
+              b.dashArray!.first == 4 &&
+              b.dashArray!.last == 4 &&
+              b.spots.isNotEmpty,
+        );
+        expect(ceilingBars, isNotEmpty);
+        for (final bar in ceilingBars) {
+          // The decimator targets ~2000 points; endpoints and the global
+          // extreme can add a couple beyond the bucket envelope.
+          expect(bar.spots.length, lessThanOrEqualTo(2008));
+          expect(bar.spots.length, lessThan(samples ~/ 2));
+        }
+      },
+    );
+  });
 }
 
 PhotoChartMarker _photoMarker({String id = 'p1', int seconds = 120}) {


### PR DESCRIPTION
## Summary

WS3 of the large-database performance program (spec:
`docs/superpowers/specs/2026-07-10-large-db-performance-design.md`; plan in
this branch). Targets the measured ~0.85 s of main-isolate CPU per
ceiling-source toggle on a dense dive (profile mode, 4,762 samples), whose
profiler signature was Skia dash-path measurement
(`SkContourMeasure::getSegment`) plus a full rebuild of every series.

**Changes:**
- **Analysis curves decimated.** The 14 analysis-curve series (ceiling,
  NDL, ppO2/ppN2/ppHe, MOD, density, GF, surface GF, mean depth, TTS, CNS,
  OTU, SAC) and all overlay series now render through the
  feature-preserving decimator from PR #412 (previously written, tested,
  and unwired) at a ~2,000-point envelope budget (min/max per bucket +
  global extreme + endpoints via the new `decimateSeriesIndices` wrapper).
- **Zoom-aware, quantized.** Decimation covers the visible window expanded
  half a window each side; the viewport enters cache signatures as a bucket
  (half-octave zoom steps, quarter-window pan steps). Inside a bucket,
  zoom/pan stays a pure cache hit exactly as before; deep zoom converges
  back to full sample resolution.
- **Scoped series cache.** `ChartSeriesCache` now carries per-key
  signatures; the assembly splits into six order-preserving groups (base /
  sac / ascent / analysis / markers / overlays) under a memoized combined
  key. An analysis re-emission — the ceiling toggle — rebuilds only the
  analysis group; depth, temperature, pressure, and markers stay cached.
  The combined key preserves outer-list identity on playback-only rebuilds
  (fl_chart's listEquals short-circuits on identity; the existing
  memoization test caught this).
- **Depth/touch series untouched at full resolution.** Tooltips, scrubbing,
  and velocity-band suppression all resolve through the depth bars
  (verified: both tooltip paths are depth-bar-guarded), so decimating only
  the analysis/overlay series leaves every interaction path byte-identical.
  Recorded deviation from the spec's "decimate the main depth line":
  post-measurement, the dash-path and multi-series rebuild were the cost,
  not the solid depth polyline; revisit only if a re-profile shows the
  depth paint mattering.
- Tank-pressure series not decimated (sparse own-domain timestamps;
  NaN-guard logic untouched).

## Test plan

- New: cache per-key signature tests (a changed analysis signature leaves
  the depth key's instance identical); dense-ceiling decimation widget test
  (5,000-sample profile: ceiling bar bounded by the budget, depth bar keeps
  all 5,000 spots).
- Full `test/features/dive_log/presentation/widgets/` sweep: 671 tests
  green (memoization/identity, tooltips, velocity suppression, sizing,
  viewport math, decimator).
- Whole-project `flutter analyze`: no issues; `dart format .`: clean.
- Residual: interactive toggle re-profile on dive #1006 rides the next
  user session (expected: well under the 200 ms target).