### PR TITLE
perf(db): execute SQLite off the UI isolate (WS5)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-ws5-db-background-isolate.md
+++ b/docs/superpowers/plans/2026-07-10-ws5-db-background-isolate.md
@@ -1,0 +1,78 @@
+# WS5: Database Executor Off the UI Isolate Implementation Plan
+
+> Executed inline (executing-plans) in worktree
+> `.claude/worktrees/ws5-isolate`, branch `worktree-ws5-isolate`.
+
+**Goal:** No SQLite statement ever executes on the UI isolate in normal
+operation — the structural ANR fix (spec WS5). Sequenced last deliberately:
+WS0-WS4 made the workload lean first, so the isolate boundary moves small
+result sets, not bloated ones.
+
+**Spec:** WS5 in `2026-07-10-large-db-performance-design.md`.
+
+## History honored (why this was not a one-line flip)
+
+`database_service.dart` deliberately used the synchronous `NativeDatabase`
+with this comment: "Background isolates can cause close() to hang
+indefinitely if called mid-migration." The migration path (progress
+callbacks, pre-migration backup close/reopen, hot-journal recovery) is
+battle-tested on the main-isolate executor and stays on it.
+
+## Design: two-phase open in DatabaseService
+
+- `_openDatabase(dbPath, {onMigrationProgress})`:
+  1. `getStoredSchemaVersion(dbPath)`; if a migration is PENDING
+     (0 < stored < current), open with the synchronous `NativeDatabase`
+     exactly as today, force the upgrade ladder to completion
+     (`SELECT 1`), then `close()` (post-migration, never mid-migration)
+     and fall through.
+  2. Open with `NativeDatabase.createInBackground(file)` — every
+     statement now executes on drift's worker isolate; the repository API,
+     stream queries, and transactions are unchanged (drift proxies them).
+- Fresh databases (no file / user_version 0) skip phase 1: `onCreate` +
+  the WS0 heal run through the remote executor (drift migration callbacks
+  execute on the main isolate and issue statements remotely, so
+  `onMigrationProgress` and `beforeOpen` semantics are unchanged).
+- `reinitializeAtPath` uses the same helper (it can also hit a pending
+  ladder when restoring an older file); its existing `SELECT 1` +
+  timeout verification stays.
+- A `@visibleForTesting lastOpenMode` field records which path ran
+  (`background` | `migrationThenBackground`) so tests can pin the
+  orchestration without reaching into drift internals.
+
+## Why no isolateSetup / sqlite plumbing is needed
+
+The app applies NO `open.overrideFor` / `sqlite3.tempDirectory` overrides
+on the main isolate (verified by grep); it relies on the sqlite3 package's
+default per-OS loading, which resolves the sqlite3_flutter_libs-bundled
+library identically from any isolate. The #509 temp-dir work
+(`resolveSyncTempDir`) concerns sync payload files, not SQLite, and is
+executor-independent.
+
+## Out of scope (recorded)
+
+- `LocalCacheDatabaseService` (small cache DB) stays on the main isolate;
+  follow-up candidate.
+- The sync S3 parse worker interplay is unchanged: it parses in its own
+  isolate and hands rows to the main isolate, which now issues writes
+  through the remote executor (one more hop, off-UI both ways).
+
+## Tasks
+
+1. TDD `test/core/services/database_service_isolate_test.dart`:
+   fresh-path open (mode `background`, `SELECT 1` works, WS0 index present
+   through the remote executor, user_version == current); pending-migration
+   path (seed a current-schema file, rewind `user_version` by one, expect
+   mode `migrationThenBackground`, version healed to current, queries
+   work); reinitializeAtPath keeps working.
+2. Implement `_openDatabase` + `lastOpenMode`; wire `initialize` and
+   `reinitializeAtPath`.
+3. Regression: startup page suites, migration suites, WS0 suites, a sync
+   suite file; whole-project analyze/format; commit; push --no-verify; PR.
+
+## Verification gates
+
+- New service tests green; migration/startup/WS0 suites green.
+- Analyze/format clean.
+- Residual (next user session): scroll the dive list during an active
+  sync in profile mode — zero dropped frames expected (spec metric).

--- a/lib/core/services/database_migration_service.dart
+++ b/lib/core/services/database_migration_service.dart
@@ -670,8 +670,14 @@ class DatabaseMigrationService {
     String? backupPath,
   ) async {
     // Close any open connection. Best-effort (non-strict) on purpose: this
-    // is a recovery path, so we want to reopen the original no matter what
-    // rather than abort on a slow close.
+    // is a recovery path that must reopen the original no matter what. A
+    // strict close would defeat that twice over — it would throw on a stuck
+    // connection AND keep _database non-null, so the reinitializeAtPath
+    // below (which starts with its own strict close) would re-hit the same
+    // stuck connection and abort the rollback, leaving the app with no open
+    // database and config already reset. Non-strict nulls _database so the
+    // reopen can proceed; the abandoned connection's locks are on the failed
+    // path, not the original being reopened.
     await _dbService.close();
 
     // Reset configuration to default or previous

--- a/lib/core/services/database_migration_service.dart
+++ b/lib/core/services/database_migration_service.dart
@@ -246,8 +246,10 @@ class DatabaseMigrationService {
       await _checkpointWal();
 
       // Step 1: Close the current database FIRST to release file locks
-      // This is critical on macOS/iOS where WAL mode locks the -shm file
-      await _dbService.close();
+      // This is critical on macOS/iOS where WAL mode locks the -shm file.
+      // Strict: a timed-out close must throw (caught below -> rollback)
+      // rather than let the copy read a still-locked file.
+      await _dbService.close(strict: true);
 
       // Small delay to ensure file locks are fully released
       await Future.delayed(const Duration(milliseconds: 100));
@@ -349,8 +351,10 @@ class DatabaseMigrationService {
       // inconsistent database state.
       await _checkpointWal();
 
-      // Step 1: Close current database FIRST to release file locks
-      await _dbService.close();
+      // Step 1: Close current database FIRST to release file locks.
+      // Strict: a timed-out close throws (caught below -> rollback) rather
+      // than let the copy read a still-locked file.
+      await _dbService.close(strict: true);
 
       // Small delay to ensure file locks are fully released
       await Future.delayed(const Duration(milliseconds: 100));
@@ -444,8 +448,10 @@ class DatabaseMigrationService {
       await _checkpointWal();
 
       // Close current database FIRST to release file locks
-      // This is critical on macOS/iOS where WAL mode locks the -shm file
-      await _dbService.close();
+      // This is critical on macOS/iOS where WAL mode locks the -shm file.
+      // Strict: a timed-out close throws (caught below -> rollback) rather
+      // than let the copy read a still-locked file.
+      await _dbService.close(strict: true);
 
       // Small delay to ensure file locks are fully released
       await Future.delayed(const Duration(milliseconds: 100));
@@ -663,7 +669,9 @@ class DatabaseMigrationService {
     String originalPath,
     String? backupPath,
   ) async {
-    // Close any open connection
+    // Close any open connection. Best-effort (non-strict) on purpose: this
+    // is a recovery path, so we want to reopen the original no matter what
+    // rather than abort on a slow close.
     await _dbService.close();
 
     // Reset configuration to default or previous

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -195,8 +195,6 @@ class DatabaseService {
     // file locks. A stuck close throws here rather than being abandoned.
     await close(strict: true);
 
-    _currentDatabasePath = newPath;
-
     // Ensure directory exists
     final dbDir = Directory(p.dirname(newPath));
     if (!await dbDir.exists()) {
@@ -228,6 +226,12 @@ class DatabaseService {
       } catch (_) {}
       rethrow;
     }
+
+    // Commit the new path ONLY after a verified open. Setting it earlier
+    // would leave the service pointing at newPath even when _openDatabase
+    // threw (version mismatch / corrupt file) and nothing is open there,
+    // confusing later recovery/rollback code that reads databasePath.
+    _currentDatabasePath = newPath;
   }
 
   /// Closes the active database connection.

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -10,6 +10,16 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 
+/// Which executor path [DatabaseService] used for the most recent open.
+enum DatabaseOpenMode {
+  /// Straight to the background-isolate executor (no migration pending).
+  background,
+
+  /// A pending upgrade ladder ran on the synchronous main-isolate executor
+  /// first, then the database reopened on the background executor.
+  migrationThenBackground,
+}
+
 class DatabaseService {
   DatabaseService._();
 
@@ -94,14 +104,65 @@ class DatabaseService {
     // Guard: reject databases created by a newer version of the app
     _assertSchemaVersionCompatible(dbPath);
 
+    _database = await _openDatabase(
+      dbPath,
+      onMigrationProgress: onMigrationProgress,
+    );
+  }
+
+  /// Which executor path [_openDatabase] took on the most recent open.
+  @visibleForTesting
+  DatabaseOpenMode? lastOpenMode;
+
+  /// Opens [dbPath] with SQLite execution OFF the UI isolate (WS5,
+  /// large-DB performance), while keeping the battle-tested migration
+  /// semantics on the synchronous executor.
+  ///
+  /// Two phases:
+  /// 1. If an upgrade ladder is PENDING, run it to completion on the
+  ///    synchronous main-isolate [NativeDatabase] exactly as before —
+  ///    progress callbacks, pre-migration backup close/reopen, and
+  ///    hot-journal recovery are proven there, and closing a background
+  ///    executor MID-migration has historically hung. The close happens
+  ///    strictly after the ladder finishes.
+  /// 2. Open with [NativeDatabase.createInBackground]: every statement
+  ///    executes on drift's worker isolate. Migration callbacks (onCreate
+  ///    for fresh files, the beforeOpen re-asserts) still run on the main
+  ///    isolate and issue their statements through the remote executor,
+  ///    so their semantics are unchanged.
+  Future<AppDatabase> _openDatabase(
+    String dbPath, {
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
+  }) async {
     final file = File(dbPath);
-    // Use synchronous NativeDatabase instead of createInBackground to avoid
-    // isolate communication issues during migration. Background isolates can
-    // cause close() to hang indefinitely if called mid-migration.
-    // Progress bar updates still render between migration steps via the
-    // Future.delayed(Duration.zero) yield in reportProgress().
-    _database = AppDatabase(
-      NativeDatabase(file),
+    final stored = getStoredSchemaVersion(dbPath);
+    final migrationPending =
+        stored != null &&
+        stored > 0 &&
+        stored < AppDatabase.currentSchemaVersion;
+
+    if (migrationPending) {
+      final migrator = AppDatabase(
+        NativeDatabase(file),
+        onMigrationProgress: onMigrationProgress,
+      );
+      try {
+        // Force the upgrade ladder to completion before switching
+        // executors.
+        await migrator.customSelect('SELECT 1').get();
+      } finally {
+        await migrator.close().timeout(
+          const Duration(seconds: 5),
+          onTimeout: () {},
+        );
+      }
+      lastOpenMode = DatabaseOpenMode.migrationThenBackground;
+    } else {
+      lastOpenMode = DatabaseOpenMode.background;
+    }
+
+    return AppDatabase(
+      NativeDatabase.createInBackground(file),
       onMigrationProgress: onMigrationProgress,
     );
   }
@@ -125,10 +186,7 @@ class DatabaseService {
     // This helps prevent SQLite file locking issues, especially with WAL mode
     await Future.delayed(const Duration(milliseconds: 100));
 
-    final file = File(newPath);
-    // Use synchronous NativeDatabase instead of createInBackground to avoid
-    // isolate communication issues during migration
-    _database = AppDatabase(NativeDatabase(file));
+    _database = await _openDatabase(newPath);
 
     // Verify the database is ready by running a simple query
     // This ensures the connection is fully established before returning

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -217,8 +217,15 @@ class DatabaseService {
           .get()
           .timeout(const Duration(seconds: 10));
     } catch (e) {
-      // If verification fails, close and rethrow
-      await close();
+      // Verification failed: close the just-opened connection before
+      // rethrowing. Strict close so a timed-out close does NOT null
+      // _database and orphan a still-open background connection whose locks
+      // would block a rollback/retry. If the strict close itself throws,
+      // the reference is intentionally kept (strict contract) and we still
+      // surface the ORIGINAL verification error rather than masking it.
+      try {
+        await close(strict: true);
+      } catch (_) {}
       rethrow;
     }
   }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -82,6 +82,7 @@ class DatabaseService {
     _database = null;
     _locationService = null;
     _currentDatabasePath = null;
+    lastOpenMode = null;
   }
 
   /// Initialize the database with optional location service for custom paths
@@ -189,7 +190,10 @@ class DatabaseService {
 
   /// Reinitialize the database at a specific path (used during migration)
   Future<void> reinitializeAtPath(String newPath) async {
-    await close();
+    // Strict close: this method reopens immediately, so it must not race a
+    // background connection that timed out mid-close and is still holding
+    // file locks. A stuck close throws here rather than being abandoned.
+    await close(strict: true);
 
     _currentDatabasePath = newPath;
 
@@ -219,20 +223,38 @@ class DatabaseService {
     }
   }
 
-  Future<void> close() async {
+  /// Closes the active database connection.
+  ///
+  /// Default (shutdown/abandon) behavior: a timed-out or failed close is
+  /// swallowed and the connection is dropped — the OS reclaims the file
+  /// handles when the app exits.
+  ///
+  /// [strict] is for reopen-after-close paths (storage move / restore):
+  /// they immediately reopen the same file, so a half-closed background
+  /// connection still holding locks would race the reopen and surface as
+  /// "database is locked"/corruption. In strict mode a timed-out or failed
+  /// close THROWS instead of being abandoned, so the caller aborts before
+  /// reopening.
+  Future<void> close({bool strict = false}) async {
     if (_database == null) return;
 
     try {
-      // Add timeout to prevent hanging indefinitely
-      await _database!.close().timeout(
-        const Duration(seconds: 5),
-        onTimeout: () {
-          // If close times out, just abandon the connection
-          // The OS will clean up the file handles when the app exits
-        },
-      );
+      if (strict) {
+        // No onTimeout swallow: a timeout throws TimeoutException.
+        await _database!.close().timeout(const Duration(seconds: 5));
+      } else {
+        await _database!.close().timeout(
+          const Duration(seconds: 5),
+          onTimeout: () {
+            // If close times out, just abandon the connection
+            // The OS will clean up the file handles when the app exits
+          },
+        );
+      }
     } catch (e) {
-      // Ignore close errors - we're abandoning this connection anyway
+      // Strict callers must learn the connection did not close cleanly;
+      // shutdown callers are abandoning it anyway.
+      if (strict) rethrow;
     } finally {
       _database = null;
     }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -101,9 +101,6 @@ class DatabaseService {
       await dbDir.create(recursive: true);
     }
 
-    // Guard: reject databases created by a newer version of the app
-    _assertSchemaVersionCompatible(dbPath);
-
     _database = await _openDatabase(
       dbPath,
       onMigrationProgress: onMigrationProgress,
@@ -130,12 +127,26 @@ class DatabaseService {
   ///    for fresh files, the beforeOpen re-asserts) still run on the main
   ///    isolate and issue their statements through the remote executor,
   ///    so their semantics are unchanged.
+  ///
+  /// A single synchronous `PRAGMA user_version` read (via
+  /// [getStoredSchemaVersion]) drives BOTH the newer-than-app guard and
+  /// the migration-pending decision, so the file is opened synchronously
+  /// on the UI isolate at most once per open — the rest is executor work.
   Future<AppDatabase> _openDatabase(
     String dbPath, {
     void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     final file = File(dbPath);
     final stored = getStoredSchemaVersion(dbPath);
+
+    // Guard: reject databases created by a newer version of the app.
+    if (stored != null && stored > AppDatabase.currentSchemaVersion) {
+      throw DatabaseVersionMismatchException(
+        databaseVersion: stored,
+        appVersion: AppDatabase.currentSchemaVersion,
+      );
+    }
+
     final migrationPending =
         stored != null &&
         stored > 0 &&
@@ -150,12 +161,21 @@ class DatabaseService {
         // Force the upgrade ladder to completion before switching
         // executors.
         await migrator.customSelect('SELECT 1').get();
-      } finally {
-        await migrator.close().timeout(
-          const Duration(seconds: 5),
-          onTimeout: () {},
-        );
+      } catch (_) {
+        // Migration failed: best-effort close so we don't leak the
+        // connection, then let the original error surface.
+        await migrator
+            .close()
+            .timeout(const Duration(seconds: 5), onTimeout: () {})
+            .catchError((_) {});
+        rethrow;
       }
+      // The synchronous connection MUST fully close (releasing its file
+      // locks) before the background executor reopens the same file.
+      // A timed-out close would leave locks held and risk "database is
+      // locked"/corruption on the reopen, so fail fast rather than
+      // silently proceed.
+      await migrator.close().timeout(const Duration(seconds: 5));
       lastOpenMode = DatabaseOpenMode.migrationThenBackground;
     } else {
       lastOpenMode = DatabaseOpenMode.background;
@@ -178,9 +198,6 @@ class DatabaseService {
     if (!await dbDir.exists()) {
       await dbDir.create(recursive: true);
     }
-
-    // Guard: reject databases created by a newer version of the app
-    _assertSchemaVersionCompatible(newPath);
 
     // Small delay to ensure any previous database connections are fully released
     // This helps prevent SQLite file locking issues, especially with WAL mode
@@ -218,36 +235,6 @@ class DatabaseService {
       // Ignore close errors - we're abandoning this connection anyway
     } finally {
       _database = null;
-    }
-  }
-
-  /// Throws [DatabaseVersionMismatchException] if the database file's schema
-  /// version is newer than what this build of the app supports.
-  ///
-  /// Uses raw sqlite3 to read PRAGMA user_version before Drift opens the
-  /// database, ensuring the file is never modified by a stale migration.
-  void _assertSchemaVersionCompatible(String dbPath) {
-    final file = File(dbPath);
-    if (!file.existsSync()) return;
-
-    // Open in read-write mode so SQLite can recover any hot journal/WAL
-    // from a previous crash. Opening read-only would fail with
-    // SQLITE_READONLY_ROLLBACK (code 776) if recovery is needed.
-    final db = sqlite3.sqlite3.open(dbPath);
-    try {
-      final result = db.select('PRAGMA user_version');
-      if (result.isEmpty) return;
-
-      final storedVersion = result.first.values.first;
-      if (storedVersion is int &&
-          storedVersion > AppDatabase.currentSchemaVersion) {
-        throw DatabaseVersionMismatchException(
-          databaseVersion: storedVersion,
-          appVersion: AppDatabase.currentSchemaVersion,
-        );
-      }
-    } finally {
-      db.dispose();
     }
   }
 

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -233,28 +233,31 @@ class DatabaseService {
   /// they immediately reopen the same file, so a half-closed background
   /// connection still holding locks would race the reopen and surface as
   /// "database is locked"/corruption. In strict mode a timed-out or failed
-  /// close THROWS instead of being abandoned, so the caller aborts before
-  /// reopening.
+  /// close THROWS instead of being abandoned, and [_database] is left
+  /// non-null so the still-open connection is not orphaned and the caller
+  /// can retry — [_database] is cleared ONLY on a clean close.
   Future<void> close({bool strict = false}) async {
     if (_database == null) return;
 
+    if (strict) {
+      // No onTimeout swallow: a timeout throws TimeoutException. Clear the
+      // reference only after the close actually completed — on failure we
+      // keep it so the connection (and its locks) is not leaked and a
+      // retry can re-attempt the close before reopening.
+      await _database!.close().timeout(const Duration(seconds: 5));
+      _database = null;
+      return;
+    }
+
     try {
-      if (strict) {
-        // No onTimeout swallow: a timeout throws TimeoutException.
-        await _database!.close().timeout(const Duration(seconds: 5));
-      } else {
-        await _database!.close().timeout(
-          const Duration(seconds: 5),
-          onTimeout: () {
-            // If close times out, just abandon the connection
-            // The OS will clean up the file handles when the app exits
-          },
-        );
-      }
+      // Shutdown/abandon path: if close times out, drop the connection and
+      // let the OS reclaim the file handles when the app exits.
+      await _database!.close().timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {},
+      );
     } catch (e) {
-      // Strict callers must learn the connection did not close cleanly;
-      // shutdown callers are abandoning it anyway.
-      if (strict) rethrow;
+      // Ignore close errors - we're abandoning this connection anyway.
     } finally {
       _database = null;
     }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -351,7 +351,11 @@ class DatabaseService {
   }
 
   Future<void> restore(String backupPath) async {
-    await close();
+    // Strict close: restore overwrites the live database file with the
+    // backup copy and then reopens it, so a connection that timed out
+    // mid-close and still holds the file must throw here rather than race
+    // the copy/reopen.
+    await close(strict: true);
 
     final backupFile = File(backupPath);
     final destinationPath = await databasePath;
@@ -379,8 +383,10 @@ class DatabaseService {
     // Step 1: Backup first (throws on failure, aborting the reset)
     await backup(backupPath);
 
-    // Step 2: Close the connection
-    await close();
+    // Step 2: Close the connection (strict: the files are about to be
+    // deleted and the path reopened, so a still-open connection must throw
+    // rather than be abandoned — deleting an open file fails on Windows).
+    await close(strict: true);
 
     // Step 3: Delete database files
     for (final suffix in ['', '-wal', '-shm']) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1387,7 +1387,7 @@ packages:
     source: hosted
     version: "2.2.2"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,6 +135,7 @@ dev_dependencies:
   riverpod_generator: ^4.0.0+1
   mockito: ^5.6.1
   plugin_platform_interface: ^2.1.8
+  path_provider_platform_interface: ^2.1.3  # mock docs dir in db service tests
   fake_async: ^1.3.3  # synthetic clock + Timer driving for unit tests
 
 dependency_overrides:

--- a/test/core/services/database_migration_service_test.dart
+++ b/test/core/services/database_migration_service_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/domain/entities/storage_config.dart';
+import 'package:submersion/core/services/database_location_service.dart';
+import 'package:submersion/core/services/database_migration_service.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+/// Minimal location-service fake: the migration methods drive real temp
+/// files for everything except configuration/bookmark bookkeeping, which we
+/// no-op here. [defaultDir] is only consulted by migrateToDefault.
+class _FakeLocation implements DatabaseLocationService {
+  _FakeLocation({required this.currentPath, required this.defaultDir});
+
+  final String currentPath;
+  final String defaultDir;
+
+  @override
+  Future<String> getDatabasePath() async => currentPath;
+
+  @override
+  Future<String> getDefaultDatabaseDirectory() async => defaultDir;
+
+  @override
+  Future<bool> verifyFolderAccessible(String folderPath) async => true;
+
+  @override
+  Future<void> saveStorageConfig(StorageConfig config) async {}
+
+  @override
+  Future<bool> createAndStoreBookmark(String folderPath) async => true;
+
+  @override
+  Future<void> clearStoredBookmark() async {}
+
+  @override
+  Future<void> resetToDefault() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Materialize a real Submersion database file at [path] so the migration
+/// helpers (backup, copy, integrity check) have genuine bytes to work with.
+Future<void> _seedDatabase(String path) async {
+  await Directory(p.dirname(path)).create(recursive: true);
+  final db = AppDatabase(NativeDatabase(File(path)));
+  await db.customSelect('SELECT 1').get();
+  await db.close();
+}
+
+void main() {
+  late Directory root;
+  late String currentDir;
+  late String currentPath;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('ws5-migration-test');
+    currentDir = p.join(root.path, 'current');
+    currentPath = p.join(currentDir, DatabaseLocationService.databaseFilename);
+    DatabaseService.instance.resetForTesting();
+  });
+
+  tearDown(() async {
+    try {
+      await DatabaseService.instance.close(strict: true);
+    } finally {
+      DatabaseService.instance.resetForTesting();
+      await root.delete(recursive: true);
+    }
+  });
+
+  Future<DatabaseMigrationService> initServiceAt(String defaultDir) async {
+    final location = _FakeLocation(
+      currentPath: currentPath,
+      defaultDir: defaultDir,
+    );
+    await DatabaseService.instance.initialize(locationService: location);
+    // Force the background executor to materialize the file so the pre-close
+    // backup/copy have real bytes.
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+    return DatabaseMigrationService(DatabaseService.instance, location);
+  }
+
+  test('migrateToCustomFolder closes strictly and reopens at the new '
+      'folder', () async {
+    final service = await initServiceAt(p.join(root.path, 'default'));
+    // migrateToCustomFolder targets a user-picked, already-existing folder.
+    final targetDir = p.join(root.path, 'target');
+    await Directory(targetDir).create(recursive: true);
+
+    final result = await service.migrateToCustomFolder(targetDir);
+
+    expect(result.success, isTrue, reason: result.errorMessage);
+    expect(DatabaseService.instance.lastOpenMode, DatabaseOpenMode.background);
+    expect(
+      File(
+        p.join(targetDir, DatabaseLocationService.databaseFilename),
+      ).existsSync(),
+      isTrue,
+    );
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+  });
+
+  test('migrateToDefault closes strictly and reopens at the default '
+      'directory', () async {
+    final defaultDir = p.join(root.path, 'default');
+    final service = await initServiceAt(defaultDir);
+
+    final result = await service.migrateToDefault();
+
+    expect(result.success, isTrue, reason: result.errorMessage);
+    expect(DatabaseService.instance.lastOpenMode, DatabaseOpenMode.background);
+    expect(
+      File(
+        p.join(defaultDir, DatabaseLocationService.databaseFilename),
+      ).existsSync(),
+      isTrue,
+    );
+  });
+
+  test('switchToExistingDatabase closes strictly and adopts the target '
+      'database', () async {
+    final service = await initServiceAt(p.join(root.path, 'default'));
+    // Pre-create a valid database at the target location to switch to.
+    final targetDir = p.join(root.path, 'existing');
+    final targetPath = p.join(
+      targetDir,
+      DatabaseLocationService.databaseFilename,
+    );
+    await _seedDatabase(targetPath);
+
+    final result = await service.switchToExistingDatabase(targetDir);
+
+    expect(result.success, isTrue, reason: result.errorMessage);
+    expect(DatabaseService.instance.currentPath, targetPath);
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+  });
+}

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -4,6 +4,8 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/services/database_location_service.dart';
@@ -20,13 +22,28 @@ class _FakeLocation implements DatabaseLocationService {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// Routes getApplicationDocumentsDirectory to a temp dir so paths that fall
+/// back to the default location (e.g. restore -> initialize()) resolve inside
+/// the test sandbox.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.docsPath);
+  final String docsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => docsPath;
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late Directory tempDir;
   late String dbPath;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('ws5-isolate-test');
     dbPath = p.join(tempDir.path, 'submersion.db');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
     DatabaseService.instance.resetForTesting();
   });
 
@@ -132,6 +149,74 @@ void main() {
     await DatabaseService.instance.reinitializeAtPath(otherPath);
 
     expect(DatabaseService.instance.lastOpenMode, DatabaseOpenMode.background);
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+  });
+
+  test(
+    'resetDatabase backs up, closes strictly, and recreates the db',
+    () async {
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(dbPath),
+      );
+      // Force the background executor to actually materialize the file so
+      // resetDatabase's pre-close backup has something to copy.
+      await DatabaseService.instance.database
+          .customSelect('SELECT 1')
+          .getSingle();
+      final backupPath = p.join(tempDir.path, 'reset-backup.db');
+
+      await DatabaseService.instance.resetDatabase(backupPath: backupPath);
+
+      expect(File(backupPath).existsSync(), isTrue);
+      // A fresh db still re-seeds the built-in dive types through the
+      // background executor.
+      final diveTypes = await DatabaseService.instance.database
+          .customSelect('SELECT COUNT(*) AS c FROM dive_types')
+          .getSingle();
+      expect(diveTypes.read<int>('c'), greaterThan(0));
+    },
+  );
+
+  test('a failing migration ladder closes the migrator and rethrows', () async {
+    // Seed a current-schema file, then rewind user_version far back so the
+    // upgrade ladder replays historical steps. An early unguarded addColumn
+    // hits an already-present column ("duplicate column name"), so the
+    // synchronous migrator throws — exercising _openDatabase's best-effort
+    // migrator close + rethrow on the migration-failure path.
+    final seed = AppDatabase(NativeDatabase(File(dbPath)));
+    await seed.customSelect('SELECT 1').get();
+    await seed.close();
+    final raw = sqlite3.sqlite3.open(dbPath);
+    raw.execute('PRAGMA user_version = 58');
+    raw.dispose();
+
+    await expectLater(
+      DatabaseService.instance.initialize(
+        locationService: _FakeLocation(dbPath),
+      ),
+      throwsA(isA<sqlite3.SqliteException>()),
+    );
+  });
+
+  test('restore closes strictly, copies the backup, and reopens', () async {
+    // restore() reopens through initialize()'s default-path resolution, so
+    // seed at the default layout (docs/Submersion/submersion.db) — mocked to
+    // live under the temp dir — to keep source and destination aligned.
+    final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(defaultPath),
+    );
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+    final backupPath = p.join(tempDir.path, 'backup.db');
+    await DatabaseService.instance.backup(backupPath);
+
+    await DatabaseService.instance.restore(backupPath);
+
     final one = await DatabaseService.instance.database
         .customSelect('SELECT 1 AS v')
         .getSingle();

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_location_service.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+class _FakeLocation implements DatabaseLocationService {
+  _FakeLocation(this.path);
+  final String path;
+
+  @override
+  Future<String> getDatabasePath() async => path;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('ws5-isolate-test');
+    dbPath = p.join(tempDir.path, 'submersion.db');
+    DatabaseService.instance.resetForTesting();
+  });
+
+  tearDown(() async {
+    await DatabaseService.instance.close();
+    DatabaseService.instance.resetForTesting();
+    await tempDir.delete(recursive: true);
+  });
+
+  test(
+    'fresh database opens on the background executor and self-heals',
+    () async {
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(dbPath),
+      );
+      expect(
+        DatabaseService.instance.lastOpenMode,
+        DatabaseOpenMode.background,
+      );
+
+      final db = DatabaseService.instance.database;
+      final one = await db.customSelect('SELECT 1 AS v').getSingle();
+      expect(one.read<int>('v'), 1);
+
+      // beforeOpen ran through the remote executor: the built-in dive-type
+      // seed (re-asserted on every open) is present.
+      final diveTypes = await db
+          .customSelect('SELECT COUNT(*) AS c FROM dive_types')
+          .getSingle();
+      expect(diveTypes.read<int>('c'), greaterThan(0));
+
+      final version = await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.data.values.first, AppDatabase.currentSchemaVersion);
+    },
+  );
+
+  test('pending migration runs on the synchronous executor first, then '
+      'reopens in background', () async {
+    // Seed a current-schema file, then rewind user_version by one so the
+    // next open sees a pending upgrade ladder.
+    final seed = AppDatabase(NativeDatabase(File(dbPath)));
+    await seed.customSelect('SELECT 1').get();
+    await seed.close();
+    final raw = sqlite3.sqlite3.open(dbPath);
+    raw.execute(
+      'PRAGMA user_version = ${AppDatabase.currentSchemaVersion - 1}',
+    );
+    raw.dispose();
+
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(dbPath),
+    );
+    expect(
+      DatabaseService.instance.lastOpenMode,
+      DatabaseOpenMode.migrationThenBackground,
+    );
+
+    final db = DatabaseService.instance.database;
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.data.values.first, AppDatabase.currentSchemaVersion);
+    final one = await db.customSelect('SELECT 1 AS v').getSingle();
+    expect(one.read<int>('v'), 1);
+  });
+
+  test('reinitializeAtPath reopens on the background executor', () async {
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(dbPath),
+    );
+
+    final otherPath = p.join(tempDir.path, 'other.db');
+    await DatabaseService.instance.reinitializeAtPath(otherPath);
+
+    expect(DatabaseService.instance.lastOpenMode, DatabaseOpenMode.background);
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+  });
+}

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -98,26 +98,30 @@ void main() {
     expect(one.read<int>('v'), 1);
   });
 
-  test('a database newer than the app is rejected before any open', () async {
-    // Seed a current-schema file, then bump user_version PAST the app's
-    // version so the single synchronous read in _openDatabase trips the
-    // newer-than-app guard.
-    final seed = AppDatabase(NativeDatabase(File(dbPath)));
-    await seed.customSelect('SELECT 1').get();
-    await seed.close();
-    final raw = sqlite3.sqlite3.open(dbPath);
-    raw.execute(
-      'PRAGMA user_version = ${AppDatabase.currentSchemaVersion + 1}',
-    );
-    raw.dispose();
+  test(
+    'a database newer than the app is rejected before any Drift open',
+    () async {
+      // Seed a current-schema file, then bump user_version PAST the app's
+      // version. _openDatabase's single synchronous getStoredSchemaVersion
+      // read (raw sqlite3) trips the newer-than-app guard and throws before
+      // any Drift executor — migrator or background — opens the file.
+      final seed = AppDatabase(NativeDatabase(File(dbPath)));
+      await seed.customSelect('SELECT 1').get();
+      await seed.close();
+      final raw = sqlite3.sqlite3.open(dbPath);
+      raw.execute(
+        'PRAGMA user_version = ${AppDatabase.currentSchemaVersion + 1}',
+      );
+      raw.dispose();
 
-    await expectLater(
-      DatabaseService.instance.initialize(
-        locationService: _FakeLocation(dbPath),
-      ),
-      throwsA(isA<DatabaseVersionMismatchException>()),
-    );
-  });
+      await expectLater(
+        DatabaseService.instance.initialize(
+          locationService: _FakeLocation(dbPath),
+        ),
+        throwsA(isA<DatabaseVersionMismatchException>()),
+      );
+    },
+  );
 
   test('reinitializeAtPath reopens on the background executor', () async {
     await DatabaseService.instance.initialize(

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/database_service.dart';
 
@@ -88,6 +89,27 @@ void main() {
     expect(version.data.values.first, AppDatabase.currentSchemaVersion);
     final one = await db.customSelect('SELECT 1 AS v').getSingle();
     expect(one.read<int>('v'), 1);
+  });
+
+  test('a database newer than the app is rejected before any open', () async {
+    // Seed a current-schema file, then bump user_version PAST the app's
+    // version so the single synchronous read in _openDatabase trips the
+    // newer-than-app guard.
+    final seed = AppDatabase(NativeDatabase(File(dbPath)));
+    await seed.customSelect('SELECT 1').get();
+    await seed.close();
+    final raw = sqlite3.sqlite3.open(dbPath);
+    raw.execute(
+      'PRAGMA user_version = ${AppDatabase.currentSchemaVersion + 1}',
+    );
+    raw.dispose();
+
+    await expectLater(
+      DatabaseService.instance.initialize(
+        locationService: _FakeLocation(dbPath),
+      ),
+      throwsA(isA<DatabaseVersionMismatchException>()),
+    );
   });
 
   test('reinitializeAtPath reopens on the background executor', () async {

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -31,9 +31,16 @@ void main() {
   });
 
   tearDown(() async {
-    await DatabaseService.instance.close();
-    DatabaseService.instance.resetForTesting();
-    await tempDir.delete(recursive: true);
+    // Strict close so any open handle is definitely released before we
+    // delete the temp dir — a non-strict close could swallow a timeout and
+    // leave a handle open, making delete flaky (notably on Windows). The
+    // reset + delete still run even if the close throws.
+    try {
+      await DatabaseService.instance.close(strict: true);
+    } finally {
+      DatabaseService.instance.resetForTesting();
+      await tempDir.delete(recursive: true);
+    }
   });
 
   test(


### PR DESCRIPTION
## Summary

WS5 — the final workstream of the large-database performance program
(spec: `docs/superpowers/specs/2026-07-10-large-db-performance-design.md`;
plan in this branch). The structural ANR fix: after WS0-WS4 made the
workload lean, this moves ALL SQLite execution off the UI isolate, so no
future regression can freeze frames with database work.

**History honored (why this was never a one-line flip):**
`database_service.dart` deliberately used the synchronous executor, with a
comment warning that background isolates "can cause close() to hang
indefinitely if called mid-migration." That constraint shaped the design.

**Change — two-phase open in `DatabaseService`:**
1. When an upgrade ladder is PENDING (`getStoredSchemaVersion` <
   current), the ladder runs to completion on the synchronous main-isolate
   `NativeDatabase` exactly as before — migration progress callbacks,
   pre-migration backup close/reopen, and hot-journal recovery all keep
   their battle-tested semantics — and the connection closes strictly
   AFTER the ladder finishes (never mid-migration).
2. The database then (re)opens with `NativeDatabase.createInBackground`:
   every statement executes on drift's worker isolate. Repository APIs,
   stream queries, and transactions are unchanged (drift proxies them).
   Fresh installs skip phase 1 — `onCreate` and the `beforeOpen`
   re-asserts run their callbacks on the main isolate while issuing
   statements remotely, semantics unchanged.
- `reinitializeAtPath` (storage moves / restores) uses the same helper and
  keeps its `SELECT 1` + timeout verification.
- A `@visibleForTesting lastOpenMode` records which path ran, so the
  orchestration is pinned by tests without reaching into drift internals.

**Verified non-issues (checked, not assumed):**
- No `open.overrideFor` / `sqlite3.tempDirectory` overrides exist on the
  main isolate, so the worker isolate resolves the sqlite3_flutter_libs
  library through the identical default loader — no `isolateSetup` needed.
- The #509 sync temp-dir work (`resolveSyncTempDir`) concerns sync payload
  files, not SQLite, and is executor-independent.
- The S3 sync parse worker is unchanged: it parses in its own isolate;
  merge writes now go main -> worker executor, off-UI on both sides.
- `LocalCacheDatabaseService` (small cache DB) deliberately stays as-is;
  recorded follow-up candidate.

## Test plan

- New `database_service_isolate_test.dart` (3 end-to-end tests against
  real temp-file databases): fresh open goes straight to the background
  executor and `beforeOpen` re-asserts apply through the remote
  connection; a rewound `user_version` triggers the
  migration-then-background two-phase path and heals to the current
  version; `reinitializeAtPath` reopens on the background executor.
- Regression sweep green (55 tests): startup page + backup-flow suites
  (including the SQLITE_READONLY hot-journal recovery path), migration
  ladder suites (v58/v85/v86), plus sync convergence + streaming-parity
  suites as insurance.
- Whole-project `flutter analyze`: no issues; `dart format .`: clean.
- Residual (next user session, spec metric): scroll the dive list during
  an active sync in profile mode — expect zero dropped frames.