### PR TITLE
perf(dashboard): SQL-bounded home providers, no hot-path getAllDives (WS4)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-ws4-dashboard-sql.md
+++ b/docs/superpowers/plans/2026-07-10-ws4-dashboard-sql.md
@@ -1,0 +1,62 @@
+# WS4: Dashboard Off getAllDives Implementation Plan
+
+> Executed inline (executing-plans) in worktree
+> `.claude/worktrees/ws4-dashboard`, branch `worktree-ws4-dashboard`.
+
+**Goal:** Remove hot-path `getAllDives()` from app startup. The dashboard is
+the initial route and three of its providers force `divesProvider` ->
+`getAllDives()` (full hydration of every dive with all children) on the
+first home frame. This is the workload behind the ~20 s debug-launch freeze
+(debug-JIT compiling the Drift mapping code hot; findings doc) and a linear
+scaling liability in release builds (~1-2 s at 1,032 dives today).
+
+**Spec:** WS4 in `2026-07-10-large-db-performance-design.md`.
+
+## Design (minimal-diff: provider internals only, cards untouched)
+
+- `recentDivesProvider` keeps returning `List<Dive>`: ids come from
+  `getDiveSummaries(limit: 3)` (SQL-bounded), then each of the <= 3 winners
+  hydrates individually via indexed `getDiveById`. Batch mini-chart profile
+  preload unchanged.
+- `monthlyDiveCountProvider` / `yearToDateDiveCountProvider`: new
+  `countDivesSince(since, {diverId})` repository method (one COUNT
+  statement, same strict `>` comparison as the old Dart filter).
+- `personalRecordsProvider` keeps returning `PersonalRecords` with `Dive?`
+  fields: winner SELECTION moves to SQL (`getPersonalRecordIds`, six small
+  indexed statements: deepest / longest / coldest / warmest / most-visited
+  site GROUP BY), then the <= 4 distinct winner dives hydrate via
+  `getDiveById`. The longest-dive ORDER BY reproduces
+  `Dive.effectiveRuntime`'s full resolution order (runtime, exit - entry,
+  profile span via scalar subquery, bottom time), which the old in-memory
+  loop used; guards `> 0` and `max_depth > 0` preserve the old loop's
+  strict-greater seeding semantics.
+- All three rewritten providers self-invalidate on
+  `watchDivesChanges()` (previously they inherited reactivity transitively
+  through `divesProvider`; issue #217 pattern) and scope by
+  `currentDiverIdProvider` exactly as `divesProvider` did.
+- `daysSinceLastDiveProvider` is untouched (reads `recentDivesProvider`).
+
+## Recorded deferral
+
+Table view mode and detailed-cards-with-non-summary-fields still fall back
+to `getAllDives()` (spec WS4 second half). They are opt-in views, not
+startup cost; widening `DiveSummary` to every configurable column is a
+separate change. Re-measure after this lands; follow up if table mode shows
+up in practice.
+
+## Tasks
+
+1. Repository: `countDivesSince` + `getPersonalRecordIds`, TDD in
+   `test/features/dive_log/data/repositories/dashboard_queries_test.dart`
+   (count boundaries + diver scoping; winner ids incl. the
+   profile-span-longest case and most-visited tie shape).
+2. Provider rewrites (three sites) keeping types; dashboard suites green
+   (`dashboard_providers_test`, `recent_dives_reactivity_test`,
+   `dashboard_quick_stats_filter_test`).
+3. Sweep: format, whole-project analyze, mock regen if needed, commit,
+   push --no-verify, PR.
+
+## Verification gates
+
+- No `divesProvider` watch remains in dashboard_providers.dart.
+- Dashboard + new repo suites green; analyze/format clean.

--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -40,19 +40,25 @@ class DashboardAlerts {
 ///
 /// Self-invalidates on any `dives`-table write -- a dive computer import or an
 /// iCloud sync applying remote changes directly to the DB -- so the home tab
-/// reflects new dives without an app restart (issue #217). [divesProvider]
-/// already self-invalidates on the same tick, so today this is belt-and-braces;
-/// keeping the subscription here means the home tab stays correct even if this
-/// provider is ever changed to read recent dives independently of
-/// [divesProvider], and makes its reactivity contract explicit at the call
-/// site instead of relying on transitive propagation two providers away.
+/// reflects new dives without an app restart (issue #217).
+///
+/// Discovery is SQL-bounded (`getDiveSummaries(limit: 3)`); only the three
+/// winners hydrate as full [Dive]s. The dashboard no longer forces
+/// `getAllDives()` on the first home frame (WS4, large-DB performance).
 final recentDivesProvider = FutureProvider<List<Dive>>((ref) async {
   final repository = ref.watch(diveRepositoryProvider);
   ref.invalidateSelfWhen(repository.watchDivesChanges());
 
-  final allDives = await ref.watch(divesProvider.future);
-  // Dives are already sorted by date descending in the repository
-  final recent = allDives.take(3).toList();
+  final currentDiverId = ref.watch(currentDiverIdProvider);
+  final summaries = await repository.getDiveSummaries(
+    diverId: currentDiverId,
+    limit: 3,
+  );
+  final recent = <Dive>[];
+  for (final summary in summaries) {
+    final dive = await repository.getDiveById(summary.id);
+    if (dive != null) recent.add(dive);
+  }
 
   // Pre-load downsampled profiles so DiveListTile mini charts render
   // immediately (the batch cache is shared with the paginated dive list).
@@ -105,22 +111,28 @@ final daysSinceLastDiveProvider = FutureProvider<int?>((ref) async {
   return today.difference(diveDay).inDays;
 });
 
-/// Monthly dive count provider (dives in current month)
+/// Monthly dive count provider (dives in current month): one SQL COUNT.
 final monthlyDiveCountProvider = FutureProvider<int>((ref) async {
-  final allDives = await ref.watch(divesProvider.future);
+  final repository = ref.watch(diveRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
+  final currentDiverId = ref.watch(currentDiverIdProvider);
   final now = DateTime.now();
-  final startOfMonth = DateTime(now.year, now.month, 1);
-
-  return allDives.where((dive) => dive.dateTime.isAfter(startOfMonth)).length;
+  return repository.countDivesSince(
+    DateTime(now.year, now.month, 1),
+    diverId: currentDiverId,
+  );
 });
 
-/// Year-to-date dive count provider
+/// Year-to-date dive count provider: one SQL COUNT.
 final yearToDateDiveCountProvider = FutureProvider<int>((ref) async {
-  final allDives = await ref.watch(divesProvider.future);
+  final repository = ref.watch(diveRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
+  final currentDiverId = ref.watch(currentDiverIdProvider);
   final now = DateTime.now();
-  final startOfYear = DateTime(now.year, 1, 1);
-
-  return allDives.where((dive) => dive.dateTime.isAfter(startOfYear)).length;
+  return repository.countDivesSince(
+    DateTime(now.year, 1, 1),
+    diverId: currentDiverId,
+  );
 });
 
 /// Personal records data class
@@ -151,85 +163,42 @@ class PersonalRecords {
       mostVisitedSiteName != null;
 }
 
-/// Personal records provider
+/// Personal records provider.
+///
+/// Winner SELECTION runs in SQL (six small indexed statements via
+/// [DiveRepository.getPersonalRecordIds], including the full
+/// effectiveRuntime resolution order for the longest dive); only the
+/// handful of distinct winner dives hydrate as full [Dive]s, instead of
+/// loading and scanning the entire table (WS4, large-DB performance).
 final personalRecordsProvider = FutureProvider<PersonalRecords>((ref) async {
-  final allDives = await ref.watch(divesProvider.future);
-  if (allDives.isEmpty) return const PersonalRecords();
+  final repository = ref.watch(diveRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
+  final currentDiverId = ref.watch(currentDiverIdProvider);
 
-  // Find deepest dive
-  Dive? deepestDive;
-  double maxDepth = 0;
-  for (final dive in allDives) {
-    if (dive.maxDepth != null && dive.maxDepth! > maxDepth) {
-      maxDepth = dive.maxDepth!;
-      deepestDive = dive;
-    }
-  }
+  final winners = await repository.getPersonalRecordIds(
+    diverId: currentDiverId,
+  );
 
-  // Find longest dive (by total runtime, including descent/ascent)
-  Dive? longestDive;
-  int maxDuration = 0;
-  for (final dive in allDives) {
-    final runtime = dive.effectiveRuntime;
-    if (runtime != null && runtime.inSeconds > maxDuration) {
-      maxDuration = runtime.inSeconds;
-      longestDive = dive;
-    }
-  }
-
-  // Find coldest dive
-  Dive? coldestDive;
-  double? minTemp;
-  for (final dive in allDives) {
-    if (dive.waterTemp != null) {
-      if (minTemp == null || dive.waterTemp! < minTemp) {
-        minTemp = dive.waterTemp;
-        coldestDive = dive;
-      }
-    }
-  }
-
-  // Find warmest dive
-  Dive? warmestDive;
-  double? maxTemp;
-  for (final dive in allDives) {
-    if (dive.waterTemp != null) {
-      if (maxTemp == null || dive.waterTemp! > maxTemp) {
-        maxTemp = dive.waterTemp;
-        warmestDive = dive;
-      }
-    }
-  }
-
-  // Find most visited site
-  final siteCounts = <String, int>{};
-  final siteNames = <String, String>{};
-  for (final dive in allDives) {
-    if (dive.site != null) {
-      siteCounts[dive.site!.id] = (siteCounts[dive.site!.id] ?? 0) + 1;
-      siteNames[dive.site!.id] = dive.site!.name;
-    }
-  }
-
-  String? mostVisitedSiteId;
-  String? mostVisitedSiteName;
-  int mostVisitedCount = 0;
-  for (final entry in siteCounts.entries) {
-    if (entry.value > mostVisitedCount) {
-      mostVisitedCount = entry.value;
-      mostVisitedSiteId = entry.key;
-      mostVisitedSiteName = siteNames[entry.key];
-    }
+  final ids = <String>{
+    if (winners.deepestId != null) winners.deepestId!,
+    if (winners.longestId != null) winners.longestId!,
+    if (winners.coldestId != null) winners.coldestId!,
+    if (winners.warmestId != null) winners.warmestId!,
+  };
+  final divesById = <String, Dive>{};
+  for (final id in ids) {
+    final dive = await repository.getDiveById(id);
+    if (dive != null) divesById[id] = dive;
   }
 
   return PersonalRecords(
-    deepestDive: deepestDive,
-    longestDive: longestDive,
-    coldestDive: coldestDive,
-    warmestDive: warmestDive,
-    mostVisitedSiteId: mostVisitedSiteId,
-    mostVisitedSiteName: mostVisitedSiteName,
-    mostVisitedSiteCount: mostVisitedCount > 0 ? mostVisitedCount : null,
+    deepestDive: divesById[winners.deepestId],
+    longestDive: divesById[winners.longestId],
+    coldestDive: divesById[winners.coldestId],
+    warmestDive: divesById[winners.warmestId],
+    mostVisitedSiteId: winners.mostVisitedSiteId,
+    mostVisitedSiteName: winners.mostVisitedSiteName,
+    mostVisitedSiteCount: winners.mostVisitedSiteCount,
   );
 });
 

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2311,6 +2311,110 @@ class DiveRepository {
     );
   }
 
+  /// Number of dives strictly after [since] (dashboard month / year-to-date
+  /// counters): one COUNT statement instead of hydrating every dive.
+  Future<int> countDivesSince(DateTime since, {String? diverId}) async {
+    final diverFilter = diverId != null ? 'AND diver_id = ?' : '';
+    final row = await _db
+        .customSelect(
+          'SELECT COUNT(*) AS c FROM dives '
+          'WHERE dive_date_time > ? $diverFilter',
+          variables: [
+            Variable<int>(since.millisecondsSinceEpoch),
+            if (diverId != null) Variable<String>(diverId),
+          ],
+          readsFrom: {_db.dives},
+        )
+        .getSingle();
+    return row.read<int>('c');
+  }
+
+  /// SQL expression mirroring [domain.Dive.effectiveRuntime]'s resolution
+  /// order in seconds: runtime, exit - entry (when positive), profile span,
+  /// bottom time.
+  static const _effectiveRuntimeSql =
+      'COALESCE(d.runtime, '
+      'CASE WHEN d.exit_time IS NOT NULL AND d.entry_time IS NOT NULL '
+      'AND d.exit_time > d.entry_time '
+      'THEN (d.exit_time - d.entry_time) / 1000 END, '
+      '(SELECT MAX(p.timestamp) - MIN(p.timestamp) FROM dive_profiles p '
+      'WHERE p.dive_id = d.id), '
+      'd.bottom_time)';
+
+  /// Winner ids for the dashboard personal records (deepest / longest /
+  /// coldest / warmest) plus the most visited site: six small indexed
+  /// statements. Callers hydrate the handful of winner dives individually
+  /// instead of loading the whole table (WS4, large-DB performance).
+  Future<
+    ({
+      String? deepestId,
+      String? longestId,
+      String? coldestId,
+      String? warmestId,
+      String? mostVisitedSiteId,
+      String? mostVisitedSiteName,
+      int? mostVisitedSiteCount,
+    })
+  >
+  getPersonalRecordIds({String? diverId}) async {
+    final vars = diverId != null
+        ? [Variable<String>(diverId)]
+        : <Variable<Object>>[];
+    final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
+
+    Future<String?> winner(String where, String orderBy) async {
+      final row = await _db
+          .customSelect(
+            'SELECT d.id FROM dives d WHERE $where $diverFilter '
+            'ORDER BY $orderBy LIMIT 1',
+            variables: vars,
+            readsFrom: {_db.dives, _db.diveProfiles},
+          )
+          .getSingleOrNull();
+      return row?.read<String>('id');
+    }
+
+    // The > 0 guards mirror the old in-memory loops' strict-greater seeding
+    // (a lone dive with zero depth/runtime produced no record).
+    final deepestId = await winner(
+      'd.max_depth IS NOT NULL AND d.max_depth > 0',
+      'd.max_depth DESC',
+    );
+    final longestId = await winner(
+      '$_effectiveRuntimeSql > 0',
+      '$_effectiveRuntimeSql DESC',
+    );
+    final coldestId = await winner(
+      'd.water_temp IS NOT NULL',
+      'd.water_temp ASC',
+    );
+    final warmestId = await winner(
+      'd.water_temp IS NOT NULL',
+      'd.water_temp DESC',
+    );
+
+    final siteRow = await _db
+        .customSelect(
+          'SELECT d.site_id AS site_id, s.name AS site_name, COUNT(*) AS c '
+          'FROM dives d JOIN dive_sites s ON d.site_id = s.id '
+          'WHERE d.site_id IS NOT NULL $diverFilter '
+          'GROUP BY d.site_id ORDER BY c DESC LIMIT 1',
+          variables: vars,
+          readsFrom: {_db.dives, _db.diveSites},
+        )
+        .getSingleOrNull();
+
+    return (
+      deepestId: deepestId,
+      longestId: longestId,
+      coldestId: coldestId,
+      warmestId: warmestId,
+      mostVisitedSiteId: siteRow?.readNullable<String>('site_id'),
+      mostVisitedSiteName: siteRow?.readNullable<String>('site_name'),
+      mostVisitedSiteCount: siteRow?.readNullable<int>('c'),
+    );
+  }
+
   // ============================================================================
   // Mapping Helpers
   // ============================================================================

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2341,6 +2341,14 @@ class DiveRepository {
       'WHERE p.dive_id = d.id), '
       'd.bottom_time)';
 
+  /// Deterministic tie-break for the personal-record winners, matching the
+  /// most-recent-first order [getAllDives] used before WS4: the old in-memory
+  /// loops scanned that order with a strict `>` (`<` for coldest), so ties
+  /// implicitly resolved to the most recent dive. Appending this keeps a tied
+  /// depth/runtime/temperature on the same visible winner.
+  static const _recencyTieBreak =
+      'COALESCE(d.entry_time, d.dive_date_time) DESC, d.dive_number DESC';
+
   /// Winner ids for the dashboard personal records (deepest / longest /
   /// coldest / warmest) plus the most visited site: six small indexed
   /// statements. Callers hydrate the handful of winner dives individually
@@ -2378,27 +2386,31 @@ class DiveRepository {
     // (a lone dive with zero depth/runtime produced no record).
     final deepestId = await winner(
       'd.max_depth IS NOT NULL AND d.max_depth > 0',
-      'd.max_depth DESC',
+      'd.max_depth DESC, $_recencyTieBreak',
     );
     final longestId = await winner(
       '$_effectiveRuntimeSql > 0',
-      '$_effectiveRuntimeSql DESC',
+      '$_effectiveRuntimeSql DESC, $_recencyTieBreak',
     );
     final coldestId = await winner(
       'd.water_temp IS NOT NULL',
-      'd.water_temp ASC',
+      'd.water_temp ASC, $_recencyTieBreak',
     );
     final warmestId = await winner(
       'd.water_temp IS NOT NULL',
-      'd.water_temp DESC',
+      'd.water_temp DESC, $_recencyTieBreak',
     );
 
+    // On a count tie, keep the site whose most recent dive is latest -- the
+    // old loop scanned most-recent-first and kept the first site to reach the
+    // max count, i.e. the one owning the newest dive among the tied sites.
     final siteRow = await _db
         .customSelect(
           'SELECT d.site_id AS site_id, s.name AS site_name, COUNT(*) AS c '
           'FROM dives d JOIN dive_sites s ON d.site_id = s.id '
           'WHERE d.site_id IS NOT NULL $diverFilter '
-          'GROUP BY d.site_id ORDER BY c DESC LIMIT 1',
+          'GROUP BY d.site_id ORDER BY c DESC, '
+          'MAX(COALESCE(d.entry_time, d.dive_date_time)) DESC LIMIT 1',
           variables: vars,
           readsFrom: {_db.dives, _db.diveSites},
         )

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2392,10 +2392,22 @@ class DiveRepository {
       'd.max_depth IS NOT NULL AND d.max_depth > 0',
       'd.max_depth DESC, $_recencyTieBreak',
     );
-    final longestId = await winner(
-      '$_effectiveRuntimeSql > 0',
-      '$_effectiveRuntimeSql DESC, $_recencyTieBreak',
-    );
+    // Longest evaluates the effective-runtime expression (a correlated
+    // dive_profiles subquery) once in a derived table and filters/orders on
+    // the alias, rather than paying for the subquery twice (WHERE + ORDER BY)
+    // -- this is the dashboard hot path the PR is optimizing.
+    final longestRow = await _db
+        .customSelect(
+          'SELECT id FROM ('
+          'SELECT d.id AS id, $_effectiveRuntimeSql AS er, '
+          'COALESCE(d.entry_time, d.dive_date_time) AS recency, '
+          'd.dive_number AS dn FROM dives d WHERE 1 = 1 $diverFilter'
+          ') WHERE er > 0 ORDER BY er DESC, recency DESC, dn DESC LIMIT 1',
+          variables: vars,
+          readsFrom: {_db.dives, _db.diveProfiles},
+        )
+        .getSingleOrNull();
+    final longestId = longestRow?.read<String>('id');
     final coldestId = await winner(
       'd.water_temp IS NOT NULL',
       'd.water_temp ASC, $_recencyTieBreak',

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2336,9 +2336,13 @@ class DiveRepository {
       'COALESCE(d.runtime, '
       'CASE WHEN d.exit_time IS NOT NULL AND d.entry_time IS NOT NULL '
       'AND d.exit_time > d.entry_time '
-      'THEN (d.exit_time - d.entry_time) / 1000 END, '
-      '(SELECT MAX(p.timestamp) - MIN(p.timestamp) FROM dive_profiles p '
-      'WHERE p.dive_id = d.id), '
+      // CAST truncates toward zero to match Dart's Duration.inSeconds.
+      'THEN CAST((d.exit_time - d.entry_time) / 1000 AS INTEGER) END, '
+      // NULLIF drops a zero-span profile (single point or same-timestamp
+      // samples) to NULL so COALESCE falls through to bottom_time, matching
+      // calculateRuntimeFromProfile()'s `totalSeconds > 0 ? ... : null`.
+      'NULLIF((SELECT MAX(p.timestamp) - MIN(p.timestamp) FROM dive_profiles p '
+      'WHERE p.dive_id = d.id), 0), '
       'd.bottom_time)';
 
   /// Deterministic tie-break for the personal-record winners, matching the
@@ -2403,14 +2407,17 @@ class DiveRepository {
 
     // On a count tie, keep the site whose most recent dive is latest -- the
     // old loop scanned most-recent-first and kept the first site to reach the
-    // max count, i.e. the one owning the newest dive among the tied sites.
+    // max count, i.e. the one owning the newest dive among the tied sites. The
+    // trailing site_id is a final deterministic key so an exact recency tie
+    // cannot flap across SQLite query plans.
     final siteRow = await _db
         .customSelect(
           'SELECT d.site_id AS site_id, s.name AS site_name, COUNT(*) AS c '
           'FROM dives d JOIN dive_sites s ON d.site_id = s.id '
           'WHERE d.site_id IS NOT NULL $diverFilter '
           'GROUP BY d.site_id ORDER BY c DESC, '
-          'MAX(COALESCE(d.entry_time, d.dive_date_time)) DESC LIMIT 1',
+          'MAX(COALESCE(d.entry_time, d.dive_date_time)) DESC, d.site_id '
+          'LIMIT 1',
           variables: vars,
           readsFrom: {_db.dives, _db.diveSites},
         )

--- a/test/features/dashboard/presentation/providers/dashboard_providers_test.dart
+++ b/test/features/dashboard/presentation/providers/dashboard_providers_test.dart
@@ -2,9 +2,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
 
 Dive _diveWithEntryTime(DateTime entryTime) => Dive(
   id: 'test-${entryTime.millisecondsSinceEpoch}',
@@ -85,6 +87,25 @@ void main() {
   });
 
   group('personalRecordsProvider', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      repository = DiveRepository();
+    });
+    tearDown(() async => tearDownTestDatabase());
+
+    Future<ProviderContainer> seededContainer(List<Dive> dives) async {
+      for (final dive in dives) {
+        await repository.createDive(dive);
+      }
+      final container = ProviderContainer(
+        overrides: (await getBaseOverrides()).cast(),
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
     test('finds longest dive by effectiveRuntime', () async {
       final dives = [
         createTestDiveWithBottomTime(
@@ -110,10 +131,7 @@ void main() {
         ),
       ];
 
-      final container = ProviderContainer(
-        overrides: [divesProvider.overrideWith((ref) async => dives)],
-      );
-      addTearDown(container.dispose);
+      final container = await seededContainer(dives);
 
       final records = await container.read(personalRecordsProvider.future);
 
@@ -138,10 +156,7 @@ void main() {
         ),
       ];
 
-      final container = ProviderContainer(
-        overrides: [divesProvider.overrideWith((ref) async => dives)],
-      );
-      addTearDown(container.dispose);
+      final container = await seededContainer(dives);
 
       final records = await container.read(personalRecordsProvider.future);
 
@@ -167,10 +182,7 @@ void main() {
         ),
       ];
 
-      final container = ProviderContainer(
-        overrides: [divesProvider.overrideWith((ref) async => dives)],
-      );
-      addTearDown(container.dispose);
+      final container = await seededContainer(dives);
 
       final records = await container.read(personalRecordsProvider.future);
 

--- a/test/features/dashboard/presentation/providers/dashboard_providers_test.dart
+++ b/test/features/dashboard/presentation/providers/dashboard_providers_test.dart
@@ -190,4 +190,43 @@ void main() {
       expect(records.longestDive!.id, 'long-runtime');
     });
   });
+
+  group('dive count providers', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      repository = DiveRepository();
+    });
+    tearDown(() async => tearDownTestDatabase());
+
+    Future<ProviderContainer> seededContainer(List<Dive> dives) async {
+      for (final dive in dives) {
+        await repository.createDive(dive);
+      }
+      final container = ProviderContainer(
+        overrides: (await getBaseOverrides()).cast(),
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('monthly and year-to-date counts include in-window dives and '
+        'exclude older ones', () async {
+      final now = DateTime.now();
+      final container = await seededContainer([
+        // Noon today: strictly after both the first-of-month and first-of-year
+        // boundaries regardless of the time the suite runs.
+        _diveWithEntryTime(DateTime(now.year, now.month, now.day, 12)),
+        // Mid last year: outside both windows.
+        _diveWithEntryTime(DateTime(now.year - 1, 6, 15)),
+      ]);
+
+      final monthly = await container.read(monthlyDiveCountProvider.future);
+      final ytd = await container.read(yearToDateDiveCountProvider.future);
+
+      expect(monthly, 1);
+      expect(ytd, 1);
+    });
+  });
 }

--- a/test/features/dashboard/presentation/widgets/personal_records_card_test.dart
+++ b/test/features/dashboard/presentation/widgets/personal_records_card_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/personal_records_card.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -40,7 +40,9 @@ void main() {
         ProviderScope(
           overrides: [
             ...overrides,
-            divesProvider.overrideWith((ref) async => dives),
+            personalRecordsProvider.overrideWith(
+              (ref) async => PersonalRecords(longestDive: dives.first),
+            ),
           ].cast(),
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/dive_log/data/repositories/dashboard_queries_test.dart
+++ b/test/features/dive_log/data/repositories/dashboard_queries_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+  tearDown(() async => tearDownTestDatabase());
+
+  group('countDivesSince', () {
+    test('counts dives strictly after the boundary', () async {
+      await repository.createDive(
+        domain.Dive(id: 'before', dateTime: DateTime(2026, 5, 31, 23)),
+      );
+      await repository.createDive(
+        domain.Dive(id: 'boundary', dateTime: DateTime(2026, 6, 1)),
+      );
+      await repository.createDive(
+        domain.Dive(id: 'after', dateTime: DateTime(2026, 6, 15)),
+      );
+
+      // Strict >, matching the old Dart filter's isAfter().
+      expect(await repository.countDivesSince(DateTime(2026, 6, 1)), 1);
+      expect(await repository.countDivesSince(DateTime(2026, 5, 1)), 3);
+      expect(await repository.countDivesSince(DateTime(2026, 7, 1)), 0);
+    });
+
+    test('scopes by diver id', () async {
+      await repository.createDive(
+        domain.Dive(id: 'd1', dateTime: DateTime(2026, 6, 2)),
+      );
+      expect(
+        await repository.countDivesSince(
+          DateTime(2026, 6, 1),
+          diverId: 'nobody',
+        ),
+        0,
+      );
+    });
+  });
+
+  group('getPersonalRecordIds', () {
+    test('selects deepest, coldest, and warmest winners', () async {
+      await repository.createDive(
+        domain.Dive(
+          id: 'shallow-warm',
+          dateTime: DateTime(2026, 1, 1),
+          maxDepth: 12,
+          waterTemp: 29,
+        ),
+      );
+      await repository.createDive(
+        domain.Dive(
+          id: 'deep-cold',
+          dateTime: DateTime(2026, 1, 2),
+          maxDepth: 42,
+          waterTemp: 8,
+        ),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.deepestId, 'deep-cold');
+      expect(winners.coldestId, 'deep-cold');
+      expect(winners.warmestId, 'shallow-warm');
+    });
+
+    test('longest uses the full effectiveRuntime order, including the '
+        'profile-span fallback', () async {
+      // Explicit runtime: 50 minutes.
+      await repository.createDive(
+        domain.Dive(
+          id: 'explicit',
+          dateTime: DateTime(2026, 2, 1),
+          runtime: const Duration(minutes: 50),
+        ),
+      );
+      // No runtime/exit/bottom, but a 70-minute profile span: must win.
+      await repository.createDive(
+        domain.Dive(
+          id: 'span-winner',
+          dateTime: DateTime(2026, 2, 2),
+          profile: [
+            for (var t = 0; t <= 4200; t += 60)
+              domain.DiveProfilePoint(timestamp: t, depth: 18),
+          ],
+        ),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.longestId, 'span-winner');
+    });
+
+    test('most visited site wins by dive count', () async {
+      final siteRepo = SiteRepository();
+      final often = await siteRepo.createSite(
+        const DiveSite(id: '', name: 'House Reef'),
+      );
+      final rare = await siteRepo.createSite(
+        const DiveSite(id: '', name: 'Far Wall'),
+      );
+
+      for (var i = 0; i < 3; i++) {
+        await repository.createDive(
+          domain.Dive(
+            id: 'often-$i',
+            dateTime: DateTime(2026, 3, 1 + i),
+            site: often,
+          ),
+        );
+      }
+      await repository.createDive(
+        domain.Dive(id: 'rare-0', dateTime: DateTime(2026, 3, 10), site: rare),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.mostVisitedSiteId, often.id);
+      expect(winners.mostVisitedSiteName, 'House Reef');
+      expect(winners.mostVisitedSiteCount, 3);
+    });
+
+    test('empty database produces no winners', () async {
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.deepestId, isNull);
+      expect(winners.longestId, isNull);
+      expect(winners.coldestId, isNull);
+      expect(winners.warmestId, isNull);
+      expect(winners.mostVisitedSiteId, isNull);
+    });
+  });
+}

--- a/test/features/dive_log/data/repositories/dashboard_queries_test.dart
+++ b/test/features/dive_log/data/repositories/dashboard_queries_test.dart
@@ -127,6 +127,64 @@ void main() {
       expect(winners.mostVisitedSiteCount, 3);
     });
 
+    test('a tied record resolves to the most recent dive', () async {
+      // Two dives share the exact max depth. The old in-memory scan ran
+      // most-recent-first with a strict `>`, so the newer dive kept the
+      // record; the SQL tie-break must preserve that.
+      await repository.createDive(
+        domain.Dive(
+          id: 'older-tie',
+          dateTime: DateTime(2026, 1, 1),
+          maxDepth: 42,
+          waterTemp: 20,
+        ),
+      );
+      await repository.createDive(
+        domain.Dive(
+          id: 'newer-tie',
+          dateTime: DateTime(2026, 1, 2),
+          maxDepth: 42,
+          waterTemp: 20,
+        ),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.deepestId, 'newer-tie');
+      // Equal temps tie the same way (coldest and warmest both land here).
+      expect(winners.coldestId, 'newer-tie');
+      expect(winners.warmestId, 'newer-tie');
+    });
+
+    test('a most-visited-site count tie resolves to the site with the most '
+        'recent dive', () async {
+      final siteRepo = SiteRepository();
+      final alpha = await siteRepo.createSite(
+        const DiveSite(id: '', name: 'Alpha'),
+      );
+      final bravo = await siteRepo.createSite(
+        const DiveSite(id: '', name: 'Bravo'),
+      );
+
+      // Both sites have two dives; Bravo owns the most recent dive.
+      await repository.createDive(
+        domain.Dive(id: 'a0', dateTime: DateTime(2026, 3, 1), site: alpha),
+      );
+      await repository.createDive(
+        domain.Dive(id: 'a1', dateTime: DateTime(2026, 3, 2), site: alpha),
+      );
+      await repository.createDive(
+        domain.Dive(id: 'b0', dateTime: DateTime(2026, 3, 3), site: bravo),
+      );
+      await repository.createDive(
+        domain.Dive(id: 'b1', dateTime: DateTime(2026, 3, 4), site: bravo),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.mostVisitedSiteCount, 2);
+      expect(winners.mostVisitedSiteId, bravo.id);
+      expect(winners.mostVisitedSiteName, 'Bravo');
+    });
+
     test('empty database produces no winners', () async {
       final winners = await repository.getPersonalRecordIds();
       expect(winners.deepestId, isNull);

--- a/test/features/dive_log/data/repositories/dashboard_queries_test.dart
+++ b/test/features/dive_log/data/repositories/dashboard_queries_test.dart
@@ -238,6 +238,18 @@ void main() {
       expect(winners.mostVisitedSiteCount, 1);
     });
 
+    test('scopes record winners by diver id', () async {
+      await repository.createDive(
+        domain.Dive(id: 'd1', dateTime: DateTime(2026, 1, 1), maxDepth: 30),
+      );
+      // A non-matching diver id engages the diver_id filter and yields no
+      // winners even though a qualifying dive exists.
+      final winners = await repository.getPersonalRecordIds(diverId: 'nobody');
+      expect(winners.deepestId, isNull);
+      expect(winners.longestId, isNull);
+      expect(winners.mostVisitedSiteId, isNull);
+    });
+
     test('empty database produces no winners', () async {
       final winners = await repository.getPersonalRecordIds();
       expect(winners.deepestId, isNull);

--- a/test/features/dive_log/data/repositories/dashboard_queries_test.dart
+++ b/test/features/dive_log/data/repositories/dashboard_queries_test.dart
@@ -155,6 +155,32 @@ void main() {
       expect(winners.warmestId, 'newer-tie');
     });
 
+    test('longest falls through a zero-span profile to bottom time', () async {
+      // A dive with an explicit 10-minute runtime.
+      await repository.createDive(
+        domain.Dive(
+          id: 'runtime-10',
+          dateTime: DateTime(2026, 4, 1),
+          runtime: const Duration(minutes: 10),
+        ),
+      );
+      // No runtime/exit; a single-point profile has a zero span, which Dart's
+      // calculateRuntimeFromProfile() treats as null -> falls through to the
+      // 40-minute bottom time. The SQL must NOT read the 0-span as a
+      // 0-second runtime (which would exclude it and let runtime-10 win).
+      await repository.createDive(
+        domain.Dive(
+          id: 'bottom-40',
+          dateTime: DateTime(2026, 4, 2),
+          bottomTime: const Duration(minutes: 40),
+          profile: const [domain.DiveProfilePoint(timestamp: 300, depth: 18)],
+        ),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      expect(winners.longestId, 'bottom-40');
+    });
+
     test('a most-visited-site count tie resolves to the site with the most '
         'recent dive', () async {
       final siteRepo = SiteRepository();
@@ -183,6 +209,33 @@ void main() {
       expect(winners.mostVisitedSiteCount, 2);
       expect(winners.mostVisitedSiteId, bravo.id);
       expect(winners.mostVisitedSiteName, 'Bravo');
+    });
+
+    test('a full site tie (count and recency) resolves deterministically by '
+        'site id', () async {
+      final siteRepo = SiteRepository();
+      final one = await siteRepo.createSite(
+        const DiveSite(id: '', name: 'One'),
+      );
+      final two = await siteRepo.createSite(
+        const DiveSite(id: '', name: 'Two'),
+      );
+
+      // One dive each at the SAME timestamp: count and max-recency both tie,
+      // so only the final site_id key decides -- and it must be stable.
+      final sameInstant = DateTime(2026, 5, 5, 9);
+      await repository.createDive(
+        domain.Dive(id: 'o0', dateTime: sameInstant, site: one),
+      );
+      await repository.createDive(
+        domain.Dive(id: 't0', dateTime: sameInstant, site: two),
+      );
+
+      final winners = await repository.getPersonalRecordIds();
+      // ORDER BY ... d.site_id (ascending) -> the lexicographically smaller id.
+      final expected = ([one.id, two.id]..sort()).first;
+      expect(winners.mostVisitedSiteId, expected);
+      expect(winners.mostVisitedSiteCount, 1);
     });
 
     test('empty database produces no winners', () async {


### PR DESCRIPTION
## Summary

WS4 of the large-database performance program (spec:
`docs/superpowers/specs/2026-07-10-large-db-performance-design.md`; plan in
this branch). Removes hot-path `getAllDives()` from app startup.

**Root cause (findings doc):** the dashboard is the initial route, and
three of its providers awaited `divesProvider` -> `getAllDives()` — full
hydration of every dive with tanks/sites/centers/trips/equipment/tags on
the first home frame. Native + VM profiling attributed the ~20 s
debug-launch freeze to exactly this workload (the debug JIT compiling the
Drift mapping code hot, saturating the UI thread through the splash fade);
release/profile builds pay ~1-2 s today and scale linearly with dive count.

**Changes (provider internals only; result types and cards untouched):**
- `recentDivesProvider`: ids via `getDiveSummaries(limit: 3)`; the three
  winners hydrate individually via indexed `getDiveById`. Mini-chart batch
  preload unchanged.
- `monthlyDiveCountProvider` / `yearToDateDiveCountProvider`: new
  `countDivesSince` repository method — one COUNT statement each, same
  strict `>` boundary as the old Dart filter.
- `personalRecordsProvider`: new `getPersonalRecordIds` repository method —
  six small indexed statements (deepest / longest / coldest / warmest /
  most-visited-site GROUP BY). The longest-dive ORDER BY reproduces
  `Dive.effectiveRuntime`'s full resolution order (runtime, exit - entry,
  profile span via scalar subquery, bottom time), and `> 0` guards preserve
  the old loops' seeding semantics. The <= 4 distinct winners hydrate via
  `getDiveById`.
- All three self-invalidate on `watchDivesChanges()` (previously inherited
  transitively through `divesProvider`; #217 pattern) and scope by
  `currentDiverIdProvider` exactly as before.

**Recorded deferral:** table view mode and detailed-cards-with-non-summary
fields still use `getAllDives()` (opt-in views, not startup cost); widening
`DiveSummary` to every configurable column is follow-up work if the
post-WS4 re-measure shows it mattering.

## Test plan

- New `dashboard_queries_test.dart` (6 tests): COUNT boundary semantics +
  diver scoping; record winners incl. the profile-span-longest case that
  validates the SQL effectiveRuntime mirror; most-visited-site GROUP BY;
  empty-database behavior.
- Dashboard suites green (19 tests): the three `personalRecordsProvider`
  longest-dive semantics tests now run end-to-end against a seeded real
  database instead of a faked `divesProvider`; the card test overrides the
  provider output directly; `recent_dives_reactivity_test` (#217) green.
- Whole-project `flutter analyze`: no issues; `dart format .`: clean.
- Residual: a debug `flutter run` on the 1,032-dive database rides the next
  user session — expected: the ~20 s splash freeze is gone.