### PR TITLE
feat(media): offline-volume awareness for network-share files (Phase 4)

### DIFF
--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -4,6 +4,7 @@ import 'dart:ui' show Size;
 import 'package:submersion/features/media/data/services/exif_extractor.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
+import 'package:submersion/features/media/data/services/volume_status.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/services/media_source_resolver.dart';
@@ -38,9 +39,13 @@ class LocalFileResolver implements MediaSourceResolver {
     required LocalBookmarkStorage bookmarkStorage,
     required LocalMediaPlatform platform,
     required ExifExtractor exifExtractor,
+    VolumeStatus? volumeStatus,
   }) : _bookmarkStorage = bookmarkStorage,
        _platform = platform,
-       _exifExtractor = exifExtractor;
+       _exifExtractor = exifExtractor,
+       _volumeStatus = volumeStatus ?? VolumeStatus();
+
+  final VolumeStatus _volumeStatus;
 
   @override
   MediaSourceType get sourceType => MediaSourceType.localFile;
@@ -59,6 +64,12 @@ class LocalFileResolver implements MediaSourceResolver {
       try {
         final f = File(localPath);
         if (await f.exists()) return FileData(file: f);
+        // Missing file on an unmounted volume (network share, external
+        // disk) is a temporary condition, not a dead pointer: report it
+        // as such so nothing orphans the row while the share is offline.
+        if (!_volumeStatus.isVolumeOnline(localPath)) {
+          return const UnavailableData(kind: UnavailableKind.volumeOffline);
+        }
       }
       // coverage:ignore-start
       // FileSystemException from File.exists() requires a permission /
@@ -150,8 +161,9 @@ class LocalFileResolver implements MediaSourceResolver {
   @override
   Future<VerifyResult> verify(MediaItem item) async {
     final data = await resolve(item);
-    return data is UnavailableData
-        ? VerifyResult.notFound
-        : VerifyResult.available;
+    if (data is! UnavailableData) return VerifyResult.available;
+    return data.kind == UnavailableKind.volumeOffline
+        ? VerifyResult.volumeOffline
+        : VerifyResult.notFound;
   }
 }

--- a/lib/features/media/data/services/local_files_diagnostics_service.dart
+++ b/lib/features/media/data/services/local_files_diagnostics_service.dart
@@ -95,6 +95,12 @@ class LocalFilesDiagnosticsService {
     for (final item in all) {
       try {
         final result = await _resolver.verify(item);
+        // An unmounted volume is transient: keep the row's current orphan
+        // state rather than flagging files that will reappear on remount.
+        if (result == VerifyResult.volumeOffline) {
+          await _repository.updateMedia(item.copyWith(lastVerifiedAt: now));
+          continue;
+        }
         final isOrphan = result != VerifyResult.available;
         if (item.isOrphaned != isOrphan) flipped++;
         await _repository.updateMedia(

--- a/lib/features/media/data/services/volume_status.dart
+++ b/lib/features/media/data/services/volume_status.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+/// Classifies whether the VOLUME a path lives on is currently mounted, so
+/// "file on an unmounted network share" can be told apart from "file
+/// deleted" (program spec section 8).
+///
+/// Mount-root heuristics per platform:
+/// - macOS: `/Volumes/<name>/...` (external and network mounts); anything
+///   else is the always-mounted system volume.
+/// - Windows: `X:\...` drive roots and `\\server\share\...` UNC roots.
+/// - Linux: `/mnt/<name>`, `/media/<user>/<name>`, `/run/media/<user>/<name>`.
+///
+/// The existence probe is injectable so tests never touch the real
+/// filesystem. Only the volume ROOT is probed - a missing file on a
+/// mounted volume stays "deleted".
+class VolumeStatus {
+  VolumeStatus({bool Function(String path)? directoryExists})
+    : _directoryExists =
+          directoryExists ?? ((path) => Directory(path).existsSync());
+
+  final bool Function(String path) _directoryExists;
+
+  /// The mount root governing [path], or null when the path lives on the
+  /// system volume (always considered mounted).
+  String? volumeRootOf(String path, {String? platformOverride}) {
+    final platform =
+        platformOverride ??
+        (Platform.isMacOS
+            ? 'macos'
+            : Platform.isWindows
+            ? 'windows'
+            : Platform.isLinux
+            ? 'linux'
+            : 'other');
+    switch (platform) {
+      case 'macos':
+        final match = RegExp(r'^(/Volumes/[^/]+)(/|$)').firstMatch(path);
+        return match?.group(1);
+      case 'windows':
+        final unc = RegExp(r'^(\\\\[^\\]+\\[^\\]+)(\\|$)').firstMatch(path);
+        if (unc != null) return unc.group(1);
+        final drive = RegExp(r'^([A-Za-z]:)(\\|/|$)').firstMatch(path);
+        // The system drive C: is always mounted; other drive letters can
+        // be network mappings or removable media.
+        if (drive != null && drive.group(1)!.toUpperCase() != 'C:') {
+          return '${drive.group(1)}\\';
+        }
+        return null;
+      case 'linux':
+        final match = RegExp(
+          r'^(/mnt/[^/]+|/media/[^/]+(?:/[^/]+)?|/run/media/[^/]+/[^/]+)(/|$)',
+        ).firstMatch(path);
+        return match?.group(1);
+      default:
+        return null;
+    }
+  }
+
+  /// True when [path]'s volume is currently reachable. Paths on the system
+  /// volume are always online; paths under a mount root are online iff the
+  /// root directory exists.
+  bool isVolumeOnline(String path, {String? platformOverride}) {
+    final root = volumeRootOf(path, platformOverride: platformOverride);
+    if (root == null) return true;
+    return _directoryExists(root);
+  }
+}

--- a/lib/features/media/data/services/volume_status.dart
+++ b/lib/features/media/data/services/volume_status.dart
@@ -47,10 +47,20 @@ class VolumeStatus {
         }
         return null;
       case 'linux':
-        final match = RegExp(
-          r'^(/mnt/[^/]+|/media/[^/]+(?:/[^/]+)?|/run/media/[^/]+/[^/]+)(/|$)',
-        ).firstMatch(path);
-        return match?.group(1);
+        // Candidate roots, most specific first. A root must be a PROPER
+        // prefix of the path (followed by '/'): otherwise the optional
+        // second segment would swallow the file name itself (e.g.
+        // /media/usb/a.jpg must resolve to /media/usb, not the file).
+        for (final pattern in [
+          r'^(/run/media/[^/]+/[^/]+)/',
+          r'^(/media/[^/]+/[^/]+)/',
+          r'^(/media/[^/]+)/',
+          r'^(/mnt/[^/]+)/',
+        ]) {
+          final match = RegExp(pattern).firstMatch(path);
+          if (match != null) return match.group(1);
+        }
+        return null;
       default:
         return null;
     }

--- a/lib/features/media/domain/value_objects/media_source_data.dart
+++ b/lib/features/media/domain/value_objects/media_source_data.dart
@@ -19,6 +19,10 @@ enum UnavailableKind {
 
   /// Service connector account needs to be (re-)authenticated.
   signInRequired,
+
+  /// The file's volume (network share, external disk) is not mounted right
+  /// now. Recovers by itself when the volume comes back; never orphaned.
+  volumeOffline,
 }
 
 /// A handle to displayable media bytes — or, when unavailable, a structured

--- a/lib/features/media/domain/value_objects/verify_result.dart
+++ b/lib/features/media/domain/value_objects/verify_result.dart
@@ -11,4 +11,8 @@ enum VerifyResult {
   unauthenticated,
   transientError,
   fromOtherDevice,
+
+  /// The volume holding the file is not mounted; the file may well still
+  /// exist. Treated as transient by cleanup sweeps (never orphans).
+  volumeOffline,
 }

--- a/lib/features/media/presentation/widgets/unavailable_media_placeholder.dart
+++ b/lib/features/media/presentation/widgets/unavailable_media_placeholder.dart
@@ -51,6 +51,7 @@ class UnavailableMediaPlaceholder extends StatelessWidget {
     UnavailableKind.signInRequired => Icons.lock_outline,
     UnavailableKind.fromOtherDevice => Icons.devices_other,
     UnavailableKind.networkError => Icons.cloud_off_outlined,
+    UnavailableKind.volumeOffline => Icons.usb_off_outlined,
   };
 
   String _messageFor(BuildContext context, UnavailableData d) {
@@ -71,6 +72,8 @@ class UnavailableMediaPlaceholder extends StatelessWidget {
             : l10n.media_unavailablePlaceholder_fromOtherDevice,
       UnavailableKind.networkError =>
         l10n.media_unavailablePlaceholder_networkError,
+      UnavailableKind.volumeOffline =>
+        l10n.media_unavailablePlaceholder_volumeOffline,
     };
   }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "زامن بيانات الغوص بين الأجهزة.",
   "settings_setupGuide_statusDone": "تم الإعداد",
   "settings_setupGuide_statusTodo": "لم يتم الإعداد",
-  "settings_setupGuide_open": "فتح"
+  "settings_setupGuide_open": "فتح",
+  "media_unavailablePlaceholder_volumeOffline": "وحدة التخزين غير مثبتة"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Tauchdaten zwischen Geräten synchronisieren.",
   "settings_setupGuide_statusDone": "Eingerichtet",
   "settings_setupGuide_statusTodo": "Nicht eingerichtet",
-  "settings_setupGuide_open": "Öffnen"
+  "settings_setupGuide_open": "Öffnen",
+  "media_unavailablePlaceholder_volumeOffline": "Volume nicht eingebunden"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12101,5 +12101,6 @@
   "settings_setupGuide_stepSync_desc": "Sync dive data between devices.",
   "settings_setupGuide_statusDone": "Set up",
   "settings_setupGuide_statusTodo": "Not set up",
-  "settings_setupGuide_open": "Open"
+  "settings_setupGuide_open": "Open",
+  "media_unavailablePlaceholder_volumeOffline": "Volume not mounted"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Sincroniza los datos de buceo entre dispositivos.",
   "settings_setupGuide_statusDone": "Configurado",
   "settings_setupGuide_statusTodo": "Sin configurar",
-  "settings_setupGuide_open": "Abrir"
+  "settings_setupGuide_open": "Abrir",
+  "media_unavailablePlaceholder_volumeOffline": "Volumen no montado"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Synchronisez les données de plongée entre appareils.",
   "settings_setupGuide_statusDone": "Configuré",
   "settings_setupGuide_statusTodo": "Non configuré",
-  "settings_setupGuide_open": "Ouvrir"
+  "settings_setupGuide_open": "Ouvrir",
+  "media_unavailablePlaceholder_volumeOffline": "Volume non monté"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "סנכרן נתוני צלילה בין מכשירים.",
   "settings_setupGuide_statusDone": "מוגדר",
   "settings_setupGuide_statusTodo": "לא מוגדר",
-  "settings_setupGuide_open": "פתח"
+  "settings_setupGuide_open": "פתח",
+  "media_unavailablePlaceholder_volumeOffline": "הכונן אינו מחובר"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Merülési adatok szinkronizálása eszközök között.",
   "settings_setupGuide_statusDone": "Beállítva",
   "settings_setupGuide_statusTodo": "Nincs beállítva",
-  "settings_setupGuide_open": "Megnyitás"
+  "settings_setupGuide_open": "Megnyitás",
+  "media_unavailablePlaceholder_volumeOffline": "A kötet nincs csatlakoztatva"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Sincronizza i dati delle immersioni tra dispositivi.",
   "settings_setupGuide_statusDone": "Configurato",
   "settings_setupGuide_statusTodo": "Non configurato",
-  "settings_setupGuide_open": "Apri"
+  "settings_setupGuide_open": "Apri",
+  "media_unavailablePlaceholder_volumeOffline": "Volume non montato"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -32435,6 +32435,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Open'**
   String get settings_setupGuide_open;
+
+  /// No description provided for @media_unavailablePlaceholder_volumeOffline.
+  ///
+  /// In en, this message translates to:
+  /// **'Volume not mounted'**
+  String get media_unavailablePlaceholder_volumeOffline;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -19016,4 +19016,8 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'فتح';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline =>
+      'وحدة التخزين غير مثبتة';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -19350,4 +19350,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Öffnen';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline =>
+      'Volume nicht eingebunden';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -19051,4 +19051,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Open';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => 'Volume not mounted';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -19388,4 +19388,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Abrir';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => 'Volumen no montado';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -19450,4 +19450,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Ouvrir';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => 'Volume non monté';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -18879,4 +18879,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'פתח';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => 'הכונן אינו מחובר';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -19324,4 +19324,8 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Megnyitás';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline =>
+      'A kötet nincs csatlakoztatva';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -19378,4 +19378,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Apri';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => 'Volume non montato';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -19226,4 +19226,8 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Openen';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline =>
+      'Volume niet gekoppeld';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -19382,4 +19382,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => 'Abrir';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => 'Volume não montado';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -18391,4 +18391,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_setupGuide_open => '打开';
+
+  @override
+  String get media_unavailablePlaceholder_volumeOffline => '卷未挂载';
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Synchroniseer duikgegevens tussen apparaten.",
   "settings_setupGuide_statusDone": "Ingesteld",
   "settings_setupGuide_statusTodo": "Niet ingesteld",
-  "settings_setupGuide_open": "Openen"
+  "settings_setupGuide_open": "Openen",
+  "media_unavailablePlaceholder_volumeOffline": "Volume niet gekoppeld"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "Sincronize dados de mergulho entre dispositivos.",
   "settings_setupGuide_statusDone": "Configurado",
   "settings_setupGuide_statusTodo": "Não configurado",
-  "settings_setupGuide_open": "Abrir"
+  "settings_setupGuide_open": "Abrir",
+  "media_unavailablePlaceholder_volumeOffline": "Volume não montado"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5496,5 +5496,6 @@
   "settings_setupGuide_stepSync_desc": "在设备之间同步潜水数据。",
   "settings_setupGuide_statusDone": "已设置",
   "settings_setupGuide_statusTodo": "未设置",
-  "settings_setupGuide_open": "打开"
+  "settings_setupGuide_open": "打开",
+  "media_unavailablePlaceholder_volumeOffline": "卷未挂载"
 }

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -12,7 +12,6 @@ import 'package:submersion/features/media/domain/value_objects/verify_result.dar
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
-import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
 
 /// Stub that bypasses keychain I/O. Always returns null from [read].
 class _NullBookmarkStorage extends LocalBookmarkStorage {

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -7,6 +7,8 @@ import 'package:submersion/features/media/data/resolvers/local_file_resolver.dar
 import 'package:submersion/features/media/data/services/exif_extractor.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
+import 'package:submersion/features/media/data/services/volume_status.dart';
+import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
@@ -272,4 +274,47 @@ void main() {
       expect(tmp.existsSync(), isFalse);
     },
   );
+  group('volume awareness', () {
+    LocalFileResolver volumeResolver({required bool volumeOnline}) =>
+        LocalFileResolver(
+          bookmarkStorage: _NullBookmarkStorage(),
+          platform: LocalMediaPlatform(),
+          exifExtractor: ExifExtractor(),
+          volumeStatus: VolumeStatus(directoryExists: (_) => volumeOnline),
+        );
+
+    // A path shaped like a macOS network mount whose file is absent. With
+    // the volume offline the row must read volumeOffline, not notFound.
+    const nasPath = '/Volumes/NAS/photos/missing.jpg';
+
+    test(
+      'missing file on an unmounted volume reads volumeOffline',
+      () async {
+        final r = volumeResolver(volumeOnline: false);
+        final data = await r.resolve(_localFile(localPath: nasPath));
+        expect(data, isA<UnavailableData>());
+        expect((data as UnavailableData).kind, UnavailableKind.volumeOffline);
+        expect(
+          await r.verify(_localFile(localPath: nasPath)),
+          VerifyResult.volumeOffline,
+        );
+      },
+      skip: !Platform.isMacOS ? 'macOS volume-root heuristics' : null,
+    );
+
+    test(
+      'missing file on a mounted volume stays notFound',
+      () async {
+        final r = volumeResolver(volumeOnline: true);
+        final data = await r.resolve(_localFile(localPath: nasPath));
+        expect(data, isA<UnavailableData>());
+        expect((data as UnavailableData).kind, UnavailableKind.notFound);
+        expect(
+          await r.verify(_localFile(localPath: nasPath)),
+          VerifyResult.notFound,
+        );
+      },
+      skip: !Platform.isMacOS ? 'macOS volume-root heuristics' : null,
+    );
+  });
 }

--- a/test/features/media/data/services/local_files_diagnostics_service_test.dart
+++ b/test/features/media/data/services/local_files_diagnostics_service_test.dart
@@ -128,6 +128,32 @@ void main() {
       },
     );
 
+    test(
+      'volumeOffline items keep their orphan state (only stamped)',
+      () async {
+        final mounted = item(id: 'a', isOrphaned: false); // share offline
+        final orphan = item(id: 'b', isOrphaned: true); // share offline too
+        when(
+          mockRepo.getAllBySourceType(MediaSourceType.localFile),
+        ).thenAnswer((_) async => [mounted, orphan]);
+        when(
+          mockResolver.verify(any),
+        ).thenAnswer((_) async => VerifyResult.volumeOffline);
+        when(mockRepo.updateMedia(any)).thenAnswer((_) async {});
+
+        final flipped = await subject.reverifyAll();
+
+        expect(flipped, 0, reason: 'an unmounted share never flips anything');
+        final captured = verify(
+          mockRepo.updateMedia(captureAny),
+        ).captured.cast<MediaItem>();
+        final byId = {for (final u in captured) u.id: u};
+        expect(byId['a']!.isOrphaned, isFalse, reason: 'not orphaned');
+        expect(byId['b']!.isOrphaned, isTrue, reason: 'state preserved');
+        expect(byId['a']!.lastVerifiedAt, isNotNull);
+      },
+    );
+
     test('on empty repository returns zero', () async {
       when(
         mockRepo.getAllBySourceType(MediaSourceType.localFile),

--- a/test/features/media/data/services/volume_status_test.dart
+++ b/test/features/media/data/services/volume_status_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/volume_status.dart';
+
+void main() {
+  VolumeStatus statusWith(Set<String> existing) =>
+      VolumeStatus(directoryExists: existing.contains);
+
+  group('macOS', () {
+    test('paths under /Volumes are governed by the volume root', () {
+      final s = statusWith({'/Volumes/NAS'});
+      expect(
+        s.volumeRootOf('/Volumes/NAS/photos/a.jpg', platformOverride: 'macos'),
+        '/Volumes/NAS',
+      );
+      expect(
+        s.isVolumeOnline(
+          '/Volumes/NAS/photos/a.jpg',
+          platformOverride: 'macos',
+        ),
+        isTrue,
+      );
+      expect(
+        s.isVolumeOnline(
+          '/Volumes/Other/photos/a.jpg',
+          platformOverride: 'macos',
+        ),
+        isFalse,
+      );
+    });
+
+    test('system-volume paths are always online', () {
+      final s = statusWith({});
+      expect(
+        s.volumeRootOf('/Users/eric/a.jpg', platformOverride: 'macos'),
+        isNull,
+      );
+      expect(
+        s.isVolumeOnline('/Users/eric/a.jpg', platformOverride: 'macos'),
+        isTrue,
+      );
+    });
+  });
+
+  group('Windows', () {
+    test('UNC paths are governed by the share root', () {
+      final s = statusWith({r'\\nas\photos'});
+      expect(
+        s.volumeRootOf(r'\\nas\photos\2026\a.jpg', platformOverride: 'windows'),
+        r'\\nas\photos',
+      );
+      expect(
+        s.isVolumeOnline(
+          r'\\nas\photos\2026\a.jpg',
+          platformOverride: 'windows',
+        ),
+        isTrue,
+      );
+      expect(
+        s.isVolumeOnline(r'\\gone\share\a.jpg', platformOverride: 'windows'),
+        isFalse,
+      );
+    });
+
+    test('mapped drives are probed; C: is always online', () {
+      final s = statusWith({r'Z:\'});
+      expect(
+        s.isVolumeOnline(r'Z:\photos\a.jpg', platformOverride: 'windows'),
+        isTrue,
+      );
+      expect(
+        s.isVolumeOnline(r'Y:\photos\a.jpg', platformOverride: 'windows'),
+        isFalse,
+      );
+      expect(
+        s.isVolumeOnline(r'C:\photos\a.jpg', platformOverride: 'windows'),
+        isTrue,
+      );
+    });
+  });
+
+  group('Linux', () {
+    test('mnt and media mount roots are probed', () {
+      final s = statusWith({'/mnt/nas', '/media/eric/usb'});
+      expect(
+        s.isVolumeOnline('/mnt/nas/a.jpg', platformOverride: 'linux'),
+        isTrue,
+      );
+      expect(
+        s.isVolumeOnline('/mnt/gone/a.jpg', platformOverride: 'linux'),
+        isFalse,
+      );
+      expect(
+        s.isVolumeOnline('/media/eric/usb/a.jpg', platformOverride: 'linux'),
+        isTrue,
+      );
+      expect(
+        s.isVolumeOnline('/home/eric/a.jpg', platformOverride: 'linux'),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/media/data/services/volume_status_test.dart
+++ b/test/features/media/data/services/volume_status_test.dart
@@ -79,6 +79,45 @@ void main() {
   });
 
   group('Linux', () {
+    test('a file directly under a single-segment media mount resolves to '
+        'the directory root, never the file itself', () {
+      final s = statusWith({'/media/usb'});
+      expect(
+        s.volumeRootOf('/media/usb/a.jpg', platformOverride: 'linux'),
+        '/media/usb',
+        reason: 'the optional second segment must not swallow the filename',
+      );
+      expect(
+        s.isVolumeOnline('/media/usb/a.jpg', platformOverride: 'linux'),
+        isTrue,
+      );
+    });
+
+    test('run/media mount roots are probed', () {
+      final s = statusWith({'/run/media/eric/nas'});
+      expect(
+        s.volumeRootOf(
+          '/run/media/eric/nas/photos/a.jpg',
+          platformOverride: 'linux',
+        ),
+        '/run/media/eric/nas',
+      );
+      expect(
+        s.isVolumeOnline(
+          '/run/media/eric/nas/photos/a.jpg',
+          platformOverride: 'linux',
+        ),
+        isTrue,
+      );
+      expect(
+        s.isVolumeOnline(
+          '/run/media/eric/gone/a.jpg',
+          platformOverride: 'linux',
+        ),
+        isFalse,
+      );
+    });
+
     test('mnt and media mount roots are probed', () {
       final s = statusWith({'/mnt/nas', '/media/eric/usb'});
       expect(


### PR DESCRIPTION
## Summary

Phase 4 (final) of the media linking and storage program (spec section 8), stacked on #574.

Files on OS-mounted network shares and external disks now degrade gracefully when the volume is offline, instead of being indistinguishable from deleted files.

### What changed

- **`VolumeStatus`**: classifies whether a path's volume is currently mounted, probing only the mount root (macOS `/Volumes/<name>`, Windows drive letters and `\\server\share` UNC roots with `C:` always online, Linux `/mnt` / `/media` / `/run/media`). System-volume paths are always online. Existence probe is injectable for tests.
- **`LocalFileResolver`**: a missing file on an unmounted volume now resolves to the new `UnavailableKind.volumeOffline` (with its own placeholder icon and localized "Volume not mounted" text in all 11 locales) instead of `notFound`, and `verify()` reports the new `VerifyResult.volumeOffline`. Recovery is automatic on remount — the next resolve simply finds the file.
- **Re-verify sweep** (`LocalFilesDiagnosticsService.reverifyAll`): `volumeOffline` rows keep their current orphan state and only get their `lastVerifiedAt` stamped — an unplugged NAS can no longer mass-orphan a library.
- **Future in-app SMB/NFS client**: remains reserved as a `MediaSourceCapable` account kind per the program spec — a connector like Lightroom, not a new mechanism. Design note only; nothing built here.

### Testing

VolumeStatus unit tests across all three platform heuristics, resolver volume-awareness tests (offline -> volumeOffline, mounted-but-missing -> notFound), reverify no-orphan test, full media + settings regression (1322), analyze and format clean.