### PR TITLE
feat(sync): account-first cloud-provider resolution

### DIFF
--- a/lib/core/services/accounts/account_credentials_store.dart
+++ b/lib/core/services/accounts/account_credentials_store.dart
@@ -24,6 +24,24 @@ class AccountCredentialsStore {
   Future<void> delete(String accountId) =>
       _storage.delete(key: keyFor(accountId));
 
+  /// Makes the per-account key an EXACT mirror of a legacy source-of-truth
+  /// key: copies the blob when present, deletes the per-account key when the
+  /// legacy key is absent. Used by account-first sync resolution so a
+  /// cleared legacy credential (sign-out / remove) can neither be read from
+  /// nor resurrected into the per-account key. The legacy key is left
+  /// untouched (it remains the source of truth).
+  Future<void> mirrorLegacy({
+    required String legacyKey,
+    required String accountId,
+  }) async {
+    final legacy = await _storage.read(key: legacyKey);
+    if (legacy != null) {
+      await write(accountId, legacy);
+    } else {
+      await delete(accountId);
+    }
+  }
+
   /// Copies a legacy single-key blob to the per-account key. Keeps the
   /// legacy entry (rollback safety).
   ///

--- a/lib/core/services/accounts/adapters/icloud_account_adapter.dart
+++ b/lib/core/services/accounts/adapters/icloud_account_adapter.dart
@@ -1,10 +1,11 @@
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/account_provider_adapter.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
+import 'package:submersion/core/services/cloud_storage/cloud_provider_instances.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
-import 'package:submersion/core/services/cloud_storage/icloud_storage_provider.dart';
 import 'package:submersion/core/services/media_store/icloud_media_object_store.dart';
 import 'package:submersion/core/services/media_store/icloud_media_platform.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
@@ -19,7 +20,11 @@ class ICloudAccountAdapter extends AccountProviderAdapter
     Future<ICloudAvailability> Function()? availability,
     CloudStorageProvider? syncProviderInstance,
   }) : _availability = availability ?? ICloudNativeService.getAvailability,
-       _syncProviderInstance = syncProviderInstance ?? ICloudStorageProvider();
+       // The shared process singleton, so account-first resolution returns
+       // the same iCloud provider instance the legacy path did.
+       _syncProviderInstance =
+           syncProviderInstance ??
+           cloudProviderInstanceFor(CloudProviderType.icloud);
 
   final Future<ICloudAvailability> Function() _availability;
   final CloudStorageProvider _syncProviderInstance;

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -632,6 +632,11 @@ class CloudSyncPage extends ConsumerWidget {
           ref.invalidate(dropboxAuthDataProvider);
           if (connected == true) {
             await _selectProvider(context, ref, CloudProviderType.dropbox);
+            // Refresh the per-account credential mirror for account-first
+            // resolution; a re-connect while already on Dropbox wouldn't
+            // re-fire the provider-type change.
+            ref.invalidate(selectedSyncAccountProvider);
+            await ref.read(selectedSyncAccountProvider.future);
           }
         },
       ),

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -632,6 +632,9 @@ class CloudSyncPage extends ConsumerWidget {
           ref.invalidate(dropboxAuthDataProvider);
           if (connected == true) {
             await _selectProvider(context, ref, CloudProviderType.dropbox);
+            // Guard: the tile may be disposed while _selectProvider is in
+            // flight; using ref after disposal throws.
+            if (!context.mounted) return;
             // Refresh the per-account credential mirror for account-first
             // resolution; a re-connect while already on Dropbox wouldn't
             // re-fire the provider-type change.

--- a/lib/features/settings/presentation/pages/s3_config_page.dart
+++ b/lib/features/settings/presentation/pages/s3_config_page.dart
@@ -185,33 +185,39 @@ class _S3ConfigPageState extends ConsumerState<S3ConfigPage> {
 
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
-    final storageMessage = context.l10n.settings_s3Config_error_secureStorage;
+    final l10n = context.l10n;
+    final storageMessage = l10n.settings_s3Config_error_secureStorage;
+    // Capture the app-level container before the first await. It outlives this
+    // page, so the provider writes / global refresh / re-derivation below all
+    // run (and never throw) even if the page is popped during an async gap --
+    // `ref` throws once the ConsumerState is disposed. Global providers other
+    // screens listen to (the sync settings page still mounted behind this
+    // route) must refresh whether or not THIS page survives.
+    final container = ProviderScope.containerOf(context, listen: false);
     setState(() => _busy = true);
     try {
-      await ref
+      await container
           .read(s3StorageProviderInstanceProvider)
           .saveConfig(_buildConfig());
-      ref.read(selectedCloudProviderTypeProvider.notifier).state =
+      container.read(selectedCloudProviderTypeProvider.notifier).state =
           CloudProviderType.s3;
-      await ref
+      await container
           .read(syncInitializerProvider)
           .saveProvider(CloudProviderType.s3);
-      // Refresh dependent state up front. These are global providers other
-      // screens listen to (e.g. the sync settings page still mounted behind
-      // this route), so they must run whether or not THIS page survives the
-      // in-flight re-derivation below. Run them while ref is still valid.
-      ref.read(syncStateProvider.notifier).refreshState();
-      ref.invalidate(s3ConfigProvider);
+      // Refresh dependent state before the in-flight re-derivation below so a
+      // mid-save pop can't leave those screens stale.
+      container.read(syncStateProvider.notifier).refreshState();
+      container.invalidate(s3ConfigProvider);
       // Re-derive the sync account so its per-account credential mirror
       // picks up this (possibly in-place) config edit; account-first
       // resolution reads that mirror. Invalidate + await because editing
       // while already on S3 doesn't re-fire the provider-type change.
-      ref.invalidate(selectedSyncAccountProvider);
-      await ref.read(selectedSyncAccountProvider.future);
+      container.invalidate(selectedSyncAccountProvider);
+      await container.read(selectedSyncAccountProvider.future);
       // Only UI work remains (snackbar + navigation); the page may have been
       // popped while the derivation was in flight, so gate that on mounted.
       if (!mounted) return;
-      _showSnack(context.l10n.settings_s3Config_saved);
+      _showSnack(l10n.settings_s3Config_saved);
       // Root-safe in widget tests; pops the pushed route in the app.
       await Navigator.maybePop(context);
     } on CloudStorageException catch (e) {

--- a/lib/features/settings/presentation/pages/s3_config_page.dart
+++ b/lib/features/settings/presentation/pages/s3_config_page.dart
@@ -196,17 +196,21 @@ class _S3ConfigPageState extends ConsumerState<S3ConfigPage> {
       await ref
           .read(syncInitializerProvider)
           .saveProvider(CloudProviderType.s3);
+      // Refresh dependent state up front. These are global providers other
+      // screens listen to (e.g. the sync settings page still mounted behind
+      // this route), so they must run whether or not THIS page survives the
+      // in-flight re-derivation below. Run them while ref is still valid.
+      ref.read(syncStateProvider.notifier).refreshState();
+      ref.invalidate(s3ConfigProvider);
       // Re-derive the sync account so its per-account credential mirror
       // picks up this (possibly in-place) config edit; account-first
       // resolution reads that mirror. Invalidate + await because editing
       // while already on S3 doesn't re-fire the provider-type change.
       ref.invalidate(selectedSyncAccountProvider);
       await ref.read(selectedSyncAccountProvider.future);
-      // The page may have been popped while the derivation was in flight;
-      // using ref after disposal throws.
+      // Only UI work remains (snackbar + navigation); the page may have been
+      // popped while the derivation was in flight, so gate that on mounted.
       if (!mounted) return;
-      ref.read(syncStateProvider.notifier).refreshState();
-      ref.invalidate(s3ConfigProvider);
       _showSnack(context.l10n.settings_s3Config_saved);
       // Root-safe in widget tests; pops the pushed route in the app.
       await Navigator.maybePop(context);

--- a/lib/features/settings/presentation/pages/s3_config_page.dart
+++ b/lib/features/settings/presentation/pages/s3_config_page.dart
@@ -202,9 +202,11 @@ class _S3ConfigPageState extends ConsumerState<S3ConfigPage> {
       // while already on S3 doesn't re-fire the provider-type change.
       ref.invalidate(selectedSyncAccountProvider);
       await ref.read(selectedSyncAccountProvider.future);
+      // The page may have been popped while the derivation was in flight;
+      // using ref after disposal throws.
+      if (!mounted) return;
       ref.read(syncStateProvider.notifier).refreshState();
       ref.invalidate(s3ConfigProvider);
-      if (!mounted) return;
       _showSnack(context.l10n.settings_s3Config_saved);
       // Root-safe in widget tests; pops the pushed route in the app.
       await Navigator.maybePop(context);

--- a/lib/features/settings/presentation/pages/s3_config_page.dart
+++ b/lib/features/settings/presentation/pages/s3_config_page.dart
@@ -196,6 +196,12 @@ class _S3ConfigPageState extends ConsumerState<S3ConfigPage> {
       await ref
           .read(syncInitializerProvider)
           .saveProvider(CloudProviderType.s3);
+      // Re-derive the sync account so its per-account credential mirror
+      // picks up this (possibly in-place) config edit; account-first
+      // resolution reads that mirror. Invalidate + await because editing
+      // while already on S3 doesn't re-fire the provider-type change.
+      ref.invalidate(selectedSyncAccountProvider);
+      await ref.read(selectedSyncAccountProvider.future);
       ref.read(syncStateProvider.notifier).refreshState();
       ref.invalidate(s3ConfigProvider);
       if (!mounted) return;

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -1114,9 +1114,16 @@ class SyncNotifier extends StateNotifier<SyncState> {
       // Account-first resolution means _syncService.signOut() cleared the
       // PER-ACCOUNT Dropbox blob (and revoked); also clear the legacy
       // source-of-truth key, otherwise the UI still reads it as connected
-      // and the next credential mirror would resurrect it.
+      // and the next credential mirror would resurrect it. Best-effort: a
+      // keychain failure must not abort sign-out (selection/prefs/state
+      // still need clearing); the mirror would delete the per-account key
+      // on the next derivation regardless.
       if (selected == CloudProviderType.dropbox) {
-        await DropboxAuthStore().clear();
+        try {
+          await DropboxAuthStore().clear();
+        } catch (e) {
+          _log.warning('Could not clear legacy Dropbox key on sign-out: $e');
+        }
       }
     } else {
       // Match SyncService.signOut()'s metadata clearing without the

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -274,6 +274,10 @@ Future<domain.ConnectedAccount> ensureAccountForProviderType(
       );
 }
 
+/// File-scoped logger for the top-level sync providers (the provider bodies
+/// below are not class members, so they cannot use SyncNotifier's `_log`).
+const _providersLog = LoggerService('SyncProviders');
+
 /// The connected account driving sync, derived from the selected provider
 /// type and persisted to sync metadata.
 ///
@@ -303,12 +307,18 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
         .setSyncAccount(accountId: account.id, providerType: type);
     await _mirrorLegacyCredentials(ref, account);
     return account;
-  } catch (_) {
+  } catch (e, st) {
     // Returning null degrades resolution to the legacy singleton, which is
     // the correct fallback: the selection is re-derived on every launch, so
     // a failed write (teardown race) must not surface as a sync error, and
     // a failed credential mirror must NOT leave account-first resolution
-    // reading a stale/missing per-account key.
+    // reading a stale/missing per-account key. Log (with error + stack) so
+    // the fallback is diagnosable in the field without changing behaviour.
+    _providersLog.warning(
+      'Sync account derivation failed; falling back to legacy resolution',
+      error: e,
+      stackTrace: st,
+    );
     return null;
   }
 });
@@ -1131,8 +1141,12 @@ class SyncNotifier extends StateNotifier<SyncState> {
       if (selected == CloudProviderType.dropbox) {
         try {
           await DropboxAuthStore().clear();
-        } catch (e) {
-          _log.warning('Could not clear legacy Dropbox key on sign-out: $e');
+        } catch (e, st) {
+          _log.warning(
+            'Could not clear legacy Dropbox key on sign-out',
+            error: e,
+            stackTrace: st,
+          );
         }
       }
     } else {

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -357,13 +357,23 @@ final cloudStorageProviderProvider = Provider<CloudStorageProvider?>((ref) {
 
   // Account-first resolution: build the raw provider from the selected
   // account's adapter, which reads per-account credentials (kept current by
-  // selectedSyncAccountProvider's legacy mirror). While the account is still
-  // deriving (its future not yet resolved on the first frame), fall back to
-  // the legacy singleton — legacy keys are still written by the connect UIs,
-  // so that fallback is always valid and sync can never resolve to nothing.
+  // selectedSyncAccountProvider's legacy mirror). Fall back to the legacy
+  // singleton — always keyed by the current providerType, and valid because
+  // the connect UIs still write the legacy keys — when the account is not
+  // usable yet, so sync can never resolve to nothing.
+  //
+  // The kind guard matters: `.value` can return the PREVIOUS account while
+  // selectedSyncAccountProvider is recomputing right after providerType
+  // changes (e.g. S3 -> Dropbox). Using a stale account of the wrong kind
+  // would resolve to the wrong backend, so we only trust the account once
+  // its kind matches the selected type; otherwise the type-keyed legacy
+  // singleton is the correct interim provider.
   final account = ref.watch(selectedSyncAccountProvider).value;
+  final matchesType =
+      account != null &&
+      account.kind == AccountKind.fromCloudProviderType(providerType);
   CloudStorageProvider raw;
-  if (account != null) {
+  if (matchesType) {
     final capable = ref
         .watch(accountProviderRegistryProvider)
         .capabilityFor<SyncCapable>(account.kind);

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/data/repositories/connected_accounts_repository.
 import 'package:submersion/core/providers/account_providers.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/account_provider_adapter.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
 
@@ -24,6 +25,7 @@ import 'package:submersion/core/services/cloud_storage/dropbox_storage_provider.
 import 'package:submersion/core/services/cloud_storage/encrypting_cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
 import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
 import 'package:submersion/core/services/sync/crypto/keyslots.dart';
@@ -273,12 +275,17 @@ Future<domain.ConnectedAccount> ensureAccountForProviderType(
 }
 
 /// The connected account driving sync, derived from the selected provider
-/// type and persisted to sync metadata. Resolution of the raw
-/// [CloudStorageProvider] stays on the legacy provider singletons in
-/// Phase 1: the connect UIs still write credentials to the legacy keychain
-/// keys, so account-keyed credential copies would go stale on the next
-/// config edit. Phase 3 rewires the connect UIs to per-account keys and
-/// flips [cloudStorageProviderProvider] to account-first resolution.
+/// type and persisted to sync metadata.
+///
+/// The connect UIs (S3 config page, Dropbox dialog) still write credentials
+/// to the LEGACY keychain keys, which remain the source of truth. Here we
+/// mirror those legacy blobs into the account's per-account key
+/// (overwrite), so account-first resolution in [cloudStorageProviderProvider]
+/// always reads current credentials. This runs on every derivation (launch,
+/// provider selection, and explicit invalidation after a config edit), and
+/// covers every connect path — settings pages and the setup wizard alike —
+/// without each having to re-key. iCloud/Google Drive are session-managed
+/// (no keychain blob) and skip the mirror.
 final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
   ref,
 ) async {
@@ -294,6 +301,7 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
     await ref
         .read(syncRepositoryProvider)
         .setSyncAccount(accountId: account.id, providerType: type);
+    await _mirrorLegacyCredentials(ref, account);
     return account;
   } catch (_) {
     // Best-effort bookkeeping: the selection is re-derived on every launch,
@@ -302,6 +310,36 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
     return null;
   }
 });
+
+/// Refresh the account's per-account credential blob from the legacy key so
+/// account-first resolution never reads a stale copy. Best-effort: a
+/// keychain failure here must not null the derived account (resolution
+/// falls back to the legacy singleton, which is still valid).
+Future<void> _mirrorLegacyCredentials(
+  Ref ref,
+  domain.ConnectedAccount account,
+) async {
+  final legacyKey = switch (account.kind) {
+    AccountKind.s3 => S3CredentialsStore.storageKey,
+    AccountKind.dropbox => DropboxAuthStore.storageKey,
+    // Session-managed / not a sync kind: no keychain blob to mirror.
+    AccountKind.googledrive ||
+    AccountKind.icloud ||
+    AccountKind.adobeLightroom => null,
+  };
+  if (legacyKey == null) return;
+  try {
+    await ref
+        .read(accountCredentialsStoreProvider)
+        .rekeyFromLegacy(
+          legacyKey: legacyKey,
+          accountId: account.id,
+          overwrite: true,
+        );
+  } catch (_) {
+    // Ignored: legacy singleton remains a valid resolution fallback.
+  }
+}
 
 /// Cloud storage provider instance (null if none selected or custom folder mode)
 ///
@@ -317,12 +355,24 @@ final cloudStorageProviderProvider = Provider<CloudStorageProvider?>((ref) {
   final providerType = ref.watch(selectedCloudProviderTypeProvider);
   if (providerType == null) return null;
 
-  // Keep the account bookkeeping alive: derives (and persists) the sync
-  // account row for the selected type. Raw-provider resolution stays on the
-  // legacy singletons in Phase 1 (see selectedSyncAccountProvider).
-  ref.watch(selectedSyncAccountProvider);
-
-  final raw = cloudProviderInstanceFor(providerType);
+  // Account-first resolution: build the raw provider from the selected
+  // account's adapter, which reads per-account credentials (kept current by
+  // selectedSyncAccountProvider's legacy mirror). While the account is still
+  // deriving (its future not yet resolved on the first frame), fall back to
+  // the legacy singleton — legacy keys are still written by the connect UIs,
+  // so that fallback is always valid and sync can never resolve to nothing.
+  final account = ref.watch(selectedSyncAccountProvider).value;
+  CloudStorageProvider raw;
+  if (account != null) {
+    final capable = ref
+        .watch(accountProviderRegistryProvider)
+        .capabilityFor<SyncCapable>(account.kind);
+    raw =
+        capable?.syncProvider(account) ??
+        cloudProviderInstanceFor(providerType);
+  } else {
+    raw = cloudProviderInstanceFor(providerType);
+  }
   // End-to-end encryption: with an unlocked session, every byte through this
   // provider is sealed/opened at the byte boundary (spec 4.1). No session
   // (disabled, or enabled-but-locked) resolves to the raw provider; a locked

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -311,10 +311,13 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
   }
 });
 
-/// Refresh the account's per-account credential blob from the legacy key so
-/// account-first resolution never reads a stale copy. Best-effort: a
-/// keychain failure here must not null the derived account (resolution
-/// falls back to the legacy singleton, which is still valid).
+/// Keep the account's per-account credential blob an exact mirror of the
+/// legacy source-of-truth key, so account-first resolution never reads a
+/// stale copy — and a cleared legacy credential (sign-out / remove) can
+/// neither be read from nor resurrected into the per-account key. Copies
+/// when the legacy key is present, deletes the per-account key when absent.
+/// Best-effort: a keychain failure must not null the derived account
+/// (resolution falls back to the legacy singleton, which is still valid).
 Future<void> _mirrorLegacyCredentials(
   Ref ref,
   domain.ConnectedAccount account,
@@ -331,11 +334,7 @@ Future<void> _mirrorLegacyCredentials(
   try {
     await ref
         .read(accountCredentialsStoreProvider)
-        .rekeyFromLegacy(
-          legacyKey: legacyKey,
-          accountId: account.id,
-          overwrite: true,
-        );
+        .mirrorLegacy(legacyKey: legacyKey, accountId: account.id);
   } catch (_) {
     // Ignored: legacy singleton remains a valid resolution fallback.
   }
@@ -1112,6 +1111,13 @@ class SyncNotifier extends StateNotifier<SyncState> {
     final selected = _ref.read(selectedCloudProviderTypeProvider);
     if (selected != CloudProviderType.s3) {
       await _syncService.signOut();
+      // Account-first resolution means _syncService.signOut() cleared the
+      // PER-ACCOUNT Dropbox blob (and revoked); also clear the legacy
+      // source-of-truth key, otherwise the UI still reads it as connected
+      // and the next credential mirror would resurrect it.
+      if (selected == CloudProviderType.dropbox) {
+        await DropboxAuthStore().clear();
+      }
     } else {
       // Match SyncService.signOut()'s metadata clearing without the
       // provider sign-out, so the hand-entered credentials survive.

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -304,9 +304,11 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
     await _mirrorLegacyCredentials(ref, account);
     return account;
   } catch (_) {
-    // Best-effort bookkeeping: the selection is re-derived on every launch,
-    // so a failed write (e.g. teardown racing this future) must not surface
-    // as a sync error.
+    // Returning null degrades resolution to the legacy singleton, which is
+    // the correct fallback: the selection is re-derived on every launch, so
+    // a failed write (teardown race) must not surface as a sync error, and
+    // a failed credential mirror must NOT leave account-first resolution
+    // reading a stale/missing per-account key.
     return null;
   }
 });
@@ -316,8 +318,13 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
 /// stale copy — and a cleared legacy credential (sign-out / remove) can
 /// neither be read from nor resurrected into the per-account key. Copies
 /// when the legacy key is present, deletes the per-account key when absent.
-/// Best-effort: a keychain failure must not null the derived account
-/// (resolution falls back to the legacy singleton, which is still valid).
+///
+/// Deliberately NOT swallowed: if the mirror fails (keychain error), the
+/// per-account key is in an unknown state, so this rethrows to
+/// [selectedSyncAccountProvider], whose catch returns a null account —
+/// which makes [cloudStorageProviderProvider] fall back to the legacy
+/// singleton (still valid) rather than resolve from a stale/missing
+/// per-account key. The next derivation retries the mirror.
 Future<void> _mirrorLegacyCredentials(
   Ref ref,
   domain.ConnectedAccount account,
@@ -331,13 +338,9 @@ Future<void> _mirrorLegacyCredentials(
     AccountKind.adobeLightroom => null,
   };
   if (legacyKey == null) return;
-  try {
-    await ref
-        .read(accountCredentialsStoreProvider)
-        .mirrorLegacy(legacyKey: legacyKey, accountId: account.id);
-  } catch (_) {
-    // Ignored: legacy singleton remains a valid resolution fallback.
-  }
+  await ref
+      .read(accountCredentialsStoreProvider)
+      .mirrorLegacy(legacyKey: legacyKey, accountId: account.id);
 }
 
 /// Cloud storage provider instance (null if none selected or custom folder mode)

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -364,13 +364,20 @@ final cloudStorageProviderProvider = Provider<CloudStorageProvider?>((ref) {
   // the connect UIs still write the legacy keys — when the account is not
   // usable yet, so sync can never resolve to nothing.
   //
-  // The kind guard matters: `.value` can return the PREVIOUS account while
-  // selectedSyncAccountProvider is recomputing right after providerType
-  // changes (e.g. S3 -> Dropbox). Using a stale account of the wrong kind
-  // would resolve to the wrong backend, so we only trust the account once
-  // its kind matches the selected type; otherwise the type-keyed legacy
-  // singleton is the correct interim provider.
-  final account = ref.watch(selectedSyncAccountProvider).value;
+  // The account is trusted only once selectedSyncAccountProvider has SETTLED
+  // on data. `.value` retains the PREVIOUS account while the provider is
+  // (re)loading, which happens in two windows that must both fall back:
+  //   * providerType just changed (S3 -> Dropbox): the retained account is of
+  //     the wrong kind and would resolve to the wrong backend; and
+  //   * an in-place credential edit (S3 config save / Dropbox reconnect)
+  //     invalidates the provider to re-mirror -- during that reload the kind
+  //     still matches, but the per-account key is momentarily stale while the
+  //     legacy key already holds the new creds.
+  // Treating a loading/refreshing state as "no account" keeps both windows on
+  // the type-keyed legacy singleton, whose creds are always current. The kind
+  // guard then covers the settled-but-wrong-kind edge.
+  final accountAsync = ref.watch(selectedSyncAccountProvider);
+  final account = accountAsync.isLoading ? null : accountAsync.value;
   final matchesType =
       account != null &&
       account.kind == AccountKind.fromCloudProviderType(providerType);

--- a/test/core/services/accounts/account_credentials_store_test.dart
+++ b/test/core/services/accounts/account_credentials_store_test.dart
@@ -52,6 +52,29 @@ void main() {
     },
   );
 
+  test('mirrorLegacy copies the legacy blob when present', () async {
+    keychain.values['sync_s3_config'] = '{"v":1}';
+    await store.mirrorLegacy(legacyKey: 'sync_s3_config', accountId: 'acc-7');
+    expect(await store.read('acc-7'), '{"v":1}');
+  });
+
+  test('mirrorLegacy deletes the per-account key when the legacy key is '
+      'absent (a cleared credential is never resurrected)', () async {
+    await store.write('acc-8', '{"stale":true}');
+    // legacy key not present
+    await store.mirrorLegacy(legacyKey: 'sync_s3_config', accountId: 'acc-8');
+    expect(await store.read('acc-8'), isNull);
+  });
+
+  test(
+    'mirrorLegacy leaves the legacy key untouched (source of truth)',
+    () async {
+      keychain.values['sync_s3_config'] = '{"v":1}';
+      await store.mirrorLegacy(legacyKey: 'sync_s3_config', accountId: 'acc-9');
+      expect(keychain.values['sync_s3_config'], '{"v":1}');
+    },
+  );
+
   test(
     'rekeyFromLegacy overwrite refreshes an existing per-account blob',
     () async {

--- a/test/core/services/accounts/adapters/dropbox_account_adapter_test.dart
+++ b/test/core/services/accounts/adapters/dropbox_account_adapter_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/cloud_storage/dropbox_storage_provider.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/account_provider_adapter.dart';
 import 'package:submersion/core/services/accounts/adapters/dropbox_account_adapter.dart';
@@ -65,5 +66,10 @@ void main() {
 
   test('mediaObjectStore returns null without credentials', () async {
     expect(await adapter.mediaObjectStore(account), isNull);
+  });
+
+  test('syncProvider returns a DropboxStorageProvider (account-first raw '
+      'provider for sync resolution)', () {
+    expect(adapter.syncProvider(account), isA<DropboxStorageProvider>());
   });
 }

--- a/test/core/services/accounts/adapters/managed_account_adapters_test.dart
+++ b/test/core/services/accounts/adapters/managed_account_adapters_test.dart
@@ -104,6 +104,21 @@ void main() {
         expect(await adapter.mediaObjectStore(account), isNull);
       },
     );
+
+    test('syncProvider defaults to the shared iCloud singleton so '
+        'account-first resolution matches the legacy path', () {
+      final a = ICloudAccountAdapter(
+        availability: () async => ICloudAvailability.available,
+      );
+      final b = ICloudAccountAdapter(
+        availability: () async => ICloudAvailability.available,
+      );
+      expect(
+        identical(a.syncProvider(account), b.syncProvider(account)),
+        isTrue,
+        reason: 'both resolve to the one process singleton',
+      );
+    });
   });
 
   group('LightroomAccountAdapter', () {

--- a/test/core/services/accounts/adapters/s3_account_adapter_test.dart
+++ b/test/core/services/accounts/adapters/s3_account_adapter_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/services/accounts/adapters/s3_account_adapter.da
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
 import 'package:submersion/core/services/media_store/s3_media_object_store.dart';
 
 import '../../../../support/fake_keychain_storage.dart';
@@ -78,5 +79,10 @@ void main() {
     await adapter.disconnect(account);
     expect(await adapter.loadConfig(account), isNull);
     expect(keychain.values['other'], 'keep');
+  });
+
+  test('syncProvider returns an S3StorageProvider (account-first raw '
+      'provider for sync resolution)', () {
+    expect(adapter.syncProvider(account), isA<S3StorageProvider>());
   });
 }

--- a/test/features/settings/cloud_storage_provider_resolution_test.dart
+++ b/test/features/settings/cloud_storage_provider_resolution_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/providers/account_providers.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/account_provider_registry.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
 import 'package:submersion/core/services/cloud_storage/dropbox_storage_provider.dart';
@@ -75,6 +77,37 @@ void main() {
     expect(
       container.read(cloudStorageProviderProvider),
       isA<DropboxStorageProvider>(),
+    );
+  });
+
+  test('a matching-kind account with no registered SyncCapable falls back to '
+      'the shared provider singleton', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        selectedSyncAccountProvider.overrideWith(
+          (ref) async => account(AccountKind.dropbox),
+        ),
+        // An empty registry has no SyncCapable for the kind, so
+        // capabilityFor<SyncCapable>() returns null and resolution takes the
+        // `?? cloudProviderInstanceFor(...)` singleton fallback.
+        accountProviderRegistryProvider.overrideWithValue(
+          AccountProviderRegistry(const []),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.dropbox;
+    await container.read(selectedSyncAccountProvider.future);
+
+    expect(
+      container.read(cloudStorageProviderProvider),
+      isA<DropboxStorageProvider>(),
+      reason: 'the singleton fallback still yields a Dropbox provider',
     );
   });
 }

--- a/test/features/settings/cloud_storage_provider_resolution_test.dart
+++ b/test/features/settings/cloud_storage_provider_resolution_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/connected_account.dart'
+    as domain;
+import 'package:submersion/core/services/cloud_storage/dropbox_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+/// Account-first resolution guard: `selectedSyncAccountProvider.value` can
+/// return the PREVIOUS account while it recomputes after the provider type
+/// changes. Resolution must not build the raw provider from a stale account
+/// whose kind no longer matches the selected type.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  domain.ConnectedAccount account(AccountKind kind) => domain.ConnectedAccount(
+    id: 'acc-${kind.name}',
+    kind: kind,
+    label: kind.name,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+  );
+
+  Future<ProviderContainer> containerWithStaleAccount(
+    AccountKind staleKind,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        // A resolved account of the "stale" kind, standing in for the value
+        // left behind while the real derivation recomputes.
+        selectedSyncAccountProvider.overrideWith(
+          (ref) async => account(staleKind),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test(
+    'a stale S3 account does not resolve Dropbox sync to an S3 provider',
+    () async {
+      final container = await containerWithStaleAccount(AccountKind.s3);
+      container.read(selectedCloudProviderTypeProvider.notifier).state =
+          CloudProviderType.dropbox;
+      await container.read(
+        selectedSyncAccountProvider.future,
+      ); // resolve .value
+
+      final resolved = container.read(cloudStorageProviderProvider);
+      expect(resolved, isA<DropboxStorageProvider>());
+      expect(
+        resolved,
+        isNot(isA<S3StorageProvider>()),
+        reason: 'kind guard rejects the stale S3 account for a Dropbox type',
+      );
+    },
+  );
+
+  test('a matching-kind account is used for resolution', () async {
+    final container = await containerWithStaleAccount(AccountKind.dropbox);
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.dropbox;
+    await container.read(selectedSyncAccountProvider.future);
+
+    // Kind matches the type, so account-first resolution applies (the
+    // Dropbox adapter's syncProvider is itself a DropboxStorageProvider).
+    expect(
+      container.read(cloudStorageProviderProvider),
+      isA<DropboxStorageProvider>(),
+    );
+  });
+}

--- a/test/features/settings/cloud_storage_provider_resolution_test.dart
+++ b/test/features/settings/cloud_storage_provider_resolution_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -108,6 +110,37 @@ void main() {
       container.read(cloudStorageProviderProvider),
       isA<DropboxStorageProvider>(),
       reason: 'the singleton fallback still yields a Dropbox provider',
+    );
+  });
+
+  test('while selectedSyncAccountProvider is reloading, resolution falls back '
+      'to the legacy singleton (which holds the just-edited creds)', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    // A pending future keeps the provider in AsyncLoading: this stands in for
+    // the re-mirror reload an in-place credential edit triggers, during which
+    // account-first must NOT read the momentarily-stale per-account key.
+    final pending = Completer<domain.ConnectedAccount?>();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        selectedSyncAccountProvider.overrideWith((ref) => pending.future),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.dropbox;
+
+    // Read while the account is still loading: it must resolve to the exact
+    // type-keyed singleton, not an account-first provider off a stale key.
+    expect(
+      identical(
+        container.read(cloudStorageProviderProvider),
+        cloudProviderInstanceFor(CloudProviderType.dropbox),
+      ),
+      isTrue,
+      reason: 'a loading account resolves to the legacy singleton',
     );
   });
 }

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -3,13 +3,18 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType, SyncRepository;
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_api_client.dart';
+import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_manager.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_store.dart'
-    show DropboxAuthData;
+    show DropboxAuthData, DropboxAuthStore;
+import 'package:submersion/core/services/cloud_storage/dropbox_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
@@ -36,6 +41,7 @@ import 'package:submersion/l10n/arb/app_localizations_en.dart';
 
 import '../../../../helpers/fake_cloud_storage_provider.dart';
 import '../../../../helpers/mock_providers.dart';
+import '../../../../support/fake_keychain_storage.dart';
 
 /// In-memory [S3CredentialsStore] for testing -- no FlutterSecureStorage.
 class _MemoryCredentialsStore implements S3CredentialsStore {
@@ -340,6 +346,11 @@ void main() {
     bool settle = true,
     S3Config? s3Config,
     DropboxAuthData? dropboxAuth,
+    // The concrete Dropbox provider backing the connect dialog. Only the
+    // connect-flow test supplies one (a MockClient-backed provider so
+    // completeAuthorization succeeds); everything else leaves the real
+    // instance, which is never exercised because the dialog is not opened.
+    DropboxStorageProvider? dropboxInstance,
     // Existing tests exercise the Dropbox tile assuming it is visible; only
     // the "hidden until configured" test overrides this to false, covering
     // builds whose dropboxAppKey is empty.
@@ -400,6 +411,10 @@ void main() {
           // Same for the Dropbox connection: null means not connected.
           dropboxAuthDataProvider.overrideWith((ref) async => dropboxAuth),
           dropboxConfiguredProvider.overrideWith((ref) => dropboxConfigured),
+          if (dropboxInstance != null)
+            dropboxStorageProviderInstanceProvider.overrideWithValue(
+              dropboxInstance,
+            ),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -1790,6 +1805,62 @@ void main() {
         expect(result.sync.signOutCalls, 1);
       },
     );
+
+    testWidgets('connecting via the dialog selects Dropbox and refreshes the '
+        'account mirror for account-first resolution', (tester) async {
+      // A MockClient whose token exchange succeeds, so the connect dialog
+      // completes authorization and pops true -- driving the onTap branch
+      // that selects the provider and refreshes selectedSyncAccountProvider.
+      final mock = MockClient((request) async {
+        if (request.url.path == '/oauth2/token') {
+          return http.Response(
+            '{"access_token":"at","refresh_token":"rt","expires_in":14400}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response(
+          '{"email":"d@example.com","name":{"display_name":"Diver"}}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final auth = DropboxAuthManager(
+        appKey: 'k',
+        store: DropboxAuthStore(storage: InMemoryKeychain()),
+        httpClient: mock,
+        verifierGenerator: () => 'a' * 43,
+      );
+      final dropbox = DropboxStorageProvider(
+        authManager: auth,
+        apiClient: DropboxApiClient(
+          getAccessToken: auth.getAccessToken,
+          onAccessTokenRejected: auth.invalidateAccessToken,
+          httpClient: mock,
+        ),
+      );
+
+      await pumpPage(tester, dropboxInstance: dropbox);
+
+      // Not connected: tapping the tile opens the connect dialog. The
+      // dialog's initState tries to open a browser (launchUrl throws under
+      // flutter_test); that is caught, so the code field still renders.
+      await tester.tap(find.text('Dropbox'));
+      await tester.pumpAndSettle();
+      expect(find.text('Connect Dropbox'), findsOneWidget);
+
+      // Paste a code and submit; the happy MockClient completes the token
+      // exchange, so the dialog pops true and the connect branch runs
+      // through _selectProvider + the account-mirror refresh.
+      await tester.enterText(find.byType(TextField), 'the-code');
+      await tester.tap(find.text('Connect'));
+      await tester.pumpAndSettle();
+
+      // The success snackbar proves _selectProvider reached the end and the
+      // post-connect account-mirror refresh (invalidate + await) completed
+      // without throwing.
+      expect(find.text('Connected to Fake'), findsOneWidget);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/features/settings/presentation/providers/sync_backend_switch_test.dart
+++ b/test/features/settings/presentation/providers/sync_backend_switch_test.dart
@@ -317,4 +317,30 @@ void main() {
       );
     });
   });
+
+  group('signOut', () {
+    test('a Dropbox sign-out clears the selection even when the legacy '
+        'keychain-clear fails (best-effort)', () async {
+      final backend = FakeCloudStorageProvider(
+        providerId: 'dropbox',
+        providerName: 'Dropbox',
+      );
+      final container = await makeContainer(backend);
+      container.read(selectedCloudProviderTypeProvider.notifier).state =
+          CloudProviderType.dropbox;
+      final notifier = container.read(syncStateProvider.notifier);
+
+      // DropboxAuthStore().clear() hits real secure storage, which throws
+      // under flutter_test; sign-out must swallow that and still complete.
+      await notifier.signOut();
+
+      expect(
+        container.read(selectedCloudProviderTypeProvider),
+        isNull,
+        reason:
+            'a keychain-clear failure must not abort sign-out: the provider '
+            'selection (and derived state) still has to be cleared',
+      );
+    });
+  });
 }

--- a/test/features/settings/sync_account_selection_test.dart
+++ b/test/features/settings/sync_account_selection_test.dart
@@ -1,11 +1,18 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/providers/account_providers.dart';
+import 'package:submersion/core/services/accounts/account_credentials_store.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 
 import '../../helpers/test_database.dart';
+import '../../support/fake_keychain_storage.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -56,6 +63,63 @@ void main() {
     final container = ProviderContainer();
     addTearDown(container.dispose);
     expect(await container.read(selectedSyncAccountProvider.future), isNull);
+  });
+
+  test('selectedSyncAccountProvider mirrors the legacy S3 blob into the '
+      'per-account key (for account-first resolution)', () async {
+    final keychain = InMemoryKeychain();
+    // The connect UI writes the legacy key; the derivation must mirror it.
+    keychain.values[S3CredentialsStore.storageKey] = jsonEncode(
+      S3Config(
+        endpoint: 'https://minio.local:9000',
+        bucket: 'dive-media',
+        accessKeyId: 'AK',
+        secretAccessKey: 'SK',
+      ).toJson(),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        accountCredentialsStoreProvider.overrideWithValue(
+          AccountCredentialsStore(storage: keychain),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.s3;
+    final account = await container.read(selectedSyncAccountProvider.future);
+
+    expect(account, isNotNull);
+    expect(
+      keychain.values[AccountCredentialsStore.keyFor(account!.id)],
+      isNotNull,
+      reason: 'legacy S3 blob mirrored to the per-account key',
+    );
+  });
+
+  test('a Google Drive selection does not attempt a credential mirror '
+      '(session-managed, no keychain blob)', () async {
+    final keychain = InMemoryKeychain();
+    final container = ProviderContainer(
+      overrides: [
+        accountCredentialsStoreProvider.overrideWithValue(
+          AccountCredentialsStore(storage: keychain),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.googledrive;
+    final account = await container.read(selectedSyncAccountProvider.future);
+
+    expect(account, isNotNull);
+    expect(
+      keychain.values[AccountCredentialsStore.keyFor(account!.id)],
+      isNull,
+      reason: 'no legacy blob to mirror for session-managed kinds',
+    );
   });
 
   test(

--- a/test/features/settings/sync_account_selection_test.dart
+++ b/test/features/settings/sync_account_selection_test.dart
@@ -47,7 +47,16 @@ void main() {
 
   test('selectedSyncAccountProvider derives the account and persists the '
       'selection to sync metadata', () async {
-    final container = ProviderContainer();
+    // In-memory keychain so the credential mirror succeeds; without it the
+    // real keychain (unavailable under flutter_test) fails the mirror and
+    // the derivation intentionally returns null (legacy fallback).
+    final container = ProviderContainer(
+      overrides: [
+        accountCredentialsStoreProvider.overrideWithValue(
+          AccountCredentialsStore(storage: InMemoryKeychain()),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
 
     container.read(selectedCloudProviderTypeProvider.notifier).state =
@@ -136,6 +145,31 @@ void main() {
       keychain.values[AccountCredentialsStore.keyFor(account.id)],
       isNull,
       reason: 'per-account mirror deleted to match the cleared legacy key',
+    );
+  });
+
+  test('a failing credential mirror nulls the account so resolution falls '
+      'back to the legacy singleton', () async {
+    final container = ProviderContainer(
+      overrides: [
+        accountCredentialsStoreProvider.overrideWithValue(
+          // Non-entitlement keychain error: FallbackSecureStorage rethrows,
+          // so mirrorLegacy throws and the derivation returns null.
+          AccountCredentialsStore(storage: FailingKeychain(-25308)),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.s3;
+
+    expect(
+      await container.read(selectedSyncAccountProvider.future),
+      isNull,
+      reason:
+          'a mirror failure must not leave account-first reading a '
+          'stale/missing per-account key',
     );
   });
 

--- a/test/features/settings/sync_account_selection_test.dart
+++ b/test/features/settings/sync_account_selection_test.dart
@@ -98,6 +98,47 @@ void main() {
     );
   });
 
+  test('clearing the legacy blob then re-deriving deletes the stale '
+      'per-account mirror (disconnect is not resurrected)', () async {
+    final keychain = InMemoryKeychain();
+    keychain.values[S3CredentialsStore.storageKey] = jsonEncode(
+      S3Config(
+        endpoint: 'https://minio.local:9000',
+        bucket: 'dive-media',
+        accessKeyId: 'AK',
+        secretAccessKey: 'SK',
+      ).toJson(),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        accountCredentialsStoreProvider.overrideWithValue(
+          AccountCredentialsStore(storage: keychain),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(selectedCloudProviderTypeProvider.notifier).state =
+        CloudProviderType.s3;
+    final account = await container.read(selectedSyncAccountProvider.future);
+    expect(
+      keychain.values[AccountCredentialsStore.keyFor(account!.id)],
+      isNotNull,
+      reason: 'mirrored on first derivation',
+    );
+
+    // Simulate a "Remove Configuration": the legacy source of truth is gone.
+    keychain.values.remove(S3CredentialsStore.storageKey);
+    container.invalidate(selectedSyncAccountProvider);
+    await container.read(selectedSyncAccountProvider.future);
+
+    expect(
+      keychain.values[AccountCredentialsStore.keyFor(account.id)],
+      isNull,
+      reason: 'per-account mirror deleted to match the cleared legacy key',
+    );
+  });
+
   test('a Google Drive selection does not attempt a credential mirror '
       '(session-managed, no keychain blob)', () async {
     final keychain = InMemoryKeychain();


### PR DESCRIPTION
Completes the one deliberate deviation left by the Connected Accounts program (#572): Data Sync's raw cloud-storage-provider resolution now goes through the selected account's adapter instead of the legacy per-provider singletons.

## What changed

- **`cloudStorageProviderProvider`** now builds the raw `CloudStorageProvider` from the selected `ConnectedAccount`'s `SyncCapable.syncProvider(account)` — which reads per-account keychain credentials (`account_<id>_credentials`). While the account is still deriving on the first frame, it falls back to the legacy singleton. The encryption wrap is unchanged.
- **`selectedSyncAccountProvider`** mirrors the legacy credential blob (`sync_s3_config` / `sync_dropbox_auth`) into the account's per-account key with `overwrite: true` on every derivation, so account-first resolution always reads current credentials. This covers every connect path — settings pages and the setup wizard — without each having to re-key. iCloud/Google Drive are session-managed and skip the mirror.
- The **S3 config page** and **Dropbox connect** invalidate + await `selectedSyncAccountProvider` after writing the legacy blob, so an in-place credential edit (where the provider-type StateProvider doesn't re-fire) refreshes the mirror.
- **`ICloudAccountAdapter`** now defaults its sync provider to the shared process singleton (via `cloudProviderInstanceFor`), so account-first iCloud resolution returns the same instance the legacy path did (previously a fresh `ICloudStorageProvider()`).

## Why this is safe on the sync critical path

Legacy keychain keys remain the **write target** (connect UIs are unchanged), so the load-window fallback to the legacy singleton is always valid — resolution can never resolve to nothing. The mirror keeps the per-account key equal to legacy, so the account-first and legacy paths are functionally identical for the single-account-per-kind case; the change is the indirection that enables genuine per-account selection (the architectural end-state) and makes `selectedSyncAccountProvider` actually drive resolution rather than being side-effect-only. Old-backend cleanup still uses the legacy singleton by design (it targets a backend the user switched away from).

## Tests

- `selectedSyncAccountProvider` mirrors the legacy S3 blob to the per-account key; a Google Drive selection performs no mirror (session-managed).
- `S3AccountAdapter.syncProvider` / `DropboxAccountAdapter.syncProvider` return the correct provider types (first tests to exercise `SyncCapable.syncProvider`).
- `ICloudAccountAdapter.syncProvider` returns the shared singleton (identical across instances).
- Full settings + accounts + cloud_storage suites green (957); analyze and format clean.