### PR TITLE
fix(backup): create temp dir before restoring on fresh installs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,25 @@
 # Codecov configuration
 # See: https://docs.codecov.com/docs/codecov-yaml
 
+codecov:
+  notify:
+    # Coverage arrives as 5 separate uploads: the 4 file-sharded test jobs
+    # (flags shard-0..3) plus the scripts job (flag scripts). Tests are sharded
+    # BY FILE (ci.yaml), so each shard's lcov only marks the lines its subset
+    # executed and Codecov must union them. Without waiting, Codecov computes
+    # the patch/project STATUS after the first upload lands -- and a shard that
+    # touched only part of a PR's diff then posts a misleadingly low patch %
+    # (e.g. 12.5% when the fully-merged coverage is 100%), which sticks. Hold
+    # the status until all 5 uploads arrive, then compute once on the merge.
+    # Both upload steps run `if: always()` (empty shards upload an empty lcov),
+    # so exactly 5 uploads occur -- keep this in sync with the shard count.
+    after_n_builds: 5
+    wait_for_ci: true
+
+comment:
+  # Same rationale: don't post/update the PR comment until every upload is in.
+  after_n_builds: 5
+
 coverage:
   status:
     project:

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -13,6 +13,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
@@ -184,7 +185,7 @@ class BackupService {
       // write that into the target (filesystem copy or SAF stream).
       storedName =
           p.basenameWithoutExtension(filename) + BackupCrypto.fileExtension;
-      final tempDir = await getTemporaryDirectory();
+      final tempDir = await resolveSyncTempDir();
       // Per-invocation prefix so a foreground backup/share and the scheduled
       // background backup cannot collide on the shared temp dir within the same
       // second (the filename has only second precision). The final stored name
@@ -275,7 +276,7 @@ class BackupService {
     if (encKey == null) {
       await _dbAdapter.backup(destinationPath);
     } else {
-      final tempDir = await getTemporaryDirectory();
+      final tempDir = await resolveSyncTempDir();
       final plainPath = p.join(tempDir.path, 'export_${_uuid.v4()}.db');
       try {
         // Inside the try so a failed/partial backup still gets its plaintext
@@ -336,7 +337,7 @@ class BackupService {
 
     final encKey = await _activeBackupKey();
     final filename = _generateFilename();
-    final tempDir = await getTemporaryDirectory();
+    final tempDir = await resolveSyncTempDir();
 
     if (encKey == null) {
       final tempPath = p.join(tempDir.path, filename);
@@ -416,7 +417,7 @@ class BackupService {
         final newName =
             p.basenameWithoutExtension(localPath) + BackupCrypto.fileExtension;
         final newPath = p.join(dir, newName);
-        final tempDir = await getTemporaryDirectory();
+        final tempDir = await resolveSyncTempDir();
         final tempSbe = p.join(tempDir.path, 'reenc_${_uuid.v4()}.sbe');
         try {
           await BackupCrypto.encryptFile(
@@ -641,7 +642,7 @@ class BackupService {
           'Backup file not found locally or in cloud',
         );
       }
-      final tempDir = await getTemporaryDirectory();
+      final tempDir = await resolveSyncTempDir();
       sourcePath = p.join(tempDir.path, record.filename);
       await _safPort.readBackup(documentUri: localRef, destPath: sourcePath);
     } else if (localRef != null && await File(localRef).exists()) {
@@ -1210,7 +1211,7 @@ class BackupService {
           'uploading backup UNENCRYPTED',
         );
       } else {
-        final tempDir = await getTemporaryDirectory();
+        final tempDir = await resolveSyncTempDir();
         uploadName =
             p.basenameWithoutExtension(filename) + BackupCrypto.fileExtension;
         uploadPath = p.join(tempDir.path, uploadName);
@@ -1256,7 +1257,7 @@ class BackupService {
     if (!await BackupCrypto.isEncryptedBackup(sourcePath)) {
       return _MaterializedBackup(sourcePath, isTemp: false);
     }
-    final tempDir = await getTemporaryDirectory();
+    final tempDir = await resolveSyncTempDir();
     final decrypted = p.join(tempDir.path, 'restore_${_uuid.v4()}.db');
     final syncKey = await _encryptionKeyStore?.loadKey();
     final backupKey = await _backupEncryptionKeyStore?.loadKey();
@@ -1331,7 +1332,7 @@ class BackupService {
     }
 
     final bytes = await _cloudProvider.downloadFile(cloudFileId);
-    final tempDir = await getTemporaryDirectory();
+    final tempDir = await resolveSyncTempDir();
     final tempPath = p.join(tempDir.path, filename);
     await File(tempPath).writeAsBytes(bytes);
     return tempPath;

--- a/test/features/backup/data/services/backup_service_replace_test.dart
+++ b/test/features/backup/data/services/backup_service_replace_test.dart
@@ -13,6 +13,8 @@ import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 
+import '../../../../support/fake_cloud_storage_provider.dart';
+
 /// Fake database adapter (mirror of backup_service_test.dart's).
 class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
@@ -232,6 +234,45 @@ void main() {
         preferences: preferences,
         syncRepository: spy,
         epochStore: epochStore,
+      );
+
+      await service.restoreFromBackup(record);
+
+      expect(spy.preservedDeviceId, 'live-device-id');
+    });
+
+    test('restoreFromBackup downloads a cloud-only backup into the temp '
+        'dir and restores it', () async {
+      // A record with only a cloudFileId (no local copy) is pulled down to a
+      // temp file first. This exercises _downloadFromCloud, whose
+      // resolveSyncTempDir() creates the temp dir on a fresh install.
+      final dbFile = File('${tempDir.path}/cloud_source.db');
+      final db = sqlite3.sqlite3.open(dbFile.path);
+      db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
+      db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
+      db.dispose();
+
+      final cloud = FakeCloudStorageProvider();
+      final upload = await cloud.uploadFile(
+        await dbFile.readAsBytes(),
+        'valid_cloud.db',
+      );
+      final record = BackupRecord(
+        id: 'r-cloud',
+        filename: 'valid_cloud.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 10,
+        location: BackupLocation.cloud,
+        cloudFileId: upload.fileId,
+      );
+
+      final spy = _EpochSpySyncRepository();
+      final service = BackupService(
+        dbAdapter: fakeDb,
+        preferences: preferences,
+        syncRepository: spy,
+        epochStore: epochStore,
+        cloudProvider: cloud,
       );
 
       await service.restoreFromBackup(record);

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:cryptography/cryptography.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,9 +10,11 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/sync/crypto/keyslots.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_crypto.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
@@ -1382,6 +1385,112 @@ void main() {
             frequency: BackupFrequency.monthly,
           ).frequencyDuration,
           const Duration(days: 30),
+        );
+      });
+    });
+
+    // Restoring an ENCRYPTED (.sbe) backup on a freshly installed system failed
+    // with `PathNotFoundException: Cannot open file, path = '.../Library/Caches/
+    // app.submersion/restore_<uuid>.db' (errno = 2)`. getTemporaryDirectory()
+    // maps to the sandbox Library/Caches/<bundleId> dir, which path_provider
+    // returns but never creates; on a fresh install it is absent, so decrypting
+    // the artifact to a temp .db threw. Same root cause as the sync #554 fix
+    // (resolveSyncTempDir does create(recursive: true)) but on the backup
+    // restore path. Mirrors sync_temp_dir_test.dart.
+    group('encrypted restore into a missing temp dir (fresh install)', () {
+      const passphrase = 'correct horse battery staple';
+      const keyId = '8f14e45f-ceea-467f-ab37-a10a8d5f4c11';
+      const fastKdf = KdfParams(m: 1024, t: 3, p: 1);
+      late Directory sandbox;
+      late Directory missingTemp;
+      late Uint8List keyslotBytes;
+      late SecretKey mlk;
+
+      setUp(() async {
+        mlk = SecretKey(List<int>.generate(32, (i) => (i * 13 + 5) % 256));
+        keyslotBytes = KeyslotFile(
+          version: 1,
+          libraryKeyId: keyId,
+          slots: [
+            await Keyslots.createSlot(
+              type: 'passphrase',
+              secret: passphrase,
+              mlk: mlk,
+              kdf: fastKdf,
+            ),
+          ],
+        ).toJsonBytes();
+
+        sandbox = await Directory.systemTemp.createTemp('backup_fresh_');
+        // path_provider hands back this path but has NOT created it -- the
+        // macOS Library/Caches situation on a fresh install.
+        missingTemp = Directory(
+          '${sandbox.path}/Library/Caches/app.submersion',
+        );
+        expect(
+          missingTemp.existsSync(),
+          isFalse,
+          reason: 'precondition: the temp dir does not exist yet',
+        );
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('plugins.flutter.io/path_provider'),
+              (call) async {
+                if (call.method == 'getTemporaryDirectory') {
+                  return missingTemp.path;
+                }
+                // The pre-restore backup writes into the documents dir, which
+                // must exist for the flow to reach the decrypt step.
+                if (call.method == 'getApplicationDocumentsDirectory') {
+                  return sandbox.path;
+                }
+                return null;
+              },
+            );
+      });
+
+      tearDown(() async {
+        // Restore the file-wide handler installed in setUpAll.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('plugins.flutter.io/path_provider'),
+              (call) async =>
+                  call.method == 'getTemporaryDirectory' ||
+                      call.method == 'getApplicationDocumentsDirectory'
+                  ? Directory.systemTemp.path
+                  : null,
+            );
+        if (sandbox.existsSync()) await sandbox.delete(recursive: true);
+      });
+
+      test('restoreFromFile decrypts and restores without a pre-created '
+          'temp dir', () async {
+        final plain = File('${sandbox.path}/plain.db');
+        await plain.writeAsString('fake db contents');
+        final sbe = File('${sandbox.path}/backup${BackupCrypto.fileExtension}');
+        await BackupCrypto.encryptFile(
+          inPath: plain.path,
+          outPath: sbe.path,
+          mlk: mlk,
+          libraryKeyId: keyId,
+          keyslotBytes: keyslotBytes,
+        );
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: _SpySyncRepository(),
+        );
+
+        await service.restoreFromFile(sbe.path, encryptionSecret: passphrase);
+
+        expect(
+          fakeDb.restoreCallCount,
+          1,
+          reason:
+              'the decrypted DB must be restored even though the temp dir '
+              'did not exist on a fresh install',
         );
       });
     });

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -1407,6 +1407,22 @@ void main() {
       late SecretKey mlk;
 
       setUp(() async {
+        // Assign `sandbox` before any awaited work so a throw from the crypto
+        // setup below cannot leave it uninitialized -- `tearDown` always runs
+        // and reads it, and an uninitialized `late` read would throw a
+        // LateInitializationError that masks the real setUp failure.
+        sandbox = Directory.systemTemp.createTempSync('backup_fresh_');
+        // path_provider hands back this path but has NOT created it -- the
+        // macOS Library/Caches situation on a fresh install.
+        missingTemp = Directory(
+          '${sandbox.path}/Library/Caches/app.submersion',
+        );
+        expect(
+          missingTemp.existsSync(),
+          isFalse,
+          reason: 'precondition: the temp dir does not exist yet',
+        );
+
         mlk = SecretKey(List<int>.generate(32, (i) => (i * 13 + 5) % 256));
         keyslotBytes = KeyslotFile(
           version: 1,
@@ -1420,18 +1436,6 @@ void main() {
             ),
           ],
         ).toJsonBytes();
-
-        sandbox = await Directory.systemTemp.createTemp('backup_fresh_');
-        // path_provider hands back this path but has NOT created it -- the
-        // macOS Library/Caches situation on a fresh install.
-        missingTemp = Directory(
-          '${sandbox.path}/Library/Caches/app.submersion',
-        );
-        expect(
-          missingTemp.existsSync(),
-          isFalse,
-          reason: 'precondition: the temp dir does not exist yet',
-        );
 
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(


### PR DESCRIPTION
## Summary

Restoring an encrypted (`.sbe`) backup on a **freshly installed system** failed with:

```
Restore failed: PathNotFoundException: Cannot open file, path =
'.../Library/Caches/app.submersion/restore_<uuid>.db'
(OS Error: No such file or directory, errno = 2)
```

On sandboxed macOS builds, `getTemporaryDirectory()` maps to `Library/Caches/<bundleId>`. `path_provider` returns that path but never creates it, and macOS treats Caches as purgeable / not-guaranteed-to-exist. On a fresh install the directory does not exist yet, so decrypting the artifact to a `restore_<uuid>.db` temp file threw when opening it for write. (A write-open only ENOENTs when the *parent directory* is missing.)

This is the **same root cause as #554** (the macOS sync crash), which was fixed for the sync code by `resolveSyncTempDir()` doing `create(recursive: true)`. `BackupService` had 8 direct `getTemporaryDirectory()` call sites that never got that treatment.

Only encrypted restores crashed: plaintext restores return before touching the temp dir. Established installs were unaffected because the Caches dir already exists by then.

## Changes

- Route all 8 `getTemporaryDirectory()` call sites in `backup_service.dart` (export / re-encrypt / upload / download / restore) through `resolveSyncTempDir()`, which idempotently `create(recursive: true)`s the dir and also carries the #509 `/tmp` EPERM hardening.
- Add a `backup_service_test.dart` group ("encrypted restore into a missing temp dir (fresh install)") that mocks `path_provider` to a not-yet-created `Library/Caches` path and restores a passphrase-encrypted `.sbe`. It reproduces the exact production error before the fix and passes after.

## Test Plan

- [x] `flutter test` passes (full suite green via pre-push hook)
- [x] `flutter analyze` passes
- [ ] Manual testing on: macOS fresh-install restore (hard to simulate locally; covered by the missing-dir reproduction test)
