### PR TITLE
fix(backup): two encrypted-restore fixes (navigator over-pop + setup-wizard passphrase prompt)

### DIFF
--- a/lib/features/settings/presentation/widgets/encryption_passphrase_dialog.dart
+++ b/lib/features/settings/presentation/widgets/encryption_passphrase_dialog.dart
@@ -53,9 +53,18 @@ class _PassphraseDialogState extends State<_PassphraseDialog> {
       _busy = true;
       _error = null;
     });
+    // Capture the navigator before the await so we neither touch a
+    // possibly-defunct context afterward nor pop the wrong navigator.
+    final navigator = Navigator.of(context);
     try {
       await widget.onSubmit(secret);
-      if (mounted) Navigator.of(context).pop(secret);
+      // A successful onSubmit can trigger a screen takeover that clears the
+      // whole stack (e.g. restore -> RestoreCompletePage.show(), which does
+      // pushAndRemoveUntil(..., (_) => false)). Popping here would then remove
+      // the last remaining route and empty the navigator history, tripping
+      // NavigatorState.build's `_history.isNotEmpty` assertion. Only self-pop
+      // when the dialog route is still on the stack to pop.
+      if (mounted && navigator.canPop()) navigator.pop(secret);
     } on WrongPassphraseException {
       if (!mounted) return;
       setState(() {

--- a/lib/features/setup_wizard/presentation/widgets/steps/restore_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/restore_step.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
+import 'package:submersion/features/settings/presentation/widgets/encryption_passphrase_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A chosen backup file: its absolute path and display name.
@@ -62,10 +64,26 @@ class RestoreStep extends ConsumerWidget {
       record,
       currentSchemaVersion: AppDatabase.currentSchemaVersion,
     );
-    if (mode != null) {
+    if (mode == null) return;
+
+    final path = picked.path;
+    try {
       await ref
           .read(backupOperationProvider.notifier)
-          .restoreFromFilePath(picked.path, mode: mode);
+          .restoreFromFilePath(path, mode: mode);
+    } on BackupEncryptedException {
+      // Encrypted (.sbe) backups need a passphrase or recovery code. Without
+      // this the exception escaped as an unhandled async error and the restore
+      // silently did nothing. Prompt, then retry with the secret.
+      if (!context.mounted) return;
+      await showEncryptionPassphraseDialog(
+        context,
+        title: context.l10n.settings_backupEncryption_restoreUnlockTitle,
+        hint: context.l10n.settings_backupEncryption_restoreUnlockHint,
+        onSubmit: (secret) => ref
+            .read(backupOperationProvider.notifier)
+            .restoreFromFilePath(path, mode: mode, encryptionSecret: secret),
+      );
     }
   }
 

--- a/test/features/settings/presentation/widgets/encryption_passphrase_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/encryption_passphrase_dialog_test.dart
@@ -51,6 +51,51 @@ void main() {
       expect(results.single, 'my secret');
     });
 
+    testWidgets(
+      'success navigation that clears the stack does not over-pop the navigator',
+      (tester) async {
+        // Reproduces the encrypted-restore crash: on a successful restore the
+        // page listener runs RestoreCompletePage.show(), which does
+        // pushAndRemoveUntil(..., (_) => false) -- wiping every route including
+        // this dialog and leaving exactly one route. The dialog's own success
+        // pop then removed that last route, emptying the navigator history and
+        // tripping `NavigatorState.build`'s `_history.isNotEmpty` assertion.
+        await tester.pumpWidget(
+          testApp(
+            child: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => showEncryptionPassphraseDialog(
+                  context,
+                  title: 'Enter key',
+                  onSubmit: (_) async {
+                    Navigator.of(
+                      context,
+                      rootNavigator: true,
+                    ).pushAndRemoveUntil(
+                      MaterialPageRoute(
+                        builder: (_) => const Scaffold(body: Text('restored')),
+                      ),
+                      (_) => false,
+                    );
+                  },
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+        await tester.enterText(find.byType(TextField), 'correct');
+        await tester.tap(find.widgetWithText(FilledButton, 'Unlock'));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('restored'), findsOneWidget);
+      },
+    );
+
     testWidgets('empty input does not call onSubmit', (tester) async {
       var calls = 0;
       await pumpOpener(

--- a/test/features/setup_wizard/presentation/widgets/steps/restore_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/restore_step_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
+import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
@@ -15,6 +17,32 @@ class _FakeBackupOp extends StateNotifier<BackupOperationState>
   _FakeBackupOp(super.state);
 
   void push(BackupOperationState next) => state = next;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Mimics the real provider's encrypted-restore contract: the first attempt
+/// (no secret) throws [BackupEncryptedException]; a retry with a secret
+/// succeeds. Records the secrets it was called with.
+class _EncryptedBackupOp extends StateNotifier<BackupOperationState>
+    implements BackupOperationNotifier {
+  _EncryptedBackupOp() : super(const BackupOperationState());
+
+  final secretsSeen = <String?>[];
+
+  @override
+  Future<void> restoreFromFilePath(
+    String filePath, {
+    RestoreMode mode = RestoreMode.merge,
+    String? encryptionSecret,
+  }) async {
+    secretsSeen.add(encryptionSecret);
+    if (encryptionSecret == null) throw const BackupEncryptedException();
+    state = const BackupOperationState(
+      status: BackupOperationStatus.restoreComplete,
+    );
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -102,6 +130,50 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(RestoreConfirmationDialog), findsOneWidget);
+  });
+
+  testWidgets('encrypted backup prompts for the passphrase and retries', (
+    tester,
+  ) async {
+    final dir = Directory.systemTemp.createTempSync('restore_step_enc_test');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final backup = File('${dir.path}/backup.sbe')..writeAsBytesSync([1, 2, 3]);
+    final fake = _EncryptedBackupOp();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [backupOperationProvider.overrideWith((ref) => fake)],
+        child: RestoreStep(
+          pickBackupFile: () async => (path: backup.path, name: 'backup.sbe'),
+        ),
+      ),
+    );
+
+    await tester.runAsync(() async {
+      await tester.tap(find.text('Choose backup file'));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+    expect(find.byType(RestoreConfirmationDialog), findsOneWidget);
+
+    // Confirm the restore (merge). The restore then throws
+    // BackupEncryptedException, which must surface a passphrase prompt rather
+    // than vanishing into an unhandled async error.
+    await tester.runAsync(() async {
+      await tester.tap(find.widgetWithText(FilledButton, 'Restore'));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+    expect(find.text('Unlock encrypted backup'), findsOneWidget);
+
+    // Entering the secret retries the restore with it.
+    await tester.enterText(find.byType(TextField), 'correct horse');
+    await tester.runAsync(() async {
+      await tester.tap(find.widgetWithText(FilledButton, 'Unlock'));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+    expect(fake.secretsSeen, [null, 'correct horse']);
   });
 
   testWidgets('restoreComplete transition shows the completion page', (


### PR DESCRIPTION
Two related fixes for restoring **encrypted `.sbe` backups**, both found while smoke-testing the restore flow on macOS.

## 1. Passphrase dialog over-popped the navigator (crash)

Restoring an encrypted backup from **backup settings** and entering the correct passphrase crashed with a full-screen red error:

```
'package:flutter/src/widgets/navigator.dart': Failed assertion: line 5910 pos 12: '_history.isNotEmpty': is not true.
```

**Cause:** on success the page listener runs `RestoreCompletePage.show()` — `pushAndRemoveUntil(route, (_) => false)`, which clears the stack down to one route (removing the open passphrase dialog). Control then returned to the dialog's `_submit()`, which unconditionally called `Navigator.pop(secret)`, popping that last route and emptying the navigator history → `NavigatorState.build`'s `_history.isNotEmpty` assertion trips. Plaintext restore was unaffected (no dialog, no second pop).

**Fix** (`encryption_passphrase_dialog.dart`): capture the navigator before the `await` and only self-pop when there is still a route to pop:
```dart
final navigator = Navigator.of(context);
await widget.onSubmit(secret);
if (mounted && navigator.canPop()) navigator.pop(secret);
```
After a stack-clearing takeover, `canPop()` is false, so the dialog defers instead of fighting it. Every normal use (dialog atop a page, `changePassphrase`, `regenerateRecoveryCode`) always has ≥2 routes, so those pop exactly as before.

## 2. Setup wizard silently did nothing for encrypted backups

In the **setup wizard**, choosing an encrypted `.sbe` and confirming Merge/Replace did nothing — no passphrase prompt, no error, no progress. Plaintext `.db` worked.

**Cause:** `RestoreStep._pickAndRestore` called `restoreFromFilePath` **without catching `BackupEncryptedException`**. The provider rethrows that exception by design (`backup_providers.dart:396`: "The page prompts for the passphrase and retries with the secret"), so every caller must catch it. The backup settings page did; the wizard — a second, independently-written restore entry point — did not, so the exception escaped as an unhandled async error.

**Fix** (`restore_step.dart`): wrap the restore in `try / on BackupEncryptedException` and show `showEncryptionPassphraseDialog`, retrying with the entered secret — the same pattern the settings page uses, so both restore surfaces behave identically.

## Testing

- **Navigator over-pop:** new regression test in `encryption_passphrase_dialog_test.dart` reproduces the exact assertion via an `onSubmit` that runs `pushAndRemoveUntil`; passes with the fix. All 13 tests in that file green.
- **Wizard:** new regression test in `restore_step_test.dart` reproduces the unhandled `BackupEncryptedException` and asserts the passphrase prompt appears and the retry carries the secret. All 7 tests in that file green.
- `flutter analyze` clean. Fix 1 confirmed end-to-end in the macOS app (encrypted settings restore prompts and completes). Fix 2 is covered by its regression test and a clean app relaunch; a live wizard re-check is pending.
