### PR TITLE
fix(dive_3d): render 3D/spatial/compare for dives missing a data-source row

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -3489,6 +3489,52 @@ class AppDatabase extends _$AppDatabase {
     ''');
   }
 
+  /// Data self-heal: synthesize a primary [DiveDataSources] row for any dive
+  /// that has profile samples but no data-source row. Older file imports (and
+  /// any import path predating dive_data_sources) wrote dive_profiles without
+  /// the metadata row, which stranded the grouped-by-source view that the 3D
+  /// scene, spatial map, and computer-compare all read -- they spun forever on
+  /// a null scene. The 2D chart survived because it reads dive.profile directly.
+  ///
+  /// Runs on every open; a cheap no-op once healed (the NOT EXISTS guard leaves
+  /// nothing to insert). Local-only by design: the id is deterministic
+  /// (`legacy-src-<diveId>`), so every device heals to the identical row
+  /// without syncing, and a device on an older build simply heals itself after
+  /// upgrade. It never touches the parent dive's HLC, so it does not trigger a
+  /// fleet re-sync of the healed dives. imported_at/created_at are Drift
+  /// dateTime() columns stored as unix SECONDS (unlike the dives table's plain
+  /// millisecond int columns), hence strftime('%s') without the *1000.
+  Future<void> _backfillMissingDataSources() async {
+    // Self-guard for partial/legacy schemas (migration tests and databases
+    // caught mid-upgrade): skip unless all three tables exist. beforeOpen runs
+    // for every open, including old-version fixtures where these tables may not
+    // exist yet.
+    final tables = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name IN ('dives', 'dive_profiles', 'dive_data_sources')",
+    ).get();
+    final present = tables.map((r) => r.read<String>('name')).toSet();
+    if (!present.containsAll({'dives', 'dive_profiles', 'dive_data_sources'})) {
+      return;
+    }
+    await customStatement('''
+      INSERT OR IGNORE INTO dive_data_sources
+        (id, dive_id, is_primary, imported_at, created_at)
+      SELECT 'legacy-src-' || d.id, d.id, 1, n.now_s, n.now_s
+      FROM dives d
+      CROSS JOIN (
+        SELECT CAST(strftime('%s','now') AS INTEGER) AS now_s
+      ) n
+      WHERE EXISTS (
+        SELECT 1 FROM dive_profiles p
+        WHERE p.dive_id = d.id AND p.is_primary = 1
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM dive_data_sources s WHERE s.dive_id = d.id
+      )
+    ''');
+  }
+
   /// Copy each buddy's inline certification into a certifications row owned by
   /// that buddy (issue #553). Invoked from the onUpgrade blocks only (v109
   /// expand + the v110 contract safety-net), NEVER the beforeOpen backstop --
@@ -6897,6 +6943,12 @@ class AppDatabase extends _$AppDatabase {
             'ALTER TABLE dive_profiles ADD COLUMN heading REAL',
           );
         }
+
+        // Data self-heal: backfill a primary dive_data_sources row for dives
+        // that have profile samples but no source row (legacy file imports).
+        // Without it, the 3D/spatial/compare views spin forever on those dives.
+        // Idempotent and local-only (deterministic ids, no HLC bump).
+        await _backfillMissingDataSources();
 
         // Performance indexes historically existed only in onUpgrade blocks,
         // so a database created fresh at a recent schema version -- or

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2807,6 +2807,19 @@ class FieldPresets extends Table {
     ServiceSchedules,
   ],
 )
+/// Prefix of the deterministic id for a synthesized/backfilled primary data
+/// source -- the row a dive gets when it has profile samples but no
+/// dive_data_sources row (older file imports). Shared by the beforeOpen
+/// backfill ([AppDatabase._backfillMissingDataSources]) and the read-time
+/// synthesis ([DiveRepository.getProfilesByDataSource]) so the id a consumer
+/// sees before the heal equals the id persisted afterward. Never change it:
+/// existing databases already carry rows with this exact prefix.
+const String kLegacyDataSourceIdPrefix = 'legacy-src-';
+
+/// Full deterministic data-source id for [diveId]. See
+/// [kLegacyDataSourceIdPrefix].
+String legacyDataSourceId(String diveId) => '$kLegacyDataSourceIdPrefix$diveId';
+
 class AppDatabase extends _$AppDatabase {
   final void Function(int currentStep, int totalSteps)? onMigrationProgress;
 
@@ -3520,7 +3533,7 @@ class AppDatabase extends _$AppDatabase {
     await customStatement('''
       INSERT OR IGNORE INTO dive_data_sources
         (id, dive_id, is_primary, imported_at, created_at)
-      SELECT 'legacy-src-' || d.id, d.id, 1, n.now_s, n.now_s
+      SELECT '$kLegacyDataSourceIdPrefix' || d.id, d.id, 1, n.now_s, n.now_s
       FROM dives d
       CROSS JOIN (
         SELECT CAST(strftime('%s','now') AS INTEGER) AS now_s

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2707,6 +2707,19 @@ class FieldPresets extends Table {
 // Database Class
 // ============================================================================
 
+/// Prefix of the deterministic id for a synthesized/backfilled primary data
+/// source -- the row a dive gets when it has profile samples but no
+/// dive_data_sources row (older file imports). Shared by the beforeOpen
+/// backfill ([AppDatabase._backfillMissingDataSources]) and the read-time
+/// synthesis ([DiveRepository.getProfilesByDataSource]) so the id a consumer
+/// sees before the heal equals the id persisted afterward. Never change it:
+/// existing databases already carry rows with this exact prefix.
+const String kLegacyDataSourceIdPrefix = 'legacy-src-';
+
+/// Full deterministic data-source id for [diveId]. See
+/// [kLegacyDataSourceIdPrefix].
+String legacyDataSourceId(String diveId) => '$kLegacyDataSourceIdPrefix$diveId';
+
 @DriftDatabase(
   tables: [
     Divers,
@@ -2807,19 +2820,6 @@ class FieldPresets extends Table {
     ServiceSchedules,
   ],
 )
-/// Prefix of the deterministic id for a synthesized/backfilled primary data
-/// source -- the row a dive gets when it has profile samples but no
-/// dive_data_sources row (older file imports). Shared by the beforeOpen
-/// backfill ([AppDatabase._backfillMissingDataSources]) and the read-time
-/// synthesis ([DiveRepository.getProfilesByDataSource]) so the id a consumer
-/// sees before the heal equals the id persisted afterward. Never change it:
-/// existing databases already carry rows with this exact prefix.
-const String kLegacyDataSourceIdPrefix = 'legacy-src-';
-
-/// Full deterministic data-source id for [diveId]. See
-/// [kLegacyDataSourceIdPrefix].
-String legacyDataSourceId(String diveId) => '$kLegacyDataSourceIdPrefix$diveId';
-
 class AppDatabase extends _$AppDatabase {
   final void Function(int currentStep, int totalSteps)? onMigrationProgress;
 

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -6944,12 +6944,6 @@ class AppDatabase extends _$AppDatabase {
           );
         }
 
-        // Data self-heal: backfill a primary dive_data_sources row for dives
-        // that have profile samples but no source row (legacy file imports).
-        // Without it, the 3D/spatial/compare views spin forever on those dives.
-        // Idempotent and local-only (deterministic ids, no HLC bump).
-        await _backfillMissingDataSources();
-
         // Performance indexes historically existed only in onUpgrade blocks,
         // so a database created fresh at a recent schema version -- or
         // arriving via restore or sync-adopt -- never got them, and per-dive
@@ -6968,6 +6962,15 @@ class AppDatabase extends _$AppDatabase {
           }
           return true;
         }());
+
+        // Data self-heal: backfill a primary dive_data_sources row for dives
+        // that have profile samples but no source row (legacy file imports).
+        // Without it, the 3D/spatial/compare views spin forever on those dives.
+        // Idempotent and local-only (deterministic ids, no HLC bump). Runs
+        // AFTER ensurePerformanceIndexes so its per-dive EXISTS/NOT EXISTS
+        // subqueries hit idx_dive_profiles_dive_id / idx_dive_data_sources_dive_id
+        // instead of full-scanning million-row tables on a fresh/restored DB.
+        await _backfillMissingDataSources();
       },
     );
   }

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -671,7 +671,30 @@ class DiveRepository {
                   (t) => OrderingTerm.asc(t.createdAt),
                 ]))
               .get();
-      if (sourceRows.isEmpty) return {};
+      if (sourceRows.isEmpty) {
+        // Legacy/imported dives can carry dive_profiles rows without a
+        // dive_data_sources metadata row (older import paths predate that
+        // table). The profile is real -- the 2D chart renders it via
+        // dive.profile -- so synthesize a single primary source from the
+        // primary rows. Without this, every profile-consuming feature that
+        // reads only the grouped view (3D scene, spatial, computer compare,
+        // profile analysis) sees an empty map and stalls on a null scene.
+        final primaryRows =
+            await (_db.select(_db.diveProfiles)
+                  ..where((t) => t.diveId.equals(diveId))
+                  ..where((t) => t.isPrimary.equals(true))
+                  ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+                .get();
+        if (primaryRows.isEmpty) return {};
+        return {
+          diveId: domain.SourceProfile(
+            sourceId: diveId,
+            computerId: primaryRows.first.computerId,
+            isEdited: false,
+            points: primaryRows.map(_profilePointFromRow).toList(),
+          ),
+        };
+      }
 
       final primary = sourceRows.first;
       final sourceIdByComputer = <String, String>{

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -679,12 +679,12 @@ class DiveRepository {
         // primary rows. Without this, every profile-consuming feature that
         // reads only the grouped view (3D scene, spatial, computer compare,
         // profile analysis) sees an empty map and stalls on a null scene.
-        final primaryRows =
+        final allRows =
             await (_db.select(_db.diveProfiles)
                   ..where((t) => t.diveId.equals(diveId))
-                  ..where((t) => t.isPrimary.equals(true))
                   ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
                 .get();
+        final primaryRows = allRows.where((r) => r.isPrimary).toList();
         if (primaryRows.isEmpty) return {};
         // Key/sourceId must equal the row that _backfillMissingDataSources
         // (AppDatabase.beforeOpen) will persist, so the synthesized-on-read
@@ -693,11 +693,18 @@ class DiveRepository {
         // would see it change out from under it when the heal runs. The id
         // format is shared via [legacyDataSourceId] so the two can't drift.
         final syntheticSourceId = legacyDataSourceId(diveId);
+        // With no dive_data_sources row there is a single conceptual source
+        // (the imported file), so any demoted (isPrimary=false) rows can only
+        // be originals a profile edit left behind -- the same signal the
+        // non-fallback path uses for hasEditedProfile. Surface it so an edited
+        // legacy dive keeps its "(edited)" label even in the window before the
+        // backfill promotes it to the normal path.
+        final isEdited = allRows.any((r) => !r.isPrimary);
         return {
           syntheticSourceId: domain.SourceProfile(
             sourceId: syntheticSourceId,
             computerId: primaryRows.first.computerId,
-            isEdited: false,
+            isEdited: isEdited,
             points: primaryRows.map(_profilePointFromRow).toList(),
           ),
         };

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -690,9 +690,9 @@ class DiveRepository {
         // (AppDatabase.beforeOpen) will persist, so the synthesized-on-read
         // source and the later backfilled row expose the SAME id. Otherwise a
         // consumer that keeps a selected source id (activeDiveSourceProvider)
-        // would see it change out from under it when the heal runs. Keep this
-        // prefix in sync with that helper's `legacy-src-` id.
-        final syntheticSourceId = 'legacy-src-$diveId';
+        // would see it change out from under it when the heal runs. The id
+        // format is shared via [legacyDataSourceId] so the two can't drift.
+        final syntheticSourceId = legacyDataSourceId(diveId);
         return {
           syntheticSourceId: domain.SourceProfile(
             sourceId: syntheticSourceId,

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -686,9 +686,16 @@ class DiveRepository {
                   ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
                 .get();
         if (primaryRows.isEmpty) return {};
+        // Key/sourceId must equal the row that _backfillMissingDataSources
+        // (AppDatabase.beforeOpen) will persist, so the synthesized-on-read
+        // source and the later backfilled row expose the SAME id. Otherwise a
+        // consumer that keeps a selected source id (activeDiveSourceProvider)
+        // would see it change out from under it when the heal runs. Keep this
+        // prefix in sync with that helper's `legacy-src-` id.
+        final syntheticSourceId = 'legacy-src-$diveId';
         return {
-          diveId: domain.SourceProfile(
-            sourceId: diveId,
+          syntheticSourceId: domain.SourceProfile(
+            sourceId: syntheticSourceId,
             computerId: primaryRows.first.computerId,
             isEdited: false,
             points: primaryRows.map(_profilePointFromRow).toList(),

--- a/test/core/database/backfill_missing_data_sources_test.dart
+++ b/test/core/database/backfill_missing_data_sources_test.dart
@@ -1,0 +1,117 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// beforeOpen data self-heal: dives that have primary profile samples but no
+/// dive_data_sources row (older file imports) get a synthesized primary source
+/// so the grouped-by-source view (3D/spatial/compare) stops spinning.
+void main() {
+  // Minimal pre-seeded schema at currentSchemaVersion: only the three tables
+  // the backfill touches. beforeOpen's other backstops self-guard on missing
+  // tables, and ensurePerformanceIndexes swallows index DDL errors, so a
+  // partial schema is safe (same technique as the v105 heading test).
+  NativeDatabase seeded(void Function(dynamic rawDb) rows) {
+    return NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute(
+          'PRAGMA user_version = ${AppDatabase.currentSchemaVersion}',
+        );
+        rawDb.execute('CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY)');
+        rawDb.execute('''
+          CREATE TABLE dive_profiles (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            is_primary INTEGER NOT NULL DEFAULT 1,
+            timestamp INTEGER NOT NULL,
+            depth REAL NOT NULL
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE dive_data_sources (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            is_primary INTEGER NOT NULL DEFAULT 0,
+            imported_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL
+          )
+        ''');
+        rows(rawDb);
+      },
+    );
+  }
+
+  test('heals a dive that has primary profile rows but no data source', () async {
+    final db = AppDatabase(
+      seeded((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('orphan')");
+        rawDb.execute(
+          "INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, depth) "
+          "VALUES ('p1', 'orphan', 1, 0, 5.0), ('p2', 'orphan', 1, 10, 8.0)",
+        );
+      }),
+    );
+    addTearDown(() => db.close());
+
+    final rows = await db
+        .customSelect(
+          "SELECT id, is_primary, imported_at FROM dive_data_sources "
+          "WHERE dive_id = 'orphan'",
+        )
+        .get();
+
+    expect(rows, hasLength(1));
+    expect(rows.single.data['id'], 'legacy-src-orphan');
+    expect(rows.single.data['is_primary'], 1);
+    // imported_at is a Drift dateTime() column: unix SECONDS, not millis.
+    final importedAt = rows.single.data['imported_at'] as int;
+    expect(importedAt, greaterThan(1000000000)); // > 2001
+    expect(importedAt, lessThan(100000000000)); // < year 5138 (i.e. not millis)
+  });
+
+  test('leaves a dive that already has a data source untouched', () async {
+    final db = AppDatabase(
+      seeded((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('sourced')");
+        rawDb.execute(
+          "INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, depth) "
+          "VALUES ('p1', 'sourced', 1, 0, 5.0)",
+        );
+        rawDb.execute(
+          "INSERT INTO dive_data_sources "
+          "(id, dive_id, is_primary, imported_at, created_at) "
+          "VALUES ('real-src', 'sourced', 1, 111, 111)",
+        );
+      }),
+    );
+    addTearDown(() => db.close());
+
+    final rows = await db
+        .customSelect(
+          "SELECT id FROM dive_data_sources WHERE dive_id = 'sourced'",
+        )
+        .get();
+
+    expect(rows.map((r) => r.data['id']), ['real-src']);
+  });
+
+  test('does not heal a dive whose only profile rows are non-primary', () async {
+    final db = AppDatabase(
+      seeded((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('demoted')");
+        rawDb.execute(
+          "INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, depth) "
+          "VALUES ('p1', 'demoted', 0, 0, 5.0)",
+        );
+      }),
+    );
+    addTearDown(() => db.close());
+
+    final rows = await db
+        .customSelect(
+          "SELECT id FROM dive_data_sources WHERE dive_id = 'demoted'",
+        )
+        .get();
+
+    expect(rows, isEmpty);
+  });
+}

--- a/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
+++ b/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
@@ -222,7 +222,12 @@ void main() {
     expect(result['src-meta']!.points, isEmpty);
   });
 
-  test('returns empty map when the dive has no data source rows', () async {
+  test('synthesizes a primary source from raw profile rows when the dive has '
+      'no data source metadata row (legacy import)', () async {
+    // Older imports wrote dive_profiles rows without a dive_data_sources
+    // row. The profile is still real and the 2D chart shows it, so the
+    // grouped view must surface it too (otherwise 3D/spatial/compare spin
+    // forever on a null scene).
     await insertProfileRow(
       diveId: 'dive-2',
       timestamp: 0,
@@ -230,7 +235,33 @@ void main() {
       computerId: null,
       isPrimary: true,
     );
+    await insertProfileRow(
+      diveId: 'dive-2',
+      timestamp: 10,
+      depth: 9.0,
+      computerId: null,
+      isPrimary: true,
+    );
+    // A demoted (non-primary) row is excluded, mirroring getDiveProfile /
+    // dive.profile, which the 2D chart renders.
+    await insertProfileRow(
+      diveId: 'dive-2',
+      timestamp: 5,
+      depth: 99.0,
+      computerId: null,
+      isPrimary: false,
+    );
 
+    final result = await repository.getProfilesByDataSource('dive-2');
+
+    expect(result, hasLength(1));
+    final source = result.values.single;
+    expect(source.points.map((p) => p.depth).toList(), [8.0, 9.0]);
+    expect(source.isEdited, false);
+  });
+
+  test('returns empty map when the dive has neither data sources nor profile '
+      'rows', () async {
     final result = await repository.getProfilesByDataSource('dive-2');
 
     expect(result, isEmpty);

--- a/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
+++ b/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
@@ -255,7 +255,12 @@ void main() {
     final result = await repository.getProfilesByDataSource('dive-2');
 
     expect(result, hasLength(1));
+    // Key and sourceId use the deterministic id the beforeOpen backfill
+    // (_backfillMissingDataSources) will persist, so the synthesized-on-read
+    // source and the later backfilled row share one id.
+    expect(result.keys.single, 'legacy-src-dive-2');
     final source = result.values.single;
+    expect(source.sourceId, 'legacy-src-dive-2');
     expect(source.points.map((p) => p.depth).toList(), [8.0, 9.0]);
     expect(source.isEdited, false);
   });

--- a/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
+++ b/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
@@ -242,15 +242,6 @@ void main() {
       computerId: null,
       isPrimary: true,
     );
-    // A demoted (non-primary) row is excluded, mirroring getDiveProfile /
-    // dive.profile, which the 2D chart renders.
-    await insertProfileRow(
-      diveId: 'dive-2',
-      timestamp: 5,
-      depth: 99.0,
-      computerId: null,
-      isPrimary: false,
-    );
 
     final result = await repository.getProfilesByDataSource('dive-2');
 
@@ -262,8 +253,42 @@ void main() {
     final source = result.values.single;
     expect(source.sourceId, 'legacy-src-dive-2');
     expect(source.points.map((p) => p.depth).toList(), [8.0, 9.0]);
+    // No demoted rows -> not an edited profile. (The edited case, including
+    // point-exclusion of demoted rows, is covered by the next test.)
     expect(source.isEdited, false);
   });
+
+  test(
+    'synthesized fallback reports isEdited when a legacy dive (no data source '
+    'row) has demoted original rows from a profile edit',
+    () async {
+      // Edit convention: originals demoted to isPrimary=false, edited rows
+      // isPrimary=true. dive-2 has no dive_data_sources row.
+      await insertProfileRow(
+        diveId: 'dive-2',
+        timestamp: 0,
+        depth: 10.0,
+        computerId: null,
+        isPrimary: false,
+      );
+      await insertProfileRow(
+        diveId: 'dive-2',
+        timestamp: 0,
+        depth: 9.5,
+        computerId: null,
+        isPrimary: true,
+      );
+
+      final result = await repository.getProfilesByDataSource('dive-2');
+
+      expect(result, hasLength(1));
+      final source = result.values.single;
+      expect(source.isEdited, true);
+      // Only the edited (isPrimary=true) rows are surfaced, matching the 2D
+      // chart / getDiveProfile.
+      expect(source.points.map((p) => p.depth).toList(), [9.5]);
+    },
+  );
 
   test('returns empty map when the dive has neither data sources nor profile '
       'rows', () async {


### PR DESCRIPTION
## Summary

The 3D View (and the spatial/compare views) spun forever on some dives — notably older 2025 dives in the debug database. Root cause: those dives were imported by older paths that wrote `dive_profiles` rows but **no `dive_data_sources` metadata row**. `getProfilesByDataSource()` returned an empty map for them, so the 3D scene provider silently `return null`ed and the page showed a `CircularProgressIndicator` with no error. The 2D profile chart was unaffected because it reads `dive.profile` directly, which is why the dives looked fine everywhere except 3D.

In the affected debug DB, 22 of 24 profile-bearing 2025 dives were missing the row; all 15 2026 dives had it.

## Changes

- **Resilience fix** (`getProfilesByDataSource`): when a dive has profile rows but no `dive_data_sources` row, synthesize a single primary `SourceProfile` from the raw `isPrimary=true` rows. This repairs every grouped-by-source consumer at once (3D scene, spatial map, computer compare, profile analysis) and matches exactly what the 2D chart already renders. Works immediately, even before any backfill runs.
- **Backfill self-heal** (`_backfillMissingDataSources`, called from `beforeOpen`): idempotently backfills a real primary `dive_data_sources` row for such dives (existing legacy imports and any future file/HealthKit import, on next open).
  - Deterministic `legacy-src-<diveId>` ids → every device converges to the identical row; local-only (no parent-dive HLC bump), so it never triggers a fleet re-sync.
  - `INSERT OR IGNORE` + `NOT EXISTS` guard → cheap no-op once healed.
  - Table-existence self-guard → safe on partial/old schemas caught mid-upgrade (migration-test fixtures).
  - `imported_at`/`created_at` written as unix **seconds** (Drift `dateTime()` encoding), not millis.

### Why not fix `createDive`?

Creating the source row in `createDive` was tried and rejected: real dive-computer downloads bypass `createDive` (insert into `dives` directly and build their own source), but the **UDDF importer calls `createDive` and also builds its own source** — so a profile-guarded insert there double-sources UDDF imports. `createDive` can't distinguish importers. The read-time synthesis + `beforeOpen` self-heal cover new imports without that hazard.

## Test Plan

- [x] `flutter test` passes (full suite: 13,329 passing, 10 skipped)
- [x] `flutter analyze` passes (no issues) + `dart format` clean
- [x] New tests: `backfill_missing_data_sources_test.dart` (heals orphans / leaves sourced dives alone / skips non-primary-only); updated `profiles_by_data_source_test.dart` (synthesizes a primary source; empty only when no profile rows)
- [x] Manual testing on **macOS**: a 2025 dive that previously spun now renders the full 3D scene. Relaunching healed the real debug DB (22 orphans → 0; 22 rows backfilled; all 39 dives intact).

## Screenshots

Before: 3D View on an affected 2025 dive showed an indefinite spinner. After: the depth ribbon, strata planes, and metric controls render normally. (macOS, debug DB.)
