### PR TITLE
Match photos and videos to dives by capture time on desktop

### DIFF
--- a/lib/features/media/data/services/capture_time_reader.dart
+++ b/lib/features/media/data/services/capture_time_reader.dart
@@ -66,6 +66,9 @@ DateTime? _readMp4CreationTime(File file) {
     if (mvhd == null) return null;
 
     final version = raf.readByteAt(mvhd.start);
+    // Only v0/v1 mvhd headers exist. Bail on anything else rather than
+    // mis-reading a corrupt byte as v0 and emitting a bogus timestamp.
+    if (version != 0 && version != 1) return null;
     // creation_time follows the 1-byte version + 3 flag bytes. It is uint32 in
     // a v0 header and uint64 in a v1 header.
     final creation = version == 1

--- a/lib/features/media/data/services/capture_time_reader.dart
+++ b/lib/features/media/data/services/capture_time_reader.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+import 'package:submersion/features/media/data/services/exif_date_parser.dart';
+
+/// Reads the capture time from a media file's own container metadata using
+/// pure-Dart parsers (no native plugins), for the platforms and files where
+/// `native_exif` yields nothing (macOS/Windows/Linux, or any file it cannot
+/// date). Returns a wall-clock-UTC [DateTime] — the same frame
+/// `DivePhotoMatcher` compares dive times in — or null when no reliable capture
+/// time is present, leaving the caller to fall back to the file mtime.
+///
+/// - JPEG: EXIF `DateTimeOriginal` (via `package:image`, EXIF-only, no pixel
+///   decode).
+/// - MP4/MOV/M4V: the `moov > mvhd` `creation_time` from the ISO-BMFF/QuickTime
+///   container.
+DateTime? readLocalCaptureTime(File file, String mime) {
+  switch (mime) {
+    case 'image/jpeg':
+      return _readJpegExifDate(file);
+    case 'video/mp4':
+    case 'video/quicktime':
+    case 'video/x-m4v':
+      return _readMp4CreationTime(file);
+    default:
+      return null;
+  }
+}
+
+DateTime? _readJpegExifDate(File file) {
+  try {
+    final exif = img.decodeJpgExif(file.readAsBytesSync());
+    if (exif == null) return null;
+    // EXIF date tags are ASCII "YYYY:MM:DD HH:MM:SS". Prefer the shutter time
+    // (DateTimeOriginal), then when it was digitized, then the basic file
+    // DateTime, so files that omit the richer tags still get a real date.
+    final raw =
+        exif.exifIfd['DateTimeOriginal'] ??
+        exif.exifIfd['DateTimeDigitized'] ??
+        exif.imageIfd['DateTime'];
+    return parseExifDateTimeOriginal(raw?.toString());
+  } on Object {
+    // Truncated/corrupt JPEG or an unreadable file: fall back to mtime.
+    return null;
+  }
+}
+
+// Seconds between the QuickTime/ISO-BMFF epoch (1904-01-01) and the Unix epoch.
+// This is a whole number of days, so the epoch shift preserves the time-of-day
+// digits exactly (only the date rolls) when reconstructing the DateTime.
+const _secondsBetween1904And1970 = 2082844800;
+
+DateTime? _readMp4CreationTime(File file) {
+  RandomAccessFile? raf;
+  try {
+    raf = file.openSync();
+    final end = raf.lengthSync();
+    // The movie header (mvhd) lives inside moov. Cameras such as GoPro place
+    // moov AFTER the multi-hundred-MB mdat, so we walk top-level boxes by size,
+    // seeking past mdat without ever reading its bytes.
+    final moov = _findBox(raf, 0, end, 'moov');
+    if (moov == null) return null;
+    final mvhd = _findBox(raf, moov.start, moov.end, 'mvhd');
+    if (mvhd == null) return null;
+
+    final version = raf.readByteAt(mvhd.start);
+    // creation_time follows the 1-byte version + 3 flag bytes. It is uint32 in
+    // a v0 header and uint64 in a v1 header.
+    final creation = version == 1
+        ? _readU64(raf, mvhd.start + 4)
+        : _readU32(raf, mvhd.start + 4);
+    if (creation == 0) return null; // 0 == "unknown"; caller uses mtime.
+
+    // GoPro (and most cameras) write the LOCAL wall clock into creation_time.
+    // Reconstructing it as a UTC DateTime preserves those digits as
+    // wall-clock-UTC, matching how EXIF and mtime are handled here.
+    return DateTime.fromMillisecondsSinceEpoch(
+      (creation - _secondsBetween1904And1970) * 1000,
+      isUtc: true,
+    );
+  } on Object {
+    return null;
+  } finally {
+    raf?.closeSync();
+  }
+}
+
+/// Half-open byte range [start, end) of a box's content (payload).
+class _BoxRange {
+  const _BoxRange(this.start, this.end);
+  final int start;
+  final int end;
+}
+
+/// Returns the content range of the first sibling box of [type] within
+/// [start, end), or null. Handles the 64-bit size form (size field == 1) and
+/// the "extends to end of file" form (size field == 0).
+_BoxRange? _findBox(RandomAccessFile raf, int start, int end, String type) {
+  var pos = start;
+  while (pos + 8 <= end) {
+    raf.setPositionSync(pos);
+    final header = raf.readSync(8);
+    if (header.length < 8) return null;
+    var size = _beU32(header, 0);
+    var headerLen = 8;
+    if (size == 1) {
+      final ext = raf.readSync(8);
+      if (ext.length < 8) return null;
+      size = _beU64(ext, 0);
+      headerLen = 16;
+    } else if (size == 0) {
+      size = end - pos;
+    }
+    if (size < headerLen || pos + size > end) return null;
+    final boxType = String.fromCharCodes(header, 4, 8);
+    if (boxType == type) return _BoxRange(pos + headerLen, pos + size);
+    pos += size;
+  }
+  return null;
+}
+
+extension _ReadAt on RandomAccessFile {
+  int readByteAt(int position) {
+    setPositionSync(position);
+    return readSync(1).first;
+  }
+}
+
+int _readU32(RandomAccessFile raf, int position) {
+  raf.setPositionSync(position);
+  return _beU32(raf.readSync(4), 0);
+}
+
+int _readU64(RandomAccessFile raf, int position) {
+  raf.setPositionSync(position);
+  return _beU64(raf.readSync(8), 0);
+}
+
+int _beU32(Uint8List b, int o) =>
+    (b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3];
+
+int _beU64(Uint8List b, int o) => (_beU32(b, o) << 32) | _beU32(b, o + 4);

--- a/lib/features/media/data/services/dive_media_enricher.dart
+++ b/lib/features/media/data/services/dive_media_enricher.dart
@@ -1,0 +1,77 @@
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/services/enrichment_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+
+/// Positions a dive's linked media on the profile chart by computing and
+/// saving a [MediaEnrichment] (elapsed seconds + depth) for every item that
+/// has a capture time but no enrichment yet.
+///
+/// The gallery and Lightroom import paths enrich at import time, but the local
+/// file/folder linking path only creates the [MediaItem] row. Without an
+/// enrichment row the chart's marker builder drops the item
+/// (`photo_marker_layout` skips `enrichment == null`), so a linked photo shows
+/// in the grid but never on the depth/time chart. This service closes that gap
+/// and, being idempotent, doubles as a backfill for already-linked media.
+class DiveMediaEnricher {
+  DiveMediaEnricher({
+    required this.loadDive,
+    required this.loadMediaForDive,
+    required this.saveEnrichment,
+    this.enrichmentService = const EnrichmentService(),
+  });
+
+  /// Loads a dive with its profile hydrated (e.g. `DiveRepository.getDiveById`,
+  /// which populates `profile`; list queries do not).
+  final Future<Dive?> Function(String diveId) loadDive;
+  final Future<List<MediaItem>> Function(String diveId) loadMediaForDive;
+  final Future<void> Function(MediaEnrichment enrichment) saveEnrichment;
+  final EnrichmentService enrichmentService;
+
+  /// Enriches every media item linked to [diveId] that has no enrichment yet.
+  /// Idempotent — already-enriched items are skipped — so it is safe to call
+  /// after a fresh link and repeatedly as a backfill. Returns the number of
+  /// items newly enriched (0 means nothing changed; callers can skip a
+  /// refresh).
+  Future<int> enrichMissingForDive(String diveId) async {
+    final dive = await loadDive(diveId);
+    if (dive == null || dive.profile.isEmpty) return 0;
+
+    final media = await loadMediaForDive(diveId);
+    var enriched = 0;
+    for (final item in media) {
+      if (item.enrichment != null) continue;
+      // Signatures are attached to a dive but not moments within it, and the
+      // chart excludes them regardless — don't fabricate a depth/time for one.
+      if (item.mediaType == MediaType.instructorSignature) continue;
+
+      final result = enrichmentService.calculateEnrichment(
+        profile: dive.profile,
+        diveStartTime: dive.effectiveEntryTime,
+        photoTime: item.takenAt,
+      );
+
+      // Mirror the gallery path: don't persist a row we couldn't actually
+      // place (no depth and no usable profile match).
+      if (result.depthMeters == null &&
+          result.matchConfidence == MatchConfidence.noProfile) {
+        continue;
+      }
+
+      await saveEnrichment(
+        MediaEnrichment(
+          id: '',
+          mediaId: item.id,
+          diveId: diveId,
+          depthMeters: result.depthMeters,
+          temperatureCelsius: result.temperatureCelsius,
+          elapsedSeconds: result.elapsedSeconds,
+          matchConfidence: result.matchConfidence,
+          timestampOffsetSeconds: result.timestampOffsetSeconds,
+          createdAt: DateTime.now(),
+        ),
+      );
+      enriched++;
+    }
+    return enriched;
+  }
+}

--- a/lib/features/media/data/services/exif_extractor.dart
+++ b/lib/features/media/data/services/exif_extractor.dart
@@ -5,19 +5,25 @@ import 'package:flutter/foundation.dart' show compute;
 import 'package:native_exif/native_exif.dart';
 
 import 'package:submersion/core/util/wall_clock_utc.dart';
+import 'package:submersion/features/media/data/services/capture_time_reader.dart';
 import 'package:submersion/features/media/data/services/exif_date_parser.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
 
 const _isolateThresholdBytes = 5 * 1024 * 1024;
 
-/// Extracts [MediaSourceMetadata] from a local file via `native_exif`.
+/// Extracts [MediaSourceMetadata] from a local file.
 ///
-/// Files larger than 5 MB run in a background isolate via `compute()` so
-/// the UI thread stays responsive during folder picks of large libraries.
-/// On EXIF parse failure (unsupported format, corrupt header) the
-/// extractor falls back to the file's mtime as `takenAt` and returns
-/// the rest of [MediaSourceMetadata] populated by extension-based mime
-/// inference. Returns null only if the file does not exist.
+/// `native_exif` is the primary reader on iOS/Android (it also handles HEIC).
+/// It has no macOS/Windows/Linux implementation, so on desktop `Exif.fromPath`
+/// throws `MissingPluginException`; the extractor then reads the capture time
+/// straight from the file's own container metadata with a pure-Dart parser
+/// ([readLocalCaptureTime]) that works on every platform. Only if that also
+/// yields nothing does `takenAt` fall back to the file mtime — which is the
+/// copy-to-disk time and would not match the dive window.
+///
+/// Files larger than 5 MB run in a background isolate via `compute()` so the UI
+/// thread stays responsive during folder picks of large libraries. Returns null
+/// only if the file does not exist.
 class ExifExtractor {
   Future<MediaSourceMetadata?> extract(File file) async {
     if (!file.existsSync()) return null;
@@ -82,9 +88,17 @@ Future<MediaSourceMetadata?> _extract(String path) async {
       height = _parseInt(attrs['PixelYDimension'] ?? attrs['ImageLength']);
     }
   } on Object {
-    // native_exif throws PlatformException on unsupported formats; treat
-    // as "no EXIF available" and fall through to mtime fallback for takenAt.
+    // native_exif throws PlatformException on unsupported formats, and
+    // MissingPluginException on macOS/Windows/Linux where it has no
+    // implementation at all. Both are treated as "no native EXIF"; the
+    // pure-Dart fallback below recovers takenAt where possible.
   }
+
+  // On desktop (and for any file native_exif could not date), recover the
+  // capture time from the file's own container metadata (JPEG EXIF or the
+  // MP4/MOV mvhd) so it lands inside the dive window instead of defaulting to
+  // the copy-to-disk mtime.
+  takenAt ??= readLocalCaptureTime(file, mime);
 
   return MediaSourceMetadata(
     takenAt: takenAt ?? mtime,

--- a/lib/features/media/presentation/providers/files_tab_providers.dart
+++ b/lib/features/media/presentation/providers/files_tab_providers.dart
@@ -154,17 +154,14 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
   /// returns the list of created IDs. Pass the list back to [undoCommit]
   /// to roll back. State is reset via [clear] before returning.
   ///
-  /// Video MIME files are skipped: Phase 2 has no local-file video playback
-  /// path. The picker / folder enumerator both restrict to images already;
-  /// this guard is belt-and-suspenders against a future regression at the
-  /// pick layer (see [FilesTab] class doc).
+  /// Both photos and videos are persisted; [_persistOne] tags each row with
+  /// the right [MediaType] from its MIME. On desktop a local-file video
+  /// resolves by localPath and plays via `VideoPlayerController.file`
+  /// (see [FilesTab] class doc for the iOS caveat).
   Future<List<String>> commit() async {
     final created = <String>[];
     for (final entry in state.match.matched.entries) {
       for (final file in entry.value) {
-        if (file.metadata.mimeType.startsWith('video/')) {
-          continue;
-        }
         final id = await _persistOne(file, entry.key);
         created.add(id);
       }

--- a/lib/features/media/presentation/providers/media_providers.dart
+++ b/lib/features/media/presentation/providers/media_providers.dart
@@ -1,6 +1,7 @@
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/dive_media_enricher.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 
 /// Repository provider (singleton)
@@ -18,6 +19,19 @@ final mediaForDiveProvider = FutureProvider.family<List<MediaItem>, String>((
     ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
   );
   return repository.getMediaForDive(diveId);
+});
+
+/// Positions a dive's linked media on the profile chart by backfilling any
+/// missing [MediaEnrichment] rows. Idempotent; wired to a dive-with-profile
+/// loader and the media repository's read/save.
+final diveMediaEnricherProvider = Provider<DiveMediaEnricher>((ref) {
+  final mediaRepo = ref.watch(mediaRepositoryProvider);
+  final diveRepo = ref.watch(diveRepositoryProvider);
+  return DiveMediaEnricher(
+    loadDive: diveRepo.getDiveById,
+    loadMediaForDive: mediaRepo.getMediaForDive,
+    saveEnrichment: mediaRepo.saveEnrichment,
+  );
 });
 
 /// Get single media by ID

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -99,6 +99,10 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
   }
 
   Future<void> _runEnrichmentBackfill() async {
+    // The post-frame callback can fire after this state is disposed; touching
+    // `ref` then throws, so bail before using it rather than leaning on the
+    // catch-all below.
+    if (!mounted) return;
     try {
       final enriched = await ref
           .read(diveMediaEnricherProvider)

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -65,6 +65,10 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
   bool _isSelectionMode = false;
   Set<int> _selectedIndices = {};
 
+  /// Media ids whose enrichment backfill we've already kicked off, so the
+  /// post-frame trigger fires once per item rather than on every rebuild.
+  final Set<String> _enrichAttempted = {};
+
   Future<void> _scanLightroom(BuildContext context) async {
     final dive = await ref
         .read(diveRepositoryProvider)
@@ -72,6 +76,43 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
     if (dive == null || !context.mounted) return;
     await runLightroomScan(context, ref, [dive]);
   }
+
+  // coverage:ignore-start
+  // Post-frame provider glue: schedules a best-effort enrichment backfill so
+  // locally-linked media (which the file/folder picker links WITHOUT an
+  // enrichment row) gets positioned on the dive profile chart. The logic lives
+  // in DiveMediaEnricher (dive_media_enricher_test); this wiring — a post-frame
+  // callback plus a provider round-trip — is exercised by manual smoke tests,
+  // as flutter_test can't deterministically pump it. Idempotent and guarded by
+  // [_enrichAttempted] so it runs once per item, not on every rebuild.
+  void _scheduleEnrichmentBackfill(List<MediaItem>? items) {
+    if (items == null) return;
+    final missing = items
+        .where((m) => m.enrichment == null)
+        .map((m) => m.id)
+        .toSet();
+    if (missing.difference(_enrichAttempted).isEmpty) return;
+    _enrichAttempted.addAll(missing);
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _runEnrichmentBackfill(),
+    );
+  }
+
+  Future<void> _runEnrichmentBackfill() async {
+    try {
+      final enriched = await ref
+          .read(diveMediaEnricherProvider)
+          .enrichMissingForDive(widget.diveId);
+      // Re-read so the grid and the profile chart (both watch
+      // mediaForDiveProvider) pick up the new markers.
+      if (enriched > 0 && mounted) {
+        ref.invalidate(mediaForDiveProvider(widget.diveId));
+      }
+    } catch (_) {
+      // Best-effort: a failure just leaves those markers absent this session.
+    }
+  }
+  // coverage:ignore-end
 
   void _exitSelectionMode() {
     setState(() {
@@ -259,6 +300,7 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
   @override
   Widget build(BuildContext context) {
     final mediaAsync = ref.watch(mediaForDiveProvider(widget.diveId));
+    _scheduleEnrichmentBackfill(mediaAsync.valueOrNull);
     final settings = ref.watch(settingsProvider);
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;

--- a/lib/features/media/presentation/widgets/file_review_card.dart
+++ b/lib/features/media/presentation/widgets/file_review_card.dart
@@ -52,7 +52,7 @@ class FileReviewCard extends ConsumerWidget {
       return const SizedBox(
         width: 48,
         height: 48,
-        child: Icon(Icons.movie_outlined, size: 32),
+        child: Center(child: Icon(Icons.movie_outlined, size: 32)),
       );
     }
     return Image.file(

--- a/lib/features/media/presentation/widgets/file_review_card.dart
+++ b/lib/features/media/presentation/widgets/file_review_card.dart
@@ -26,19 +26,7 @@ class FileReviewCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // TODO(media): l10n
     return ListTile(
-      leading: Image.file(
-        file.file,
-        width: 48,
-        height: 48,
-        fit: BoxFit.cover,
-        // coverage:ignore-start
-        // FileImage failure is dispatched on the async decoder isolate and
-        // doesn't fire deterministically under `flutter test` without a real
-        // image-decoding pipeline. Exercised by manual desktop smoke tests.
-        errorBuilder: (_, _, _) =>
-            const Icon(Icons.broken_image_outlined, size: 32),
-        // coverage:ignore-end
-      ),
+      leading: _buildLeading(),
       title: Text(
         p.basename(file.sourcePath),
         maxLines: 1,
@@ -54,6 +42,31 @@ class FileReviewCard extends ConsumerWidget {
             .read(filesTabNotifierProvider.notifier)
             .removeFile(file.sourcePath),
       ),
+    );
+  }
+
+  /// A 48x48 leading preview. Videos can't be decoded by [Image.file], so they
+  /// get an explicit video icon rather than the broken-image error fallback.
+  Widget _buildLeading() {
+    if (file.metadata.mimeType.startsWith('video/')) {
+      return const SizedBox(
+        width: 48,
+        height: 48,
+        child: Icon(Icons.movie_outlined, size: 32),
+      );
+    }
+    return Image.file(
+      file.file,
+      width: 48,
+      height: 48,
+      fit: BoxFit.cover,
+      // coverage:ignore-start
+      // FileImage failure is dispatched on the async decoder isolate and
+      // doesn't fire deterministically under `flutter test` without a real
+      // image-decoding pipeline. Exercised by manual desktop smoke tests.
+      errorBuilder: (_, _, _) =>
+          const Icon(Icons.broken_image_outlined, size: 32),
+      // coverage:ignore-end
     );
   }
 }

--- a/lib/features/media/presentation/widgets/files_tab.dart
+++ b/lib/features/media/presentation/widgets/files_tab.dart
@@ -27,11 +27,18 @@ import 'package:submersion/features/media/presentation/widgets/file_review_pane.
 ///
 /// Commit flow (Task 13) layers on top.
 ///
-/// Photos only — local-file video imports are out of scope for Phase 2:
-/// `PhotoViewerPage` does not yet resolve playable file paths for
-/// `MediaSourceType.localFile` videos. The picker is filtered to
-/// `FileType.image`, the folder enumerator excludes video extensions, and
-/// the commit loop drops any video MIME defensively.
+/// Photos and videos: the picker uses `FileType.media`, the folder enumerator
+/// admits `.mp4/.mov/.m4v`, and the commit loop persists each with its
+/// [MediaType]. A picked file's capture time comes from its own metadata
+/// (JPEG EXIF or the MP4/MOV `mvhd`) via the `ExifExtractor`, so both match
+/// dives on every platform.
+///
+/// Playback caveat: `PhotoViewerPage` resolves a local-file video by
+/// `localPath`, which is populated on macOS/Windows/Linux but null on iOS
+/// (where only a security-scoped bookmark is stored). Local-file video
+/// playback on iOS therefore still needs bookmark->path resolution; until
+/// then an iOS-imported video matches and stores but shows the viewer's
+/// video-unavailable state rather than playing.
 class FilesTab extends ConsumerWidget {
   const FilesTab({super.key});
 
@@ -43,10 +50,11 @@ class FilesTab extends ConsumerWidget {
   // build() rendering branches that this method drives — extraction
   // progress, empty/non-empty file lists — are tested via `files_tab_test`.
   Future<void> _pickFiles(WidgetRef ref) async {
-    // FileType.image excludes video extensions at the OS picker layer.
-    // Phase 2 has no local-file video playback yet; see class doc.
+    // FileType.media admits both images and videos at the OS picker layer.
+    // Their capture time is recovered by ExifExtractor (JPEG EXIF or the
+    // MP4/MOV mvhd) so both match dives; see class doc.
     final result = await FilePicker.pickFiles(
-      type: FileType.image,
+      type: FileType.media,
       allowMultiple: true,
     );
     if (result == null) return;
@@ -190,7 +198,7 @@ class FilesTab extends ConsumerWidget {
                     .toggleAutoMatch(),
               ),
               const Expanded(
-                child: Text('Auto-match photos to dives by EXIF date'),
+                child: Text('Auto-match photos and videos to dives by date'),
               ),
             ],
           ),
@@ -242,9 +250,16 @@ class FilesTab extends ConsumerWidget {
   // exercised by manual desktop smoke tests + by the notifier unit tests.
   Future<void> _commit(BuildContext context, WidgetRef ref) async {
     final notifier = ref.read(filesTabNotifierProvider.notifier);
+    // The picker uses a bare Scaffold, so this resolves to the root
+    // ScaffoldMessenger, which outlives the pop below and shows the snackbar
+    // on the dive-detail view we return to.
     final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     final created = await notifier.commit();
     if (!context.mounted) return;
+    // Return to the dive-detail view now that the files are linked; the grid
+    // refreshes reactively via mediaForDiveProvider's watchDiveDetailChanges.
+    navigator.pop();
     // TODO(media): l10n, pluralization
     messenger.showSnackBar(
       SnackBar(
@@ -273,8 +288,20 @@ class FilesTab extends ConsumerWidget {
 /// Caps at 5,000 files per the Phase 2 spec to bound memory and the
 /// subsequent EXIF extraction loop.
 Future<List<String>> _enumerateMediaFiles(String rootPath) async {
-  // Photos only in Phase 2; see [FilesTab] class doc.
-  const exts = {'.jpg', '.jpeg', '.heic', '.heif', '.png', '.webp', '.gif'};
+  // Images plus the video containers whose mvhd creation_time the capture-time
+  // reader understands (see [FilesTab] class doc).
+  const exts = {
+    '.jpg',
+    '.jpeg',
+    '.heic',
+    '.heif',
+    '.png',
+    '.webp',
+    '.gif',
+    '.mp4',
+    '.mov',
+    '.m4v',
+  };
   final results = <String>[];
   final dir = Directory(rootPath);
   if (!dir.existsSync()) return results;

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -186,9 +186,16 @@ class _VideoThumbnailPlaceholder extends StatelessWidget {
   }
 }
 
-/// Graceful fallback when image bytes fail to decode (corrupt/unsupported),
-/// so the raw "Invalid image data" exception never reaches the UI.
-Widget _imageError(BuildContext context, Object error, StackTrace? stack) =>
-    const UnavailableMediaPlaceholder(
-      data: UnavailableData(kind: UnavailableKind.notFound),
-    );
+/// Graceful fallback when image bytes fail to decode (corrupt/unsupported), so
+/// the raw "Invalid image data" exception never reaches the UI. Shows a
+/// broken-image tile rather than the "file not found" placeholder: the file is
+/// present, it just couldn't be rendered.
+Widget _imageError(BuildContext context, Object error, StackTrace? stack) {
+  final scheme = Theme.of(context).colorScheme;
+  return ColoredBox(
+    color: scheme.surfaceContainerHighest,
+    child: Center(
+      child: Icon(Icons.broken_image_outlined, color: scheme.onSurfaceVariant),
+    ),
+  );
+}

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -127,7 +127,17 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         }
         final data = snapshot.data!;
         return switch (data) {
-          FileData(file: final f) => Image.file(f, fit: widget.fit),
+          // A local video resolves to the raw video file, which Image.file
+          // cannot decode. Show a placeholder instead of surfacing an
+          // "Invalid image data" exception. (Connector video posters arrive as
+          // BytesData JPEGs below and render normally.)
+          FileData() when widget.item.isVideo =>
+            const _VideoThumbnailPlaceholder(),
+          FileData(file: final f) => Image.file(
+            f,
+            fit: widget.fit,
+            errorBuilder: _imageError,
+          ),
           NetworkData(url: final u, headers: final h) => CachedNetworkImage(
             imageUrl: u.toString(),
             httpHeaders: h,
@@ -137,7 +147,11 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
               data: UnavailableData(kind: UnavailableKind.networkError),
             ),
           ),
-          BytesData(bytes: final b) => Image.memory(b, fit: widget.fit),
+          BytesData(bytes: final b) => Image.memory(
+            b,
+            fit: widget.fit,
+            errorBuilder: _imageError,
+          ),
           UnavailableData() => UnavailableMediaPlaceholder(data: data),
         };
       },
@@ -154,3 +168,27 @@ class _ShimmerThumbnail extends StatelessWidget {
     );
   }
 }
+
+/// Neutral tile shown in place of a decodable image for local videos (whose
+/// raw bytes Image.file/Image.memory cannot render). The grid stacks its own
+/// videocam badge over this.
+class _VideoThumbnailPlaceholder extends StatelessWidget {
+  const _VideoThumbnailPlaceholder();
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return ColoredBox(
+      color: scheme.surfaceContainerHighest,
+      child: Center(
+        child: Icon(Icons.movie_outlined, color: scheme.onSurfaceVariant),
+      ),
+    );
+  }
+}
+
+/// Graceful fallback when image bytes fail to decode (corrupt/unsupported),
+/// so the raw "Invalid image data" exception never reaches the UI.
+Widget _imageError(BuildContext context, Object error, StackTrace? stack) =>
+    const UnavailableMediaPlaceholder(
+      data: UnavailableData(kind: UnavailableKind.notFound),
+    );

--- a/test/features/media/data/services/capture_time_reader_test.dart
+++ b/test/features/media/data/services/capture_time_reader_test.dart
@@ -97,6 +97,21 @@ void main() {
       expect(readLocalCaptureTime(f, 'video/mp4'), isNull);
     });
 
+    test('unknown mvhd version returns null (falls back to mtime)', () async {
+      // Spec allows only v0/v1. A corrupt byte here must not be parsed as v0,
+      // which would emit a plausible-but-wrong timestamp.
+      final badVersion = <int>[
+        2, 0, 0, 0, // version 2 + flags
+        ..._u32(goProRaw),
+        ..._u32(0),
+        ..._u32(1000),
+        ..._u32(0),
+      ];
+      final f = File('${tempDir.path}/badver.mp4')
+        ..writeAsBytesSync(_goProMp4(badVersion));
+      expect(readLocalCaptureTime(f, 'video/mp4'), isNull);
+    });
+
     test('truncated / non-MP4 bytes return null without throwing', () async {
       final f = File('${tempDir.path}/junk.mp4')
         ..writeAsBytesSync([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/test/features/media/data/services/capture_time_reader_test.dart
+++ b/test/features/media/data/services/capture_time_reader_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:submersion/features/media/data/services/capture_time_reader.dart';
+
+// Big-endian byte builders for hand-assembling MP4/MOV boxes.
+List<int> _u32(int v) => [
+  (v >> 24) & 0xff,
+  (v >> 16) & 0xff,
+  (v >> 8) & 0xff,
+  v & 0xff,
+];
+List<int> _u64(int v) => [..._u32(v >> 32), ..._u32(v & 0xffffffff)];
+
+/// A box is [size:uint32][type:4 ascii][payload]. When [largeSize] is set the
+/// box uses the 64-bit form (size field == 1, followed by an 8-byte size).
+List<int> _box(String type, List<int> payload, {bool largeSize = false}) {
+  if (largeSize) {
+    return [
+      ..._u32(1),
+      ...type.codeUnits,
+      ..._u64(16 + payload.length),
+      ...payload,
+    ];
+  }
+  return [..._u32(8 + payload.length), ...type.codeUnits, ...payload];
+}
+
+List<int> _mvhdV0(int creationTime) => [
+  0, 0, 0, 0, // version 0 + 3 flag bytes
+  ..._u32(creationTime),
+  ..._u32(0), // modification_time
+  ..._u32(1000), // timescale
+  ..._u32(0), // duration
+];
+
+List<int> _mvhdV1(int creationTime) => [
+  1, 0, 0, 0, // version 1 + 3 flag bytes
+  ..._u64(creationTime),
+  ..._u64(0), // modification_time
+  ..._u32(1000), // timescale
+  ..._u64(0), // duration
+];
+
+/// Mirrors the real GoPro layout: ftyp, then a large mdat, then moov LAST.
+List<int> _goProMp4(List<int> mvhd, {bool largeMdat = false}) => [
+  ..._box('ftyp', 'isom'.codeUnits),
+  ..._box('mdat', List<int>.filled(largeMdat ? 4096 : 8, 0)),
+  ..._box('moov', _box('mvhd', mvhd)),
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('capture_time_');
+  });
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  group('MP4/MOV creation_time', () {
+    // Real value read from the user's GoPro Tortuga clip (GX015934-2.MP4):
+    // mvhd creation_time raw = 3849681049 -> 2025-12-27 11:50:49 UTC, which
+    // falls inside that dive's 11:26-12:09 window. Used here as the test vector.
+    const goProRaw = 3849681049;
+    final expected = DateTime.utc(2025, 12, 27, 11, 50, 49);
+
+    test('reads mvhd v0 with moov after mdat (GoPro layout)', () async {
+      final f = File('${tempDir.path}/gopro.mp4')
+        ..writeAsBytesSync(_goProMp4(_mvhdV0(goProRaw)));
+      expect(readLocalCaptureTime(f, 'video/mp4'), expected);
+    });
+
+    test('result is wall-clock UTC', () async {
+      final f = File('${tempDir.path}/g.mp4')
+        ..writeAsBytesSync(_goProMp4(_mvhdV0(goProRaw)));
+      expect(readLocalCaptureTime(f, 'video/mp4')!.isUtc, isTrue);
+    });
+
+    test('reads mvhd v1 (64-bit creation_time)', () async {
+      final f = File('${tempDir.path}/v1.mov')
+        ..writeAsBytesSync(_goProMp4(_mvhdV1(goProRaw)));
+      expect(readLocalCaptureTime(f, 'video/quicktime'), expected);
+    });
+
+    test('handles a large mdat without reading it all', () async {
+      final f = File('${tempDir.path}/big.mp4')
+        ..writeAsBytesSync(_goProMp4(_mvhdV0(goProRaw), largeMdat: true));
+      expect(readLocalCaptureTime(f, 'video/mp4'), expected);
+    });
+
+    test('creation_time of 0 (unknown) returns null', () async {
+      final f = File('${tempDir.path}/zero.mp4')
+        ..writeAsBytesSync(_goProMp4(_mvhdV0(0)));
+      expect(readLocalCaptureTime(f, 'video/mp4'), isNull);
+    });
+
+    test('truncated / non-MP4 bytes return null without throwing', () async {
+      final f = File('${tempDir.path}/junk.mp4')
+        ..writeAsBytesSync([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(readLocalCaptureTime(f, 'video/mp4'), isNull);
+    });
+  });
+
+  group('JPEG EXIF (shared reader)', () {
+    test('reads DateTimeOriginal from JPEG bytes', () async {
+      final image = img.Image(width: 4, height: 4);
+      image.exif.exifIfd['DateTimeOriginal'] = '2025:12:27 12:08:19';
+      final f = File('${tempDir.path}/p.jpg')
+        ..writeAsBytesSync(img.encodeJpg(image));
+      expect(
+        readLocalCaptureTime(f, 'image/jpeg'),
+        DateTime.utc(2025, 12, 27, 12, 8, 19),
+      );
+    });
+
+    test('unsupported mime returns null', () async {
+      final f = File('${tempDir.path}/x.png')..writeAsBytesSync([0x89, 0x50]);
+      expect(readLocalCaptureTime(f, 'image/png'), isNull);
+    });
+  });
+}

--- a/test/features/media/data/services/dive_media_enricher_test.dart
+++ b/test/features/media/data/services/dive_media_enricher_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/services/dive_media_enricher.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+Dive _diveWithProfile() => Dive(
+  id: 'd1',
+  dateTime: DateTime.utc(2025, 12, 27, 11, 26),
+  entryTime: DateTime.utc(2025, 12, 27, 11, 26),
+  profile: const [
+    DiveProfilePoint(timestamp: 0, depth: 0),
+    DiveProfilePoint(timestamp: 2520, depth: 20, temperature: 26), // 42 min in
+    DiveProfilePoint(timestamp: 2580, depth: 5),
+  ],
+);
+
+MediaItem _media(
+  String id, {
+  required DateTime takenAt,
+  MediaEnrichment? enrichment,
+}) => MediaItem(
+  id: id,
+  diveId: 'd1',
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.localFile,
+  takenAt: takenAt,
+  enrichment: enrichment,
+  createdAt: DateTime.utc(2025),
+  updatedAt: DateTime.utc(2025),
+);
+
+void main() {
+  test('enriches a linked item that has no enrichment yet', () async {
+    final saved = <MediaEnrichment>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => _diveWithProfile(),
+      loadMediaForDive: (_) async => [
+        // Shutter at 12:08 == 2520s (42 min) after the 11:26 entry.
+        _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
+      ],
+      saveEnrichment: (e) async => saved.add(e),
+    );
+
+    final count = await enricher.enrichMissingForDive('d1');
+
+    expect(count, 1);
+    expect(saved, hasLength(1));
+    expect(saved.single.mediaId, 'm1');
+    expect(saved.single.diveId, 'd1');
+    expect(saved.single.elapsedSeconds, 2520);
+    expect(saved.single.depthMeters, 20.0);
+  });
+
+  test('is idempotent: skips items already enriched', () async {
+    final saved = <MediaEnrichment>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => _diveWithProfile(),
+      loadMediaForDive: (_) async => [
+        _media(
+          'm1',
+          takenAt: DateTime.utc(2025, 12, 27, 12, 8),
+          enrichment: MediaEnrichment(
+            id: 'e1',
+            mediaId: 'm1',
+            diveId: 'd1',
+            elapsedSeconds: 2520,
+            matchConfidence: MatchConfidence.exact,
+            createdAt: DateTime.utc(2025),
+          ),
+        ),
+      ],
+      saveEnrichment: (e) async => saved.add(e),
+    );
+
+    expect(await enricher.enrichMissingForDive('d1'), 0);
+    expect(saved, isEmpty);
+  });
+
+  test('returns 0 and saves nothing when the dive has no profile', () async {
+    final saved = <MediaEnrichment>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => Dive(id: 'd1', dateTime: DateTime.utc(2025)),
+      loadMediaForDive: (_) async => [
+        _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
+      ],
+      saveEnrichment: (e) async => saved.add(e),
+    );
+
+    expect(await enricher.enrichMissingForDive('d1'), 0);
+    expect(saved, isEmpty);
+  });
+
+  test('skips instructor signatures (never plotted on the chart)', () async {
+    final saved = <MediaEnrichment>[];
+    final signature = MediaItem(
+      id: 'sig',
+      diveId: 'd1',
+      mediaType: MediaType.instructorSignature,
+      sourceType: MediaSourceType.localFile,
+      takenAt: DateTime.utc(2025, 12, 27, 12, 8),
+      createdAt: DateTime.utc(2025),
+      updatedAt: DateTime.utc(2025),
+    );
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => _diveWithProfile(),
+      loadMediaForDive: (_) async => [signature],
+      saveEnrichment: (e) async => saved.add(e),
+    );
+
+    expect(await enricher.enrichMissingForDive('d1'), 0);
+    expect(saved, isEmpty);
+  });
+
+  test('returns 0 when the dive is not found', () async {
+    final saved = <MediaEnrichment>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => null,
+      loadMediaForDive: (_) async => [
+        _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
+      ],
+      saveEnrichment: (e) async => saved.add(e),
+    );
+
+    expect(await enricher.enrichMissingForDive('d1'), 0);
+    expect(saved, isEmpty);
+  });
+}

--- a/test/features/media/data/services/exif_extractor_test.dart
+++ b/test/features/media/data/services/exif_extractor_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
 import 'package:submersion/features/media/data/services/exif_extractor.dart';
 
 void main() {
@@ -265,6 +266,66 @@ void main() {
         expect(meta!.takenAt, isNotNull); // mtime fallback
       },
     );
+  });
+
+  group('pure-Dart image fallback (native_exif unavailable)', () {
+    // No mocked native_exif channel in this group: Exif.fromPath throws
+    // MissingPluginException, exactly as it does on macOS/Windows/Linux where
+    // native_exif has no platform implementation. The extractor must then
+    // recover the shutter time from the JPEG's own EXIF bytes via the pure-Dart
+    // `image` package instead of silently falling back to the file mtime (which
+    // is the copy-to-disk time and never matches the dive window).
+    Uint8List jpegWithDateTimeOriginal(String exifDate) {
+      final image = img.Image(width: 4, height: 4);
+      image.exif.exifIfd['DateTimeOriginal'] = exifDate;
+      return img.encodeJpg(image);
+    }
+
+    test(
+      'reads DateTimeOriginal from JPEG bytes when native_exif is absent',
+      () async {
+        final f = File('${tempDir.path}/gopro.jpg')
+          ..writeAsBytesSync(jpegWithDateTimeOriginal('2025:12:27 12:08:19'));
+        final meta = await ExifExtractor().extract(f);
+        expect(meta, isNotNull);
+        // The real shutter time from EXIF, not the file's copy-to-disk mtime.
+        expect(meta!.takenAt, DateTime.utc(2025, 12, 27, 12, 8, 19));
+        // Wall-clock-UTC convention so the matcher compares against dive times.
+        expect(meta.takenAt!.isUtc, isTrue);
+      },
+    );
+
+    test('falls back to DateTime when DateTimeOriginal is absent', () async {
+      final image = img.Image(width: 4, height: 4);
+      image.exif.imageIfd['DateTime'] = '2025:12:27 12:08:19';
+      final f = File('${tempDir.path}/only_datetime.jpg')
+        ..writeAsBytesSync(img.encodeJpg(image));
+      final meta = await ExifExtractor().extract(f);
+      expect(meta!.takenAt, DateTime.utc(2025, 12, 27, 12, 8, 19));
+    });
+
+    test('non-JPEG with no EXIF still falls back to mtime', () async {
+      // A .png (or any non-JPEG) has no readable EXIF via decodeJpgExif; the
+      // extractor must not crash and should return the mtime fallback.
+      final f = File('${tempDir.path}/plain.png')
+        ..writeAsBytesSync([0x89, 0x50, 0x4e, 0x47, 0, 1, 2, 3]);
+      final meta = await ExifExtractor().extract(f);
+      expect(meta, isNotNull);
+      expect(meta!.takenAt, isNotNull); // mtime fallback, close to now
+      final now = DateTime.now();
+      final nowAsWallUtc = DateTime.utc(
+        now.year,
+        now.month,
+        now.day,
+        now.hour,
+        now.minute,
+        now.second,
+      );
+      expect(
+        meta.takenAt!.difference(nowAsWallUtc).abs(),
+        lessThan(const Duration(minutes: 5)),
+      );
+    });
   });
 
   test('large files (>5 MB) take the compute() isolate path', () async {

--- a/test/features/media/presentation/providers/files_tab_providers_test.dart
+++ b/test/features/media/presentation/providers/files_tab_providers_test.dart
@@ -359,48 +359,46 @@ void main() {
       },
     );
 
-    test(
-      'commit skips video MIME files (Phase 2 photo-only constraint)',
-      () async {
-        // Phase 2 doesn't yet support local-file video playback — videos
-        // are filtered at the picker, but `commit()` defends against pick
-        // bypass by skipping any video MIME inside the loop.
-        final photo = _ef(
-          '/a.jpg',
-          metadata: const MediaSourceMetadata(mimeType: 'image/jpeg'),
-        );
-        final video = _ef(
-          '/b.mp4',
-          metadata: const MediaSourceMetadata(mimeType: 'video/mp4'),
-        );
-        final notifier = container.read(filesTabNotifierProvider.notifier);
-        notifier.setFiles(
-          [photo, video],
-          match: MatchedSelection(
-            matched: {
-              'd1': [photo, video],
-            },
-            unmatched: const [],
-          ),
-        );
+    test('commit persists video MIME files as MediaType.video', () async {
+      // Local-file video import is supported on desktop: the file resolves
+      // by localPath and plays via VideoPlayerController.file, so commit()
+      // persists videos alongside photos and tags the row MediaType.video.
+      final photo = _ef(
+        '/a.jpg',
+        metadata: const MediaSourceMetadata(mimeType: 'image/jpeg'),
+      );
+      final video = _ef(
+        '/b.mp4',
+        metadata: const MediaSourceMetadata(mimeType: 'video/mp4'),
+      );
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      notifier.setFiles(
+        [photo, video],
+        match: MatchedSelection(
+          matched: {
+            'd1': [photo, video],
+          },
+          unmatched: const [],
+        ),
+      );
 
-        when(
-          mockPlatform.createBookmark(any),
-        ).thenAnswer((_) async => Uint8List.fromList([1]));
-        when(mockBookmarkStorage.write(any, any)).thenAnswer((_) async {});
-        when(
-          mockRepo.createMedia(any),
-        ).thenAnswer((_) async => _saved('saved-1'));
+      when(
+        mockPlatform.createBookmark(any),
+      ).thenAnswer((_) async => Uint8List.fromList([1]));
+      when(mockBookmarkStorage.write(any, any)).thenAnswer((_) async {});
+      when(
+        mockRepo.createMedia(any),
+      ).thenAnswer((_) async => _saved('saved-1'));
 
-        final created = await notifier.commit();
+      final created = await notifier.commit();
 
-        // Only the photo was persisted — the video MIME entry was dropped.
-        expect(created.length, 1);
-        final captured = verify(mockRepo.createMedia(captureAny)).captured;
-        expect(captured.length, 1);
-        expect((captured.single as MediaItem).mediaType, MediaType.photo);
-      },
-    );
+      // Both the photo and the video were persisted.
+      expect(created.length, 2);
+      final captured = verify(mockRepo.createMedia(captureAny)).captured;
+      expect(captured.length, 2);
+      final types = captured.map((c) => (c as MediaItem).mediaType).toList();
+      expect(types, containsAll([MediaType.photo, MediaType.video]));
+    });
 
     test('commit on empty match returns empty list and clears state', () async {
       final notifier = container.read(filesTabNotifierProvider.notifier);

--- a/test/features/media/presentation/widgets/file_review_card_test.dart
+++ b/test/features/media/presentation/widgets/file_review_card_test.dart
@@ -78,6 +78,30 @@ void main() {
     expect(find.byTooltip('Remove from selection'), findsOneWidget);
   });
 
+  testWidgets('renders a video icon (not Image.file) for video MIME', (
+    tester,
+  ) async {
+    final file = _ef(
+      '/tmp/clip.mp4',
+      metadata: const MediaSourceMetadata(mimeType: 'video/mp4'),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: FileReviewCard(file: file, targetDiveId: 'd1'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Videos can't be decoded as images; show an explicit video icon rather
+    // than Image.file's broken-image fallback (which reads as an error).
+    expect(find.byIcon(Icons.movie_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+  });
+
   // Note: the `errorBuilder` for `Image.file` in `FileReviewCard` is the
   // broken-image fallback. It is not exercised here because `FileImage`'s
   // load failure is dispatched on the asynchronous decoder isolate and

--- a/test/features/media/presentation/widgets/media_item_view_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -153,7 +154,37 @@ final _pngBytes = Uint8List.fromList([
   0x82,
 ]);
 
+MediaItem _videoItem({String id = 'v'}) => MediaItem(
+  id: id,
+  mediaType: MediaType.video,
+  sourceType: MediaSourceType.localFile,
+  takenAt: DateTime.utc(2024, 1, 1),
+  createdAt: DateTime.utc(2024, 1, 1),
+  updatedAt: DateTime.utc(2024, 1, 1),
+);
+
 void main() {
+  testWidgets('renders a video placeholder for a video FileData', (
+    tester,
+  ) async {
+    // A local video resolves to the raw video file, which Image.file cannot
+    // decode ("Invalid image data"). The view must show a video placeholder
+    // instead of feeding the file to Image.file.
+    final stub = _StubResolver(
+      FileData(file: File('/tmp/no-such-clip.mp4')),
+      MediaSourceType.localFile,
+    );
+    await tester.pumpWidget(
+      _wrap(
+        child: MediaItemView(item: _videoItem()),
+        resolver: stub,
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.movie_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+  });
+
   testWidgets('renders Image.memory for BytesData', (tester) async {
     final stub = _StubResolver(
       BytesData(bytes: _pngBytes),


### PR DESCRIPTION
## Summary

The file/folder media picker never auto-matched photos or videos to dives on
desktop. `native_exif` has no macOS/Windows/Linux implementation, so
`Exif.fromPath` threw `MissingPluginException` and every picked file silently
fell back to its filesystem mtime (copy-to-disk time) instead of its capture
time — which never lands inside a dive's time window. This adds a pure-Dart
capture-time reader for both photos and videos, enables video import, and fixes
three follow-on issues so linked media shows up correctly.

## Changes

- **Desktop capture-time reader** (`capture_time_reader.dart`): reads JPEG EXIF
  `DateTimeOriginal` via `package:image` (`decodeJpgExif` — EXIF-only, no pixel
  decode) and the MP4/MOV `moov > mvhd` `creation_time` (seek-based; handles
  GoPro's `moov`-after-`mdat` layout and 32/64-bit box sizes). Used only when
  `native_exif` yields nothing, so iOS/Android are unchanged. GoPro writes local
  wall-clock into `mvhd`, which the app's wall-clock-UTC convention already
  expects.
- **Video import**: picker uses `FileType.media`, the folder enumerator accepts
  `.mp4/.mov/.m4v`, and `commit()` persists videos as `MediaType.video`.
- **Navigation**: linking returns to the dive detail view instead of staying on
  the Select Photos page.
- **Video thumbnails**: the grid shows a video placeholder instead of feeding
  raw video bytes to `Image.file` (which surfaced an "Invalid image data"
  error); added a graceful `errorBuilder` for any undecodable image.
- **Profile chart**: linked media now positions on the depth/time chart.
  `DiveMediaEnricher` computes the missing `MediaEnrichment` (elapsed seconds +
  depth) per item — the picker created the `MediaItem` row but no enrichment
  row, which the chart's marker builder requires. It is idempotent, so one
  trigger both enriches fresh links and backfills already-linked media.

## Test Plan

- [x] `flutter test` passes (full suite green; 12 new tests, all written TDD)
- [x] `flutter analyze` passes (clean, whole project)
- [x] Capture-time extraction validated against a real GoPro JPG and MP4 from a
      known dive (both decode to the correct in-window timestamp)
- [x] macOS: final pick → link → return-to-detail → chart-markers → video-tile
      smoke pass (earlier smoke surfaced the three follow-on bugs fixed here)

### Known follow-ups (out of scope)

- **HEIC/HEIF EXIF on desktop**: the picker and folder enumerator accept
  `.heic/.heif`, but the pure-Dart reader only parses JPEG EXIF — `package:image`
  can't decode HEIC. On desktop (no `native_exif`), HEIC photos still import and
  display but fall back to mtime, so they may not auto-match by date. A proper
  fix parses the HEIC ISO-BMFF `meta` box to locate the embedded EXIF item;
  it needs validation against a real HEIC file before shipping. HEIC matches
  correctly on iOS/Android today (native_exif handles it).
- Real per-frame video thumbnails (needs native frame extraction per platform;
  today local videos show a film-icon placeholder tile).
- iOS local-file video *playback* (`resolvedFilePathProvider` resolves by
  `localPath`, which is null on iOS where only a security-scoped bookmark
  exists). Import + matching work on iOS; playback does not yet.
- OCR `importLocalFileForDive` has the same enrichment gap this PR closes for
  the picker.
