### PR TITLE
fix(dive-log): show junction buddies in table Buddy/Dive Master columns

### DIFF
--- a/lib/core/constants/dive_field_extractor.dart
+++ b/lib/core/constants/dive_field_extractor.dart
@@ -2,6 +2,7 @@ import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 
 /// Extension providing raw value extraction from [Dive] and [DiveSummary]
 /// entities for each [DiveField].
@@ -108,9 +109,9 @@ extension DiveFieldExtractor on DiveField {
       case DiveField.setpointDeco:
         return dive.setpointDeco;
       case DiveField.buddy:
-        return dive.buddy;
+        return _buddyColumnValue(dive);
       case DiveField.diveMaster:
-        return dive.diveMaster;
+        return _diveMasterColumnValue(dive);
       case DiveField.siteLocation:
         return dive.site?.locationString;
       case DiveField.diveCenterName:
@@ -190,6 +191,42 @@ extension DiveFieldExtractor on DiveField {
 ///   (back gas tank pressure drop; no tank volume required).
 double? _computeSacRate(Dive dive, SacUnit sacUnit) =>
     sacUnit == SacUnit.litersPerMin ? dive.sac : dive.sacPressure;
+
+/// Names shown in the Buddy table column: every recorded participant whose
+/// role is NOT a guide/divemaster (see [_isGuideRole]), comma-joined.
+///
+/// Modern dives store people in the `dive_buddies` junction (#553), so this
+/// prefers the hydrated [Dive.buddies]. Falls back to the legacy free-text
+/// [Dive.buddy] scalar when no junction buddies are present -- either a legacy
+/// dive that only ever used the scalar, or a code path that did not hydrate
+/// buddies (in which case the scalar preserves prior behavior).
+String? _buddyColumnValue(Dive dive) {
+  final names = dive.buddies
+      .where((b) => !_isGuideRole(b.role.id))
+      .map((b) => b.buddy.name.trim())
+      .where((n) => n.isNotEmpty)
+      .toList();
+  if (names.isNotEmpty) return names.join(', ');
+  return dive.buddy;
+}
+
+/// Names shown in the Dive Master table column: recorded participants whose
+/// role is a guide/divemaster, comma-joined. Falls back to the legacy
+/// free-text [Dive.diveMaster] scalar when none are hydrated.
+String? _diveMasterColumnValue(Dive dive) {
+  final names = dive.buddies
+      .where((b) => _isGuideRole(b.role.id))
+      .map((b) => b.buddy.name.trim())
+      .where((n) => n.isNotEmpty)
+      .toList();
+  if (names.isNotEmpty) return names.join(', ');
+  return dive.diveMaster;
+}
+
+/// A `dive_roles` id representing someone guiding the dive rather than a peer
+/// buddy: the built-in dive guide or dive master roles (#553).
+bool _isGuideRole(String roleId) =>
+    roleId == DiveRole.diveGuideId || roleId == DiveRole.diveMasterId;
 
 /// Compute the total gas consumed in liters across all tanks of a [Dive].
 double? _computeGasConsumed(Dive dive) {

--- a/lib/core/constants/dive_field_extractor.dart
+++ b/lib/core/constants/dive_field_extractor.dart
@@ -195,32 +195,36 @@ double? _computeSacRate(Dive dive, SacUnit sacUnit) =>
 /// Names shown in the Buddy table column: every recorded participant whose
 /// role is NOT a guide/divemaster (see [_isGuideRole]), comma-joined.
 ///
-/// Modern dives store people in the `dive_buddies` junction (#553), so this
-/// prefers the hydrated [Dive.buddies]. Falls back to the legacy free-text
-/// [Dive.buddy] scalar when no junction buddies are present -- either a legacy
-/// dive that only ever used the scalar, or a code path that did not hydrate
-/// buddies (in which case the scalar preserves prior behavior).
+/// The `dive_buddies` junction (#553) is the source of truth for modern dives.
+/// The legacy free-text [Dive.buddy] scalar is only a whole-dive fallback: it
+/// is used when the junction is empty -- a legacy dive that only ever used the
+/// scalar, or a code path that did not hydrate [Dive.buddies]. Once the
+/// junction holds any participant the dive is treated as junction-authoritative
+/// and the (frozen, never-migrated) scalar is ignored, so stale legacy text
+/// cannot leak onto -- or duplicate a name already shown for -- a modern dive.
 String? _buddyColumnValue(Dive dive) {
+  if (dive.buddies.isEmpty) return dive.buddy;
   final names = dive.buddies
       .where((b) => !_isGuideRole(b.role.id))
       .map((b) => b.buddy.name.trim())
       .where((n) => n.isNotEmpty)
       .toList();
-  if (names.isNotEmpty) return names.join(', ');
-  return dive.buddy;
+  return names.isEmpty ? null : names.join(', ');
 }
 
 /// Names shown in the Dive Master table column: recorded participants whose
-/// role is a guide/divemaster, comma-joined. Falls back to the legacy
-/// free-text [Dive.diveMaster] scalar when none are hydrated.
+/// role is a guide/divemaster, comma-joined.
+///
+/// Uses the same junction-authoritative rule as [_buddyColumnValue]: the legacy
+/// [Dive.diveMaster] scalar is used only when [Dive.buddies] is empty.
 String? _diveMasterColumnValue(Dive dive) {
+  if (dive.buddies.isEmpty) return dive.diveMaster;
   final names = dive.buddies
       .where((b) => _isGuideRole(b.role.id))
       .map((b) => b.buddy.name.trim())
       .where((n) => n.isNotEmpty)
       .toList();
-  if (names.isNotEmpty) return names.join(', ');
-  return dive.diveMaster;
+  return names.isEmpty ? null : names.join(', ');
 }
 
 /// A `dive_roles` id representing someone guiding the dive rather than a peer

--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -399,6 +399,59 @@ class BuddyRepository {
     ];
   }
 
+  /// Lean batch load of buddies for many dives at once, for list/table views.
+  ///
+  /// Returns a map keyed by dive id (dives with no buddies are simply absent).
+  /// Unlike [getBuddiesForDive] this skips the primary-certification hydration
+  /// ([_withPrimaryCerts]) because list/table views only render names and
+  /// roles -- keeping it to two queries total (the junction join plus
+  /// dive_roles) regardless of how many dives are passed. Uses the same
+  /// `isIn(diveIds)` batching as the other related-data loads in
+  /// [DiveRepository.getAllDives].
+  Future<Map<String, List<domain.BuddyWithRole>>> getBuddiesForDives(
+    List<String> diveIds,
+  ) async {
+    if (diveIds.isEmpty) return {};
+
+    final joinRows =
+        await (_db.select(_db.buddies).join([
+                innerJoin(
+                  _db.diveBuddies,
+                  _db.diveBuddies.buddyId.equalsExp(_db.buddies.id),
+                ),
+              ])
+              ..where(_db.diveBuddies.diveId.isIn(diveIds))
+              ..orderBy([OrderingTerm.asc(_db.buddies.name)]))
+            .get();
+
+    // Resolve role ids against dive_roles once; unknown slugs stay visible as
+    // synthetic roles instead of silently coercing to Buddy.
+    final roleRows = await _db.select(_db.diveRoles).get();
+    final rolesById = {for (final r in roleRows) r.id: mapDiveRoleRow(r)};
+
+    final byDive = <String, List<domain.BuddyWithRole>>{};
+    for (final jr in joinRows) {
+      final b = jr.readTable(_db.buddies);
+      final link = jr.readTable(_db.diveBuddies);
+      final buddy = domain.Buddy(
+        id: b.id,
+        diverId: b.diverId,
+        name: b.name,
+        email: b.email,
+        phone: b.phone,
+        photoPath: b.photoPath,
+        notes: b.notes,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(b.createdAt),
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(b.updatedAt),
+      );
+      final role = rolesById[link.role] ?? DiveRole.synthetic(link.role);
+      byDive
+          .putIfAbsent(link.diveId, () => [])
+          .add(domain.BuddyWithRole(buddy: buddy, role: role));
+    }
+    return byDive;
+  }
+
   /// Set buddies for a dive (replaces existing)
   Future<void> setBuddiesForDive(
     String diveId,

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -38,6 +38,9 @@ import 'package:submersion/features/dive_log/data/repositories/dive_custom_field
 import 'package:submersion/features/tags/domain/entities/tag.dart' as domain;
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart' as domain;
+import 'package:submersion/features/buddies/domain/entities/buddy.dart'
+    as domain;
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 
 class DiveRepository {
   AppDatabase get _db => DatabaseService.instance.database;
@@ -45,6 +48,7 @@ class DiveRepository {
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(DiveRepository);
   final TagRepository _tagRepository = TagRepository();
+  final BuddyRepository _buddyRepository = BuddyRepository();
   late final DiveCustomFieldRepository _customFieldRepository =
       DiveCustomFieldRepository(_db);
 
@@ -255,6 +259,13 @@ class DiveRepository {
         final customFieldsByDive = await _customFieldRepository
             .getFieldsForDiveIds(diveIds);
 
+        // Load all buddies (junction) for these dives in one query so the
+        // table view's Buddy / Dive Master columns render recorded people
+        // (issue #626). Scalar buddy/diveMaster remain the fallback.
+        final buddiesByDive = await _buddyRepository.getBuddiesForDives(
+          diveIds,
+        );
+
         return rows
             .map(
               (row) => _mapRowToDiveWithPreloadedData(
@@ -269,6 +280,7 @@ class DiveRepository {
                 tags: tagsByDive[row.id] ?? [],
                 diveTypeIds: diveTypesByDive[row.id],
                 customFields: customFieldsByDive[row.id] ?? [],
+                buddies: buddiesByDive[row.id] ?? const [],
               ),
             )
             .toList();
@@ -2578,6 +2590,7 @@ class DiveRepository {
     List<domain.Tag> tags = const [],
     List<String>? diveTypeIds,
     List<domain.DiveCustomField> customFields = const [],
+    List<domain.BuddyWithRole> buddies = const [],
   }) {
     // Map site if exists
     domain.DiveSite? domainSite;
@@ -2681,6 +2694,7 @@ class DiveRepository {
       diveTypeIds: diveTypeIds ?? [row.diveType],
       buddy: row.buddy,
       diveMaster: row.diveMaster,
+      buddies: buddies,
       diverRoleId: row.diverRole,
       notes: row.notes,
       name: row.name,

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -3,6 +3,7 @@ import 'package:equatable/equatable.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
 import 'package:submersion/core/utils/gas_compressibility.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
@@ -48,6 +49,15 @@ class Dive extends Equatable {
   final DiveTypeEntity? diveType; // Loaded dive type entity (for display)
   final String? buddy;
   final String? diveMaster;
+
+  /// Buddies and dive guides recorded on this dive via the many-to-many
+  /// `dive_buddies` junction (#553), each paired with their [DiveRole].
+  ///
+  /// Display-only: hydrated for list/table views (see
+  /// `DiveRepository.getAllDives`) and never persisted from this entity — the
+  /// dive editor writes the junction directly. Empty on the legacy scalar-only
+  /// path, in which case the [buddy] / [diveMaster] text fields are the source.
+  final List<BuddyWithRole> buddies;
 
   /// The active diver's own role on this dive (dive_roles id, #547).
   final String? diverRoleId;
@@ -168,6 +178,7 @@ class Dive extends Equatable {
     this.diveType,
     this.buddy,
     this.diveMaster,
+    this.buddies = const [],
     this.diverRoleId,
     this.rating,
     this.currentDirection,
@@ -541,6 +552,7 @@ class Dive extends Equatable {
     DiveTypeEntity? diveType,
     String? buddy,
     String? diveMaster,
+    List<BuddyWithRole>? buddies,
     String? diverRoleId,
     int? rating,
     CurrentDirection? currentDirection,
@@ -632,6 +644,7 @@ class Dive extends Equatable {
       diveType: diveType ?? this.diveType,
       buddy: buddy ?? this.buddy,
       diveMaster: diveMaster ?? this.diveMaster,
+      buddies: buddies ?? this.buddies,
       diverRoleId: diverRoleId ?? this.diverRoleId,
       rating: rating ?? this.rating,
       currentDirection: currentDirection ?? this.currentDirection,
@@ -726,6 +739,7 @@ class Dive extends Equatable {
     diveType,
     buddy,
     diveMaster,
+    buddies,
     diverRoleId,
     rating,
     currentDirection,

--- a/test/core/constants/dive_field_extractor_test.dart
+++ b/test/core/constants/dive_field_extractor_test.dart
@@ -2,13 +2,39 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
+
+/// A junction participant with the given display [name] and dive_roles [roleId].
+BuddyWithRole _person(String name, String roleId) => BuddyWithRole(
+  buddy: Buddy(
+    id: name,
+    name: name,
+    createdAt: DateTime(2024, 1, 1),
+    updatedAt: DateTime(2024, 1, 1),
+  ),
+  role: DiveRole.synthetic(roleId),
+);
+
+/// A minimal dive carrying junction [buddies] plus optional legacy scalars.
+Dive _diveWithBuddies(
+  List<BuddyWithRole> buddies, {
+  String? buddy,
+  String? diveMaster,
+}) => Dive(
+  id: 'dive-b',
+  dateTime: DateTime(2024, 1, 1),
+  buddy: buddy,
+  diveMaster: diveMaster,
+  buddies: buddies,
+);
 
 void main() {
   final now = DateTime(2024, 6, 15, 10, 30);
@@ -306,6 +332,94 @@ void main() {
 
     test('diveMaster returns dive master name', () {
       expect(DiveField.diveMaster.extractFromDive(testDive), 'Jane Smith');
+    });
+
+    // Issue #626: modern dives store people in the dive_buddies junction, so
+    // the Buddy / Dive Master columns must read the hydrated Dive.buddies, not
+    // just the legacy scalar text fields.
+    group('junction-hydrated buddies (#626)', () {
+      test('buddy column shows junction buddy names', () {
+        final dive = _diveWithBuddies([_person('Alice', DiveRole.buddyId)]);
+        expect(DiveField.buddy.extractFromDive(dive), 'Alice');
+      });
+
+      test('buddy column comma-joins multiple buddies', () {
+        final dive = _diveWithBuddies([
+          _person('Alice', DiveRole.buddyId),
+          _person('Bob', DiveRole.buddyId),
+        ]);
+        expect(DiveField.buddy.extractFromDive(dive), 'Alice, Bob');
+      });
+
+      test('diveMaster column shows dive master role names', () {
+        final dive = _diveWithBuddies([
+          _person('Guido', DiveRole.diveMasterId),
+        ]);
+        expect(DiveField.diveMaster.extractFromDive(dive), 'Guido');
+      });
+
+      test('diveMaster column also includes dive guide role', () {
+        final dive = _diveWithBuddies([_person('Gaia', DiveRole.diveGuideId)]);
+        expect(DiveField.diveMaster.extractFromDive(dive), 'Gaia');
+      });
+
+      test('guides are excluded from the buddy column', () {
+        final dive = _diveWithBuddies([
+          _person('Alice', DiveRole.buddyId),
+          _person('Guido', DiveRole.diveMasterId),
+        ]);
+        expect(DiveField.buddy.extractFromDive(dive), 'Alice');
+        expect(DiveField.diveMaster.extractFromDive(dive), 'Guido');
+      });
+
+      test(
+        'non-guide roles (student, instructor) fall in the buddy column',
+        () {
+          // Names are joined in list order (the repository query pre-sorts by
+          // name; the extractor does not re-sort).
+          final dive = _diveWithBuddies([
+            _person('Sam', DiveRole.studentId),
+            _person('Ines', DiveRole.instructorId),
+          ]);
+          expect(DiveField.buddy.extractFromDive(dive), 'Sam, Ines');
+          expect(DiveField.diveMaster.extractFromDive(dive), isNull);
+        },
+      );
+
+      test('junction data takes precedence over the legacy scalar', () {
+        final dive = _diveWithBuddies(
+          [_person('Alice', DiveRole.buddyId)],
+          buddy: 'Legacy Name',
+          diveMaster: 'Legacy DM',
+        );
+        expect(DiveField.buddy.extractFromDive(dive), 'Alice');
+      });
+
+      test('falls back to the legacy scalar when no junction buddies', () {
+        final dive = _diveWithBuddies(
+          const [],
+          buddy: 'Legacy Buddy',
+          diveMaster: 'Legacy DM',
+        );
+        expect(DiveField.buddy.extractFromDive(dive), 'Legacy Buddy');
+        expect(DiveField.diveMaster.extractFromDive(dive), 'Legacy DM');
+      });
+
+      test('buddy column falls back to scalar when junction has only a DM', () {
+        final dive = _diveWithBuddies([
+          _person('Guido', DiveRole.diveMasterId),
+        ], buddy: 'Legacy Buddy');
+        // No non-guide participant -> scalar buddy still shows.
+        expect(DiveField.buddy.extractFromDive(dive), 'Legacy Buddy');
+        expect(DiveField.diveMaster.extractFromDive(dive), 'Guido');
+      });
+
+      test('blank buddy names are ignored', () {
+        final dive = _diveWithBuddies([
+          _person('   ', DiveRole.buddyId),
+        ], buddy: 'Legacy Buddy');
+        expect(DiveField.buddy.extractFromDive(dive), 'Legacy Buddy');
+      });
     });
 
     test('siteLocation returns site location string', () {

--- a/test/core/constants/dive_field_extractor_test.dart
+++ b/test/core/constants/dive_field_extractor_test.dart
@@ -386,13 +386,17 @@ void main() {
         },
       );
 
-      test('junction data takes precedence over the legacy scalar', () {
+      test('a populated junction is authoritative over both scalars', () {
+        // Modern dive: buddy present in junction, DM only in the legacy scalar.
+        // The buddy column shows the junction name; the DM column must NOT leak
+        // the stale scalar just because the junction has no guide role.
         final dive = _diveWithBuddies(
           [_person('Alice', DiveRole.buddyId)],
           buddy: 'Legacy Name',
           diveMaster: 'Legacy DM',
         );
         expect(DiveField.buddy.extractFromDive(dive), 'Alice');
+        expect(DiveField.diveMaster.extractFromDive(dive), isNull);
       });
 
       test('falls back to the legacy scalar when no junction buddies', () {
@@ -405,20 +409,26 @@ void main() {
         expect(DiveField.diveMaster.extractFromDive(dive), 'Legacy DM');
       });
 
-      test('buddy column falls back to scalar when junction has only a DM', () {
-        final dive = _diveWithBuddies([
-          _person('Guido', DiveRole.diveMasterId),
-        ], buddy: 'Legacy Buddy');
-        // No non-guide participant -> scalar buddy still shows.
-        expect(DiveField.buddy.extractFromDive(dive), 'Legacy Buddy');
-        expect(DiveField.diveMaster.extractFromDive(dive), 'Guido');
-      });
+      test(
+        'buddy column is null (no scalar leak) when junction has only a DM',
+        () {
+          // Junction is populated, so the dive is junction-authoritative: the
+          // frozen legacy scalar must not resurface in the buddy column.
+          final dive = _diveWithBuddies([
+            _person('Guido', DiveRole.diveMasterId),
+          ], buddy: 'Legacy Buddy');
+          expect(DiveField.buddy.extractFromDive(dive), isNull);
+          expect(DiveField.diveMaster.extractFromDive(dive), 'Guido');
+        },
+      );
 
-      test('blank buddy names are ignored', () {
+      test('blank junction names do not fall back to the scalar', () {
+        // Junction populated (even if only with blank names) -> authoritative,
+        // so the buddy column is null rather than the stale scalar.
         final dive = _diveWithBuddies([
           _person('   ', DiveRole.buddyId),
         ], buddy: 'Legacy Buddy');
-        expect(DiveField.buddy.extractFromDive(dive), 'Legacy Buddy');
+        expect(DiveField.buddy.extractFromDive(dive), isNull);
       });
     });
 

--- a/test/features/buddies/data/repositories/buddy_repository_test.dart
+++ b/test/features/buddies/data/repositories/buddy_repository_test.dart
@@ -301,6 +301,54 @@ void main() {
       );
     });
 
+    group('getBuddiesForDives (batch, #626)', () {
+      Future<void> insertDive(String id) async {
+        final db = DatabaseService.instance.database;
+        await db.customStatement(
+          "INSERT INTO dives (id, dive_date_time, created_at, updated_at) "
+          "VALUES ('$id', 1000, 1000, 1000)",
+        );
+      }
+
+      test('returns an empty map for empty input', () async {
+        expect(await repository.getBuddiesForDives([]), isEmpty);
+      });
+
+      test('groups buddies by dive id and resolves roles', () async {
+        await insertDive('d1');
+        await insertDive('d2');
+        final alice = await repository.createBuddy(
+          createTestBuddy(id: 'b1', name: 'Alice'),
+        );
+        final guido = await repository.createBuddy(
+          createTestBuddy(id: 'b2', name: 'Guido'),
+        );
+        await repository.addBuddyToDive('d1', alice.id, DiveRole.buddyId);
+        await repository.addBuddyToDive('d1', guido.id, DiveRole.diveMasterId);
+        await repository.addBuddyToDive('d2', alice.id, DiveRole.buddyId);
+
+        final result = await repository.getBuddiesForDives(['d1', 'd2']);
+
+        expect(result['d1'], hasLength(2));
+        expect(result['d2'], hasLength(1));
+        expect(
+          result['d1']!.map((b) => b.buddy.name),
+          containsAll(['Alice', 'Guido']),
+        );
+        final guidoLink = result['d1']!.firstWhere(
+          (b) => b.buddy.name == 'Guido',
+        );
+        expect(guidoLink.role.id, DiveRole.diveMasterId);
+        expect(result['d2']!.single.buddy.name, 'Alice');
+      });
+
+      test('omits dives that have no buddies', () async {
+        await insertDive('d1');
+        final result = await repository.getBuddiesForDives(['d1']);
+        expect(result.containsKey('d1'), isFalse);
+      });
+    });
+
     group('dive role resolution', () {
       Future<void> insertDive(String id) async {
         final db = DatabaseService.instance.database;

--- a/test/features/dive_log/data/repositories/dive_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_test.dart
@@ -234,6 +234,40 @@ void main() {
         expect(result[1].diveNumber, equals(2));
         expect(result[2].diveNumber, equals(1)); // Oldest
       });
+
+      // Issue #626: junction buddies must be hydrated onto the Dive entities
+      // so the table view's Buddy / Dive Master columns can render them.
+      test('hydrates junction buddies onto each dive', () async {
+        final created = await repository.createDive(
+          createTestDive(diveNumber: 1, dateTime: DateTime(2024, 1, 1)),
+        );
+        final buddyRepo = BuddyRepository();
+        final alice = await buddyRepo.createBuddy(
+          Buddy(
+            id: 'b1',
+            name: 'Alice',
+            createdAt: DateTime(2024, 1, 1),
+            updatedAt: DateTime(2024, 1, 1),
+          ),
+        );
+        await buddyRepo.addBuddyToDive(created.id, alice.id, DiveRole.buddyId);
+
+        final result = await repository.getAllDives();
+
+        expect(result.single.buddies, hasLength(1));
+        expect(result.single.buddies.single.buddy.name, 'Alice');
+        expect(result.single.buddies.single.role.id, DiveRole.buddyId);
+      });
+
+      test('leaves buddies empty for dives with no junction records', () async {
+        await repository.createDive(
+          createTestDive(diveNumber: 1, dateTime: DateTime(2024, 1, 1)),
+        );
+
+        final result = await repository.getAllDives();
+
+        expect(result.single.buddies, isEmpty);
+      });
     });
 
     group('updateDive', () {


### PR DESCRIPTION
## Summary

Fixes #626. In the Dives table view, the **Buddy** and **Dive Master** columns
were blank even when buddies/divemasters had been recorded for the dive.

Root cause: those columns read the legacy scalar `dive.buddy` / `dive.diveMaster`
text fields, but the modern editor records people in the `dive_buddies` junction
(`BuddyWithRole`, #553) and leaves the scalars frozen. `getAllDives` — which
feeds the table — batch-hydrates tanks, sites, centers, trips, equipment, tags,
and dive types, but never buddies, so the junction data never reached the table.
(The dive detail page looked correct because it reads the junction via
`buddiesForDiveProvider`.)

## Changes

- Add a display-only `List<BuddyWithRole> buddies` to the `Dive` entity
  (default `const []`; never persisted from the entity — the editor writes the
  junction directly, and saves still preserve the legacy scalar).
- Add a lean batch `BuddyRepository.getBuddiesForDives(diveIds)` — a single
  typed join returning names and roles only (no primary-certification
  hydration) — and call it from `getAllDives`, grouped by dive id like the
  other related-data loads.
- `DiveFieldExtractor` now derives the Buddy / Dive Master column strings from
  `Dive.buddies`, **falling back** to the legacy scalar when the junction is
  empty. Role split: `diveMaster` / `diveGuide` → Dive Master column; all other
  roles (buddy, student, instructor, solo, …) → Buddy column. Multiple names
  are comma-joined.

This also fixes **sort by Buddy / sort by Dive Master**, which run through the
same extractor. Legacy dives and any un-hydrated code path keep prior behavior
via the scalar fallback.

Reactivity matches the existing tag column: editing a dive's buddies writes the
dives row, which reloads the table. (A sync applying only junction rows refreshes
on the next dives-row tick — consistent with tags, not a regression.)

## Test Plan

- [x] `flutter test` passes (10 new extractor unit tests; 3 `getBuddiesForDives`
  batch tests; 2 `getAllDives` hydration integration tests; table/list widget
  suites green)
- [x] `flutter analyze` passes
- [ ] Manual testing on: macOS (visual smoke of the table columns) — pending

## Screenshots

<!-- macOS smoke pending -->
