### PR TITLE
fix(sync): create the sync temp dir before writing (macOS #554)

### DIFF
--- a/lib/core/services/sync/changeset_log/sync_temp_dir.dart
+++ b/lib/core/services/sync/changeset_log/sync_temp_dir.dart
@@ -20,9 +20,20 @@ import 'package:path_provider/path_provider.dart';
 /// a genuine runtime problem and propagates, rather than silently
 /// reintroducing the `/tmp` EPERM this fix exists to avoid. In production
 /// getTemporaryDirectory resolves normally, so no fallback runs.
+///
+/// The resolved directory is created if absent (issue #554). On macOS
+/// getTemporaryDirectory maps to the sandbox `Library/Caches/<bundleId>` dir,
+/// which the OS may purge and does not guarantee exists; path_provider returns
+/// the path without creating it. Opening a base-export temp file for write in a
+/// missing dir threw `PathNotFoundException: Cannot open file ... No such file
+/// or directory (errno = 2)`, crashing every macOS sync while iPhone/iPad --
+/// which reliably have the dir -- were unaffected. `create(recursive: true)` is
+/// idempotent and always permitted inside the app's own container.
 Future<Directory> resolveSyncTempDir() async {
   try {
-    return await getTemporaryDirectory();
+    final dir = await getTemporaryDirectory();
+    await dir.create(recursive: true);
+    return dir;
   } on MissingPluginException {
     return Directory.systemTemp;
   } on FlutterError catch (e) {

--- a/test/core/services/sync/changeset_log/sync_temp_dir_test.dart
+++ b/test/core/services/sync/changeset_log/sync_temp_dir_test.dart
@@ -22,7 +22,7 @@ void main() {
 
     setUp(() async {
       parent = await Directory.systemTemp.createTemp('sync_temp_dir_test_');
-      // A path path_provider hands back but which has NOT been created -- the
+      // A path that path_provider hands back but has NOT created yet -- the
       // macOS Library/Caches situation.
       missing = Directory('${parent.path}/Library/Caches/app.submersion');
       expect(

--- a/test/core/services/sync/changeset_log/sync_temp_dir_test.dart
+++ b/test/core/services/sync/changeset_log/sync_temp_dir_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+
+  // Issue #554: On macOS, getTemporaryDirectory() maps to the sandbox
+  // Library/Caches dir, which macOS may purge and does not guarantee exists.
+  // The base-export writer then opened a file for write in the missing dir and
+  // crashed with "PathNotFoundException: Cannot open file ... No such file or
+  // directory (errno = 2)". iPhone/iPad were unaffected because iOS reliably
+  // has that directory. resolveSyncTempDir must return a directory that
+  // actually exists, so writers can open temp files in it.
+  group('resolveSyncTempDir ensures the temp dir exists (issue #554)', () {
+    late Directory parent;
+    late Directory missing;
+
+    setUp(() async {
+      parent = await Directory.systemTemp.createTemp('sync_temp_dir_test_');
+      // A path path_provider hands back but which has NOT been created -- the
+      // macOS Library/Caches situation.
+      missing = Directory('${parent.path}/Library/Caches/app.submersion');
+      expect(
+        missing.existsSync(),
+        isFalse,
+        reason: 'precondition: the resolved dir does not exist yet',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            channel,
+            (call) async =>
+                call.method == 'getTemporaryDirectory' ? missing.path : null,
+          );
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+      if (parent.existsSync()) await parent.delete(recursive: true);
+    });
+
+    test('returns the resolved path as a directory that exists', () async {
+      final dir = await resolveSyncTempDir();
+      expect(dir.path, missing.path);
+      expect(
+        dir.existsSync(),
+        isTrue,
+        reason: 'macOS Caches dir may be absent; it must be created',
+      );
+    });
+
+    test(
+      'a base temp file can be opened for write in the returned dir',
+      () async {
+        // The exact operation that threw in production
+        // (sync_data_serializer.dart:734, FileMode.write in a missing dir).
+        final dir = await resolveSyncTempDir();
+        final file = File('${dir.path}/ssv1_base_probe.json');
+        final raf = await file.open(mode: FileMode.write);
+        await raf.writeString('{}');
+        await raf.close();
+        expect(file.existsSync(), isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the macOS-only "Sync error" reported in #554:

```
PathNotFoundException: Cannot open file, path = '.../Data/Library/Caches/
app.submersion/ssv1_base_<deviceId>_<seq>.<uuid>.json'
(OS Error: No such file or directory, errno = 2)
```

macOS hit this on every sync; iPhone and iPad on the **same cloud user** synced fine. "Tried all cloud fixes" — because it isn't a cloud problem, it's a local filesystem one.

**Root cause.** On Apple platforms, `path_provider`'s `getTemporaryDirectory()` maps to the sandbox `Library/Caches/<bundleId>` directory (`NSCachesDirectory` — verified in `path_provider_foundation`'s Swift: `.temp → cachesDirectory`). The plugin returns the path but **never creates the directory**, and macOS treats Caches as purgeable / not-guaranteed-to-exist. The base-export writer (`SyncDataSerializer.exportBaseToTempFile`) then opens a temp file for **write** in that directory. A write-open only fails with `ENOENT` when the **parent directory** is missing (it creates the file, not missing parents) — so `errno 2` here means the *directory* was absent, not that a file vanished. That `.open()` sits outside the writer's try/catch, so it threw raw to the UI. iOS reliably provisions this directory (and omits the bundle-id subfolder), which is why phones/tablets were unaffected.

**Fix.** `resolveSyncTempDir()` now `create(recursive: true)`s the resolved directory before returning it. It's the single chokepoint for all three sync-temp consumers (base export, base-part assembly, leftover-temp cleanup). `create(recursive: true)` is idempotent (no-op when present) and always permitted inside the app's own container, so it's safe on every platform. This also hardens `BasePartFileSink.assemble`, which hit the same missing dir but *swallowed* it (`catch (_) { ok = false }` → returned null → sync silently stalled).

## Changes

- `lib/core/services/sync/changeset_log/sync_temp_dir.dart` — ensure the resolved temp/cache directory exists (`create(recursive: true)`) before returning it; document the macOS Caches behavior.
- `test/core/services/sync/changeset_log/sync_temp_dir_test.dart` — new regression test: mocks the `path_provider` channel to return a not-yet-created path (the macOS condition) and asserts the directory is created and a base temp file can be opened for write in it (the exact operation that crashed).

## Test Plan

- [x] `flutter test` passes — new test fails before the fix with the identical `PathNotFoundException ... errno = 2`, passes after; sync suite (`changeset_log/` + base-publish parity) green (96 tests).
- [x] `flutter analyze` passes — whole project, no issues.
- [x] Manual testing on macOS: the exact failure needs a container whose `Library/Caches/<bundleId>` dir is absent, which the unit test reproduces deterministically. A live macOS sync smoke-test still recommended before release; CI re-runs analyze + test on the pushed branch.


Closes #554
