### PR TITLE
fix(android): self-heal stale BLE bonds on the connect path (#621)

### DIFF
--- a/.github/workflows/native-plugin-tests.yml
+++ b/.github/workflows/native-plugin-tests.yml
@@ -173,6 +173,10 @@ jobs:
           flutter-version: ${{ steps.flutter-version.outputs.version }}
 
       - name: Install Linux dependencies
+        # libwebkit2gtk-4.1-dev: required since flutter_web_auth_2 pulled in
+        # desktop_webview_window, whose Linux plugin links webkit2gtk (4.1 on
+        # Ubuntu 24.04; its CMake falls back to the 4.0 name only on older
+        # distros). Matches the ci.yaml build-linux dependency list.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -183,7 +187,8 @@ jobs:
             libgtk-3-dev \
             libglib2.0-dev \
             libdbus-1-dev \
-            libsecret-1-dev
+            libsecret-1-dev \
+            libwebkit2gtk-4.1-dev
 
       - name: Run code generation
         run: dart run build_runner build --delete-conflicting-outputs

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -330,32 +330,46 @@ class DiveComputerHostApiImpl(
         }
 
         if (!bleStream.connectAndDiscover()) {
+            // Capture the failure status BEFORE tearing the stream down: the
+            // close() below disconnects, and that may report a fresh (benign)
+            // status over the one that explains the failure.
+            val disconnectStatus = bleStream.lastDisconnectStatus
+
+            // Tear down the GATT client connectAndDiscover created even when
+            // giving up: a leaked client/callback can interfere with later
+            // connection attempts.
+            bleStream.close()
+
             // A stale bond makes connection establishment itself fail:
             // Android auto-starts encryption on connect when a bond exists,
             // and rejected keys disconnect with GATT status 5 before any
             // service discovery runs. Remove the bond and retry once,
             // mirroring the same repair on the download-failure path below
-            // (issue #621).
-            if (!isRetry &&
-                bleStream.lastDisconnectStatus == GATT_INSUFFICIENT_AUTHENTICATION
-            ) {
+            // (issue #621). If the bond cannot be removed there is nothing
+            // to repair, so fall through and report the failure.
+            if (!isRetry && disconnectStatus == GATT_INSUFFICIENT_AUTHENTICATION) {
                 NativeLogger.w(
                     TAG, "BLE",
                     "Auth failure during connect (GATT status 5), removing stale bond and retrying"
                 )
-                bleStream.close()
-                bleStream.removeBond()
-                activeBleStream = null
-                LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
-                downloadSessionPtr = 0
-                // Reconnecting immediately after tearing down the encrypted
-                // link and removing the bond races the Bluetooth stack and
-                // the device's advertising recovery; the fresh connectGatt
-                // then never establishes (status 147). Give both sides a
-                // moment to settle before the retry.
-                Thread.sleep(BOND_REPAIR_SETTLE_MS)
-                performDownload(device, fingerprint, isRetry = true)
-                return
+                if (bleStream.removeBond()) {
+                    activeBleStream = null
+                    LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
+                    downloadSessionPtr = 0
+                    // Reconnecting immediately after tearing down the
+                    // encrypted link and removing the bond races the
+                    // Bluetooth stack and the device's advertising recovery;
+                    // the fresh connectGatt then never establishes
+                    // (status 147). Give both sides a moment to settle
+                    // before the retry.
+                    Thread.sleep(BOND_REPAIR_SETTLE_MS)
+                    performDownload(device, fingerprint, isRetry = true)
+                    return
+                }
+                NativeLogger.e(
+                    TAG, "BLE",
+                    "Stale-bond repair failed: bond could not be removed"
+                )
             }
             reportError("connect_failed", "Failed to connect to device")
             LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
@@ -410,15 +424,23 @@ class DiveComputerHostApiImpl(
             ) {
                 NativeLogger.w(TAG, "BLE", "Auth failure (GATT status 5), removing stale bond and retrying")
                 bleStream.close()
-                bleStream.removeBond()
-                activeBleStream = null
-                LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
-                downloadSessionPtr = 0
-                // Same settle wait as the connect-path repair: an immediate
-                // reconnect after removeBond fails to establish (status 147).
-                Thread.sleep(BOND_REPAIR_SETTLE_MS)
-                performDownload(device, fingerprint, isRetry = true)
-                return
+                if (bleStream.removeBond()) {
+                    activeBleStream = null
+                    LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
+                    downloadSessionPtr = 0
+                    // Same settle wait as the connect-path repair: an
+                    // immediate reconnect after removeBond fails to
+                    // establish (status 147).
+                    Thread.sleep(BOND_REPAIR_SETTLE_MS)
+                    performDownload(device, fingerprint, isRetry = true)
+                    return
+                }
+                // Bond removal failed; fall through and surface the
+                // original download error.
+                NativeLogger.e(
+                    TAG, "BLE",
+                    "Stale-bond repair failed: bond could not be removed"
+                )
             }
 
             val errorMsg = String(errorBuf).trim('\u0000')

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -23,6 +23,12 @@ private const val LIBDC_STATUS_CANCELLED = -10
 private const val UINT32_SENTINEL: Long = 4294967295L  // UINT32_MAX = unavailable
 private const val GATT_INSUFFICIENT_AUTHENTICATION = 5
 
+// Settle time between a stale-bond repair (GATT close + removeBond) and the
+// reconnect attempt. An immediate reconnect races the Bluetooth stack's
+// teardown and the peripheral's advertising recovery and fails to establish
+// (status 147).
+private const val BOND_REPAIR_SETTLE_MS = 2500L
+
 private const val TAG = "DiveComputerHost"
 
 // Bluetooth permissions are requested at the Dart layer before BLE methods are called.
@@ -324,6 +330,33 @@ class DiveComputerHostApiImpl(
         }
 
         if (!bleStream.connectAndDiscover()) {
+            // A stale bond makes connection establishment itself fail:
+            // Android auto-starts encryption on connect when a bond exists,
+            // and rejected keys disconnect with GATT status 5 before any
+            // service discovery runs. Remove the bond and retry once,
+            // mirroring the same repair on the download-failure path below
+            // (issue #621).
+            if (!isRetry &&
+                bleStream.lastDisconnectStatus == GATT_INSUFFICIENT_AUTHENTICATION
+            ) {
+                NativeLogger.w(
+                    TAG, "BLE",
+                    "Auth failure during connect (GATT status 5), removing stale bond and retrying"
+                )
+                bleStream.close()
+                bleStream.removeBond()
+                activeBleStream = null
+                LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
+                downloadSessionPtr = 0
+                // Reconnecting immediately after tearing down the encrypted
+                // link and removing the bond races the Bluetooth stack and
+                // the device's advertising recovery; the fresh connectGatt
+                // then never establishes (status 147). Give both sides a
+                // moment to settle before the retry.
+                Thread.sleep(BOND_REPAIR_SETTLE_MS)
+                performDownload(device, fingerprint, isRetry = true)
+                return
+            }
             reportError("connect_failed", "Failed to connect to device")
             LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
             downloadSessionPtr = 0
@@ -381,6 +414,9 @@ class DiveComputerHostApiImpl(
                 activeBleStream = null
                 LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
                 downloadSessionPtr = 0
+                // Same settle wait as the connect-path repair: an immediate
+                // reconnect after removeBond fails to establish (status 147).
+                Thread.sleep(BOND_REPAIR_SETTLE_MS)
                 performDownload(device, fingerprint, isRetry = true)
                 return
             }


### PR DESCRIPTION
## Summary

Fixes the Android arm of #621: Shearwater downloads (Teric, Perdix, Petrel) that fail before the transfer even starts, with the dive computer repeatedly prompting to pair. Verified end-to-end on a Pixel 6a + Shearwater Teric.

## Root cause

A stale Bluetooth bond makes connection establishment itself fail on Android: the stack auto-starts link encryption on connect when a bond exists, the dive computer rejects the outdated keys, and the connection drops with GATT status 5 (`GATT_INSUFFICIENT_AUTHENTICATION`) before service discovery ever runs:

```
onClientConnectionState() - status=0 connected=true
configureMTU() - mtu: 512
onClientConnectionState() - status=5 connected=false
connectAndDiscover: connected=false writeChar=null result=false
[LDC] [ERROR] Download failed (connect_failed): Failed to connect to device
```

The app already had a stale-bond repair (`removeBond()` + one retry) — but only on the **download**-failure path. On the **connect**-failure path it just reported `connect_failed`, so a phone in this state could never connect again; every retry hit the same wall, and the DC kept asking to pair (the reporters' "it wants to pair, which Shearwater Cloud never does"). Bond state lives on the phone and the DC, not in the app — once poisoned (pairing-list eviction on the DC, BT stack updates, or churn from failed sessions), *every* build fails identically, which is why this looked like an app regression while the code path was unchanged.

This also explains the platform split reported in #621: Android is the only platform where the app bonds at all (`ensureBonded()` runs for every BLE device); macOS/iOS use CoreBluetooth without bonding, and the same fork content downloads fine there (verified on v1.6.0.114 on macOS).

## Fix

- Mirror the stale-bond repair on the `connectAndDiscover()` failure branch: on GATT status 5, close the GATT, `removeBond()`, and retry the download once.
- Add a 2.5s settle wait between `removeBond()` and the reconnect on **both** repair paths. An immediate reconnect races the stack teardown and the peripheral's advertising recovery and fails to establish (status 147) — observed on hardware during testing.

After the repair, the app prompts for a fresh pairing once, then downloads normally; subsequent downloads connect silently.

## Hardware verification (Pixel 6a + Teric)

1. Poisoned state reproduced: connect died with status 5 on every attempt.
2. With the fix: `Auth failure during connect (GATT status 5), removing stale bond and retrying` → `removeBond: result=true` → (with settle wait) reconnect succeeds → one pairing prompt → full dive transfer completed.

## What remains open in #621

The second reporter saw "download fails at the end of the transfer of the dive list" on **Windows** as well as Android (builds 114/116). Windows does not use this bonding path, so that failure is still undiagnosed — it needs logs from a Windows run. The shared libdivecomputer driver content is exonerated on macOS and (with this fix) on Android.
