### PR TITLE
Hide Lightroom UI pending Adobe review

### DIFF
--- a/lib/core/constants/feature_flags.dart
+++ b/lib/core/constants/feature_flags.dart
@@ -1,0 +1,31 @@
+/// Compile-time feature flags for gating in-progress or externally-blocked
+/// features out of the user-facing UI without deleting their implementation.
+///
+/// These flags intentionally gate UI surfaces only. The backing services,
+/// providers, repositories, auth flows, and database code remain fully intact
+/// and functional so a feature can be restored by flipping a single flag.
+library;
+
+/// Whether the Adobe Lightroom integration is surfaced in the UI.
+///
+/// The Lightroom integration is code-complete but pending review/approval by
+/// Adobe. Until that review resolves, every Lightroom entry point is hidden so
+/// we do not advertise a connection users cannot actually complete (and to
+/// avoid giving false hope should Adobe reject the integration outright).
+///
+/// This flag hides UI ONLY. All Lightroom services, providers, auth managers,
+/// and stored-account handling under `lib/core/services/lightroom/`,
+/// `lib/features/media/.../lightroom_*`, etc. are left untouched and keep
+/// working. Any account already connected on a device continues to sync.
+///
+/// It is a mutable top-level variable rather than a `const` so that widget
+/// tests can toggle it to exercise both the hidden and enabled UI wiring;
+/// production code only ever reads it. Tests that set it must reset it (e.g.
+/// via `addTearDown`) so the value does not leak between tests.
+///
+/// To re-enable once Adobe approves: set the default below to `true`. That
+/// single change restores the media-sources entry point, the settings page +
+/// route, and the per-dive / per-trip / photo-viewer scan and "Open in
+/// Lightroom" actions. If Adobe permanently rejects the integration, the
+/// Lightroom code and this flag can be deleted together in a follow-up cleanup.
+bool kLightroomUiEnabled = false;

--- a/lib/core/constants/feature_flags.dart
+++ b/lib/core/constants/feature_flags.dart
@@ -1,9 +1,13 @@
-/// Compile-time feature flags for gating in-progress or externally-blocked
-/// features out of the user-facing UI without deleting their implementation.
+/// Feature flags for gating in-progress or externally-blocked features out of
+/// the user-facing UI without deleting their implementation.
 ///
 /// These flags intentionally gate UI surfaces only. The backing services,
 /// providers, repositories, auth flows, and database code remain fully intact
 /// and functional so a feature can be restored by flipping a single flag.
+///
+/// Flags here are plain mutable top-level variables (not `const`) so that
+/// widget tests can toggle them; they are evaluated at runtime, and production
+/// code only ever reads them.
 library;
 
 /// Whether the Adobe Lightroom integration is surfaced in the UI.
@@ -28,4 +32,4 @@ library;
 /// route, and the per-dive / per-trip / photo-viewer scan and "Open in
 /// Lightroom" actions. If Adobe permanently rejects the integration, the
 /// Lightroom code and this flag can be deleted together in a follow-up cleanup.
-bool kLightroomUiEnabled = false;
+bool lightroomUiEnabled = false;

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:submersion/core/accessibility/app_shortcuts.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
@@ -939,11 +940,15 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   ),
                 ],
               ),
-              GoRoute(
-                path: 'lightroom',
-                name: 'lightroom',
-                builder: (context, state) => const LightroomSettingsPage(),
-              ),
+              // Lightroom settings route gated out pending Adobe review
+              // (kLightroomUiEnabled). Removing the route makes the page
+              // unreachable even via deep link while the entry point is hidden.
+              if (kLightroomUiEnabled)
+                GoRoute(
+                  path: 'lightroom',
+                  name: 'lightroom',
+                  builder: (context, state) => const LightroomSettingsPage(),
+                ),
               GoRoute(
                 path: 'photos-media',
                 name: 'photosMedia',

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -940,15 +940,19 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   ),
                 ],
               ),
-              // Lightroom settings route gated out pending Adobe review
-              // (kLightroomUiEnabled). Removing the route makes the page
-              // unreachable even via deep link while the entry point is hidden.
-              if (kLightroomUiEnabled)
-                GoRoute(
-                  path: 'lightroom',
-                  name: 'lightroom',
-                  builder: (context, state) => const LightroomSettingsPage(),
-                ),
+              // Lightroom settings page hidden pending Adobe review
+              // (lightroomUiEnabled). The route stays defined so any lingering
+              // navigation to it (a deep link, or PendingSetupService which
+              // computes '/settings/lightroom' for an on-device Lightroom
+              // account) degrades gracefully by redirecting to the media
+              // sources page instead of hitting an unknown-route error screen.
+              GoRoute(
+                path: 'lightroom',
+                name: 'lightroom',
+                redirect: (context, state) =>
+                    lightroomUiEnabled ? null : '/settings/media-sources',
+                builder: (context, state) => const LightroomSettingsPage(),
+              ),
               GoRoute(
                 path: 'photos-media',
                 name: 'photosMedia',

--- a/lib/features/media/presentation/pages/media_sources_page.dart
+++ b/lib/features/media/presentation/pages/media_sources_page.dart
@@ -128,9 +128,9 @@ class MediaSourcesPage extends ConsumerWidget {
             ),
           ),
           // Lightroom entry point hidden pending Adobe review
-          // (kLightroomUiEnabled). Wraps the spacer too so no orphan gap
+          // (lightroomUiEnabled). Wraps the spacer too so no orphan gap
           // is left behind when hidden.
-          if (kLightroomUiEnabled) ...[
+          if (lightroomUiEnabled) ...[
             const SizedBox(height: 16),
             Card(
               child: ListTile(

--- a/lib/features/media/presentation/pages/media_sources_page.dart
+++ b/lib/features/media/presentation/pages/media_sources_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -126,16 +127,21 @@ class MediaSourcesPage extends ConsumerWidget {
                   context.push('/settings/media-sources/network-sources'),
             ),
           ),
-          const SizedBox(height: 16),
-          Card(
-            child: ListTile(
-              leading: const Icon(Icons.cloud_sync_outlined),
-              title: Text(context.l10n.settings_lightroom_title),
-              subtitle: Text(context.l10n.settings_lightroom_subtitle),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => context.push('/settings/lightroom'),
+          // Lightroom entry point hidden pending Adobe review
+          // (kLightroomUiEnabled). Wraps the spacer too so no orphan gap
+          // is left behind when hidden.
+          if (kLightroomUiEnabled) ...[
+            const SizedBox(height: 16),
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.cloud_sync_outlined),
+                title: Text(context.l10n.settings_lightroom_title),
+                subtitle: Text(context.l10n.settings_lightroom_subtitle),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => context.push('/settings/lightroom'),
+              ),
             ),
-          ),
+          ],
         ],
       ),
     );

--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -351,9 +351,9 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
   /// (the catalog id lives only on the connected device).
   String? _lightroomWebUrl(MediaItem item) {
     // Lightroom "Open in Lightroom" action hidden pending Adobe review
-    // (kLightroomUiEnabled). Returning null here suppresses both the toolbar
+    // (lightroomUiEnabled). Returning null here suppresses both the toolbar
     // button and the video-poster overlay, which are gated on this URL.
-    if (!kLightroomUiEnabled) return null;
+    if (!lightroomUiEnabled) return null;
     if (item.sourceType != MediaSourceType.serviceConnector ||
         item.remoteAssetId == null) {
       return null;

--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -11,6 +11,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:video_player/video_player.dart';
 
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/lightroom/lightroom_api_client.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -349,6 +350,10 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
   /// item is not Lightroom-linked or this device has no connected account
   /// (the catalog id lives only on the connected device).
   String? _lightroomWebUrl(MediaItem item) {
+    // Lightroom "Open in Lightroom" action hidden pending Adobe review
+    // (kLightroomUiEnabled). Returning null here suppresses both the toolbar
+    // button and the video-poster overlay, which are gated on this URL.
+    if (!kLightroomUiEnabled) return null;
     if (item.sourceType != MediaSourceType.serviceConnector ||
         item.remoteAssetId == null) {
       return null;

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -307,8 +307,8 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
                       onPressed: widget.onScanPressed,
                     ),
                   // Lightroom scan hidden pending Adobe review
-                  // (kLightroomUiEnabled).
-                  if (kLightroomUiEnabled &&
+                  // (lightroomUiEnabled).
+                  if (lightroomUiEnabled &&
                       ref.watch(lightroomAccountProvider).value != null)
                     IconButton(
                       icon: Icon(
@@ -407,8 +407,8 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
               ),
             ),
             // Lightroom suggestions hidden pending Adobe review
-            // (kLightroomUiEnabled).
-            if (kLightroomUiEnabled)
+            // (lightroomUiEnabled).
+            if (lightroomUiEnabled)
               LightroomSuggestionsRow(diveId: widget.diveId),
           ],
         ),

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
@@ -305,7 +306,10 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
                       tooltip: context.l10n.media_diveScan_scanTooltip,
                       onPressed: widget.onScanPressed,
                     ),
-                  if (ref.watch(lightroomAccountProvider).value != null)
+                  // Lightroom scan hidden pending Adobe review
+                  // (kLightroomUiEnabled).
+                  if (kLightroomUiEnabled &&
+                      ref.watch(lightroomAccountProvider).value != null)
                     IconButton(
                       icon: Icon(
                         Icons.cloud_sync_outlined,
@@ -402,7 +406,10 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
                 style: textTheme.bodyMedium?.copyWith(color: colorScheme.error),
               ),
             ),
-            LightroomSuggestionsRow(diveId: widget.diveId),
+            // Lightroom suggestions hidden pending Adobe review
+            // (kLightroomUiEnabled).
+            if (kLightroomUiEnabled)
+              LightroomSuggestionsRow(diveId: widget.diveId),
           ],
         ),
       ),

--- a/lib/features/trips/presentation/pages/trip_detail_page.dart
+++ b/lib/features/trips/presentation/pages/trip_detail_page.dart
@@ -406,10 +406,9 @@ class _TripDetailContent extends ConsumerWidget {
     // Read this during build, not inside itemBuilder: itemBuilder runs when the
     // menu opens (outside this consumer's build phase), where ref.watch would
     // register a dependency outside Riverpod's build lifecycle.
-    // Lightroom scan hidden pending Adobe review (kLightroomUiEnabled).
+    // Lightroom scan hidden pending Adobe review (lightroomUiEnabled).
     final hasLightroomAccount =
-        kLightroomUiEnabled &&
-        ref.watch(lightroomAccountProvider).value != null;
+        lightroomUiEnabled && ref.watch(lightroomAccountProvider).value != null;
     return PopupMenuButton<String>(
       tooltip: context.l10n.trips_detail_tooltip_moreOptions,
       onSelected: (value) async {

--- a/lib/features/trips/presentation/pages/trip_detail_page.dart
+++ b/lib/features/trips/presentation/pages/trip_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -405,7 +406,9 @@ class _TripDetailContent extends ConsumerWidget {
     // Read this during build, not inside itemBuilder: itemBuilder runs when the
     // menu opens (outside this consumer's build phase), where ref.watch would
     // register a dependency outside Riverpod's build lifecycle.
+    // Lightroom scan hidden pending Adobe review (kLightroomUiEnabled).
     final hasLightroomAccount =
+        kLightroomUiEnabled &&
         ref.watch(lightroomAccountProvider).value != null;
     return PopupMenuButton<String>(
       tooltip: context.l10n.trips_detail_tooltip_moreOptions,

--- a/lib/features/trips/presentation/widgets/trip_photo_section.dart
+++ b/lib/features/trips/presentation/widgets/trip_photo_section.dart
@@ -81,8 +81,8 @@ class TripPhotoSection extends ConsumerWidget {
                     onPressed: onScanPressed,
                   ),
                 // Lightroom scan hidden pending Adobe review
-                // (kLightroomUiEnabled).
-                if (kLightroomUiEnabled && onLightroomScanPressed != null)
+                // (lightroomUiEnabled).
+                if (lightroomUiEnabled && onLightroomScanPressed != null)
                   IconButton(
                     icon: Icon(
                       Icons.cloud_sync_outlined,

--- a/lib/features/trips/presentation/widgets/trip_photo_section.dart
+++ b/lib/features/trips/presentation/widgets/trip_photo_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
@@ -79,7 +80,9 @@ class TripPhotoSection extends ConsumerWidget {
                     tooltip: context.l10n.trips_photos_tooltip_scan,
                     onPressed: onScanPressed,
                   ),
-                if (onLightroomScanPressed != null)
+                // Lightroom scan hidden pending Adobe review
+                // (kLightroomUiEnabled).
+                if (kLightroomUiEnabled && onLightroomScanPressed != null)
                   IconButton(
                     icon: Icon(
                       Icons.cloud_sync_outlined,

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/router/app_router.dart';
 import 'package:submersion/features/checklists/presentation/pages/checklist_template_edit_page.dart';
 import 'package:submersion/features/checklists/presentation/pages/checklist_templates_page.dart';
@@ -494,6 +495,57 @@ void main() {
       );
       // The GoRouter initialLocation is /dashboard
       // which is resolved via the shell route
+    });
+  });
+
+  group('app_router lightroom route (pending Adobe review)', () {
+    test('lightroom route stays defined so navigation degrades gracefully', () {
+      // The route is intentionally kept (not removed) while the UI is hidden so
+      // deep links and PendingSetupService's '/settings/lightroom' target
+      // redirect instead of hitting an unknown-route error screen.
+      final route = _findRouteByName(router.configuration.routes, 'lightroom');
+      expect(route, isNotNull);
+      expect(route!.path, 'lightroom');
+      expect(route.redirect, isNotNull);
+    });
+
+    testWidgets('redirects to media sources when lightroomUiEnabled is false, '
+        'and passes through when true', (tester) async {
+      final config = router.configuration;
+      final route = _findRouteByName(config.routes, 'lightroom');
+      expect(route, isNotNull);
+
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final state = GoRouterState(
+        config,
+        uri: Uri.parse('/settings/lightroom'),
+        matchedLocation: '/settings/lightroom',
+        fullPath: '/settings/lightroom',
+        pathParameters: const {},
+        pageKey: const ValueKey('/settings/lightroom'),
+      );
+
+      addTearDown(() => lightroomUiEnabled = false);
+
+      lightroomUiEnabled = false;
+      expect(
+        await route!.redirect!(capturedContext, state),
+        '/settings/media-sources',
+      );
+
+      lightroomUiEnabled = true;
+      expect(await route.redirect!(capturedContext, state), isNull);
     });
   });
 }

--- a/test/features/media/presentation/pages/media_sources_page_test.dart
+++ b/test/features/media/presentation/pages/media_sources_page_test.dart
@@ -60,12 +60,12 @@ Widget _wrapWith(List<Object> overrides) => ProviderScope(
 );
 
 void main() {
-  // The Lightroom entry point is gated behind [kLightroomUiEnabled], which
+  // The Lightroom entry point is gated behind [lightroomUiEnabled], which
   // defaults to false while the integration is pending Adobe review. Enable it
   // for the surface tests that assert the Lightroom UI wires up correctly, and
   // reset after each test so the value does not leak.
-  setUp(() => kLightroomUiEnabled = true);
-  tearDown(() => kLightroomUiEnabled = false);
+  setUp(() => lightroomUiEnabled = true);
+  tearDown(() => lightroomUiEnabled = false);
 
   testWidgets('renders Photo library and Adobe Lightroom, without the '
       'hidden-picker-tabs toggle', (tester) async {
@@ -80,9 +80,9 @@ void main() {
     expect(find.byType(Switch), findsNothing);
   });
 
-  testWidgets('hides the Adobe Lightroom entry point when kLightroomUiEnabled '
+  testWidgets('hides the Adobe Lightroom entry point when lightroomUiEnabled '
       'is false (pending Adobe review)', (tester) async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await tester.pumpWidget(_wrap());
     await tester.pumpAndSettle();
 

--- a/test/features/media/presentation/pages/media_sources_page_test.dart
+++ b/test/features/media/presentation/pages/media_sources_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/features/media/data/services/local_files_diagnostics_service.dart';
 import 'package:submersion/features/media/presentation/pages/media_sources_page.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
@@ -59,6 +60,13 @@ Widget _wrapWith(List<Object> overrides) => ProviderScope(
 );
 
 void main() {
+  // The Lightroom entry point is gated behind [kLightroomUiEnabled], which
+  // defaults to false while the integration is pending Adobe review. Enable it
+  // for the surface tests that assert the Lightroom UI wires up correctly, and
+  // reset after each test so the value does not leak.
+  setUp(() => kLightroomUiEnabled = true);
+  tearDown(() => kLightroomUiEnabled = false);
+
   testWidgets('renders Photo library and Adobe Lightroom, without the '
       'hidden-picker-tabs toggle', (tester) async {
     await tester.pumpWidget(_wrap());
@@ -70,6 +78,18 @@ void main() {
     // The debug toggle is retired; the picker always shows all tabs.
     expect(find.text('Show hidden picker tabs'), findsNothing);
     expect(find.byType(Switch), findsNothing);
+  });
+
+  testWidgets('hides the Adobe Lightroom entry point when kLightroomUiEnabled '
+      'is false (pending Adobe review)', (tester) async {
+    kLightroomUiEnabled = false;
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    // Other sources remain; only the Lightroom card is gated out.
+    expect(find.text('Photo library'), findsOneWidget);
+    expect(find.text('Network sources'), findsOneWidget);
+    expect(find.text('Adobe Lightroom'), findsNothing);
   });
 
   testWidgets(

--- a/test/features/media/presentation/pages/photo_viewer_lightroom_test.dart
+++ b/test/features/media/presentation/pages/photo_viewer_lightroom_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
@@ -22,9 +23,13 @@ void main() {
     await setUpTestDatabase();
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
+    // Enabled so the "Open in Lightroom" wiring can be verified; the flag
+    // defaults to false while Lightroom is pending Adobe review.
+    kLightroomUiEnabled = true;
   });
 
   tearDown(() async {
+    kLightroomUiEnabled = false;
     await tearDownTestDatabase();
   });
 
@@ -87,6 +92,15 @@ void main() {
       'connected device', (tester) async {
     await pump(tester, media: item(), withAccount: account);
     expect(find.byTooltip('Open in Lightroom'), findsOneWidget);
+  });
+
+  testWidgets('hides Open in Lightroom when kLightroomUiEnabled is false even '
+      'for a connected-device connector item (pending Adobe review)', (
+    tester,
+  ) async {
+    kLightroomUiEnabled = false;
+    await pump(tester, media: item(), withAccount: account);
+    expect(find.byTooltip('Open in Lightroom'), findsNothing);
   });
 
   testWidgets('hides Open in Lightroom without a connected account', (

--- a/test/features/media/presentation/pages/photo_viewer_lightroom_test.dart
+++ b/test/features/media/presentation/pages/photo_viewer_lightroom_test.dart
@@ -25,11 +25,11 @@ void main() {
     prefs = await SharedPreferences.getInstance();
     // Enabled so the "Open in Lightroom" wiring can be verified; the flag
     // defaults to false while Lightroom is pending Adobe review.
-    kLightroomUiEnabled = true;
+    lightroomUiEnabled = true;
   });
 
   tearDown(() async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await tearDownTestDatabase();
   });
 
@@ -94,11 +94,11 @@ void main() {
     expect(find.byTooltip('Open in Lightroom'), findsOneWidget);
   });
 
-  testWidgets('hides Open in Lightroom when kLightroomUiEnabled is false even '
+  testWidgets('hides Open in Lightroom when lightroomUiEnabled is false even '
       'for a connected-device connector item (pending Adobe review)', (
     tester,
   ) async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await pump(tester, media: item(), withAccount: account);
     expect(find.byTooltip('Open in Lightroom'), findsNothing);
   });

--- a/test/features/media/presentation/widgets/dive_media_section_lightroom_test.dart
+++ b/test/features/media/presentation/widgets/dive_media_section_lightroom_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
@@ -19,9 +20,13 @@ void main() {
     await setUpTestDatabase();
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
+    // Enabled so the connected-account scan wiring can be verified; the flag
+    // defaults to false while Lightroom is pending Adobe review.
+    kLightroomUiEnabled = true;
   });
 
   tearDown(() async {
+    kLightroomUiEnabled = false;
     await tearDownTestDatabase();
   });
 
@@ -84,6 +89,13 @@ void main() {
     tester,
   ) async {
     await pump(tester);
+    expect(find.byTooltip('Scan Lightroom'), findsNothing);
+  });
+
+  testWidgets('hides the Lightroom scan action when kLightroomUiEnabled is '
+      'false even if connected (pending Adobe review)', (tester) async {
+    kLightroomUiEnabled = false;
+    await pump(tester, withAccount: account);
     expect(find.byTooltip('Scan Lightroom'), findsNothing);
   });
 }

--- a/test/features/media/presentation/widgets/dive_media_section_lightroom_test.dart
+++ b/test/features/media/presentation/widgets/dive_media_section_lightroom_test.dart
@@ -22,11 +22,11 @@ void main() {
     prefs = await SharedPreferences.getInstance();
     // Enabled so the connected-account scan wiring can be verified; the flag
     // defaults to false while Lightroom is pending Adobe review.
-    kLightroomUiEnabled = true;
+    lightroomUiEnabled = true;
   });
 
   tearDown(() async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await tearDownTestDatabase();
   });
 
@@ -92,9 +92,9 @@ void main() {
     expect(find.byTooltip('Scan Lightroom'), findsNothing);
   });
 
-  testWidgets('hides the Lightroom scan action when kLightroomUiEnabled is '
+  testWidgets('hides the Lightroom scan action when lightroomUiEnabled is '
       'false even if connected (pending Adobe review)', (tester) async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await pump(tester, withAccount: account);
     expect(find.byTooltip('Scan Lightroom'), findsNothing);
   });

--- a/test/features/trips/presentation/pages/trip_detail_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_detail_page_test.dart
@@ -140,10 +140,10 @@ void main() {
     // Exercises the overflow-menu scan actions and the Lightroom item, which
     // only shows when a Lightroom account is connected.
     testWidgets('overflow menu runs scan actions', (tester) async {
-      // The Lightroom menu item is gated behind kLightroomUiEnabled (default
+      // The Lightroom menu item is gated behind lightroomUiEnabled (default
       // false while pending Adobe review); enable it to verify the wiring.
-      kLightroomUiEnabled = true;
-      addTearDown(() => kLightroomUiEnabled = false);
+      lightroomUiEnabled = true;
+      addTearDown(() => lightroomUiEnabled = false);
       _setMobileTestSurfaceSize(tester);
       final story = buildTripStory(
         trip: testTrip,

--- a/test/features/trips/presentation/pages/trip_detail_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -139,6 +140,10 @@ void main() {
     // Exercises the overflow-menu scan actions and the Lightroom item, which
     // only shows when a Lightroom account is connected.
     testWidgets('overflow menu runs scan actions', (tester) async {
+      // The Lightroom menu item is gated behind kLightroomUiEnabled (default
+      // false while pending Adobe review); enable it to verify the wiring.
+      kLightroomUiEnabled = true;
+      addTearDown(() => kLightroomUiEnabled = false);
       _setMobileTestSurfaceSize(tester);
       final story = buildTripStory(
         trip: testTrip,

--- a/test/features/trips/presentation/widgets/trip_photo_section_lightroom_test.dart
+++ b/test/features/trips/presentation/widgets/trip_photo_section_lightroom_test.dart
@@ -12,10 +12,10 @@ void main() {
     await setUpTestDatabase();
     // Enabled so the scan-button wiring can be verified; the flag defaults to
     // false while Lightroom is pending Adobe review.
-    kLightroomUiEnabled = true;
+    lightroomUiEnabled = true;
   });
   tearDown(() async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await tearDownTestDatabase();
   });
 
@@ -62,9 +62,9 @@ void main() {
     expect(find.byTooltip('Scan Lightroom'), findsNothing);
   });
 
-  testWidgets('hides the Lightroom scan button when kLightroomUiEnabled is '
+  testWidgets('hides the Lightroom scan button when lightroomUiEnabled is '
       'false even with a handler (pending Adobe review)', (tester) async {
-    kLightroomUiEnabled = false;
+    lightroomUiEnabled = false;
     await pump(tester, onLightroomScanPressed: () {});
     expect(find.byTooltip('Scan Lightroom'), findsNothing);
   });

--- a/test/features/trips/presentation/widgets/trip_photo_section_lightroom_test.dart
+++ b/test/features/trips/presentation/widgets/trip_photo_section_lightroom_test.dart
@@ -1,14 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/features/trips/presentation/widgets/trip_photo_section.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/test_database.dart';
 
 void main() {
-  setUp(setUpTestDatabase);
-  tearDown(tearDownTestDatabase);
+  setUp(() async {
+    await setUpTestDatabase();
+    // Enabled so the scan-button wiring can be verified; the flag defaults to
+    // false while Lightroom is pending Adobe review.
+    kLightroomUiEnabled = true;
+  });
+  tearDown(() async {
+    kLightroomUiEnabled = false;
+    await tearDownTestDatabase();
+  });
 
   Future<void> pump(
     WidgetTester tester, {
@@ -50,6 +59,13 @@ void main() {
     tester,
   ) async {
     await pump(tester);
+    expect(find.byTooltip('Scan Lightroom'), findsNothing);
+  });
+
+  testWidgets('hides the Lightroom scan button when kLightroomUiEnabled is '
+      'false even with a handler (pending Adobe review)', (tester) async {
+    kLightroomUiEnabled = false;
+    await pump(tester, onLightroomScanPressed: () {});
     expect(find.byTooltip('Scan Lightroom'), findsNothing);
   });
 }


### PR DESCRIPTION
## Why

The Adobe Lightroom integration is code-complete but pending review/approval by Adobe. Until that resolves, every Lightroom entry point should be hidden so the app does not advertise a connection users cannot actually complete — and to avoid giving false hope should Adobe reject the integration outright.

## What

A **UI-only** gate behind a single flag: `lightroomUiEnabled` in `lib/core/constants/feature_flags.dart`, defaulting to `false`.

All Lightroom services, providers, auth managers, and stored-account handling (`lib/core/services/lightroom/`, `lib/features/media/.../lightroom_*`, the account adapters, etc.) are **left completely untouched** and keep working. Any account already connected on a device continues to sync.

### Re-enabling after Adobe approves

Flip the default in `feature_flags.dart` from `false` to `true` — a one-line change. That single flip restores every surface below. If Adobe permanently rejects the integration, the Lightroom code and this flag can be deleted together in a follow-up cleanup. **This PR is the reference for that revert.**

## Surfaces gated

| Surface | File |
| --- | --- |
| Media Sources entry-point card | `media_sources_page.dart` |
| `/settings/lightroom` route — kept, but redirects to `/settings/media-sources` when off | `app_router.dart` |
| Per-dive "Scan Lightroom" button + suggestions row | `dive_media_section.dart` |
| Trip overflow "Scan Lightroom" menu item | `trip_detail_page.dart` |
| Trip photo section scan button | `trip_photo_section.dart` |
| Photo viewer "Open in Lightroom" (toolbar + video-poster overlay) | `photo_viewer_page.dart` |

## Graceful route degradation

The `/settings/lightroom` route stays defined and gains a `redirect` to `/settings/media-sources` while the flag is off, rather than being removed. This means any lingering navigation to it — a deep link, or `PendingSetupService._routeFor` (which computes `/settings/lightroom` for an on-device `adobeLightroom` account in dev/internal builds) — degrades gracefully instead of hitting an unknown-route error screen. `PendingSetupService` itself is not modified.

The `connected_accounts_page` icon mapping is also left as-is: it is data-driven and only surfaces for an already-connected Lightroom account, which no real user can have since the integration was never approved.

## Testing

The flag is a mutable top-level variable (not `const`) specifically so widget tests can toggle it and keep verifying the underlying UI wiring — this is what keeps re-enabling low-risk.

- Existing Lightroom UI tests now enable the flag to assert the enabled wiring still works.
- Added flag-off regression tests pinning the hidden behavior for the media-sources card, per-dive scan button, trip photo scan button, and photo-viewer action.
- Added an `app_router_test` group asserting the Lightroom route stays defined and its redirect flips with the flag.
- `dart format` clean, `flutter analyze` clean, full pre-push suite passes.