### PR TITLE
No-fly countdown and safety hub (safety features phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-no-fly-countdown.md
+++ b/docs/superpowers/plans/2026-07-17-no-fly-countdown.md
@@ -4,14 +4,14 @@
 
 **Goal:** DAN/UHMS guideline no-fly countdown surfaced on the dashboard and a new Safety hub, plus the altitude-UX flag from the spec.
 
-**Architecture:** Pure `NoFlyService` classifier over a lightweight trailing-window dive query (end time + had-deco flag from `dive_profiles.deco_type`/`ceiling` aggregates). New `lib/features/safety/` slice hosts the hub page. Settings gain a conservatism preset (schema v117). Spec: `docs/superpowers/specs/2026-07-16-safety-features-design.md` Phase 2.
+**Architecture:** Pure `NoFlyService` classifier over a lightweight trailing-window dive query (end time + had-deco flag from `dive_profiles.deco_type`/`ceiling` aggregates). New `lib/features/safety/` slice hosts the hub page. Settings gain a conservatism preset (schema v124, renumbered from v117 when main advanced past it at merge time). Spec: `docs/superpowers/specs/2026-07-16-safety-features-design.md` Phase 2.
 
 **Tech Stack:** Flutter, Drift, Riverpod, go_router. Branch `safety-phase2-no-fly` stacked on `worktree-safety-features`.
 
 ## Global Constraints
 
 - Same as Phase 1 plan (worktree-only, `dart format .` before commits, tests by file, no emojis, l10n all 11 locales, units respect diver settings, commit per task, no attribution lines).
-- Schema: claim **v117** (v116 = phase 1). Update the exact-latest tripwire and `migrationVersions`.
+- Schema: **v124** (renumbered from the originally-claimed v117 as main advanced past it at merge time; v123 = phase 1 safety review). Update the exact-latest tripwire and `migrationVersions`.
 - Spec deviations (documented in spec): the educational tissue view is a labeled link to the existing Surface Interval tool (its chart is hardwired to its own input providers; seeding from a recorded dive is a follow-up). Planner altitude surfacing already exists (`plan_settings_panel.dart` `_AltitudeInput`); no planner change needed. No-fly expiry notification (stretch, off by default) is deferred.
 
 ## Tasks

--- a/docs/superpowers/plans/2026-07-17-no-fly-countdown.md
+++ b/docs/superpowers/plans/2026-07-17-no-fly-countdown.md
@@ -1,0 +1,45 @@
+# Flying-After-Diving (Safety Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** DAN/UHMS guideline no-fly countdown surfaced on the dashboard and a new Safety hub, plus the altitude-UX flag from the spec.
+
+**Architecture:** Pure `NoFlyService` classifier over a lightweight trailing-window dive query (end time + had-deco flag from `dive_profiles.deco_type`/`ceiling` aggregates). New `lib/features/safety/` slice hosts the hub page. Settings gain a conservatism preset (schema v117). Spec: `docs/superpowers/specs/2026-07-16-safety-features-design.md` Phase 2.
+
+**Tech Stack:** Flutter, Drift, Riverpod, go_router. Branch `safety-phase2-no-fly` stacked on `worktree-safety-features`.
+
+## Global Constraints
+
+- Same as Phase 1 plan (worktree-only, `dart format .` before commits, tests by file, no emojis, l10n all 11 locales, units respect diver settings, commit per task, no attribution lines).
+- Schema: claim **v117** (v116 = phase 1). Update the exact-latest tripwire and `migrationVersions`.
+- Spec deviations (documented in spec): the educational tissue view is a labeled link to the existing Surface Interval tool (its chart is hardwired to its own input providers; seeding from a recorded dive is a follow-up). Planner altitude surfacing already exists (`plan_settings_panel.dart` `_AltitudeInput`); no planner change needed. No-fly expiry notification (stretch, off by default) is deferred.
+
+## Tasks
+
+### Task 1: NoFlyService (pure classifier)
+- Create `lib/features/safety/domain/services/no_fly_service.dart`, test `test/features/safety/domain/services/no_fly_service_test.dart`.
+- Produces: `enum NoFlyPreset { standard, strict }` (dbValue/fromDbValue), `enum NoFlyCategory { single, repetitive, deco }`, `class NoFlyDiveInput { DateTime endTime; bool hadDecoObligation; }`, `class NoFlyStatus { DateTime until; NoFlyCategory category; Duration remaining(DateTime now); }`,
+  `class NoFlyService { static const lookback = Duration(hours: 48); NoFlyStatus? evaluate({required List<NoFlyDiveInput> dives, required NoFlyPreset preset, required DateTime now}); }`.
+- Rules: dives ending within `lookback` of `now`; none → null. Category: any deco → deco; else >1 dive in window OR dives spanning >1 calendar day → repetitive; else single. Intervals: standard 12/18/24 h, strict 18/24/48 h from the latest dive end. Returns null when `until <= now`.
+- TDD: single no-deco, two dives, deco dive, strict preset, expired, empty.
+
+### Task 2: Trailing-window dive query + provider
+- Modify `dive_repository_impl.dart`: `Future<List<NoFlyDiveInput>> getNoFlyDiveInputs({required DateTime since, String? diverId})` — SQL over `dives d`: end ms = `COALESCE(d.exit_time, COALESCE(d.entry_time, d.dive_date_time) + COALESCE(d.runtime,0)*1000)`; filter end >= since; deco flag = `EXISTS(SELECT 1 FROM dive_profiles p WHERE p.dive_id = d.id AND (p.deco_type = 2 OR p.ceiling > 0))`.
+- Create `lib/features/safety/presentation/providers/no_fly_providers.dart`: `noFlyStatusProvider = FutureProvider<NoFlyStatus?>` (reads repository + `settingsProvider.noFlyPreset`, `DateTime.now()`), self-invalidating on dive changes via `watchDivesChanges` tick (mirror existing usage) with a periodic-ish recompute left to consumers.
+- Test: repository test with in-memory DB (deco vs no-deco profiles, window filtering).
+
+### Task 3: Settings preset (schema v117)
+- `DiverSettings.noFlyPreset` text default 'standard'; migration `_assertNoFlySettingsColumn()` in onUpgrade `if (from < 117)` + beforeOpen backstop; bump `currentSchemaVersion` 116→117; append 117 to `migrationVersions`; update tripwire test.
+- `AppSettings.noFlyPreset` (NoFlyPreset, default standard) + copyWith + notifier `setNoFlyPreset` + repository row mapping + MockSettingsNotifier stubs (all 4 mock sites) + notifier test.
+- Safety settings page: preset selector (SegmentedButton or dropdown) under a "Flying after diving" header.
+
+### Task 4: Safety hub page + routes + dashboard surfacing
+- Create `lib/features/safety/presentation/pages/safety_hub_page.dart`: no-fly status card (countdown "until <time>", category label, guideline text, or all-clear), educational link to `/planning/surface-interval`, link to safety settings. Route `/safety` (name `safety`) as a direct child of the root ShellRoute (mirror `/gps-log`).
+- Dashboard: add `noFlyUntil`/`noFlyCategory` to `DashboardAlerts` + provider population + `_alertText`/`_onTap` (route to `/safety`) in alerts_card. Not counted as a "problem" alert? It IS an alert (spec: ambient visibility) — include in hasAlerts/alertCount while active.
+- Widget test for hub page with overridden providers.
+
+### Task 5: Altitude flag in dive detail
+- In `_buildAltitudeSection` / section builder: when `dive.altitude == null && (dive.site?.altitude ?? 0) > 100` show an informational row (site is at altitude, dive not altitude-adjusted; link opens edit). When `dive.altitude` set, unchanged behavior. Adjust altitude section builder gating accordingly. Widget-level test optional; unit-test the predicate helper.
+
+### Task 6: l10n sweep + verification
+- All new strings into `app_en.arb` + 10 locales; `flutter gen-l10n`; `dart format .`; `flutter analyze`; run new + neighboring test files.

--- a/docs/superpowers/plans/2026-07-17-no-fly-countdown.md
+++ b/docs/superpowers/plans/2026-07-17-no-fly-countdown.md
@@ -4,14 +4,14 @@
 
 **Goal:** DAN/UHMS guideline no-fly countdown surfaced on the dashboard and a new Safety hub, plus the altitude-UX flag from the spec.
 
-**Architecture:** Pure `NoFlyService` classifier over a lightweight trailing-window dive query (end time + had-deco flag from `dive_profiles.deco_type`/`ceiling` aggregates). New `lib/features/safety/` slice hosts the hub page. Settings gain a conservatism preset (schema v124, renumbered from v117 when main advanced past it at merge time). Spec: `docs/superpowers/specs/2026-07-16-safety-features-design.md` Phase 2.
+**Architecture:** Pure `NoFlyService` classifier over a lightweight trailing-window dive query (end time + had-deco flag from `dive_profiles.deco_type`/`ceiling` aggregates). New `lib/features/safety/` slice hosts the hub page. Settings gain a conservatism preset (schema v125, renumbered from v117/v124 as main advanced past it at merge time). Spec: `docs/superpowers/specs/2026-07-16-safety-features-design.md` Phase 2.
 
 **Tech Stack:** Flutter, Drift, Riverpod, go_router. Branch `safety-phase2-no-fly` stacked on `worktree-safety-features`.
 
 ## Global Constraints
 
 - Same as Phase 1 plan (worktree-only, `dart format .` before commits, tests by file, no emojis, l10n all 11 locales, units respect diver settings, commit per task, no attribution lines).
-- Schema: **v124** (renumbered from the originally-claimed v117 as main advanced past it at merge time; v123 = phase 1 safety review). Update the exact-latest tripwire and `migrationVersions`.
+- Schema: **v125** (renumbered from the originally-claimed v117 as main advanced past it at merge time; v123 = phase 1 safety review, v124 = equipment attributes). Update the exact-latest tripwire and `migrationVersions`.
 - Spec deviations (documented in spec): the educational tissue view is a labeled link to the existing Surface Interval tool (its chart is hardwired to its own input providers; seeding from a recorded dive is a follow-up). Planner altitude surfacing already exists (`plan_settings_panel.dart` `_AltitudeInput`); no planner change needed. No-fly expiry notification (stretch, off by default) is deferred.
 
 ## Tasks

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1308,7 +1308,7 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(true))();
   // JSON array of SafetyRuleId.dbValue strings; null/absent = none disabled.
   TextColumn get safetyReviewDisabledRules => text().nullable()();
-  // Flying-after-diving conservatism (NoFlyPreset.dbValue, v117).
+  // Flying-after-diving conservatism (NoFlyPreset.dbValue, v124).
   TextColumn get noFlyPreset =>
       text().withDefault(const Constant('standard'))();
   // Appearance settings
@@ -2888,7 +2888,7 @@ class AppDatabase extends _$AppDatabase {
     }
   }
 
-  /// v117: diver_settings.no_fly_preset column. Idempotent so it is safe to
+  /// v124: diver_settings.no_fly_preset column. Idempotent so it is safe to
   /// call from both onUpgrade and the beforeOpen backstop.
   Future<void> _assertNoFlySettingsColumn() async {
     final cols = await customSelect(

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1308,6 +1308,9 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(true))();
   // JSON array of SafetyRuleId.dbValue strings; null/absent = none disabled.
   TextColumn get safetyReviewDisabledRules => text().nullable()();
+  // Flying-after-diving conservatism (NoFlyPreset.dbValue, v117).
+  TextColumn get noFlyPreset =>
+      text().withDefault(const Constant('standard'))();
   // Appearance settings
   BoolColumn get showDepthColoredDiveCards =>
       boolean().withDefault(const Constant(false))();
@@ -2452,7 +2455,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 124;
+  static const int currentSchemaVersion = 125;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -2585,6 +2588,10 @@ class AppDatabase extends _$AppDatabase {
     // v124: equipment type-specific attributes (renumbered from v115/v123 as
     // main advanced past it at merge time; see schema-version ladder).
     124,
+    // v125: diver_settings.no_fly_preset column (safety phase 2, no-fly
+    // countdown). Renumbered from v117/v124 as main advanced past it at merge
+    // time.
+    125,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -2877,6 +2884,21 @@ class AppDatabase extends _$AppDatabase {
       await customStatement(
         'ALTER TABLE diver_settings ADD COLUMN safety_review_disabled_rules '
         'TEXT',
+      );
+    }
+  }
+
+  /// v117: diver_settings.no_fly_preset column. Idempotent so it is safe to
+  /// call from both onUpgrade and the beforeOpen backstop.
+  Future<void> _assertNoFlySettingsColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('diver_settings')",
+    ).get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (cols.isNotEmpty && !names.contains('no_fly_preset')) {
+      await customStatement(
+        "ALTER TABLE diver_settings ADD COLUMN no_fly_preset TEXT "
+        "NOT NULL DEFAULT 'standard'",
       );
     }
   }
@@ -6169,6 +6191,13 @@ class AppDatabase extends _$AppDatabase {
           await _migrateLegacyEquipmentColumnsToAttributes();
         }
         if (from < 124) await reportProgress();
+        // v125: diver_settings.no_fly_preset column (safety phase 2, no-fly
+        // countdown). Renumbered from v117/v124 as main advanced past it at
+        // merge time.
+        if (from < 125) {
+          await _assertNoFlySettingsColumn();
+        }
+        if (from < 125) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -6241,6 +6270,9 @@ class AppDatabase extends _$AppDatabase {
         // only -- the legacy-column copy must NOT run here, it would
         // resurrect attribute rows the user has cleared).
         await _assertEquipmentAttributesSchema();
+
+        // v125 backstop: re-assert diver_settings.no_fly_preset.
+        await _assertNoFlySettingsColumn();
 
         // Built-in dive types are reference data: identical on every device and
         // undeletable through DiveTypeRepository. Nothing else restores them --

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1308,7 +1308,7 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(true))();
   // JSON array of SafetyRuleId.dbValue strings; null/absent = none disabled.
   TextColumn get safetyReviewDisabledRules => text().nullable()();
-  // Flying-after-diving conservatism (NoFlyPreset.dbValue, v124).
+  // Flying-after-diving conservatism (NoFlyPreset.dbValue, v125).
   TextColumn get noFlyPreset =>
       text().withDefault(const Constant('standard'))();
   // Appearance settings
@@ -2888,7 +2888,7 @@ class AppDatabase extends _$AppDatabase {
     }
   }
 
-  /// v124: diver_settings.no_fly_preset column. Idempotent so it is safe to
+  /// v125: diver_settings.no_fly_preset column. Idempotent so it is safe to
   /// call from both onUpgrade and the beforeOpen backstop.
   Future<void> _assertNoFlySettingsColumn() async {
     final cols = await customSelect(

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -92,6 +92,7 @@ import 'package:submersion/features/settings/presentation/pages/appearance_page.
 import 'package:submersion/features/settings/presentation/pages/column_config_page.dart';
 import 'package:submersion/features/settings/presentation/pages/default_visible_metrics_page.dart';
 import 'package:submersion/features/settings/presentation/pages/dive_detail_sections_page.dart';
+import 'package:submersion/features/safety/presentation/pages/safety_hub_page.dart';
 import 'package:submersion/features/settings/presentation/pages/safety_settings_page.dart';
 import 'package:submersion/features/settings/presentation/pages/language_settings_page.dart';
 import 'package:submersion/features/settings/presentation/pages/nav_customization_page.dart';
@@ -797,6 +798,13 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               key: state.pageKey,
               child: const GpsLoggerPage(),
             ),
+          ),
+
+          // Safety hub (no-fly status, emergency card, near-miss log)
+          GoRoute(
+            path: '/safety',
+            name: 'safety',
+            builder: (context, state) => const SafetyHubPage(),
           ),
 
           // Settings

--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -30,16 +30,23 @@ class DashboardAlerts {
     this.noFlyStatus,
   });
 
+  /// Whether an unexpired flying-after-diving restriction is in effect right
+  /// now. [noFlyStatus] is a cached snapshot that can elapse while the
+  /// dashboard stays mounted, so every consumer must re-check it against the
+  /// clock instead of treating a non-null value as active.
+  bool get hasActiveNoFly =>
+      noFlyStatus != null && noFlyStatus!.isActiveAt(DateTime.now().toUtc());
+
   bool get hasAlerts =>
       serviceClocksDue.isNotEmpty ||
       insuranceExpiringSoon ||
       insuranceExpired ||
-      noFlyStatus != null;
+      hasActiveNoFly;
 
   int get alertCount {
     int count = serviceClocksDue.length;
     if (insuranceExpiringSoon || insuranceExpired) count++;
-    if (noFlyStatus != null) count++;
+    if (hasActiveNoFly) count++;
     return count;
   }
 }

--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -5,6 +5,8 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
 import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
 
 /// Dashboard alerts data class
@@ -16,20 +18,28 @@ class DashboardAlerts {
   final DateTime? insuranceExpiryDate;
   final String? insuranceProvider;
 
+  /// Active flying-after-diving restriction (null when clear).
+  final NoFlyStatus? noFlyStatus;
+
   const DashboardAlerts({
     this.serviceClocksDue = const [],
     required this.insuranceExpiringSoon,
     required this.insuranceExpired,
     this.insuranceExpiryDate,
     this.insuranceProvider,
+    this.noFlyStatus,
   });
 
   bool get hasAlerts =>
-      serviceClocksDue.isNotEmpty || insuranceExpiringSoon || insuranceExpired;
+      serviceClocksDue.isNotEmpty ||
+      insuranceExpiringSoon ||
+      insuranceExpired ||
+      noFlyStatus != null;
 
   int get alertCount {
     int count = serviceClocksDue.length;
     if (insuranceExpiringSoon || insuranceExpired) count++;
+    if (noFlyStatus != null) count++;
     return count;
   }
 }
@@ -82,6 +92,7 @@ final recentDivesProvider = FutureProvider<List<Dive>>((ref) async {
 final dashboardAlertsProvider = FutureProvider<DashboardAlerts>((ref) async {
   final clocksDue = await ref.watch(dueClocksProvider.future);
   final diver = await ref.watch(currentDiverProvider.future);
+  final noFlyStatus = await ref.watch(noFlyStatusProvider.future);
 
   return DashboardAlerts(
     serviceClocksDue: clocksDue,
@@ -89,6 +100,7 @@ final dashboardAlertsProvider = FutureProvider<DashboardAlerts>((ref) async {
     insuranceExpired: diver?.insurance.isExpired ?? false,
     insuranceExpiryDate: diver?.insurance.expiryDate,
     insuranceProvider: diver?.insurance.provider,
+    noFlyStatus: noFlyStatus,
   );
 });
 

--- a/lib/features/dashboard/presentation/widgets/alerts_card.dart
+++ b/lib/features/dashboard/presentation/widgets/alerts_card.dart
@@ -4,8 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
-import 'package:submersion/features/safety/presentation/pages/safety_hub_page.dart'
-    show formatNoFlyRemaining;
+import 'package:submersion/features/safety/presentation/formatters/no_fly_format.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A compact single-line banner showing alerts and reminders.

--- a/lib/features/dashboard/presentation/widgets/alerts_card.dart
+++ b/lib/features/dashboard/presentation/widgets/alerts_card.dart
@@ -35,7 +35,10 @@ class _CompactAlertsBanner extends StatelessWidget {
 
   String _alertText(BuildContext context) {
     final noFly = alerts.noFlyStatus;
-    if (noFly != null) {
+    // A cached status can expire while the dashboard stays mounted; only show
+    // the countdown while it is still active, otherwise fall through to the
+    // next-priority alert.
+    if (noFly != null && alerts.hasActiveNoFly) {
       return context.l10n.safetyHub_alert_noFly(
         formatNoFlyRemaining(noFly.remaining(DateTime.now().toUtc())),
       );
@@ -60,7 +63,7 @@ class _CompactAlertsBanner extends StatelessWidget {
   }
 
   void _onTap(BuildContext context) {
-    if (alerts.noFlyStatus != null) {
+    if (alerts.hasActiveNoFly) {
       context.push('/safety');
       return;
     }

--- a/lib/features/dashboard/presentation/widgets/alerts_card.dart
+++ b/lib/features/dashboard/presentation/widgets/alerts_card.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
+import 'package:submersion/features/safety/presentation/pages/safety_hub_page.dart'
+    show formatNoFlyRemaining;
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A compact single-line banner showing alerts and reminders.
@@ -33,6 +35,12 @@ class _CompactAlertsBanner extends StatelessWidget {
   const _CompactAlertsBanner({required this.alerts});
 
   String _alertText(BuildContext context) {
+    final noFly = alerts.noFlyStatus;
+    if (noFly != null) {
+      return context.l10n.safetyHub_alert_noFly(
+        formatNoFlyRemaining(noFly.remaining(DateTime.now().toUtc())),
+      );
+    }
     if (alerts.insuranceExpired) {
       return context.l10n.dashboard_alerts_insuranceExpired;
     }
@@ -53,6 +61,10 @@ class _CompactAlertsBanner extends StatelessWidget {
   }
 
   void _onTap(BuildContext context) {
+    if (alerts.noFlyStatus != null) {
+      context.push('/safety');
+      return;
+    }
     if (alerts.alertCount == 1) {
       if (alerts.insuranceExpired || alerts.insuranceExpiringSoon) {
         context.go('/settings');

--- a/lib/features/dashboard/presentation/widgets/alerts_card.dart
+++ b/lib/features/dashboard/presentation/widgets/alerts_card.dart
@@ -37,10 +37,12 @@ class _CompactAlertsBanner extends StatelessWidget {
     final noFly = alerts.noFlyStatus;
     // A cached status can expire while the dashboard stays mounted; only show
     // the countdown while it is still active, otherwise fall through to the
-    // next-priority alert.
-    if (noFly != null && alerts.hasActiveNoFly) {
+    // next-priority alert. Sample the clock once so the active check and the
+    // remaining-time label agree at the expiry boundary.
+    final now = DateTime.now().toUtc();
+    if (noFly != null && noFly.isActiveAt(now)) {
       return context.l10n.safetyHub_alert_noFly(
-        formatNoFlyRemaining(noFly.remaining(DateTime.now().toUtc())),
+        formatNoFlyRemaining(noFly.remaining(now)),
       );
     }
     if (alerts.insuranceExpired) {

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -37,6 +37,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_custom_field.d
     as domain;
 import 'package:submersion/features/dive_log/data/repositories/dive_custom_field_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart' as domain;
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart' as domain;
@@ -3932,6 +3933,56 @@ class DiveRepository {
   // ============================================================================
   // Surface Interval Operations
   // ============================================================================
+
+  /// Lightweight trailing-window query for the flying-after-diving
+  /// classifier: end time (exit time, else entry/date + runtime) plus a
+  /// had-deco flag derived from the recorded profile (any sample with
+  /// deco_type = 2 or a positive ceiling).
+  Future<List<NoFlyDiveInput>> getNoFlyDiveInputs({
+    required DateTime since,
+    String? diverId,
+  }) async {
+    try {
+      final diverClause = diverId != null ? 'AND d.diver_id = ?' : '';
+      final rows = await _db
+          .customSelect(
+            'SELECT '
+            'COALESCE(d.exit_time, '
+            'COALESCE(d.entry_time, d.dive_date_time) '
+            '+ COALESCE(d.runtime, 0) * 1000) AS end_ms, '
+            'EXISTS(SELECT 1 FROM dive_profiles p WHERE p.dive_id = d.id '
+            'AND (p.deco_type = 2 OR p.ceiling > 0)) AS had_deco '
+            'FROM dives d '
+            'WHERE COALESCE(d.exit_time, '
+            'COALESCE(d.entry_time, d.dive_date_time) '
+            '+ COALESCE(d.runtime, 0) * 1000) >= ? '
+            '$diverClause',
+            variables: [
+              Variable(since.millisecondsSinceEpoch),
+              if (diverId != null) Variable(diverId),
+            ],
+            readsFrom: {_db.dives, _db.diveProfiles},
+          )
+          .get();
+      return [
+        for (final row in rows)
+          NoFlyDiveInput(
+            endTime: DateTime.fromMillisecondsSinceEpoch(
+              row.read<int>('end_ms'),
+              isUtc: true,
+            ),
+            hadDecoObligation: row.read<int>('had_deco') == 1,
+          ),
+      ];
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to load no-fly dive inputs',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
 
   /// Get the previous dive (by entry time) for surface interval calculation
   /// Returns null if this is the first dive

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -29,30 +29,36 @@ import 'package:submersion/features/dive_log/data/services/profile_markers_servi
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
-import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
-import 'package:submersion/features/dive_log/domain/services/field_attribution_service.dart';
-import 'package:submersion/features/dive_log/domain/services/source_name_resolver.dart';
 import 'package:submersion/features/dive_log/presentation/formatters/dive_mode_label.dart';
-import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
-import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_detail_ui_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_analysis_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
-import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
-import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
-import 'package:submersion/features/dive_log/presentation/providers/profile_tracking_provider.dart';
+import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
+import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
+import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
+import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_tracking_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/collapsible_section.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_review_section.dart';
+import 'package:submersion/features/safety/domain/services/altitude_flag.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_locations_map.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/surface_gps_section.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/data_sources_section.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_detail_row.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/domain/services/field_attribution_service.dart';
+import 'package:submersion/features/dive_log/domain/services/source_name_resolver.dart';
+import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_deco_status_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/cylinders_card.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/data_sources_section.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/dive_detail_row.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/dive_locations_map.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/environment_enum_display.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_card.dart';
@@ -62,9 +68,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/playback_stats
 import 'package:submersion/features/dive_log/presentation/widgets/range_selection_overlay.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/range_stats_panel.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/responsive_section_pair.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/safety_review_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/source_bar.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/surface_gps_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/tissue_saturation_panel.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/dive_roles/presentation/dive_role_display.dart';
@@ -78,7 +82,6 @@ import 'package:submersion/features/media/presentation/helpers/photo_import_help
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/dive_media_section.dart';
-import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
 import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
@@ -89,8 +92,6 @@ import 'package:submersion/features/tides/domain/entities/tide_record.dart';
 import 'package:submersion/features/tides/presentation/providers/tide_providers.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_cycle_graph.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
-import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
-import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 
 class DiveDetailPage extends ConsumerStatefulWidget {
   final String diveId;
@@ -328,7 +329,21 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         ];
       },
       DiveDetailSectionId.altitude: () {
-        if (dive.altitude == null || dive.altitude! <= 0) return [];
+        if (dive.altitude == null || dive.altitude! <= 0) {
+          // Safety phase 2: the site is at altitude but the dive was not
+          // altitude-adjusted -- surface an informational note instead of
+          // silently hiding the section.
+          if (needsAltitudeAdjustmentFlag(
+            diveAltitude: dive.altitude,
+            siteAltitude: dive.site?.altitude,
+          )) {
+            return [
+              const SizedBox(height: 24),
+              _buildAltitudeMismatchNote(context, dive),
+            ];
+          }
+          return [];
+        }
         return [
           const SizedBox(height: 24),
           _buildAltitudeSection(context, ref, dive),
@@ -3023,6 +3038,21 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             ],
           ],
         ),
+      ),
+    );
+  }
+
+  /// Informational note shown when the site records a meaningful altitude
+  /// but the dive itself has none, so deco replay ran at sea-level pressure.
+  Widget _buildAltitudeMismatchNote(BuildContext context, Dive dive) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      child: ListTile(
+        leading: Icon(Icons.terrain, color: colorScheme.onSurfaceVariant),
+        title: Text(context.l10n.diveLog_detail_altitudeMismatch_title),
+        subtitle: Text(context.l10n.diveLog_detail_altitudeMismatch_subtitle),
+        trailing: const Icon(Icons.edit_outlined, size: 18),
+        onTap: () => context.push('/dives/${dive.id}/edit'),
       ),
     );
   }

--- a/lib/features/safety/domain/services/altitude_flag.dart
+++ b/lib/features/safety/domain/services/altitude_flag.dart
@@ -1,0 +1,13 @@
+/// Whether a dive should show the "site is at altitude but the dive is not
+/// altitude-adjusted" informational note (safety phase 2).
+///
+/// Threshold of 100 m: below that, atmospheric pressure differs from sea
+/// level by well under 1.5% and no agency treats it as altitude diving.
+bool needsAltitudeAdjustmentFlag({
+  required double? diveAltitude,
+  required double? siteAltitude,
+}) {
+  final diveHasAltitude = diveAltitude != null && diveAltitude > 0;
+  if (diveHasAltitude) return false;
+  return siteAltitude != null && siteAltitude > 100;
+}

--- a/lib/features/safety/domain/services/no_fly_service.dart
+++ b/lib/features/safety/domain/services/no_fly_service.dart
@@ -43,6 +43,12 @@ class NoFlyStatus {
 
   Duration remaining(DateTime now) =>
       until.isAfter(now) ? until.difference(now) : Duration.zero;
+
+  /// Whether the restriction is still in effect at [now]. A [NoFlyStatus] is a
+  /// snapshot: once computed it can be cached past its deadline (e.g. on the
+  /// dashboard), so consumers must re-check against the clock rather than
+  /// treating a non-null status as active.
+  bool isActiveAt(DateTime now) => until.isAfter(now);
 }
 
 /// Classifies the trailing dive window per DAN/UHMS flying-after-diving

--- a/lib/features/safety/domain/services/no_fly_service.dart
+++ b/lib/features/safety/domain/services/no_fly_service.dart
@@ -32,7 +32,14 @@ class NoFlyStatus {
   final DateTime until;
   final NoFlyCategory category;
 
-  const NoFlyStatus({required this.until, required this.category});
+  /// The guideline interval that produced [until] (preset-scaled).
+  final Duration interval;
+
+  const NoFlyStatus({
+    required this.until,
+    required this.category,
+    required this.interval,
+  });
 
   Duration remaining(DateTime now) =>
       until.isAfter(now) ? until.difference(now) : Duration.zero;
@@ -87,6 +94,6 @@ class NoFlyService {
 
     final until = lastEnd.add(interval);
     if (!until.isAfter(now)) return null;
-    return NoFlyStatus(until: until, category: category);
+    return NoFlyStatus(until: until, category: category, interval: interval);
   }
 }

--- a/lib/features/safety/domain/services/no_fly_service.dart
+++ b/lib/features/safety/domain/services/no_fly_service.dart
@@ -1,0 +1,92 @@
+/// Conservatism preset for the flying-after-diving countdown.
+enum NoFlyPreset {
+  standard,
+  strict;
+
+  String get dbValue => name;
+
+  static NoFlyPreset fromDbValue(String? value) {
+    for (final preset in NoFlyPreset.values) {
+      if (preset.name == value) return preset;
+    }
+    return NoFlyPreset.standard;
+  }
+}
+
+/// DAN/UHMS guideline category for the trailing dive window.
+enum NoFlyCategory { single, repetitive, deco }
+
+/// Minimal dive facts the classifier needs.
+class NoFlyDiveInput {
+  final DateTime endTime;
+  final bool hadDecoObligation;
+
+  const NoFlyDiveInput({
+    required this.endTime,
+    required this.hadDecoObligation,
+  });
+}
+
+/// An active flying restriction.
+class NoFlyStatus {
+  final DateTime until;
+  final NoFlyCategory category;
+
+  const NoFlyStatus({required this.until, required this.category});
+
+  Duration remaining(DateTime now) =>
+      until.isAfter(now) ? until.difference(now) : Duration.zero;
+}
+
+/// Classifies the trailing dive window per DAN/UHMS flying-after-diving
+/// guidance and computes the countdown anchor. The fixed guideline intervals
+/// are authoritative here by design -- no agency endorses computed
+/// (tissue-model) no-fly times, so the Buhlmann engine is never consulted.
+class NoFlyService {
+  /// How far back to look for dives that still influence the restriction.
+  /// 48 h covers the longest (strict deco) interval.
+  static const Duration lookback = Duration(hours: 48);
+
+  const NoFlyService();
+
+  /// Returns the active restriction, or null when there is none (no recent
+  /// dives, or the interval has already elapsed).
+  NoFlyStatus? evaluate({
+    required List<NoFlyDiveInput> dives,
+    required NoFlyPreset preset,
+    required DateTime now,
+  }) {
+    final windowStart = now.subtract(lookback);
+    final recent = dives
+        .where((d) => d.endTime.isAfter(windowStart) && !d.endTime.isAfter(now))
+        .toList();
+    if (recent.isEmpty) return null;
+
+    final category = recent.any((d) => d.hadDecoObligation)
+        ? NoFlyCategory.deco
+        : recent.length > 1
+        ? NoFlyCategory.repetitive
+        : NoFlyCategory.single;
+
+    final lastEnd = recent
+        .map((d) => d.endTime)
+        .reduce((a, b) => a.isAfter(b) ? a : b);
+
+    final interval = switch ((preset, category)) {
+      (NoFlyPreset.standard, NoFlyCategory.single) => const Duration(hours: 12),
+      (NoFlyPreset.standard, NoFlyCategory.repetitive) => const Duration(
+        hours: 18,
+      ),
+      (NoFlyPreset.standard, NoFlyCategory.deco) => const Duration(hours: 24),
+      (NoFlyPreset.strict, NoFlyCategory.single) => const Duration(hours: 18),
+      (NoFlyPreset.strict, NoFlyCategory.repetitive) => const Duration(
+        hours: 24,
+      ),
+      (NoFlyPreset.strict, NoFlyCategory.deco) => const Duration(hours: 48),
+    };
+
+    final until = lastEnd.add(interval);
+    if (!until.isAfter(now)) return null;
+    return NoFlyStatus(until: until, category: category);
+  }
+}

--- a/lib/features/safety/presentation/formatters/no_fly_format.dart
+++ b/lib/features/safety/presentation/formatters/no_fly_format.dart
@@ -1,0 +1,10 @@
+/// Remaining-time label shared by the safety hub and the dashboard alerts
+/// banner. Mirrors the app's duration convention (see
+/// `dive_field_formatter.dart`): "Xh Ym" once there is at least an hour left,
+/// "Ymin" for a minutes-only remainder.
+String formatNoFlyRemaining(Duration remaining) {
+  final hours = remaining.inHours;
+  final minutes = remaining.inMinutes % 60;
+  if (hours == 0) return '${minutes}min';
+  return '${hours}h ${minutes}m';
+}

--- a/lib/features/safety/presentation/formatters/no_fly_format.dart
+++ b/lib/features/safety/presentation/formatters/no_fly_format.dart
@@ -5,6 +5,11 @@
 String formatNoFlyRemaining(Duration remaining) {
   final hours = remaining.inHours;
   final minutes = remaining.inMinutes % 60;
-  if (hours == 0) return '${minutes}min';
+  if (hours == 0) {
+    // A positive remainder under a minute floors to 0; show "<1min" rather
+    // than a misleading "0min" while the restriction is still active.
+    if (minutes == 0 && remaining > Duration.zero) return '<1min';
+    return '${minutes}min';
+  }
   return '${hours}h ${minutes}m';
 }

--- a/lib/features/safety/presentation/pages/safety_hub_page.dart
+++ b/lib/features/safety/presentation/pages/safety_hub_page.dart
@@ -99,7 +99,7 @@ class _NoFlyCard extends StatelessWidget {
     final l10n = context.l10n;
     final theme = Theme.of(context);
     final now = DateTime.now().toUtc();
-    final active = status != null && status!.until.isAfter(now);
+    final active = status != null && status!.isActiveAt(now);
 
     if (!active) {
       return Card(

--- a/lib/features/safety/presentation/pages/safety_hub_page.dart
+++ b/lib/features/safety/presentation/pages/safety_hub_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/safety/presentation/formatters/no_fly_format.dart';
 import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -47,7 +48,23 @@ class _SafetyHubPageState extends ConsumerState<SafetyHubPage> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          _NoFlyCard(status: statusAsync.value),
+          // Only render the all-clear/active card once we actually have a
+          // result. During the very first load or an error with no prior
+          // value, show an explicit placeholder instead of silently implying
+          // "no restriction" -- misleading for a safety readout. A refresh
+          // after data exists keeps the retained value (no flicker).
+          if (statusAsync.hasValue)
+            _NoFlyCard(status: statusAsync.value)
+          else if (statusAsync.hasError)
+            _NoFlyStatusPlaceholder(
+              icon: Icons.error_outline,
+              text: l10n.common_label_error,
+            )
+          else
+            _NoFlyStatusPlaceholder(
+              icon: Icons.hourglass_empty,
+              text: l10n.common_label_loading,
+            ),
           const SizedBox(height: 16),
           Card(
             child: ListTile(
@@ -130,7 +147,7 @@ class _NoFlyCard extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             Text(
-              _categoryText(l10n, status!.category, remaining),
+              _categoryText(l10n, status!.category),
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -149,11 +166,7 @@ class _NoFlyCard extends StatelessWidget {
     );
   }
 
-  String _categoryText(
-    AppLocalizations l10n,
-    NoFlyCategory category,
-    Duration remaining,
-  ) {
+  String _categoryText(AppLocalizations l10n, NoFlyCategory category) {
     final hours = status!.interval.inHours;
     return switch (category) {
       NoFlyCategory.single => l10n.safetyHub_noFly_category_single(hours),
@@ -165,10 +178,22 @@ class _NoFlyCard extends StatelessWidget {
   }
 }
 
-/// "14h 20m" style remaining-time label shared by hub and dashboard.
-String formatNoFlyRemaining(Duration remaining) {
-  final hours = remaining.inHours;
-  final minutes = remaining.inMinutes % 60;
-  if (hours == 0) return '${minutes}m';
-  return '${hours}h ${minutes}m';
+/// Neutral placeholder shown while the no-fly status is still loading or has
+/// failed to load, so the hub never implies "no restriction" before it knows.
+class _NoFlyStatusPlaceholder extends StatelessWidget {
+  final IconData icon;
+  final String text;
+
+  const _NoFlyStatusPlaceholder({required this.icon, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: ListTile(
+        leading: Icon(icon, color: theme.colorScheme.onSurfaceVariant),
+        title: Text(text),
+      ),
+    );
+  }
 }

--- a/lib/features/safety/presentation/pages/safety_hub_page.dart
+++ b/lib/features/safety/presentation/pages/safety_hub_page.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Safety hub: current no-fly status plus entry points to the safety
+/// tooling (emergency card and near-miss log arrive in later phases).
+class SafetyHubPage extends ConsumerStatefulWidget {
+  const SafetyHubPage({super.key});
+
+  @override
+  ConsumerState<SafetyHubPage> createState() => _SafetyHubPageState();
+}
+
+class _SafetyHubPageState extends ConsumerState<SafetyHubPage> {
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    // Refresh the countdown display once a minute while the page is open.
+    _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final statusAsync = ref.watch(noFlyStatusProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.safetyHub_title)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _NoFlyCard(status: statusAsync.value),
+          const SizedBox(height: 16),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.hourglass_bottom),
+              title: Text(l10n.safetyHub_surfaceIntervalLink),
+              subtitle: Text(l10n.safetyHub_surfaceIntervalLink_subtitle),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push('/planning/surface-interval'),
+            ),
+          ),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.settings_outlined),
+              title: Text(l10n.safetyHub_settingsLink),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push('/settings/safety'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NoFlyCard extends StatelessWidget {
+  final NoFlyStatus? status;
+
+  const _NoFlyCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final now = DateTime.now().toUtc();
+    final active = status != null && status!.until.isAfter(now);
+
+    if (!active) {
+      return Card(
+        child: ListTile(
+          leading: Icon(Icons.flight_takeoff, color: theme.colorScheme.primary),
+          title: Text(l10n.safetyHub_noFly_clear_title),
+          subtitle: Text(l10n.safetyHub_noFly_clear_subtitle),
+        ),
+      );
+    }
+
+    final remaining = status!.remaining(now);
+    final untilLocal = status!.until.toLocal();
+    final untilText = DateFormat.E().add_jm().format(untilLocal);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.airplanemode_inactive,
+                  color: theme.colorScheme.tertiary,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    l10n.safetyHub_noFly_active_title(
+                      formatNoFlyRemaining(remaining),
+                    ),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.safetyHub_noFly_until(untilText),
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _categoryText(l10n, status!.category, remaining),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.safetyHub_noFly_disclaimer,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _categoryText(
+    AppLocalizations l10n,
+    NoFlyCategory category,
+    Duration remaining,
+  ) {
+    final hours = status!.interval.inHours;
+    return switch (category) {
+      NoFlyCategory.single => l10n.safetyHub_noFly_category_single(hours),
+      NoFlyCategory.repetitive => l10n.safetyHub_noFly_category_repetitive(
+        hours,
+      ),
+      NoFlyCategory.deco => l10n.safetyHub_noFly_category_deco(hours),
+    };
+  }
+}
+
+/// "14h 20m" style remaining-time label shared by hub and dashboard.
+String formatNoFlyRemaining(Duration remaining) {
+  final hours = remaining.inHours;
+  final minutes = remaining.inMinutes % 60;
+  if (hours == 0) return '${minutes}m';
+  return '${hours}h ${minutes}m';
+}

--- a/lib/features/safety/presentation/providers/no_fly_providers.dart
+++ b/lib/features/safety/presentation/providers/no_fly_providers.dart
@@ -15,6 +15,12 @@ final noFlyStatusProvider = FutureProvider<NoFlyStatus?>((ref) async {
   final diverId = ref.watch(currentDiverIdProvider);
   final preset = ref.watch(settingsProvider.select((s) => s.noFlyPreset));
 
+  // No active diver yet (transient at startup, or a fresh install): report no
+  // restriction rather than folding every diver's dives into one countdown.
+  // `getNoFlyDiveInputs` drops its diver filter when diverId is null, which
+  // would otherwise scan the whole logbook.
+  if (diverId == null) return null;
+
   final now = DateTime.now().toUtc();
   final dives = await repository.getNoFlyDiveInputs(
     since: now.subtract(NoFlyService.lookback),

--- a/lib/features/safety/presentation/providers/no_fly_providers.dart
+++ b/lib/features/safety/presentation/providers/no_fly_providers.dart
@@ -1,0 +1,24 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Active flying-after-diving restriction for the current diver, or null.
+///
+/// Self-invalidates on dive-table writes (import, sync, edit). The countdown
+/// display refreshes in the UI layer; this provider anchors the deadline.
+final noFlyStatusProvider = FutureProvider<NoFlyStatus?>((ref) async {
+  final repository = ref.watch(diveRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
+
+  final diverId = ref.watch(currentDiverIdProvider);
+  final preset = ref.watch(settingsProvider.select((s) => s.noFlyPreset));
+
+  final now = DateTime.now().toUtc();
+  final dives = await repository.getNoFlyDiveInputs(
+    since: now.subtract(NoFlyService.lookback),
+    diverId: diverId,
+  );
+  return const NoFlyService().evaluate(dives: dives, preset: preset, now: now);
+});

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
@@ -89,6 +90,7 @@ class DiverSettingsRepository {
               safetyReviewDisabledRules: Value(
                 _encodeDisabledRules(s.safetyReviewDisabledRules),
               ),
+              noFlyPreset: Value(s.noFlyPreset.dbValue),
               showAscentRateColors: Value(s.showAscentRateColors),
               showNdlOnProfile: Value(s.showNdlOnProfile),
               lastStopDepth: Value(s.lastStopDepth),
@@ -232,6 +234,7 @@ class DiverSettingsRepository {
           safetyReviewDisabledRules: Value(
             _encodeDisabledRules(settings.safetyReviewDisabledRules),
           ),
+          noFlyPreset: Value(settings.noFlyPreset.dbValue),
           showAscentRateColors: Value(settings.showAscentRateColors),
           showNdlOnProfile: Value(settings.showNdlOnProfile),
           lastStopDepth: Value(settings.lastStopDepth),
@@ -415,6 +418,7 @@ class DiverSettingsRepository {
       safetyReviewDisabledRules: _decodeDisabledRules(
         row.safetyReviewDisabledRules,
       ),
+      noFlyPreset: NoFlyPreset.fromDbValue(row.noFlyPreset),
       showAscentRateColors: row.showAscentRateColors,
       showNdlOnProfile: row.showNdlOnProfile,
       lastStopDepth: row.lastStopDepth,

--- a/lib/features/settings/presentation/pages/safety_settings_page.dart
+++ b/lib/features/settings/presentation/pages/safety_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -65,6 +66,44 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
                   ? (value) => notifier.setSafetyRuleEnabled(rule, value)
                   : null,
             ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Text(
+              l10n.safetySettings_noFlyHeader,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: SegmentedButton<NoFlyPreset>(
+              segments: [
+                ButtonSegment(
+                  value: NoFlyPreset.standard,
+                  label: Text(l10n.safetySettings_noFlyPreset_standard),
+                ),
+                ButtonSegment(
+                  value: NoFlyPreset.strict,
+                  label: Text(l10n.safetySettings_noFlyPreset_strict),
+                ),
+              ],
+              selected: {settings.noFlyPreset},
+              onSelectionChanged: (selection) =>
+                  notifier.setNoFlyPreset(selection.first),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              l10n.safetySettings_noFlyPreset_subtitle,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
           const Divider(height: 1),
           ListTile(
             leading: const Icon(Icons.manage_search),

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -12,6 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/deco/entities/cns_calculation_method.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -136,6 +137,9 @@ class AppSettings {
 
   /// SafetyRuleId.dbValue strings whose findings are hidden in the UI
   final Set<String> safetyReviewDisabledRules;
+
+  /// Flying-after-diving conservatism preset
+  final NoFlyPreset noFlyPreset;
 
   /// Show color-coded ascent rate on dive profile
   final bool showAscentRateColors;
@@ -379,6 +383,7 @@ class AppSettings {
     this.showCeilingOnProfile = true,
     this.safetyReviewEnabled = true,
     this.safetyReviewDisabledRules = const {},
+    this.noFlyPreset = NoFlyPreset.standard,
     this.showAscentRateColors = false,
     this.showNdlOnProfile = true,
     this.lastStopDepth = 3.0,
@@ -520,6 +525,7 @@ class AppSettings {
     bool? showCeilingOnProfile,
     bool? safetyReviewEnabled,
     Set<String>? safetyReviewDisabledRules,
+    NoFlyPreset? noFlyPreset,
     bool? showAscentRateColors,
     bool? showNdlOnProfile,
     double? lastStopDepth,
@@ -629,6 +635,7 @@ class AppSettings {
       safetyReviewEnabled: safetyReviewEnabled ?? this.safetyReviewEnabled,
       safetyReviewDisabledRules:
           safetyReviewDisabledRules ?? this.safetyReviewDisabledRules,
+      noFlyPreset: noFlyPreset ?? this.noFlyPreset,
       showAscentRateColors: showAscentRateColors ?? this.showAscentRateColors,
       showNdlOnProfile: showNdlOnProfile ?? this.showNdlOnProfile,
       lastStopDepth: lastStopDepth ?? this.lastStopDepth,
@@ -1095,6 +1102,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
       rules.add(rule.dbValue);
     }
     state = state.copyWith(safetyReviewDisabledRules: rules);
+    await _saveSettings();
+  }
+
+  Future<void> setNoFlyPreset(NoFlyPreset preset) async {
+    state = state.copyWith(noFlyPreset: preset);
     await _saveSettings();
   }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "لا قيود على الطيران",
-  "safetyHub_noFly_clear_subtitle": "لا غطسات خلال الـ 48 ساعة الماضية",
+  "safetyHub_noFly_clear_subtitle": "لا يوجد قيد نشط على الطيران",
   "safetyHub_noFly_category_single": "بعد غطسة واحدة بلا توقفات: إرشاد {hours} ساعة",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "ملاحظات تلقائية على ملف الغوص بعد الغطسة",
   "safetyReview_sectionTitle": "مراجعة السلامة",
   "safetyReview_findingCount": "{count, plural, =1{ملاحظة واحدة} other{{count} ملاحظات}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "تجاوز الصعود {rate} لمدة {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "كان العمق أعلى من سقف التوقف المطلوب بمقدار {excess} لمدة {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "تم تقصير توقف السلامة الموصى به بمقدار {remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} تغيرات متكررة في العمق صعودًا وهبوطًا أثناء الغطسة",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "الصعود إلى السطح بعامل تدرج {gf}، أعلى من {gfHigh} المُعد",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "عند {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "تجاهل",
   "safetyReview_restore": "استعادة",
   "safetyReview_showDismissed": "{count, plural, =1{إظهار ملاحظة متجاهلة واحدة} other{إظهار {count} ملاحظات متجاهلة}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "مراجعة السلامة",
   "safetySettings_entry_subtitle": "ملاحظات وقواعد ما بعد الغطسة",
   "safetySettings_masterToggle": "مراجعة السلامة بعد الغطسة",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "تحليل جميع الغطسات",
   "safetySettings_analyzeAll_subtitle": "تشغيل مراجعة السلامة على كل غطسة ذات ملف لم تُحلل بعد",
   "safetySettings_analyzeAll_progress": "تم تحليل {done} من {total}",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "اكتمل التحليل",
   "safetySettings_analyzeAll_doneWithErrors": "اكتمل التحليل — {count, plural, =1{تعذّر تحليل غوصة واحدة} other{تعذّر تحليل {count} غوصات}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "الطيران بعد الغوص",
+  "safetySettings_noFlyPreset_standard": "قياسي (12/18/24 س)",
+  "safetySettings_noFlyPreset_strict": "صارم (18/24/48 س)",
+  "safetySettings_noFlyPreset_subtitle": "فترات إرشادية بعد غطسة واحدة بلا توقفات، وغطسات متكررة، وغطسات بتخفيف الضغط",
+  "safetyHub_title": "السلامة",
+  "safetyHub_noFly_active_title": "حظر الطيران: متبقٍ {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "حتى {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "لا قيود على الطيران",
+  "safetyHub_noFly_clear_subtitle": "لا غطسات خلال الـ 48 ساعة الماضية",
+  "safetyHub_noFly_category_single": "بعد غطسة واحدة بلا توقفات: إرشاد {hours} ساعة",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "بعد غطسات متكررة: إرشاد {hours} ساعة",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "بعد غطسة بتخفيف الضغط: إرشاد {hours} ساعة",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "إرشادات DAN/UHMS منذ آخر غطسة. ليست بديلاً عن وقت حظر الطيران في حاسوب الغوص الخاص بك.",
+  "safetyHub_surfaceIntervalLink": "أداة الفاصل السطحي",
+  "safetyHub_surfaceIntervalLink_subtitle": "نموذج تعليمي لتخلص الأنسجة من التشبع",
+  "safetyHub_settingsLink": "إعدادات السلامة",
+  "safetyHub_alert_noFly": "حظر الطيران: متبقٍ {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "موقع الغوص على ارتفاع",
+  "diveLog_detail_altitudeMismatch_subtitle": "هذا الموقع مسجل له ارتفاع لكن الغطسة بلا ارتفاع، لذا افترض تحليل تخفيف الضغط مستوى سطح البحر. عيّن ارتفاع الغطسة للتصحيح."
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Keine Flugeinschränkung",
-  "safetyHub_noFly_clear_subtitle": "Keine Tauchgänge in den letzten 48 Stunden",
+  "safetyHub_noFly_clear_subtitle": "Keine aktive Flugbeschränkung",
   "safetyHub_noFly_category_single": "Nach einem einzelnen Nullzeit-Tauchgang: {hours} h Richtwert",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Automatische Profilbeobachtungen nach dem Tauchgang",
   "safetyReview_sectionTitle": "Sicherheitsüberprüfung",
   "safetyReview_findingCount": "{count, plural, =1{1 Beobachtung} other{{count} Beobachtungen}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "Aufstieg überschritt {rate} für {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "Tiefe lag für {duration} {excess} über dem erforderlichen Deko-Ceiling",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "Der empfohlene Sicherheitsstopp wurde um {remaining} verkürzt",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} wiederholte Auf- und Abwärtsbewegungen während des Tauchgangs",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Aufgetaucht bei Gradientenfaktor {gf}, über dem konfigurierten {gfHigh}",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "Bei {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Ausblenden",
   "safetyReview_restore": "Wiederherstellen",
   "safetyReview_showDismissed": "{count, plural, =1{1 Ausgeblendete anzeigen} other{{count} Ausgeblendete anzeigen}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Sicherheitsüberprüfung",
   "safetySettings_entry_subtitle": "Beobachtungen und Regeln nach dem Tauchgang",
   "safetySettings_masterToggle": "Sicherheitsüberprüfung nach dem Tauchgang",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Alle Tauchgänge analysieren",
   "safetySettings_analyzeAll_subtitle": "Sicherheitsüberprüfung für alle noch nicht analysierten Tauchgänge mit Profil ausführen",
   "safetySettings_analyzeAll_progress": "{done} von {total} analysiert",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Analyse abgeschlossen",
   "safetySettings_analyzeAll_doneWithErrors": "Analyse abgeschlossen — {count, plural, =1{1 Tauchgang konnte nicht analysiert werden} other{{count} Tauchgänge konnten nicht analysiert werden}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Fliegen nach dem Tauchen",
+  "safetySettings_noFlyPreset_standard": "Standard (12/18/24 h)",
+  "safetySettings_noFlyPreset_strict": "Streng (18/24/48 h)",
+  "safetySettings_noFlyPreset_subtitle": "Richtwerte nach einem einzelnen Nullzeit-Tauchgang, Wiederholungstauchgängen und Deko-Tauchgängen",
+  "safetyHub_title": "Sicherheit",
+  "safetyHub_noFly_active_title": "Flugverbot: noch {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Bis {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Keine Flugeinschränkung",
+  "safetyHub_noFly_clear_subtitle": "Keine Tauchgänge in den letzten 48 Stunden",
+  "safetyHub_noFly_category_single": "Nach einem einzelnen Nullzeit-Tauchgang: {hours} h Richtwert",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Nach Wiederholungstauchgängen: {hours} h Richtwert",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Nach einem Deko-Tauchgang: {hours} h Richtwert",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "DAN/UHMS-Richtwerte ab dem letzten Tauchgang. Kein Ersatz für die Flugverbotszeit Ihres Tauchcomputers.",
+  "safetyHub_surfaceIntervalLink": "Oberflächenpausen-Tool",
+  "safetyHub_surfaceIntervalLink_subtitle": "Lehrreiches Modell der Gewebeentsättigung",
+  "safetyHub_settingsLink": "Sicherheitseinstellungen",
+  "safetyHub_alert_noFly": "Flugverbot: noch {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "Tauchplatz liegt in Höhenlage",
+  "diveLog_detail_altitudeMismatch_subtitle": "Für diesen Platz ist eine Höhe hinterlegt, der Tauchgang hat jedoch keine, daher ging die Deko-Analyse von Meereshöhe aus. Höhe des Tauchgangs setzen, um dies zu korrigieren."
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -13071,7 +13071,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "No flying restriction",
-  "safetyHub_noFly_clear_subtitle": "No dives in the last 48 hours",
+  "safetyHub_noFly_clear_subtitle": "No active flying restriction",
   "safetyHub_noFly_category_single": "After a single no-deco dive: {hours} h guideline",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,12 +1,20 @@
 {
   "diveLog_edit_geofenceSuggestion_near": "Near {location}",
   "@diveLog_edit_geofenceSuggestion_near": {
-    "placeholders": { "location": { "type": "String" } }
+    "placeholders": {
+      "location": {
+        "type": "String"
+      }
+    }
   },
   "diveLog_edit_geofenceSuggestion_title": "Equipment suggestion",
   "diveLog_edit_geofenceSuggestion_body": "Apply your \"{setName}\" set?",
   "@diveLog_edit_geofenceSuggestion_body": {
-    "placeholders": { "setName": { "type": "String" } }
+    "placeholders": {
+      "setName": {
+        "type": "String"
+      }
+    }
   },
   "diveLog_edit_geofenceSuggestion_apply": "Apply",
   "common_action_dismiss": "Dismiss",
@@ -19,7 +27,11 @@
   "equipment_setEdit_removeGeofence": "Remove geofence",
   "equipment_setEdit_geofenceRadius": "Radius: {distance}",
   "@equipment_setEdit_geofenceRadius": {
-    "placeholders": { "distance": { "type": "String" } }
+    "placeholders": {
+      "distance": {
+        "type": "String"
+      }
+    }
   },
   "equipment_geofenceEditor_title": "Geofence",
   "equipment_geofenceEditor_fromSite": "From dive site",
@@ -31,7 +43,11 @@
   "equipment_setDetail_setAsDefault": "Set as default",
   "equipment_setDetail_setAsDefaultSnackbar": "\"{name}\" is now your default set",
   "@equipment_setDetail_setAsDefaultSnackbar": {
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
   "equipment_setDetail_geofencesTitle": "Geofences",
   "equipment_setDetail_noGeofences": "No geofences",
@@ -13032,5 +13048,66 @@
   "statistics_progression_divesBySuitThickness_error": "Could not load suit thickness data",
   "diveLog_filter_sectionSuitThickness": "Suit thickness (mm)",
   "diveLog_filter_thicknessMin": "Min",
-  "diveLog_filter_thicknessMax": "Max"
+  "diveLog_filter_thicknessMax": "Max",
+  "safetySettings_noFlyHeader": "Flying after diving",
+  "safetySettings_noFlyPreset_standard": "Standard (12/18/24 h)",
+  "safetySettings_noFlyPreset_strict": "Strict (18/24/48 h)",
+  "safetySettings_noFlyPreset_subtitle": "Guideline intervals after a single no-deco dive, repetitive dives, and deco dives",
+  "safetyHub_title": "Safety",
+  "safetyHub_noFly_active_title": "No-fly: {remaining} remaining",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Until {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "No flying restriction",
+  "safetyHub_noFly_clear_subtitle": "No dives in the last 48 hours",
+  "safetyHub_noFly_category_single": "After a single no-deco dive: {hours} h guideline",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "After repetitive dives: {hours} h guideline",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "After a decompression dive: {hours} h guideline",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "DAN/UHMS guideline intervals from your last dive. Not a substitute for your dive computer's no-fly time.",
+  "safetyHub_surfaceIntervalLink": "Surface interval tool",
+  "safetyHub_surfaceIntervalLink_subtitle": "Educational tissue desaturation model",
+  "safetyHub_settingsLink": "Safety settings",
+  "diveLog_detail_altitudeMismatch_title": "Site is at altitude",
+  "diveLog_detail_altitudeMismatch_subtitle": "This site records an altitude but the dive has none set, so decompression analysis assumed sea level. Set the dive's altitude to correct it.",
+  "safetyHub_alert_noFly": "No-fly: {remaining} remaining",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Sin restricción de vuelo",
-  "safetyHub_noFly_clear_subtitle": "Sin inmersiones en las últimas 48 horas",
+  "safetyHub_noFly_clear_subtitle": "Sin restricción de vuelo activa",
   "safetyHub_noFly_category_single": "Tras una única inmersión sin deco: pauta de {hours} h",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Observaciones automáticas del perfil tras la inmersión",
   "safetyReview_sectionTitle": "Revisión de seguridad",
   "safetyReview_findingCount": "{count, plural, =1{1 observación} other{{count} observaciones}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "El ascenso superó {rate} durante {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "La profundidad estuvo {excess} por encima del techo de parada requerido durante {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "La parada de seguridad recomendada se acortó en {remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} cambios repetidos de profundidad de subida y bajada durante la inmersión",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Salida a superficie con factor de gradiente {gf}, por encima del {gfHigh} configurado",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "En {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Descartar",
   "safetyReview_restore": "Restaurar",
   "safetyReview_showDismissed": "{count, plural, =1{Mostrar 1 descartada} other{Mostrar {count} descartadas}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Revisión de seguridad",
   "safetySettings_entry_subtitle": "Observaciones y reglas tras la inmersión",
   "safetySettings_masterToggle": "Revisión de seguridad tras la inmersión",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Analizar todas las inmersiones",
   "safetySettings_analyzeAll_subtitle": "Ejecutar la revisión de seguridad en todas las inmersiones con perfil que aún no se hayan analizado",
   "safetySettings_analyzeAll_progress": "Analizadas {done} de {total}",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Análisis completado",
   "safetySettings_analyzeAll_doneWithErrors": "Análisis completado — {count, plural, =1{No se pudo analizar 1 inmersión} other{No se pudieron analizar {count} inmersiones}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Volar después de bucear",
+  "safetySettings_noFlyPreset_standard": "Estándar (12/18/24 h)",
+  "safetySettings_noFlyPreset_strict": "Estricto (18/24/48 h)",
+  "safetySettings_noFlyPreset_subtitle": "Intervalos orientativos tras una única inmersión sin deco, inmersiones sucesivas e inmersiones con deco",
+  "safetyHub_title": "Seguridad",
+  "safetyHub_noFly_active_title": "No volar: quedan {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Hasta {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Sin restricción de vuelo",
+  "safetyHub_noFly_clear_subtitle": "Sin inmersiones en las últimas 48 horas",
+  "safetyHub_noFly_category_single": "Tras una única inmersión sin deco: pauta de {hours} h",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Tras inmersiones sucesivas: pauta de {hours} h",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Tras una inmersión con descompresión: pauta de {hours} h",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "Pautas DAN/UHMS desde tu última inmersión. No sustituye el tiempo de no volar de tu ordenador de buceo.",
+  "safetyHub_surfaceIntervalLink": "Herramienta de intervalo en superficie",
+  "safetyHub_surfaceIntervalLink_subtitle": "Modelo educativo de desaturación de tejidos",
+  "safetyHub_settingsLink": "Ajustes de seguridad",
+  "safetyHub_alert_noFly": "No volar: quedan {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "El punto de buceo está en altitud",
+  "diveLog_detail_altitudeMismatch_subtitle": "Este punto registra una altitud pero la inmersión no tiene ninguna, así que el análisis de descompresión asumió nivel del mar. Establece la altitud de la inmersión para corregirlo."
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Aucune restriction de vol",
-  "safetyHub_noFly_clear_subtitle": "Aucune plongée dans les dernières 48 heures",
+  "safetyHub_noFly_clear_subtitle": "Aucune restriction de vol active",
   "safetyHub_noFly_category_single": "Après une plongée unique sans déco : recommandation de {hours} h",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Observations automatiques du profil après la plongée",
   "safetyReview_sectionTitle": "Bilan de sécurité",
   "safetyReview_findingCount": "{count, plural, =1{1 observation} other{{count} observations}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "La remontée a dépassé {rate} pendant {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "La profondeur est restée {excess} au-dessus du plafond de palier requis pendant {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "Le palier de sécurité recommandé a été écourté de {remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} variations répétées de profondeur en montée et descente pendant la plongée",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Surface atteinte avec un facteur de gradient de {gf}, au-dessus du {gfHigh} configuré",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "À {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Ignorer",
   "safetyReview_restore": "Restaurer",
   "safetyReview_showDismissed": "{count, plural, =1{Afficher 1 ignorée} other{Afficher {count} ignorées}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Bilan de sécurité",
   "safetySettings_entry_subtitle": "Observations et règles après la plongée",
   "safetySettings_masterToggle": "Bilan de sécurité après la plongée",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Analyser toutes les plongées",
   "safetySettings_analyzeAll_subtitle": "Exécuter le bilan de sécurité sur toutes les plongées avec profil pas encore analysées",
   "safetySettings_analyzeAll_progress": "{done} sur {total} analysées",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Analyse terminée",
   "safetySettings_analyzeAll_doneWithErrors": "Analyse terminée — {count, plural, =1{1 plongée n'a pas pu être analysée} other{{count} plongées n'ont pas pu être analysées}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Voler après la plongée",
+  "safetySettings_noFlyPreset_standard": "Standard (12/18/24 h)",
+  "safetySettings_noFlyPreset_strict": "Strict (18/24/48 h)",
+  "safetySettings_noFlyPreset_subtitle": "Intervalles indicatifs après une plongée unique sans déco, des plongées successives et des plongées avec déco",
+  "safetyHub_title": "Sécurité",
+  "safetyHub_noFly_active_title": "Interdiction de vol : {remaining} restant",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Jusqu'à {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Aucune restriction de vol",
+  "safetyHub_noFly_clear_subtitle": "Aucune plongée dans les dernières 48 heures",
+  "safetyHub_noFly_category_single": "Après une plongée unique sans déco : recommandation de {hours} h",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Après des plongées successives : recommandation de {hours} h",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Après une plongée avec décompression : recommandation de {hours} h",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "Recommandations DAN/UHMS depuis votre dernière plongée. Ne remplace pas le temps d'interdiction de vol de votre ordinateur de plongée.",
+  "safetyHub_surfaceIntervalLink": "Outil d'intervalle de surface",
+  "safetyHub_surfaceIntervalLink_subtitle": "Modèle pédagogique de désaturation des tissus",
+  "safetyHub_settingsLink": "Réglages de sécurité",
+  "safetyHub_alert_noFly": "Interdiction de vol : {remaining} restant",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "Le site est en altitude",
+  "diveLog_detail_altitudeMismatch_subtitle": "Ce site indique une altitude mais la plongée n'en a aucune : l'analyse de décompression a supposé le niveau de la mer. Définissez l'altitude de la plongée pour corriger."
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "אין הגבלת טיסה",
-  "safetyHub_noFly_clear_subtitle": "לא היו צלילות ב-48 השעות האחרונות",
+  "safetyHub_noFly_clear_subtitle": "אין הגבלת טיסה פעילה",
   "safetyHub_noFly_category_single": "אחרי צלילה בודדת ללא דקו: הנחיה של {hours} שעות",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "תצפיות אוטומטיות על פרופיל הצלילה לאחר הצלילה",
   "safetyReview_sectionTitle": "סקירת בטיחות",
   "safetyReview_findingCount": "{count, plural, =1{תצפית אחת} other{{count} תצפיות}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "העלייה חרגה מ-{rate} למשך {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "העומק היה {excess} מעל תקרת העצירה הנדרשת למשך {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "עצירת הבטיחות המומלצת קוצרה ב-{remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} שינויי עומק חוזרים מעלה ומטה במהלך הצלילה",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "עלייה לפני השטח עם פקטור גרדיאנט {gf}, מעל {gfHigh} שהוגדר",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "ב-{start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "התעלם",
   "safetyReview_restore": "שחזר",
   "safetyReview_showDismissed": "{count, plural, =1{הצג תצפית אחת שהוסתרה} other{הצג {count} תצפיות שהוסתרו}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "סקירת בטיחות",
   "safetySettings_entry_subtitle": "תצפיות וכללים לאחר הצלילה",
   "safetySettings_masterToggle": "סקירת בטיחות לאחר הצלילה",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "נתח את כל הצלילות",
   "safetySettings_analyzeAll_subtitle": "הרצת סקירת הבטיחות על כל צלילה עם פרופיל שטרם נותחה",
   "safetySettings_analyzeAll_progress": "נותחו {done} מתוך {total}",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "הניתוח הושלם",
   "safetySettings_analyzeAll_doneWithErrors": "הניתוח הושלם — {count, plural, =1{לא ניתן היה לנתח צלילה אחת} other{לא ניתן היה לנתח {count} צלילות}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "טיסה אחרי צלילה",
+  "safetySettings_noFlyPreset_standard": "רגיל (12/18/24 ש')",
+  "safetySettings_noFlyPreset_strict": "מחמיר (18/24/48 ש')",
+  "safetySettings_noFlyPreset_subtitle": "מרווחים מנחים אחרי צלילה בודדת ללא דקו, צלילות חוזרות וצלילות דקומפרסיה",
+  "safetyHub_title": "בטיחות",
+  "safetyHub_noFly_active_title": "איסור טיסה: נותרו {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "עד {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "אין הגבלת טיסה",
+  "safetyHub_noFly_clear_subtitle": "לא היו צלילות ב-48 השעות האחרונות",
+  "safetyHub_noFly_category_single": "אחרי צלילה בודדת ללא דקו: הנחיה של {hours} שעות",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "אחרי צלילות חוזרות: הנחיה של {hours} שעות",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "אחרי צלילת דקומפרסיה: הנחיה של {hours} שעות",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "הנחיות DAN/UHMS מאז הצלילה האחרונה. אינו תחליף לזמן איסור הטיסה של מחשב הצלילה שלך.",
+  "safetyHub_surfaceIntervalLink": "כלי מרווח פני השטח",
+  "safetyHub_surfaceIntervalLink_subtitle": "מודל לימודי של פליטת גזים מהרקמות",
+  "safetyHub_settingsLink": "הגדרות בטיחות",
+  "safetyHub_alert_noFly": "איסור טיסה: נותרו {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "אתר הצלילה נמצא בגובה",
+  "diveLog_detail_altitudeMismatch_subtitle": "לאתר זה רשום גובה אך לצלילה אין, ולכן ניתוח הדקומפרסיה הניח גובה פני הים. הגדר את גובה הצלילה כדי לתקן."
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Nincs repülési korlátozás",
-  "safetyHub_noFly_clear_subtitle": "Nem volt merülés az elmúlt 48 órában",
+  "safetyHub_noFly_clear_subtitle": "Nincs aktív repülési korlátozás",
   "safetyHub_noFly_category_single": "Egyetlen nullidős merülés után: {hours} ó irányelv",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Automatikus profilmegfigyelések a merülés után",
   "safetyReview_sectionTitle": "Biztonsági áttekintés",
   "safetyReview_findingCount": "{count, plural, =1{1 megfigyelés} other{{count} megfigyelés}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "A felemelkedés {duration} ideig meghaladta a(z) {rate} értéket",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "A mélység {duration} ideig {excess} értékkel az előírt megállási plafon felett volt",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "Az ajánlott biztonsági megálló {remaining} idővel rövidült",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} ismételt fel-le mélységváltozás a merülés során",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Felszínre érkezés {gf} gradiens faktorral, a beállított {gfHigh} felett",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "{start}–{end} időpontban",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Elvetés",
   "safetyReview_restore": "Visszaállítás",
   "safetyReview_showDismissed": "{count, plural, =1{1 elvetett megjelenítése} other{{count} elvetett megjelenítése}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Biztonsági áttekintés",
   "safetySettings_entry_subtitle": "Merülés utáni megfigyelések és szabályok",
   "safetySettings_masterToggle": "Merülés utáni biztonsági áttekintés",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Összes merülés elemzése",
   "safetySettings_analyzeAll_subtitle": "A biztonsági áttekintés futtatása minden olyan profillal rendelkező merülésen, amely még nincs elemezve",
   "safetySettings_analyzeAll_progress": "{done} / {total} elemezve",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Elemzés kész",
   "safetySettings_analyzeAll_doneWithErrors": "Elemzés kész — {count, plural, =1{1 merülést nem sikerült elemezni} other{{count} merülést nem sikerült elemezni}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Repülés merülés után",
+  "safetySettings_noFlyPreset_standard": "Normál (12/18/24 ó)",
+  "safetySettings_noFlyPreset_strict": "Szigorú (18/24/48 ó)",
+  "safetySettings_noFlyPreset_subtitle": "Irányadó időközök egyetlen nullidős merülés, ismétlő merülések és dekós merülések után",
+  "safetyHub_title": "Biztonság",
+  "safetyHub_noFly_active_title": "Repülési tilalom: {remaining} van hátra",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Eddig: {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Nincs repülési korlátozás",
+  "safetyHub_noFly_clear_subtitle": "Nem volt merülés az elmúlt 48 órában",
+  "safetyHub_noFly_category_single": "Egyetlen nullidős merülés után: {hours} ó irányelv",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Ismétlő merülések után: {hours} ó irányelv",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Dekompressziós merülés után: {hours} ó irányelv",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "DAN/UHMS irányelvek az utolsó merüléstől számítva. Nem helyettesíti a búvárkomputer no-fly idejét.",
+  "safetyHub_surfaceIntervalLink": "Felszíni intervallum eszköz",
+  "safetyHub_surfaceIntervalLink_subtitle": "Oktató jellegű szöveti telítettségcsökkenési modell",
+  "safetyHub_settingsLink": "Biztonsági beállítások",
+  "safetyHub_alert_noFly": "Repülési tilalom: {remaining} van hátra",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "A merülőhely magaslaton fekszik",
+  "diveLog_detail_altitudeMismatch_subtitle": "Ehhez a helyhez magasság van rögzítve, a merüléshez azonban nincs, így a dekompressziós elemzés tengerszintet feltételezett. A javításhoz állítsd be a merülés magasságát."
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Nessuna restrizione di volo",
-  "safetyHub_noFly_clear_subtitle": "Nessuna immersione nelle ultime 48 ore",
+  "safetyHub_noFly_clear_subtitle": "Nessuna restrizione di volo attiva",
   "safetyHub_noFly_category_single": "Dopo una singola immersione senza deco: linea guida di {hours} h",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Osservazioni automatiche del profilo dopo l'immersione",
   "safetyReview_sectionTitle": "Revisione di sicurezza",
   "safetyReview_findingCount": "{count, plural, =1{1 osservazione} other{{count} osservazioni}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "La risalita ha superato {rate} per {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "La profondità è rimasta {excess} sopra il ceiling di tappa richiesto per {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "La tappa di sicurezza consigliata è stata accorciata di {remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} variazioni ripetute di profondità su e giù durante l'immersione",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Emersione con fattore di gradiente {gf}, oltre il {gfHigh} configurato",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "A {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Ignora",
   "safetyReview_restore": "Ripristina",
   "safetyReview_showDismissed": "{count, plural, =1{Mostra 1 ignorata} other{Mostra {count} ignorate}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Revisione di sicurezza",
   "safetySettings_entry_subtitle": "Osservazioni e regole post-immersione",
   "safetySettings_masterToggle": "Revisione di sicurezza post-immersione",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Analizza tutte le immersioni",
   "safetySettings_analyzeAll_subtitle": "Esegui la revisione di sicurezza su tutte le immersioni con profilo non ancora analizzate",
   "safetySettings_analyzeAll_progress": "Analizzate {done} di {total}",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Analisi completata",
   "safetySettings_analyzeAll_doneWithErrors": "Analisi completata — {count, plural, =1{Impossibile analizzare 1 immersione} other{Impossibile analizzare {count} immersioni}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Volare dopo l'immersione",
+  "safetySettings_noFlyPreset_standard": "Standard (12/18/24 h)",
+  "safetySettings_noFlyPreset_strict": "Rigoroso (18/24/48 h)",
+  "safetySettings_noFlyPreset_subtitle": "Intervalli indicativi dopo una singola immersione senza deco, immersioni ripetitive e immersioni con deco",
+  "safetyHub_title": "Sicurezza",
+  "safetyHub_noFly_active_title": "No-fly: mancano {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Fino alle {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Nessuna restrizione di volo",
+  "safetyHub_noFly_clear_subtitle": "Nessuna immersione nelle ultime 48 ore",
+  "safetyHub_noFly_category_single": "Dopo una singola immersione senza deco: linea guida di {hours} h",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Dopo immersioni ripetitive: linea guida di {hours} h",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Dopo un'immersione con decompressione: linea guida di {hours} h",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "Linee guida DAN/UHMS dall'ultima immersione. Non sostituisce il tempo no-fly del tuo computer subacqueo.",
+  "safetyHub_surfaceIntervalLink": "Strumento intervallo di superficie",
+  "safetyHub_surfaceIntervalLink_subtitle": "Modello educativo di desaturazione dei tessuti",
+  "safetyHub_settingsLink": "Impostazioni di sicurezza",
+  "safetyHub_alert_noFly": "No-fly: mancano {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "Il sito è in quota",
+  "diveLog_detail_altitudeMismatch_subtitle": "Questo sito registra un'altitudine ma l'immersione non ne ha una, quindi l'analisi di decompressione ha assunto il livello del mare. Imposta l'altitudine dell'immersione per correggere."
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -34977,7 +34977,7 @@ abstract class AppLocalizations {
   /// No description provided for @safetyHub_noFly_clear_subtitle.
   ///
   /// In en, this message translates to:
-  /// **'No dives in the last 48 hours'**
+  /// **'No active flying restriction'**
   String get safetyHub_noFly_clear_subtitle;
 
   /// No description provided for @safetyHub_noFly_category_single.

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -34925,6 +34925,120 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Max'**
   String get diveLog_filter_thicknessMax;
+
+  /// No description provided for @safetySettings_noFlyHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Flying after diving'**
+  String get safetySettings_noFlyHeader;
+
+  /// No description provided for @safetySettings_noFlyPreset_standard.
+  ///
+  /// In en, this message translates to:
+  /// **'Standard (12/18/24 h)'**
+  String get safetySettings_noFlyPreset_standard;
+
+  /// No description provided for @safetySettings_noFlyPreset_strict.
+  ///
+  /// In en, this message translates to:
+  /// **'Strict (18/24/48 h)'**
+  String get safetySettings_noFlyPreset_strict;
+
+  /// No description provided for @safetySettings_noFlyPreset_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Guideline intervals after a single no-deco dive, repetitive dives, and deco dives'**
+  String get safetySettings_noFlyPreset_subtitle;
+
+  /// No description provided for @safetyHub_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Safety'**
+  String get safetyHub_title;
+
+  /// No description provided for @safetyHub_noFly_active_title.
+  ///
+  /// In en, this message translates to:
+  /// **'No-fly: {remaining} remaining'**
+  String safetyHub_noFly_active_title(String remaining);
+
+  /// No description provided for @safetyHub_noFly_until.
+  ///
+  /// In en, this message translates to:
+  /// **'Until {time}'**
+  String safetyHub_noFly_until(String time);
+
+  /// No description provided for @safetyHub_noFly_clear_title.
+  ///
+  /// In en, this message translates to:
+  /// **'No flying restriction'**
+  String get safetyHub_noFly_clear_title;
+
+  /// No description provided for @safetyHub_noFly_clear_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No dives in the last 48 hours'**
+  String get safetyHub_noFly_clear_subtitle;
+
+  /// No description provided for @safetyHub_noFly_category_single.
+  ///
+  /// In en, this message translates to:
+  /// **'After a single no-deco dive: {hours} h guideline'**
+  String safetyHub_noFly_category_single(int hours);
+
+  /// No description provided for @safetyHub_noFly_category_repetitive.
+  ///
+  /// In en, this message translates to:
+  /// **'After repetitive dives: {hours} h guideline'**
+  String safetyHub_noFly_category_repetitive(int hours);
+
+  /// No description provided for @safetyHub_noFly_category_deco.
+  ///
+  /// In en, this message translates to:
+  /// **'After a decompression dive: {hours} h guideline'**
+  String safetyHub_noFly_category_deco(int hours);
+
+  /// No description provided for @safetyHub_noFly_disclaimer.
+  ///
+  /// In en, this message translates to:
+  /// **'DAN/UHMS guideline intervals from your last dive. Not a substitute for your dive computer\'s no-fly time.'**
+  String get safetyHub_noFly_disclaimer;
+
+  /// No description provided for @safetyHub_surfaceIntervalLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Surface interval tool'**
+  String get safetyHub_surfaceIntervalLink;
+
+  /// No description provided for @safetyHub_surfaceIntervalLink_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Educational tissue desaturation model'**
+  String get safetyHub_surfaceIntervalLink_subtitle;
+
+  /// No description provided for @safetyHub_settingsLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Safety settings'**
+  String get safetyHub_settingsLink;
+
+  /// No description provided for @diveLog_detail_altitudeMismatch_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Site is at altitude'**
+  String get diveLog_detail_altitudeMismatch_title;
+
+  /// No description provided for @diveLog_detail_altitudeMismatch_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'This site records an altitude but the dive has none set, so decompression analysis assumed sea level. Set the dive\'s altitude to correct it.'**
+  String get diveLog_detail_altitudeMismatch_subtitle;
+
+  /// No description provided for @safetyHub_alert_noFly.
+  ///
+  /// In en, this message translates to:
+  /// **'No-fly: {remaining} remaining'**
+  String safetyHub_alert_noFly(String remaining);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -20512,8 +20512,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get safetyHub_noFly_clear_title => 'لا قيود على الطيران';
 
   @override
-  String get safetyHub_noFly_clear_subtitle =>
-      'لا غطسات خلال الـ 48 ساعة الماضية';
+  String get safetyHub_noFly_clear_subtitle => 'لا يوجد قيد نشط على الطيران';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -20481,4 +20481,78 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'الأقصى';
+
+  @override
+  String get safetySettings_noFlyHeader => 'الطيران بعد الغوص';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'قياسي (12/18/24 س)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'صارم (18/24/48 س)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'فترات إرشادية بعد غطسة واحدة بلا توقفات، وغطسات متكررة، وغطسات بتخفيف الضغط';
+
+  @override
+  String get safetyHub_title => 'السلامة';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'حظر الطيران: متبقٍ $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'حتى $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'لا قيود على الطيران';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'لا غطسات خلال الـ 48 ساعة الماضية';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'بعد غطسة واحدة بلا توقفات: إرشاد $hours ساعة';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'بعد غطسات متكررة: إرشاد $hours ساعة';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'بعد غطسة بتخفيف الضغط: إرشاد $hours ساعة';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'إرشادات DAN/UHMS منذ آخر غطسة. ليست بديلاً عن وقت حظر الطيران في حاسوب الغوص الخاص بك.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'أداة الفاصل السطحي';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'نموذج تعليمي لتخلص الأنسجة من التشبع';
+
+  @override
+  String get safetyHub_settingsLink => 'إعدادات السلامة';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => 'موقع الغوص على ارتفاع';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'هذا الموقع مسجل له ارتفاع لكن الغطسة بلا ارتفاع، لذا افترض تحليل تخفيف الضغط مستوى سطح البحر. عيّن ارتفاع الغطسة للتصحيح.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'حظر الطيران: متبقٍ $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20859,8 +20859,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get safetyHub_noFly_clear_title => 'Keine Flugeinschränkung';
 
   @override
-  String get safetyHub_noFly_clear_subtitle =>
-      'Keine Tauchgänge in den letzten 48 Stunden';
+  String get safetyHub_noFly_clear_subtitle => 'Keine aktive Flugbeschränkung';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20828,4 +20828,79 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Max';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Fliegen nach dem Tauchen';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Standard (12/18/24 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Streng (18/24/48 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Richtwerte nach einem einzelnen Nullzeit-Tauchgang, Wiederholungstauchgängen und Deko-Tauchgängen';
+
+  @override
+  String get safetyHub_title => 'Sicherheit';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'Flugverbot: noch $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Bis $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Keine Flugeinschränkung';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Keine Tauchgänge in den letzten 48 Stunden';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Nach einem einzelnen Nullzeit-Tauchgang: $hours h Richtwert';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Nach Wiederholungstauchgängen: $hours h Richtwert';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Nach einem Deko-Tauchgang: $hours h Richtwert';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'DAN/UHMS-Richtwerte ab dem letzten Tauchgang. Kein Ersatz für die Flugverbotszeit Ihres Tauchcomputers.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'Oberflächenpausen-Tool';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Lehrreiches Modell der Gewebeentsättigung';
+
+  @override
+  String get safetyHub_settingsLink => 'Sicherheitseinstellungen';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title =>
+      'Tauchplatz liegt in Höhenlage';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Für diesen Platz ist eine Höhe hinterlegt, der Tauchgang hat jedoch keine, daher ging die Deko-Analyse von Meereshöhe aus. Höhe des Tauchgangs setzen, um dies zu korrigieren.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'Flugverbot: noch $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -20541,7 +20541,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get safetyHub_noFly_clear_title => 'No flying restriction';
 
   @override
-  String get safetyHub_noFly_clear_subtitle => 'No dives in the last 48 hours';
+  String get safetyHub_noFly_clear_subtitle => 'No active flying restriction';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -20510,4 +20510,77 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Max';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Flying after diving';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Standard (12/18/24 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Strict (18/24/48 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Guideline intervals after a single no-deco dive, repetitive dives, and deco dives';
+
+  @override
+  String get safetyHub_title => 'Safety';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'No-fly: $remaining remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Until $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'No flying restriction';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle => 'No dives in the last 48 hours';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'After a single no-deco dive: $hours h guideline';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'After repetitive dives: $hours h guideline';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'After a decompression dive: $hours h guideline';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'DAN/UHMS guideline intervals from your last dive. Not a substitute for your dive computer\'s no-fly time.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'Surface interval tool';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Educational tissue desaturation model';
+
+  @override
+  String get safetyHub_settingsLink => 'Safety settings';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => 'Site is at altitude';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'This site records an altitude but the dive has none set, so decompression analysis assumed sea level. Set the dive\'s altitude to correct it.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'No-fly: $remaining remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20904,7 +20904,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get safetyHub_noFly_clear_subtitle =>
-      'Sin inmersiones en las últimas 48 horas';
+      'Sin restricción de vuelo activa';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20872,4 +20872,80 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Máx';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Volar después de bucear';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Estándar (12/18/24 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Estricto (18/24/48 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Intervalos orientativos tras una única inmersión sin deco, inmersiones sucesivas e inmersiones con deco';
+
+  @override
+  String get safetyHub_title => 'Seguridad';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'No volar: quedan $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Hasta $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Sin restricción de vuelo';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Sin inmersiones en las últimas 48 horas';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Tras una única inmersión sin deco: pauta de $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Tras inmersiones sucesivas: pauta de $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Tras una inmersión con descompresión: pauta de $hours h';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'Pautas DAN/UHMS desde tu última inmersión. No sustituye el tiempo de no volar de tu ordenador de buceo.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink =>
+      'Herramienta de intervalo en superficie';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Modelo educativo de desaturación de tejidos';
+
+  @override
+  String get safetyHub_settingsLink => 'Ajustes de seguridad';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title =>
+      'El punto de buceo está en altitud';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Este punto registra una altitud pero la inmersión no tiene ninguna, así que el análisis de descompresión asumió nivel del mar. Establece la altitud de la inmersión para corregirlo.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'No volar: quedan $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20966,7 +20966,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get safetyHub_noFly_clear_subtitle =>
-      'Aucune plongée dans les dernières 48 heures';
+      'Aucune restriction de vol active';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20934,4 +20934,78 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Max';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Voler après la plongée';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Standard (12/18/24 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Strict (18/24/48 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Intervalles indicatifs après une plongée unique sans déco, des plongées successives et des plongées avec déco';
+
+  @override
+  String get safetyHub_title => 'Sécurité';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'Interdiction de vol : $remaining restant';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Jusqu\'à $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Aucune restriction de vol';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Aucune plongée dans les dernières 48 heures';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Après une plongée unique sans déco : recommandation de $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Après des plongées successives : recommandation de $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Après une plongée avec décompression : recommandation de $hours h';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'Recommandations DAN/UHMS depuis votre dernière plongée. Ne remplace pas le temps d\'interdiction de vol de votre ordinateur de plongée.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'Outil d\'intervalle de surface';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Modèle pédagogique de désaturation des tissus';
+
+  @override
+  String get safetyHub_settingsLink => 'Réglages de sécurité';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => 'Le site est en altitude';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Ce site indique une altitude mais la plongée n\'en a aucune : l\'analyse de décompression a supposé le niveau de la mer. Définissez l\'altitude de la plongée pour corriger.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'Interdiction de vol : $remaining restant';
+  }
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -20366,8 +20366,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get safetyHub_noFly_clear_title => 'אין הגבלת טיסה';
 
   @override
-  String get safetyHub_noFly_clear_subtitle =>
-      'לא היו צלילות ב-48 השעות האחרונות';
+  String get safetyHub_noFly_clear_subtitle => 'אין הגבלת טיסה פעילה';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -20335,4 +20335,78 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'מקס\'';
+
+  @override
+  String get safetySettings_noFlyHeader => 'טיסה אחרי צלילה';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'רגיל (12/18/24 ש\')';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'מחמיר (18/24/48 ש\')';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'מרווחים מנחים אחרי צלילה בודדת ללא דקו, צלילות חוזרות וצלילות דקומפרסיה';
+
+  @override
+  String get safetyHub_title => 'בטיחות';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'איסור טיסה: נותרו $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'עד $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'אין הגבלת טיסה';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'לא היו צלילות ב-48 השעות האחרונות';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'אחרי צלילה בודדת ללא דקו: הנחיה של $hours שעות';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'אחרי צלילות חוזרות: הנחיה של $hours שעות';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'אחרי צלילת דקומפרסיה: הנחיה של $hours שעות';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'הנחיות DAN/UHMS מאז הצלילה האחרונה. אינו תחליף לזמן איסור הטיסה של מחשב הצלילה שלך.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'כלי מרווח פני השטח';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'מודל לימודי של פליטת גזים מהרקמות';
+
+  @override
+  String get safetyHub_settingsLink => 'הגדרות בטיחות';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => 'אתר הצלילה נמצא בגובה';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'לאתר זה רשום גובה אך לצלילה אין, ולכן ניתוח הדקומפרסיה הניח גובה פני הים. הגדר את גובה הצלילה כדי לתקן.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'איסור טיסה: נותרו $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20828,7 +20828,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get safetyHub_noFly_clear_subtitle =>
-      'Nem volt merülés az elmúlt 48 órában';
+      'Nincs aktív repülési korlátozás';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20796,4 +20796,79 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Max';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Repülés merülés után';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Normál (12/18/24 ó)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Szigorú (18/24/48 ó)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Irányadó időközök egyetlen nullidős merülés, ismétlő merülések és dekós merülések után';
+
+  @override
+  String get safetyHub_title => 'Biztonság';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'Repülési tilalom: $remaining van hátra';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Eddig: $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Nincs repülési korlátozás';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Nem volt merülés az elmúlt 48 órában';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Egyetlen nullidős merülés után: $hours ó irányelv';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Ismétlő merülések után: $hours ó irányelv';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Dekompressziós merülés után: $hours ó irányelv';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'DAN/UHMS irányelvek az utolsó merüléstől számítva. Nem helyettesíti a búvárkomputer no-fly idejét.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'Felszíni intervallum eszköz';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Oktató jellegű szöveti telítettségcsökkenési modell';
+
+  @override
+  String get safetyHub_settingsLink => 'Biztonsági beállítások';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title =>
+      'A merülőhely magaslaton fekszik';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Ehhez a helyhez magasság van rögzítve, a merüléshez azonban nincs, így a dekompressziós elemzés tengerszintet feltételezett. A javításhoz állítsd be a merülés magasságát.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'Repülési tilalom: $remaining van hátra';
+  }
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20894,7 +20894,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get safetyHub_noFly_clear_subtitle =>
-      'Nessuna immersione nelle ultime 48 ore';
+      'Nessuna restrizione di volo attiva';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20862,4 +20862,79 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Max';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Volare dopo l\'immersione';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Standard (12/18/24 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Rigoroso (18/24/48 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Intervalli indicativi dopo una singola immersione senza deco, immersioni ripetitive e immersioni con deco';
+
+  @override
+  String get safetyHub_title => 'Sicurezza';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'No-fly: mancano $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Fino alle $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Nessuna restrizione di volo';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Nessuna immersione nelle ultime 48 ore';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Dopo una singola immersione senza deco: linea guida di $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Dopo immersioni ripetitive: linea guida di $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Dopo un\'immersione con decompressione: linea guida di $hours h';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'Linee guida DAN/UHMS dall\'ultima immersione. Non sostituisce il tempo no-fly del tuo computer subacqueo.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink =>
+      'Strumento intervallo di superficie';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Modello educativo di desaturazione dei tessuti';
+
+  @override
+  String get safetyHub_settingsLink => 'Impostazioni di sicurezza';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => 'Il sito è in quota';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Questo sito registra un\'altitudine ma l\'immersione non ne ha una, quindi l\'analisi di decompressione ha assunto il livello del mare. Imposta l\'altitudine dell\'immersione per correggere.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'No-fly: mancano $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20728,8 +20728,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get safetyHub_noFly_clear_title => 'Geen vliegbeperking';
 
   @override
-  String get safetyHub_noFly_clear_subtitle =>
-      'Geen duiken in de afgelopen 48 uur';
+  String get safetyHub_noFly_clear_subtitle => 'Geen actieve vliegbeperking';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20697,4 +20697,78 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Max';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Vliegen na het duiken';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Standaard (12/18/24 u)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Strikt (18/24/48 u)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Richttijden na een enkele duik zonder deco, herhalingsduiken en decoduiken';
+
+  @override
+  String get safetyHub_title => 'Veiligheid';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'Vliegverbod: nog $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Tot $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Geen vliegbeperking';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Geen duiken in de afgelopen 48 uur';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Na een enkele duik zonder deco: richtlijn van $hours u';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Na herhalingsduiken: richtlijn van $hours u';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Na een decompressieduik: richtlijn van $hours u';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'DAN/UHMS-richtlijnen vanaf je laatste duik. Geen vervanging voor de no-fly-tijd van je duikcomputer.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => 'Oppervlakte-interval-tool';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Educatief model van weefselontzadiging';
+
+  @override
+  String get safetyHub_settingsLink => 'Veiligheidsinstellingen';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => 'Duikstek ligt op hoogte';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Deze stek heeft een hoogte geregistreerd maar de duik niet, dus de deco-analyse ging uit van zeeniveau. Stel de hoogte van de duik in om dit te corrigeren.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'Vliegverbod: nog $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20891,8 +20891,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get safetyHub_noFly_clear_title => 'Sem restrição de voo';
 
   @override
-  String get safetyHub_noFly_clear_subtitle =>
-      'Sem mergulhos nas últimas 48 horas';
+  String get safetyHub_noFly_clear_subtitle => 'Nenhuma restrição de voo ativa';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20860,4 +20860,80 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => 'Máx';
+
+  @override
+  String get safetySettings_noFlyHeader => 'Voar depois de mergulhar';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => 'Padrão (12/18/24 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => 'Rigoroso (18/24/48 h)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle =>
+      'Intervalos orientativos após um único mergulho sem deco, mergulhos repetitivos e mergulhos com deco';
+
+  @override
+  String get safetyHub_title => 'Segurança';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return 'Não voar: faltam $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return 'Até $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => 'Sem restrição de voo';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle =>
+      'Sem mergulhos nas últimas 48 horas';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return 'Após um único mergulho sem deco: orientação de $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return 'Após mergulhos repetitivos: orientação de $hours h';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return 'Após um mergulho com descompressão: orientação de $hours h';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      'Orientações DAN/UHMS desde o último mergulho. Não substitui o tempo de não voar do seu computador de mergulho.';
+
+  @override
+  String get safetyHub_surfaceIntervalLink =>
+      'Ferramenta de intervalo de superfície';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle =>
+      'Modelo educativo de dessaturação dos tecidos';
+
+  @override
+  String get safetyHub_settingsLink => 'Configurações de segurança';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title =>
+      'O ponto de mergulho fica em altitude';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      'Este ponto registra uma altitude, mas o mergulho não tem nenhuma, então a análise de descompressão assumiu o nível do mar. Defina a altitude do mergulho para corrigir.';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return 'Não voar: faltam $remaining';
+  }
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19836,7 +19836,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get safetyHub_noFly_clear_title => '无飞行限制';
 
   @override
-  String get safetyHub_noFly_clear_subtitle => '过去 48 小时内没有潜水';
+  String get safetyHub_noFly_clear_subtitle => '无活动的飞行限制';
 
   @override
   String safetyHub_noFly_category_single(int hours) {

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19806,4 +19806,75 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get diveLog_filter_thicknessMax => '最大';
+
+  @override
+  String get safetySettings_noFlyHeader => '潜水后飞行';
+
+  @override
+  String get safetySettings_noFlyPreset_standard => '标准(12/18/24 小时)';
+
+  @override
+  String get safetySettings_noFlyPreset_strict => '严格(18/24/48 小时)';
+
+  @override
+  String get safetySettings_noFlyPreset_subtitle => '单次免减压潜水、重复潜水和减压潜水后的指导间隔';
+
+  @override
+  String get safetyHub_title => '安全';
+
+  @override
+  String safetyHub_noFly_active_title(String remaining) {
+    return '禁飞:剩余 $remaining';
+  }
+
+  @override
+  String safetyHub_noFly_until(String time) {
+    return '直到 $time';
+  }
+
+  @override
+  String get safetyHub_noFly_clear_title => '无飞行限制';
+
+  @override
+  String get safetyHub_noFly_clear_subtitle => '过去 48 小时内没有潜水';
+
+  @override
+  String safetyHub_noFly_category_single(int hours) {
+    return '单次免减压潜水后:$hours 小时指导值';
+  }
+
+  @override
+  String safetyHub_noFly_category_repetitive(int hours) {
+    return '重复潜水后:$hours 小时指导值';
+  }
+
+  @override
+  String safetyHub_noFly_category_deco(int hours) {
+    return '减压潜水后:$hours 小时指导值';
+  }
+
+  @override
+  String get safetyHub_noFly_disclaimer =>
+      '自最后一次潜水起的 DAN/UHMS 指导值。不能替代潜水电脑的禁飞时间。';
+
+  @override
+  String get safetyHub_surfaceIntervalLink => '水面间隔工具';
+
+  @override
+  String get safetyHub_surfaceIntervalLink_subtitle => '组织脱饱和教学模型';
+
+  @override
+  String get safetyHub_settingsLink => '安全设置';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_title => '潜点位于高海拔';
+
+  @override
+  String get diveLog_detail_altitudeMismatch_subtitle =>
+      '该潜点记录了海拔,但此次潜水未设置海拔,因此减压分析按海平面计算。请设置潜水海拔以更正。';
+
+  @override
+  String safetyHub_alert_noFly(String remaining) {
+    return '禁飞:剩余 $remaining';
+  }
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Geen vliegbeperking",
-  "safetyHub_noFly_clear_subtitle": "Geen duiken in de afgelopen 48 uur",
+  "safetyHub_noFly_clear_subtitle": "Geen actieve vliegbeperking",
   "safetyHub_noFly_category_single": "Na een enkele duik zonder deco: richtlijn van {hours} u",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Automatische profielobservaties na de duik",
   "safetyReview_sectionTitle": "Veiligheidscontrole",
   "safetyReview_findingCount": "{count, plural, =1{1 observatie} other{{count} observaties}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "Opstijging overschreed {rate} gedurende {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "Diepte lag {excess} boven het vereiste stopplafond gedurende {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "De aanbevolen veiligheidsstop is met {remaining} ingekort",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} herhaalde op-en-neer dieptewisselingen tijdens de duik",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Aan de oppervlakte gekomen met gradiëntfactor {gf}, boven de ingestelde {gfHigh}",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "Op {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Negeren",
   "safetyReview_restore": "Herstellen",
   "safetyReview_showDismissed": "{count, plural, =1{Toon 1 genegeerde} other{Toon {count} genegeerde}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Veiligheidscontrole",
   "safetySettings_entry_subtitle": "Observaties en regels na de duik",
   "safetySettings_masterToggle": "Veiligheidscontrole na de duik",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Alle duiken analyseren",
   "safetySettings_analyzeAll_subtitle": "Voer de veiligheidscontrole uit op alle duiken met een profiel die nog niet geanalyseerd zijn",
   "safetySettings_analyzeAll_progress": "{done} van {total} geanalyseerd",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Analyse voltooid",
   "safetySettings_analyzeAll_doneWithErrors": "Analyse voltooid — {count, plural, =1{1 duik kon niet worden geanalyseerd} other{{count} duiken konden niet worden geanalyseerd}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Vliegen na het duiken",
+  "safetySettings_noFlyPreset_standard": "Standaard (12/18/24 u)",
+  "safetySettings_noFlyPreset_strict": "Strikt (18/24/48 u)",
+  "safetySettings_noFlyPreset_subtitle": "Richttijden na een enkele duik zonder deco, herhalingsduiken en decoduiken",
+  "safetyHub_title": "Veiligheid",
+  "safetyHub_noFly_active_title": "Vliegverbod: nog {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Tot {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Geen vliegbeperking",
+  "safetyHub_noFly_clear_subtitle": "Geen duiken in de afgelopen 48 uur",
+  "safetyHub_noFly_category_single": "Na een enkele duik zonder deco: richtlijn van {hours} u",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Na herhalingsduiken: richtlijn van {hours} u",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Na een decompressieduik: richtlijn van {hours} u",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "DAN/UHMS-richtlijnen vanaf je laatste duik. Geen vervanging voor de no-fly-tijd van je duikcomputer.",
+  "safetyHub_surfaceIntervalLink": "Oppervlakte-interval-tool",
+  "safetyHub_surfaceIntervalLink_subtitle": "Educatief model van weefselontzadiging",
+  "safetyHub_settingsLink": "Veiligheidsinstellingen",
+  "safetyHub_alert_noFly": "Vliegverbod: nog {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "Duikstek ligt op hoogte",
+  "diveLog_detail_altitudeMismatch_subtitle": "Deze stek heeft een hoogte geregistreerd maar de duik niet, dus de deco-analyse ging uit van zeeniveau. Stel de hoogte van de duik in om dit te corrigeren."
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "Sem restrição de voo",
-  "safetyHub_noFly_clear_subtitle": "Sem mergulhos nas últimas 48 horas",
+  "safetyHub_noFly_clear_subtitle": "Nenhuma restrição de voo ativa",
   "safetyHub_noFly_category_single": "Após um único mergulho sem deco: orientação de {hours} h",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "Observações automáticas do perfil após o mergulho",
   "safetyReview_sectionTitle": "Revisão de segurança",
   "safetyReview_findingCount": "{count, plural, =1{1 observação} other{{count} observações}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "A subida excedeu {rate} durante {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "A profundidade ficou {excess} acima do teto de parada exigido durante {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "A parada de segurança recomendada foi encurtada em {remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "{count} variações repetidas de profundidade para cima e para baixo durante o mergulho",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "Chegou à superfície com fator de gradiente {gf}, acima do {gfHigh} configurado",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "Em {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "Dispensar",
   "safetyReview_restore": "Restaurar",
   "safetyReview_showDismissed": "{count, plural, =1{Mostrar 1 dispensada} other{Mostrar {count} dispensadas}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Revisão de segurança",
   "safetySettings_entry_subtitle": "Observações e regras pós-mergulho",
   "safetySettings_masterToggle": "Revisão de segurança pós-mergulho",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "Analisar todos os mergulhos",
   "safetySettings_analyzeAll_subtitle": "Executar a revisão de segurança em todos os mergulhos com perfil ainda não analisados",
   "safetySettings_analyzeAll_progress": "Analisados {done} de {total}",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "Análise concluída",
   "safetySettings_analyzeAll_doneWithErrors": "Análise concluída — {count, plural, =1{Não foi possível analisar 1 mergulho} other{Não foi possível analisar {count} mergulhos}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "Voar depois de mergulhar",
+  "safetySettings_noFlyPreset_standard": "Padrão (12/18/24 h)",
+  "safetySettings_noFlyPreset_strict": "Rigoroso (18/24/48 h)",
+  "safetySettings_noFlyPreset_subtitle": "Intervalos orientativos após um único mergulho sem deco, mergulhos repetitivos e mergulhos com deco",
+  "safetyHub_title": "Segurança",
+  "safetyHub_noFly_active_title": "Não voar: faltam {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "Até {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "Sem restrição de voo",
+  "safetyHub_noFly_clear_subtitle": "Sem mergulhos nas últimas 48 horas",
+  "safetyHub_noFly_category_single": "Após um único mergulho sem deco: orientação de {hours} h",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "Após mergulhos repetitivos: orientação de {hours} h",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "Após um mergulho com descompressão: orientação de {hours} h",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "Orientações DAN/UHMS desde o último mergulho. Não substitui o tempo de não voar do seu computador de mergulho.",
+  "safetyHub_surfaceIntervalLink": "Ferramenta de intervalo de superfície",
+  "safetyHub_surfaceIntervalLink_subtitle": "Modelo educativo de dessaturação dos tecidos",
+  "safetyHub_settingsLink": "Configurações de segurança",
+  "safetyHub_alert_noFly": "Não voar: faltam {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "O ponto de mergulho fica em altitude",
+  "diveLog_detail_altitudeMismatch_subtitle": "Este ponto registra uma altitude, mas o mergulho não tem nenhuma, então a análise de descompressão assumiu o nível do mar. Defina a altitude do mergulho para corrigir."
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6135,7 +6135,7 @@
     }
   },
   "safetyHub_noFly_clear_title": "无飞行限制",
-  "safetyHub_noFly_clear_subtitle": "过去 48 小时内没有潜水",
+  "safetyHub_noFly_clear_subtitle": "无活动的飞行限制",
   "safetyHub_noFly_category_single": "单次免减压潜水后:{hours} 小时指导值",
   "@safetyHub_noFly_category_single": {
     "placeholders": {

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6004,23 +6004,83 @@
   "diveDetailSection_safetyReview_description": "潜水后自动生成的剖面观察",
   "safetyReview_sectionTitle": "安全回顾",
   "safetyReview_findingCount": "{count, plural, =1{1 条观察} other{{count} 条观察}}",
-  "@safetyReview_findingCount": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_findingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_rapidAscent_title": "上升速度超过 {rate},持续 {duration}",
-  "@safetyReview_rapidAscent_title": {"placeholders": {"rate": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_rapidAscent_title": {
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_missedDecoStop_title": "深度高于所需停留天花板 {excess},持续 {duration}",
-  "@safetyReview_missedDecoStop_title": {"placeholders": {"excess": {"type": "String"}, "duration": {"type": "String"}}},
+  "@safetyReview_missedDecoStop_title": {
+    "placeholders": {
+      "excess": {
+        "type": "String"
+      },
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_omittedSafetyStop_title": "建议的安全停留缩短了 {remaining}",
-  "@safetyReview_omittedSafetyStop_title": {"placeholders": {"remaining": {"type": "String"}}},
+  "@safetyReview_omittedSafetyStop_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_sawtoothProfile_title": "潜水期间出现 {count} 次反复的上下深度变化",
-  "@safetyReview_sawtoothProfile_title": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_sawtoothProfile_title": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_highSurfaceGf_title": "出水时梯度因子为 {gf},高于设定的 {gfHigh}",
-  "@safetyReview_highSurfaceGf_title": {"placeholders": {"gf": {"type": "String"}, "gfHigh": {"type": "String"}}},
+  "@safetyReview_highSurfaceGf_title": {
+    "placeholders": {
+      "gf": {
+        "type": "String"
+      },
+      "gfHigh": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_timeRange": "于 {start}–{end}",
-  "@safetyReview_timeRange": {"placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@safetyReview_timeRange": {
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "safetyReview_dismiss": "忽略",
   "safetyReview_restore": "恢复",
   "safetyReview_showDismissed": "{count, plural, =1{显示 1 条已忽略} other{显示 {count} 条已忽略}}",
-  "@safetyReview_showDismissed": {"placeholders": {"count": {"type": "int"}}},
+  "@safetyReview_showDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "安全回顾",
   "safetySettings_entry_subtitle": "潜水后的观察与规则",
   "safetySettings_masterToggle": "潜水后安全回顾",
@@ -6034,7 +6094,16 @@
   "safetySettings_analyzeAll": "分析所有潜水",
   "safetySettings_analyzeAll_subtitle": "对所有具有剖面且尚未分析的潜水运行安全回顾",
   "safetySettings_analyzeAll_progress": "已分析 {done}/{total}",
-  "@safetySettings_analyzeAll_progress": {"placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
+  "@safetySettings_analyzeAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_analyzeAll_done": "分析完成",
   "safetySettings_analyzeAll_doneWithErrors": "分析完成 — {count, plural, =1{有 1 次潜水无法分析} other{有 {count} 次潜水无法分析}}",
   "@safetySettings_analyzeAll_doneWithErrors": {
@@ -6043,5 +6112,66 @@
         "type": "int"
       }
     }
-  }
+  },
+  "safetySettings_noFlyHeader": "潜水后飞行",
+  "safetySettings_noFlyPreset_standard": "标准(12/18/24 小时)",
+  "safetySettings_noFlyPreset_strict": "严格(18/24/48 小时)",
+  "safetySettings_noFlyPreset_subtitle": "单次免减压潜水、重复潜水和减压潜水后的指导间隔",
+  "safetyHub_title": "安全",
+  "safetyHub_noFly_active_title": "禁飞:剩余 {remaining}",
+  "@safetyHub_noFly_active_title": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_until": "直到 {time}",
+  "@safetyHub_noFly_until": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "safetyHub_noFly_clear_title": "无飞行限制",
+  "safetyHub_noFly_clear_subtitle": "过去 48 小时内没有潜水",
+  "safetyHub_noFly_category_single": "单次免减压潜水后:{hours} 小时指导值",
+  "@safetyHub_noFly_category_single": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_repetitive": "重复潜水后:{hours} 小时指导值",
+  "@safetyHub_noFly_category_repetitive": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_category_deco": "减压潜水后:{hours} 小时指导值",
+  "@safetyHub_noFly_category_deco": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "safetyHub_noFly_disclaimer": "自最后一次潜水起的 DAN/UHMS 指导值。不能替代潜水电脑的禁飞时间。",
+  "safetyHub_surfaceIntervalLink": "水面间隔工具",
+  "safetyHub_surfaceIntervalLink_subtitle": "组织脱饱和教学模型",
+  "safetyHub_settingsLink": "安全设置",
+  "safetyHub_alert_noFly": "禁飞:剩余 {remaining}",
+  "@safetyHub_alert_noFly": {
+    "placeholders": {
+      "remaining": {
+        "type": "String"
+      }
+    }
+  },
+  "diveLog_detail_altitudeMismatch_title": "潜点位于高海拔",
+  "diveLog_detail_altitudeMismatch_subtitle": "该潜点记录了海拔,但此次潜水未设置海拔,因此减压分析按海平面计算。请设置潜水海拔以更正。"
 }

--- a/test/core/database/migration_v124_no_fly_preset_test.dart
+++ b/test/core/database/migration_v124_no_fly_preset_test.dart
@@ -37,7 +37,10 @@ void main() {
   });
 
   test('v124 is the current schema version (exact-latest tripwire)', () {
-    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(124));
+    // Exact assertion: the newest migration owns the tripwire, so the next
+    // schema bump must move it forward. Relax to greaterThanOrEqualTo and add
+    // a fresh exact test when a later migration lands on top of v124.
+    expect(AppDatabase.currentSchemaVersion, 124);
     expect(AppDatabase.migrationVersions, contains(124));
   });
 }

--- a/test/core/database/migration_v124_no_fly_preset_test.dart
+++ b/test/core/database/migration_v124_no_fly_preset_test.dart
@@ -1,0 +1,43 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Minimal pre-no-fly shape: a diver_settings table with at least one column
+/// (so the PRAGMA-guarded ALTER fires). Stamped at v123 so the 123->124
+/// upgrade runs the no-fly migration block directly.
+NativeDatabase _dbAt123() {
+  return NativeDatabase.memory(
+    setup: (rawDb) {
+      rawDb.execute('PRAGMA user_version = 123');
+      rawDb.execute('''
+        CREATE TABLE diver_settings (
+          id TEXT NOT NULL PRIMARY KEY
+        )
+      ''');
+      rawDb.execute("INSERT INTO diver_settings (id) VALUES ('settings')");
+    },
+  );
+}
+
+void main() {
+  test('v124 adds no_fly_preset to diver_settings', () async {
+    final db = AppDatabase(_dbAt123());
+    addTearDown(() => db.close());
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('diver_settings')")
+        .get();
+    final byName = {for (final c in cols) c.read<String>('name'): c};
+    expect(byName.keys, contains('no_fly_preset'));
+    // Existing rows take the guideline default.
+    final rows = await db
+        .customSelect("SELECT no_fly_preset FROM diver_settings")
+        .get();
+    expect(rows.single.read<String>('no_fly_preset'), 'standard');
+  });
+
+  test('v124 is the current schema version (exact-latest tripwire)', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(124));
+    expect(AppDatabase.migrationVersions, contains(124));
+  });
+}

--- a/test/core/database/migration_v125_no_fly_preset_test.dart
+++ b/test/core/database/migration_v125_no_fly_preset_test.dart
@@ -3,12 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 
 /// Minimal pre-no-fly shape: a diver_settings table with at least one column
-/// (so the PRAGMA-guarded ALTER fires). Stamped at v123 so the 123->124
-/// upgrade runs the no-fly migration block directly.
-NativeDatabase _dbAt123() {
+/// (so the PRAGMA-guarded ALTER fires). Stamped at v124 so the 124->125
+/// upgrade runs the no-fly migration block directly, without invoking the
+/// v124 equipment-attributes migration (which expects an equipment table).
+NativeDatabase _dbAt124() {
   return NativeDatabase.memory(
     setup: (rawDb) {
-      rawDb.execute('PRAGMA user_version = 123');
+      rawDb.execute('PRAGMA user_version = 124');
       rawDb.execute('''
         CREATE TABLE diver_settings (
           id TEXT NOT NULL PRIMARY KEY
@@ -20,8 +21,8 @@ NativeDatabase _dbAt123() {
 }
 
 void main() {
-  test('v124 adds no_fly_preset to diver_settings', () async {
-    final db = AppDatabase(_dbAt123());
+  test('v125 adds no_fly_preset to diver_settings', () async {
+    final db = AppDatabase(_dbAt124());
     addTearDown(() => db.close());
 
     final cols = await db
@@ -36,11 +37,11 @@ void main() {
     expect(rows.single.read<String>('no_fly_preset'), 'standard');
   });
 
-  test('v124 is the current schema version (exact-latest tripwire)', () {
+  test('v125 is the current schema version (exact-latest tripwire)', () {
     // Exact assertion: the newest migration owns the tripwire, so the next
     // schema bump must move it forward. Relax to greaterThanOrEqualTo and add
-    // a fresh exact test when a later migration lands on top of v124.
-    expect(AppDatabase.currentSchemaVersion, 124);
-    expect(AppDatabase.migrationVersions, contains(124));
+    // a fresh exact test when a later migration lands on top of v125.
+    expect(AppDatabase.currentSchemaVersion, 125);
+    expect(AppDatabase.migrationVersions, contains(125));
   });
 }

--- a/test/features/dashboard/presentation/providers/dashboard_alerts_test.dart
+++ b/test/features/dashboard/presentation/providers/dashboard_alerts_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+
+NoFlyStatus _status({required Duration untilOffset}) {
+  return NoFlyStatus(
+    until: DateTime.now().toUtc().add(untilOffset),
+    category: NoFlyCategory.single,
+    interval: const Duration(hours: 12),
+  );
+}
+
+void main() {
+  test('an active no-fly restriction counts as an alert', () {
+    final alerts = DashboardAlerts(
+      insuranceExpiringSoon: false,
+      insuranceExpired: false,
+      noFlyStatus: _status(untilOffset: const Duration(hours: 2)),
+    );
+    expect(alerts.hasActiveNoFly, isTrue);
+    expect(alerts.hasAlerts, isTrue);
+    expect(alerts.alertCount, 1);
+  });
+
+  test('an expired cached no-fly status clears the alert and badge', () {
+    final alerts = DashboardAlerts(
+      insuranceExpiringSoon: false,
+      insuranceExpired: false,
+      // Deadline already in the past: the snapshot lingers but is no longer
+      // an active restriction.
+      noFlyStatus: _status(untilOffset: const Duration(minutes: -1)),
+    );
+    expect(alerts.hasActiveNoFly, isFalse);
+    expect(alerts.hasAlerts, isFalse);
+    expect(alerts.alertCount, 0);
+  });
+
+  test('expired no-fly does not inflate the count alongside insurance', () {
+    final alerts = DashboardAlerts(
+      insuranceExpiringSoon: false,
+      insuranceExpired: true,
+      noFlyStatus: _status(untilOffset: const Duration(minutes: -1)),
+    );
+    expect(alerts.hasActiveNoFly, isFalse);
+    expect(alerts.alertCount, 1);
+  });
+}

--- a/test/features/dashboard/presentation/widgets/alerts_card_test.dart
+++ b/test/features/dashboard/presentation/widgets/alerts_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -122,6 +123,56 @@ void main() {
 
       // Badge count should be visible
       expect(find.text('1'), findsWidgets);
+    });
+
+    testWidgets('active no-fly renders the countdown and taps to /safety', (
+      tester,
+    ) async {
+      final overrides = await getBaseOverrides();
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(body: AlertsCard()),
+          ),
+          GoRoute(
+            path: '/safety',
+            builder: (_, _) => const Scaffold(body: Text('safety-hub-reached')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            serviceDueEquipmentProvider.overrideWith((ref) async => []),
+            dueClocksProvider.overrideWith((ref) async => []),
+            currentDiverProvider.overrideWith((ref) async => null),
+            noFlyStatusProvider.overrideWith(
+              (ref) async => NoFlyStatus(
+                until: DateTime.now().toUtc().add(const Duration(hours: 5)),
+                category: NoFlyCategory.single,
+                interval: const Duration(hours: 12),
+              ),
+            ),
+          ].cast(),
+          child: MaterialApp.router(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('No-fly:'), findsOneWidget);
+
+      await tester.tap(find.byType(AlertsCard));
+      await tester.pumpAndSettle();
+      expect(find.text('safety-hub-reached'), findsOneWidget);
     });
   });
 }

--- a/test/features/dashboard/presentation/widgets/alerts_card_test.dart
+++ b/test/features/dashboard/presentation/widgets/alerts_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -35,6 +36,7 @@ void main() {
             serviceDueEquipmentProvider.overrideWith((ref) async => []),
             dueClocksProvider.overrideWith((ref) async => []),
             currentDiverProvider.overrideWith((ref) async => null),
+            noFlyStatusProvider.overrideWith((ref) async => null),
           ].cast(),
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -107,6 +109,7 @@ void main() {
               ],
             ),
             currentDiverProvider.overrideWith((ref) async => null),
+            noFlyStatusProvider.overrideWith((ref) async => null),
           ].cast(),
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/dive_log/data/repositories/no_fly_dive_inputs_test.dart
+++ b/test/features/dive_log/data/repositories/no_fly_dive_inputs_test.dart
@@ -22,6 +22,7 @@ void main() {
     DateTime? exitTime,
     DateTime? entryTime,
     int? runtimeSeconds,
+    String? diverId,
   }) async {
     final created = now.millisecondsSinceEpoch;
     await db
@@ -29,6 +30,7 @@ void main() {
         .insert(
           DivesCompanion(
             id: Value(id),
+            diverId: Value(diverId),
             diveDateTime: Value(
               (entryTime ?? exitTime ?? now).millisecondsSinceEpoch,
             ),
@@ -115,5 +117,26 @@ void main() {
       since: now.subtract(const Duration(hours: 48)),
     );
     expect(inputs.single.hadDecoObligation, isFalse);
+  });
+
+  test('passing a diverId scopes the query to that diver', () async {
+    // A dive with no diver assigned must not surface when the query is scoped
+    // to a specific diver (exercises the diver_id WHERE clause).
+    await insertDive(
+      'unowned',
+      exitTime: now.subtract(const Duration(hours: 1)),
+    );
+
+    final scoped = await repository.getNoFlyDiveInputs(
+      since: now.subtract(const Duration(hours: 48)),
+      diverId: 'diver-1',
+    );
+    expect(scoped, isEmpty);
+
+    // Without a diver filter the same dive is returned.
+    final unscoped = await repository.getNoFlyDiveInputs(
+      since: now.subtract(const Duration(hours: 48)),
+    );
+    expect(unscoped, hasLength(1));
   });
 }

--- a/test/features/dive_log/data/repositories/no_fly_dive_inputs_test.dart
+++ b/test/features/dive_log/data/repositories/no_fly_dive_inputs_test.dart
@@ -1,0 +1,119 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late DiveRepository repository;
+  final now = DateTime.utc(2026, 7, 17, 12);
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  Future<void> insertDive(
+    String id, {
+    DateTime? exitTime,
+    DateTime? entryTime,
+    int? runtimeSeconds,
+  }) async {
+    final created = now.millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(
+              (entryTime ?? exitTime ?? now).millisecondsSinceEpoch,
+            ),
+            entryTime: Value(entryTime?.millisecondsSinceEpoch),
+            exitTime: Value(exitTime?.millisecondsSinceEpoch),
+            runtime: Value(runtimeSeconds),
+            createdAt: Value(created),
+            updatedAt: Value(created),
+          ),
+        );
+  }
+
+  Future<void> insertProfilePoint(
+    String diveId, {
+    int? decoType,
+    double? ceiling,
+  }) async {
+    await db
+        .into(db.diveProfiles)
+        .insert(
+          DiveProfilesCompanion(
+            id: Value('$diveId-p${decoType ?? 0}-${ceiling ?? 0}'),
+            diveId: Value(diveId),
+            timestamp: const Value(60),
+            depth: const Value(20.0),
+            decoType: Value(decoType),
+            ceiling: Value(ceiling),
+          ),
+        );
+  }
+
+  test('returns dives ending after the cutoff with deco flags', () async {
+    final since = now.subtract(const Duration(hours: 48));
+
+    // Recent dive with explicit exit time, deco profile sample.
+    await insertDive(
+      'recent-deco',
+      exitTime: now.subtract(const Duration(hours: 2)),
+    );
+    await insertProfilePoint('recent-deco', decoType: 2);
+
+    // Recent dive with end derived from entry + runtime, clean profile.
+    await insertDive(
+      'recent-clean',
+      entryTime: now.subtract(const Duration(hours: 6)),
+      runtimeSeconds: 3600,
+    );
+    await insertProfilePoint('recent-clean', decoType: 0, ceiling: 0);
+
+    // Old dive outside the window.
+    await insertDive('old', exitTime: now.subtract(const Duration(hours: 72)));
+    await insertProfilePoint('old', decoType: 2);
+
+    final inputs = await repository.getNoFlyDiveInputs(since: since);
+    final byEnd = {for (final i in inputs) i.endTime.millisecondsSinceEpoch: i};
+
+    expect(inputs, hasLength(2));
+    final decoEnd = now
+        .subtract(const Duration(hours: 2))
+        .millisecondsSinceEpoch;
+    final cleanEnd = now
+        .subtract(const Duration(hours: 5))
+        .millisecondsSinceEpoch;
+    expect(byEnd[decoEnd]!.hadDecoObligation, isTrue);
+    expect(byEnd[cleanEnd]!.hadDecoObligation, isFalse);
+  });
+
+  test('ceiling > 0 also counts as deco', () async {
+    await insertDive(
+      'ceiling-dive',
+      exitTime: now.subtract(const Duration(hours: 1)),
+    );
+    await insertProfilePoint('ceiling-dive', ceiling: 3.0);
+
+    final inputs = await repository.getNoFlyDiveInputs(
+      since: now.subtract(const Duration(hours: 48)),
+    );
+    expect(inputs.single.hadDecoObligation, isTrue);
+  });
+
+  test('dive without profile counts as no-deco', () async {
+    await insertDive('bare', exitTime: now.subtract(const Duration(hours: 1)));
+    final inputs = await repository.getNoFlyDiveInputs(
+      since: now.subtract(const Duration(hours: 48)),
+    );
+    expect(inputs.single.hadDecoObligation, isFalse);
+  });
+}

--- a/test/features/safety/domain/services/altitude_flag_test.dart
+++ b/test/features/safety/domain/services/altitude_flag_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/safety/domain/services/altitude_flag.dart';
+
+void main() {
+  test('flags when site is at altitude and dive has none', () {
+    expect(
+      needsAltitudeAdjustmentFlag(diveAltitude: null, siteAltitude: 2000),
+      isTrue,
+    );
+    expect(
+      needsAltitudeAdjustmentFlag(diveAltitude: 0, siteAltitude: 350),
+      isTrue,
+    );
+  });
+
+  test('does not flag adjusted dives or low sites', () {
+    expect(
+      needsAltitudeAdjustmentFlag(diveAltitude: 2000, siteAltitude: 2000),
+      isFalse,
+    );
+    expect(
+      needsAltitudeAdjustmentFlag(diveAltitude: null, siteAltitude: 50),
+      isFalse,
+    );
+    expect(
+      needsAltitudeAdjustmentFlag(diveAltitude: null, siteAltitude: null),
+      isFalse,
+    );
+  });
+}

--- a/test/features/safety/domain/services/no_fly_service_test.dart
+++ b/test/features/safety/domain/services/no_fly_service_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+
+void main() {
+  const service = NoFlyService();
+  final now = DateTime.utc(2026, 7, 17, 12);
+
+  NoFlyDiveInput dive({required int hoursAgo, bool deco = false}) =>
+      NoFlyDiveInput(
+        endTime: now.subtract(Duration(hours: hoursAgo)),
+        hadDecoObligation: deco,
+      );
+
+  test('no dives means no restriction', () {
+    expect(
+      service.evaluate(dives: const [], preset: NoFlyPreset.standard, now: now),
+      isNull,
+    );
+  });
+
+  test('single no-deco dive: 12 h from dive end (standard)', () {
+    final status = service.evaluate(
+      dives: [dive(hoursAgo: 2)],
+      preset: NoFlyPreset.standard,
+      now: now,
+    );
+    expect(status, isNotNull);
+    expect(status!.category, NoFlyCategory.single);
+    expect(status.until, now.add(const Duration(hours: 10)));
+    expect(status.remaining(now), const Duration(hours: 10));
+  });
+
+  test('two dives in the window: repetitive, 18 h (standard)', () {
+    final status = service.evaluate(
+      dives: [dive(hoursAgo: 2), dive(hoursAgo: 6)],
+      preset: NoFlyPreset.standard,
+      now: now,
+    );
+    expect(status!.category, NoFlyCategory.repetitive);
+    expect(status.until, now.add(const Duration(hours: 16)));
+  });
+
+  test('any deco dive: 24 h (standard)', () {
+    final status = service.evaluate(
+      dives: [dive(hoursAgo: 2), dive(hoursAgo: 6, deco: true)],
+      preset: NoFlyPreset.standard,
+      now: now,
+    );
+    expect(status!.category, NoFlyCategory.deco);
+    expect(status.until, now.add(const Duration(hours: 22)));
+  });
+
+  test('strict preset raises intervals to 18/24/48', () {
+    final single = service.evaluate(
+      dives: [dive(hoursAgo: 2)],
+      preset: NoFlyPreset.strict,
+      now: now,
+    );
+    expect(single!.until, now.add(const Duration(hours: 16)));
+
+    final deco = service.evaluate(
+      dives: [dive(hoursAgo: 2, deco: true)],
+      preset: NoFlyPreset.strict,
+      now: now,
+    );
+    expect(deco!.until, now.add(const Duration(hours: 46)));
+  });
+
+  test('expired restriction returns null', () {
+    expect(
+      service.evaluate(
+        dives: [dive(hoursAgo: 13)],
+        preset: NoFlyPreset.standard,
+        now: now,
+      ),
+      isNull,
+    );
+  });
+
+  test('dives outside the 48 h lookback are ignored', () {
+    expect(
+      service.evaluate(
+        dives: [dive(hoursAgo: 49, deco: true)],
+        preset: NoFlyPreset.standard,
+        now: now,
+      ),
+      isNull,
+    );
+  });
+
+  test('multi-day diving counts as repetitive even with one dive today', () {
+    // One dive yesterday (35 h ago, still in lookback) and one 2 h ago:
+    // window has 2 dives -> repetitive.
+    final status = service.evaluate(
+      dives: [dive(hoursAgo: 2), dive(hoursAgo: 35)],
+      preset: NoFlyPreset.standard,
+      now: now,
+    );
+    expect(status!.category, NoFlyCategory.repetitive);
+  });
+
+  test('preset enum round-trips db values', () {
+    expect(NoFlyPreset.fromDbValue('strict'), NoFlyPreset.strict);
+    expect(NoFlyPreset.fromDbValue('nonsense'), NoFlyPreset.standard);
+    expect(NoFlyPreset.strict.dbValue, 'strict');
+  });
+}

--- a/test/features/safety/presentation/pages/safety_hub_page_test.dart
+++ b/test/features/safety/presentation/pages/safety_hub_page_test.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/safety/presentation/formatters/no_fly_format.dart';
 import 'package:submersion/features/safety/presentation/pages/safety_hub_page.dart';
 import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
 
@@ -12,7 +16,12 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [noFlyStatusProvider.overrideWith((ref) async => status)],
-        child: localizedMaterialApp(home: const SafetyHubPage()),
+        // Pin English so the asserted UI strings do not depend on the host
+        // environment's locale.
+        child: localizedMaterialApp(
+          home: const SafetyHubPage(),
+          locale: const Locale('en'),
+        ),
       ),
     );
     await tester.pump();
@@ -22,6 +31,48 @@ void main() {
   testWidgets('shows all-clear when no restriction', (tester) async {
     await pump(tester, null);
     expect(find.text('No flying restriction'), findsOneWidget);
+  });
+
+  testWidgets('shows a loading placeholder before the status resolves', (
+    tester,
+  ) async {
+    final pending = Completer<NoFlyStatus?>();
+    addTearDown(() => pending.complete(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [noFlyStatusProvider.overrideWith((ref) => pending.future)],
+        child: localizedMaterialApp(
+          home: const SafetyHubPage(),
+          locale: const Locale('en'),
+        ),
+      ),
+    );
+    await tester.pump();
+    // Never implies "no restriction" while still loading.
+    expect(find.text('Loading'), findsOneWidget);
+    expect(find.text('No flying restriction'), findsNothing);
+  });
+
+  testWidgets('shows an error placeholder when the status fails to load', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          noFlyStatusProvider.overrideWith(
+            (ref) async => throw Exception('boom'),
+          ),
+        ],
+        child: localizedMaterialApp(
+          home: const SafetyHubPage(),
+          locale: const Locale('en'),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('Error'), findsOneWidget);
+    expect(find.text('No flying restriction'), findsNothing);
   });
 
   testWidgets('shows countdown for an active restriction', (tester) async {
@@ -41,6 +92,6 @@ void main() {
       formatNoFlyRemaining(const Duration(hours: 14, minutes: 20)),
       '14h 20m',
     );
-    expect(formatNoFlyRemaining(const Duration(minutes: 45)), '45m');
+    expect(formatNoFlyRemaining(const Duration(minutes: 45)), '45min');
   });
 }

--- a/test/features/safety/presentation/pages/safety_hub_page_test.dart
+++ b/test/features/safety/presentation/pages/safety_hub_page_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/safety/presentation/pages/safety_hub_page.dart';
+import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
+
+import '../../../../helpers/l10n_test_helpers.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, NoFlyStatus? status) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [noFlyStatusProvider.overrideWith((ref) async => status)],
+        child: localizedMaterialApp(home: const SafetyHubPage()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('shows all-clear when no restriction', (tester) async {
+    await pump(tester, null);
+    expect(find.text('No flying restriction'), findsOneWidget);
+  });
+
+  testWidgets('shows countdown for an active restriction', (tester) async {
+    final status = NoFlyStatus(
+      until: DateTime.now().toUtc().add(const Duration(hours: 10)),
+      category: NoFlyCategory.repetitive,
+      interval: const Duration(hours: 18),
+    );
+    await pump(tester, status);
+    expect(find.textContaining('No-fly:'), findsOneWidget);
+    expect(find.textContaining('repetitive dives: 18 h'), findsOneWidget);
+    expect(find.textContaining('Not a substitute'), findsOneWidget);
+  });
+
+  test('formatNoFlyRemaining formats hours and minutes', () {
+    expect(
+      formatNoFlyRemaining(const Duration(hours: 14, minutes: 20)),
+      '14h 20m',
+    );
+    expect(formatNoFlyRemaining(const Duration(minutes: 45)), '45m');
+  });
+}

--- a/test/features/safety/presentation/pages/safety_hub_page_test.dart
+++ b/test/features/safety/presentation/pages/safety_hub_page_test.dart
@@ -87,6 +87,16 @@ void main() {
     expect(find.textContaining('Not a substitute'), findsOneWidget);
   });
 
+  testWidgets('shows the deco-dive guideline category', (tester) async {
+    final status = NoFlyStatus(
+      until: DateTime.now().toUtc().add(const Duration(hours: 20)),
+      category: NoFlyCategory.deco,
+      interval: const Duration(hours: 24),
+    );
+    await pump(tester, status);
+    expect(find.textContaining('decompression dive: 24 h'), findsOneWidget);
+  });
+
   test('formatNoFlyRemaining formats hours and minutes', () {
     expect(
       formatNoFlyRemaining(const Duration(hours: 14, minutes: 20)),
@@ -94,4 +104,12 @@ void main() {
     );
     expect(formatNoFlyRemaining(const Duration(minutes: 45)), '45min');
   });
+
+  test(
+    'formatNoFlyRemaining shows <1min for a positive sub-minute remainder',
+    () {
+      expect(formatNoFlyRemaining(const Duration(seconds: 30)), '<1min');
+      expect(formatNoFlyRemaining(Duration.zero), '0min');
+    },
+  );
 }

--- a/test/features/safety/presentation/providers/no_fly_providers_test.dart
+++ b/test/features/safety/presentation/providers/no_fly_providers_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Fake repository that fails if the no-fly query is ever run, so the test can
+/// prove the provider short-circuits before touching the database.
+class _NoQueryDiveRepository extends Fake implements DiveRepository {
+  @override
+  Stream<void> watchDivesChanges() => const Stream.empty();
+
+  @override
+  Future<List<NoFlyDiveInput>> getNoFlyDiveInputs({
+    required DateTime since,
+    String? diverId,
+  }) async {
+    throw StateError('getNoFlyDiveInputs must not run without an active diver');
+  }
+}
+
+void main() {
+  test('returns null without querying dives when no diver is active', () async {
+    final container = ProviderContainer(
+      overrides: [
+        diveRepositoryProvider.overrideWithValue(_NoQueryDiveRepository()),
+        // MockCurrentDiverIdNotifier defaults to null (no active diver).
+        currentDiverIdProvider.overrideWith(
+          (ref) => MockCurrentDiverIdNotifier(),
+        ),
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final status = await container.read(noFlyStatusProvider.future);
+    expect(status, isNull);
+  });
+}

--- a/test/features/safety/presentation/providers/no_fly_providers_test.dart
+++ b/test/features/safety/presentation/providers/no_fly_providers_test.dart
@@ -25,6 +25,27 @@ class _NoQueryDiveRepository extends Fake implements DiveRepository {
   }
 }
 
+/// Fake repository that returns a fixed set of dive inputs for the active-diver
+/// happy path. Records the diverId it was queried with.
+class _StubDiveRepository extends Fake implements DiveRepository {
+  final List<NoFlyDiveInput> inputs;
+  String? queriedDiverId;
+
+  _StubDiveRepository(this.inputs);
+
+  @override
+  Stream<void> watchDivesChanges() => const Stream.empty();
+
+  @override
+  Future<List<NoFlyDiveInput>> getNoFlyDiveInputs({
+    required DateTime since,
+    String? diverId,
+  }) async {
+    queriedDiverId = diverId;
+    return inputs;
+  }
+}
+
 void main() {
   test('returns null without querying dives when no diver is active', () async {
     final container = ProviderContainer(
@@ -42,4 +63,33 @@ void main() {
     final status = await container.read(noFlyStatusProvider.future);
     expect(status, isNull);
   });
+
+  test(
+    'computes a restriction for the active diver from recent dives',
+    () async {
+      // One no-deco dive an hour ago -> single-dive category, 12 h guideline.
+      final repo = _StubDiveRepository([
+        NoFlyDiveInput(
+          endTime: DateTime.now().toUtc().subtract(const Duration(hours: 1)),
+          hadDecoObligation: false,
+        ),
+      ]);
+      final diverNotifier = MockCurrentDiverIdNotifier();
+      diverNotifier.setCurrentDiver('diver-1');
+
+      final container = ProviderContainer(
+        overrides: [
+          diveRepositoryProvider.overrideWithValue(repo),
+          currentDiverIdProvider.overrideWith((ref) => diverNotifier),
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(noFlyStatusProvider.future);
+      expect(status, isNotNull);
+      expect(status!.category, NoFlyCategory.single);
+      expect(repo.queriedDiverId, 'diver-1');
+    },
+  );
 }

--- a/test/features/settings/presentation/pages/safety_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/safety_settings_page_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dar
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/settings/presentation/pages/safety_settings_page.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -48,6 +49,20 @@ void main() {
       find.byType(SwitchListTile).first,
     );
     expect(master.value, isTrue);
+  });
+
+  testWidgets('selecting the strict no-fly preset persists it', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final notifier = MockSettingsNotifier();
+    await tester.pumpWidget(_buildTestWidget(notifier));
+    await tester.pumpAndSettle();
+
+    expect(notifier.state.noFlyPreset, NoFlyPreset.standard);
+    await tester.tap(find.text('Strict (18/24/48 h)'));
+    await tester.pumpAndSettle();
+    expect(notifier.state.noFlyPreset, NoFlyPreset.strict);
   });
 
   testWidgets('toggling master off disables rule switches', (tester) async {

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -115,6 +116,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setSafetyReviewEnabled(bool value) async =>
       state = state.copyWith(safetyReviewEnabled: value);
+  @override
+  Future<void> setNoFlyPreset(NoFlyPreset preset) async =>
+      state = state.copyWith(noFlyPreset: preset);
   @override
   Future<void> setSafetyRuleEnabled(SafetyRuleId rule, bool enabled) async {
     final rules = {...state.safetyReviewDisabledRules};

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 // ignore: implementation_imports
@@ -130,6 +131,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setSafetyReviewEnabled(bool value) async =>
       state = state.copyWith(safetyReviewEnabled: value);
+  @override
+  Future<void> setNoFlyPreset(NoFlyPreset preset) async =>
+      state = state.copyWith(noFlyPreset: preset);
   @override
   Future<void> setSafetyRuleEnabled(SafetyRuleId rule, bool enabled) async {
     final rules = {...state.safetyReviewDisabledRules};

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/divers/data/repositories/diver_repository.da
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/dive_sites/domain/matching/site_match_sensitivity.dart';
@@ -472,6 +473,18 @@ void main() {
       expect(container.read(settingsProvider).safetyReviewEnabled, isTrue);
       await notifier.setSafetyReviewEnabled(false);
       expect(container.read(settingsProvider).safetyReviewEnabled, isFalse);
+    });
+
+    test('setNoFlyPreset persists', () async {
+      final notifier = container.read(settingsProvider.notifier);
+      await waitForInit();
+
+      expect(
+        container.read(settingsProvider).noFlyPreset,
+        NoFlyPreset.standard,
+      );
+      await notifier.setNoFlyPreset(NoFlyPreset.strict);
+      expect(container.read(settingsProvider).noFlyPreset, NoFlyPreset.strict);
     });
 
     test('setSafetyRuleEnabled toggles the disabled-rules set', () async {

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 // ignore: implementation_imports
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
@@ -121,6 +122,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setSafetyReviewEnabled(bool value) async =>
       state = state.copyWith(safetyReviewEnabled: value);
+  @override
+  Future<void> setNoFlyPreset(NoFlyPreset preset) async =>
+      state = state.copyWith(noFlyPreset: preset);
   @override
   Future<void> setSafetyRuleEnabled(SafetyRuleId rule, bool enabled) async {
     final rules = {...state.safetyReviewDisabledRules};

--- a/test/helpers/l10n_test_helpers.dart
+++ b/test/helpers/l10n_test_helpers.dart
@@ -4,9 +4,12 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 /// Creates a [MaterialApp] with localization delegates configured.
 ///
 /// Use this in widget tests instead of bare `MaterialApp(home: ...)` to ensure
-/// `context.l10n` calls resolve correctly.
-MaterialApp localizedMaterialApp({required Widget home}) {
+/// `context.l10n` calls resolve correctly. Pass [locale] to pin the resolved
+/// language when a test asserts on specific localized strings, so the result
+/// does not depend on the host environment's locale.
+MaterialApp localizedMaterialApp({required Widget home, Locale? locale}) {
   return MaterialApp(
+    locale: locale,
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: home,

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/features/dive_sites/domain/matching/site_match_sensitivity.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/deco/entities/cns_calculation_method.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -108,6 +109,9 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   @override
   Future<void> setSafetyReviewEnabled(bool value) async =>
       state = state.copyWith(safetyReviewEnabled: value);
+  @override
+  Future<void> setNoFlyPreset(NoFlyPreset preset) async =>
+      state = state.copyWith(noFlyPreset: preset);
   @override
   Future<void> setSafetyRuleEnabled(SafetyRuleId rule, bool enabled) async {
     final rules = {...state.safetyReviewDisabledRules};


### PR DESCRIPTION
## Summary

Phase 2 of the safety features program (stacked on #606): **flying-after-diving countdown** plus the altitude-UX flag.

- **`NoFlyService`** — pure DAN/UHMS guideline classifier over a 48 h trailing window: single no-deco dive → 12 h, repetitive → 18 h, any deco dive → 24 h; a strict preset raises these to 18/24/48 h. Deliberately guideline-based: no agency endorses computed (tissue-model) no-fly times, so the Bühlmann engine is never consulted for this number.
- **Trailing-window query** — `getNoFlyDiveInputs` derives each dive's end (exit time, else entry + runtime) and a had-deco flag from recorded profile samples (`deco_type = 2` or positive ceiling) in one SQL pass.
- **Safety hub** (`/safety`) — countdown card with category and guideline explanation, an "educational, not a flight clearance" disclaimer, plus links to the Surface Interval tool and safety settings. Countdown display refreshes per minute; the provider self-invalidates on dive-table writes.
- **Dashboard** — active restriction rides the existing `DashboardAlerts` banner (highest priority) and taps through to the hub.
- **Settings (schema v125)** — `no_fly_preset` column, standard/strict segmented control on the safety settings page.
- **Altitude flag** — when a dive site records >100 m altitude but the dive has none, the altitude section now shows an informational "deco analysis assumed sea level" note linking to edit, instead of hiding silently.
- All strings translated into the 10 non-English locales.

Spec deviations documented in the plan: the tissue-desaturation view links to the existing Surface Interval tool rather than seeding it from the last dive (its chart is hardwired to its own inputs); planner altitude surfacing already exists; the expiry notification (stretch) is deferred.

## Test plan

- Classifier unit tests (all categories, presets, expiry, lookback edge); trailing-window SQL tests (exit-time vs entry+runtime ends, deco flags, window filtering); settings persistence tests; hub widget tests; schema tripwire updated to v125.
- Affected sweep (safety, settings, dashboard, dive_log, core/database): green; `flutter analyze` clean.