### PR TITLE
fix(lightroom): scan oldest-first so in-window photos link

### DIFF
--- a/lib/core/services/lightroom/lightroom_api_client.dart
+++ b/lib/core/services/lightroom/lightroom_api_client.dart
@@ -101,12 +101,14 @@ class LightroomApiClient {
             queryParameters: {
               'subtype': 'image;video',
               // captured_after and captured_before are mutually exclusive on
-              // this endpoint (Adobe returns 400 if both are sent). Prefer the
-              // upper bound; the scanner pages `next` (older) from there.
-              if (capturedBefore != null)
-                'captured_before': _isoWallClock(capturedBefore)!
-              else if (capturedAfter != null)
-                'captured_after': _isoWallClock(capturedAfter)!,
+              // this endpoint (Adobe returns 400 if both are sent). Adobe lists
+              // assets oldest-first, so the scanner queries the lower bound
+              // (captured_after) and pages `next` toward newer assets; prefer
+              // it when both are supplied.
+              if (capturedAfter != null)
+                'captured_after': _isoWallClock(capturedAfter)!
+              else if (capturedBefore != null)
+                'captured_before': _isoWallClock(capturedBefore)!,
             },
           );
     final json = await _getJson(uri);

--- a/lib/features/media/data/services/lightroom_scan_service.dart
+++ b/lib/features/media/data/services/lightroom_scan_service.dart
@@ -213,21 +213,22 @@ class LightroomScanService {
     final assets = <LightroomAsset>[];
     for (final span in spans) {
       // captured_after/captured_before are mutually exclusive on the assets
-      // endpoint, so query the upper bound only and page `next` (older). The
-      // listing is newest-first, so once assets cross below the window start
-      // every later page is older too -- stop then.
+      // endpoint, so query the lower bound only and page `next`. Adobe lists
+      // assets oldest-first, so querying captured_after=window start puts the
+      // window's assets on the first pages; once an asset crosses above the
+      // window end every later asset is newer too -- stop then.
       _log.info(
         '[LR-SCAN] span ${span.start.toIso8601String()} .. '
         '${span.end.toIso8601String()} '
-        '(query captured_before=${span.end.toIso8601String()})',
+        '(query captured_after=${span.start.toIso8601String()})',
       );
       String? next;
-      var reachedStart = false;
+      var reachedEnd = false;
       var pageNum = 0;
       do {
         final page = await _api.listAssets(
           catalogId,
-          capturedBefore: span.end,
+          capturedAfter: span.start,
           nextUrl: next,
         );
         pageNum++;
@@ -242,18 +243,18 @@ class LightroomScanService {
         );
         for (final asset in page.assets) {
           final captureDate = asset.captureDate;
-          if (captureDate != null && captureDate.isBefore(span.start)) {
-            // Assets page newest-first, so everything after this one is older
-            // than the window start too -- stop scanning this page.
-            reachedStart = true;
+          if (captureDate != null && captureDate.isAfter(span.end)) {
+            // Assets page oldest-first, so everything after this one is newer
+            // than the window end too -- stop scanning this page.
+            reachedEnd = true;
             break;
           }
           assets.add(asset);
         }
-        next = reachedStart ? null : page.nextUrl;
+        next = reachedEnd ? null : page.nextUrl;
       } while (next != null);
-      if (reachedStart) {
-        _log.info('[LR-SCAN] early-stop fired (asset older than window start)');
+      if (reachedEnd) {
+        _log.info('[LR-SCAN] early-stop fired (asset newer than window end)');
       }
     }
     _log.info('[LR-SCAN] total collected within windows=${assets.length}');

--- a/test/core/services/lightroom/lightroom_api_client_test.dart
+++ b/test/core/services/lightroom/lightroom_api_client_test.dart
@@ -114,15 +114,16 @@ void main() {
       expect(captured.url.path, '/v2/catalogs/cat1/assets');
       expect(captured.url.queryParameters['subtype'], 'image;video');
       // captured_after and captured_before are mutually exclusive on this
-      // endpoint (Adobe returns 400 if both are sent); with both supplied,
-      // only the upper bound goes on the wire.
+      // endpoint (Adobe returns 400 if both are sent); Adobe lists oldest-first
+      // so the scanner queries the lower bound -- with both supplied, only
+      // captured_after goes on the wire.
       expect(
-        captured.url.queryParameters.containsKey('captured_after'),
+        captured.url.queryParameters.containsKey('captured_before'),
         isFalse,
       );
       expect(
-        captured.url.queryParameters['captured_before'],
-        '2026-07-01T12:00:00.000',
+        captured.url.queryParameters['captured_after'],
+        '2026-07-01T09:00:00.000',
       );
       expect(page.assets, hasLength(3));
       final a1 = page.assets[0];

--- a/test/features/media/data/lightroom_scan_service_test.dart
+++ b/test/features/media/data/lightroom_scan_service_test.dart
@@ -62,6 +62,64 @@ class _FakeLightroomApi extends LightroomApiClient {
   }
 }
 
+/// Models the live Lightroom assets endpoint faithfully: results are sorted
+/// oldest-first (ascending capture date) and paginated via `next`. The cursor
+/// (captured_after / captured_before) is honoured on the first call and then
+/// re-encoded into the next URL, mirroring how the real `next` link carries the
+/// original query forward.
+class _PagingLightroomApi extends LightroomApiClient {
+  _PagingLightroomApi({required this.assets, this.pageSize = 2})
+    : super(auth: AdobeImsAuthManager());
+
+  final List<LightroomAsset> assets;
+  final int pageSize;
+  final List<({DateTime? after, DateTime? before})> assetCalls = [];
+
+  @override
+  Future<LightroomAssetPage> listAssets(
+    String catalogId, {
+    DateTime? capturedAfter,
+    DateTime? capturedBefore,
+    String? nextUrl,
+  }) async {
+    DateTime? after = capturedAfter;
+    DateTime? before = capturedBefore;
+    var offset = 0;
+    if (nextUrl != null) {
+      final u = Uri.parse(nextUrl);
+      final a = u.queryParameters['after'];
+      final b = u.queryParameters['before'];
+      after = a == null ? null : DateTime.parse(a);
+      before = b == null ? null : DateTime.parse(b);
+      offset = int.parse(u.queryParameters['offset'] ?? '0');
+    } else {
+      assetCalls.add((after: capturedAfter, before: capturedBefore));
+    }
+
+    final filtered = assets.where((x) => x.captureDate != null).where((x) {
+      final t = x.captureDate!;
+      return (after == null || !t.isBefore(after)) &&
+          (before == null || !t.isAfter(before));
+    }).toList()..sort((p, q) => p.captureDate!.compareTo(q.captureDate!));
+
+    final slice = filtered.skip(offset).take(pageSize).toList();
+    final consumed = offset + slice.length;
+    String? next;
+    if (consumed < filtered.length) {
+      next = Uri.parse('https://lr.adobe.io/next')
+          .replace(
+            queryParameters: {
+              'offset': '$consumed',
+              if (after != null) 'after': after.toIso8601String(),
+              if (before != null) 'before': before.toIso8601String(),
+            },
+          )
+          .toString();
+    }
+    return LightroomAssetPage(assets: slice, nextUrl: next);
+  }
+}
+
 void main() {
   late MediaRepository mediaRepository;
   late DiveRepository diveRepository;
@@ -91,7 +149,7 @@ void main() {
     await tearDownTestDatabase();
   });
 
-  LightroomScanService service(_FakeLightroomApi api) => LightroomScanService(
+  LightroomScanService service(LightroomApiClient api) => LightroomScanService(
     api: api,
     mediaRepository: mediaRepository,
     diveRepository: diveRepository,
@@ -139,8 +197,37 @@ void main() {
     expect(spans[1].end, DateTime.utc(2026, 7, 3, 12));
   });
 
-  test('catalog scan sends a single cursor - captured_before only, never '
-      'captured_after (Adobe 400s on both)', () async {
+  test('attaches an in-window asset the API returns after many older assets '
+      '(oldest-first paginated catalog)', () async {
+    // Reproduces the field regression: the catalog contains months of older
+    // photos plus one taken during the dive. Adobe lists assets oldest-first
+    // across pages, so the in-window asset is NOT on page 1. The scan must
+    // still reach and attach it.
+    final dive = await createDive(
+      entry: DateTime.utc(2026, 7, 1, 10),
+      exit: DateTime.utc(2026, 7, 1, 11),
+    );
+    final api = _PagingLightroomApi(
+      pageSize: 2,
+      assets: [
+        image('old1', DateTime.utc(2026, 4, 10)),
+        image('old2', DateTime.utc(2026, 5, 12)),
+        image('old3', DateTime.utc(2026, 6, 20)),
+        image('inWindow', DateTime.utc(2026, 7, 1, 10, 30)),
+      ],
+    );
+
+    final summary = await service(
+      api,
+    ).scanDives(account: account, dives: [dive], state: state);
+
+    expect(summary.attached, 1);
+    final media = await mediaRepository.getMediaForDive(dive.id);
+    expect(media.single.remoteAssetId, 'inWindow');
+  });
+
+  test('catalog scan sends a single cursor - captured_after only, never '
+      'captured_before (Adobe 400s on both)', () async {
     final dive = await createDive(
       entry: DateTime.utc(2026, 7, 1, 10),
       exit: DateTime.utc(2026, 7, 1, 11),
@@ -152,29 +239,38 @@ void main() {
 
     expect(api.assetCalls, isNotEmpty);
     for (final call in api.assetCalls) {
-      expect(call.after, isNull, reason: 'captured_after must not be sent');
-      expect(call.before, isNotNull);
+      expect(call.before, isNull, reason: 'captured_before must not be sent');
+      expect(call.after, DateTime.utc(2026, 7, 1, 9, 30));
     }
   });
 
-  test('scan early-stops when the pager returns an asset older than the '
-      'window start (nothing attaches)', () async {
+  test('scan early-stops when the pager returns an asset newer than the '
+      'window end (later assets are not attached)', () async {
     final dive = await createDive(
       entry: DateTime.utc(2026, 7, 1, 10),
       exit: DateTime.utc(2026, 7, 1, 11),
     );
-    // Window is [09:30, 12:00]; this asset predates the start. The listing is
-    // newest-first, so crossing below the start means every later asset is
-    // older too -- the scan stops here and attaches nothing.
-    final api = _FakeLightroomApi(
-      assets: [image('old', DateTime.utc(2026, 7, 1, 9))],
+    // Window is [09:30, 12:00]. Assets page oldest-first: the in-window shot
+    // comes first, then one past the window end. Once the pager crosses above
+    // the end, everything later is newer too -- the scan stops and only the
+    // in-window asset attaches.
+    final api = _PagingLightroomApi(
+      pageSize: 1,
+      assets: [
+        image('inWindow', DateTime.utc(2026, 7, 1, 10, 30)),
+        image('after', DateTime.utc(2026, 7, 1, 13)),
+        image('wayAfter', DateTime.utc(2026, 7, 2, 9)),
+      ],
     );
     final summary = await service(
       api,
     ).scanDives(account: account, dives: [dive], state: state);
 
-    expect(summary.attached, 0);
-    expect(api.assetCalls, isNotEmpty);
+    expect(summary.attached, 1);
+    expect(
+      (await mediaRepository.getMediaForDive(dive.id)).single.remoteAssetId,
+      'inWindow',
+    );
   });
 
   test('confident match attaches a connector media row with enrichment and '

--- a/test/features/media/data/lightroom_scan_service_test.dart
+++ b/test/features/media/data/lightroom_scan_service_test.dart
@@ -62,11 +62,13 @@ class _FakeLightroomApi extends LightroomApiClient {
   }
 }
 
-/// Models the live Lightroom assets endpoint faithfully: results are sorted
-/// oldest-first (ascending capture date) and paginated via `next`. The cursor
-/// (captured_after / captured_before) is honoured on the first call and then
-/// re-encoded into the next URL, mirroring how the real `next` link carries the
-/// original query forward.
+/// Models the ordering and pagination of the live Lightroom assets endpoint:
+/// dated assets are sorted oldest-first (ascending capture date) and paginated
+/// via `next`. The cursor (captured_after / captured_before) is honoured on the
+/// first call and then re-encoded into the next URL, mirroring how the real
+/// `next` link carries the original query forward. Assets without a capture
+/// date are not modelled here (the catalog path is capture-date filtered); the
+/// null-capture accounting is exercised through [_FakeLightroomApi] instead.
 class _PagingLightroomApi extends LightroomApiClient {
   _PagingLightroomApi({required this.assets, this.pageSize = 2})
     : super(auth: AdobeImsAuthManager());


### PR DESCRIPTION
## Problem

Lightroom **Scan** stopped linking photos to dives. Confirmed from live device logs: for every dive-window span, the catalog fetch collected **zero** assets and `early-stop fired` on page 1.

Root cause: the scan queried `captured_before = window.end` and paged `next`, assuming Adobe lists assets **newest-first** so it could early-stop once it saw an asset older than the window start. The live API actually returns assets **oldest-first**, so the very first asset on page 1 (the oldest photo in the catalog, often months prior) is older than the window start and trips the early-stop immediately. The in-window assets sit at the *end* of the pagination and are never reached, so the matcher is never consulted and confident matches never attach.

This regressed in #617's fix for the mutually-exclusive `captured_after`/`captured_before` 400 error, which introduced the `captured_before` + early-stop path.

Example (from device logs): a dive window of `07:53Z..10:32Z` returned page 1 `firstDates=[2025-09-16 ...]`, older than the window start, so the scan stopped having collected nothing.

## Fix

Mirror the cursor to the correct end of the window:

- `LightroomApiClient.listAssets` now prefers `captured_after` when supplied (still honoring the mutual exclusivity — only one bound goes on the wire).
- `LightroomScanService._fetchCatalogAssets` queries `captured_after = window.start` and pages `next` toward newer assets, stopping once an asset is **newer than `window.end`**.

Because the listing is oldest-first, `captured_after = window.start` puts the window's assets on the first pages, and the stop condition trips only after the window is fully covered. No new API calls, no schema change.

## Tests (TDD)

- New paginating test fake (`_PagingLightroomApi`) that faithfully models the oldest-first, `next`-paged endpoint. The previous fake collapsed every asset into a single page and never exercised the early-stop — which is how the bug shipped green.
- New regression test: an in-window asset preceded by months of older assets (the field scenario) — fails on the old code (`attached: 0`), passes now (`attached: 1`).
- Rewrote the two tests that had hard-coded the newest-first / `captured_before` contract to assert the corrected direction.
- 717 media + Lightroom tests pass; `flutter analyze` clean; formatted.

## Verification still pending

Logic is proven by unit tests; the oldest-first ordering claim rests on production logs rather than a live re-scan. The meaningful end-to-end check is running **Scan Lightroom** on-device and confirming in-window photos link and the log shows `total collected within windows` > 0. Good to fold into the feature's pending device smoke.