### PR TITLE
Detail-pane scroll retention + previous/next adjacent-dive navigation

### DIFF
--- a/docs/superpowers/plans/2026-07-11-detail-pane-scroll-retention.md
+++ b/docs/superpowers/plans/2026-07-11-detail-pane-scroll-retention.md
@@ -1,0 +1,516 @@
+# Detail Pane Scroll Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the wide-screen master-detail detail pane scrolled to the same place when the user selects a different item, so they can compare a section across dives/sites/etc. without re-scrolling.
+
+**Architecture:** Flutter `Scrollable` auto-saves/restores its offset to the nearest ancestor `PageStorageBucket` when it carries a `PageStorageKey`. Every routed page already provides a bucket, and the per-id `ValueKey('detail_$id')` on the detail pane is *not* a `PageStorageKey`, so all items of a section share one storage slot. The entire fix is therefore adding a stable `PageStorageKey` to each in-scope detail page's scroll view (verified by spike, 2026-07-11 — no scaffold bucket needed).
+
+**Tech Stack:** Flutter (Material 3), Riverpod, go_router, `flutter_test`.
+
+## Global Constraints
+
+- All Dart must pass `dart format .` with no changes (run it before every commit).
+- All Dart must pass `flutter analyze` with no new issues.
+- No emojis in code/comments. Immutability; small focused changes.
+- Do NOT add a scaffold-owned `PageStorageBucket` — the spike proved it redundant. The change is keys-only plus one comment.
+- `PageStorageKey` strings must be unique per page (values below), so sections never collide even under a shared bucket.
+- `PageStorageKey` and `PageStorage` are exported by `package:flutter/material.dart`, already imported in every target file — no new imports.
+- Worktree hygiene (from project memory): never `git add -A` here (it can record a stale submodule gitlink); `git add` explicit paths only. The pre-push hook runs against the main tree — if pushing, use `--no-verify`. Do not push unless asked.
+
+---
+
+### Task 1: Retention contract test + scaffold breadcrumb comment
+
+Locks in the retention behavior at the scaffold level using a dummy detail builder (no real pages / DB), and drops a comment so future maintainers know the `ValueKey` deliberately does not defeat `PageStorage`.
+
+**Files:**
+- Create: `test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart`
+- Modify: `lib/shared/widgets/master_detail/master_detail_scaffold.dart` (comment only, near the `ValueKey('detail_$selectedId')` at ~line 452)
+
+**Interfaces:**
+- Consumes: `MasterDetailScaffold` public API (`sectionId`, `masterBuilder`, `detailBuilder`, `summaryBuilder`).
+- Produces: nothing consumed by later tasks. This test is the regression guard for the mechanism all later tasks rely on.
+
+> **Note on TDD color:** The mechanism already works in the test harness via the ambient route bucket (proven by spike), so this test passes as soon as it is written — it is a *characterization / contract* test, not a red→green driver. That is expected and correct; its job is to fail if someone later breaks retention (e.g. introduces a `PageStorage` boundary or makes the detail `ValueKey` a `PageStorageKey`). Do not contrive an artificial failure.
+
+- [ ] **Step 1: Write the contract test**
+
+Create `test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
+
+/// Builds a [MasterDetailScaffold] inside a router at desktop width (>=800) so
+/// the split layout renders. The master pane exposes two buttons that call
+/// [onItemSelected] to drive selection changes via query params.
+///
+/// [detailHeight] returns the content height for a given item id, so tests can
+/// make item 2 shorter than item 1 to exercise clamping. When [tagKey] is
+/// false the detail scroll view carries no [PageStorageKey] (opt-out case).
+Widget _app({
+  required double Function(String id) detailHeight,
+  bool tagKey = true,
+}) {
+  final router = GoRouter(
+    initialLocation: '/test?selected=1',
+    routes: [
+      GoRoute(
+        path: '/test',
+        builder: (context, state) => MediaQuery(
+          data: const MediaQueryData(size: Size(1200, 800)),
+          child: MasterDetailScaffold(
+            sectionId: 'test',
+            masterBuilder: (context, onSelect, selectedId) => Column(
+              children: [
+                TextButton(
+                  onPressed: () => onSelect('1'),
+                  child: const Text('select-1'),
+                ),
+                TextButton(
+                  onPressed: () => onSelect('2'),
+                  child: const Text('select-2'),
+                ),
+              ],
+            ),
+            detailBuilder: (_, id) => SingleChildScrollView(
+              key: tagKey ? const PageStorageKey('testDetailScroll') : null,
+              child: SizedBox(
+                height: detailHeight(id),
+                child: Text('Detail $id'),
+              ),
+            ),
+            summaryBuilder: (_) => const Text('Summary'),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    child: MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+/// The (single, post-settle) detail scroll view's scroll state.
+ScrollableState _detailScrollable(WidgetTester tester) {
+  return tester.state<ScrollableState>(
+    find.descendant(
+      of: find.byType(SingleChildScrollView),
+      matching: find.byType(Scrollable),
+    ),
+  );
+}
+
+void main() {
+  group('MasterDetailScaffold detail scroll retention', () {
+    testWidgets('retains offset when switching to another item', (tester) async {
+      await tester.pumpWidget(_app(detailHeight: (_) => 3000));
+      await tester.pumpAndSettle();
+
+      _detailScrollable(tester).position.jumpTo(800);
+      await tester.pump();
+      expect(_detailScrollable(tester).position.pixels, 800);
+
+      await tester.tap(find.text('select-2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Detail 2'), findsOneWidget);
+      expect(_detailScrollable(tester).position.pixels, 800);
+    });
+
+    testWidgets('clamps retained offset to the new item extent', (tester) async {
+      // Item 1 is tall (scrollable); item 2 is only slightly taller than the
+      // ~800px viewport, so its maxScrollExtent is small and 800 must clamp.
+      await tester.pumpWidget(
+        _app(detailHeight: (id) => id == '2' ? 900 : 3000),
+      );
+      await tester.pumpAndSettle();
+
+      _detailScrollable(tester).position.jumpTo(800);
+      await tester.pump();
+
+      await tester.tap(find.text('select-2'));
+      await tester.pumpAndSettle();
+
+      final position = _detailScrollable(tester).position;
+      expect(position.pixels, position.maxScrollExtent);
+      expect(position.pixels, lessThan(800));
+    });
+
+    testWidgets('without a PageStorageKey the offset resets to top',
+        (tester) async {
+      await tester.pumpWidget(_app(detailHeight: (_) => 3000, tagKey: false));
+      await tester.pumpAndSettle();
+
+      _detailScrollable(tester).position.jumpTo(800);
+      await tester.pump();
+
+      await tester.tap(find.text('select-2'));
+      await tester.pumpAndSettle();
+
+      expect(_detailScrollable(tester).position.pixels, 0);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `flutter test test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart`
+Expected: PASS (3 tests). This confirms the mechanism the page tasks depend on. If the first two FAIL, stop — the environment differs from the spike and later tasks would be built on a false premise.
+
+- [ ] **Step 3: Add the breadcrumb comment in the scaffold**
+
+In `lib/shared/widgets/master_detail/master_detail_scaffold.dart`, find the view-mode branch in `_DetailPane._buildContent`:
+
+```dart
+    // View mode with selected item
+    if (selectedId != null) {
+      return KeyedSubtree(
+        key: ValueKey('detail_$selectedId'),
+        child: detailBuilder(context, selectedId!),
+      );
+    }
+```
+
+Replace it with (comment added; behavior unchanged):
+
+```dart
+    // View mode with selected item.
+    //
+    // This ValueKey deliberately rebuilds the detail subtree per item so each
+    // item gets fresh local state. It is NOT a PageStorageKey, so it does not
+    // participate in PageStorage's storage path: a detail page whose scroll
+    // view carries a stable PageStorageKey therefore retains its scroll offset
+    // across selections (compare a section across items without re-scrolling).
+    // See docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md.
+    if (selectedId != null) {
+      return KeyedSubtree(
+        key: ValueKey('detail_$selectedId'),
+        child: detailBuilder(context, selectedId!),
+      );
+    }
+```
+
+- [ ] **Step 4: Format, analyze, re-run the test**
+
+Run:
+```bash
+dart format lib/shared/widgets/master_detail/master_detail_scaffold.dart test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
+flutter analyze lib/shared/widgets/master_detail/master_detail_scaffold.dart test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
+flutter test test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
+```
+Expected: format makes no changes (or reformats cleanly), analyze reports no issues, test PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/shared/widgets/master_detail/master_detail_scaffold.dart test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
+git commit -m "test(master-detail): lock in detail-pane scroll retention contract"
+```
+
+---
+
+### Task 2: Add PageStorageKeys to the seven single-scroll detail pages
+
+Each of these pages builds `final body = SingleChildScrollView(...)`. Add a unique `PageStorageKey` as the first argument. This is the load-bearing change for dives, sites, courses, certifications, dive centers, equipment, and buddies.
+
+**Files (all Modify):**
+- `lib/features/dive_log/presentation/pages/dive_detail_page.dart` (~line 449)
+- `lib/features/dive_sites/presentation/pages/site_detail_page.dart` (~line 145)
+- `lib/features/courses/presentation/pages/course_detail_page.dart` (~line 53)
+- `lib/features/certifications/presentation/pages/certification_detail_page.dart` (~line 120)
+- `lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart` (~line 94)
+- `lib/features/equipment/presentation/pages/equipment_detail_page.dart` (~line 129)
+- `lib/features/buddies/presentation/pages/buddy_detail_page.dart` (~line 119)
+
+**Interfaces:**
+- Consumes: the retention mechanism validated in Task 1.
+- Produces: user-visible scroll retention for these seven sections. Key strings: `diveDetailScroll`, `siteDetailScroll`, `courseDetailScroll`, `certificationDetailScroll`, `diveCenterDetailScroll`, `equipmentDetailScroll`, `buddyDetailScroll`.
+
+- [ ] **Step 1: Edit the six `padding`-first pages**
+
+For each file below, the current opening (4-space `final body`, 6-space first arg) is:
+
+```dart
+    final body = SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+```
+
+Change it to insert the key line (exact key per file):
+
+```dart
+    final body = SingleChildScrollView(
+      key: const PageStorageKey('<KEY>'),
+      padding: const EdgeInsets.all(16),
+```
+
+Apply with these `<KEY>` values:
+- `dive_detail_page.dart` -> `diveDetailScroll`
+- `site_detail_page.dart` -> `siteDetailScroll`
+- `course_detail_page.dart` -> `courseDetailScroll`
+- `certification_detail_page.dart` -> `certificationDetailScroll`
+- `equipment_detail_page.dart` -> `equipmentDetailScroll`
+- `buddy_detail_page.dart` -> `buddyDetailScroll`
+
+- [ ] **Step 2: Edit the dive-center page (deeper indent, `child`-first)**
+
+In `lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart`, the current opening (8-space `final body`, 10-space first arg) is:
+
+```dart
+        final body = SingleChildScrollView(
+          child: Column(
+```
+
+Change it to:
+
+```dart
+        final body = SingleChildScrollView(
+          key: const PageStorageKey('diveCenterDetailScroll'),
+          child: Column(
+```
+
+- [ ] **Step 3: Format and analyze all seven files**
+
+Run:
+```bash
+dart format \
+  lib/features/dive_log/presentation/pages/dive_detail_page.dart \
+  lib/features/dive_sites/presentation/pages/site_detail_page.dart \
+  lib/features/courses/presentation/pages/course_detail_page.dart \
+  lib/features/certifications/presentation/pages/certification_detail_page.dart \
+  lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart \
+  lib/features/equipment/presentation/pages/equipment_detail_page.dart \
+  lib/features/buddies/presentation/pages/buddy_detail_page.dart
+flutter analyze \
+  lib/features/dive_log/presentation/pages/dive_detail_page.dart \
+  lib/features/dive_sites/presentation/pages/site_detail_page.dart \
+  lib/features/courses/presentation/pages/course_detail_page.dart \
+  lib/features/certifications/presentation/pages/certification_detail_page.dart \
+  lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart \
+  lib/features/equipment/presentation/pages/equipment_detail_page.dart \
+  lib/features/buddies/presentation/pages/buddy_detail_page.dart
+```
+Expected: no formatting changes needed, analyze reports no issues.
+
+- [ ] **Step 4: Sanity-run existing detail-page tests (regression guard)**
+
+Run any existing tests for these pages so the key additions don't break current expectations:
+```bash
+flutter test test/features/dive_log test/features/dive_sites test/features/courses test/features/certifications test/features/dive_centers test/features/equipment test/features/buddies 2>&1 | tail -20
+```
+Expected: all pass (or the same pass/skip set as before your change — if a suite was already failing on `main`, note it and continue; do not fix unrelated pre-existing failures here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  lib/features/dive_log/presentation/pages/dive_detail_page.dart \
+  lib/features/dive_sites/presentation/pages/site_detail_page.dart \
+  lib/features/courses/presentation/pages/course_detail_page.dart \
+  lib/features/certifications/presentation/pages/certification_detail_page.dart \
+  lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart \
+  lib/features/equipment/presentation/pages/equipment_detail_page.dart \
+  lib/features/buddies/presentation/pages/buddy_detail_page.dart
+git commit -m "feat(master-detail): retain scroll on dive/site/course/cert/center/equipment/buddy detail"
+```
+
+---
+
+### Task 3: Add PageStorageKeys across the trips detail (tabbed)
+
+Trips has a standard layout (`body = TripOverviewTab(...)`) and a 5-tab liveaboard `TabBarView`. Its scroll views live across three files. Tag each so both standard trips and each liveaboard tab retain scroll across trip selection.
+
+**Files (all Modify):**
+- `lib/features/trips/presentation/widgets/trip_overview_tab.dart` (~line 63) — Overview tab / standard-layout body
+- `lib/features/trips/presentation/widgets/trip_itinerary_tab.dart` (~line 78) — Itinerary tab
+- `lib/features/trips/presentation/pages/trip_detail_page.dart` (~lines 161, 218, 240) — checklist, photos, dives tabs
+
+**Interfaces:**
+- Consumes: the retention mechanism validated in Task 1.
+- Produces: scroll retention for trips. Key strings: `tripOverviewScroll`, `tripItineraryScroll`, `tripPhotosScroll`, `tripDivesScroll`, `tripChecklistScroll`.
+
+- [ ] **Step 1: Tag the Overview tab scroll view**
+
+In `lib/features/trips/presentation/widgets/trip_overview_tab.dart`, current (4-space `return`, 6-space first arg):
+
+```dart
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+```
+
+Change to:
+
+```dart
+    return SingleChildScrollView(
+      key: const PageStorageKey('tripOverviewScroll'),
+      padding: const EdgeInsets.all(16),
+```
+
+- [ ] **Step 2: Tag the Itinerary tab list**
+
+In `lib/features/trips/presentation/widgets/trip_itinerary_tab.dart`, current:
+
+```dart
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+```
+
+Change to:
+
+```dart
+    return ListView.builder(
+      key: const PageStorageKey('tripItineraryScroll'),
+      padding: const EdgeInsets.all(16),
+```
+
+- [ ] **Step 3: Tag the three in-page tabs in `trip_detail_page.dart`**
+
+(a) Checklist tab (inline in the `TabBarView`, 16-space `SingleChildScrollView`, 18-space first arg):
+
+```dart
+                SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: TripChecklistSection(trip: tripWithStats.trip),
+                ),
+```
+
+Change to:
+
+```dart
+                SingleChildScrollView(
+                  key: const PageStorageKey('tripChecklistScroll'),
+                  padding: const EdgeInsets.all(16),
+                  child: TripChecklistSection(trip: tripWithStats.trip),
+                ),
+```
+
+(b) Photos tab in `_buildPhotosTab` (4-space `return`, 6-space first arg):
+
+```dart
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: TripPhotoSection(tripId: trip.id),
+    );
+```
+
+Change to:
+
+```dart
+    return SingleChildScrollView(
+      key: const PageStorageKey('tripPhotosScroll'),
+      padding: const EdgeInsets.all(16),
+      child: TripPhotoSection(tripId: trip.id),
+    );
+```
+
+(c) Dives tab list in `_buildDivesTab` (8-space `return ListView.builder(`, 10-space first arg):
+
+```dart
+        return ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: sortedDives.length,
+```
+
+Change to:
+
+```dart
+        return ListView.builder(
+          key: const PageStorageKey('tripDivesScroll'),
+          padding: const EdgeInsets.all(16),
+          itemCount: sortedDives.length,
+```
+
+- [ ] **Step 4: Format and analyze the trips files**
+
+Run:
+```bash
+dart format \
+  lib/features/trips/presentation/widgets/trip_overview_tab.dart \
+  lib/features/trips/presentation/widgets/trip_itinerary_tab.dart \
+  lib/features/trips/presentation/pages/trip_detail_page.dart
+flutter analyze \
+  lib/features/trips/presentation/widgets/trip_overview_tab.dart \
+  lib/features/trips/presentation/widgets/trip_itinerary_tab.dart \
+  lib/features/trips/presentation/pages/trip_detail_page.dart
+```
+Expected: no formatting changes needed, analyze reports no issues.
+
+- [ ] **Step 5: Sanity-run existing trips tests**
+
+Run:
+```bash
+flutter test test/features/trips 2>&1 | tail -20
+```
+Expected: all pass (or same pass/skip set as before; note but do not fix unrelated pre-existing failures).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  lib/features/trips/presentation/widgets/trip_overview_tab.dart \
+  lib/features/trips/presentation/widgets/trip_itinerary_tab.dart \
+  lib/features/trips/presentation/pages/trip_detail_page.dart
+git commit -m "feat(trips): retain scroll per trip and per liveaboard tab in detail pane"
+```
+
+---
+
+### Task 4: Whole-project verification + manual macOS check
+
+Confirms the change is clean project-wide and actually behaves in the running app.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Whole-project format and analyze**
+
+Run (per project memory: format and analyze the WHOLE project, never `| tail` the analyze that hides failures):
+```bash
+dart format .
+flutter analyze
+```
+Expected: `dart format .` reports no changes; `flutter analyze` reports "No issues found!". If format changed anything, review and commit the reformat.
+
+- [ ] **Step 2: Run the master-detail + touched-feature test suites**
+
+Run:
+```bash
+flutter test test/shared/widgets/master_detail
+```
+Expected: PASS, including the Task 1 contract test.
+
+- [ ] **Step 3: Manual verification via the run skill (macOS)**
+
+Launch the app (`flutter run -d macos`, honoring the single-instance rule from project memory — check for an existing session first). Then, in a wide window:
+1. Open **Dives**, select a dive, scroll the detail pane down to a lower section (e.g. Marine Life or Cylinders).
+2. Click a different dive in the list. Confirm the detail pane **stays scrolled** to roughly that section (does not jump to the header).
+3. Select a much shorter dive and confirm it lands at its own bottom (clamped), not an error.
+4. Repeat step 1-2 for **Sites** to confirm a second section works.
+5. Open **Settings** (excluded), navigate between sections, and confirm it still starts at the top (no accidental retention).
+
+- [ ] **Step 4: Final commit (only if format/step-1 produced changes)**
+
+```bash
+git add -- <only the specific reformatted files>
+git commit -m "style: dart format after scroll-retention changes"
+```
+
+If no changes were produced by Step 1, skip this step.
+
+---
+
+## Notes for the executor
+
+- The behavior is pixel-offset retention, clamped by `Scrollable` to the new item's extent. Shorter items landing at their own bottom is correct, not a bug.
+- Do not add a `PageStorageBucket` anywhere — the ambient route bucket is sufficient (spike-verified). Adding one is redundant scope.
+- If any edit's "current code" block does not match (line numbers may drift), locate the `SingleChildScrollView` / `ListView.builder` named `body` (or the specified tab builder) in that file and insert the `key:` as the first argument with matching indentation.

--- a/docs/superpowers/plans/2026-07-12-dive-detail-prev-next-navigation.md
+++ b/docs/superpowers/plans/2026-07-12-dive-detail-prev-next-navigation.md
@@ -1,0 +1,776 @@
+# Dive Detail Previous / Next Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user step to the adjacent dive from the dive detail page via Previous/Next buttons (and Left/Right arrow keys on desktop), following the current list filter + sort order.
+
+**Architecture:** A new lightweight repository query returns the ordered dive IDs for the active filter+sort (reusing the visible list's SQL clauses). Riverpod providers expose that list and compute each dive's `(previousId, nextId)`. A reusable `DiveNavButtons` widget renders the controls; the detail page mounts it in both surfaces and handles navigation + keyboard shortcuts.
+
+**Tech Stack:** Flutter (Material 3), Riverpod, go_router, Drift, `flutter_test`.
+
+## Global Constraints
+
+- All Dart must pass `dart format .` with no changes (run before every commit).
+- All Dart must pass `flutter analyze` with no new issues.
+- No emojis in code/comments. Immutability; small focused files.
+- `DiveRepository` is a single concrete class in
+  `lib/features/dive_log/data/repositories/dive_repository_impl.dart` — there is
+  **no separate abstract interface** to update.
+- The existing `getPreviousDive(String diveId)` is the chronological
+  surface-interval/deco "previous by entry time" query — **unrelated**. Do not
+  reuse or modify it; the new navigation is filter+sort aware.
+- `getOrderedDiveIds` MUST reuse `_buildFilterWhereClauses` and
+  `_buildSortOrderBy` so its order matches `getDiveSummaries` exactly.
+- Adjacency follows `diveFilterProvider` + `diveSortProvider` (app-global).
+- Scope: dives only.
+- Worktree hygiene (project memory): never `git add -A` (records stale submodule
+  gitlink); stage explicit paths. Pre-push hook runs vs the main tree — if
+  pushing, `--no-verify`. Do not push unless asked.
+
+---
+
+### Task 1: `getOrderedDiveIds` repository query
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (add method near `getDiveSummaries`, ~line 1473)
+- Test: `test/features/dive_log/data/repositories/dive_ordered_ids_test.dart` (new)
+
+**Interfaces:**
+- Consumes: private `_buildFilterWhereClauses(filter, whereClauses, args)` and `_buildSortOrderBy(sort)` on the same class; `PerfTimer.measure`; `_db.customSelect`.
+- Produces: `Future<List<String>> getOrderedDiveIds({String? diverId, DiveFilterState filter, SortState<DiveSortField>? sort})` returning dive IDs in the active filter+sort order (no pagination).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/data/repositories/dive_ordered_ids_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:submersion/core/constants/sort_options.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/models/sort_state.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertDive(String id, int dateTimeMs, {int? number}) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db.into(db.dives).insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(dateTimeMs),
+            diveNumber: Value(number),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    return id;
+  }
+
+  test('returns ids in the same order as getDiveSummaries (date desc)', () async {
+    await insertDive('a', 1000, number: 1);
+    await insertDive('b', 3000, number: 3);
+    await insertDive('c', 2000, number: 2);
+
+    const sort = SortState(
+      field: DiveSortField.date,
+      direction: SortDirection.descending,
+    );
+
+    final ids = await repository.getOrderedDiveIds(sort: sort);
+    final summaries = await repository.getDiveSummaries(sort: sort, limit: 1000);
+
+    expect(ids, summaries.map((s) => s.id).toList());
+    expect(ids, ['b', 'c', 'a']); // newest first
+  });
+
+  test('respects sort direction (date asc)', () async {
+    await insertDive('a', 1000);
+    await insertDive('b', 3000);
+    await insertDive('c', 2000);
+
+    final ids = await repository.getOrderedDiveIds(
+      sort: const SortState(
+        field: DiveSortField.date,
+        direction: SortDirection.ascending,
+      ),
+    );
+    expect(ids, ['a', 'c', 'b']);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_ordered_ids_test.dart`
+Expected: FAIL — `getOrderedDiveIds` is not defined.
+
+- [ ] **Step 3: Implement the method**
+
+In `dive_repository_impl.dart`, add immediately after `getDiveSummaries` (before `getDiveCount`):
+
+```dart
+  /// Returns every dive id matching [filter] in [sort] order — the same order
+  /// as [getDiveSummaries] but without pagination and selecting only the id.
+  ///
+  /// Used to compute previous/next navigation from the detail page. Distinct
+  /// from [getPreviousDive], which is the chronological surface-interval query.
+  Future<List<String>> getOrderedDiveIds({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+    SortState<DiveSortField>? sort,
+  }) async {
+    try {
+      return await PerfTimer.measure('getOrderedDiveIds', () async {
+        final whereClauses = <String>[];
+        final args = <Variable<Object>>[];
+
+        if (diverId != null) {
+          whereClauses.add('d.diver_id = ?');
+          args.add(Variable(diverId));
+        }
+
+        _buildFilterWhereClauses(filter, whereClauses, args);
+
+        final whereClause = whereClauses.isNotEmpty
+            ? 'WHERE ${whereClauses.join(' AND ')}'
+            : '';
+        final orderByClause = _buildSortOrderBy(sort);
+
+        final sql =
+            'SELECT d.id '
+            'FROM dives d '
+            'LEFT JOIN dive_sites s ON d.site_id = s.id '
+            '$whereClause '
+            'ORDER BY $orderByClause';
+
+        final rows = await _db
+            .customSelect(
+              sql,
+              variables: args,
+              readsFrom: {_db.dives, _db.diveSites},
+            )
+            .get();
+
+        return rows.map((r) => r.read<String>('id')).toList();
+      });
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get ordered dive ids',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/dive_ordered_ids_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
+flutter analyze lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
+git add lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
+git commit -m "feat(dive-log): getOrderedDiveIds query for adjacent-dive navigation"
+```
+Expected: format no changes, analyze clean, both tests pass.
+
+---
+
+### Task 2: Ordered-ids + neighbors providers
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/providers/dive_providers.dart`
+- Test: `test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `diveRepositoryProvider`, `currentDiverIdProvider` (from `diver_providers.dart`, already imported/available in `dive_providers.dart`), `diveFilterProvider`, `diveSortProvider`, and `getOrderedDiveIds` from Task 1.
+- Produces:
+  - `typedef DiveNeighbors = ({String? previousId, String? nextId});`
+  - `final orderedDiveIdsProvider = FutureProvider.autoDispose<List<String>>(...)`
+  - `final diveNeighborsProvider = Provider.family<DiveNeighbors, String>(...)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+void main() {
+  test('middle item has both neighbors', () async {
+    final container = ProviderContainer(
+      overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c'])],
+    );
+    addTearDown(container.dispose);
+    await container.read(orderedDiveIdsProvider.future);
+    expect(
+      container.read(diveNeighborsProvider('b')),
+      (previousId: 'a', nextId: 'c'),
+    );
+  });
+
+  test('first item has no previous', () async {
+    final container = ProviderContainer(
+      overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c'])],
+    );
+    addTearDown(container.dispose);
+    await container.read(orderedDiveIdsProvider.future);
+    expect(
+      container.read(diveNeighborsProvider('a')),
+      (previousId: null, nextId: 'b'),
+    );
+  });
+
+  test('last item has no next', () async {
+    final container = ProviderContainer(
+      overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c'])],
+    );
+    addTearDown(container.dispose);
+    await container.read(orderedDiveIdsProvider.future);
+    expect(
+      container.read(diveNeighborsProvider('c')),
+      (previousId: 'b', nextId: null),
+    );
+  });
+
+  test('id not in list has no neighbors', () async {
+    final container = ProviderContainer(
+      overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c'])],
+    );
+    addTearDown(container.dispose);
+    await container.read(orderedDiveIdsProvider.future);
+    expect(
+      container.read(diveNeighborsProvider('z')),
+      (previousId: null, nextId: null),
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart`
+Expected: FAIL — `orderedDiveIdsProvider` / `diveNeighborsProvider` / `DiveNeighbors` undefined.
+
+- [ ] **Step 3: Add the providers**
+
+In `dive_providers.dart`, near the other list providers (after `sortedFilteredDivesProvider`), add:
+
+```dart
+/// A dive's adjacent ids in the current filter+sort order.
+typedef DiveNeighbors = ({String? previousId, String? nextId});
+
+/// All dive ids in the active filter+sort order — the source for previous/next
+/// navigation from the detail page. IDs only (not full dives), so it stays
+/// cheap even on large libraries. Recomputes when filter/sort/diver change.
+final orderedDiveIdsProvider = FutureProvider.autoDispose<List<String>>((
+  ref,
+) async {
+  final diverId = ref.watch(currentDiverIdProvider);
+  final filter = ref.watch(diveFilterProvider);
+  final sort = ref.watch(diveSortProvider);
+  final repository = ref.watch(diveRepositoryProvider);
+  return repository.getOrderedDiveIds(
+    diverId: diverId,
+    filter: filter,
+    sort: sort,
+  );
+});
+
+/// The previous/next dive ids adjacent to [diveId] in the current list order.
+/// Both are null when the dive is not in the current filtered list.
+final diveNeighborsProvider = Provider.family<DiveNeighbors, String>((
+  ref,
+  diveId,
+) {
+  final ids = ref.watch(orderedDiveIdsProvider).valueOrNull ?? const <String>[];
+  final index = ids.indexOf(diveId);
+  if (index < 0) return (previousId: null, nextId: null);
+  return (
+    previousId: index > 0 ? ids[index - 1] : null,
+    nextId: index < ids.length - 1 ? ids[index + 1] : null,
+  );
+});
+```
+
+If `currentDiverIdProvider` is not already imported in `dive_providers.dart`, add:
+`import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';`
+(check the existing imports first — the paginated notifier already reads it, so it is likely imported).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/providers/dive_providers.dart test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart
+flutter analyze lib/features/dive_log/presentation/providers/dive_providers.dart test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart
+git add lib/features/dive_log/presentation/providers/dive_providers.dart test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart
+git commit -m "feat(dive-log): orderedDiveIds + diveNeighbors providers"
+```
+Expected: format no changes, analyze clean, tests pass.
+
+---
+
+### Task 3: `DiveNavButtons` widget
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart`
+- Test: `test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `diveNeighborsProvider(diveId)` from Task 2; `context.l10n` for tooltips.
+- Produces: `class DiveNavButtons extends ConsumerWidget` with
+  `const DiveNavButtons({required String diveId, required void Function(String neighborId) onNavigate})`.
+
+Localization: add two ARB keys (English + all 10 non-en locales per project
+memory `l10n-all-locales`, then regenerate): `diveLog_detail_tooltip_previousDive`
+= "Previous dive", `diveLog_detail_tooltip_nextDive` = "Next dive". If adding to
+all locales is heavy, use the English value in every locale as a placeholder
+(translation follow-up) — but the keys MUST exist in every locale's ARB and be
+regenerated, or the build breaks.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
+
+Widget _host({
+  required String diveId,
+  required List<String> ids,
+  required void Function(String) onNavigate,
+}) {
+  return ProviderScope(
+    overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ids)],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Consumer(
+          builder: (context, ref, _) {
+            // Prime the future so the family reads a value.
+            ref.watch(orderedDiveIdsProvider);
+            return DiveNavButtons(diveId: diveId, onNavigate: onNavigate);
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('middle item: both enabled, tap navigates', (tester) async {
+    final tapped = <String>[];
+    await tester.pumpWidget(_host(
+      diveId: 'b',
+      ids: ['a', 'b', 'c'],
+      onNavigate: tapped.add,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    expect(tapped, ['a', 'c']);
+  });
+
+  testWidgets('first item: previous disabled', (tester) async {
+    await tester.pumpWidget(_host(
+      diveId: 'a',
+      ids: ['a', 'b', 'c'],
+      onNavigate: (_) {},
+    ));
+    await tester.pumpAndSettle();
+
+    final prev = tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byIcon(Icons.chevron_left),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(prev.onPressed, isNull);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart`
+Expected: FAIL — `DiveNavButtons` / `dive_nav_buttons.dart` do not exist.
+
+- [ ] **Step 3: Add the ARB keys**
+
+Add to `lib/l10n/arb/app_en.arb` (and each of the 10 non-en `app_<locale>.arb`
+files — English value as placeholder is acceptable pending translation):
+
+```json
+"diveLog_detail_tooltip_previousDive": "Previous dive",
+"diveLog_detail_tooltip_nextDive": "Next dive",
+```
+
+Regenerate: `flutter gen-l10n` (or `flutter pub get` if the project regenerates
+on pub get — check `l10n.yaml`).
+
+- [ ] **Step 4: Implement the widget**
+
+Create `lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+/// Previous / next controls for stepping to the dive adjacent to [diveId] in
+/// the current list (filter + sort) order. Each button is disabled when there
+/// is no neighbor in that direction (list ends, or dive not in the filter).
+class DiveNavButtons extends ConsumerWidget {
+  const DiveNavButtons({
+    super.key,
+    required this.diveId,
+    required this.onNavigate,
+  });
+
+  final String diveId;
+  final void Function(String neighborId) onNavigate;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final neighbors = ref.watch(diveNeighborsProvider(diveId));
+    final previousId = neighbors.previousId;
+    final nextId = neighbors.nextId;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          tooltip: context.l10n.diveLog_detail_tooltip_previousDive,
+          onPressed: previousId == null ? null : () => onNavigate(previousId),
+        ),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          tooltip: context.l10n.diveLog_detail_tooltip_nextDive,
+          onPressed: nextId == null ? null : () => onNavigate(nextId),
+        ),
+      ],
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart
+flutter analyze lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart lib/l10n
+git add lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart lib/l10n
+git commit -m "feat(dive-log): DiveNavButtons previous/next widget + l10n"
+```
+Expected: format no changes, analyze clean, tests pass.
+
+---
+
+### Task 4: Wire into DiveDetailPage — surfaces, navigation, arrow keys
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_detail_page.dart`
+- Test: `test/features/dive_log/presentation/pages/dive_detail_nav_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `DiveNavButtons` (Task 3), `orderedDiveIdsProvider` (Task 2, for the widget test override), `widget.embedded`, `widget.diveId`, `context.go`/`context.replace`.
+- Produces: navigation behavior; a private `void _navigateToDive(String neighborId)` helper.
+
+- [ ] **Step 1: Add the navigation helper**
+
+In `_DiveDetailPageState` (the state class of `DiveDetailPage`), add near `diveId`:
+
+```dart
+  void _navigateToDive(String neighborId) {
+    if (widget.embedded) {
+      // Master-detail: swap the selected item (the DetailScrollRetainer keeps
+      // the scroll offset, so you land on the same section of the next dive).
+      context.go('/dives?selected=$neighborId');
+    } else {
+      // Standalone route: replace so stepping through dives does not pile up
+      // the back stack.
+      context.replace('/dives/$neighborId');
+    }
+  }
+```
+
+Add the import at the top (grouped with local imports):
+```dart
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
+```
+
+- [ ] **Step 2: Add nav buttons to the standalone AppBar**
+
+In `_buildContent`, in the standalone `Scaffold`'s `AppBar`, prepend the buttons
+to `actions`. The current actions list begins:
+
+```dart
+      appBar: AppBar(
+        title: Text(context.l10n.diveLog_detail_appBar),
+        actions: [
+          IconButton(
+            icon: Icon(
+              dive.isFavorite ? Icons.favorite : Icons.favorite_border,
+```
+
+Insert before that first `IconButton`:
+
+```dart
+        actions: [
+          DiveNavButtons(diveId: diveId, onNavigate: _navigateToDive),
+          IconButton(
+            icon: Icon(
+              dive.isFavorite ? Icons.favorite : Icons.favorite_border,
+```
+
+- [ ] **Step 3: Add nav buttons to the embedded header**
+
+In `_buildEmbeddedHeader`, the header `Row` ends its `Expanded` name column and
+then has the favorite `IconButton`. Insert the nav buttons right before the
+favorite button:
+
+```dart
+          // Favorite toggle
+          IconButton(
+            icon: Icon(
+              dive.isFavorite ? Icons.favorite : Icons.favorite_border,
+```
+
+becomes:
+
+```dart
+          DiveNavButtons(diveId: dive.id, onNavigate: _navigateToDive),
+          // Favorite toggle
+          IconButton(
+            icon: Icon(
+              dive.isFavorite ? Icons.favorite : Icons.favorite_border,
+```
+
+- [ ] **Step 4: Add arrow-key shortcuts**
+
+Wrap both widgets `_buildContent` returns in `CallbackShortcuts` + `Focus`.
+There are two return sites:
+
+- Embedded: `return Column(children: [_buildEmbeddedHeader(...), Expanded(child: body)]);`
+- Standalone: `return Scaffold(appBar: AppBar(...), body: body ...);`
+
+Wrap each returned widget by passing it through the helper — e.g. the embedded
+one becomes:
+
+```dart
+    if (widget.embedded) {
+      return _wrapWithDiveShortcuts(
+        dive,
+        Column(
+          children: [
+            _buildEmbeddedHeader(context, ref, dive, hasRawData: hasRawData),
+            Expanded(child: body),
+          ],
+        ),
+      );
+    }
+```
+
+and the standalone `return Scaffold(...)` becomes
+`return _wrapWithDiveShortcuts(dive, Scaffold(...));` (wrap the whole existing
+`Scaffold(...)` expression unchanged).
+
+Add the helper to `_DiveDetailPageState`:
+
+```dart
+  Widget _wrapWithDiveShortcuts(Dive dive, Widget child) {
+    final neighbors = ref.watch(diveNeighborsProvider(dive.id));
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.arrowLeft): () {
+          final id = neighbors.previousId;
+          if (id != null) _navigateToDive(id);
+        },
+        const SingleActivator(LogicalKeyboardKey.arrowRight): () {
+          final id = neighbors.nextId;
+          if (id != null) _navigateToDive(id);
+        },
+      },
+      child: Focus(autofocus: false, child: child),
+    );
+  }
+```
+
+Add imports:
+```dart
+import 'package:flutter/services.dart'; // LogicalKeyboardKey (if not present)
+```
+(`diveNeighborsProvider` comes from the dive providers import already used by the
+page; confirm it is imported — the page already imports `dive_providers.dart`.)
+
+- [ ] **Step 5: Write the widget test**
+
+Create `test/features/dive_log/presentation/pages/dive_detail_nav_test.dart`.
+
+**Coverage note (honest scoping):** a full `DiveDetailPage` needs a seeded DB and
+many providers, which the existing dive-detail tests avoid. This test therefore
+covers the navigation *contract* — `DiveNavButtons` in a router host firing the
+same `context.go('/dives?selected=$id')` the embedded surface uses. The two
+page-specific behaviours that can't be cheaply unit-tested here — the
+embedded-vs-standalone branch in `_navigateToDive` and the arrow-key bindings in
+`_wrapWithDiveShortcuts` — are verified in Task 5's manual check (steps 5-6).
+Do not claim automated coverage for the arrow keys.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
+
+void main() {
+  testWidgets('embedded onNavigate swaps the selected query param', (
+    tester,
+  ) async {
+    String? lastLocation;
+    final router = GoRouter(
+      initialLocation: '/dives?selected=b',
+      routes: [
+        GoRoute(
+          path: '/dives',
+          builder: (context, state) {
+            lastLocation = state.uri.toString();
+            return Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  ref.watch(orderedDiveIdsProvider);
+                  return DiveNavButtons(
+                    diveId: 'b',
+                    onNavigate: (id) => context.go('/dives?selected=$id'),
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c']),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
+    expect(lastLocation, '/dives?selected=c');
+  });
+}
+```
+
+- [ ] **Step 6: Run the test**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_detail_nav_test.dart`
+Expected: PASS.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/pages/dive_detail_page.dart test/features/dive_log/presentation/pages/dive_detail_nav_test.dart
+flutter analyze lib/features/dive_log/presentation/pages/dive_detail_page.dart test/features/dive_log/presentation/pages/dive_detail_nav_test.dart
+git add lib/features/dive_log/presentation/pages/dive_detail_page.dart test/features/dive_log/presentation/pages/dive_detail_nav_test.dart
+git commit -m "feat(dive-log): previous/next buttons + arrow keys on dive detail"
+```
+Expected: format no changes, analyze clean, test passes.
+
+---
+
+### Task 5: Whole-project verification + manual check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Whole-project format and analyze**
+
+```bash
+dart format .
+flutter analyze
+```
+Expected: `dart format .` no changes; `flutter analyze` "No issues found!". Commit any format-only changes if produced.
+
+- [ ] **Step 2: Run the dive_log suite**
+
+```bash
+flutter test test/features/dive_log 2>&1 | tail -20
+```
+Expected: all pass (same pass/skip set as before, plus the new tests).
+
+- [ ] **Step 3: Manual verification (run skill, macOS)**
+
+Launch the app (honor the single-instance rule — check for an existing session
+first). Then:
+1. Open Dives (wide window, master-detail). Open a dive, click Next a few times —
+   confirm it steps to adjacent dives and the scroll section is retained.
+2. Confirm Previous is disabled on the newest dive and Next on the oldest (with
+   default date-desc sort).
+3. Change the sort (e.g. by depth) and confirm Next/Previous follow the new
+   order.
+4. Filter the list to exclude the open dive and confirm both buttons disable.
+5. Focus the detail pane and press Left / Right arrows — confirm they step
+   previous / next.
+6. On a narrow window (or the standalone route), confirm the AppBar buttons work
+   and the back stack does not grow per step.
+
+---
+
+## Notes for the executor
+
+- Navigation intentionally differs by surface: embedded uses `context.go(?selected=)`, standalone uses `context.replace(/dives/:id)`. Do not unify them.
+- The nav order must match the visible list; it does because `getOrderedDiveIds` reuses `getDiveSummaries`'s `_buildFilterWhereClauses` / `_buildSortOrderBy`. If you change one, change both.
+- Arrow keys are Left = previous, Right = next (Up/Down stay with scrolling).
+- If an edit's "current code" block does not match (line drift), locate the named method/anchor and apply the same change.

--- a/docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md
+++ b/docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md
@@ -1,7 +1,11 @@
 # Detail Pane Scroll Retention
 
 **Date:** 2026-07-11
-**Status:** Approved (design)
+**Status:** Superseded by the 2026-07-12 revision below — the `PageStorageKey`
+approach in the body of this doc shipped, then failed manual testing (offset
+degraded to 0 after ~3 selections). See "Revision" at the end for the mechanism
+that replaced it. The Problem / Root cause / Scope / Semantics sections still
+hold; only the mechanism changed.
 **Branch/worktree:** `worktree-detail-scroll-retention`
 
 ## Problem
@@ -164,3 +168,66 @@ section (e.g. sites) and confirm an excluded section (settings) still resets.
   retention rides on per-page `PageStorageKey`s (no behavior change).
 - `test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart` —
   new widget test.
+
+---
+
+## Revision (2026-07-12): PageStorageKey approach replaced with a retainer
+
+The `PageStorageKey` mechanism above shipped but **failed manual testing**: the
+detail offset held for a couple of selections, then reset to the top. Root cause
+(confirmed against the Flutter SDK and reproduced in a widget test):
+
+- `ScrollPosition.saveScrollOffset()` writes to the shared `PageStorage` slot
+  from `didEndScroll()` — i.e. on the end of *any* scroll activity, including the
+  involuntary settle when a just-restored offset is **clamped** because the
+  detail's content has not finished loading its height yet (real pages are
+  `async.when(loading: spinner, data: scrollview)` and their sections — profile
+  chart, photos, marine life — keep growing after the scroll view mounts).
+- So each restore-into-still-loading content clamped the offset and **saved the
+  clamped (smaller) value back** into the shared slot, ratcheting it toward 0
+  over successive selections. PageStorage offers no hook to distinguish a user
+  scroll from a transient clamp. The original synchronous, single-selection
+  widget test never exercised this.
+
+### New mechanism: `DetailScrollRetainer`
+
+`lib/shared/widgets/master_detail/detail_scroll_retainer.dart`:
+
+- The scaffold owns the retained offset (`_detailScrollOffset`, mutated on scroll
+  without `setState`) and wraps each view-mode detail in a `DetailScrollRetainer`
+  inside the per-id `KeyedSubtree`.
+- The retainer creates a **per-detail** `ScrollController(keepScrollOffset:
+  false)` — so `PageStorage` never runs and cannot be corrupted — and exposes it
+  via a `DetailScrollController` `InheritedWidget`. A per-detail controller means
+  the `AnimatedSwitcher` cross-fade (two details briefly mounted) causes no
+  controller conflict.
+- Each detail page attaches that controller to its primary scroll view with
+  `controller: DetailScrollController.maybeOf(context)` (replacing the
+  `PageStorageKey`). `InheritedWidget` injection is used rather than
+  `PrimaryScrollController` because the latter auto-inherits only on mobile and
+  would also be adopted by *nested* vertical scrollables (→ "attached to multiple
+  positions" crash); the explicit `controller:` targets exactly one scroll view.
+- **Capture:** a `NotificationListener` records the offset from user scrolls only
+  (it is inert during the retainer's own restore jumps; content growth does not
+  move `pixels`, so it emits no spurious capture).
+- **Restore:** a deferred, extent-guarded post-frame loop jumps to
+  `min(target, maxScrollExtent)` and re-checks while the content is still growing
+  (tolerating brief pauses, hard-capped), so a still-short viewport can never
+  clamp-and-corrupt the value.
+
+### Scope change
+
+- **In (retainer):** dives, sites, courses, certifications, dive centers,
+  equipment, buddies — each `body` scroll view swaps its `PageStorageKey` for
+  `controller: DetailScrollController.maybeOf(context)`.
+- **Trips dropped:** its liveaboard layout is a 5-tab `TabBarView` (multiple
+  scroll views per detail), which a single injected controller cannot serve
+  without per-tab wiring. Trips reverts to no retention (its `PageStorageKey`s
+  were removed). A future change could give each trip tab its own retainer.
+
+### Testing (revised)
+
+The widget test now uses content that **grows after the scroll view mounts** and
+drives **five sequential selections**, asserting the offset survives — the exact
+scenario the shipped approach failed. Plus the clamp case and an opt-out
+(no-controller → resets) guard.

--- a/docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md
+++ b/docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md
@@ -1,0 +1,154 @@
+# Detail Pane Scroll Retention
+
+**Date:** 2026-07-11
+**Status:** Approved (design)
+**Branch/worktree:** `worktree-detail-scroll-retention`
+
+## Problem
+
+In the wide-screen master-detail layout (list on the left, detail on the
+right, `>= 800px`), scrolling a detail pane down to a section and then selecting
+a different item in the list **resets the detail pane to the top**. This forces
+the user to re-scroll to the same section for every item, which defeats the
+common workflow of scrolling to a section (e.g. Marine Life, Cylinders) and
+quickly comparing that section across several dives/sites/etc.
+
+Desired behavior: when you switch the selected item, the detail pane **keeps its
+scroll offset** so the same region stays in view.
+
+## Root cause
+
+`MasterDetailScaffold._DetailPane`
+(`lib/shared/widgets/master_detail/master_detail_scaffold.dart`) renders the
+detail via an `AnimatedSwitcher` whose child is wrapped in
+`KeyedSubtree(key: ValueKey('detail_$selectedId'))`. When `selectedId` changes,
+the `ValueKey` changes, so Flutter tears down the old detail element subtree and
+builds a brand-new one. The detail page's top-level `SingleChildScrollView`
+(e.g. `dive_detail_page.dart`'s `body`) therefore gets a fresh `ScrollPosition`
+starting at offset 0.
+
+The per-id `ValueKey` is **intentional**: it isolates each item's local UI
+state (active data source, expanded panels, etc.), so it must stay. We need
+scroll retention *without* removing that key.
+
+## Approach: `PageStorage` offset retention
+
+Flutter's `Scrollable` automatically saves and restores its scroll offset to the
+nearest ancestor `PageStorageBucket`, keyed by the chain of `PageStorageKey`s
+between the bucket and the scrollable. Crucially, a plain `ValueKey` is **not** a
+`PageStorageKey` and does not participate in that path. So if:
+
+1. a `PageStorageBucket` lives **above** the per-id `KeyedSubtree`, and
+2. each detail page's scroll view carries a **stable** `PageStorageKey`,
+
+then every item reads and writes the **same** storage slot — exactly the
+cross-item retention we want — while each item still gets a fresh element (no
+state leakage) and its own `ScrollController` (so the `AnimatedSwitcher`
+cross-fade, which briefly mounts both panes, causes no controller conflict).
+
+### Part 1 — Scaffold provides a persistent, isolated bucket
+
+In `_MasterDetailScaffoldState`:
+
+- Add `final PageStorageBucket _detailBucket = PageStorageBucket();`. Because the
+  `State` object outlives the per-id `KeyedSubtree` teardown, the bucket (and
+  thus the saved offset) persists across selections.
+- Wrap the detail-pane subtree (the `_DetailPane` / map-view `Expanded` child)
+  in `PageStorage(bucket: _detailBucket, child: ...)`. Owning the bucket at the
+  scaffold guarantees a bucket exists and isolates it per section, so
+  `PageStorageKey` strings cannot collide across sections (defensive; sections
+  are already separate routes today).
+
+### Part 2 — Each in-scope detail page tags its scroll view
+
+Add a constant `PageStorageKey` to the top-level vertical scroll view of each
+in-scope detail page. The key string is descriptive and unique per page:
+
+| Page | File | Scroll view | Key |
+| ---- | ---- | ----------- | --- |
+| Dive | `dive_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('diveDetailScroll')` |
+| Site | `dive_sites/.../site_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('siteDetailScroll')` |
+| Course | `courses/.../course_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('courseDetailScroll')` |
+| Certification | `certifications/.../certification_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('certificationDetailScroll')` |
+| Dive center | `dive_centers/.../dive_center_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('diveCenterDetailScroll')` |
+| Equipment | `equipment/.../equipment_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('equipmentDetailScroll')` |
+| Buddy | `buddies/.../buddy_detail_page.dart` | `body = SingleChildScrollView` | `PageStorageKey('buddyDetailScroll')` |
+| Trip | `trips/.../trip_detail_page.dart` | tabbed — each tab's scroll view (`TripOverviewTab` and siblings) | `PageStorageKey('trip<Tab>Scroll')` per tab |
+
+Notes:
+
+- Most pages expose a single `final body = SingleChildScrollView(...)`; adding
+  `key:` to that widget is a one-line change and is applied whether or not the
+  page is in `embedded` mode (the key sits on the scroll view itself).
+- **Trips** is the exception: its detail is a `TabBarView` (`body =
+  TripOverviewTab(...)`), so the scroll views live one level deeper inside each
+  tab. Tag each tab's own scroll view. Retaining scroll *per trip* is the goal;
+  per-tab scroll retention within a trip is a natural side benefit.
+
+## Scope
+
+- **In:** dives, sites, courses, certifications, dive centers, equipment,
+  buddies, trips.
+- **Out:** statistics, settings, transfer (sectioned/config panes, not
+  comparable entity records), and species (reference data). These use
+  `MasterDetailScaffold` too but are explicitly excluded.
+
+The scaffold change (Part 1) is global, but it is inert for the excluded
+sections because their detail panes carry no `PageStorageKey`, so nothing is
+saved or restored for them.
+
+## Semantics & edge cases
+
+- **Pixel offset, clamped.** The restored offset is the raw pixel value,
+  clamped by `Scrollable` to the new content's scroll extent. A shorter item
+  lands at its own bottom. This matches "I don't have to re-scroll to roughly
+  the same place"; true section-anchoring is intentionally out of scope (YAGNI —
+  sections are user-reorderable and vary in height per item).
+- **Cross-fade preserved.** The existing `AnimatedSwitcher` stays. Each pane
+  keeps its own controller; the two panes only share a saved-offset value, so
+  the brief double-mount during the fade is safe (both write the same value).
+- **Mobile unaffected.** On narrow layouts each detail is its own route with a
+  fresh `PageStorageBucket` and no sibling to compare against, so it still opens
+  at the top. No regression.
+- **Edit/create/summary untouched.** Only the view-mode scroll view is tagged.
+  Edit forms and the empty-state summary keep current behavior.
+- **Section switching (dives -> sites).** Different routes -> different
+  buckets -> independent offsets. No contamination.
+
+## Testing
+
+### Widget test (primary)
+
+New file `test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart`,
+modeled on the existing `master_detail_scaffold_focus_test.dart` harness
+(`GoRouter` + `MediaQuery` at width 1200 to force the desktop layout). Because
+the harness supplies its own `detailBuilder`, the test proves the scaffold
+wiring without depending on any real detail page:
+
+1. `detailBuilder: (_, id) => SingleChildScrollView(key: const
+   PageStorageKey('testDetailScroll'), child: SizedBox(height: 3000, child:
+   Text('Detail $id')))`.
+2. Render at `/test?selected=1`, scroll the detail pane to a known offset (e.g.
+   `drag`/`jumpTo` to 800), `pumpAndSettle`.
+3. Drive selection to item 2 (navigate to `/test?selected=2`), `pumpAndSettle`.
+4. Assert the detail pane's `ScrollPosition.pixels == 800` (retained).
+5. Second case: item 2's content is shorter (e.g. height 400); assert the
+   offset **clamps** to `maxScrollExtent` rather than throwing or staying at
+   800.
+6. Regression guard: assert an untagged detail scroll view (no
+   `PageStorageKey`) still resets to 0, documenting that the key is what opts a
+   section in.
+
+### Manual verification (run skill, macOS)
+
+Scroll a dive detail to Marine Life / Cylinders, click a different dive in the
+list, confirm the pane stays scrolled. Repeat for at least one other in-scope
+section (e.g. sites) and confirm an excluded section (settings) still resets.
+
+## Files touched
+
+- `lib/shared/widgets/master_detail/master_detail_scaffold.dart` — bucket +
+  `PageStorage` wrapper (Part 1).
+- 8 detail pages — one `PageStorageKey` each (trips: one per tab) (Part 2).
+- `test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart` —
+  new widget test.

--- a/docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md
+++ b/docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md
@@ -36,30 +36,37 @@ scroll retention *without* removing that key.
 Flutter's `Scrollable` automatically saves and restores its scroll offset to the
 nearest ancestor `PageStorageBucket`, keyed by the chain of `PageStorageKey`s
 between the bucket and the scrollable. Crucially, a plain `ValueKey` is **not** a
-`PageStorageKey` and does not participate in that path. So if:
+`PageStorageKey` and does not participate in that path. So when a detail page's
+scroll view carries a **stable** `PageStorageKey`, every item reads and writes
+the **same** storage slot — exactly the cross-item retention we want — while
+each item still gets a fresh element (no state leakage) and its own
+`ScrollController` (so the `AnimatedSwitcher` cross-fade, which briefly mounts
+both panes, causes no controller conflict).
 
-1. a `PageStorageBucket` lives **above** the per-id `KeyedSubtree`, and
-2. each detail page's scroll view carries a **stable** `PageStorageKey`,
+### Why the fix is *only* adding keys (spike finding, 2026-07-11)
 
-then every item reads and writes the **same** storage slot — exactly the
-cross-item retention we want — while each item still gets a fresh element (no
-state leakage) and its own `ScrollController` (so the `AnimatedSwitcher`
-cross-fade, which briefly mounts both panes, causes no controller conflict).
+The real reason the app resets today is that Flutter's
+`PageStorageBucket._computeIdentifier` returns `null` when there is **no
+`PageStorageKey`** in the scrollable's ancestry, making `writeState` /
+`readState` silent no-ops. The current detail scroll views have no key, so their
+offset is never persisted.
 
-### Part 1 — Scaffold provides a persistent, isolated bucket
+A spike (`MasterDetailScaffold` in a `GoRouter` at desktop width, dummy detail
+items) confirmed the mechanism end-to-end:
 
-In `_MasterDetailScaffoldState`:
+- **Tagged** scroll view (`PageStorageKey` present) → offset **retained** across
+  selection, using the ambient route-provided `PageStorageBucket` — *with no
+  scaffold change at all*.
+- **Untagged** scroll view → resets to 0.
 
-- Add `final PageStorageBucket _detailBucket = PageStorageBucket();`. Because the
-  `State` object outlives the per-id `KeyedSubtree` teardown, the bucket (and
-  thus the saved offset) persists across selections.
-- Wrap the detail-pane subtree (the `_DetailPane` / map-view `Expanded` child)
-  in `PageStorage(bucket: _detailBucket, child: ...)`. Owning the bucket at the
-  scaffold guarantees a bucket exists and isolates it per section, so
-  `PageStorageKey` strings cannot collide across sections (defensive; sections
-  are already separate routes today).
+Every routed page in Flutter already exposes a `PageStorageBucket` (via
+`ModalRoute`), and each section is its own route with a unique key string, so
+there is **nothing to isolate** and **no bucket to add** at the scaffold level.
+An earlier draft of this design added a scaffold-owned `PageStorageBucket`; the
+spike showed it to be redundant, so it was dropped (YAGNI). The scaffold change
+is reduced to a single explanatory comment.
 
-### Part 2 — Each in-scope detail page tags its scroll view
+### Each in-scope detail page tags its scroll view
 
 Add a constant `PageStorageKey` to the top-level vertical scroll view of each
 in-scope detail page. The key string is descriptive and unique per page:
@@ -93,9 +100,9 @@ Notes:
   comparable entity records), and species (reference data). These use
   `MasterDetailScaffold` too but are explicitly excluded.
 
-The scaffold change (Part 1) is global, but it is inert for the excluded
-sections because their detail panes carry no `PageStorageKey`, so nothing is
-saved or restored for them.
+No opt-out logic is needed for the excluded sections: their detail scroll views
+carry no `PageStorageKey`, so `PageStorageBucket` treats them as no-ops and
+nothing is saved or restored.
 
 ## Semantics & edge cases
 
@@ -147,8 +154,13 @@ section (e.g. sites) and confirm an excluded section (settings) still resets.
 
 ## Files touched
 
-- `lib/shared/widgets/master_detail/master_detail_scaffold.dart` — bucket +
-  `PageStorage` wrapper (Part 1).
-- 8 detail pages — one `PageStorageKey` each (trips: one per tab) (Part 2).
+- 7 single-scroll detail pages (dive, site, course, certification, dive center,
+  equipment, buddy) — one `PageStorageKey` each on `body`.
+- Trips (3 files) — `trip_overview_tab.dart`, `trip_itinerary_tab.dart`, and the
+  three in-page tab builders in `trip_detail_page.dart` (photos, dives,
+  checklist) — one `PageStorageKey` per scroll view.
+- `lib/shared/widgets/master_detail/master_detail_scaffold.dart` — a single
+  explanatory comment near the `ValueKey('detail_$id')` noting that scroll
+  retention rides on per-page `PageStorageKey`s (no behavior change).
 - `test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart` —
   new widget test.

--- a/docs/superpowers/specs/2026-07-12-dive-detail-prev-next-navigation-design.md
+++ b/docs/superpowers/specs/2026-07-12-dive-detail-prev-next-navigation-design.md
@@ -1,0 +1,148 @@
+# Dive Detail Previous / Next Navigation
+
+**Date:** 2026-07-12
+**Status:** Approved (design)
+**Branch/worktree:** `worktree-detail-scroll-retention`
+
+## Problem
+
+From an open dive's detail page there is no way to step to the adjacent dive.
+Users must go back to the list, find the next dive, and open it — tedious when
+comparing several dives in a row. Add **Previous / Next** controls (buttons plus
+desktop arrow keys) that walk to adjacent dives.
+
+## Definition of "adjacent"
+
+Previous/Next follow the **current list order** — the dive list's active filter
+and sort (`diveFilterProvider` + `diveSortProvider`). If the user filtered to one
+site sorted by depth, "next" is the next dive in that filtered, sorted sequence.
+This matches what the user sees, so adjacency is never surprising.
+
+Both providers are app-global `StateProvider`s, so the current filter/sort is
+available from the detail page on every platform (embedded master-detail and
+standalone mobile route alike).
+
+## Root of the ordering: reuse the visible list's SQL
+
+The visible list is ordered in SQL:
+`DiveRepositoryImpl.getDiveSummaries` builds its query from
+`_buildFilterWhereClauses(filter, ...)` and `_buildSortOrderBy(sort)`
+(`dive_repository_impl.dart`). Prev/Next MUST reuse those same clause builders so
+the neighbor order can never drift from the list order.
+
+## Architecture
+
+### 1. Ordering source — `getOrderedDiveIds` (Approach A)
+
+Add a repository method that returns just the ordered IDs — not full `Dive`
+objects, keeping it friendly to the large-DB perf work:
+
+```
+Future<List<String>> getOrderedDiveIds({
+  String? diverId,
+  DiveFilterState filter = const DiveFilterState(),
+  SortState<DiveSortField>? sort,
+});
+```
+
+Implementation mirrors `getDiveSummaries` exactly, minus pagination:
+`SELECT d.id FROM dives d LEFT JOIN dive_sites s ON d.site_id = s.id`
+`<same WHERE from _buildFilterWhereClauses> ORDER BY <same _buildSortOrderBy>`
+— no `LIMIT`, no `OFFSET`, no cursor. The `LEFT JOIN dive_sites` is kept because
+site-name sort references `s.name`. Returns the ordered `List<String>`.
+
+Rejected alternatives:
+- **B (reuse `sortedFilteredDivesProvider`):** relies on the full in-memory
+  `Dive` list the app moved away from for large DBs, and its Dart sort can drift
+  from the DB order.
+- **C (keyset neighbor queries):** lightest at scale but needs bespoke comparator
+  SQL per sort field × direction × nulls. Error-prone; not worth it now.
+
+### 2. Providers
+
+- `orderedDiveIdsProvider` — a `FutureProvider<List<String>>` (autoDispose) that
+  reads `currentDiverIdProvider`, `diveFilterProvider`, `diveSortProvider` and
+  calls `getOrderedDiveIds`. Recomputes when filter/sort/diver change.
+- `diveNeighborsProvider` — a `Provider.family<DiveNeighbors, String>` (by dive
+  id) that reads the ordered IDs and computes:
+  - `index = ids.indexOf(diveId)`
+  - `previousId = index > 0 ? ids[index - 1] : null`
+  - `nextId = index >= 0 && index < ids.length - 1 ? ids[index + 1] : null`
+  - `index == -1` (dive not in the current filtered list) → both null.
+  `DiveNeighbors` is a tiny immutable value type `(String? previousId, String?
+  nextId)`.
+
+### 3. UI — `DiveNavButtons`
+
+A small, reusable stateless widget: two `IconButton`s
+(`Icons.chevron_left` "Previous", `Icons.chevron_right` "Next"), each disabled
+(`onPressed: null`) when its neighbor id is null. It reads
+`diveNeighborsProvider(diveId)` and calls an injected
+`void Function(String neighborId) onNavigate`.
+
+Placed in both detail surfaces of `dive_detail_page.dart`:
+- **Standalone `AppBar`:** prepend the pair to `actions` (before favorite/edit).
+- **Embedded header** (`_buildEmbeddedHeader`, master-detail): add the pair to
+  the compact header row.
+
+### 4. Navigation
+
+The detail page owns navigation and branches on `widget.embedded`:
+- **Embedded (master-detail desktop):**
+  `context.go('/dives?selected=$neighborId')` — the same query-param swap the
+  list uses. Bonus: the `DetailScrollRetainer` keeps the scroll offset, so the
+  user lands on the same section of the adjacent dive.
+- **Standalone (mobile route `/dives/:id`):**
+  `context.replace('/dives/$neighborId')` — replace (not push) so stepping
+  through dives does not pile up the back stack.
+
+### 5. Arrow keys (desktop)
+
+Wrap the detail content in `CallbackShortcuts` (inside a focused subtree) binding:
+- `LogicalKeyboardKey.arrowLeft` → previous
+- `LogicalKeyboardKey.arrowRight` → next
+
+Left/Right are chosen so Up/Down remain free for vertical scrolling. Each binding
+is a no-op when its neighbor is null. The shortcuts live on the detail pane's
+focus scope so they do not fight the master list's own key handling.
+
+## Edge cases
+
+- **Dive not in the current filter** (user filtered it out after opening) → both
+  controls disabled; arrow keys no-op.
+- **Ends of the list** → Previous disabled on the first, Next on the last.
+- **Single-dive list** → both disabled.
+- **Filter/sort changes while viewing** → `orderedDiveIdsProvider` recomputes and
+  the buttons re-enable/disable reactively.
+
+## Testing
+
+- **Repository test:** `getOrderedDiveIds` returns the same id order as
+  `getDiveSummaries` (paged, concatenated) for a representative filter and for at
+  least two sorts (date desc, depth asc), including a filtered subset.
+- **Provider test:** `diveNeighborsProvider` — middle (both), first (prev null),
+  last (next null), not-found (both null), single-item (both null).
+- **Widget test:** `DiveNavButtons` renders both buttons; disabled at ends; tap
+  fires `onNavigate` with the right id. Detail-page test: Left/Right arrow keys
+  invoke previous/next.
+
+## Scope
+
+- **Dives only** (per the request). `DiveNavButtons`, `DiveNeighbors`, and the
+  ordered-ids/neighbors provider pattern are written to generalize, so other
+  detail pages (sites, etc.) could adopt the same shape later — but no other
+  section is touched here.
+
+## Files touched
+
+- `lib/features/dive_log/domain/repositories/dive_repository.dart` — add
+  `getOrderedDiveIds` to the interface.
+- `lib/features/dive_log/data/repositories/dive_repository_impl.dart` — implement
+  it (reusing `_buildFilterWhereClauses` / `_buildSortOrderBy`).
+- `lib/features/dive_log/presentation/providers/dive_providers.dart` — add
+  `orderedDiveIdsProvider` and `diveNeighborsProvider` (+ `DiveNeighbors`).
+- `lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart` — new
+  `DiveNavButtons` widget.
+- `lib/features/dive_log/presentation/pages/dive_detail_page.dart` — mount the
+  buttons in the AppBar and embedded header; navigation; arrow-key shortcuts.
+- Tests under `test/features/dive_log/` for repo, providers, and widget/keys.

--- a/lib/features/buddies/presentation/pages/buddy_detail_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_detail_page.dart
@@ -7,6 +7,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
@@ -117,7 +118,7 @@ class _BuddyDetailContent extends ConsumerWidget {
     final statsAsync = ref.watch(buddyStatsProvider(buddy.id));
 
     final body = SingleChildScrollView(
-      key: const PageStorageKey('buddyDetailScroll'),
+      controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/buddies/presentation/pages/buddy_detail_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_detail_page.dart
@@ -117,6 +117,7 @@ class _BuddyDetailContent extends ConsumerWidget {
     final statsAsync = ref.watch(buddyStatsProvider(buddy.id));
 
     final body = SingleChildScrollView(
+      key: const PageStorageKey('buddyDetailScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/certifications/presentation/pages/certification_detail_page.dart
+++ b/lib/features/certifications/presentation/pages/certification_detail_page.dart
@@ -118,6 +118,7 @@ class _CertificationDetailContent extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final body = SingleChildScrollView(
+      key: const PageStorageKey('certificationDetailScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/certifications/presentation/pages/certification_detail_page.dart
+++ b/lib/features/certifications/presentation/pages/certification_detail_page.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
@@ -118,7 +119,7 @@ class _CertificationDetailContent extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final body = SingleChildScrollView(
-      key: const PageStorageKey('certificationDetailScroll'),
+      controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/courses/presentation/pages/course_detail_page.dart
+++ b/lib/features/courses/presentation/pages/course_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/services/export/export_service.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
 import 'package:submersion/features/courses/domain/entities/course.dart';
@@ -51,7 +52,7 @@ class CourseDetailPage extends ConsumerWidget {
     final formatter = UnitFormatter(ref.watch(settingsProvider));
 
     final body = SingleChildScrollView(
-      key: const PageStorageKey('courseDetailScroll'),
+      controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/courses/presentation/pages/course_detail_page.dart
+++ b/lib/features/courses/presentation/pages/course_detail_page.dart
@@ -51,6 +51,7 @@ class CourseDetailPage extends ConsumerWidget {
     final formatter = UnitFormatter(ref.watch(settingsProvider));
 
     final body = SingleChildScrollView(
+      key: const PageStorageKey('courseDetailScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -92,6 +92,7 @@ class _DiveCenterDetailPageState extends ConsumerState<DiveCenterDetailPage> {
         }
 
         final body = SingleChildScrollView(
+          key: const PageStorageKey('diveCenterDetailScroll'),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
@@ -92,7 +93,7 @@ class _DiveCenterDetailPageState extends ConsumerState<DiveCenterDetailPage> {
         }
 
         final body = SingleChildScrollView(
-          key: const PageStorageKey('diveCenterDetailScroll'),
+          controller: DetailScrollController.maybeOf(context),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1567,6 +1567,63 @@ class DiveRepository {
     }
   }
 
+  /// Returns every dive id matching [filter] in [sort] order -- the same order
+  /// as [getDiveSummaries] but without pagination and selecting only the id.
+  ///
+  /// Used to compute previous/next navigation from the detail page. Distinct
+  /// from [getPreviousDive], which is the chronological surface-interval query.
+  Future<List<String>> getOrderedDiveIds({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+    SortState<DiveSortField>? sort,
+  }) async {
+    try {
+      return await PerfTimer.measure('getOrderedDiveIds', () async {
+        final whereClauses = <String>[];
+        final args = <Variable<Object>>[];
+
+        if (diverId != null) {
+          whereClauses.add('d.diver_id = ?');
+          args.add(Variable(diverId));
+        }
+
+        _buildFilterWhereClauses(filter, whereClauses, args);
+
+        final whereClause = whereClauses.isNotEmpty
+            ? 'WHERE ${whereClauses.join(' AND ')}'
+            : '';
+        final orderByClause = _buildSortOrderBy(sort);
+
+        // sort_timestamp / s.name aliases are referenced by _buildSortOrderBy,
+        // so they must appear here even though only id is read back.
+        final sql =
+            'SELECT d.id, '
+            'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp '
+            'FROM dives d '
+            'LEFT JOIN dive_sites s ON d.site_id = s.id '
+            '$whereClause '
+            'ORDER BY $orderByClause';
+
+        final rows = await _db
+            .customSelect(
+              sql,
+              variables: args,
+              readsFrom: {_db.dives, _db.diveSites},
+            )
+            .get();
+
+        return rows.map((r) => r.read<String>('id')).toList();
+      });
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get ordered dive ids',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Get total count of dives matching the given filters.
   ///
   /// Used to display "X dives" in the UI header without loading all data.

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -38,6 +38,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_anal
 import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
 import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_tracking_provider.dart';
@@ -447,7 +448,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
 
     final body = SingleChildScrollView(
-      key: const PageStorageKey('diveDetailScroll'),
+      controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
       child: RepaintBoundary(
         key: _pageExportKey,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -206,7 +206,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             body: Center(child: Text(context.l10n.diveLog_detail_notFound)),
           );
         }
-        return _buildContent(context, ref, dive);
+        return _wrapWithDiveShortcuts(dive, _buildContent(context, ref, dive));
       },
       loading: () => Scaffold(
         appBar: AppBar(title: Text(context.l10n.diveLog_detail_appBar)),
@@ -529,95 +529,89 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     // Embedded mode: Return content with a compact header bar (no Scaffold)
     if (widget.embedded) {
-      return _wrapWithDiveShortcuts(
-        dive,
-        Column(
-          children: [
-            _buildEmbeddedHeader(context, ref, dive, hasRawData: hasRawData),
-            Expanded(child: body),
-          ],
-        ),
+      return Column(
+        children: [
+          _buildEmbeddedHeader(context, ref, dive, hasRawData: hasRawData),
+          Expanded(child: body),
+        ],
       );
     }
 
     // Standalone mode: Full Scaffold with AppBar
-    return _wrapWithDiveShortcuts(
-      dive,
-      Scaffold(
-        appBar: AppBar(
-          title: Text(context.l10n.diveLog_detail_appBar),
-          actions: [
-            DiveNavButtons(diveId: diveId, onNavigate: _navigateToDive),
-            IconButton(
-              icon: Icon(
-                dive.isFavorite ? Icons.favorite : Icons.favorite_border,
-                color: dive.isFavorite ? Colors.red : null,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.diveLog_detail_appBar),
+        actions: [
+          DiveNavButtons(diveId: diveId, onNavigate: _navigateToDive),
+          IconButton(
+            icon: Icon(
+              dive.isFavorite ? Icons.favorite : Icons.favorite_border,
+              color: dive.isFavorite ? Colors.red : null,
+            ),
+            tooltip: dive.isFavorite
+                ? context.l10n.diveLog_detail_tooltip_removeFromFavorites
+                : context.l10n.diveLog_detail_tooltip_addToFavorites,
+            onPressed: () {
+              ref
+                  .read(paginatedDiveListProvider.notifier)
+                  .toggleFavorite(diveId);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: context.l10n.diveLog_detail_tooltip_editDive,
+            onPressed: () => context.push('/dives/$diveId/edit'),
+          ),
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              switch (value) {
+                case 'export':
+                  _showExportOptions(context, ref, dive);
+                  break;
+                case 'reparse':
+                  _reparseDive(context, ref, dive);
+                  break;
+                case 'delete':
+                  _showDeleteConfirmation(context, ref);
+                  break;
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'export',
+                child: ListTile(
+                  leading: const Icon(Icons.download),
+                  title: Text(context.l10n.diveLog_detail_menu_export),
+                  contentPadding: EdgeInsets.zero,
+                ),
               ),
-              tooltip: dive.isFavorite
-                  ? context.l10n.diveLog_detail_tooltip_removeFromFavorites
-                  : context.l10n.diveLog_detail_tooltip_addToFavorites,
-              onPressed: () {
-                ref
-                    .read(paginatedDiveListProvider.notifier)
-                    .toggleFavorite(diveId);
-              },
-            ),
-            IconButton(
-              icon: const Icon(Icons.edit),
-              tooltip: context.l10n.diveLog_detail_tooltip_editDive,
-              onPressed: () => context.push('/dives/$diveId/edit'),
-            ),
-            PopupMenuButton<String>(
-              onSelected: (value) {
-                switch (value) {
-                  case 'export':
-                    _showExportOptions(context, ref, dive);
-                    break;
-                  case 'reparse':
-                    _reparseDive(context, ref, dive);
-                    break;
-                  case 'delete':
-                    _showDeleteConfirmation(context, ref);
-                    break;
-                }
-              },
-              itemBuilder: (context) => [
+              if (hasRawData)
                 PopupMenuItem(
-                  value: 'export',
+                  value: 'reparse',
                   child: ListTile(
-                    leading: const Icon(Icons.download),
-                    title: Text(context.l10n.diveLog_detail_menu_export),
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ),
-                if (hasRawData)
-                  PopupMenuItem(
-                    value: 'reparse',
-                    child: ListTile(
-                      leading: const Icon(Icons.refresh),
-                      title: Text(
-                        context.l10n.diveLog_detail_menu_reparseRawData,
-                      ),
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                  ),
-                PopupMenuItem(
-                  value: 'delete',
-                  child: ListTile(
-                    leading: const Icon(Icons.delete, color: Colors.red),
+                    leading: const Icon(Icons.refresh),
                     title: Text(
-                      context.l10n.diveLog_detail_menu_delete,
-                      style: const TextStyle(color: Colors.red),
+                      context.l10n.diveLog_detail_menu_reparseRawData,
                     ),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-              ],
-            ),
-          ],
-        ),
-        body: body,
+              PopupMenuItem(
+                value: 'delete',
+                child: ListTile(
+                  leading: const Icon(Icons.delete, color: Colors.red),
+                  title: Text(
+                    context.l10n.diveLog_detail_menu_delete,
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
+      body: body,
     );
   }
 

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -447,6 +447,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
 
     final body = SingleChildScrollView(
+      key: const PageStorageKey('diveDetailScroll'),
       padding: const EdgeInsets.all(16),
       child: RepaintBoundary(
         key: _pageExportKey,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart' show DateFormat;
 import 'package:submersion/core/icons/mdi_icons.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -32,6 +33,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_detail_ui_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_analysis_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
@@ -144,6 +146,37 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   String? _lastSacSegmentsAnalysisDiveId;
 
   String get diveId => widget.diveId;
+
+  /// Navigate to an adjacent dive. Embedded (master-detail) swaps the selected
+  /// query param -- the DetailScrollRetainer then keeps the scroll offset, so
+  /// the same section stays in view. Standalone replaces the route so stepping
+  /// through dives does not pile up the back stack.
+  void _navigateToDive(String neighborId) {
+    if (widget.embedded) {
+      context.go('/dives?selected=$neighborId');
+    } else {
+      context.replace('/dives/$neighborId');
+    }
+  }
+
+  /// Wraps [child] with Left/Right arrow-key bindings for previous/next dive.
+  /// Up/Down are left untouched so vertical scrolling still works.
+  Widget _wrapWithDiveShortcuts(Dive dive, Widget child) {
+    final neighbors = ref.watch(diveNeighborsProvider(dive.id));
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.arrowLeft): () {
+          final id = neighbors.previousId;
+          if (id != null) _navigateToDive(id);
+        },
+        const SingleActivator(LogicalKeyboardKey.arrowRight): () {
+          final id = neighbors.nextId;
+          if (id != null) _navigateToDive(id);
+        },
+      },
+      child: Focus(child: child),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -496,88 +529,95 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     // Embedded mode: Return content with a compact header bar (no Scaffold)
     if (widget.embedded) {
-      return Column(
-        children: [
-          _buildEmbeddedHeader(context, ref, dive, hasRawData: hasRawData),
-          Expanded(child: body),
-        ],
+      return _wrapWithDiveShortcuts(
+        dive,
+        Column(
+          children: [
+            _buildEmbeddedHeader(context, ref, dive, hasRawData: hasRawData),
+            Expanded(child: body),
+          ],
+        ),
       );
     }
 
     // Standalone mode: Full Scaffold with AppBar
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(context.l10n.diveLog_detail_appBar),
-        actions: [
-          IconButton(
-            icon: Icon(
-              dive.isFavorite ? Icons.favorite : Icons.favorite_border,
-              color: dive.isFavorite ? Colors.red : null,
-            ),
-            tooltip: dive.isFavorite
-                ? context.l10n.diveLog_detail_tooltip_removeFromFavorites
-                : context.l10n.diveLog_detail_tooltip_addToFavorites,
-            onPressed: () {
-              ref
-                  .read(paginatedDiveListProvider.notifier)
-                  .toggleFavorite(diveId);
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.edit),
-            tooltip: context.l10n.diveLog_detail_tooltip_editDive,
-            onPressed: () => context.push('/dives/$diveId/edit'),
-          ),
-          PopupMenuButton<String>(
-            onSelected: (value) {
-              switch (value) {
-                case 'export':
-                  _showExportOptions(context, ref, dive);
-                  break;
-                case 'reparse':
-                  _reparseDive(context, ref, dive);
-                  break;
-                case 'delete':
-                  _showDeleteConfirmation(context, ref);
-                  break;
-              }
-            },
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'export',
-                child: ListTile(
-                  leading: const Icon(Icons.download),
-                  title: Text(context.l10n.diveLog_detail_menu_export),
-                  contentPadding: EdgeInsets.zero,
-                ),
+    return _wrapWithDiveShortcuts(
+      dive,
+      Scaffold(
+        appBar: AppBar(
+          title: Text(context.l10n.diveLog_detail_appBar),
+          actions: [
+            DiveNavButtons(diveId: diveId, onNavigate: _navigateToDive),
+            IconButton(
+              icon: Icon(
+                dive.isFavorite ? Icons.favorite : Icons.favorite_border,
+                color: dive.isFavorite ? Colors.red : null,
               ),
-              if (hasRawData)
+              tooltip: dive.isFavorite
+                  ? context.l10n.diveLog_detail_tooltip_removeFromFavorites
+                  : context.l10n.diveLog_detail_tooltip_addToFavorites,
+              onPressed: () {
+                ref
+                    .read(paginatedDiveListProvider.notifier)
+                    .toggleFavorite(diveId);
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.edit),
+              tooltip: context.l10n.diveLog_detail_tooltip_editDive,
+              onPressed: () => context.push('/dives/$diveId/edit'),
+            ),
+            PopupMenuButton<String>(
+              onSelected: (value) {
+                switch (value) {
+                  case 'export':
+                    _showExportOptions(context, ref, dive);
+                    break;
+                  case 'reparse':
+                    _reparseDive(context, ref, dive);
+                    break;
+                  case 'delete':
+                    _showDeleteConfirmation(context, ref);
+                    break;
+                }
+              },
+              itemBuilder: (context) => [
                 PopupMenuItem(
-                  value: 'reparse',
+                  value: 'export',
                   child: ListTile(
-                    leading: const Icon(Icons.refresh),
+                    leading: const Icon(Icons.download),
+                    title: Text(context.l10n.diveLog_detail_menu_export),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
+                if (hasRawData)
+                  PopupMenuItem(
+                    value: 'reparse',
+                    child: ListTile(
+                      leading: const Icon(Icons.refresh),
+                      title: Text(
+                        context.l10n.diveLog_detail_menu_reparseRawData,
+                      ),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                PopupMenuItem(
+                  value: 'delete',
+                  child: ListTile(
+                    leading: const Icon(Icons.delete, color: Colors.red),
                     title: Text(
-                      context.l10n.diveLog_detail_menu_reparseRawData,
+                      context.l10n.diveLog_detail_menu_delete,
+                      style: const TextStyle(color: Colors.red),
                     ),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-              PopupMenuItem(
-                value: 'delete',
-                child: ListTile(
-                  leading: const Icon(Icons.delete, color: Colors.red),
-                  title: Text(
-                    context.l10n.diveLog_detail_menu_delete,
-                    style: const TextStyle(color: Colors.red),
-                  ),
-                  contentPadding: EdgeInsets.zero,
-                ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
+        body: body,
       ),
-      body: body,
     );
   }
 
@@ -648,6 +688,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               ],
             ),
           ),
+          DiveNavButtons(diveId: dive.id, onNavigate: _navigateToDive),
           // Favorite toggle
           IconButton(
             icon: Icon(

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -62,6 +62,41 @@ final sortedFilteredDivesProvider = Provider<AsyncValue<List<domain.Dive>>>((
   return divesAsync.whenData((dives) => _applySorting(dives, sort));
 });
 
+/// A dive's adjacent ids in the current filter+sort order.
+typedef DiveNeighbors = ({String? previousId, String? nextId});
+
+/// All dive ids in the active filter+sort order -- the source for previous/next
+/// navigation from the detail page. IDs only (not full dives), so it stays
+/// cheap even on large libraries. Recomputes when filter/sort/diver change.
+final orderedDiveIdsProvider = FutureProvider.autoDispose<List<String>>((
+  ref,
+) async {
+  final diverId = ref.watch(currentDiverIdProvider);
+  final filter = ref.watch(diveFilterProvider);
+  final sort = ref.watch(diveSortProvider);
+  final repository = ref.watch(diveRepositoryProvider);
+  return repository.getOrderedDiveIds(
+    diverId: diverId,
+    filter: filter,
+    sort: sort,
+  );
+});
+
+/// The previous/next dive ids adjacent to [diveId] in the current list order.
+/// Both are null when the dive is not in the current filtered list.
+final diveNeighborsProvider = Provider.family<DiveNeighbors, String>((
+  ref,
+  diveId,
+) {
+  final ids = ref.watch(orderedDiveIdsProvider).valueOrNull ?? const <String>[];
+  final index = ids.indexOf(diveId);
+  if (index < 0) return (previousId: null, nextId: null);
+  return (
+    previousId: index > 0 ? ids[index - 1] : null,
+    nextId: index < ids.length - 1 ? ids[index + 1] : null,
+  );
+});
+
 /// Apply sorting to a list of dives
 List<domain.Dive> _applySorting(
   List<domain.Dive> dives,

--- a/lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_nav_buttons.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+/// Previous / next controls for stepping to the dive adjacent to [diveId] in
+/// the current list (filter + sort) order. Each button is disabled when there
+/// is no neighbor in that direction (list ends, or dive not in the filter).
+class DiveNavButtons extends ConsumerWidget {
+  const DiveNavButtons({
+    super.key,
+    required this.diveId,
+    required this.onNavigate,
+  });
+
+  final String diveId;
+  final void Function(String neighborId) onNavigate;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final neighbors = ref.watch(diveNeighborsProvider(diveId));
+    final previousId = neighbors.previousId;
+    final nextId = neighbors.nextId;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          tooltip: context.l10n.diveLog_detail_tooltip_previousDive,
+          onPressed: previousId == null ? null : () => onNavigate(previousId),
+        ),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          tooltip: context.l10n.diveLog_detail_tooltip_nextDive,
+          onPressed: nextId == null ? null : () => onNavigate(nextId),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -143,6 +143,7 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
     final siteId = widget.siteId;
     final embedded = widget.embedded;
     final body = SingleChildScrollView(
+      key: const PageStorageKey('siteDetailScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/maps/presentation/widgets/map_attribution.da
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/site_marine_life_section.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_section.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -143,7 +144,7 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
     final siteId = widget.siteId;
     final embedded = widget.embedded;
     final body = SingleChildScrollView(
-      key: const PageStorageKey('siteDetailScroll'),
+      controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/equipment/presentation/pages/equipment_detail_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 
 import 'package:submersion/core/constants/enums.dart';
@@ -127,7 +128,7 @@ class _EquipmentDetailContent extends ConsumerWidget {
     final units = UnitFormatter(settings);
 
     final body = SingleChildScrollView(
-      key: const PageStorageKey('equipmentDetailScroll'),
+      controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/equipment/presentation/pages/equipment_detail_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_detail_page.dart
@@ -127,6 +127,7 @@ class _EquipmentDetailContent extends ConsumerWidget {
     final units = UnitFormatter(settings);
 
     final body = SingleChildScrollView(
+      key: const PageStorageKey('equipmentDetailScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/trips/presentation/pages/trip_detail_page.dart
+++ b/lib/features/trips/presentation/pages/trip_detail_page.dart
@@ -159,7 +159,6 @@ class _TripDetailContent extends ConsumerWidget {
                 _buildPhotosTab(context, ref, trip),
                 _buildDivesTab(context, ref, trip),
                 SingleChildScrollView(
-                  key: const PageStorageKey('tripChecklistScroll'),
                   padding: const EdgeInsets.all(16),
                   child: TripChecklistSection(trip: tripWithStats.trip),
                 ),
@@ -217,7 +216,6 @@ class _TripDetailContent extends ConsumerWidget {
   /// Standalone photos tab for the liveaboard tabbed layout.
   Widget _buildPhotosTab(BuildContext context, WidgetRef ref, Trip trip) {
     return SingleChildScrollView(
-      key: const PageStorageKey('tripPhotosScroll'),
       padding: const EdgeInsets.all(16),
       child: TripPhotoSection(tripId: trip.id),
     );
@@ -240,7 +238,6 @@ class _TripDetailContent extends ConsumerWidget {
         final sortedDives = List.of(dives)
           ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
         return ListView.builder(
-          key: const PageStorageKey('tripDivesScroll'),
           padding: const EdgeInsets.all(16),
           itemCount: sortedDives.length,
           itemBuilder: (context, index) {

--- a/lib/features/trips/presentation/pages/trip_detail_page.dart
+++ b/lib/features/trips/presentation/pages/trip_detail_page.dart
@@ -159,6 +159,7 @@ class _TripDetailContent extends ConsumerWidget {
                 _buildPhotosTab(context, ref, trip),
                 _buildDivesTab(context, ref, trip),
                 SingleChildScrollView(
+                  key: const PageStorageKey('tripChecklistScroll'),
                   padding: const EdgeInsets.all(16),
                   child: TripChecklistSection(trip: tripWithStats.trip),
                 ),
@@ -216,6 +217,7 @@ class _TripDetailContent extends ConsumerWidget {
   /// Standalone photos tab for the liveaboard tabbed layout.
   Widget _buildPhotosTab(BuildContext context, WidgetRef ref, Trip trip) {
     return SingleChildScrollView(
+      key: const PageStorageKey('tripPhotosScroll'),
       padding: const EdgeInsets.all(16),
       child: TripPhotoSection(tripId: trip.id),
     );
@@ -238,6 +240,7 @@ class _TripDetailContent extends ConsumerWidget {
         final sortedDives = List.of(dives)
           ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
         return ListView.builder(
+          key: const PageStorageKey('tripDivesScroll'),
           padding: const EdgeInsets.all(16),
           itemCount: sortedDives.length,
           itemBuilder: (context, index) {

--- a/lib/features/trips/presentation/widgets/trip_itinerary_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_itinerary_tab.dart
@@ -76,7 +76,6 @@ class TripItineraryTab extends ConsumerWidget {
     );
 
     return ListView.builder(
-      key: const PageStorageKey('tripItineraryScroll'),
       padding: const EdgeInsets.all(16),
       itemCount: days.length,
       itemBuilder: (context, index) {

--- a/lib/features/trips/presentation/widgets/trip_itinerary_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_itinerary_tab.dart
@@ -76,6 +76,7 @@ class TripItineraryTab extends ConsumerWidget {
     );
 
     return ListView.builder(
+      key: const PageStorageKey('tripItineraryScroll'),
       padding: const EdgeInsets.all(16),
       itemCount: days.length,
       itemBuilder: (context, index) {

--- a/lib/features/trips/presentation/widgets/trip_overview_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_overview_tab.dart
@@ -61,7 +61,6 @@ class _TripOverviewTabState extends ConsumerState<TripOverviewTab> {
     final dateFormat = DateFormat.yMMMd();
 
     return SingleChildScrollView(
-      key: const PageStorageKey('tripOverviewScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/trips/presentation/widgets/trip_overview_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_overview_tab.dart
@@ -61,6 +61,7 @@ class _TripOverviewTabState extends ConsumerState<TripOverviewTab> {
     final dateFormat = DateFormat.yMMMd();
 
     return SingleChildScrollView(
+      key: const PageStorageKey('tripOverviewScroll'),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1370,6 +1370,8 @@
   "diveLog_detail_tooltip_addToFavorites": "إضافة إلى المفضلة",
   "diveLog_detail_tooltip_edit": "تعديل",
   "diveLog_detail_tooltip_editDive": "تعديل الغوصة",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "تصدير الملف كصورة",
   "diveLog_detail_tooltip_removeFromFavorites": "إزالة من المفضلة",
   "diveLog_detail_tooltip_viewFullscreen": "عرض بملء الشاشة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1370,6 +1370,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Zu Favoriten hinzufügen",
   "diveLog_detail_tooltip_edit": "Bearbeiten",
   "diveLog_detail_tooltip_editDive": "Tauchgang bearbeiten",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Profil als Bild exportieren",
   "diveLog_detail_tooltip_removeFromFavorites": "Aus Favoriten entfernen",
   "diveLog_detail_tooltip_viewFullscreen": "Vollbild anzeigen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2011,6 +2011,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Add to favorites",
   "diveLog_detail_tooltip_edit": "Edit",
   "diveLog_detail_tooltip_editDive": "Edit dive",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Export profile as image",
   "diveLog_detail_tooltip_removeFromFavorites": "Remove from favorites",
   "diveLog_detail_tooltip_viewFullscreen": "View fullscreen",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1370,6 +1370,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Agregar a favoritos",
   "diveLog_detail_tooltip_edit": "Editar",
   "diveLog_detail_tooltip_editDive": "Editar inmersión",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Exportar perfil como imagen",
   "diveLog_detail_tooltip_removeFromFavorites": "Quitar de favoritos",
   "diveLog_detail_tooltip_viewFullscreen": "Ver en pantalla completa",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1336,6 +1336,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Ajouter aux favoris",
   "diveLog_detail_tooltip_edit": "Modifier",
   "diveLog_detail_tooltip_editDive": "Modifier la plongee",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Exporter le profil en image",
   "diveLog_detail_tooltip_removeFromFavorites": "Retirer des favoris",
   "diveLog_detail_tooltip_viewFullscreen": "Voir en plein ecran",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1336,6 +1336,8 @@
   "diveLog_detail_tooltip_addToFavorites": "הוספה למועדפים",
   "diveLog_detail_tooltip_edit": "עריכה",
   "diveLog_detail_tooltip_editDive": "עריכת צלילה",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "ייצוא פרופיל כתמונה",
   "diveLog_detail_tooltip_removeFromFavorites": "הסרה מהמועדפים",
   "diveLog_detail_tooltip_viewFullscreen": "הצגה במסך מלא",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1336,6 +1336,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Hozzaadas a kedvencekhez",
   "diveLog_detail_tooltip_edit": "Szerkesztes",
   "diveLog_detail_tooltip_editDive": "Merules szerkesztese",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Profil exportalasa kepkent",
   "diveLog_detail_tooltip_removeFromFavorites": "Eltavolitas a kedvencekbol",
   "diveLog_detail_tooltip_viewFullscreen": "Teljes kepernyo",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1336,6 +1336,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Aggiungi ai preferiti",
   "diveLog_detail_tooltip_edit": "Modifica",
   "diveLog_detail_tooltip_editDive": "Modifica immersione",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Esporta profilo come immagine",
   "diveLog_detail_tooltip_removeFromFavorites": "Rimuovi dai preferiti",
   "diveLog_detail_tooltip_viewFullscreen": "Visualizza a schermo intero",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -6392,6 +6392,18 @@ abstract class AppLocalizations {
   /// **'Edit dive'**
   String get diveLog_detail_tooltip_editDive;
 
+  /// No description provided for @diveLog_detail_tooltip_previousDive.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous dive'**
+  String get diveLog_detail_tooltip_previousDive;
+
+  /// No description provided for @diveLog_detail_tooltip_nextDive.
+  ///
+  /// In en, this message translates to:
+  /// **'Next dive'**
+  String get diveLog_detail_tooltip_nextDive;
+
   /// No description provided for @diveLog_detail_tooltip_exportProfileImage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -3732,6 +3732,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'تعديل الغوصة';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage => 'تصدير الملف كصورة';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -3821,6 +3821,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Tauchgang bearbeiten';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Profil als Bild exportieren';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -3745,6 +3745,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Edit dive';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Export profile as image';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -3814,6 +3814,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Editar inmersión';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Exportar perfil como imagen';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -3831,6 +3831,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Modifier la plongee';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Exporter le profil en image';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -3710,6 +3710,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'עריכת צלילה';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage => 'ייצוא פרופיל כתמונה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -3798,6 +3798,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Merules szerkesztese';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Profil exportalasa kepkent';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -3814,6 +3814,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Modifica immersione';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Esporta profilo come immagine';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -3789,6 +3789,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Duik bewerken';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Profiel exporteren als afbeelding';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -3815,6 +3815,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => 'Editar mergulho';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage =>
       'Exportar perfil como imagem';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -3623,6 +3623,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_detail_tooltip_editDive => '编辑潜水';
 
   @override
+  String get diveLog_detail_tooltip_previousDive => 'Previous dive';
+
+  @override
+  String get diveLog_detail_tooltip_nextDive => 'Next dive';
+
+  @override
   String get diveLog_detail_tooltip_exportProfileImage => '导出轮廓为图片';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1370,6 +1370,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Aan favorieten toevoegen",
   "diveLog_detail_tooltip_edit": "Bewerken",
   "diveLog_detail_tooltip_editDive": "Duik bewerken",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Profiel exporteren als afbeelding",
   "diveLog_detail_tooltip_removeFromFavorites": "Uit favorieten verwijderen",
   "diveLog_detail_tooltip_viewFullscreen": "Volledig scherm bekijken",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1370,6 +1370,8 @@
   "diveLog_detail_tooltip_addToFavorites": "Adicionar aos favoritos",
   "diveLog_detail_tooltip_edit": "Editar",
   "diveLog_detail_tooltip_editDive": "Editar mergulho",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "Exportar perfil como imagem",
   "diveLog_detail_tooltip_removeFromFavorites": "Remover dos favoritos",
   "diveLog_detail_tooltip_viewFullscreen": "Ver em tela cheia",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1480,6 +1480,8 @@
   "diveLog_detail_tooltip_addToFavorites": "添加到收藏",
   "diveLog_detail_tooltip_edit": "编辑",
   "diveLog_detail_tooltip_editDive": "编辑潜水",
+  "diveLog_detail_tooltip_previousDive": "Previous dive",
+  "diveLog_detail_tooltip_nextDive": "Next dive",
   "diveLog_detail_tooltip_exportProfileImage": "导出轮廓为图片",
   "diveLog_detail_tooltip_removeFromFavorites": "从收藏中移除",
   "diveLog_detail_tooltip_viewFullscreen": "查看全屏",

--- a/lib/shared/widgets/master_detail/detail_scroll_retainer.dart
+++ b/lib/shared/widgets/master_detail/detail_scroll_retainer.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/widgets.dart';
+
+/// Exposes the [ScrollController] that a [DetailScrollRetainer] owns to the
+/// detail subtree below it.
+///
+/// A detail page opts into scroll retention by handing its primary scroll view
+/// this controller:
+///
+/// ```dart
+/// SingleChildScrollView(
+///   controller: DetailScrollController.maybeOf(context),
+///   ...
+/// )
+/// ```
+///
+/// When no retainer is present (e.g. the page is shown standalone on mobile),
+/// [maybeOf] returns null and the scroll view falls back to its own internal
+/// controller, so standalone behaviour is unchanged.
+class DetailScrollController extends InheritedWidget {
+  const DetailScrollController({
+    super.key,
+    required this.controller,
+    required super.child,
+  });
+
+  /// The controller to attach to the detail's primary scroll view.
+  final ScrollController controller;
+
+  /// The nearest retainer's controller, or null if there is none.
+  static ScrollController? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<DetailScrollController>()
+        ?.controller;
+  }
+
+  @override
+  bool updateShouldNotify(DetailScrollController oldWidget) =>
+      controller != oldWidget.controller;
+}
+
+/// Preserves a detail pane's scroll offset across item selections in a
+/// master-detail layout.
+///
+/// Why this exists instead of a [PageStorageKey]: `Scrollable` auto-saves its
+/// offset to [PageStorage] on *any* scroll-activity end, including the settle
+/// that fires when a just-restored offset is clamped because the detail's
+/// content has not finished loading its height yet. That clamped value gets
+/// written back to the shared slot, ratcheting the saved offset down to zero
+/// over a few selections. There is no PageStorage hook to distinguish a user
+/// scroll from a transient clamp.
+///
+/// This retainer instead owns a controller with `keepScrollOffset: false` (so
+/// PageStorage never runs), remembers the offset via [onOffsetChanged] (called
+/// only for genuine user scrolls, never for its own restore jumps), and
+/// re-applies [initialOffset] with a deferred, extent-guarded jump that waits
+/// for the content to grow tall enough — so a still-loading viewport can never
+/// corrupt the remembered value.
+class DetailScrollRetainer extends StatefulWidget {
+  const DetailScrollRetainer({
+    super.key,
+    required this.initialOffset,
+    required this.onOffsetChanged,
+    required this.child,
+  });
+
+  /// The offset to restore once the content can accommodate it. Read once, at
+  /// mount; a fresh retainer is created per selection.
+  final double initialOffset;
+
+  /// Called with the latest user-driven scroll offset. The caller should store
+  /// this without triggering a rebuild (it fires on every scroll update).
+  final ValueChanged<double> onOffsetChanged;
+
+  final Widget child;
+
+  @override
+  State<DetailScrollRetainer> createState() => _DetailScrollRetainerState();
+}
+
+class _DetailScrollRetainerState extends State<DetailScrollRetainer> {
+  // keepScrollOffset:false keeps PageStorage entirely out of the loop.
+  final ScrollController _controller = ScrollController(
+    keepScrollOffset: false,
+  );
+
+  /// True while we are applying a restore jump, so the notification listener
+  /// does not mistake our own jump for a user scroll.
+  bool _restoring = false;
+
+  static const double _epsilon = 0.5;
+  static const int _maxAttempts = 120;
+  static const int _maxStableFrames = 3;
+
+  int _attempts = 0;
+  int _stableFrames = 0;
+  double _lastMax = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialOffset > _epsilon) {
+      _scheduleRestore();
+    }
+  }
+
+  /// Chase [DetailScrollRetainer.initialOffset] across frames: the content
+  /// height may still be growing (async sections), so we jump to the best
+  /// offset available now and re-check until the target is reachable or the
+  /// content stops growing.
+  void _scheduleRestore() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (!_controller.hasClients) {
+        if (_attempts++ < _maxAttempts) _scheduleRestore();
+        return;
+      }
+
+      final double max = _controller.position.maxScrollExtent;
+      final double desired = widget.initialOffset.clamp(0.0, max);
+      if ((_controller.offset - desired).abs() > _epsilon) {
+        _restoring = true;
+        _controller.jumpTo(desired);
+        _restoring = false;
+      }
+
+      final bool reachedTarget = max + _epsilon >= widget.initialOffset;
+      if (reachedTarget) return;
+
+      // Not yet reachable: keep polling while the content is still growing,
+      // tolerating brief pauses, with a hard cap as a backstop.
+      if (max > _lastMax + _epsilon) {
+        _stableFrames = 0;
+      } else {
+        _stableFrames++;
+      }
+      _lastMax = max;
+      if (_stableFrames < _maxStableFrames && _attempts++ < _maxAttempts) {
+        _scheduleRestore();
+      }
+    });
+  }
+
+  bool _onNotification(ScrollNotification notification) {
+    if (!_restoring &&
+        (notification is ScrollUpdateNotification ||
+            notification is ScrollEndNotification)) {
+      widget.onOffsetChanged(notification.metrics.pixels);
+    }
+    return false;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: _onNotification,
+      child: DetailScrollController(
+        controller: _controller,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/master_detail/master_detail_scaffold.dart
+++ b/lib/shared/widgets/master_detail/master_detail_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 
 /// Mode for the detail pane in master-detail layout.
@@ -162,6 +163,12 @@ class MasterDetailScaffold extends ConsumerStatefulWidget {
 }
 
 class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
+  /// Last known scroll offset of the detail pane, preserved across item
+  /// selections so switching between items keeps the same section in view.
+  /// Mutated on scroll without setState (it must not trigger a rebuild); read
+  /// when a new detail is built. See [DetailScrollRetainer].
+  double _detailScrollOffset = 0;
+
   /// Get the currently selected item ID from URL query params
   String? get _selectedId {
     final state = GoRouterState.of(context);
@@ -333,6 +340,9 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
                     onClose: () => _onItemSelected(null),
                     onSaved: _onSaved,
                     onCancel: _onCancel,
+                    detailScrollOffset: _detailScrollOffset,
+                    onDetailScrollOffsetChanged: (offset) =>
+                        _detailScrollOffset = offset,
                   ),
           ),
         ],
@@ -408,6 +418,12 @@ class _DetailPane extends StatelessWidget {
   final void Function(String savedId) onSaved;
   final VoidCallback onCancel;
 
+  /// Offset to restore into a newly-built detail (see [DetailScrollRetainer]).
+  final double detailScrollOffset;
+
+  /// Records the detail pane's latest user-driven scroll offset.
+  final ValueChanged<double> onDetailScrollOffsetChanged;
+
   const _DetailPane({
     required this.selectedId,
     required this.mode,
@@ -416,6 +432,8 @@ class _DetailPane extends StatelessWidget {
     required this.onClose,
     required this.onSaved,
     required this.onCancel,
+    required this.detailScrollOffset,
+    required this.onDetailScrollOffsetChanged,
     this.editBuilder,
     this.createBuilder,
   });
@@ -451,16 +469,21 @@ class _DetailPane extends StatelessWidget {
 
     // View mode with selected item.
     //
-    // This ValueKey deliberately rebuilds the detail subtree per item so each
-    // item gets fresh local state. It is NOT a PageStorageKey, so it does not
-    // participate in PageStorage's storage path: a detail page whose scroll
-    // view carries a stable PageStorageKey therefore retains its scroll offset
-    // across selections (compare a section across items without re-scrolling).
-    // See docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md.
+    // The ValueKey deliberately rebuilds the detail subtree per item so each
+    // item gets fresh local state. The DetailScrollRetainer sits inside that
+    // per-item subtree and re-applies the pane's scroll offset once the new
+    // content has laid out, so switching items keeps the same section in view
+    // (compare a section across items without re-scrolling). A detail page
+    // opts in by attaching DetailScrollController.maybeOf(context) to its
+    // primary scroll view.
     if (selectedId != null) {
       return KeyedSubtree(
         key: ValueKey('detail_$selectedId'),
-        child: detailBuilder(context, selectedId!),
+        child: DetailScrollRetainer(
+          initialOffset: detailScrollOffset,
+          onOffsetChanged: onDetailScrollOffsetChanged,
+          child: detailBuilder(context, selectedId!),
+        ),
       );
     }
 

--- a/lib/shared/widgets/master_detail/master_detail_scaffold.dart
+++ b/lib/shared/widgets/master_detail/master_detail_scaffold.dart
@@ -449,7 +449,14 @@ class _DetailPane extends StatelessWidget {
       );
     }
 
-    // View mode with selected item
+    // View mode with selected item.
+    //
+    // This ValueKey deliberately rebuilds the detail subtree per item so each
+    // item gets fresh local state. It is NOT a PageStorageKey, so it does not
+    // participate in PageStorage's storage path: a detail page whose scroll
+    // view carries a stable PageStorageKey therefore retains its scroll offset
+    // across selections (compare a section across items without re-scrolling).
+    // See docs/superpowers/specs/2026-07-11-detail-pane-scroll-retention-design.md.
     if (selectedId != null) {
       return KeyedSubtree(
         key: ValueKey('detail_$selectedId'),

--- a/test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
+++ b/test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
 
 import '../../../../helpers/test_database.dart';
 
@@ -19,7 +20,12 @@ void main() {
     await tearDownTestDatabase();
   });
 
-  Future<String> insertDive(String id, int dateTimeMs, {int? number}) async {
+  Future<String> insertDive(
+    String id,
+    int dateTimeMs, {
+    int? number,
+    String? diverId,
+  }) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await db
         .into(db.dives)
@@ -28,6 +34,7 @@ void main() {
             id: Value(id),
             diveDateTime: Value(dateTimeMs),
             diveNumber: Value(number),
+            diverId: Value(diverId),
             createdAt: Value(now),
             updatedAt: Value(now),
           ),
@@ -70,5 +77,28 @@ void main() {
       ),
     );
     expect(ids, ['a', 'c', 'b']);
+  });
+
+  test('applies filter where-clause', () async {
+    await insertDive('a', 2000);
+    await insertDive('c', 500); // before the filter window
+
+    final ids = await repository.getOrderedDiveIds(
+      filter: DiveFilterState(
+        startDate: DateTime.fromMillisecondsSinceEpoch(1000),
+      ),
+    );
+
+    expect(ids, ['a']);
+  });
+
+  test('scopes to diverId (diver_id where-clause)', () async {
+    await insertDive('a', 2000);
+
+    // No diver matches, so the diver_id predicate returns nothing -- this
+    // exercises the diverId branch without needing a seeded divers row.
+    final ids = await repository.getOrderedDiveIds(diverId: 'nobody');
+
+    expect(ids, isEmpty);
   });
 }

--- a/test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
+++ b/test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:submersion/core/constants/sort_options.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/models/sort_state.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertDive(String id, int dateTimeMs, {int? number}) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(dateTimeMs),
+            diveNumber: Value(number),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    return id;
+  }
+
+  test(
+    'returns ids in the same order as getDiveSummaries (date desc)',
+    () async {
+      await insertDive('a', 1000, number: 1);
+      await insertDive('b', 3000, number: 3);
+      await insertDive('c', 2000, number: 2);
+
+      const sort = SortState(
+        field: DiveSortField.date,
+        direction: SortDirection.descending,
+      );
+
+      final ids = await repository.getOrderedDiveIds(sort: sort);
+      final summaries = await repository.getDiveSummaries(
+        sort: sort,
+        limit: 1000,
+      );
+
+      expect(ids, summaries.map((s) => s.id).toList());
+      expect(ids, ['b', 'c', 'a']); // newest first
+    },
+  );
+
+  test('respects sort direction (date asc)', () async {
+    await insertDive('a', 1000);
+    await insertDive('b', 3000);
+    await insertDive('c', 2000);
+
+    final ids = await repository.getOrderedDiveIds(
+      sort: const SortState(
+        field: DiveSortField.date,
+        direction: SortDirection.ascending,
+      ),
+    );
+    expect(ids, ['a', 'c', 'b']);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_nav_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_nav_page_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Renders a real [DiveDetailPage] inside a router so the previous/next
+/// controls and arrow keys exercise the page's navigation helpers.
+Future<List<String>> _pumpNav(
+  WidgetTester tester, {
+  required bool embedded,
+  required Size size,
+}) async {
+  final dive = createTestDiveWithBottomTime(id: 'b');
+  final overrides = await getBaseOverrides();
+  final locations = <String>[];
+
+  final router = GoRouter(
+    initialLocation: '/dives',
+    routes: [
+      GoRoute(
+        path: '/dives',
+        builder: (context, state) {
+          locations.add(state.uri.toString());
+          return DiveDetailPage(diveId: 'b', embedded: embedded);
+        },
+      ),
+      GoRoute(
+        path: '/dives/:id',
+        builder: (context, state) {
+          locations.add(state.uri.toString());
+          return DiveDetailPage(
+            diveId: state.pathParameters['id']!,
+            embedded: embedded,
+          );
+        },
+      ),
+    ],
+  );
+
+  final originalOnError = FlutterError.onError;
+  FlutterError.onError = (d) {
+    if (d.toString().contains('overflowed')) return;
+    originalOnError?.call(d);
+  };
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        ...overrides,
+        diveProvider(dive.id).overrideWith((ref) async => dive),
+        diveDataSourcesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <DiveDataSource>[]),
+        orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c']),
+      ],
+      child: MediaQuery(
+        data: MediaQueryData(size: size),
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+  FlutterError.onError = originalOnError;
+  return locations;
+}
+
+void main() {
+  testWidgets('embedded: Next/Previous buttons swap the selected dive', (
+    tester,
+  ) async {
+    final locations = await _pumpNav(
+      tester,
+      embedded: true,
+      size: const Size(1200, 800),
+    );
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pump();
+    expect(locations.last, '/dives?selected=c');
+
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.pump();
+    expect(locations.last, '/dives?selected=a');
+  });
+
+  // Arrow-key navigation (Left/Right) is wired in _wrapWithDiveShortcuts and
+  // verified manually: the widget tester's focus handling is unreliable across
+  // the route rebuild that each navigation triggers. The button tests above and
+  // below cover the shared _navigateToDive helper the shortcuts delegate to.
+
+  testWidgets('standalone: Next uses replace navigation', (tester) async {
+    final locations = await _pumpNav(
+      tester,
+      embedded: false,
+      // Narrow so the desktop master-detail redirect does not fire.
+      size: const Size(500, 800),
+    );
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pump();
+    expect(locations.last, '/dives/c');
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_nav_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_nav_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
+
+// Covers the navigation contract the detail page relies on: DiveNavButtons in a
+// router host fires the same `?selected=` swap the embedded surface uses. The
+// embedded-vs-standalone branch and arrow keys are verified manually (a full
+// DiveDetailPage needs a seeded DB).
+void main() {
+  testWidgets('onNavigate swaps the selected query param', (tester) async {
+    String? lastLocation;
+    final router = GoRouter(
+      initialLocation: '/dives?selected=b',
+      routes: [
+        GoRoute(
+          path: '/dives',
+          builder: (context, state) {
+            lastLocation = state.uri.toString();
+            return Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  ref.watch(orderedDiveIdsProvider);
+                  return DiveNavButtons(
+                    diveId: 'b',
+                    onNavigate: (id) => context.go('/dives?selected=$id'),
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c']),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
+    expect(lastLocation, '/dives?selected=c');
+  });
+}

--- a/test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_neighbors_provider_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+void main() {
+  Future<DiveNeighbors> neighborsFor(List<String> ids, String id) async {
+    final container = ProviderContainer(
+      overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ids)],
+    );
+    addTearDown(container.dispose);
+    await container.read(orderedDiveIdsProvider.future);
+    return container.read(diveNeighborsProvider(id));
+  }
+
+  test('middle item has both neighbors', () async {
+    expect(await neighborsFor(['a', 'b', 'c'], 'b'), (
+      previousId: 'a',
+      nextId: 'c',
+    ));
+  });
+
+  test('first item has no previous', () async {
+    expect(await neighborsFor(['a', 'b', 'c'], 'a'), (
+      previousId: null,
+      nextId: 'b',
+    ));
+  });
+
+  test('last item has no next', () async {
+    expect(await neighborsFor(['a', 'b', 'c'], 'c'), (
+      previousId: 'b',
+      nextId: null,
+    ));
+  });
+
+  test('id not in list has no neighbors', () async {
+    expect(await neighborsFor(['a', 'b', 'c'], 'z'), (
+      previousId: null,
+      nextId: null,
+    ));
+  });
+
+  test('single item has no neighbors', () async {
+    expect(await neighborsFor(['only'], 'only'), (
+      previousId: null,
+      nextId: null,
+    ));
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_nav_buttons_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
+
+Widget _host({
+  required String diveId,
+  required List<String> ids,
+  required void Function(String) onNavigate,
+}) {
+  return ProviderScope(
+    overrides: [orderedDiveIdsProvider.overrideWith((ref) async => ids)],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Consumer(
+          builder: (context, ref, _) {
+            ref.watch(orderedDiveIdsProvider);
+            return DiveNavButtons(diveId: diveId, onNavigate: onNavigate);
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('middle item: both enabled, tap navigates', (tester) async {
+    final tapped = <String>[];
+    await tester.pumpWidget(
+      _host(diveId: 'b', ids: ['a', 'b', 'c'], onNavigate: tapped.add),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    expect(tapped, ['a', 'c']);
+  });
+
+  testWidgets('first item: previous disabled', (tester) async {
+    await tester.pumpWidget(
+      _host(diveId: 'a', ids: ['a', 'b', 'c'], onNavigate: (_) {}),
+    );
+    await tester.pumpAndSettle();
+
+    final prev = tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byIcon(Icons.chevron_left),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(prev.onPressed, isNull);
+  });
+}

--- a/test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
+++ b/test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
@@ -3,19 +3,42 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
 
-/// Builds a [MasterDetailScaffold] inside a router at desktop width (>=800) so
-/// the split layout renders. The master pane exposes two buttons that call
-/// [onItemSelected] to drive selection changes via query params.
-///
-/// [detailHeight] returns the content height for a given item id, so tests can
-/// make item 2 shorter than item 1 to exercise clamping. When [tagKey] is
-/// false the detail scroll view carries no [PageStorageKey] (opt-out case).
-Widget _app({
-  required double Function(String id) detailHeight,
-  bool tagKey = true,
-}) {
+/// A detail whose content starts short and grows to [finalHeight] one microtask
+/// after mount — mimicking the real detail pages, whose sections (profile
+/// chart, photos, marine life) fill in height asynchronously. Its scroll view
+/// opts into retention via [DetailScrollController.maybeOf].
+class _GrowingDetail extends StatefulWidget {
+  const _GrowingDetail(this.id, this.finalHeight);
+  final String id;
+  final double finalHeight;
+  @override
+  State<_GrowingDetail> createState() => _GrowingDetailState();
+}
+
+class _GrowingDetailState extends State<_GrowingDetail> {
+  double _height = 150;
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      if (mounted) setState(() => _height = widget.finalHeight);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      controller: DetailScrollController.maybeOf(context),
+      child: SizedBox(height: _height, child: Text('Detail ${widget.id}')),
+    );
+  }
+}
+
+/// Builds a [MasterDetailScaffold] at desktop width with five selectable items.
+Widget _app({required double Function(String id) finalHeight}) {
   final router = GoRouter(
     initialLocation: '/test?selected=1',
     routes: [
@@ -27,23 +50,14 @@ Widget _app({
             sectionId: 'test',
             masterBuilder: (context, onSelect, selectedId) => Column(
               children: [
-                TextButton(
-                  onPressed: () => onSelect('1'),
-                  child: const Text('select-1'),
-                ),
-                TextButton(
-                  onPressed: () => onSelect('2'),
-                  child: const Text('select-2'),
-                ),
+                for (final id in ['1', '2', '3', '4', '5'])
+                  TextButton(
+                    onPressed: () => onSelect(id),
+                    child: Text('select-$id'),
+                  ),
               ],
             ),
-            detailBuilder: (_, id) => SingleChildScrollView(
-              key: tagKey ? const PageStorageKey('testDetailScroll') : null,
-              child: SizedBox(
-                height: detailHeight(id),
-                child: Text('Detail $id'),
-              ),
-            ),
+            detailBuilder: (_, id) => _GrowingDetail(id, finalHeight(id)),
             summaryBuilder: (_) => const Text('Summary'),
           ),
         ),
@@ -60,7 +74,6 @@ Widget _app({
   );
 }
 
-/// The (single, post-settle) detail scroll view's scroll state.
 ScrollableState _detailScrollable(WidgetTester tester) {
   return tester.state<ScrollableState>(
     find.descendant(
@@ -72,30 +85,38 @@ ScrollableState _detailScrollable(WidgetTester tester) {
 
 void main() {
   group('MasterDetailScaffold detail scroll retention', () {
-    testWidgets('retains offset when switching to another item', (
+    testWidgets('retains offset across many selections despite content growing', (
       tester,
     ) async {
-      await tester.pumpWidget(_app(detailHeight: (_) => 3000));
+      await tester.pumpWidget(_app(finalHeight: (_) => 3000));
       await tester.pumpAndSettle();
 
+      // A user scroll on item 1 (fires notifications -> captured into the pane).
       _detailScrollable(tester).position.jumpTo(800);
       await tester.pump();
       expect(_detailScrollable(tester).position.pixels, 800);
 
-      await tester.tap(find.text('select-2'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Detail 2'), findsOneWidget);
-      expect(_detailScrollable(tester).position.pixels, 800);
+      // Switching through several items must not degrade the offset — this is
+      // the regression: the old PageStorage approach ratcheted to 0 here
+      // because restore clamped against still-loading content and saved that.
+      for (final id in ['2', '3', '4', '5']) {
+        await tester.tap(find.text('select-$id'));
+        await tester.pumpAndSettle();
+        expect(find.text('Detail $id'), findsOneWidget);
+        expect(
+          _detailScrollable(tester).position.pixels,
+          800,
+          reason: 'offset lost after selecting item $id',
+        );
+      }
     });
 
-    testWidgets('clamps retained offset to the new item extent', (
+    testWidgets('clamps retained offset to a shorter item extent', (
       tester,
     ) async {
-      // Item 1 is tall (scrollable); item 2 is only slightly taller than the
-      // ~800px viewport, so its maxScrollExtent is small and 800 must clamp.
+      // Item 2 is only slightly taller than the ~800px viewport.
       await tester.pumpWidget(
-        _app(detailHeight: (id) => id == '2' ? 900 : 3000),
+        _app(finalHeight: (id) => id == '2' ? 900 : 3000),
       );
       await tester.pumpAndSettle();
 
@@ -110,10 +131,49 @@ void main() {
       expect(position.pixels, lessThan(800));
     });
 
-    testWidgets('without a PageStorageKey the offset resets to top', (
+    testWidgets('a detail that does not opt in starts at the top', (
       tester,
     ) async {
-      await tester.pumpWidget(_app(detailHeight: (_) => 3000, tagKey: false));
+      // Detail with no DetailScrollController wiring: no retention.
+      final router = GoRouter(
+        initialLocation: '/test?selected=1',
+        routes: [
+          GoRoute(
+            path: '/test',
+            builder: (context, state) => MediaQuery(
+              data: const MediaQueryData(size: Size(1200, 800)),
+              child: MasterDetailScaffold(
+                sectionId: 'test',
+                masterBuilder: (context, onSelect, selectedId) => Column(
+                  children: [
+                    TextButton(
+                      onPressed: () => onSelect('1'),
+                      child: const Text('select-1'),
+                    ),
+                    TextButton(
+                      onPressed: () => onSelect('2'),
+                      child: const Text('select-2'),
+                    ),
+                  ],
+                ),
+                detailBuilder: (_, id) => SingleChildScrollView(
+                  child: SizedBox(height: 3000, child: Text('Detail $id')),
+                ),
+                summaryBuilder: (_) => const Text('Summary'),
+              ),
+            ),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
       _detailScrollable(tester).position.jumpTo(800);

--- a/test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
+++ b/test/shared/widgets/master_detail/master_detail_scaffold_scroll_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
+
+/// Builds a [MasterDetailScaffold] inside a router at desktop width (>=800) so
+/// the split layout renders. The master pane exposes two buttons that call
+/// [onItemSelected] to drive selection changes via query params.
+///
+/// [detailHeight] returns the content height for a given item id, so tests can
+/// make item 2 shorter than item 1 to exercise clamping. When [tagKey] is
+/// false the detail scroll view carries no [PageStorageKey] (opt-out case).
+Widget _app({
+  required double Function(String id) detailHeight,
+  bool tagKey = true,
+}) {
+  final router = GoRouter(
+    initialLocation: '/test?selected=1',
+    routes: [
+      GoRoute(
+        path: '/test',
+        builder: (context, state) => MediaQuery(
+          data: const MediaQueryData(size: Size(1200, 800)),
+          child: MasterDetailScaffold(
+            sectionId: 'test',
+            masterBuilder: (context, onSelect, selectedId) => Column(
+              children: [
+                TextButton(
+                  onPressed: () => onSelect('1'),
+                  child: const Text('select-1'),
+                ),
+                TextButton(
+                  onPressed: () => onSelect('2'),
+                  child: const Text('select-2'),
+                ),
+              ],
+            ),
+            detailBuilder: (_, id) => SingleChildScrollView(
+              key: tagKey ? const PageStorageKey('testDetailScroll') : null,
+              child: SizedBox(
+                height: detailHeight(id),
+                child: Text('Detail $id'),
+              ),
+            ),
+            summaryBuilder: (_) => const Text('Summary'),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    child: MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+/// The (single, post-settle) detail scroll view's scroll state.
+ScrollableState _detailScrollable(WidgetTester tester) {
+  return tester.state<ScrollableState>(
+    find.descendant(
+      of: find.byType(SingleChildScrollView),
+      matching: find.byType(Scrollable),
+    ),
+  );
+}
+
+void main() {
+  group('MasterDetailScaffold detail scroll retention', () {
+    testWidgets('retains offset when switching to another item', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app(detailHeight: (_) => 3000));
+      await tester.pumpAndSettle();
+
+      _detailScrollable(tester).position.jumpTo(800);
+      await tester.pump();
+      expect(_detailScrollable(tester).position.pixels, 800);
+
+      await tester.tap(find.text('select-2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Detail 2'), findsOneWidget);
+      expect(_detailScrollable(tester).position.pixels, 800);
+    });
+
+    testWidgets('clamps retained offset to the new item extent', (
+      tester,
+    ) async {
+      // Item 1 is tall (scrollable); item 2 is only slightly taller than the
+      // ~800px viewport, so its maxScrollExtent is small and 800 must clamp.
+      await tester.pumpWidget(
+        _app(detailHeight: (id) => id == '2' ? 900 : 3000),
+      );
+      await tester.pumpAndSettle();
+
+      _detailScrollable(tester).position.jumpTo(800);
+      await tester.pump();
+
+      await tester.tap(find.text('select-2'));
+      await tester.pumpAndSettle();
+
+      final position = _detailScrollable(tester).position;
+      expect(position.pixels, position.maxScrollExtent);
+      expect(position.pixels, lessThan(800));
+    });
+
+    testWidgets('without a PageStorageKey the offset resets to top', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app(detailHeight: (_) => 3000, tagKey: false));
+      await tester.pumpAndSettle();
+
+      _detailScrollable(tester).position.jumpTo(800);
+      await tester.pump();
+
+      await tester.tap(find.text('select-2'));
+      await tester.pumpAndSettle();
+
+      expect(_detailScrollable(tester).position.pixels, 0);
+    });
+  });
+}


### PR DESCRIPTION
Two related dive-detail improvements.

## 1. Detail-pane scroll retention

In the wide-screen master-detail layout, scrolling a detail pane to a section then selecting a different item reset the pane to the top, defeating the "scroll to a section and compare across dives" workflow.

**Root cause:** `Scrollable` auto-saves its offset to `PageStorage` on every scroll-activity end — including the settle when a restored offset is clamped because the detail content (`async.when`, sections grow after mount) isn't tall enough yet. Each restore-into-still-loading content saved the clamped value back, ratcheting the offset to 0 over a few selections.

**Fix — `DetailScrollRetainer`:** the scaffold remembers the offset and re-applies it through a per-detail `ScrollController` (`keepScrollOffset: false`, PageStorage bypassed), capturing only genuine user scrolls and restoring with a deferred, extent-guarded jump after the content lays out. The controller reaches exactly the page's main scroll view via a small `InheritedWidget` (not `PrimaryScrollController`, which nested scrollables would grab). Applied to: dives, sites, courses, certifications, dive centers, equipment, buddies. Trips (tabbed, multiple scroll views per detail) is out of scope.

## 2. Previous / Next adjacent-dive navigation

Previous/Next controls on the dive detail page (buttons in the AppBar and embedded header, plus Left/Right arrow keys on desktop) step to the adjacent dive.

- **Adjacency follows the current list order** (active filter + sort). A new `getOrderedDiveIds` repository query reuses `getDiveSummaries`'s exact WHERE/ORDER BY clauses (IDs only, so it stays cheap on large libraries), guaranteeing the neighbor order matches the visible list.
- `orderedDiveIdsProvider` + `diveNeighborsProvider(diveId)` compute `(previousId, nextId)`; both null when the dive isn't in the current filtered list (buttons disable).
- Embedded navigation reuses the `?selected=` swap, so the scroll retainer above keeps you on the same section of the next dive.

## Testing

- Scroll retention: widget test with content that grows after mount across five selections (the regression), plus clamp and opt-out cases.
- Prev/next: repo test asserting `getOrderedDiveIds` order equals `getDiveSummaries`; provider tests for neighbor computation (ends / not-found / single); widget test for button enable/disable + navigation. Arrow-key wiring verified manually.
- Whole-project `dart format .` clean; `flutter analyze` clean; dive_log + touched-feature suites pass.

Design/plan docs under `docs/superpowers/`.