### PR TITLE
fix(consolidation): carry entry/exit GPS onto the target when folding dives (#542)

### DIFF
--- a/lib/features/dive_log/data/services/dive_consolidation_service.dart
+++ b/lib/features/dive_log/data/services/dive_consolidation_service.dart
@@ -536,9 +536,46 @@ class DiveConsolidationService {
         }
       }
 
+      // Entry/exit GPS fixes live as scalar columns on the dives row, not as
+      // re-parented child rows, so a secondary's coordinates would be lost
+      // when it is tombstoned below. Adopt them onto the target when the
+      // target has none of its own -- target wins, the same "fill the gap"
+      // rule already applied to weights above and to DiveMergeBuilder's
+      // _firstNonNull(entryLocation) on the sequential-combine path. Without
+      // this, consolidating a dive whose only surface fix came from a
+      // secondary computer drops the coordinates and the detail-page map --
+      // gated on entry/exit/site location -- disappears (#542).
+      final entryFill = plan.primary.entryLocation == null
+          ? plan.secondaries
+                .map((s) => s.entryLocation)
+                .firstWhere((l) => l != null, orElse: () => null)
+          : null;
+      final exitFill = plan.primary.exitLocation == null
+          ? plan.secondaries
+                .map((s) => s.exitLocation)
+                .firstWhere((l) => l != null, orElse: () => null)
+          : null;
+
       // Touch the target so sync carries the consolidation.
-      await (_db.update(_db.dives)..where((t) => t.id.equals(targetDiveId)))
-          .write(DivesCompanion(updatedAt: Value(now)));
+      await (_db.update(
+        _db.dives,
+      )..where((t) => t.id.equals(targetDiveId))).write(
+        DivesCompanion(
+          updatedAt: Value(now),
+          entryLatitude: entryFill != null
+              ? Value(entryFill.latitude)
+              : const Value.absent(),
+          entryLongitude: entryFill != null
+              ? Value(entryFill.longitude)
+              : const Value.absent(),
+          exitLatitude: exitFill != null
+              ? Value(exitFill.latitude)
+              : const Value.absent(),
+          exitLongitude: exitFill != null
+              ? Value(exitFill.longitude)
+              : const Value.absent(),
+        ),
+      );
       await _sync.markRecordPending(
         entityType: 'dives',
         recordId: targetDiveId,

--- a/test/features/dive_log/data/services/dive_consolidation_service_test.dart
+++ b/test/features/dive_log/data/services/dive_consolidation_service_test.dart
@@ -5,6 +5,8 @@ import 'package:submersion/features/dive_log/data/repositories/dive_repository_i
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
+    as domain;
 
 import '../../../../helpers/test_database.dart';
 
@@ -52,6 +54,8 @@ void main() {
     String? computerId,
     String? serial,
     Duration? bottomTime,
+    domain.GeoPoint? entryLocation,
+    domain.GeoPoint? exitLocation,
     List<domain.DiveTank> tanks = const [],
     List<domain.DiveProfilePoint>? profile,
   }) async {
@@ -65,6 +69,8 @@ void main() {
         bottomTime: bottomTime,
         maxDepth: depth,
         diveComputerSerial: serial,
+        entryLocation: entryLocation,
+        exitLocation: exitLocation,
         tanks: tanks,
         profile:
             profile ??
@@ -1014,6 +1020,142 @@ void main() {
           db.deletionLog,
         )..where((t) => t.recordId.equals('t'))).get();
         expect(targetTombstones, isEmpty);
+      },
+    );
+  });
+
+  // #542: entry/exit GPS fixes are scalar columns on the dives row, not
+  // re-parented child rows, so a secondary's coordinates would vanish when it
+  // is folded in and tombstoned. The detail-page map is gated on entry/exit/
+  // site location, so dropping them makes the map disappear entirely. The
+  // fold must adopt a secondary's fix onto the target when the target has none
+  // of its own (target wins -- the same "fill the gap" rule already applied to
+  // weights, and DiveMergeBuilder's _firstNonNull(entryLocation) on the
+  // sequential-combine path).
+  group('apply GPS (#542)', () {
+    const secEntry = domain.GeoPoint(12.5, -70.0);
+    const secExit = domain.GeoPoint(12.51, -70.01);
+
+    test('target lacking GPS adopts entry and exit from a secondary', () async {
+      await seedDive(
+        't',
+        entry: DateTime.utc(2026, 7, 1, 9),
+        computerId: 'comp-t',
+        serial: 'SER-T',
+      );
+      await seedDive(
+        's',
+        entry: DateTime.utc(2026, 7, 1, 9, 1),
+        computerId: 'comp-s',
+        serial: 'SER-S',
+        entryLocation: secEntry,
+        exitLocation: secExit,
+      );
+
+      await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+      final target = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('t'))).getSingle();
+      expect(target.entryLatitude, secEntry.latitude);
+      expect(target.entryLongitude, secEntry.longitude);
+      expect(target.exitLatitude, secExit.latitude);
+      expect(target.exitLongitude, secExit.longitude);
+    });
+
+    test('target GPS is never overwritten by a secondary', () async {
+      const targetEntry = domain.GeoPoint(40.0, -74.0);
+      const targetExit = domain.GeoPoint(40.01, -74.01);
+      await seedDive(
+        't',
+        entry: DateTime.utc(2026, 7, 1, 9),
+        computerId: 'comp-t',
+        serial: 'SER-T',
+        entryLocation: targetEntry,
+        exitLocation: targetExit,
+      );
+      await seedDive(
+        's',
+        entry: DateTime.utc(2026, 7, 1, 9, 1),
+        computerId: 'comp-s',
+        serial: 'SER-S',
+        entryLocation: secEntry,
+        exitLocation: secExit,
+      );
+
+      await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+      final target = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('t'))).getSingle();
+      expect(target.entryLatitude, targetEntry.latitude);
+      expect(target.entryLongitude, targetEntry.longitude);
+      expect(target.exitLatitude, targetExit.latitude);
+      expect(target.exitLongitude, targetExit.longitude);
+    });
+
+    test('entry and exit fill independently across sources', () async {
+      const targetEntry = domain.GeoPoint(40.0, -74.0);
+      await seedDive(
+        't',
+        entry: DateTime.utc(2026, 7, 1, 9),
+        computerId: 'comp-t',
+        serial: 'SER-T',
+        entryLocation: targetEntry, // exit intentionally absent
+      );
+      await seedDive(
+        's',
+        entry: DateTime.utc(2026, 7, 1, 9, 1),
+        computerId: 'comp-s',
+        serial: 'SER-S',
+        entryLocation: secEntry,
+        exitLocation: secExit,
+      );
+
+      await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+      final target = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('t'))).getSingle();
+      // The target keeps its own entry fix...
+      expect(target.entryLatitude, targetEntry.latitude);
+      expect(target.entryLongitude, targetEntry.longitude);
+      // ...and fills only its missing exit from the secondary.
+      expect(target.exitLatitude, secExit.latitude);
+      expect(target.exitLongitude, secExit.longitude);
+    });
+
+    test(
+      'undo restores the target to its pre-consolidation no-GPS state',
+      () async {
+        await seedDive(
+          't',
+          entry: DateTime.utc(2026, 7, 1, 9),
+          computerId: 'comp-t',
+          serial: 'SER-T',
+        );
+        await seedDive(
+          's',
+          entry: DateTime.utc(2026, 7, 1, 9, 1),
+          computerId: 'comp-s',
+          serial: 'SER-S',
+          entryLocation: secEntry,
+          exitLocation: secExit,
+        );
+
+        final outcome = await service.apply(
+          targetDiveId: 't',
+          secondaryDiveIds: ['s'],
+        );
+        await service.undo(outcome.snapshot);
+
+        final target = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals('t'))).getSingle();
+        expect(target.entryLatitude, isNull);
+        expect(target.entryLongitude, isNull);
+        expect(target.exitLatitude, isNull);
+        expect(target.exitLongitude, isNull);
       },
     );
   });


### PR DESCRIPTION
## Summary

Fixes #542 — combining dives from two computers (e.g. a Garmin Mk3i with GPS + a Perdix 2) dropped the dive's GPS coordinates and made the map disappear.

Multi-computer consolidation (`DiveConsolidationService.apply`) folds a secondary dive's **child rows** (profiles, tanks, events, tags, sightings, media…) into the target and tombstones the secondary. But entry/exit GPS are **scalar columns on the `dives` row** (`entryLatitude/entryLongitude/exitLatitude/exitLongitude`), not child rows — so when the target lacked GPS and a secondary carried it, the coordinates were silently discarded when that dive was deleted. The detail-page map is gated on `entryLocation || exitLocation || site.location`, so a siteless dive lost its map entirely.

This is an asymmetry between the two merge paths: `DiveMergeBuilder` (sequential combine) already preserves GPS via `_firstNonNull(entryLocation)`/`_lastNonNull(exitLocation)`, but overlapping same-dive selections are deliberately routed to consolidation, which had no equivalent handling.

## Changes

- `DiveConsolidationService.apply()` now adopts entry/exit GPS from the first secondary that has it **only when the target has none of its own** (target wins; entry and exit fill independently). Mirrors the sequential path's `_firstNonNull` and the existing "weights fill the gap" rule.
- Undo needs no special handling — it re-inserts the pre-fold `dives` row verbatim from the snapshot, restoring the original (possibly null) coordinates.
- Adds a `apply GPS (#542)` test group: adopt-when-absent, target-wins (no overwrite), independent entry/exit fill, and undo restores the no-GPS state.

## Test Plan

- [x] `flutter analyze` passes (whole project — "No issues found!")
- [x] `flutter test` — consolidation suites all green locally: service (17), sync-roundtrip, repository, builder, and import-adapter consolidation; full suite runs in CI
- [x] Manual testing on: device round-trip (download both computers → Combine → confirm the map + coordinates persist) — pending

## Notes

- The reporter also mentioned the Perdix's Swift GPS "not showing" — that is a **separate** pre-existing issue (Swift GPS is only captured on direct download, not from a Cloud `.db`) and is out of scope here; this fix ensures the merged dive still shows the Garmin's GPS regardless of which computer is chosen as primary.
- Latent sibling gap (not addressed, doesn't affect the map): when a secondary has no `dive_data_sources` row, the *synthesized* `DiveDataSourcesCompanion` also omits GPS columns. Can follow up if per-source attribution should carry GPS.