### PR TITLE
ci: post build artifact download links on every PR

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -63,18 +63,22 @@ jobs:
               { label: 'Linux',         job: 'Build Linux',   artifact: 'linux-build' },
             ];
 
-            // 3. List this run's artifacts and jobs.
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              { owner, repo, run_id: run.id, per_page: 100 },
+            // 3. List this run's artifacts and jobs. Both Actions endpoints
+            // return { total_count, artifacts|jobs: [...] }; read the namespaced
+            // array off .data directly (unambiguous, unlike paginate's response
+            // normalization). per_page: 100 covers this run's counts — a CI run
+            // has well under 100 artifacts/jobs — so no pagination is needed.
+            const artifactsResp = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: run.id, per_page: 100,
+            });
+            const artifactByName = new Map(
+              artifactsResp.data.artifacts.map(a => [a.name, a]),
             );
-            const artifactByName = new Map(artifacts.map(a => [a.name, a]));
 
-            const jobs = await github.paginate(
-              github.rest.actions.listJobsForWorkflowRun,
-              { owner, repo, run_id: run.id, per_page: 100 },
-            );
-            const jobByName = new Map(jobs.map(j => [j.name, j]));
+            const jobsResp = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 100,
+            });
+            const jobByName = new Map(jobsResp.data.jobs.map(j => [j.name, j]));
 
             // 4. Render one row per platform.
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
@@ -88,6 +92,10 @@ jobs:
                 cell = `❌ [build failed](${job.html_url})`;
               } else if (job && (job.conclusion === 'cancelled' || job.conclusion === 'skipped')) {
                 cell = '⚠️ skipped';
+              } else if (job && job.conclusion === 'success') {
+                // Job passed but its upload step produced no artifact (e.g. the
+                // if-guard skipped the upload). Distinct from a missing job.
+                cell = '⚠️ artifact missing';
               } else {
                 cell = '⚠️ unavailable';
               }

--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -70,11 +70,17 @@ jobs:
               core.info(`Could not fetch PR #${prNumber}: ${e.message}`);
               return;
             }
-            if (pr.data.head.sha !== run.head_sha) {
+            // run.head_sha is the PR branch head for pull_request runs, but may
+            // be the test-merge commit in some environments — accept either so a
+            // legitimate run is never refused, while a forged pr-number pointing
+            // at an unrelated PR (whose head/merge SHAs the attacker cannot
+            // control) still fails.
+            const runSha = run.head_sha;
+            if (runSha !== pr.data.head.sha && runSha !== pr.data.merge_commit_sha) {
               core.info(
-                `PR #${prNumber} head ${pr.data.head.sha} does not match run head ` +
-                `${run.head_sha}; refusing to comment (forged pr-number or ` +
-                `superseded run).`,
+                `PR #${prNumber} (head ${pr.data.head.sha}, merge ` +
+                `${pr.data.merge_commit_sha}) does not match run head ${runSha}; ` +
+                `refusing to comment (forged pr-number or superseded run).`,
               );
               return;
             }
@@ -105,7 +111,8 @@ jobs:
             const jobByName = new Map(jobsResp.data.jobs.map(j => [j.name, j]));
 
             // 4. Render one row per platform.
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
+            const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+            const runUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
             const rows = PLATFORMS.map(p => {
               const artifact = artifactByName.get(p.artifact);
               const job = jobByName.get(p.job);

--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -20,6 +20,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # issues: write — PR conversation comments go through the issues-comment
+      # API; pull-requests: write covers PR targets, but issues: write guarantees
+      # no 403 on this post-merge-only path.
+      issues: write
       actions: read
     steps:
       # First-party download of the pr-number artifact from the CI run onto disk.
@@ -52,6 +56,26 @@ jobs:
             const prNumber = parseInt(fs.readFileSync(prPath, 'utf8').trim(), 10);
             if (!Number.isInteger(prNumber)) {
               core.info('pr-number artifact did not contain a valid integer.');
+              return;
+            }
+
+            // 1b. Verify the PR corresponds to this run. The pr-number artifact
+            // is produced by the untrusted PR run, so a malicious PR could forge
+            // a different number to make this trusted job comment on an unrelated
+            // PR. Confirm the PR's head SHA matches the run's before trusting it.
+            let pr;
+            try {
+              pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            } catch (e) {
+              core.info(`Could not fetch PR #${prNumber}: ${e.message}`);
+              return;
+            }
+            if (pr.data.head.sha !== run.head_sha) {
+              core.info(
+                `PR #${prNumber} head ${pr.data.head.sha} does not match run head ` +
+                `${run.head_sha}; refusing to comment (forged pr-number or ` +
+                `superseded run).`,
+              );
               return;
             }
 
@@ -136,7 +160,12 @@ jobs:
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
             );
-            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            // Match only our own bot's marked comment so a human quoting the
+            // marker can never be overwritten.
+            const existing = comments.find(c =>
+              c.user && c.user.login === 'github-actions[bot]' &&
+              c.body && c.body.includes(MARKER),
+            );
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
               core.info(`Updated comment ${existing.id} on PR #${prNumber}.`);

--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -1,0 +1,138 @@
+name: PR artifact links
+
+on:
+  workflow_run:
+    workflows: ["CI/CD"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-links:
+    name: Post artifact links to PR
+    runs-on: ubuntu-latest
+    # PR runs only; a run cancelled by cancel-in-progress leaves the last-good
+    # comment untouched (the newer run will update it).
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      # First-party download of the pr-number artifact from the CI run onto disk.
+      # github-script has no bundled unzip, so we do not decode the artifact zip
+      # inline. continue-on-error so a CI run that died before emitting pr-number
+      # does not fail this workflow.
+      - name: Download pr-number artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./pr-meta
+
+      - name: Upsert artifact-links comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+
+            // 1. Resolve the PR number from the downloaded artifact.
+            const prPath = './pr-meta/pr-number.txt';
+            if (!fs.existsSync(prPath)) {
+              core.info('No pr-number artifact; nothing to comment on.');
+              return;
+            }
+            const prNumber = parseInt(fs.readFileSync(prPath, 'utf8').trim(), 10);
+            if (!Number.isInteger(prNumber)) {
+              core.info('pr-number artifact did not contain a valid integer.');
+              return;
+            }
+
+            // 2. Platform -> job name + artifact name + display label.
+            const PLATFORMS = [
+              { label: 'Android (APK)', job: 'Build Android', artifact: 'android-apk' },
+              { label: 'macOS',         job: 'Build macOS',   artifact: 'macos-build' },
+              { label: 'Windows',       job: 'Build Windows', artifact: 'windows-build' },
+              { label: 'Linux',         job: 'Build Linux',   artifact: 'linux-build' },
+            ];
+
+            // 3. List this run's artifacts and jobs.
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const artifactByName = new Map(artifacts.map(a => [a.name, a]));
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const jobByName = new Map(jobs.map(j => [j.name, j]));
+
+            // 4. Render one row per platform.
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
+            const rows = PLATFORMS.map(p => {
+              const artifact = artifactByName.get(p.artifact);
+              const job = jobByName.get(p.job);
+              let cell;
+              if (artifact) {
+                cell = `[${p.artifact}](${runUrl}/artifacts/${artifact.id})`;
+              } else if (job && job.conclusion === 'failure') {
+                cell = `❌ [build failed](${job.html_url})`;
+              } else if (job && (job.conclusion === 'cancelled' || job.conclusion === 'skipped')) {
+                cell = '⚠️ skipped';
+              } else {
+                cell = '⚠️ unavailable';
+              }
+              return `| ${p.label} | ${cell} |`;
+            }).join('\n');
+
+            // Skip entirely if there is nothing useful to report.
+            const anyArtifact = PLATFORMS.some(p => artifactByName.has(p.artifact));
+            const anyFailure = PLATFORMS.some(p => {
+              const j = jobByName.get(p.job);
+              return j && j.conclusion === 'failure';
+            });
+            if (!anyArtifact && !anyFailure) {
+              core.info('No build artifacts and no build failures; skipping comment.');
+              return;
+            }
+
+            // 5. Build the comment body with the hidden sticky marker.
+            const MARKER = '<!-- submersion-artifact-links -->';
+            const shortSha = run.head_sha.substring(0, 7);
+            const body = [
+              `**📦 Build artifacts for this PR** · commit \`${shortSha}\``,
+              '',
+              '| Platform | Download |',
+              '| --- | --- |',
+              rows,
+              '',
+              'Artifacts expire in 7 days. Downloading requires being signed in to GitHub. ' +
+              'The macOS build is ad-hoc signed — right-click → Open on first launch.',
+              '',
+              '<sub>Updated automatically on each push.</sub>',
+              '',
+              MARKER,
+            ].join('\n');
+
+            // 6. Upsert: update the existing marked comment, else create one.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated comment ${existing.id} on PR #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              core.info(`Created comment on PR #${prNumber}.`);
+            }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -543,7 +543,9 @@ jobs:
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v7
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.ref == 'refs/heads/main' && github.event_name == 'push')
         with:
           name: macos-build
           path: build/macos/Build/Products/Release/submersion.app
@@ -640,7 +642,9 @@ jobs:
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v7
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.ref == 'refs/heads/main' && github.event_name == 'push')
         with:
           name: android-apk
           path: build/app/outputs/flutter-apk/app-release.apk
@@ -713,7 +717,9 @@ jobs:
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v7
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.ref == 'refs/heads/main' && github.event_name == 'push')
         with:
           name: linux-build
           path: build/linux/x64/release/bundle
@@ -787,11 +793,27 @@ jobs:
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.ref == 'refs/heads/main' && github.event_name == 'push')
         with:
           name: windows-build
           path: build\windows\x64\runner\Release
           retention-days: 7
+
+  pr-number:
+    name: Record PR number
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write PR number to file
+        run: echo "${{ github.event.number }}" > pr-number.txt
+      - name: Upload PR number artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-number
+          path: pr-number.txt
+          retention-days: 1
 
   # Single aggregation gate. Because the build jobs now run in parallel with the
   # test shards (needs: codegen, not needs: test), a green build no longer

--- a/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
+++ b/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
@@ -204,18 +204,21 @@ jobs:
               { label: 'Linux',         job: 'Build Linux',   artifact: 'linux-build' },
             ];
 
-            // 3. List this run's artifacts and jobs.
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              { owner, repo, run_id: run.id, per_page: 100 },
+            // 3. List this run's artifacts and jobs. Both Actions endpoints
+            // return { total_count, artifacts|jobs: [...] }; read the namespaced
+            // array off .data directly (unambiguous, unlike paginate's response
+            // normalization). per_page: 100 covers this run's counts.
+            const artifactsResp = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: run.id, per_page: 100,
+            });
+            const artifactByName = new Map(
+              artifactsResp.data.artifacts.map(a => [a.name, a]),
             );
-            const artifactByName = new Map(artifacts.map(a => [a.name, a]));
 
-            const jobs = await github.paginate(
-              github.rest.actions.listJobsForWorkflowRun,
-              { owner, repo, run_id: run.id, per_page: 100 },
-            );
-            const jobByName = new Map(jobs.map(j => [j.name, j]));
+            const jobsResp = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 100,
+            });
+            const jobByName = new Map(jobsResp.data.jobs.map(j => [j.name, j]));
 
             // 4. Render one row per platform.
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
@@ -229,6 +232,8 @@ jobs:
                 cell = `❌ [build failed](${job.html_url})`;
               } else if (job && (job.conclusion === 'cancelled' || job.conclusion === 'skipped')) {
                 cell = '⚠️ skipped';
+              } else if (job && job.conclusion === 'success') {
+                cell = '⚠️ artifact missing';
               } else {
                 cell = '⚠️ unavailable';
               }

--- a/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
+++ b/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
@@ -1,0 +1,381 @@
+# PR Build Artifact Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Post an auto-updating comment on every PR (including fork PRs) with download links to the Android, macOS, Windows, and Linux build artifacts.
+
+**Architecture:** Two workflows. `ci.yaml` (unchanged trigger `pull_request`) starts uploading its four testable build artifacts on PRs and emits the PR number as a `pr-number` artifact. A new `artifact-links.yml`, triggered on `workflow_run` completion of "CI/CD", runs in the trusted base-repo context, reads the PR number, lists the run's artifacts and jobs, and upserts a single "sticky" comment.
+
+**Tech Stack:** GitHub Actions YAML; first-party actions `actions/upload-artifact@v7`, `actions/download-artifact@v4`, `actions/github-script@v7`.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md`
+
+## Global Constraints
+
+- **First-party actions only** in the write-capable `workflow_run` context — no third-party action (supply-chain rule from `CLAUDE.md`).
+- **Pin actions by version tag** (`@v7`, `@v4`), matching the existing `ci.yaml` house style — not by SHA.
+- **PR artifact retention: 7 days**, matching the existing main-push `retention-days: 7`.
+- **iOS is excluded** — `ios-build` stays `main`-push-only (unsigned, not sideloadable).
+- **Sticky-comment marker (exact):** `<!-- submersion-artifact-links -->`
+- **Least privilege** for the `workflow_run` job: `contents: read`, `pull-requests: write`, `actions: read`.
+- **Workflow the second file listens for (exact):** `CI/CD` (the `name:` of `ci.yaml`).
+- All YAML must parse cleanly (`python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"`).
+
+## File Structure
+
+- **Modify** `.github/workflows/ci.yaml`
+  - Widen the `if:` guard on the four testable `upload-artifact` steps so they also upload on PRs.
+  - Add one new `pr-number` job that writes `${{ github.event.number }}` to a file and uploads it as the `pr-number` artifact.
+- **Create** `.github/workflows/artifact-links.yml`
+  - The `workflow_run`-triggered commenter: one `download-artifact` step + one `github-script` step.
+
+---
+
+### Task 1: Wire PR artifact uploads and PR-number emission in `ci.yaml`
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (four `if:` guards at lines 546, 643, 716, 790; new job inserted before `ci-success:` ~line 804)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: on `pull_request` runs of "CI/CD", the artifacts `android-apk`, `macos-build`, `windows-build`, `linux-build`, and `pr-number` (a text file containing the PR number). These names are consumed by Task 2.
+
+**Note on the guard lines:** the `if:` for the macOS/Android/Linux/Windows uploads currently reads `github.ref == 'refs/heads/main' && github.event_name == 'push'`. The iOS upload (around line 438, `name: ios-build`) uses the **same** string but must be left unchanged — so edit by locating each guard adjacent to the correct `name:` rather than blind find-replace.
+
+- [ ] **Step 1: Write the failing assertion**
+
+Create a throwaway check that the four testable uploads are NOT yet PR-enabled (this fails after we edit, confirming the edit landed). Run:
+
+```bash
+cd .github/workflows
+# Expect: 5 lines still using the old main-only guard (4 testable + iOS) BEFORE the edit
+grep -c "github.ref == 'refs/heads/main' && github.event_name == 'push'" ci.yaml
+```
+
+Expected now: `5`. After Step 3 it must become `1` (iOS only).
+
+- [ ] **Step 2: Widen the four testable upload guards**
+
+For each of the four upload steps whose `name:` is `macos-build`, `android-apk`, `linux-build`, and `windows-build`, replace the single-line guard:
+
+```yaml
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+```
+
+with:
+
+```yaml
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.ref == 'refs/heads/main' && github.event_name == 'push')
+```
+
+Leave the `ios-build` upload's guard exactly as it was.
+
+- [ ] **Step 3: Add the `pr-number` job**
+
+Insert this job into `ci.yaml` immediately before the `ci-success:` job (do NOT add it to any `needs:` list — it is not a gating check):
+
+```yaml
+  pr-number:
+    name: Record PR number
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write PR number to file
+        run: echo "${{ github.event.number }}" > pr-number.txt
+      - name: Upload PR number artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-number
+          path: pr-number.txt
+          retention-days: 1
+```
+
+- [ ] **Step 4: Verify the edits**
+
+```bash
+cd .github/workflows
+python3 -c "import yaml,sys; yaml.safe_load(open('ci.yaml')); print('yaml ok')"
+# Only iOS keeps the old main-only guard:
+grep -c "github.ref == 'refs/heads/main' && github.event_name == 'push'" ci.yaml   # expect 1
+# Four widened guards now present:
+grep -c "github.event_name == 'pull_request' ||" ci.yaml                            # expect 4
+# The new job exists:
+grep -c "name: Record PR number" ci.yaml                                            # expect 1
+grep -A0 "name: pr-number" ci.yaml                                                  # artifact name present
+```
+
+Expected: `yaml ok`, then `1`, `4`, `1`, and the `pr-number` artifact line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yaml
+git commit -m "ci: upload testable build artifacts and PR number on pull requests"
+```
+
+---
+
+### Task 2: Create the `artifact-links.yml` commenter workflow
+
+**Files:**
+- Create: `.github/workflows/artifact-links.yml`
+
+**Interfaces:**
+- Consumes (from Task 1): artifacts `android-apk`, `macos-build`, `windows-build`, `linux-build`, `pr-number`; job names `Build Android`, `Build macOS`, `Build Windows`, `Build Linux`; the workflow name `CI/CD`.
+- Produces: a sticky PR comment carrying the marker `<!-- submersion-artifact-links -->`.
+
+- [ ] **Step 1: Write the failing assertion**
+
+```bash
+test -f .github/workflows/artifact-links.yml && echo "exists" || echo "missing"
+```
+
+Expected now: `missing`.
+
+- [ ] **Step 2: Create the workflow file**
+
+Write `.github/workflows/artifact-links.yml` with exactly this content:
+
+```yaml
+name: PR artifact links
+
+on:
+  workflow_run:
+    workflows: ["CI/CD"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-links:
+    name: Post artifact links to PR
+    runs-on: ubuntu-latest
+    # PR runs only; a run cancelled by cancel-in-progress leaves the last-good
+    # comment untouched (the newer run will update it).
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      # First-party download of the pr-number artifact from the CI run onto disk.
+      # github-script has no bundled unzip, so we do not decode the artifact zip
+      # inline. continue-on-error so a CI run that died before emitting pr-number
+      # does not fail this workflow.
+      - name: Download pr-number artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./pr-meta
+
+      - name: Upsert artifact-links comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+
+            // 1. Resolve the PR number from the downloaded artifact.
+            const prPath = './pr-meta/pr-number.txt';
+            if (!fs.existsSync(prPath)) {
+              core.info('No pr-number artifact; nothing to comment on.');
+              return;
+            }
+            const prNumber = parseInt(fs.readFileSync(prPath, 'utf8').trim(), 10);
+            if (!Number.isInteger(prNumber)) {
+              core.info('pr-number artifact did not contain a valid integer.');
+              return;
+            }
+
+            // 2. Platform -> job name + artifact name + display label.
+            const PLATFORMS = [
+              { label: 'Android (APK)', job: 'Build Android', artifact: 'android-apk' },
+              { label: 'macOS',         job: 'Build macOS',   artifact: 'macos-build' },
+              { label: 'Windows',       job: 'Build Windows', artifact: 'windows-build' },
+              { label: 'Linux',         job: 'Build Linux',   artifact: 'linux-build' },
+            ];
+
+            // 3. List this run's artifacts and jobs.
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const artifactByName = new Map(artifacts.map(a => [a.name, a]));
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const jobByName = new Map(jobs.map(j => [j.name, j]));
+
+            // 4. Render one row per platform.
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
+            const rows = PLATFORMS.map(p => {
+              const artifact = artifactByName.get(p.artifact);
+              const job = jobByName.get(p.job);
+              let cell;
+              if (artifact) {
+                cell = `[${p.artifact}](${runUrl}/artifacts/${artifact.id})`;
+              } else if (job && job.conclusion === 'failure') {
+                cell = `❌ [build failed](${job.html_url})`;
+              } else if (job && (job.conclusion === 'cancelled' || job.conclusion === 'skipped')) {
+                cell = '⚠️ skipped';
+              } else {
+                cell = '⚠️ unavailable';
+              }
+              return `| ${p.label} | ${cell} |`;
+            }).join('\n');
+
+            // Skip entirely if there is nothing useful to report.
+            const anyArtifact = PLATFORMS.some(p => artifactByName.has(p.artifact));
+            const anyFailure = PLATFORMS.some(p => {
+              const j = jobByName.get(p.job);
+              return j && j.conclusion === 'failure';
+            });
+            if (!anyArtifact && !anyFailure) {
+              core.info('No build artifacts and no build failures; skipping comment.');
+              return;
+            }
+
+            // 5. Build the comment body with the hidden sticky marker.
+            const MARKER = '<!-- submersion-artifact-links -->';
+            const shortSha = run.head_sha.substring(0, 7);
+            const body = [
+              `**📦 Build artifacts for this PR** · commit \`${shortSha}\``,
+              '',
+              '| Platform | Download |',
+              '| --- | --- |',
+              rows,
+              '',
+              'Artifacts expire in 7 days. Downloading requires being signed in to GitHub. ' +
+              'The macOS build is ad-hoc signed — right-click → Open on first launch.',
+              '',
+              '<sub>Updated automatically on each push.</sub>',
+              '',
+              MARKER,
+            ].join('\n');
+
+            // 6. Upsert: update the existing marked comment, else create one.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated comment ${existing.id} on PR #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              core.info(`Created comment on PR #${prNumber}.`);
+            }
+```
+
+- [ ] **Step 3: Verify the file parses and has the required shape**
+
+```bash
+cd .github/workflows
+python3 -c "import yaml,sys; d=yaml.safe_load(open('artifact-links.yml')); print('yaml ok')"
+# Note: PyYAML parses the top-level `on:` key as boolean True; assert on triggers via grep instead.
+grep -q 'workflows: \["CI/CD"\]' artifact-links.yml && echo "trigger ok"
+grep -q "pull-requests: write" artifact-links.yml && echo "perm ok"
+grep -q "submersion-artifact-links" artifact-links.yml && echo "marker ok"
+grep -q "conclusion != 'cancelled'" artifact-links.yml && echo "guard ok"
+```
+
+Expected: `yaml ok`, `trigger ok`, `perm ok`, `marker ok`, `guard ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/artifact-links.yml
+git commit -m "ci: add PR comment with build artifact download links"
+```
+
+---
+
+### Task 3: End-to-end validation on GitHub
+
+**Files:** none (live verification).
+
+**Interfaces:** consumes the two committed workflows; produces evidence the feature works.
+
+This is the only place the `workflow_run` path can actually be exercised — it cannot run locally. Push the branch and open a real PR.
+
+> **CRITICAL — `workflow_run` runs from the default branch.** `artifact-links.yml`
+> executes the version of itself that exists on `main`, not the version on this PR
+> branch. Therefore **the commenter will NOT post on this feature's own introducing
+> PR.** On the introducing PR you can only verify the `ci.yaml` half: the four build
+> artifacts and the `pr-number` artifact appear on the run's artifacts page. Full
+> end-to-end verification (the sticky comment) requires **merging to `main` first**,
+> then opening a *subsequent* throwaway PR. Steps 2–4 below apply to that subsequent
+> PR, not the introducing one.
+
+- [ ] **Step 1: Push the branch and open a draft PR**
+
+```bash
+git push -u origin worktree-pr-artifact-links
+gh pr create --draft --fill --base main
+```
+
+- [ ] **Step 2: Wait for "CI/CD" to finish, then confirm the comment appears**
+
+```bash
+gh pr checks --watch
+```
+
+Then verify the PR has a comment containing the marker with four rows:
+
+```bash
+gh pr view --json comments --jq '.comments[].body' | grep -c "submersion-artifact-links"   # expect 1
+gh pr view --json comments --jq '.comments[].body' | grep -E "android-apk|macos-build|windows-build|linux-build"
+```
+
+Expected: one marked comment; four platform links present. Manually click one link (e.g. `android-apk`) and confirm it downloads.
+
+- [ ] **Step 3: Confirm the sticky comment updates in place on a new commit**
+
+```bash
+git commit --allow-empty -m "chore: trigger CI to test sticky comment update"
+git push
+gh pr checks --watch
+gh pr view --json comments --jq '[.comments[].body | select(contains("submersion-artifact-links"))] | length'   # expect 1 (not 2)
+```
+
+Expected: still exactly **one** marked comment (updated in place, no duplicate), now referencing the newer commit's short SHA.
+
+- [ ] **Step 4: (Optional) Confirm the failure path**
+
+Temporarily break one platform build (e.g., introduce a compile error touched only by the Linux bundle step), push, and confirm that platform's row renders `❌ build failed` linking to the job logs while the others still link. Revert the break afterward.
+
+- [ ] **Step 5: Mark the PR ready and record the result**
+
+Once verified, `gh pr ready`. Note in the PR description that artifact links are posted automatically.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Fork-safe two-workflow architecture → Task 1 (`pr-number` artifact) + Task 2 (`workflow_run` trigger). ✓
+- Upload four testable platforms on PRs; iOS excluded → Task 1 Step 2 (four guards; iOS untouched). ✓
+- `pr-number` handoff across trust boundary → Task 1 Step 3 + Task 2 download step. ✓
+- Self-contained first-party `github-script`; no third-party in write context → Task 2. ✓
+- Sticky comment via marker; rewrite each push → Task 2 Step 2 (upsert) + Task 3 Step 3 (verified). ✓
+- `❌ build failed` linking to job logs → Task 2 render logic. ✓
+- Cancelled-run guard → Task 2 job `if:` (`conclusion != 'cancelled'`). ✓
+- Least-privilege permissions → Task 2 job `permissions:`. ✓
+- 7-day retention → Task 1 (guards reuse existing `retention-days: 7`). ✓
+- Testing plan (test PR, second push, failure path) → Task 3. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full content. ✓
+
+**Type/name consistency:** Artifact names (`android-apk`, `macos-build`, `windows-build`, `linux-build`, `pr-number`), job names (`Build Android/macOS/Windows/Linux`), workflow name (`CI/CD`), and marker (`<!-- submersion-artifact-links -->`) are identical across Task 1 and Task 2. ✓

--- a/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
+++ b/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
@@ -210,11 +210,15 @@ jobs:
               core.info(`Could not fetch PR #${prNumber}: ${e.message}`);
               return;
             }
-            if (pr.data.head.sha !== run.head_sha) {
+            // Accept head.sha OR merge_commit_sha: pull_request runs may report
+            // the test-merge commit as run.head_sha, and refusing those would
+            // suppress the comment on every legitimate run.
+            const runSha = run.head_sha;
+            if (runSha !== pr.data.head.sha && runSha !== pr.data.merge_commit_sha) {
               core.info(
-                `PR #${prNumber} head ${pr.data.head.sha} does not match run head ` +
-                `${run.head_sha}; refusing to comment (forged pr-number or ` +
-                `superseded run).`,
+                `PR #${prNumber} (head ${pr.data.head.sha}, merge ` +
+                `${pr.data.merge_commit_sha}) does not match run head ${runSha}; ` +
+                `refusing to comment (forged pr-number or superseded run).`,
               );
               return;
             }
@@ -244,7 +248,8 @@ jobs:
             const jobByName = new Map(jobsResp.data.jobs.map(j => [j.name, j]));
 
             // 4. Render one row per platform.
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
+            const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+            const runUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
             const rows = PLATFORMS.map(p => {
               const artifact = artifactByName.get(p.artifact);
               const job = jobByName.get(p.job);

--- a/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
+++ b/docs/superpowers/plans/2026-07-16-pr-artifact-links.md
@@ -161,6 +161,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # PR comments go through the issues-comment API; issues: write avoids a
+      # 403 on this post-merge-only path.
+      issues: write
       actions: read
     steps:
       # First-party download of the pr-number artifact from the CI run onto disk.
@@ -193,6 +196,26 @@ jobs:
             const prNumber = parseInt(fs.readFileSync(prPath, 'utf8').trim(), 10);
             if (!Number.isInteger(prNumber)) {
               core.info('pr-number artifact did not contain a valid integer.');
+              return;
+            }
+
+            // 1b. Verify the PR corresponds to this run. The pr-number artifact
+            // is produced by the untrusted PR run, so a malicious PR could forge
+            // a different number to make this trusted job comment on an unrelated
+            // PR. Confirm the PR's head SHA matches the run's before trusting it.
+            let pr;
+            try {
+              pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            } catch (e) {
+              core.info(`Could not fetch PR #${prNumber}: ${e.message}`);
+              return;
+            }
+            if (pr.data.head.sha !== run.head_sha) {
+              core.info(
+                `PR #${prNumber} head ${pr.data.head.sha} does not match run head ` +
+                `${run.head_sha}; refusing to comment (forged pr-number or ` +
+                `superseded run).`,
+              );
               return;
             }
 
@@ -274,7 +297,12 @@ jobs:
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
             );
-            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            // Match only our own bot's marked comment so a human quoting the
+            // marker can never be overwritten.
+            const existing = comments.find(c =>
+              c.user && c.user.login === 'github-actions[bot]' &&
+              c.body && c.body.includes(MARKER),
+            );
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
               core.info(`Updated comment ${existing.id} on PR #${prNumber}.`);

--- a/docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md
+++ b/docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md
@@ -1,0 +1,303 @@
+# PR Build Artifact Links — Design
+
+- **Date:** 2026-07-16
+- **Status:** Approved (pending spec review)
+- **Author:** Eric Griffin (with Claude Code)
+
+## Problem
+
+Reviewers and testers have no easy way to grab a runnable build of the change in
+a pull request. To test a PR today you must check out the branch and build
+locally. We want every PR to carry links to downloadable, testable build
+artifacts (Android, macOS, Windows, Linux), automatically kept up to date as new
+commits land.
+
+Reference precedent: Subsurface's
+[`artifact-links.yml`](https://github.com/subsurface/subsurface/blob/master/.github/workflows/artifact-links.yml)
+and an [example PR comment](https://github.com/subsurface/subsurface/pull/4708#issuecomment-3856046243).
+
+## Current-state findings
+
+Established by inspecting `.github/workflows/ci.yaml` (workflow `name: CI/CD`):
+
+- CI is triggered on `push` to `main` and on `pull_request` to `main`.
+- The platform build jobs — `build-ios`, `build-macos`, `build-android`,
+  `build-linux`, `build-windows` — have **no job-level `if:` guard**, so they
+  already **run on every PR** (they `needs: codegen`, nothing more).
+- However, each `actions/upload-artifact@v7` step is gated by:
+
+  ```yaml
+  if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+  ```
+
+  So on a PR the apps **compile and are then discarded** — the binaries are
+  never uploaded.
+- Concurrency uses `cancel-in-progress: true`, so a new push cancels the
+  in-flight run for that ref.
+
+Consequence: surfacing testable artifacts on PRs costs **almost no new compute** —
+the expensive `macos-26` iOS/macOS builds already run on every PR. We only need
+to (1) upload the builds on PRs and (2) post the links.
+
+Confirmed names (used later in this spec):
+
+| Job name (`name:`) | Artifact name | PR-testable? |
+| --- | --- | --- |
+| `Build Android` | `android-apk` | Yes — directly sideloadable |
+| `Build macOS` | `macos-build` | Yes — ad-hoc signed; right-click → Open on other Macs |
+| `Build Windows` | `windows-build` | Yes — unzip and run |
+| `Build Linux` | `linux-build` | Yes — unzip and run |
+| `Build iOS` | `ios-build` | **No** — built `--no-codesign`; not sideloadable |
+
+## Goals
+
+- Every PR (including PRs from forks) gets a single comment listing download
+  links for the four testable platform builds.
+- The comment is a **sticky comment**: updated in place on each new commit, always
+  pointing at the newest run's artifacts.
+- A platform whose build **failed** shows `❌ build failed` linking to that job's
+  logs, rather than silently disappearing.
+- Least-privilege, supply-chain-conscious implementation using only first-party
+  GitHub actions.
+
+## Non-goals
+
+- Publishing an iOS artifact (unsigned, not sideloadable — deliberately excluded).
+- Code-signing / notarizing artifacts for distribution.
+- Changing what/when `main`-push uploads produce (those stay exactly as-is).
+- Any stable "latest artifact" URL — GitHub artifact URLs are inherently
+  run-scoped (see Insight in Section 3).
+
+## Architecture
+
+Two workflows, because a fork's `pull_request` run receives a **read-only**
+`GITHUB_TOKEN` and cannot comment. The commenting must happen in the base repo's
+trusted context, which is what the `workflow_run` trigger provides.
+
+```
+PR opened / updated  (same-repo OR fork)
+        │
+        ▼
+┌───────────────────────────────────────────────┐
+│  ci.yaml   (name: "CI/CD")                     │  trigger: pull_request
+│  - build-{android,macos,windows,linux} already │    (read-only token on forks)
+│    run on PRs today                            │
+│  CHANGE 1: upload those 4 artifacts on PRs     │
+│  CHANGE 2: new pr-number job emits the PR       │
+│            number as a `pr-number` artifact    │
+└───────────────────────────────────────────────┘
+        │  on: workflow_run "completed"
+        ▼
+┌───────────────────────────────────────────────┐
+│  artifact-links.yml   (NEW)                    │  trigger: workflow_run
+│  permissions: pull-requests: write,            │    (trusted base-repo token)
+│               actions: read, contents: read    │
+│  single actions/github-script step:            │
+│   - guard: event=='pull_request',              │
+│            conclusion != 'cancelled'           │
+│   - read pr-number artifact -> PR number       │
+│   - list run artifacts + list run jobs         │
+│   - render per-platform status                 │
+│   - upsert sticky comment (hidden marker)      │
+└───────────────────────────────────────────────┘
+```
+
+### Why a `pr-number` artifact instead of the event payload
+
+`github.event.workflow_run.pull_requests` is populated only for **same-repo**
+PRs; for forks it is empty. The robust, GitHub-documented pattern is to have the
+(untrusted) PR run write its own PR number to a file and upload it as an
+artifact, which the (trusted) second workflow downloads and reads. We never
+execute fork code in the trusted context, and we only trust a plain integer to
+decide *where* to comment.
+
+## Change 1 — `ci.yaml`: upload the four builds on PRs
+
+For each of the four testable upload steps (`android-apk`, `macos-build`,
+`windows-build`, `linux-build`), widen the guard so it also fires on PRs:
+
+```yaml
+if: >
+  github.event_name == 'pull_request' ||
+  (github.ref == 'refs/heads/main' && github.event_name == 'push')
+```
+
+- **iOS is left unchanged** (`ios-build` stays `main`-push only).
+- **Retention:** PR uploads use `retention-days: 7`, matching existing main-push
+  retention. (The upload steps already set `retention-days: 7`; widening the
+  `if:` reuses the same value — no separate PR retention path.)
+
+## Change 2 — `ci.yaml`: emit the PR number
+
+Add one small job (runs only on PRs; no build dependency; ~5 seconds):
+
+```yaml
+pr-number:
+  name: Record PR number
+  if: github.event_name == 'pull_request'
+  runs-on: ubuntu-latest
+  steps:
+    - run: echo "${{ github.event.number }}" > pr-number.txt
+    - uses: actions/upload-artifact@v7
+      with:
+        name: pr-number
+        path: pr-number.txt
+        retention-days: 1
+```
+
+This job is independent of the `ci-success` gate and does not affect required
+checks.
+
+## Change 3 — NEW `.github/workflows/artifact-links.yml`
+
+```yaml
+name: PR artifact links
+
+on:
+  workflow_run:
+    workflows: ["CI/CD"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-links:
+    name: Post artifact links to PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+      contents: read
+    # PR-only; superseded/cancelled runs leave the last-good comment untouched.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      # First-party download of the pr-number artifact from the OTHER run onto
+      # disk (github-script has no bundled unzip, so we do not decode the zip
+      # inline). continue-on-error so a CI run that died before emitting
+      # pr-number does not hard-fail this workflow.
+      - name: Download pr-number artifact
+        id: pr_number
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./pr-meta
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // (logic described below)
+```
+
+### `github-script` logic
+
+Given `const run = context.payload.workflow_run;`
+
+1. **Resolve the PR number.**
+   - Read `./pr-meta/pr-number.txt` (downloaded by the prior step) with
+     `fs.readFileSync` and parse the integer. If the file is missing (the
+     download step was skipped/failed), exit quietly — nothing to comment on.
+2. **Gather per-platform status.**
+   - `actions.listJobsForWorkflowRun(run.id)` → map job `name` → `{conclusion,
+     html_url}` for `Build Android`, `Build macOS`, `Build Windows`,
+     `Build Linux`.
+   - From the artifact list, map artifact `name` → per-artifact download URL:
+     `https://github.com/<owner>/<repo>/actions/runs/<run.id>/artifacts/<artifact.id>`.
+3. **Render each platform row** (order: Android, macOS, Windows, Linux):
+
+   | Job conclusion | Artifact present | Cell renders |
+   | --- | --- | --- |
+   | `success` | yes | `[<artifact-name>](<download URL>)` |
+   | `failure` | (no) | `❌ [build failed](<job html_url>)` |
+   | `cancelled` / `skipped` (single job) | (no) | `⚠️ skipped` |
+   | `success` | no (unexpected) | `⚠️ artifact missing` |
+
+4. **Upsert the sticky comment.**
+   - Marker: `<!-- submersion-artifact-links -->` (hidden HTML comment).
+   - `issues.listComments(pr)` → find the comment authored by the bot whose body
+     contains the marker.
+   - If found → `issues.updateComment`; else → `issues.createComment`.
+
+### Rendered comment (approximate)
+
+> **📦 Build artifacts for this PR** &nbsp;·&nbsp; commit `abc1234`
+>
+> | Platform | Download |
+> | --- | --- |
+> | Android (APK) | [android-apk](…) |
+> | macOS | [macos-build](…) |
+> | Windows | ❌ [build failed](…job logs…) |
+> | Linux | [linux-build](…) |
+>
+> Artifacts expire in 7 days. Downloading requires being signed in to GitHub.
+> The macOS build is ad-hoc signed — right-click → Open on first launch.
+> <sub>Updated automatically on each push.</sub>
+>
+> `<!-- submersion-artifact-links -->`
+
+### Why the comment is rewritten every push (not left alone)
+
+GitHub artifact download URLs are **run-scoped**: every artifact lives under a
+specific `run_id`, and there is no stable "latest artifact for platform X on this
+PR" URL. Each new commit produces a new run with new `artifact_id`s and therefore
+new URLs, so the whole comment body must be regenerated to keep the links live.
+
+## Error handling & edge cases
+
+- **Fork PRs:** handled by the `pr-number` artifact handoff; no fork code runs in
+  the trusted context; the second workflow always runs in the base repo with a
+  write token.
+- **Superseded run (cancelled by `cancel-in-progress`):** the job-level guard
+  `conclusion != 'cancelled'` skips it entirely, leaving the last-good comment
+  intact. The newer run will update the comment when it completes.
+- **Partial build failure:** the failing platform shows `❌ build failed` linked
+  to its job logs; other platforms still show working links.
+- **CI fails before any upload / no `pr-number` artifact:** the script exits
+  quietly without creating an empty comment.
+- **Multiple pushes in quick succession:** each real completion updates the same
+  sticky comment; only the latest survives.
+
+## Security considerations
+
+- **Trust boundary:** untrusted PR code runs only in the `pull_request` context
+  (read-only token on forks). All write operations occur in the `workflow_run`
+  context, which uses the base repo's trusted token and never checks out or
+  executes PR code.
+- **Least privilege:** the `workflow_run` job requests only
+  `pull-requests: write`, `actions: read`, `contents: read`.
+- **First-party only:** commenting uses `actions/github-script@v7` (GitHub-
+  maintained) — no third-party action in the write-capable context. This matches
+  the repo convention of referencing actions by version tag and satisfies the
+  project's supply-chain caution (`CLAUDE.md` Security rules).
+- **Data trusted across the boundary:** only a parsed integer (the PR number)
+  from the `pr-number` artifact.
+
+## Testing / validation
+
+CI infra is validated on GitHub, not locally:
+
+1. Lint both YAML files (`actionlint` if available; otherwise YAML syntax check).
+2. Open a throwaway **same-repo** test PR → confirm the sticky comment appears
+   with four working links.
+3. Push a second commit → confirm the **same** comment updates in place (no
+   duplicate) and links point at the newer run.
+4. Induce a single-platform build failure (temporary) → confirm that platform
+   renders `❌ build failed` linking to the job logs while others still link.
+5. If feasible, a **fork** PR smoke test to confirm the fork path comments
+   correctly.
+
+## Rollout
+
+- Purely additive to CI: one new workflow file, one widened `if:` on four upload
+  steps, one small new job. No change to existing `main`-push behavior or to
+  required status checks.
+- Reversible by reverting the two files.
+- **`workflow_run` runs from the default branch.** `artifact-links.yml` executes
+  the copy of itself on `main`, so it does **not** comment on its own introducing
+  PR. The `ci.yaml` changes (uploads + `pr-number`) do run on the introducing PR,
+  but the sticky comment only begins appearing on PRs opened **after** this merges
+  to `main`. Plan for a post-merge test PR to confirm end-to-end behavior.

--- a/docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md
+++ b/docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md
@@ -205,7 +205,9 @@ Given `const run = context.payload.workflow_run;`
    - **Verify the PR belongs to this run.** The `pr-number` artifact is produced
      by the untrusted PR run, so a fork could forge a different number to make
      this trusted job comment on an unrelated PR. Fetch the PR (`pulls.get`) and
-     confirm `pr.head.sha === run.head_sha`; otherwise exit without commenting.
+     confirm `run.head_sha` matches `pr.head.sha` **or** `pr.merge_commit_sha`
+     (accepting either avoids refusing legitimate runs where the run SHA is the
+     test-merge commit); otherwise exit without commenting.
 2. **Gather per-platform status.**
    - `actions.listJobsForWorkflowRun(run.id)` → map job `name` → `{conclusion,
      html_url}` for `Build Android`, `Build macOS`, `Build Windows`,
@@ -278,8 +280,11 @@ new URLs, so the whole comment body must be regenerated to keep the links live.
   (`issues: write` is included because PR comments go through the issues-comment
   API; it prevents a 403 on this post-merge-only path.)
 - **PR-target binding:** before commenting, the job fetches the PR and requires
-  `pr.head.sha === run.head_sha`. This defeats a forged `pr-number` from an
-  untrusted PR run trying to redirect the comment to an unrelated PR.
+  `run.head_sha` to equal `pr.head.sha` or `pr.merge_commit_sha`. This defeats a
+  forged `pr-number` from an untrusted PR run trying to redirect the comment to
+  an unrelated PR (an attacker cannot make their run's SHA equal an unrelated
+  PR's head or merge SHA), while accepting the test-merge SHA that some
+  `pull_request` runs report.
 - **Author-restricted upsert:** only a comment authored by `github-actions[bot]`
   and carrying the marker is updated, so a human comment quoting the marker is
   never overwritten.

--- a/docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md
+++ b/docs/superpowers/specs/2026-07-16-pr-artifact-links-design.md
@@ -167,6 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
       actions: read
       contents: read
     # PR-only; superseded/cancelled runs leave the last-good comment untouched.
@@ -201,6 +202,10 @@ Given `const run = context.payload.workflow_run;`
    - Read `./pr-meta/pr-number.txt` (downloaded by the prior step) with
      `fs.readFileSync` and parse the integer. If the file is missing (the
      download step was skipped/failed), exit quietly — nothing to comment on.
+   - **Verify the PR belongs to this run.** The `pr-number` artifact is produced
+     by the untrusted PR run, so a fork could forge a different number to make
+     this trusted job comment on an unrelated PR. Fetch the PR (`pulls.get`) and
+     confirm `pr.head.sha === run.head_sha`; otherwise exit without commenting.
 2. **Gather per-platform status.**
    - `actions.listJobsForWorkflowRun(run.id)` → map job `name` → `{conclusion,
      html_url}` for `Build Android`, `Build macOS`, `Build Windows`,
@@ -218,8 +223,9 @@ Given `const run = context.payload.workflow_run;`
 
 4. **Upsert the sticky comment.**
    - Marker: `<!-- submersion-artifact-links -->` (hidden HTML comment).
-   - `issues.listComments(pr)` → find the comment authored by the bot whose body
-     contains the marker.
+   - `issues.listComments(pr)` → find the comment **authored by
+     `github-actions[bot]`** whose body contains the marker (author-restricted so
+     a human quoting the marker cannot be overwritten).
    - If found → `issues.updateComment`; else → `issues.createComment`.
 
 ### Rendered comment (approximate)
@@ -268,7 +274,15 @@ new URLs, so the whole comment body must be regenerated to keep the links live.
   context, which uses the base repo's trusted token and never checks out or
   executes PR code.
 - **Least privilege:** the `workflow_run` job requests only
-  `pull-requests: write`, `actions: read`, `contents: read`.
+  `pull-requests: write`, `issues: write`, `actions: read`, `contents: read`.
+  (`issues: write` is included because PR comments go through the issues-comment
+  API; it prevents a 403 on this post-merge-only path.)
+- **PR-target binding:** before commenting, the job fetches the PR and requires
+  `pr.head.sha === run.head_sha`. This defeats a forged `pr-number` from an
+  untrusted PR run trying to redirect the comment to an unrelated PR.
+- **Author-restricted upsert:** only a comment authored by `github-actions[bot]`
+  and carrying the marker is updated, so a human comment quoting the marker is
+  never overwritten.
 - **First-party only:** commenting uses `actions/github-script@v7` (GitHub-
   maintained) — no third-party action in the write-capable context. This matches
   the repo convention of referencing actions by version tag and satisfies the


### PR DESCRIPTION
## Summary

Adds an auto-updating comment to every pull request with download links to the
Android, macOS, Windows, and Linux build artifacts, so reviewers can test a
change without checking out the branch and building locally. Modeled on
Subsurface's `artifact-links.yml`.

The platform builds already run on every PR today; their binaries were simply
discarded (uploads were gated to `main`-push). This wires those existing builds
up to testable download links at near-zero added compute.

## Changes

- **`ci.yaml`:** the macOS/Android/Windows/Linux `upload-artifact` steps now also
  upload on `pull_request` (previously `main`-push only). iOS is intentionally
  left out (built `--no-codesign`, not sideloadable). A small `pr-number` job
  records the PR number as an artifact so the commenter can find the PR safely
  across the fork trust boundary.
- **`artifact-links.yml` (new):** a `workflow_run`-triggered workflow that runs
  after "CI/CD" completes, in the trusted base-repo context, and upserts a single
  sticky comment. Fork-safe by design. Uses only first-party
  `actions/github-script` (no third-party action in the write-capable context).
  Per-platform status: a link when built, `❌ build failed` linking to the job
  logs when not. Runs cancelled by `cancel-in-progress` are skipped so a
  superseded build never clobbers the last-good comment.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test Plan

This change is CI-only (GitHub Actions YAML); it touches no Dart, so
`flutter test` / `flutter analyze` are not applicable.

- [x] Both workflows parse (`yaml.safe_load`); embedded github-script validates
      under `node --check` (async-wrapped, as github-script executes it).
- [x] Exactly one standalone `main`-only upload guard remains (iOS); the four
      testable guards widened to include `pull_request`.
- [x] **Post-merge validation required.** `workflow_run` executes the workflow
      definition from the **default branch**, so `artifact-links.yml` does **not**
      comment on this introducing PR. After merge, open a throwaway PR and
      confirm: the sticky comment appears with four working links; a second push
      updates the same comment in place (no duplicate); a deliberately-broken
      platform renders `❌ build failed`.

On this PR you can still confirm the `ci.yaml` half: the four build artifacts and
the `pr-number` artifact appear on the CI run's artifacts page.
