### PR TITLE
feat(dive-sites): water type flows from dive site to dive (#624)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-water-type-from-dive-site.md
+++ b/docs/superpowers/plans/2026-07-18-water-type-from-dive-site.md
@@ -1,0 +1,851 @@
+# Water Type from Dive Site — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a diver set water type once on a dive site; when that site is assigned to a dive, the dive's water type auto-fills from it (still manually editable).
+
+**Architecture:** Revive the already-existing-but-dormant `dive_sites.waterType` column (hydrate it into the entity, persist it, expose it in the site editor), then snapshot it onto the dive on site assignment. The dive keeps storing its own `waterType` (snapshot model), so every existing reader — exports, statistics, deco/buoyancy density — is untouched.
+
+**Tech Stack:** Flutter, Drift ORM (SQLite), Riverpod, `flutter_test`. Water type is the existing `WaterType` enum (`salt`/`fresh`/`brackish`) in `lib/core/constants/enums.dart`.
+
+## Global Constraints
+
+- **No schema migration / no schema-version bump.** `dive_sites.waterType` already exists (`database.dart:639`) and already syncs via `toJson()`. Do not add a column or bump the version ladder.
+- **Snapshot model.** The dive stores its own `waterType`; the site is only a source of defaults. Never make the dive read through to the site at display time.
+- **Canonical column values are `WaterType.name`** (`'salt'`/`'fresh'`/`'brackish'`) — importers already write these; hydration must parse them and yield `null` on an unknown/absent string (never fabricate a default).
+- **Localization:** any new UI string is added to all 11 ARB files (`lib/l10n/arb/app_{en,ar,de,es,fr,he,hu,it,nl,pt,zh}.arb`) and regenerated with `flutter gen-l10n`. Generated `app_localizations*.dart` is tracked — commit it.
+- **`dart format .` clean and `flutter analyze` clean** before every commit (pre-push hook enforces format + analyze + test).
+- **Commit messages:** no `Co-Authored-By` trailer, no session-URL trailer.
+- **Worktree paths:** all work happens in `.claude/worktrees/site-water-type-autofill`; use worktree-absolute paths for edits.
+
+---
+
+### Task 0: Worktree setup (codegen)
+
+The fresh worktree has no generated code. `lib/core/database/database.g.dart` is gitignored and absent; nothing compiles or tests until codegen runs.
+
+**Files:** none (setup only).
+
+- [ ] **Step 1: Initialize submodules**
+
+Run: `git submodule update --init --recursive`
+Expected: libdivecomputer and other submodules populate (no error).
+
+- [ ] **Step 2: Fetch packages**
+
+Run: `flutter pub get`
+Expected: "Got dependencies!" (or "Resolving dependencies…" then success).
+
+- [ ] **Step 3: Run code generation**
+
+Run: `dart run build_runner build --delete-conflicting-outputs`
+Expected: build completes; `lib/core/database/database.g.dart` now exists.
+
+- [ ] **Step 4: Verify the toolchain runs a test**
+
+Run: `flutter test test/features/dive_sites/data/repositories/site_repository_test.dart`
+Expected: existing tests PASS (proves DB codegen + harness work).
+
+No commit (generated artifacts are gitignored).
+
+---
+
+### Task 1: Entity + repository — revive `dive_sites.waterType`
+
+**Deliverable:** a site's water type persists and round-trips through the repository (including rows written directly by importers). No UI yet.
+
+**Files:**
+- Modify: `lib/features/dive_sites/domain/entities/dive_site.dart`
+- Modify: `lib/features/dive_sites/data/repositories/site_repository_impl.dart`
+- Modify: `lib/features/dive_sites/domain/constants/site_field.dart:459-460`
+- Test: `test/features/dive_sites/data/repositories/site_repository_test.dart`
+- Test: `test/features/dive_sites/domain/constants/site_field_test.dart` (fix an existing test)
+
+**Interfaces:**
+- Produces: `DiveSite.waterType` of type `WaterType?` (new named field on the entity + `copyWith` param). Later tasks read/write it.
+
+- [ ] **Step 1: Write failing repository round-trip tests**
+
+Add these tests inside the `group('SiteRepository', () {` block in `site_repository_test.dart` (after the `bodyOfWater` round-trip test near line 71). `WaterType` and `Value` are already imported in this file.
+
+```dart
+    test('create then read round-trips waterType', () async {
+      const site = DiveSite(
+        id: 'wt-1',
+        name: 'Water Type Site',
+        waterType: WaterType.brackish,
+      );
+      await repository.createSite(site);
+      final loaded = await repository.getSiteById('wt-1');
+      expect(loaded!.waterType, WaterType.brackish);
+    });
+
+    test('imported water_type column is read back into the entity', () async {
+      // Importers write the column directly (no entity mapping).
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await database
+          .into(database.diveSites)
+          .insert(
+            db.DiveSitesCompanion.insert(
+              id: 'wt-ghost',
+              name: 'Imported Site',
+              createdAt: now,
+              updatedAt: now,
+              waterType: const Value('salt'),
+            ),
+          );
+      final loaded = await repository.getSiteById('wt-ghost');
+      expect(loaded!.waterType, WaterType.salt);
+    });
+
+    test('unknown water_type string maps to null (no crash)', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await database
+          .into(database.diveSites)
+          .insert(
+            db.DiveSitesCompanion.insert(
+              id: 'wt-bad',
+              name: 'Bad Water Type',
+              createdAt: now,
+              updatedAt: now,
+              waterType: const Value('lava'),
+            ),
+          );
+      final loaded = await repository.getSiteById('wt-bad');
+      expect(loaded!.waterType, isNull);
+    });
+
+    test('updateSite persists a changed waterType', () async {
+      const site = DiveSite(id: 'wt-up', name: 'Upd', waterType: WaterType.salt);
+      await repository.createSite(site);
+      await repository.updateSite(site.copyWith(waterType: WaterType.fresh));
+      final loaded = await repository.getSiteById('wt-up');
+      expect(loaded!.waterType, WaterType.fresh);
+    });
+
+    test('waterType survives Drift row JSON serialization (sync path)', () async {
+      // Sync serializes each row with row.toJson(); this proves the column
+      // rides that generic path. Key-agnostic: fromJson reads back whatever
+      // key toJson wrote.
+      const site = DiveSite(
+        id: 'wt-json',
+        name: 'JSON Site',
+        waterType: WaterType.fresh,
+      );
+      await repository.createSite(site);
+      final row = await (database.select(
+        database.diveSites,
+      )..where((t) => t.id.equals('wt-json'))).getSingle();
+      final restored = db.DiveSite.fromJson(row.toJson());
+      expect(restored.waterType, 'fresh');
+    });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/dive_sites/data/repositories/site_repository_test.dart`
+Expected: compile FAIL — `DiveSite` has no named parameter `waterType`.
+
+- [ ] **Step 3: Add `waterType` to the `DiveSite` entity**
+
+In `dive_site.dart`, add the import at the top (after the equatable import on line 1):
+
+```dart
+import 'package:submersion/core/constants/enums.dart';
+```
+
+Add the field after `difficulty` (line 41):
+
+```dart
+  final SiteDifficulty? difficulty; // Site difficulty level
+  final WaterType? waterType; // Salt / fresh / brackish
+```
+
+Add the constructor param after `this.difficulty,` (line 67):
+
+```dart
+    this.difficulty,
+    this.waterType,
+```
+
+Add the `copyWith` param after `SiteDifficulty? difficulty,` (line 130):
+
+```dart
+    SiteDifficulty? difficulty,
+    WaterType? waterType,
+```
+
+Add to the `copyWith` body after `difficulty: difficulty ?? this.difficulty,` (line 155):
+
+```dart
+      difficulty: difficulty ?? this.difficulty,
+      waterType: waterType ?? this.waterType,
+```
+
+Add to `props` after `difficulty,` (line 183):
+
+```dart
+    difficulty,
+    waterType,
+```
+
+- [ ] **Step 4: Hydrate and persist `waterType` in the repository**
+
+In `site_repository_impl.dart`, in `_mapRowToSite` (line 705), add after the `difficulty:` line:
+
+```dart
+      difficulty: domain.SiteDifficulty.fromString(row.difficulty),
+      waterType: row.waterType == null
+          ? null
+          : WaterType.values.asNameMap()[row.waterType],
+```
+
+`WaterType` is exported from `package:submersion/core/constants/enums.dart`. If that import is not already present in this file, add it.
+
+Add `waterType: Value(site.waterType?.name),` immediately after each `difficulty: Value(site.difficulty?.name),` line in all four `DiveSitesCompanion` builders:
+- `createSite` insert (line 79)
+- `updateSite` update (line 133)
+- restore-insert path (line 508)
+- `_updateSiteRow` (line 731)
+
+Each edit looks like:
+
+```dart
+              difficulty: Value(site.difficulty?.name),
+              waterType: Value(site.waterType?.name),
+```
+
+- [ ] **Step 5: Point the site-table read path at the new field**
+
+In `site_field.dart`, change only the value-extraction arm (line 459-460):
+
+```dart
+      case SiteField.waterType:
+        return site.waterType?.displayName;
+```
+
+(The `formatValue` arm at line 497 already handles `waterType` as a `String` passthrough — `displayName` is a `String`, so it still works.)
+
+- [ ] **Step 6: Fix the existing `site_field_test.dart` expectation**
+
+That test currently reads water type from the dead `conditions` object. Import `WaterType` (add `import 'package:submersion/core/constants/enums.dart';` if absent), add a top-level `waterType` to the shared `testSite` after its `difficulty:` line (near line 23):
+
+```dart
+    difficulty: SiteDifficulty.advanced,
+    waterType: WaterType.salt,
+```
+
+Replace the test at lines 168-173 with:
+
+```dart
+    test('returns waterType displayName from the entity', () {
+      expect(
+        adapter.extractValue(SiteField.waterType, testEntity),
+        equals('Salt Water'),
+      );
+    });
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `flutter test test/features/dive_sites/data/repositories/site_repository_test.dart test/features/dive_sites/domain/constants/site_field_test.dart`
+Expected: PASS.
+
+- [ ] **Step 8: Guard against entity-equality regressions**
+
+Run: `flutter test test/features/dive_sites/`
+Expected: PASS (confirms the new `props` entry didn't break equality/copyWith tests elsewhere).
+
+- [ ] **Step 9: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_sites/domain/entities/dive_site.dart lib/features/dive_sites/data/repositories/site_repository_impl.dart lib/features/dive_sites/domain/constants/site_field.dart test/features/dive_sites/data/repositories/site_repository_test.dart test/features/dive_sites/domain/constants/site_field_test.dart
+flutter analyze lib/features/dive_sites test/features/dive_sites
+git add lib/features/dive_sites/domain/entities/dive_site.dart lib/features/dive_sites/data/repositories/site_repository_impl.dart lib/features/dive_sites/domain/constants/site_field.dart test/features/dive_sites/data/repositories/site_repository_test.dart test/features/dive_sites/domain/constants/site_field_test.dart
+git commit -m "feat(dive-sites): persist and hydrate site water type"
+```
+
+---
+
+### Task 2: Site editor — Water Type picker
+
+**Deliverable:** the site editor's Dive Info section shows a Water Type chip row (Salt Water / Fresh Water / Brackish); selecting one and saving persists it.
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` + the 10 other ARB files
+- Modify (generated): `lib/l10n/arb/app_localizations*.dart` (via `flutter gen-l10n`)
+- Modify: `lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart`
+- Modify: `lib/features/dive_sites/presentation/pages/site_edit_page.dart`
+- Test: `test/features/dive_sites/presentation/pages/site_edit_page_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveSite.waterType` (Task 1).
+- Produces: `DiveInfoSection` gains required `WaterType? waterType`, `ValueChanged<WaterType?> onWaterTypeChanged`, and optional `MergeFieldExtras? waterTypeExtras`. `SiteEditPage` gains `WaterType? _waterType` state.
+
+- [ ] **Step 1: Add the localized label to all 11 ARB files**
+
+In `app_en.arb`, add after `"diveSites_edit_section_rating"` (line 4106):
+
+```json
+  "diveSites_edit_section_waterType": "Water Type",
+```
+
+Add the same key with these values to each locale file (place it near the other `diveSites_edit_section_*` keys):
+
+- `app_de.arb`: `"diveSites_edit_section_waterType": "Gewässertyp",`
+- `app_es.arb`: `"diveSites_edit_section_waterType": "Tipo de agua",`
+- `app_fr.arb`: `"diveSites_edit_section_waterType": "Type d'eau",`
+- `app_it.arb`: `"diveSites_edit_section_waterType": "Tipo di acqua",`
+- `app_nl.arb`: `"diveSites_edit_section_waterType": "Watertype",`
+- `app_pt.arb`: `"diveSites_edit_section_waterType": "Tipo de água",`
+- `app_hu.arb`: `"diveSites_edit_section_waterType": "Víztípus",`
+- `app_he.arb`: `"diveSites_edit_section_waterType": "סוג מים",`
+- `app_ar.arb`: `"diveSites_edit_section_waterType": "نوع المياه",`
+- `app_zh.arb`: `"diveSites_edit_section_waterType": "水体类型",`
+
+- [ ] **Step 2: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: regenerates `lib/l10n/arb/app_localizations*.dart`; `AppLocalizations` now exposes `diveSites_edit_section_waterType`. (Untranslated-message warnings for unrelated keys are fine.)
+
+- [ ] **Step 3: Write the failing widget test**
+
+Add this test in `site_edit_page_test.dart`, right after the `'selecting a difficulty chip updates state'` test (ends line 376). It mirrors that test exactly.
+
+```dart
+    testWidgets('selecting a water type chip updates state', (tester) async {
+      tester.view.physicalSize = const Size(900, 3200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        _buildHarness(prefs: prefs, divers: const [], shareByDefault: false),
+      );
+      await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Water Type'),
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      // Tap the Brackish chip.
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Brackish'));
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Brackish'))
+            .selected,
+        isTrue,
+      );
+      // Tap again to deselect.
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Brackish'));
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Brackish'))
+            .selected,
+        isFalse,
+      );
+    });
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_page_test.dart -n "water type chip"`
+Expected: FAIL — no "Water Type" text / no such chip.
+
+- [ ] **Step 5: Add the water-type control to `DiveInfoSection`**
+
+In `dive_info_section.dart`, add the import after line 4:
+
+```dart
+import 'package:submersion/core/constants/enums.dart';
+```
+
+Add constructor params — after `required this.onRatingCleared,` (line 25):
+
+```dart
+    required this.onRatingCleared,
+    required this.waterType,
+    required this.onWaterTypeChanged,
+```
+
+and after `this.ratingExtras,` (line 28):
+
+```dart
+    this.ratingExtras,
+    this.waterTypeExtras,
+```
+
+Add the fields after `final VoidCallback onRatingCleared;` (line 42) and after `final MergeFieldExtras? ratingExtras;` (line 45):
+
+```dart
+  final VoidCallback onRatingCleared;
+  final WaterType? waterType;
+  final ValueChanged<WaterType?> onWaterTypeChanged;
+```
+
+```dart
+  final MergeFieldExtras? ratingExtras;
+  final MergeFieldExtras? waterTypeExtras;
+```
+
+In `build`, insert this block into `children` immediately after the difficulty `Column(...)` block closes (after line 116, before the rating `Column`):
+
+```dart
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (waterTypeExtras != null)
+              MergeSourceRow(
+                sourceLabel: waterTypeExtras!.sourceLabel,
+                onCycle: waterTypeExtras!.onCycle,
+              ),
+            FormRow.custom(
+              label: l10n.diveSites_edit_section_waterType,
+              child: Wrap(
+                alignment: WrapAlignment.end,
+                spacing: 6,
+                runSpacing: 4,
+                children: WaterType.values.map((value) {
+                  final isSelected = waterType == value;
+                  return ChoiceChip(
+                    label: Text(value.displayName),
+                    selected: isSelected,
+                    visualDensity: VisualDensity.compact,
+                    onSelected: (selected) =>
+                        onWaterTypeChanged(selected ? value : null),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+```
+
+- [ ] **Step 6: Wire state into `SiteEditPage`**
+
+In `site_edit_page.dart`, add the import (with the other `core/constants` imports):
+
+```dart
+import 'package:submersion/core/constants/enums.dart';
+```
+
+Add the state field after `SiteDifficulty? _difficulty;` (line 83):
+
+```dart
+  SiteDifficulty? _difficulty;
+  WaterType? _waterType;
+```
+
+Seed it after `_difficulty = site.difficulty;` (line 219):
+
+```dart
+    _difficulty = site.difficulty;
+    _waterType = site.waterType;
+```
+
+Add it to the section summary — after the difficulty line in `_diveInfoSummary()` (line 694):
+
+```dart
+    if (_difficulty != null) _difficulty!.displayName,
+    if (_waterType != null) _waterType!.displayName,
+```
+
+Wire the `DiveInfoSection` call — after the `onRatingCleared: …` closure (ends line 796), add:
+
+```dart
+            onRatingCleared: () => setState(() {
+              _rating = 0;
+              _hasChanges = true;
+            }),
+            waterType: _waterType,
+            onWaterTypeChanged: (value) => setState(() {
+              _waterType = value;
+              _hasChanges = true;
+            }),
+```
+
+Add `waterType:` to the saved `DiveSite(...)` — after `altitude: altitudeMeters,` (line 1319):
+
+```dart
+        altitude: altitudeMeters,
+        waterType: _waterType,
+        isShared: _isShared,
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_page_test.dart`
+Expected: PASS (the new test and all existing site-editor tests).
+
+- [ ] **Step 8: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart lib/features/dive_sites/presentation/pages/site_edit_page.dart test/features/dive_sites/presentation/pages/site_edit_page_test.dart
+flutter analyze lib/features/dive_sites lib/l10n test/features/dive_sites
+git add lib/l10n/arb lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart lib/features/dive_sites/presentation/pages/site_edit_page.dart test/features/dive_sites/presentation/pages/site_edit_page_test.dart
+git commit -m "feat(dive-sites): edit water type in the site editor"
+```
+
+---
+
+### Task 3: Site editor — merge parity for water type (optional, separable)
+
+**Deliverable:** when merging sites with different water types, the editor offers a cycle affordance like difficulty/rating. Tasks 1, 2, and 4 deliver the issue without this; skip if deferring.
+
+**Files:**
+- Modify: `lib/features/dive_sites/presentation/pages/site_edit_page.dart`
+- Test: `test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveInfoSection.waterTypeExtras` (Task 2), `DiveSite.waterType` (Task 1), existing private helpers `_buildDistinctCandidates<T>`, `_firstMeaningfulIndex`, `_MergeFieldCandidate<T>`, `_mergeFieldIndices`.
+
+- [ ] **Step 1: Write the failing merge test**
+
+Add this test in `site_edit_merge_page_test.dart`, right after the `'merge mode cycles difficulty when sites have different difficulties'` test. It mirrors that test's structure; reuse the file's existing `siteRepository`, `prefs`, and merge harness.
+
+```dart
+  testWidgets(
+    'merge mode cycles water type when sites differ',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 3200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final site1 = await siteRepository.createSite(
+        const DiveSite(id: '', name: 'Salt Site', waterType: WaterType.salt),
+      );
+      final site2 = await siteRepository.createSite(
+        const DiveSite(id: '', name: 'Fresh Site', waterType: WaterType.fresh),
+      );
+
+      await tester.pumpWidget(
+        _buildMergeHarness(
+          prefs: prefs,
+          divers: const [],
+          mergeSiteIds: [site1.id, site2.id],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Water Type'),
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // Initial value is the first non-empty candidate (Salt Water).
+      expect(
+        tester
+            .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Salt Water'))
+            .selected,
+        isTrue,
+      );
+
+      final waterTypeSection = find.ancestor(
+        of: find.text('Water Type'),
+        matching: find.byType(Card),
+      );
+      final cycleButton = find.descendant(
+        of: waterTypeSection,
+        matching: find.byIcon(Icons.sync_alt),
+      );
+      expect(cycleButton, findsOneWidget);
+
+      await tester.tap(cycleButton);
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Fresh Water'))
+            .selected,
+        isTrue,
+      );
+    },
+  );
+```
+
+Ensure `WaterType` is imported in this test file (add `import 'package:submersion/core/constants/enums.dart';` if absent).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart -n "water type"`
+Expected: FAIL — no water-type cycle button in merge mode.
+
+- [ ] **Step 3: Add the merge candidate state**
+
+In `site_edit_page.dart`, add the candidate list after `_difficultyCandidates` (line 96):
+
+```dart
+  List<_MergeFieldCandidate<SiteDifficulty?>> _difficultyCandidates = [];
+  List<_MergeFieldCandidate<WaterType?>> _waterTypeCandidates = [];
+```
+
+- [ ] **Step 4: Build the candidates on merge load**
+
+After the difficulty candidate block (ends line 361), add:
+
+```dart
+    _waterTypeCandidates = _buildDistinctCandidates<WaterType?>(
+      data.sites,
+      (site) => site.waterType,
+      equals: (a, b) => a == b,
+    );
+    _mergeFieldIndices['waterType'] = _firstMeaningfulIndex(
+      _waterTypeCandidates,
+      (value) => value != null,
+    );
+    _waterType =
+        _waterTypeCandidates[_mergeFieldIndices['waterType'] ?? 0].value;
+```
+
+- [ ] **Step 5: Add the extras + cycle methods**
+
+After `_difficultyExtras()` (ends line 651), add:
+
+```dart
+  MergeFieldExtras? _waterTypeExtras() {
+    if (!widget.isMerging || _waterTypeCandidates.length < 2) return null;
+    final index = _mergeFieldIndices['waterType'] ?? 0;
+    return MergeFieldExtras(
+      sourceLabel: context.l10n.diveSites_edit_merge_fieldSourceLabel(
+        _waterTypeCandidates[index].siteName,
+        index + 1,
+        _waterTypeCandidates.length,
+      ),
+      onCycle: _cycleWaterType,
+    );
+  }
+```
+
+After `_cycleDifficulty()` (ends line 1028), add:
+
+```dart
+  void _cycleWaterType() {
+    if (_waterTypeCandidates.length < 2) return;
+    setState(() {
+      final nextIndex =
+          ((_mergeFieldIndices['waterType'] ?? 0) + 1) %
+          _waterTypeCandidates.length;
+      _mergeFieldIndices['waterType'] = nextIndex;
+      _waterType = _waterTypeCandidates[nextIndex].value;
+      _hasChanges = true;
+    });
+  }
+```
+
+- [ ] **Step 6: Pass the extras to the section**
+
+In the `DiveInfoSection(...)` call, add after the `onWaterTypeChanged:` closure (added in Task 2):
+
+```dart
+            waterTypeExtras: _waterTypeExtras(),
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart`
+Expected: PASS.
+
+- [ ] **Step 8: Format, analyze, commit**
+
+```bash
+dart format lib/features/dive_sites/presentation/pages/site_edit_page.dart test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart
+flutter analyze lib/features/dive_sites test/features/dive_sites
+git add lib/features/dive_sites/presentation/pages/site_edit_page.dart test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart
+git commit -m "feat(dive-sites): cycle water type when merging sites"
+```
+
+---
+
+### Task 4: Dive form — snap water type on site assign
+
+**Deliverable:** assigning or changing a site on a dive auto-fills the dive's water type (snap when the site has one; keep the current value otherwise, including when clearing the site). Only needs Task 1.
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/utils/water_type_autofill.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart`
+- Test: `test/features/dive_log/presentation/utils/water_type_autofill_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveSite.waterType` (Task 1).
+- Produces: `WaterType? waterTypeAfterSiteAssign(WaterType? current, DiveSite? site)` — the pure snap rule. `_assignSite(DiveSite? site)` on the dive edit page.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `test/features/dive_log/presentation/utils/water_type_autofill_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/presentation/utils/water_type_autofill.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+void main() {
+  DiveSite site({WaterType? waterType}) =>
+      DiveSite(id: 's', name: 'S', waterType: waterType);
+
+  group('waterTypeAfterSiteAssign', () {
+    test('snaps to the site water type when the site has one', () {
+      expect(
+        waterTypeAfterSiteAssign(null, site(waterType: WaterType.salt)),
+        WaterType.salt,
+      );
+    });
+
+    test('overwrites the current value when the new site has a water type', () {
+      expect(
+        waterTypeAfterSiteAssign(
+          WaterType.fresh,
+          site(waterType: WaterType.salt),
+        ),
+        WaterType.salt,
+      );
+    });
+
+    test('keeps the current value when the site has no water type', () {
+      expect(waterTypeAfterSiteAssign(WaterType.fresh, site()), WaterType.fresh);
+    });
+
+    test('keeps the current value when the site is cleared (null)', () {
+      expect(
+        waterTypeAfterSiteAssign(WaterType.brackish, null),
+        WaterType.brackish,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/utils/water_type_autofill_test.dart`
+Expected: compile FAIL — `water_type_autofill.dart` / `waterTypeAfterSiteAssign` do not exist.
+
+- [ ] **Step 3: Create the pure snap function**
+
+Create `lib/features/dive_log/presentation/utils/water_type_autofill.dart`:
+
+```dart
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// The dive's water type after [site] is assigned to it, given the dive's
+/// [current] value.
+///
+/// Snap-on-assign: take the site's water type when it has one; otherwise keep
+/// the current value. A site with no water type — or clearing the site
+/// ([site] == null) — never wipes a value the diver already set.
+WaterType? waterTypeAfterSiteAssign(WaterType? current, DiveSite? site) =>
+    site?.waterType ?? current;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/utils/water_type_autofill_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Add `_assignSite` and route user-initiated assignments through it**
+
+In `dive_edit_page.dart`, add the import (with the other `features/dive_log` imports):
+
+```dart
+import 'package:submersion/features/dive_log/presentation/utils/water_type_autofill.dart';
+```
+
+Add this method near the other site handlers (e.g., just above `_showSitePicker`, line 1961):
+
+```dart
+  /// Assigns [site] to the dive and snaps the water type from it (manual
+  /// overrides survive when the site has none). Use for user-initiated
+  /// assignments and new-dive prefill — NOT the load path, which restores the
+  /// dive's own saved water type.
+  void _assignSite(DiveSite? site) {
+    _selectedSite = site;
+    _waterType = waterTypeAfterSiteAssign(_waterType, site);
+  }
+```
+
+Change these five call sites (leave line 588 load and line 1947 GPS-update untouched):
+
+Line 453 (new-dive prefill):
+
+```dart
+    if (p.site != null) _assignSite(p.site);
+```
+
+Line 1735 (clear site):
+
+```dart
+        setState(() => _assignSite(null));
+```
+
+Line 1920 (photo-GPS create — inside the existing `setState`):
+
+```dart
+      setState(() {
+        _assignSite(createdSite);
+        _gpsSuggestionDismissed = true;
+      });
+```
+
+Line 1978 (site picker selection):
+
+```dart
+            setState(() => _assignSite(site));
+```
+
+Line 1996 (create-new site result):
+
+```dart
+          setState(() => _assignSite(site));
+```
+
+- [ ] **Step 6: Analyze and run the dive-log tests**
+
+Run: `flutter analyze lib/features/dive_log test/features/dive_log`
+Then: `flutter test test/features/dive_log/presentation/pages/dive_edit_page_test.dart test/features/dive_log/presentation/utils/water_type_autofill_test.dart`
+Expected: analyze clean; tests PASS (existing dive-edit tests still green — the load path is unchanged).
+
+- [ ] **Step 7: Format, commit**
+
+```bash
+dart format lib/features/dive_log/presentation/utils/water_type_autofill.dart lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/utils/water_type_autofill_test.dart
+git add lib/features/dive_log/presentation/utils/water_type_autofill.dart lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/utils/water_type_autofill_test.dart
+git commit -m "feat(dive-log): auto-fill dive water type from the assigned site"
+```
+
+---
+
+### Task 5: Full verification
+
+**Deliverable:** confidence the whole feature works end-to-end.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `flutter test`
+Expected: all PASS.
+
+- [ ] **Step 2: Format + analyze the whole project**
+
+Run: `dart format .` then `flutter analyze`
+Expected: no changes from format; analyze clean.
+
+- [ ] **Step 3: Manual smoke test (macOS)**
+
+Run: `flutter run -d macos`
+Verify:
+1. Edit a dive site → Dive Info → set Water Type = Salt Water → save.
+2. New dive → assign that site → the dive's Water Type shows Salt Water.
+3. Manually change the dive's Water Type to Fresh → change some other field → it stays Fresh.
+4. Change the dive to a different site (with a different or no water type) → snaps to that site's value / stays put if the site has none.
+5. Clear the site → water type is retained.
+
+- [ ] **Step 4:** Note macOS smoke result in the PR description (device-verified vs not).
+
+---
+
+## Notes for the implementer
+
+- **Line numbers** are from `main` at plan-writing time; if a file has shifted, anchor on the quoted code (e.g. `difficulty: Value(site.difficulty?.name),`) rather than the line number.
+- **Snapshot, not derive:** never change the dive to read water type live from the site. The dive owns its value.
+- **Do not touch** `SiteConditions.waterType` (the dead String field) or `dive_plans.waterType` (planner deco). Out of scope.
+- **No schema/version work** — the column already exists and already syncs.

--- a/docs/superpowers/specs/2026-07-18-water-type-from-dive-site-design.md
+++ b/docs/superpowers/specs/2026-07-18-water-type-from-dive-site-design.md
@@ -1,0 +1,199 @@
+# Water Type from Dive Site — Design
+
+- **Issue:** [#624 — Dive / Conditions – Water Type](https://github.com/submersion-app/submersion/issues/624)
+- **Date:** 2026-07-18
+- **Branch:** `worktree-site-water-type-autofill`
+
+## Problem
+
+The reporter notes that entering water type on every dive record "is a bit of a
+faff to do separately." For them, water type is a property of the **dive site**
+(a body of water is salt or fresh — that doesn't change dive to dive). They want
+to enter it once at the site; once a site is assigned to a dive, the dive should
+"automatically take that value." With no site, manual entry stays available.
+
+Investigation shows the plumbing is *mostly already there but dead-ended*:
+
+- `dives.waterType` (`database.dart:451`) is fully alive: a `WaterType` enum
+  (`enums.dart:52` — `salt`/`fresh`/`brackish`), editable in the Conditions
+  section of the dive form, saved/loaded, and consumed by exports (CSV/UDDF/
+  Excel/PDF/KML), statistics, and the buoyancy/deco density math
+  (`buoyancy_physics.dart:49`, `dive_environment.dart:55`).
+- `dive_sites.waterType` (`database.dart:639`) **exists** (added in an earlier
+  migration, `database.dart:4720`) and **already syncs** — `_exportDiveSites`
+  serializes the whole row via `r.toJson()` (`sync_data_serializer.dart:3601`).
+  But it is a **dormant column**: written only by importers
+  (`applyImportedMetadata`, `site_repository_impl.dart:173`), **dropped** by the
+  entity mapper `_mapRowToSite` (`site_repository_impl.dart:695` never sets
+  `conditions`), **never persisted** by `_updateSiteRow`, and exposed by **no
+  editor**. `SiteField.waterType` reads `site.conditions?.waterType`
+  (`site_field.dart:460`), which is therefore always `null`.
+
+So the issue's premise ("enter it once at the site") is not achievable today.
+Delivering it is two parts: **(1) revive the site's water type** (hydrate +
+persist + edit UI), then **(2) snap it onto the dive on assignment.**
+
+## Decisions (confirmed with maintainer)
+
+1. **Full scope.** Water type becomes a real, editable attribute of a dive site,
+   *and* auto-fills onto the dive when a site is assigned. (Not import-only; not
+   dive-only.)
+2. **Snap-on-assign, stays editable.** Each time the user picks or changes the
+   site, the dive's water type is set to that site's value **if the site has
+   one**. A site with no water type never clears an existing value. The dive
+   field remains manually editable afterward; re-picking a site re-applies its
+   value. No "was it edited?" override flag (rejected as unnecessary state).
+3. **Snapshot, not live-derive.** The dive keeps storing its own `waterType`; we
+   *copy* the site value in. Chosen over computing `dive.site?.waterType` at read
+   time because (a) snap-on-assign + manual override requires an independently
+   stored per-dive value, (b) every existing reader of `dives.waterType` keeps
+   working untouched, and (c) a dive retains its recorded water type even if the
+   site is later edited or deleted (historically correct for a logbook).
+
+## Non-goals
+
+- **No schema migration / version bump.** `dive_sites.waterType` already exists
+  and already syncs. This sidesteps the schema-version ladder entirely — no v123.
+- **No change to sync serialization.** The column already round-trips through
+  `toJson()`; reviving the UI is sufficient.
+- **No backfill needed.** Sites previously imported from MacDive/UDDF already
+  carry the column value; once hydration lands they simply start displaying and
+  auto-filling. No data migration.
+- **`SiteConditions` is not removed.** The dead `SiteConditions.waterType` String
+  field (`dive_site.dart:219`) is left in place (out of scope), but water type no
+  longer routes through it — it moves to a top-level entity field.
+- **Planner water type untouched.** `dive_plans.waterType` (`database.dart:276`)
+  is a separate deco-calc concern and is out of scope.
+
+## Architecture
+
+### 1. Domain & repository — revive the site column (no migration)
+
+- **Entity** (`dive_sites/domain/entities/dive_site.dart`): add a top-level
+  `final WaterType? waterType;` to `DiveSite` (mirroring the dive), threaded
+  through the constructor, `copyWith`, and `props`. Import `WaterType` from
+  `core/constants/enums.dart`.
+- **Hydrate** (`site_repository_impl.dart:695`, `_mapRowToSite`): parse the
+  column with a safe lookup, matching the dive repo's pattern
+  (`dive_repository_impl.dart:2718`):
+  `waterType: row.waterType == null ? null : WaterType.values.asNameMap()[row.waterType]`
+  (null-safe; unknown string → null rather than a forced default, so we never
+  fabricate a value the user didn't set).
+- **Persist**: add `waterType: Value(site.waterType?.name)` to every
+  `DiveSitesCompanion` builder that currently sets `difficulty`/`bodyOfWater` —
+  the insert/upsert/import paths (`site_repository_impl.dart` ~79, ~133, ~508)
+  and `_updateSiteRow` (~731).
+- **Read path for the table view**: update only the value-extraction arm of
+  `SiteField.waterType` (`site_field.dart:460`) to read
+  `site.waterType?.displayName` instead of `site.conditions?.waterType`. The
+  other `SiteField.waterType` `case` arms (label, column width, etc.) don't touch
+  `conditions` and need no change. Bonus: the existing site-table water-type
+  column (`site_providers.dart:680`) starts showing real values for free.
+
+### 2. Site editor — a Water Type picker
+
+- Add a water-type control to the **Dive Info** section of the site editor
+  (`dive_sites/presentation/widgets/edit_sections/dive_info_section.dart`),
+  alongside min/max depth, difficulty, and rating. Mirror the **difficulty**
+  control's shape (a chip row over `WaterType.values`, using each value's
+  `displayName`; null = unset).
+- Wire the new state through `site_edit_page.dart` (a nullable `WaterType?`
+  field, seeded from the loaded site, flushed into the `DiveSite` on save).
+- **Merge-aware:** water type must participate in the site merge/import-conflict
+  flow like difficulty/rating do. Add a `waterTypeExtras` `MergeFieldExtras?`
+  (or route through the generic `mergeExtras('waterType')`) mirroring
+  `difficultyExtras` (`merge_field_extras.dart`).
+- **Localization:** add one new label string (site-editor water-type label) to
+  `en` and all 10 non-en locales, then regenerate `app_localizations*` (repo
+  l10n rule — new strings into all locales + regen).
+
+### 3. Dive form — snap on assign
+
+- Today `_selectedSite` is set in several scattered places in
+  `dive_log/presentation/pages/dive_edit_page.dart`. Centralize the
+  **user-initiated** assignments behind one helper:
+
+  ```dart
+  void _selectSite(DiveSite? site) {
+    setState(() {
+      _selectedSite = site;
+      if (site?.waterType != null) _waterType = site!.waterType; // snap; never null-clobber
+    });
+  }
+  ```
+
+- Route these paths through `_selectSite`:
+  - site picker result (`onPickSite: _showSitePicker`, `:1732`),
+  - quick-create / photo-GPS site create (`:1920`),
+  - new-dive prefill (`:453`, `if (p.site != null) …`).
+- **Do NOT** route the load-existing-dive path (`:588` `_selectedSite =
+  dive.site` / `:608` `_waterType = dive.waterType`) through `_selectSite`.
+  Loading a saved dive must preserve its stored water type, not re-snap from the
+  site's current value.
+- **Clearing the site** (`onClearSite`, `:1735`) sets `_selectedSite = null` and
+  leaves `_waterType` untouched.
+- The dive's `EnumPickerRow<WaterType>` (`:3490`) and save wiring
+  (`waterType: _waterType`, `:4363`; `waterType: _waterType?.name`, `:1001`) are
+  unchanged — they already handle the value; we're only changing what pre-fills
+  it.
+
+## Data flow
+
+```
+Site editor  ──save──▶ DiveSite.waterType ──▶ DiveSitesCompanion(waterType: name)
+                                                        │
+                                              dive_sites.waterType (TEXT, existing)
+                                                        │  (syncs via toJson today)
+                          _mapRowToSite ◀───────────────┘
+                                │  WaterType? (asNameMap lookup)
+                                ▼
+Dive form: _selectSite(site) ──snap──▶ _waterType ──save──▶ dives.waterType
+                                            ▲
+                                   manual override (EnumPickerRow) wins until
+                                   the site is re-assigned
+```
+
+## Edge cases
+
+- **Site has no water type:** assigning it does not change/clear the dive's
+  current value.
+- **Manual override then change unrelated field:** override persists (snap only
+  fires on site assignment).
+- **Change to a different site:** water type re-snaps to the new site's value
+  (fixes the stale-value problem of a fill-only-when-empty rule).
+- **Re-pick the same site after a manual override:** value re-snaps to the
+  site's — accepted (rare; predictable minimal-state behavior).
+- **Open an older dive whose water type is null but whose site now has one:**
+  stays null on load (loading is not an assign). User can re-pick the site or set
+  it manually. Intended.
+- **Unknown/legacy string in the column** (defensive): `asNameMap` lookup yields
+  null rather than crashing or defaulting.
+
+## Testing (TDD — tests written first)
+
+- **Repository round-trip** (`test/features/dive_sites/…`): save a site with each
+  `WaterType`, reload via `_mapRowToSite`, assert equality; assert `null` when
+  the column is null; assert an unknown string maps to `null`.
+- **Sync round-trip**: export a site with a water type through
+  `_exportDiveSites` and re-apply, asserting the value survives (guards the
+  "already syncs" claim).
+- **Dive auto-fill matrix** (`test/features/dive_log/…`, widget or notifier
+  level):
+  - assign site w/ type → `_waterType` snaps;
+  - assign site w/o type → `_waterType` unchanged;
+  - manual edit, then change an unrelated field → override retained;
+  - change to a second site w/ a different type → re-snaps;
+  - clear site → value retained;
+  - load an existing dive → stored value preserved (not re-snapped).
+- **Site editor widget test**: the water-type control is present, defaults to the
+  loaded value, and a change persists into the saved `DiveSite`.
+- **`SiteField.waterType`**: returns the `displayName` for a hydrated site.
+
+## Open questions (flagged, non-blocking)
+
+1. **Field placement in the site editor.** Proposed home is the Dive Info section
+   (physical characteristics). Alternative: a dedicated Conditions grouping on the
+   site (none exists today). Dive Info chosen to avoid inventing a section for one
+   field; trivially movable.
+2. **Control style.** Chip row (matches difficulty) vs. the shared
+   `EnumPickerRow`. Proposed: chips, for visual parity within the section.

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -59,6 +59,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/pickers/edit_s
 import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_set_picker_sheet.dart';
+import 'package:submersion/features/dive_log/presentation/utils/water_type_autofill.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/species_picker_sheet.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -450,7 +451,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     }
     if (p.notes != null) _notesController.text = p.notes!;
     if (p.rating != null) _rating = p.rating!;
-    if (p.site != null) _selectedSite = p.site;
+    if (p.site != null) _assignSite(p.site);
     if (p.weightKg != null) {
       // Paper logs record a total; the carry type is unknown.
       _weights = [
@@ -1732,7 +1733,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       onPickSite: _showSitePicker,
       onClearSite: () {
         _markDirty();
-        setState(() => _selectedSite = null);
+        setState(() => _assignSite(null));
       },
       maxDepthSuggestion: hasProfile
           ? _depthSuggestion(
@@ -1917,7 +1918,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       final createdSite = await siteNotifier.addSite(newSite);
 
       setState(() {
-        _selectedSite = createdSite;
+        _assignSite(createdSite);
         _gpsSuggestionDismissed = true;
       });
 
@@ -1958,6 +1959,15 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     }
   }
 
+  /// Assigns [site] to the dive and snaps the water type from it (manual
+  /// overrides survive when the site has none). Use for user-initiated
+  /// assignments and new-dive prefill — NOT the load path, which restores the
+  /// dive's own saved water type.
+  void _assignSite(DiveSite? site) {
+    _selectedSite = site;
+    _waterType = waterTypeAfterSiteAssign(_waterType, site);
+  }
+
   Future<void> _showSitePicker() async {
     final anchor = _existingDive?.entryLocation ?? _existingDive?.exitLocation;
     final result = await showModalBottomSheet<String>(
@@ -1975,7 +1985,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           diveLocation: anchor,
           onSiteSelected: (site) {
             _markDirty();
-            setState(() => _selectedSite = site);
+            setState(() => _assignSite(site));
             _reevaluateGeofenceForSite();
             Navigator.of(sheetContext).pop();
           },
@@ -1993,7 +2003,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         final site = await repo.getSiteById(siteId);
         if (site != null && mounted) {
           _markDirty();
-          setState(() => _selectedSite = site);
+          setState(() => _assignSite(site));
           _reevaluateGeofenceForSite();
         }
       }

--- a/lib/features/dive_log/presentation/utils/water_type_autofill.dart
+++ b/lib/features/dive_log/presentation/utils/water_type_autofill.dart
@@ -1,0 +1,11 @@
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// The dive's water type after [site] is assigned to it, given the dive's
+/// [current] value.
+///
+/// Snap-on-assign: take the site's water type when it has one; otherwise keep
+/// the current value. A site with no water type — or clearing the site
+/// ([site] == null) — never wipes a value the diver already set.
+WaterType? waterTypeAfterSiteAssign(WaterType? current, DiveSite? site) =>
+    site?.waterType ?? current;

--- a/lib/features/dive_sites/data/repositories/site_repository_impl.dart
+++ b/lib/features/dive_sites/data/repositories/site_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/data/visibility/visibility_filter.dart';
 import 'package:submersion/core/database/database.dart';
@@ -77,6 +78,7 @@ class SiteRepository {
               minDepth: Value(site.minDepth),
               maxDepth: Value(site.maxDepth),
               difficulty: Value(site.difficulty?.name),
+              waterType: Value(site.waterType?.name),
               country: Value(site.country),
               region: Value(site.region),
               city: Value(site.city),
@@ -131,6 +133,7 @@ class SiteRepository {
           minDepth: Value(site.minDepth),
           maxDepth: Value(site.maxDepth),
           difficulty: Value(site.difficulty?.name),
+          waterType: Value(site.waterType?.name),
           country: Value(site.country),
           region: Value(site.region),
           city: Value(site.city),
@@ -506,6 +509,7 @@ class SiteRepository {
                   minDepth: Value(site.minDepth),
                   maxDepth: Value(site.maxDepth),
                   difficulty: Value(site.difficulty?.name),
+                  waterType: Value(site.waterType?.name),
                   country: Value(site.country),
                   region: Value(site.region),
                   city: Value(site.city),
@@ -703,6 +707,9 @@ class SiteRepository {
       minDepth: row.minDepth,
       maxDepth: row.maxDepth,
       difficulty: domain.SiteDifficulty.fromString(row.difficulty),
+      waterType: row.waterType == null
+          ? null
+          : WaterType.values.asNameMap()[row.waterType],
       country: row.country,
       region: row.region,
       city: row.city,
@@ -729,6 +736,7 @@ class SiteRepository {
         minDepth: Value(site.minDepth),
         maxDepth: Value(site.maxDepth),
         difficulty: Value(site.difficulty?.name),
+        waterType: Value(site.waterType?.name),
         country: Value(site.country),
         region: Value(site.region),
         city: Value(site.city),

--- a/lib/features/dive_sites/domain/constants/site_field.dart
+++ b/lib/features/dive_sites/domain/constants/site_field.dart
@@ -457,7 +457,7 @@ class SiteFieldAdapter extends EntityFieldAdapter<SiteWithCount, SiteField> {
       case SiteField.altitude:
         return site.altitude;
       case SiteField.waterType:
-        return site.conditions?.waterType;
+        return site.waterType?.displayName;
       case SiteField.typicalVisibility:
         return site.conditions?.typicalVisibility;
       case SiteField.typicalCurrent:

--- a/lib/features/dive_sites/domain/entities/dive_site.dart
+++ b/lib/features/dive_sites/domain/entities/dive_site.dart
@@ -1,5 +1,7 @@
 import 'package:equatable/equatable.dart';
 
+import 'package:submersion/core/constants/enums.dart';
+
 /// Site difficulty levels
 enum SiteDifficulty {
   beginner,
@@ -39,6 +41,7 @@ class DiveSite extends Equatable {
   final double? minDepth; // meters - shallowest point of the site
   final double? maxDepth; // meters - deepest point of the site
   final SiteDifficulty? difficulty; // Site difficulty level
+  final WaterType? waterType; // Salt / fresh / brackish
   final String? country;
   final String? region;
   final String? city;
@@ -65,6 +68,7 @@ class DiveSite extends Equatable {
     this.minDepth,
     this.maxDepth,
     this.difficulty,
+    this.waterType,
     this.country,
     this.region,
     this.city,
@@ -128,6 +132,7 @@ class DiveSite extends Equatable {
     double? minDepth,
     double? maxDepth,
     SiteDifficulty? difficulty,
+    WaterType? waterType,
     String? country,
     String? region,
     String? city,
@@ -153,6 +158,7 @@ class DiveSite extends Equatable {
       minDepth: minDepth ?? this.minDepth,
       maxDepth: maxDepth ?? this.maxDepth,
       difficulty: difficulty ?? this.difficulty,
+      waterType: waterType ?? this.waterType,
       country: country ?? this.country,
       region: region ?? this.region,
       city: city ?? this.city,
@@ -181,6 +187,7 @@ class DiveSite extends Equatable {
     minDepth,
     maxDepth,
     difficulty,
+    waterType,
     country,
     region,
     city,

--- a/lib/features/dive_sites/presentation/pages/site_edit_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_edit_page.dart
@@ -2,6 +2,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/providers/location_service_provider.dart';
 import 'package:go_router/go_router.dart';
@@ -81,6 +82,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
 
   double _rating = 0;
   SiteDifficulty? _difficulty;
+  WaterType? _waterType;
   bool _isLoading = false;
   bool _isInitialized = false;
   bool _hasChanges = false;
@@ -217,6 +219,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     _parkingInfoController.text = site.parkingInfo ?? '';
     _rating = site.rating ?? 0;
     _difficulty = site.difficulty;
+    _waterType = site.waterType;
     _isShared = site.isShared;
     _altitudeController.text = site.altitude != null
         ? units.convertAltitude(site.altitude!).toStringAsFixed(0)
@@ -692,6 +695,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
       '${_minDepthController.text.isEmpty ? '?' : _minDepthController.text}'
           '-${_maxDepthController.text.isEmpty ? '?' : _maxDepthController.text}',
     if (_difficulty != null) _difficulty!.displayName,
+    if (_waterType != null) _waterType!.displayName,
     if (_rating > 0) '★' * _rating.round(),
   ].join(' · ');
 
@@ -792,6 +796,11 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
             }),
             onRatingCleared: () => setState(() {
               _rating = 0;
+              _hasChanges = true;
+            }),
+            waterType: _waterType,
+            onWaterTypeChanged: (value) => setState(() {
+              _waterType = value;
               _hasChanges = true;
             }),
             mergeExtras: widget.isMerging ? _mergeExtras : null,
@@ -1317,6 +1326,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
             ? null
             : _parkingInfoController.text.trim(),
         altitude: altitudeMeters,
+        waterType: _waterType,
         isShared: _isShared,
       );
 

--- a/lib/features/dive_sites/presentation/pages/site_edit_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_edit_page.dart
@@ -96,6 +96,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
       {};
   final Map<String, int> _mergeFieldIndices = {};
   List<_MergeFieldCandidate<SiteDifficulty?>> _difficultyCandidates = [];
+  List<_MergeFieldCandidate<WaterType?>> _waterTypeCandidates = [];
   List<_MergeFieldCandidate<double>> _ratingCandidates = [];
   List<_MergeFieldCandidate<_CoordinateCandidate>> _coordinateCandidates = [];
 
@@ -362,6 +363,18 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     );
     _difficulty =
         _difficultyCandidates[_mergeFieldIndices['difficulty'] ?? 0].value;
+
+    _waterTypeCandidates = _buildDistinctCandidates<WaterType?>(
+      data.sites,
+      (site) => site.waterType,
+      equals: (a, b) => a == b,
+    );
+    _mergeFieldIndices['waterType'] = _firstMeaningfulIndex(
+      _waterTypeCandidates,
+      (value) => value != null,
+    );
+    _waterType =
+        _waterTypeCandidates[_mergeFieldIndices['waterType'] ?? 0].value;
 
     _ratingCandidates = _buildDistinctCandidates<double>(
       data.sites,
@@ -653,6 +666,19 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     );
   }
 
+  MergeFieldExtras? _waterTypeExtras() {
+    if (!widget.isMerging || _waterTypeCandidates.length < 2) return null;
+    final index = _mergeFieldIndices['waterType'] ?? 0;
+    return MergeFieldExtras(
+      sourceLabel: context.l10n.diveSites_edit_merge_fieldSourceLabel(
+        _waterTypeCandidates[index].siteName,
+        index + 1,
+        _waterTypeCandidates.length,
+      ),
+      onCycle: _cycleWaterType,
+    );
+  }
+
   MergeFieldExtras? _ratingExtras() {
     if (!widget.isMerging || _ratingCandidates.length < 2) return null;
     final index = _mergeFieldIndices['rating'] ?? 0;
@@ -806,6 +832,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
             mergeExtras: widget.isMerging ? _mergeExtras : null,
             difficultyExtras: _difficultyExtras(),
             ratingExtras: _ratingExtras(),
+            waterTypeExtras: _waterTypeExtras(),
           ),
           AccessSafetySection(
             expanded: _siteSectionExpanded('access'),
@@ -1032,6 +1059,18 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
           _difficultyCandidates.length;
       _mergeFieldIndices['difficulty'] = nextIndex;
       _difficulty = _difficultyCandidates[nextIndex].value;
+      _hasChanges = true;
+    });
+  }
+
+  void _cycleWaterType() {
+    if (_waterTypeCandidates.length < 2) return;
+    setState(() {
+      final nextIndex =
+          ((_mergeFieldIndices['waterType'] ?? 0) + 1) %
+          _waterTypeCandidates.length;
+      _mergeFieldIndices['waterType'] = nextIndex;
+      _waterType = _waterTypeCandidates[nextIndex].value;
       _hasChanges = true;
     });
   }

--- a/lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart
+++ b/lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/widgets/edit_sections/merge_field_extras.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -23,9 +24,12 @@ class DiveInfoSection extends StatelessWidget {
     required this.rating,
     required this.onRatingChanged,
     required this.onRatingCleared,
+    required this.waterType,
+    required this.onWaterTypeChanged,
     this.mergeExtras,
     this.difficultyExtras,
     this.ratingExtras,
+    this.waterTypeExtras,
   });
 
   final bool expanded;
@@ -40,9 +44,12 @@ class DiveInfoSection extends StatelessWidget {
   final int rating;
   final ValueChanged<int> onRatingChanged;
   final VoidCallback onRatingCleared;
+  final WaterType? waterType;
+  final ValueChanged<WaterType?> onWaterTypeChanged;
   final MergeFieldExtras? Function(String key)? mergeExtras;
   final MergeFieldExtras? difficultyExtras;
   final MergeFieldExtras? ratingExtras;
+  final MergeFieldExtras? waterTypeExtras;
 
   Widget _depthRow(
     BuildContext context, {
@@ -108,6 +115,34 @@ class DiveInfoSection extends StatelessWidget {
                     visualDensity: VisualDensity.compact,
                     onSelected: (selected) =>
                         onDifficultyChanged(selected ? value : null),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (waterTypeExtras != null)
+              MergeSourceRow(
+                sourceLabel: waterTypeExtras!.sourceLabel,
+                onCycle: waterTypeExtras!.onCycle,
+              ),
+            FormRow.custom(
+              label: l10n.diveSites_edit_section_waterType,
+              child: Wrap(
+                alignment: WrapAlignment.end,
+                spacing: 6,
+                runSpacing: 4,
+                children: WaterType.values.map((value) {
+                  final isSelected = waterType == value;
+                  return ChoiceChip(
+                    label: Text(value.displayName),
+                    selected: isSelected,
+                    visualDensity: VisualDensity.compact,
+                    onSelected: (selected) =>
+                        onWaterTypeChanged(selected ? value : null),
                   );
                 }).toList(),
               ),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -2406,6 +2406,7 @@
   "diveSites_edit_section_gpsCoordinates": "إحداثيات GPS",
   "diveSites_edit_section_hazards": "المخاطر والسلامة",
   "diveSites_edit_section_rating": "التقييم",
+  "diveSites_edit_section_waterType": "نوع المياه",
   "diveSites_edit_snackbar_errorDeleting": "خطأ في حذف الموقع: {error}",
   "diveSites_edit_snackbar_errorSaving": "خطأ في حفظ الموقع: {error}",
   "diveSites_edit_snackbar_locationCaptured": "تم التقاط الموقع",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -2406,6 +2406,7 @@
   "diveSites_edit_section_gpsCoordinates": "GPS-Koordinaten",
   "diveSites_edit_section_hazards": "Gefahren & Sicherheit",
   "diveSites_edit_section_rating": "Bewertung",
+  "diveSites_edit_section_waterType": "Gewässertyp",
   "diveSites_edit_snackbar_errorDeleting": "Fehler beim Löschen des Tauchplatzes: {error}",
   "diveSites_edit_snackbar_errorSaving": "Fehler beim Speichern des Tauchplatzes: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Standort erfasst",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -4104,6 +4104,7 @@
   "diveSites_edit_section_gpsCoordinates": "GPS Coordinates",
   "diveSites_edit_section_hazards": "Hazards & Safety",
   "diveSites_edit_section_rating": "Rating",
+  "diveSites_edit_section_waterType": "Water Type",
   "diveSites_edit_snackbar_errorDeleting": "Error deleting site: {error}",
   "diveSites_edit_snackbar_errorSaving": "Error saving site: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Location captured",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -2406,6 +2406,7 @@
   "diveSites_edit_section_gpsCoordinates": "Coordenadas GPS",
   "diveSites_edit_section_hazards": "Peligros y seguridad",
   "diveSites_edit_section_rating": "Calificacion",
+  "diveSites_edit_section_waterType": "Tipo de agua",
   "diveSites_edit_snackbar_errorDeleting": "Error al eliminar el sitio: {error}",
   "diveSites_edit_snackbar_errorSaving": "Error al guardar el sitio: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Ubicacion capturada",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -2372,6 +2372,7 @@
   "diveSites_edit_section_gpsCoordinates": "Coordonnees GPS",
   "diveSites_edit_section_hazards": "Dangers et securite",
   "diveSites_edit_section_rating": "Evaluation",
+  "diveSites_edit_section_waterType": "Type d'eau",
   "diveSites_edit_snackbar_errorDeleting": "Erreur de suppression du site : {error}",
   "diveSites_edit_snackbar_errorSaving": "Erreur d'enregistrement du site : {error}",
   "diveSites_edit_snackbar_locationCaptured": "Position capturee",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -2372,6 +2372,7 @@
   "diveSites_edit_section_gpsCoordinates": "קואורדינטות GPS",
   "diveSites_edit_section_hazards": "סכנות ובטיחות",
   "diveSites_edit_section_rating": "דירוג",
+  "diveSites_edit_section_waterType": "סוג מים",
   "diveSites_edit_snackbar_errorDeleting": "שגיאה במחיקת אתר: {error}",
   "diveSites_edit_snackbar_errorSaving": "שגיאה בשמירת אתר: {error}",
   "diveSites_edit_snackbar_locationCaptured": "המיקום נקלט",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -2372,6 +2372,7 @@
   "diveSites_edit_section_gpsCoordinates": "GPS koordinatak",
   "diveSites_edit_section_hazards": "Veszelyek es biztonsag",
   "diveSites_edit_section_rating": "Ertekeles",
+  "diveSites_edit_section_waterType": "Víztípus",
   "diveSites_edit_snackbar_errorDeleting": "Hiba a helyszin torlesekor: {error}",
   "diveSites_edit_snackbar_errorSaving": "Hiba a helyszin mentesekor: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Helyzet rogzitve",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -2372,6 +2372,7 @@
   "diveSites_edit_section_gpsCoordinates": "Coordinate GPS",
   "diveSites_edit_section_hazards": "Pericoli e sicurezza",
   "diveSites_edit_section_rating": "Valutazione",
+  "diveSites_edit_section_waterType": "Tipo di acqua",
   "diveSites_edit_snackbar_errorDeleting": "Errore nell'eliminazione del sito: {error}",
   "diveSites_edit_snackbar_errorSaving": "Errore nel salvataggio del sito: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Posizione acquisita",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -12673,6 +12673,12 @@ abstract class AppLocalizations {
   /// **'Rating'**
   String get diveSites_edit_section_rating;
 
+  /// No description provided for @diveSites_edit_section_waterType.
+  ///
+  /// In en, this message translates to:
+  /// **'Water Type'**
+  String get diveSites_edit_section_waterType;
+
   /// No description provided for @diveSites_edit_snackbar_errorDeleting.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -7327,6 +7327,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveSites_edit_section_rating => 'التقييم';
 
   @override
+  String get diveSites_edit_section_waterType => 'نوع المياه';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'خطأ في حذف الموقع: $error';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -7471,6 +7471,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Bewertung';
 
   @override
+  String get diveSites_edit_section_waterType => 'Gewässertyp';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Fehler beim Löschen des Tauchplatzes: $error';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -7350,6 +7350,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Rating';
 
   @override
+  String get diveSites_edit_section_waterType => 'Water Type';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Error deleting site: $error';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -7473,6 +7473,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Calificacion';
 
   @override
+  String get diveSites_edit_section_waterType => 'Tipo de agua';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Error al eliminar el sitio: $error';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -7509,6 +7509,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Evaluation';
 
   @override
+  String get diveSites_edit_section_waterType => 'Type d\'eau';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Erreur de suppression du site : $error';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -7283,6 +7283,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveSites_edit_section_rating => 'דירוג';
 
   @override
+  String get diveSites_edit_section_waterType => 'סוג מים';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'שגיאה במחיקת אתר: $error';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -7458,6 +7458,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Ertekeles';
 
   @override
+  String get diveSites_edit_section_waterType => 'Víztípus';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Hiba a helyszin torlesekor: $error';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -7479,6 +7479,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Valutazione';
 
   @override
+  String get diveSites_edit_section_waterType => 'Tipo di acqua';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Errore nell\'eliminazione del sito: $error';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -7418,6 +7418,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Beoordeling';
 
   @override
+  String get diveSites_edit_section_waterType => 'Watertype';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Fout bij verwijderen van stek: $error';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -7472,6 +7472,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveSites_edit_section_rating => 'Avaliacao';
 
   @override
+  String get diveSites_edit_section_waterType => 'Tipo de água';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return 'Erro ao excluir ponto: $error';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -7107,6 +7107,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveSites_edit_section_rating => '评分';
 
   @override
+  String get diveSites_edit_section_waterType => '水体类型';
+
+  @override
   String diveSites_edit_snackbar_errorDeleting(Object error) {
     return '删除潜水点出错：$error';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -2406,6 +2406,7 @@
   "diveSites_edit_section_gpsCoordinates": "GPS-coordinaten",
   "diveSites_edit_section_hazards": "Gevaren & veiligheid",
   "diveSites_edit_section_rating": "Beoordeling",
+  "diveSites_edit_section_waterType": "Watertype",
   "diveSites_edit_snackbar_errorDeleting": "Fout bij verwijderen van stek: {error}",
   "diveSites_edit_snackbar_errorSaving": "Fout bij opslaan van stek: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Locatie vastgelegd",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -2406,6 +2406,7 @@
   "diveSites_edit_section_gpsCoordinates": "Coordenadas GPS",
   "diveSites_edit_section_hazards": "Perigos e Seguranca",
   "diveSites_edit_section_rating": "Avaliacao",
+  "diveSites_edit_section_waterType": "Tipo de água",
   "diveSites_edit_snackbar_errorDeleting": "Erro ao excluir ponto: {error}",
   "diveSites_edit_snackbar_errorSaving": "Erro ao salvar ponto: {error}",
   "diveSites_edit_snackbar_locationCaptured": "Localizacao capturada",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -2536,6 +2536,7 @@
   "diveSites_edit_section_gpsCoordinates": "GPS 坐标",
   "diveSites_edit_section_hazards": "危险 & 安全",
   "diveSites_edit_section_rating": "评分",
+  "diveSites_edit_section_waterType": "水体类型",
   "diveSites_edit_snackbar_errorDeleting": "删除潜水点出错：{error}",
   "diveSites_edit_snackbar_errorSaving": "保存潜水点出错：{error}",
   "diveSites_edit_snackbar_locationCaptured": "位置已获取",

--- a/test/features/dive_log/presentation/utils/water_type_autofill_test.dart
+++ b/test/features/dive_log/presentation/utils/water_type_autofill_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/presentation/utils/water_type_autofill.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+void main() {
+  DiveSite site({WaterType? waterType}) =>
+      DiveSite(id: 's', name: 'S', waterType: waterType);
+
+  group('waterTypeAfterSiteAssign', () {
+    test('snaps to the site water type when the site has one', () {
+      expect(
+        waterTypeAfterSiteAssign(null, site(waterType: WaterType.salt)),
+        WaterType.salt,
+      );
+    });
+
+    test('overwrites the current value when the new site has a water type', () {
+      expect(
+        waterTypeAfterSiteAssign(
+          WaterType.fresh,
+          site(waterType: WaterType.salt),
+        ),
+        WaterType.salt,
+      );
+    });
+
+    test('keeps the current value when the site has no water type', () {
+      expect(
+        waterTypeAfterSiteAssign(WaterType.fresh, site()),
+        WaterType.fresh,
+      );
+    });
+
+    test('keeps the current value when the site is cleared (null)', () {
+      expect(
+        waterTypeAfterSiteAssign(WaterType.brackish, null),
+        WaterType.brackish,
+      );
+    });
+  });
+}

--- a/test/features/dive_sites/data/repositories/site_repository_test.dart
+++ b/test/features/dive_sites/data/repositories/site_repository_test.dart
@@ -70,6 +70,84 @@ void main() {
       expect(loaded.bodyOfWater, 'Visayan Sea');
     });
 
+    test('create then read round-trips waterType', () async {
+      const site = DiveSite(
+        id: 'wt-1',
+        name: 'Water Type Site',
+        waterType: WaterType.brackish,
+      );
+      await repository.createSite(site);
+      final loaded = await repository.getSiteById('wt-1');
+      expect(loaded!.waterType, WaterType.brackish);
+    });
+
+    test('imported water_type column is read back into the entity', () async {
+      // Importers write the column directly (no entity mapping).
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await database
+          .into(database.diveSites)
+          .insert(
+            db.DiveSitesCompanion.insert(
+              id: 'wt-ghost',
+              name: 'Imported Site',
+              createdAt: now,
+              updatedAt: now,
+              waterType: const Value('salt'),
+            ),
+          );
+      final loaded = await repository.getSiteById('wt-ghost');
+      expect(loaded!.waterType, WaterType.salt);
+    });
+
+    test('unknown water_type string maps to null (no crash)', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await database
+          .into(database.diveSites)
+          .insert(
+            db.DiveSitesCompanion.insert(
+              id: 'wt-bad',
+              name: 'Bad Water Type',
+              createdAt: now,
+              updatedAt: now,
+              waterType: const Value('lava'),
+            ),
+          );
+      final loaded = await repository.getSiteById('wt-bad');
+      expect(loaded!.waterType, isNull);
+    });
+
+    test('updateSite persists a changed waterType', () async {
+      const site = DiveSite(
+        id: 'wt-up',
+        name: 'Upd',
+        waterType: WaterType.salt,
+      );
+      await repository.createSite(site);
+      await repository.updateSite(site.copyWith(waterType: WaterType.fresh));
+      final loaded = await repository.getSiteById('wt-up');
+      expect(loaded!.waterType, WaterType.fresh);
+    });
+
+    test(
+      'waterType survives Drift row JSON serialization (sync path)',
+      () async {
+        // Sync serializes each row with row.toJson(); this proves the column
+        // rides that generic path. Key-agnostic: fromJson reads back whatever
+        // key toJson wrote.
+        const site = DiveSite(
+          id: 'wt-json',
+          name: 'JSON Site',
+          waterType: WaterType.fresh,
+        );
+        await repository.createSite(site);
+        final row = await (database.select(
+          database.diveSites,
+        )..where((t) => t.id.equals('wt-json'))).getSingle();
+        final restored = db.DiveSite.fromJson(row.toJson());
+        expect(restored.waterType, 'fresh');
+      },
+    );
+
     test('imported body_of_water is now read back into the entity', () async {
       // Simulate an importer writing the column directly (no entity mapping).
       final now = DateTime.now().millisecondsSinceEpoch;

--- a/test/features/dive_sites/domain/constants/site_field_test.dart
+++ b/test/features/dive_sites/domain/constants/site_field_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_sites/domain/constants/site_field.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
@@ -21,6 +22,7 @@ void main() {
     minDepth: 5.0,
     altitude: 200.0,
     difficulty: SiteDifficulty.advanced,
+    waterType: WaterType.salt,
     rating: 4.5,
     notes: 'Great site',
     hazards: 'Strong current',
@@ -165,10 +167,10 @@ void main() {
       expect(adapter.extractValue(SiteField.rating, testEntity), equals(4.5));
     });
 
-    test('returns waterType from conditions', () {
+    test('returns waterType displayName from the entity', () {
       expect(
         adapter.extractValue(SiteField.waterType, testEntity),
-        equals('salt'),
+        equals('Salt Water'),
       );
     });
 

--- a/test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_merge_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
@@ -144,6 +145,65 @@ void main() {
       expect(advancedChip.selected, isTrue);
     },
   );
+
+  testWidgets('merge mode cycles water type when sites differ', (tester) async {
+    tester.view.physicalSize = const Size(900, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    final site1 = await siteRepository.createSite(
+      const DiveSite(id: 'wt-m1', name: 'Salt Site', waterType: WaterType.salt),
+    );
+    final site2 = await siteRepository.createSite(
+      const DiveSite(
+        id: 'wt-m2',
+        name: 'Fresh Site',
+        waterType: WaterType.fresh,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _buildMergePageHarness(
+        prefs: prefs,
+        siteRepository: siteRepository,
+        siteIds: [site1.id, site2.id],
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Water Type'),
+      100,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    // Salt Water (site1, the first non-empty candidate) selected initially.
+    expect(
+      tester
+          .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Salt Water'))
+          .selected,
+      isTrue,
+    );
+
+    // Only water type differs, so exactly one cycle button sits in Dive Info.
+    final waterTypeSection = find.ancestor(
+      of: find.text('Water Type'),
+      matching: find.byType(FormSection),
+    );
+    final cycleButton = find.descendant(
+      of: waterTypeSection,
+      matching: find.byIcon(Icons.sync_alt),
+    );
+    expect(cycleButton, findsOneWidget);
+
+    await tester.tap(cycleButton);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Fresh Water'))
+          .selected,
+      isTrue,
+    );
+  });
 
   testWidgets('merge mode cycles rating when sites have different ratings', (
     tester,

--- a/test/features/dive_sites/presentation/pages/site_edit_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_page_test.dart
@@ -374,6 +374,39 @@ void main() {
         isFalse,
       );
     });
+
+    testWidgets('selecting a water type chip updates state', (tester) async {
+      tester.view.physicalSize = const Size(900, 3200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        _buildHarness(prefs: prefs, divers: const [], shareByDefault: false),
+      );
+      await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Water Type'),
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      // Tap the Brackish chip.
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Brackish'));
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Brackish'))
+            .selected,
+        isTrue,
+      );
+      // Tap again to deselect.
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Brackish'));
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Brackish'))
+            .selected,
+        isFalse,
+      );
+    });
   });
 
   group('edit existing site', () {


### PR DESCRIPTION
## Summary

Closes #624. Water type (salt / fresh / brackish) is now a first-class, editable attribute of a **dive site**, and auto-fills onto a **dive** when a site is assigned. This removes the "faff" of re-entering water type on every dive record: enter it once at the site, and each dive picks it up. With no site assigned, manual entry on the dive still works as before.

Investigation found the plumbing was already half-present but dormant: `dive_sites.waterType` existed as a column (populated import-only, e.g. MacDive/UDDF) and already synced, but was never hydrated into the entity, never persisted from an editor, and had no UI. This PR revives that column and snapshots it onto the dive. **No schema migration and no schema-version bump** — the column already existed and already rode the generic sync path.

## Changes

- **Site entity + repository:** added `DiveSite.waterType` (`WaterType?`). The repository now hydrates it from the existing column (unknown/legacy strings map to `null` rather than a forced default) and persists it in all four write paths (create / update / restore-insert / merge-update). `SiteField.waterType` now reads the real value, so the site-table column displays it too.
- **Site editor:** a Water Type chip row (Salt Water / Fresh Water / Brackish) in the Dive Info section, mirroring the difficulty control — including merge-conflict cycling parity when merging two sites with different water types. New `diveSites_edit_section_waterType` string localized into all 11 locales.
- **Dive form auto-fill:** assigning or changing a dive's site snaps the dive's water type from the site, via a single `_assignSite` helper routed through every user-initiated assignment path (picker, quick-create-from-GPS, new-dive prefill, clear). The rule (pure, unit-tested): take the site's value when it has one, otherwise keep the current value — so a site without a water type, or clearing the site, never wipes a manual entry. The load path is deliberately untouched, so opening a saved dive preserves its stored value.
- **Model:** snapshot / denormalized — the dive keeps storing its own `waterType`, so exports, statistics, and buoyancy/deco density math are unaffected.

## Test Plan

- [x] `flutter test` passes — 12,439 tests green. The single per-run failure is a pre-existing nondeterministic full-suite flake: it moved to a different test between two runs (`ocr_scan_page_test` then `global_drop_target_test`), both in features untouched by this PR, and both pass deterministically in isolation.
- [x] `flutter analyze` passes (whole project, no issues found)
- [x] `dart format .` clean (0 files changed)
- [x] Manual testing on: **macOS smoke pending** — set water type on a site, assign it to a dive, confirm auto-fill, then verify manual override sticks, re-snap on site change, and retention on site clear.

New/updated tests: site-repository round-trip (imported-column hydration, unknown-string→null, and a key-agnostic sync JSON round-trip); site-editor water-type widget test; merge-cycle widget test; and a pure-function unit test covering the auto-fill rule (snap / overwrite / keep-on-empty / keep-on-clear).
