### PR TITLE
feat(dc): Shearwater Perdix 3 download support (V2 protocol)

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/cpp/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/CMakeLists.txt
@@ -62,7 +62,7 @@ set(LIBDC_SOURCES
     ${LIBDC_DIR}/src/ihex.c
     ${LIBDC_DIR}/src/hw_ostc.c
     ${LIBDC_DIR}/src/hw_ostc_parser.c
-    ${LIBDC_DIR}/src/hw_frog.c
+    # hw_frog.c was merged into hw_ostc3.c upstream (frog/ostc3 integration).
     ${LIBDC_DIR}/src/hw_ostc3.c
     ${LIBDC_DIR}/src/aes.c
     ${LIBDC_DIR}/src/cressi_edy.c

--- a/packages/libdivecomputer_plugin/ios/build_libdc.sh
+++ b/packages/libdivecomputer_plugin/ios/build_libdc.sh
@@ -85,7 +85,7 @@ SOURCES=(
     mares_iconhd.c mares_iconhd_parser.c
     ihex.c
     hw_ostc.c hw_ostc_parser.c
-    hw_frog.c
+    # hw_frog.c was merged into hw_ostc3.c upstream (frog/ostc3 integration).
     hw_ostc3.c
     aes.c
     cressi_edy.c cressi_edy_parser.c

--- a/packages/libdivecomputer_plugin/linux/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/linux/CMakeLists.txt
@@ -63,7 +63,7 @@ set(LIBDC_SOURCES
     ${LIBDC_DIR}/src/ihex.c
     ${LIBDC_DIR}/src/hw_ostc.c
     ${LIBDC_DIR}/src/hw_ostc_parser.c
-    ${LIBDC_DIR}/src/hw_frog.c
+    # hw_frog.c was merged into hw_ostc3.c upstream (frog/ostc3 integration).
     ${LIBDC_DIR}/src/hw_ostc3.c
     ${LIBDC_DIR}/src/aes.c
     ${LIBDC_DIR}/src/cressi_edy.c

--- a/packages/libdivecomputer_plugin/macos/build_libdc.sh
+++ b/packages/libdivecomputer_plugin/macos/build_libdc.sh
@@ -75,7 +75,7 @@ SOURCES=(
     mares_iconhd.c mares_iconhd_parser.c
     ihex.c
     hw_ostc.c hw_ostc_parser.c
-    hw_frog.c
+    # hw_frog.c was merged into hw_ostc3.c upstream (frog/ostc3 integration).
     hw_ostc3.c
     aes.c
     cressi_edy.c cressi_edy_parser.c

--- a/packages/libdivecomputer_plugin/patches/0001-shearwater-swift-exit-gps.patch
+++ b/packages/libdivecomputer_plugin/patches/0001-shearwater-swift-exit-gps.patch
@@ -1,33 +1,34 @@
 diff --git a/src/shearwater_predator_parser.c b/src/shearwater_predator_parser.c
-index 80de939..1a0469f 100644
+index f0bd891..81f6826 100644
 --- a/src/shearwater_predator_parser.c
 +++ b/src/shearwater_predator_parser.c
-@@ -880,18 +880,24 @@ shearwater_predator_parser_get_field (dc_parser_t *abstract, dc_field_type_t typ
+@@ -883,6 +883,30 @@ shearwater_predator_parser_get_field (dc_parser_t *abstract, dc_field_type_t typ
  				return DC_STATUS_DATAFORMAT;
  			}
  			break;
--		case DC_FIELD_LOCATION:
--			if (parser->opening[9] == UNDEFINED || parser->logversion < 17)
 +		case DC_FIELD_LOCATION: {
 +			// flags: 0 = entry (opening record 9), 1 = exit (closing record 9).
-+			// Submersion patch (Swift GPS exit) layered on top of upstream's
-+			// GNSS-status detection. See
++			// Submersion patch (Swift GPS exit): the app reads entry/exit GPS as
++			// scalar dive-row fields via dc_parser_get_field(..., DC_FIELD_LOCATION,
++			// 0/1) in libdc_download.c. Upstream replaced this static field with
++			// DC_SAMPLE_LOCATION samples (emitted in samples_foreach below); we
++			// re-layer the field API on top so both remain available. Locals are
++			// declared in-block because upstream removed the function-scope
++			// declarations along with the original case. See
 +			// packages/libdivecomputer_plugin/patches/0001-shearwater-swift-exit-gps.patch.
++			dc_location_t *location = (dc_location_t *) value;
 +			unsigned int gps_rec = (flags == 1) ? parser->closing[9] : parser->opening[9];
 +			if (gps_rec == UNDEFINED || parser->logversion < 17)
- 				return DC_STATUS_UNSUPPORTED;
--			gnss = data[parser->opening[9] + 16];
--			latitude  = (signed int) array_uint32_be (data + parser->opening[9] + 21);
--			longitude = (signed int) array_uint32_be (data + parser->opening[9] + 25);
-+			gnss = data[gps_rec + 16];
-+			latitude  = (signed int) array_uint32_be (data + gps_rec + 21);
-+			longitude = (signed int) array_uint32_be (data + gps_rec + 25);
- 			if (gnss != GNSS_FIX_2D && gnss != GNSS_FIX_3D)
- 				return DC_STATUS_UNSUPPORTED;
- 			location->latitude  = latitude  / 100000.0;
- 			location->longitude = longitude / 100000.0;
- 			location->altitude  = 0.0;
- 			break;
++				return DC_STATUS_UNSUPPORTED;
++			unsigned int gnss = data[gps_rec + 16];
++			int latitude  = (signed int) array_uint32_be (data + gps_rec + 21);
++			int longitude = (signed int) array_uint32_be (data + gps_rec + 25);
++			if (gnss != GNSS_FIX_2D && gnss != GNSS_FIX_3D)
++				return DC_STATUS_UNSUPPORTED;
++			location->latitude  = latitude  / 100000.0;
++			location->longitude = longitude / 100000.0;
++			location->altitude  = 0.0;
++			break;
 +		}
  		default:
  			return DC_STATUS_UNSUPPORTED;

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -72,6 +72,9 @@ add_executable(test_hw_ostc3_read
     ${LIBDC_DIR}/src/packet.c
     ${LIBDC_DIR}/src/common.c
     ${LIBDC_DIR}/src/platform.c
+    # ringbuffer.c: hw_ostc3.c gained a ringbuffer_distance() dependency in the
+    # upstream frog/ostc3 integration merged for Perdix 3 V2 support.
+    ${LIBDC_DIR}/src/ringbuffer.c
 )
 target_include_directories(test_hw_ostc3_read PRIVATE
     ${WRAPPER_DIR}

--- a/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
+++ b/packages/libdivecomputer_plugin/test/native/test_hw_ostc3_read.c
@@ -30,6 +30,13 @@
 
 #include "hw_ostc3.c"  // for the static hw_ostc3_read + hw_ostc3_device_t
 
+// hw_ostc3.c replaced its HDR_FULL_* offset macros with a struct-based layout
+// table (upstream frog/ostc3 integration). build_dive() below still constructs
+// a "full" DIVE header, whose pointer field remains at byte offset 2 (see the
+// full-header layout entry, pointers = 2). Define the offset locally now that
+// the driver no longer exposes it as a macro.
+#define HDR_FULL_POINTERS 2
+
 #include "ostc_nano_dive_394.h"  // real OSTC nano DIVE capture from issue #394
 
 // Stubs for the device-private symbols that the #included hw_ostc3.c

--- a/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
+++ b/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
@@ -132,10 +132,12 @@ static void set_record(int page, int slot, int deleted, unsigned char id) {
 
 dc_status_t shearwater_common_setup(shearwater_common_device_t *device,
                                     dc_context_t *context,
-                                    dc_iostream_t *iostream) {
+                                    dc_iostream_t *iostream,
+                                    unsigned int model) {
   (void)device;
   (void)context;
   (void)iostream;
+  (void)model;
   return DC_STATUS_SUCCESS;
 }
 

--- a/packages/libdivecomputer_plugin/windows/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/windows/CMakeLists.txt
@@ -63,7 +63,7 @@ set(LIBDC_SOURCES
     ${LIBDC_DIR}/src/ihex.c
     ${LIBDC_DIR}/src/hw_ostc.c
     ${LIBDC_DIR}/src/hw_ostc_parser.c
-    ${LIBDC_DIR}/src/hw_frog.c
+    # hw_frog.c was merged into hw_ostc3.c upstream (frog/ostc3 integration).
     ${LIBDC_DIR}/src/hw_ostc3.c
     ${LIBDC_DIR}/src/aes.c
     ${LIBDC_DIR}/src/cressi_edy.c


### PR DESCRIPTION
## Summary

Adds actual **download** support for the Shearwater Perdix 3. Recognition (BLE scan + pairing) already shipped in #562 as a descriptor row + `dc_filter_shearwater` whitelist entry (model 14). But the Perdix 3 speaks a new **V2 wire protocol**, so recognition-only connected and then downloaded nothing (mirrors Subsurface #4858's "no new dives"). This bumps the `libdivecomputer` submodule to the `submersion-patches` merge that adds V2.

### What V2 changes (in the fork)
- 4096-byte packets (`SZ_PACKET_V2`) vs V1's 254, selected by `protocol = (model == PERDIX3) ? V2 : V1`.
- 514-byte BLE MTU, 16-bit length fields, 5-byte frame headers.
- SLIP framing **without** the per-notification 2-byte BLE header (`header = transport == BLE && protocol != V2`).

### Are BLE transport changes needed? No.
The V2 read path reassembles each logical packet across notifications via SLIP (END-delimited, byte-stream framing) instead of stripping a per-read header. SLIP is chunk-boundary agnostic, so the app's existing **one-notification-per-read** layer (Darwin `PacketReadBuffer`, Android `BleIoStream`) already satisfies V2 — feeding it one ~512-byte notification at a time correctly rebuilds a 4096-byte packet across ~8 reads. Android already requests MTU 512; Darwin negotiates automatically. MTU only affects throughput, not correctness (SLIP reassembles regardless).

## Integration approach

The V2 series is built on top of an upstream advance (`24a68b7`'s parent is the upstream tip), and the fork's oldest-first patches (#480) are **not** in the V2 branch. A straight submodule bump to the V2 tip would have silently dropped those. So this is a **merge** of the V2 branch into `submersion-patches`, preserving:
- oldest-first Shearwater delivery + deleted-record manifest (#480)
- hw_ostc3 BLE partial-read accumulation (#280/#394)

### Conflict resolution
One conflict, in `shearwater_predator_parser.c`: upstream replaced the static `DC_FIELD_LOCATION` field with `DC_SAMPLE_LOCATION` samples. The app reads entry/exit GPS as scalar dive-row fields via `dc_parser_get_field(..., DC_FIELD_LOCATION, 0/1)` in `libdc_download.c`, so the field case is **re-layered** on top of upstream's samples — both remain available (upstream's samples feed the #497 surface-track logger; the fields feed the dive-row GPS columns). Locals are declared in-block because upstream removed the function-scope declarations with the original case.

## Native-test fallout from the upstream advance (fixed here)
- `test_shearwater_petrel_foreach.c` — `shearwater_common_setup()` gained a `model` param; mock signature updated.
- `test_hw_ostc3_read.c` — the ostc3/frog integration replaced `HDR_FULL_*` macros with a layout table; `HDR_FULL_POINTERS` (offset 2) defined locally for `build_dive()`.
- `CMakeLists.txt` — `hw_ostc3.c` now needs `ringbuffer.c` (`ringbuffer_distance`).
- `patches/0001` — exit-GPS mirror refreshed to the re-layered case.

## Verification
All native libdivecomputer tests pass locally: `test_parse_raw_dive`, `test_shearwater_petrel_foreach` (#480, 15 assertions), `test_hw_ostc3_read` (#280/#394), `test_descriptor_match_integration`, `test_descriptor_matcher`, `test_dive_converter`, `test_serial_callbacks`. Full merged libdivecomputer + `libdc_download.c` compiles clean.

- Model 14 is unchanged from #562 → **no DB migration**.
- **No Dart changes** (recognition is descriptor-driven; file-import `_knownModels` already has "Perdix 3").

## Not done / follow-ups
- [ ] **Real Perdix 3 hardware download** verification (the gate that closes the #4858-style empty-download risk).
- [ ] Versioned release note at release-cut time (version currently in flux across branches).

## Fork dependency
Requires `submersion-app/libdivecomputer` `submersion-patches` at `1a47a01` (pushed). CI's recursive submodule checkout resolves the pinned SHA.