### PR TITLE
fix(sync): enable encrypted sync on secondary devices after unlock

### DIFF
--- a/lib/core/services/sync/crypto/sync_encryption_service.dart
+++ b/lib/core/services/sync/crypto/sync_encryption_service.dart
@@ -106,7 +106,10 @@ class SyncEncryptionService {
   }
 
   /// Unlock this device against the cloud keyslot file with a passphrase or
-  /// recovery code. Persists key + mirror on success.
+  /// recovery code. Persists key + mirror and flags encryption on so the
+  /// session survives a relaunch (EncryptionKeyNotifier gates the provider
+  /// wrap on the flag; without it the device reverts to plaintext and
+  /// re-prompts on the next sync).
   Future<UnlockedKey> unlock({
     required CloudStorageProvider rawProvider,
     required String secret,
@@ -125,6 +128,7 @@ class SyncEncryptionService {
       mlkBytes: await mlk.extractBytes(),
     );
     await _keyStore.saveKeyslotMirror(fileBytes);
+    await _preferences.setSyncEncryptionEnabled(true);
     _log.info('Unlocked encrypted library ${keyslotFile.libraryKeyId}');
     return UnlockedKey(libraryKeyId: keyslotFile.libraryKeyId, mlk: mlk);
   }

--- a/test/core/services/sync/crypto/sync_encryption_service_test.dart
+++ b/test/core/services/sync/crypto/sync_encryption_service_test.dart
@@ -94,6 +94,27 @@ void main() {
     expect(await keyStoreB.loadKeyslotMirror(), isNotNull);
   });
 
+  test('unlock flags encryption on so it survives a relaunch', () async {
+    await enable();
+    // Model a fresh second device: its own (empty) key store and a local
+    // feature flag that has never been turned on. EncryptionKeyNotifier
+    // gates session restore on this flag, so if unlock does not set it the
+    // next launch silently reverts to plaintext and re-prompts forever.
+    await prefs.setSyncEncryptionEnabled(false);
+    final keyStoreB = EncryptionKeyStore(storage: InMemoryKeychain());
+    final serviceB = SyncEncryptionService(
+      keyStore: keyStoreB,
+      preferences: prefs,
+    );
+
+    await serviceB.unlock(
+      rawProvider: cloud,
+      secret: 'correct horse battery staple',
+    );
+
+    expect(prefs.syncEncryptionEnabled, isTrue);
+  });
+
   test('unlock failures: wrong secret and missing keyslot file', () async {
     await enable();
     await expectLater(

--- a/test/features/settings/presentation/widgets/encryption_settings_section_flows_test.dart
+++ b/test/features/settings/presentation/widgets/encryption_settings_section_flows_test.dart
@@ -78,6 +78,7 @@ class _FakeEncryptionService implements SyncEncryptionService {
       libraryKeyId: _keyId,
       mlkBytes: await _mlk().extractBytes(),
     );
+    await _preferences.setSyncEncryptionEnabled(true);
     return UnlockedKey(libraryKeyId: _keyId, mlk: _mlk());
   }
 


### PR DESCRIPTION
## Problem

When a secondary device syncs an encrypted library for the first time, it discovers the cloud keyslot file, prompts for the passphrase, and accepts it — but encrypted sync is never actually *enabled* on that device. On the next launch it reverts to plaintext and re-prompts for the passphrase, and it keeps doing so on every sync.

## Root cause

`SyncEncryptionService.unlock()` — the "join an existing encrypted library" path — persisted the library key and keyslot mirror but never set the durable `syncEncryptionEnabled` preference flag. Its sibling `enable()` does set it.

That flag is the real gate: `EncryptionKeyNotifier._load()` restores the encryption session only when `syncEncryptionEnabled` is true. So after unlock:

- The in-memory `setUnlocked()` call made the *current* session encrypt/decrypt correctly.
- But the flag stayed `false`, so on the next launch the notifier rebuilt with no session, `_load()` returned `null`, and the `EncryptingCloudStorageProvider` wrap reverted to plaintext. The next sync re-hit `SyncEncryptionRequired` → passphrase prompt again, indefinitely.
- The settings UI reads the same flag, so it showed encryption as "off" the whole time.

A fresh device reaches unlock via the sync-page "passphrase needed" banner (the settings-section locked tile is only reachable once the flag is already on), so fixing the single service chokepoint that every entry point funnels through (`runEncryptionUnlockFlow` → `unlock()`) covers all of them.

## Fix

`unlock()` now calls `setSyncEncryptionEnabled(true)` after persisting key custody, symmetric with `enable()`. Because `runEncryptionUnlockFlow` calls `setUnlocked()` immediately afterward (which rebuilds the encryption settings section), the same rebuild re-reads the now-true flag, so the in-session UI flips to "on" as well — the same reactivity path `enable()` already relied on.

## Tests

- New service-level regression test models a genuinely fresh second device (its own key store, flag defaulting off) and asserts `unlock()` flips the flag on. Confirmed it fails before the fix (`Expected: true, Actual: false`) and passes after.
- The pre-existing two-device unit test shared a single `SyncPreferences` between both simulated devices, so `enable()`'s flag write leaked into "device B" and masked the missing write; the new test avoids that coupling.
- Updated `_FakeEncryptionService.unlock()` in the flows widget test so the test double mirrors the corrected contract (its `enable()` already set the flag).

`dart format` and `flutter analyze` clean; full test suite green.
