### PR TITLE
fix(dc): recognize the Shearwater Perdix 3 during BLE scanning

### DIFF
--- a/lib/features/universal_import/data/services/shearwater_filename_parser.dart
+++ b/lib/features/universal_import/data/services/shearwater_filename_parser.dart
@@ -17,6 +17,7 @@ class ShearwaterFilenameParser {
     'Teric': ('Shearwater', 'Teric'),
     'Perdix': ('Shearwater', 'Perdix'),
     'Perdix 2': ('Shearwater', 'Perdix 2'),
+    'Perdix 3': ('Shearwater', 'Perdix 3'),
     'Perdix AI': ('Shearwater', 'Perdix AI'),
     'Peregrine': ('Shearwater', 'Peregrine'),
     'Petrel': ('Shearwater', 'Petrel'),

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
@@ -17,12 +17,14 @@ private const val LIBDC_TRANSPORT_BLE = 1 shl 5
 class BleScanner(private val context: Context) {
     private var scanCallback: ScanCallback? = null
     private val seenAddresses = mutableSetOf<String>()
+    private val loggedUnmatched = mutableSetOf<String>()
 
     var onDeviceDiscovered: ((DiscoveredDevice) -> Unit)? = null
     var onComplete: (() -> Unit)? = null
 
     fun start() {
         seenAddresses.clear()
+        loggedUnmatched.clear()
         val bluetoothManager =
             context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager ?: return
         val adapter = bluetoothManager.adapter ?: return
@@ -41,9 +43,24 @@ class BleScanner(private val context: Context) {
                 val matched = LibdcWrapper.nativeDescriptorMatch(
                     name, LIBDC_TRANSPORT_BLE, info
                 )
-                if (!matched) return
+                if (!matched) {
+                    // onScanResult redelivers every advertisement packet, so
+                    // log each unmatched device only once per scan session.
+                    if (loggedUnmatched.add(address)) {
+                        NativeLogger.d(
+                            "BleScanner", "BLE",
+                            "Unmatched device $address ($name)"
+                        )
+                    }
+                    return
+                }
 
                 seenAddresses.add(address)
+                NativeLogger.d(
+                    "BleScanner", "BLE",
+                    "Matched device $address ($name) -> " +
+                        "${info.vendor} ${info.product} (${info.model})"
+                )
 
                 val device = DiscoveredDevice(
                     vendor = info.vendor,

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -90,6 +90,27 @@ static void test_non_uwatec_device_unaffected(void) {
     printf("PASS: test_non_uwatec_device_unaffected\n");
 }
 
+// Issue #483: the Shearwater Perdix 3 advertises the BLE name "Perdix 3",
+// which was absent from both the descriptor table and dc_filter_shearwater's
+// exact-match whitelist, so every descriptor rejected it and the device never
+// appeared during scanning. Model 14 continues Shearwater's sequential model
+// numbering (Petrel 3 = 10, Perdix 2 = 11, Tern = 12, Peregrine TX = 13).
+static void test_perdix_3_resolves(void) {
+    expect_ble_match("Perdix 3", "Perdix 3", 14);
+    expect_ble_match("perdix 3", "Perdix 3", 14);
+    printf("PASS: test_perdix_3_resolves\n");
+}
+
+// Issue #483 regression guard: dc_filter_shearwater passes a whitelisted name
+// for EVERY Shearwater row, so resolution relies on the wrapper preferring the
+// row whose product exactly equals the BLE name. The new "Perdix 3" row must
+// not disturb that for the older Perdix models.
+static void test_other_perdix_models_unchanged(void) {
+    expect_ble_match("Perdix", "Perdix", 5);
+    expect_ble_match("Perdix 2", "Perdix 2", 11);
+    printf("PASS: test_other_perdix_models_unchanged\n");
+}
+
 // Issue #357: a Handset serial (model-code digits [4:6] = "07") must resolve to
 // the "Symbios Handset" descriptor (model 7), not the "Symbios HUD" row
 // (model 1) that previously always won because both rows matched the union
@@ -113,6 +134,8 @@ int main(void) {
     test_alias_match_is_case_insensitive();
     test_exact_product_names_unchanged();
     test_non_uwatec_device_unaffected();
+    test_perdix_3_resolves();
+    test_other_perdix_models_unchanged();
     test_symbios_handset_resolves_to_handset();
     test_symbios_hud_resolves_to_hud();
     printf("\nAll descriptor match integration tests passed.\n");

--- a/test/features/universal_import/data/services/shearwater_filename_parser_test.dart
+++ b/test/features/universal_import/data/services/shearwater_filename_parser_test.dart
@@ -31,6 +31,15 @@ void main() {
         expect(result.diveNumber, 7);
       });
 
+      test('extracts Perdix 3 with space in name', () {
+        final result = ShearwaterFilenameParser.parse(
+          'Perdix 3[04C2A1B9]#12 2026-7-1 9-15-00.swlogzp',
+        );
+        expect(result.model, 'Perdix 3');
+        expect(result.serial, '04C2A1B9');
+        expect(result.diveNumber, 12);
+      });
+
       test('extracts Peregrine', () {
         final result = ShearwaterFilenameParser.parse(
           'Peregrine[DEADBEEF]#100 2025-1-1 0-0-0.swlogzp',
@@ -67,6 +76,10 @@ void main() {
         expect(ShearwaterFilenameParser.vendorProduct('Petrel 3'), (
           'Shearwater',
           'Petrel 3',
+        ));
+        expect(ShearwaterFilenameParser.vendorProduct('Perdix 3'), (
+          'Shearwater',
+          'Perdix 3',
         ));
       });
 


### PR DESCRIPTION
## Summary

The Shearwater Perdix 3 (new for 2026) never appeared during BLE scanning: it was missing from the libdivecomputer descriptor table and from `dc_filter_shearwater`'s BLE name whitelist, which is matched with `dc_match_name` (exact, case-insensitive). Every descriptor rejected the advertised name `Perdix 3`, so the native scanners dropped the device before it ever reached Dart — invisible rather than mis-identified.

The Android scanner also dropped unmatched devices with no logging at all (the Darwin scanner logs them at DEBUG), which is why the reporter's debug logs stayed empty.

## Changes

- **libdivecomputer fork** (submodule bump to `150672e`): add the `Perdix 3` descriptor row (`DC_FAMILY_SHEARWATER_PETREL`, model 14, BLE) and the `"Perdix 3"` whitelist entry in `dc_filter_shearwater`, plus `#define PERDIX3 14` in `shearwater_common.h`, mirroring upstream's pattern for new Shearwater models.
- **Android `BleScanner.kt`**: log matched and unmatched devices through `NativeLogger` (reaches the in-app debug log viewer), with a per-scan dedup set for unmatched devices since `onScanResult` redelivers every advertisement packet. Future unrecognized models will now self-diagnose from a user's debug log.
- **Shearwater Cloud file import**: map `Perdix 3` in `shearwater_filename_parser.dart` so `.swlogzp` imports attribute vendor/product correctly.
- **Native regression test**: `test_descriptor_match_integration.c` now asserts `Perdix 3` (and lowercase) resolves to Shearwater/Perdix 3/model 14, and guards that `Perdix` (5) and `Perdix 2` (11) still resolve to themselves.

## Model number note

Neither upstream libdivecomputer nor Subsurface supports the Perdix 3 yet, so model 14 is provisional: it continues Shearwater's sequential numbering (Petrel 3 = 10, Perdix 2 = 11, Tern = 12, Peregrine TX = 13) and matches the jdevost/libdc-swift fork that syncs with real Perdix 3 hardware (which also confirms the advertised name is exactly `Perdix 3`). Risk is low: since upstream f351434 the backend reads the true model from the device (RDBI 0x8060) and the parser re-reads it from each log's closing block, so the descriptor value only labels the scan-time match.

## Verification

- Native descriptor integration test: written first and failing (`"Perdix 3" did not match any descriptor`), passing after the fork bump; full native suite 7/7 via ctest
- `shearwater_filename_parser_test.dart` 9/9 (new Perdix 3 cases red then green); Shearwater import pipeline tests 82 passing
- Plugin Kotlin compiles (`:libdivecomputer_plugin:compileDebugKotlin`)
- `flutter analyze`: no issues; `dart format .`: no changes
- Not verified on real hardware — needs a Perdix 3 owner to confirm discovery and download (issue reporters can test the next build)

Fixes #483