### PR TITLE
feat(maps): add reset-to-north compass on rotatable maps

### DIFF
--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/shared/providers/map_list_selection_provider.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
 
@@ -272,6 +273,13 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
               const MapAttribution(),
             ],
           ),
+        ),
+
+        // Reset-to-north compass (hidden until the map is rotated)
+        Positioned(
+          top: 16,
+          right: 16,
+          child: MapCompassButton(controller: _mapController),
         ),
 
         // Empty state overlay

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_centers/domain/entities/dive_center.dar
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -265,6 +266,14 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
               const MapAttribution(),
             ],
           ),
+        ),
+
+        // Reset-to-north compass (hidden until the map is rotated), tucked
+        // below the fit-all control so the two controls stack rather than overlap.
+        Positioned(
+          top: 64,
+          right: 8,
+          child: MapCompassButton(controller: _mapController),
         ),
 
         // Empty state overlay

--- a/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Marker colors for the GPS entry/exit fixes, matching the values the dive
@@ -150,45 +151,56 @@ class _DiveLocationsMapState extends ConsumerState<DiveLocationsMap> {
         ),
     ];
 
-    return TrackpadZoomMap(
-      controller: _effectiveController,
-      child: FlutterMap(
-        mapController: _effectiveController,
-        options: MapOptions(
-          initialCenter: center,
-          initialZoom: zoom,
-          initialCameraFit: fit,
-          interactionOptions: InteractionOptions(
-            flags: interactive ? InteractiveFlag.all : InteractiveFlag.none,
+    return Stack(
+      children: [
+        TrackpadZoomMap(
+          controller: _effectiveController,
+          child: FlutterMap(
+            mapController: _effectiveController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: zoom,
+              initialCameraFit: fit,
+              interactionOptions: InteractionOptions(
+                flags: interactive ? InteractiveFlag.all : InteractiveFlag.none,
+              ),
+            ),
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              if (entry != null && exit != null)
+                PolylineLayer(
+                  polylines: [
+                    Polyline(
+                      points: [
+                        LatLng(entry.latitude, entry.longitude),
+                        LatLng(exit.latitude, exit.longitude),
+                      ],
+                      strokeWidth: 3.0,
+                      color: colorScheme.onSurface.withValues(alpha: 0.7),
+                      pattern: const StrokePattern.dotted(),
+                    ),
+                  ],
+                ),
+              MarkerLayer(markers: markers),
+              const MapAttribution(),
+            ],
           ),
         ),
-        children: [
-          TileLayer(
-            urlTemplate: ref.watch(mapTileUrlProvider),
-            userAgentPackageName: 'app.submersion',
-            maxZoom: ref.watch(mapTileMaxZoomProvider),
-            tileProvider: TileCacheService.instance.isInitialized
-                ? TileCacheService.instance.getTileProvider()
-                : null,
+        // Reset-to-north compass (only when the map accepts rotation gestures)
+        if (interactive)
+          Positioned(
+            top: 16,
+            right: 16,
+            child: MapCompassButton(controller: _effectiveController),
           ),
-          if (entry != null && exit != null)
-            PolylineLayer(
-              polylines: [
-                Polyline(
-                  points: [
-                    LatLng(entry.latitude, entry.longitude),
-                    LatLng(exit.latitude, exit.longitude),
-                  ],
-                  strokeWidth: 3.0,
-                  color: colorScheme.onSurface.withValues(alpha: 0.7),
-                  pattern: const StrokePattern.dotted(),
-                ),
-              ],
-            ),
-          MarkerLayer(markers: markers),
-          const MapAttribution(),
-        ],
-      ),
+      ],
     );
   }
 }

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/maps/presentation/providers/heat_map_provide
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -379,6 +380,14 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
               const MapAttribution(),
             ],
           ),
+        ),
+
+        // Reset-to-north compass (hidden until the map is rotated), tucked
+        // below the heat-map toggle so the two controls stack rather than overlap.
+        Positioned(
+          top: 64,
+          right: 8,
+          child: MapCompassButton(controller: _mapController),
         ),
 
         // Loading indicator

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/maps/presentation/providers/heat_map_provide
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
@@ -355,6 +356,13 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
               const MapAttribution(),
             ],
           ),
+        ),
+
+        // Reset-to-north compass (hidden until the map is rotated)
+        Positioned(
+          top: 16,
+          right: 16,
+          child: MapCompassButton(controller: _mapController),
         ),
 
         // Empty state overlay

--- a/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Map for the Match-Sites review: shows the focused dive's GPS point plus its
@@ -53,63 +54,72 @@ class _MatchSitesMapState extends ConsumerState<MatchSitesMap> {
           )
         : null;
 
-    return TrackpadZoomMap(
-      controller: _controller,
-      child: FlutterMap(
-        mapController: _controller,
-        options: MapOptions(
-          initialCenter: pts.first,
-          initialZoom: 13,
-          initialCameraFit: fit,
-          interactionOptions: const InteractionOptions(
-            flags: InteractiveFlag.all,
-          ),
-        ),
-        children: [
-          TileLayer(
-            urlTemplate: ref.watch(mapTileUrlProvider),
-            userAgentPackageName: 'app.submersion',
-            maxZoom: ref.watch(mapTileMaxZoomProvider),
-            tileProvider: TileCacheService.instance.isInitialized
-                ? TileCacheService.instance.getTileProvider()
-                : null,
-          ),
-          MarkerLayer(
-            markers: [
-              Marker(
-                point: LatLng(
-                  widget.divePoint.latitude,
-                  widget.divePoint.longitude,
-                ),
-                width: 38,
-                height: 38,
-                child: _pin(
-                  scheme.primary,
-                  Icons.my_location,
-                  scheme.onPrimary,
-                ),
+    return Stack(
+      children: [
+        TrackpadZoomMap(
+          controller: _controller,
+          child: FlutterMap(
+            mapController: _controller,
+            options: MapOptions(
+              initialCenter: pts.first,
+              initialZoom: 13,
+              initialCameraFit: fit,
+              interactionOptions: const InteractionOptions(
+                flags: InteractiveFlag.all,
               ),
-              for (final c in widget.candidates)
-                Marker(
-                  point: LatLng(c.location.latitude, c.location.longitude),
-                  width: c.id == widget.selectedCandidateId ? 46 : 38,
-                  height: c.id == widget.selectedCandidateId ? 46 : 38,
-                  child: GestureDetector(
-                    onTap: () => widget.onSelectCandidate(c.id),
+            ),
+            children: [
+              TileLayer(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+                userAgentPackageName: 'app.submersion',
+                maxZoom: ref.watch(mapTileMaxZoomProvider),
+                tileProvider: TileCacheService.instance.isInitialized
+                    ? TileCacheService.instance.getTileProvider()
+                    : null,
+              ),
+              MarkerLayer(
+                markers: [
+                  Marker(
+                    point: LatLng(
+                      widget.divePoint.latitude,
+                      widget.divePoint.longitude,
+                    ),
+                    width: 38,
+                    height: 38,
                     child: _pin(
-                      c.id == widget.selectedCandidateId
-                          ? scheme.secondary
-                          : (c.isExisting ? Colors.teal : Colors.indigo),
-                      Icons.place,
-                      Colors.white,
+                      scheme.primary,
+                      Icons.my_location,
+                      scheme.onPrimary,
                     ),
                   ),
-                ),
+                  for (final c in widget.candidates)
+                    Marker(
+                      point: LatLng(c.location.latitude, c.location.longitude),
+                      width: c.id == widget.selectedCandidateId ? 46 : 38,
+                      height: c.id == widget.selectedCandidateId ? 46 : 38,
+                      child: GestureDetector(
+                        onTap: () => widget.onSelectCandidate(c.id),
+                        child: _pin(
+                          c.id == widget.selectedCandidateId
+                              ? scheme.secondary
+                              : (c.isExisting ? Colors.teal : Colors.indigo),
+                          Icons.place,
+                          Colors.white,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              const MapAttribution(),
             ],
           ),
-          const MapAttribution(),
-        ],
-      ),
+        ),
+        Positioned(
+          top: 16,
+          right: 16,
+          child: MapCompassButton(controller: _controller),
+        ),
+      ],
     );
   }
 

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/maps/presentation/providers/heat_map_provide
 import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.dart';
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -385,6 +386,14 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
               const MapAttribution(),
             ],
           ),
+        ),
+
+        // Reset-to-north compass (hidden until the map is rotated), tucked
+        // below the heat-map toggle so the two controls stack rather than overlap.
+        Positioned(
+          top: 64,
+          right: 8,
+          child: MapCompassButton(controller: _mapController),
         ),
 
         // Empty state overlay

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
@@ -343,6 +344,13 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
               const MapAttribution(),
             ],
           ),
+        ),
+
+        // Reset-to-north compass (hidden until the map is rotated)
+        Positioned(
+          top: 16,
+          right: 16,
+          child: MapCompassButton(controller: _mapController),
         ),
 
         // Loading indicator

--- a/lib/features/maps/presentation/widgets/map_compass_button.dart
+++ b/lib/features/maps/presentation/widgets/map_compass_button.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+/// A compass control that resets a rotated [FlutterMap] back to north.
+///
+/// `flutter_map` enables two-finger rotation by default but ships no visible
+/// affordance to undo it, so a map that has been twisted stays crooked with no
+/// way back (see issue #625). This control mirrors the Google/Apple Maps
+/// convention: it stays hidden while the map is north-up, fades in as soon as
+/// the map is rotated, points its needle at true north, and animates the
+/// bearing back to zero when tapped.
+///
+/// Drop it into the [Stack] that hosts a [FlutterMap] (typically wrapped in a
+/// [Positioned]) and pass the same [MapController] the map uses. It listens to
+/// [MapController.mapEventStream], so the host page does not need to rebuild or
+/// track rotation itself.
+class MapCompassButton extends StatefulWidget {
+  const MapCompassButton({
+    super.key,
+    required this.controller,
+    this.resetDuration = const Duration(milliseconds: 300),
+  });
+
+  /// The controller of the [FlutterMap] this compass steers.
+  final MapController controller;
+
+  /// How long the animated glide back to north takes when tapped.
+  final Duration resetDuration;
+
+  @override
+  State<MapCompassButton> createState() => _MapCompassButtonState();
+}
+
+class _MapCompassButtonState extends State<MapCompassButton>
+    with SingleTickerProviderStateMixin {
+  /// Rotations within this many degrees of north are treated as "north-up",
+  /// hiding the control. Keeps floating-point drift from leaving it visible.
+  static const double _hideThresholdDeg = 0.5;
+
+  StreamSubscription<MapEvent>? _eventSub;
+  late final AnimationController _resetController;
+
+  /// Current map bearing in degrees, mirrored from map events.
+  double _rotation = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _resetController = AnimationController(
+      vsync: this,
+      duration: widget.resetDuration,
+    );
+    _eventSub = widget.controller.mapEventStream.listen(_onMapEvent);
+  }
+
+  @override
+  void didUpdateWidget(covariant MapCompassButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      _eventSub?.cancel();
+      _eventSub = widget.controller.mapEventStream.listen(_onMapEvent);
+    }
+    _resetController.duration = widget.resetDuration;
+  }
+
+  @override
+  void dispose() {
+    _eventSub?.cancel();
+    _resetController.dispose();
+    super.dispose();
+  }
+
+  void _onMapEvent(MapEvent event) {
+    final rotation = event.camera.rotation;
+    if (rotation != _rotation && mounted) {
+      setState(() => _rotation = rotation);
+    }
+  }
+
+  /// Whether the map is currently (near enough to) north-up.
+  bool get _isNorthUp {
+    final normalized = _rotation % 360;
+    final fromNorth = normalized < 0 ? normalized + 360 : normalized;
+    return fromNorth < _hideThresholdDeg || fromNorth > 360 - _hideThresholdDeg;
+  }
+
+  Future<void> _resetToNorth() async {
+    final start = _rotation;
+    // Snap to the nearest multiple of 360 so the needle takes the shortest
+    // path home (e.g. 350 degrees glides forward to 360, not back through 0).
+    final end = (start / 360).roundToDouble() * 360;
+    if (start == end) return;
+
+    _resetController
+      ..stop()
+      ..reset();
+    final animation = CurvedAnimation(
+      parent: _resetController,
+      curve: Curves.easeInOut,
+    );
+    void applyFrame() {
+      widget.controller.rotate(start + (end - start) * animation.value);
+    }
+
+    animation.addListener(applyFrame);
+    try {
+      await _resetController.forward();
+    } finally {
+      animation.removeListener(applyFrame);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final northUp = _isNorthUp;
+
+    return IgnorePointer(
+      ignoring: northUp,
+      child: AnimatedOpacity(
+        opacity: northUp ? 0 : 1,
+        duration: const Duration(milliseconds: 200),
+        child: Tooltip(
+          message: 'North up',
+          child: Material(
+            color: colorScheme.surface,
+            elevation: 2,
+            shape: CircleBorder(
+              side: BorderSide(color: colorScheme.outlineVariant),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: _resetToNorth,
+              child: Semantics(
+                button: true,
+                label: 'Reset map orientation to north',
+                child: SizedBox(
+                  width: 44,
+                  height: 44,
+                  child: Center(
+                    child: Transform.rotate(
+                      angle: -_rotation * math.pi / 180,
+                      child: CustomPaint(
+                        size: const Size.square(22),
+                        painter: _CompassNeedlePainter(
+                          northColor: Colors.red.shade600,
+                          southColor: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints a two-tone compass needle: a colored north half and a muted south
+/// half meeting at the center, so the pointing direction is unambiguous at any
+/// rotation.
+class _CompassNeedlePainter extends CustomPainter {
+  _CompassNeedlePainter({required this.northColor, required this.southColor});
+
+  final Color northColor;
+  final Color southColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final cx = size.width / 2;
+    final cy = size.height / 2;
+    final halfWidth = size.width * 0.18;
+    final top = size.height * 0.1;
+    final bottom = size.height * 0.9;
+
+    final north = Path()
+      ..moveTo(cx, top)
+      ..lineTo(cx - halfWidth, cy)
+      ..lineTo(cx + halfWidth, cy)
+      ..close();
+    final south = Path()
+      ..moveTo(cx, bottom)
+      ..lineTo(cx - halfWidth, cy)
+      ..lineTo(cx + halfWidth, cy)
+      ..close();
+
+    canvas
+      ..drawPath(south, Paint()..color = southColor)
+      ..drawPath(north, Paint()..color = northColor);
+  }
+
+  @override
+  bool shouldRepaint(covariant _CompassNeedlePainter oldDelegate) =>
+      oldDelegate.northColor != northColor ||
+      oldDelegate.southColor != southColor;
+}

--- a/lib/features/maps/presentation/widgets/map_compass_button.dart
+++ b/lib/features/maps/presentation/widgets/map_compass_button.dart
@@ -55,7 +55,7 @@ class _MapCompassButtonState extends State<MapCompassButton>
       vsync: this,
       duration: widget.resetDuration,
     );
-    _eventSub = widget.controller.mapEventStream.listen(_onMapEvent);
+    _subscribe();
   }
 
   @override
@@ -63,9 +63,23 @@ class _MapCompassButtonState extends State<MapCompassButton>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.controller != widget.controller) {
       _eventSub?.cancel();
-      _eventSub = widget.controller.mapEventStream.listen(_onMapEvent);
+      _subscribe();
     }
     _resetController.duration = widget.resetDuration;
+  }
+
+  /// Listen to the controller's events and seed [_rotation] from its current
+  /// bearing. Seeding matters when the controller is already rotated as this
+  /// widget mounts (or when a new controller is swapped in): without it the
+  /// needle would show north until the next map event arrives.
+  void _subscribe() {
+    _eventSub = widget.controller.mapEventStream.listen(_onMapEvent);
+    try {
+      _rotation = widget.controller.camera.rotation;
+    } on StateError {
+      // The map is not attached to this controller yet; the first emitted
+      // map event will sync the rotation.
+    }
   }
 
   @override

--- a/lib/features/maps/presentation/widgets/map_compass_button.dart
+++ b/lib/features/maps/presentation/widgets/map_compass_button.dart
@@ -62,6 +62,9 @@ class _MapCompassButtonState extends State<MapCompassButton>
   void didUpdateWidget(covariant MapCompassButton oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.controller != widget.controller) {
+      // Abandon any reset in flight on the old controller before switching, so
+      // its animation can never drive the newly swapped-in controller.
+      _resetController.stop();
       _eventSub?.cancel();
       _subscribe();
     }
@@ -104,6 +107,10 @@ class _MapCompassButtonState extends State<MapCompassButton>
   }
 
   Future<void> _resetToNorth() async {
+    // Capture the controller this reset targets: if the widget is rebuilt with
+    // a different controller mid-glide, the frames must keep driving the
+    // original one, never the newly swapped-in controller.
+    final controller = widget.controller;
     final start = _rotation;
     // Snap to the nearest multiple of 360 so the needle takes the shortest
     // path home (e.g. 350 degrees glides forward to 360, not back through 0).
@@ -119,7 +126,7 @@ class _MapCompassButtonState extends State<MapCompassButton>
     );
     void applyFrame() {
       if (!mounted) return;
-      widget.controller.rotate(start + (end - start) * animation.value);
+      controller.rotate(start + (end - start) * animation.value);
     }
 
     animation.addListener(applyFrame);

--- a/lib/features/maps/presentation/widgets/map_compass_button.dart
+++ b/lib/features/maps/presentation/widgets/map_compass_button.dart
@@ -4,6 +4,8 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 
+import 'package:submersion/l10n/l10n_extension.dart';
+
 /// A compass control that resets a rotated [FlutterMap] back to north.
 ///
 /// `flutter_map` enables two-finger rotation by default but ships no visible
@@ -118,36 +120,41 @@ class _MapCompassButtonState extends State<MapCompassButton>
     final colorScheme = Theme.of(context).colorScheme;
     final northUp = _isNorthUp;
 
-    return IgnorePointer(
-      ignoring: northUp,
-      child: AnimatedOpacity(
-        opacity: northUp ? 0 : 1,
-        duration: const Duration(milliseconds: 200),
-        child: Tooltip(
-          message: 'North up',
-          child: Material(
-            color: colorScheme.surface,
-            elevation: 2,
-            shape: CircleBorder(
-              side: BorderSide(color: colorScheme.outlineVariant),
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: _resetToNorth,
-              child: Semantics(
-                button: true,
-                label: 'Reset map orientation to north',
-                child: SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: Center(
-                    child: Transform.rotate(
-                      angle: -_rotation * math.pi / 180,
-                      child: CustomPaint(
-                        size: const Size.square(22),
-                        painter: _CompassNeedlePainter(
-                          northColor: Colors.red.shade600,
-                          southColor: colorScheme.onSurfaceVariant,
+    // Exclude from the semantics tree while hidden: an invisible,
+    // non-interactive button should not be reachable by screen readers.
+    return ExcludeSemantics(
+      excluding: northUp,
+      child: IgnorePointer(
+        ignoring: northUp,
+        child: AnimatedOpacity(
+          opacity: northUp ? 0 : 1,
+          duration: const Duration(milliseconds: 200),
+          child: Tooltip(
+            message: context.l10n.maps_compass_resetTooltip,
+            child: Material(
+              color: colorScheme.surface,
+              elevation: 2,
+              shape: CircleBorder(
+                side: BorderSide(color: colorScheme.outlineVariant),
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: InkWell(
+                onTap: _resetToNorth,
+                child: Semantics(
+                  button: true,
+                  label: context.l10n.maps_compass_resetLabel,
+                  child: SizedBox(
+                    width: 44,
+                    height: 44,
+                    child: Center(
+                      child: Transform.rotate(
+                        angle: -_rotation * math.pi / 180,
+                        child: CustomPaint(
+                          size: const Size.square(22),
+                          painter: _CompassNeedlePainter(
+                            northColor: Colors.red.shade600,
+                            southColor: colorScheme.onSurfaceVariant,
+                          ),
                         ),
                       ),
                     ),

--- a/lib/features/maps/presentation/widgets/map_compass_button.dart
+++ b/lib/features/maps/presentation/widgets/map_compass_button.dart
@@ -104,12 +104,16 @@ class _MapCompassButtonState extends State<MapCompassButton>
       curve: Curves.easeInOut,
     );
     void applyFrame() {
+      if (!mounted) return;
       widget.controller.rotate(start + (end - start) * animation.value);
     }
 
     animation.addListener(applyFrame);
     try {
       await _resetController.forward();
+    } on TickerCanceled {
+      // The widget was disposed mid-glide (e.g. the map was navigated away);
+      // the reset is simply abandoned.
     } finally {
       animation.removeListener(applyFrame);
     }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -3335,6 +3335,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "ترايمكس طبيعي الأكسجين 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "إعادة ضبط اتجاه الخريطة نحو الشمال",
+  "maps_compass_resetTooltip": "الشمال للأعلى",
   "maps_heatMap_hide": "إخفاء خريطة الحرارة",
   "maps_heatMap_overlayOff": "طبقة خريطة الحرارة معطلة",
   "maps_heatMap_overlayOn": "طبقة خريطة الحرارة مفعلة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -3335,6 +3335,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Normoxisches Trimix 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Kartenausrichtung nach Norden zurücksetzen",
+  "maps_compass_resetTooltip": "Norden oben",
   "maps_heatMap_hide": "Heatmap ausblenden",
   "maps_heatMap_overlayOff": "Heatmap-Overlay ist aus",
   "maps_heatMap_overlayOn": "Heatmap-Overlay ist an",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -11348,6 +11348,8 @@
     }
   },
   "gpsLogger_tracksHeader": "Recorded tracks",
+  "maps_compass_resetLabel": "Reset map orientation to north",
+  "maps_compass_resetTooltip": "North up",
   "maps_heatMap_hide": "Hide Heat Map",
   "maps_heatMap_overlayOff": "Heat map overlay is off",
   "maps_heatMap_overlayOn": "Heat map overlay is on",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -3335,6 +3335,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Trimix normóxico 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Restablecer la orientación del mapa al norte",
+  "maps_compass_resetTooltip": "Norte arriba",
   "maps_heatMap_hide": "Ocultar mapa de calor",
   "maps_heatMap_overlayOff": "La capa de mapa de calor esta desactivada",
   "maps_heatMap_overlayOn": "La capa de mapa de calor esta activada",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -3301,6 +3301,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Trimix normoxique 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Réinitialiser l'orientation de la carte vers le nord",
+  "maps_compass_resetTooltip": "Nord en haut",
   "maps_heatMap_hide": "Masquer la carte de chaleur",
   "maps_heatMap_overlayOff": "La carte de chaleur est desactivee",
   "maps_heatMap_overlayOn": "La carte de chaleur est activee",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -3301,6 +3301,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "טרימיקס נורמוקסי 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "איפוס כיוון המפה לצפון",
+  "maps_compass_resetTooltip": "צפון למעלה",
   "maps_heatMap_hide": "הסתר מפת חום",
   "maps_heatMap_overlayOff": "שכבת מפת חום כבויה",
   "maps_heatMap_overlayOn": "שכבת מפת חום פעילה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -3301,6 +3301,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Normoxikus trimix 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Terkep tajolasanak visszaallitasa eszakra",
+  "maps_compass_resetTooltip": "Eszak felul",
   "maps_heatMap_hide": "Hoterkep elrejtese",
   "maps_heatMap_overlayOff": "A hoterkep reteg ki van kapcsolva",
   "maps_heatMap_overlayOn": "A hoterkep reteg be van kapcsolva",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -3301,6 +3301,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Trimix normossico 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Reimposta l'orientamento della mappa a nord",
+  "maps_compass_resetTooltip": "Nord in alto",
   "maps_heatMap_hide": "Nascondi mappa termica",
   "maps_heatMap_overlayOff": "Sovrapposizione mappa termica disattivata",
   "maps_heatMap_overlayOn": "Sovrapposizione mappa termica attivata",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -30847,6 +30847,18 @@ abstract class AppLocalizations {
   /// **'Recorded tracks'**
   String get gpsLogger_tracksHeader;
 
+  /// No description provided for @maps_compass_resetLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset map orientation to north'**
+  String get maps_compass_resetLabel;
+
+  /// No description provided for @maps_compass_resetTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'North up'**
+  String get maps_compass_resetTooltip;
+
   /// No description provided for @maps_heatMap_hide.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -18088,6 +18088,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'المسارات المسجّلة';
 
   @override
+  String get maps_compass_resetLabel => 'إعادة ضبط اتجاه الخريطة نحو الشمال';
+
+  @override
+  String get maps_compass_resetTooltip => 'الشمال للأعلى';
+
+  @override
   String get maps_heatMap_hide => 'إخفاء خريطة الحرارة';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -18397,6 +18397,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Aufgezeichnete Tracks';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Kartenausrichtung nach Norden zurücksetzen';
+
+  @override
+  String get maps_compass_resetTooltip => 'Norden oben';
+
+  @override
   String get maps_heatMap_hide => 'Heatmap ausblenden';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -18112,6 +18112,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Recorded tracks';
 
   @override
+  String get maps_compass_resetLabel => 'Reset map orientation to north';
+
+  @override
+  String get maps_compass_resetTooltip => 'North up';
+
+  @override
   String get maps_heatMap_hide => 'Hide Heat Map';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -18434,6 +18434,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Tracks grabados';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Restablecer la orientación del mapa al norte';
+
+  @override
+  String get maps_compass_resetTooltip => 'Norte arriba';
+
+  @override
   String get maps_heatMap_hide => 'Ocultar mapa de calor';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -18496,6 +18496,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Traces enregistrées';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Réinitialiser l\'orientation de la carte vers le nord';
+
+  @override
+  String get maps_compass_resetTooltip => 'Nord en haut';
+
+  @override
   String get maps_heatMap_hide => 'Masquer la carte de chaleur';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -17951,6 +17951,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'מסלולים שהוקלטו';
 
   @override
+  String get maps_compass_resetLabel => 'איפוס כיוון המפה לצפון';
+
+  @override
+  String get maps_compass_resetTooltip => 'צפון למעלה';
+
+  @override
   String get maps_heatMap_hide => 'הסתר מפת חום';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -18374,6 +18374,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Rögzített útvonalak';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Terkep tajolasanak visszaallitasa eszakra';
+
+  @override
+  String get maps_compass_resetTooltip => 'Eszak felul';
+
+  @override
   String get maps_heatMap_hide => 'Hoterkep elrejtese';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -18421,6 +18421,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Tracce registrate';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Reimposta l\'orientamento della mappa a nord';
+
+  @override
+  String get maps_compass_resetTooltip => 'Nord in alto';
+
+  @override
   String get maps_heatMap_hide => 'Nascondi mappa termica';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -18275,6 +18275,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Opgenomen tracks';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Kaartoriëntatie terugzetten naar het noorden';
+
+  @override
+  String get maps_compass_resetTooltip => 'Noorden boven';
+
+  @override
   String get maps_heatMap_hide => 'Heatmap verbergen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -18425,6 +18425,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get gpsLogger_tracksHeader => 'Trilhas gravadas';
 
   @override
+  String get maps_compass_resetLabel =>
+      'Redefinir a orientação do mapa para o norte';
+
+  @override
+  String get maps_compass_resetTooltip => 'Norte para cima';
+
+  @override
   String get maps_heatMap_hide => 'Ocultar Mapa de Calor';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -17478,6 +17478,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get gpsLogger_tracksHeader => '已记录的轨迹';
 
   @override
+  String get maps_compass_resetLabel => '将地图方向重置为正北';
+
+  @override
+  String get maps_compass_resetTooltip => '正北朝上';
+
+  @override
   String get maps_heatMap_hide => '隐藏热力图';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -3335,6 +3335,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Normoxisch trimix 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Kaartoriëntatie terugzetten naar het noorden",
+  "maps_compass_resetTooltip": "Noorden boven",
   "maps_heatMap_hide": "Heatmap verbergen",
   "maps_heatMap_overlayOff": "Heatmap-overlay is uit",
   "maps_heatMap_overlayOn": "Heatmap-overlay is aan",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -3335,6 +3335,8 @@
   "gas_tmx1845_displayName": "Tx 18/45",
   "gas_tmx2135_description": "Trimix normoxico 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
+  "maps_compass_resetLabel": "Redefinir a orientação do mapa para o norte",
+  "maps_compass_resetTooltip": "Norte para cima",
   "maps_heatMap_hide": "Ocultar Mapa de Calor",
   "maps_heatMap_overlayOff": "Sobreposicao do mapa de calor desativada",
   "maps_heatMap_overlayOn": "Sobreposicao do mapa de calor ativada",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -3478,6 +3478,8 @@
   "gas_tmx2135_description": "常氧三混气 21/35",
   "gas_tmx2135_displayName": "Tx 21/35",
   "importWizard_tagsLabel": "标签",
+  "maps_compass_resetLabel": "将地图方向重置为正北",
+  "maps_compass_resetTooltip": "正北朝上",
   "maps_heatMap_hide": "隐藏热力图",
   "maps_heatMap_overlayOff": "热力图叠加层已关闭",
   "maps_heatMap_overlayOn": "热力图叠加层已开启",

--- a/test/features/dive_sites/presentation/widgets/match_sites_map_test.dart
+++ b/test/features/dive_sites/presentation/widgets/match_sites_map_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dive_sites/data/services/site_matching_servi
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/widgets/match_sites_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
 
@@ -21,6 +22,9 @@ void main() {
           settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
         ],
         child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: MatchSitesMap(
               divePoint: const GeoPoint(0, 0),
@@ -58,6 +62,9 @@ void main() {
           settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
         ],
         child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: MatchSitesMap(
               divePoint: const GeoPoint(0, 0),

--- a/test/features/maps/presentation/widgets/map_compass_button_test.dart
+++ b/test/features/maps/presentation/widgets/map_compass_button_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+
+void main() {
+  Future<MapController> pumpCompass(WidgetTester tester) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              FlutterMap(
+                mapController: controller,
+                options: const MapOptions(
+                  initialCenter: LatLng(0, 0),
+                  initialZoom: 5,
+                ),
+                children: const [],
+              ),
+              Positioned(
+                top: 16,
+                right: 16,
+                child: MapCompassButton(controller: controller),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return controller;
+  }
+
+  // Scope to the compass: FlutterMap has its own AnimatedOpacity/IgnorePointer.
+  final compassOpacity = find.descendant(
+    of: find.byType(MapCompassButton),
+    matching: find.byType(AnimatedOpacity),
+  );
+  final compassIgnorePointer = find.descendant(
+    of: find.byType(MapCompassButton),
+    matching: find.byType(IgnorePointer),
+  );
+
+  double opacity(WidgetTester tester) =>
+      tester.widget<AnimatedOpacity>(compassOpacity).opacity;
+
+  bool ignoring(WidgetTester tester) =>
+      tester.widget<IgnorePointer>(compassIgnorePointer).ignoring;
+
+  testWidgets('is hidden while the map is north-up', (tester) async {
+    await pumpCompass(tester);
+
+    expect(opacity(tester), 0, reason: 'no affordance needed at 0 degrees');
+    // Hidden control must not steal taps meant for the map beneath it.
+    expect(ignoring(tester), isTrue);
+  });
+
+  testWidgets('fades in once the map is rotated', (tester) async {
+    final controller = await pumpCompass(tester);
+
+    controller.rotate(45);
+    await tester.pump();
+
+    expect(opacity(tester), 1);
+    expect(ignoring(tester), isFalse);
+  });
+
+  testWidgets('tapping resets the map back to north and hides again', (
+    tester,
+  ) async {
+    final controller = await pumpCompass(tester);
+
+    controller.rotate(45);
+    await tester.pump();
+    expect(controller.camera.rotation, 45);
+
+    await tester.tap(find.byTooltip('North up'));
+    await tester.pumpAndSettle();
+
+    expect(controller.camera.rotation.abs() % 360, closeTo(0, 0.01));
+    expect(opacity(tester), 0);
+  });
+
+  testWidgets('near-360 rotation glides forward to north, not back through 0', (
+    tester,
+  ) async {
+    final controller = await pumpCompass(tester);
+
+    // 350 degrees is only 10 degrees short of a full turn; resetting should
+    // land on 360 (a multiple of 360, i.e. north) rather than unwinding to 0.
+    controller.rotate(350);
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('North up'));
+    await tester.pumpAndSettle();
+
+    expect(controller.camera.rotation, 360);
+    expect(opacity(tester), 0);
+  });
+}

--- a/test/features/maps/presentation/widgets/map_compass_button_test.dart
+++ b/test/features/maps/presentation/widgets/map_compass_button_test.dart
@@ -92,14 +92,40 @@ void main() {
     final controller = await pumpCompass(tester);
 
     // 350 degrees is only 10 degrees short of a full turn; resetting should
-    // land on 360 (a multiple of 360, i.e. north) rather than unwinding to 0.
+    // climb forward toward 360 rather than unwinding ~350 degrees back to 0.
     controller.rotate(350);
     await tester.pump();
 
     await tester.tap(find.byTooltip('North up'));
+    // Sample mid-glide: the shortest path forward keeps the bearing at/above
+    // the 350 start; unwinding to 0 would instead drop it below 350.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(controller.camera.rotation, greaterThanOrEqualTo(350));
+
     await tester.pumpAndSettle();
 
-    expect(controller.camera.rotation, 360);
+    // End state is north-up regardless of whether the controller keeps 360 or
+    // normalizes it to 0.
+    expect(controller.camera.rotation % 360, closeTo(0, 0.01));
     expect(opacity(tester), 0);
+  });
+
+  testWidgets('disposing mid-reset does not throw', (tester) async {
+    final controller = await pumpCompass(tester);
+
+    controller.rotate(90);
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('North up'));
+    await tester.pump(); // start the glide-to-north animation
+    await tester.pump(const Duration(milliseconds: 100)); // partway through
+
+    // Tear the compass out of the tree while the animation is still running,
+    // cancelling the ticker mid-flight.
+    await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/features/maps/presentation/widgets/map_compass_button_test.dart
+++ b/test/features/maps/presentation/widgets/map_compass_button_test.dart
@@ -4,29 +4,31 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
 
+import '../../../../helpers/test_app.dart';
+
 void main() {
   Future<MapController> pumpCompass(WidgetTester tester) async {
     final controller = MapController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Stack(
-            children: [
-              FlutterMap(
-                mapController: controller,
-                options: const MapOptions(
-                  initialCenter: LatLng(0, 0),
-                  initialZoom: 5,
-                ),
-                children: const [],
+      // Pinned to English so the tooltip finder is deterministic.
+      testApp(
+        locale: const Locale('en'),
+        child: Stack(
+          children: [
+            FlutterMap(
+              mapController: controller,
+              options: const MapOptions(
+                initialCenter: LatLng(0, 0),
+                initialZoom: 5,
               ),
-              Positioned(
-                top: 16,
-                right: 16,
-                child: MapCompassButton(controller: controller),
-              ),
-            ],
-          ),
+              children: const [],
+            ),
+            Positioned(
+              top: 16,
+              right: 16,
+              child: MapCompassButton(controller: controller),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary

`flutter_map` enables two-finger map rotation by default but ships no
affordance to undo it, so a rotated map stays crooked with no way back to
north (issue #625, reported on the Dive Activity map). This adds a
Google/Apple-Maps-style compass control that resets the bearing.

Fixes #625.

## Changes

- **New shared widget `MapCompassButton`** (`lib/features/maps/presentation/widgets/map_compass_button.dart`):
  - Subscribes to `MapController.mapEventStream` and tracks the live bearing —
    no host page needs to rebuild or thread rotation state.
  - Hidden (opacity 0 + `IgnorePointer`) while north-up; fades in once the map
    is rotated.
  - Two-tone needle points at true geographic north; tapping animates the
    bearing back to zero, snapping to the nearest multiple of 360° so the
    needle takes the shortest path home (e.g. 350° glides forward to 360°,
    not backward through 0°).
- **Wired into all 8 maps that permit rotation:** Dive Activity, the Sites map
  (page + embedded content), the dive-site match picker, the Dives map content,
  the dive-locations map (interactive mode only), and both Dive Centers maps.
  Maps that disable rotation (`InteractiveFlag` without `rotate`) are untouched.
- On the three maps with an existing top-right control (heat-map toggle /
  fit-all), the compass stacks just below it (`top:64, right:8`) instead of
  overlapping; elsewhere it sits at `top:16, right:16`.
- **Test** (`test/features/maps/presentation/widgets/map_compass_button_test.dart`):
  4 cases driving a real `FlutterMap` — hidden at north, fades in on rotation,
  tap resets and re-hides, and the 350°→360° shortest-path case.

## Test Plan

- [x] `flutter test` passes (new compass tests + all existing map page/widget tests; full suite green via pre-push hook)
- [x] `flutter analyze` passes (no issues)
- [x] Needle direction verified against a placed due-north marker via golden render (points at true north after a 90° rotation, not mirrored)
- [x] Manual testing on: device/desktop smoke pending

## Screenshots

Verified via golden render (light + dark): circular Material button with a
red-north / muted-south needle; appears only when the map is rotated.
