### PR TITLE
fix(sync): stop restored/reset data from vanishing under cloud sync

### DIFF
--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -52,6 +52,19 @@ class DiverRepository {
     }
   }
 
+  /// Number of divers, counted in SQL without loading or mapping any rows.
+  ///
+  /// Used by the setup wizard's post-restore "did a library arrive?" gate,
+  /// which only needs existence -- loading and mapping every diver row (with
+  /// its emergency contacts, insurance, etc.) just to call `isNotEmpty` is
+  /// wasted work after a pull that may have brought in a large library.
+  Future<int> getDiverCount() async {
+    final result = await _db
+        .customSelect('SELECT COUNT(*) AS count FROM divers')
+        .getSingle();
+    return result.read<int>('count');
+  }
+
   /// Emits whenever the `divers` table changes so list providers can
   /// refresh after a sync or any other write.
   Stream<void> watchDiversChanges() =>

--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -59,10 +59,15 @@ class DiverRepository {
   /// its emergency contacts, insurance, etc.) just to call `isNotEmpty` is
   /// wasted work after a pull that may have brought in a large library.
   Future<int> getDiverCount() async {
-    final result = await _db
-        .customSelect('SELECT COUNT(*) AS count FROM divers')
-        .getSingle();
-    return result.read<int>('count');
+    try {
+      final result = await _db
+          .customSelect('SELECT COUNT(*) AS count FROM divers')
+          .getSingle();
+      return result.read<int>('count');
+    } catch (e, stackTrace) {
+      _log.error('Failed to get diver count', error: e, stackTrace: stackTrace);
+      rethrow;
+    }
   }
 
   /// Emits whenever the `divers` table changes so list providers can

--- a/lib/features/settings/presentation/pages/storage_settings_page.dart
+++ b/lib/features/settings/presentation/pages/storage_settings_page.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/database_migration_service.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/settings/presentation/pages/reset_complete_page.dart';
 import 'package:submersion/features/settings/presentation/providers/storage_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/existing_database_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/migration_confirmation_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/migration_progress_dialog.dart';
@@ -418,6 +419,17 @@ class _StorageSettingsPageState extends ConsumerState<StorageSettingsPage> {
   Future<void> _handleResetDatabase() async {
     final confirmed = await ResetDatabaseDialog.show(context);
     if (!confirmed || !mounted) return;
+
+    // Turn cloud sync off before wiping. Otherwise the post-reset launch sync
+    // re-pulls the entire cloud library and resurrects the data the user just
+    // cleared (the reset appears to do nothing). Best-effort: a failure here
+    // must not block the reset -- the worst case is the old re-pull behaviour.
+    try {
+      await ref.read(syncStateProvider.notifier).disableForDatabaseReset();
+    } catch (e) {
+      debugPrint('Could not disable cloud sync during reset: $e');
+    }
+    if (!mounted) return;
 
     // Generate a timestamped backup path
     final appDir = await getApplicationDocumentsDirectory();

--- a/lib/features/settings/presentation/pages/storage_settings_page.dart
+++ b/lib/features/settings/presentation/pages/storage_settings_page.dart
@@ -426,8 +426,8 @@ class _StorageSettingsPageState extends ConsumerState<StorageSettingsPage> {
     // must not block the reset -- the worst case is the old re-pull behaviour.
     try {
       await ref.read(syncStateProvider.notifier).disableForDatabaseReset();
-    } catch (e) {
-      debugPrint('Could not disable cloud sync during reset: $e');
+    } catch (e, st) {
+      debugPrint('Could not disable cloud sync during reset: $e\n$st');
     }
     if (!mounted) return;
 

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -1164,6 +1164,21 @@ class SyncNotifier extends StateNotifier<SyncState> {
     state = const SyncState();
   }
 
+  /// Turns cloud sync off as part of a database reset.
+  ///
+  /// Without this, wiping the local database is immediately undone: the
+  /// post-reset launch sync ([SubmersionApp]'s `_maybeSyncOnLaunch`) merges
+  /// the entire cloud library back in, resurrecting the data the user just
+  /// cleared. Disabling auto-sync closes that launch/resume path and signing
+  /// out disconnects the provider so a manual sync cannot re-pull either.
+  ///
+  /// The cloud library itself is left intact -- reconnecting sync re-adopts
+  /// it -- so this is a local-only reset, not a fleet-wide wipe.
+  Future<void> disableForDatabaseReset() async {
+    await _ref.read(syncBehaviorProvider.notifier).setAutoSyncEnabled(false);
+    await signOut();
+  }
+
   /// Reset sync state
   ///
   /// Also adopts a brand-new device identity. Reset is the user-facing

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -1175,8 +1175,30 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// The cloud library itself is left intact -- reconnecting sync re-adopts
   /// it -- so this is a local-only reset, not a fleet-wide wipe.
   Future<void> disableForDatabaseReset() async {
-    await _ref.read(syncBehaviorProvider.notifier).setAutoSyncEnabled(false);
-    await signOut();
+    // Two independent guards against the post-reset re-pull: disabling
+    // auto-sync closes the launch/resume sync, and signing out disconnects the
+    // provider so a manual sync cannot pull either. Attempt BOTH even if one
+    // throws -- either surviving still helps the reset stick -- then surface
+    // the first failure so the caller can log it.
+    Object? firstError;
+    StackTrace? firstStack;
+    Future<void> attempt(Future<void> Function() op) async {
+      try {
+        await op();
+      } catch (e, st) {
+        firstError ??= e;
+        firstStack ??= st;
+      }
+    }
+
+    await attempt(
+      () => _ref.read(syncBehaviorProvider.notifier).setAutoSyncEnabled(false),
+    );
+    await attempt(signOut);
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStack!);
+    }
   }
 
   /// Reset sync state

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -1175,6 +1175,13 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// The cloud library itself is left intact -- reconnecting sync re-adopts
   /// it -- so this is a local-only reset, not a fleet-wide wipe.
   Future<void> disableForDatabaseReset() async {
+    // Cancel any in-flight auto-sync debounce first. Its callback calls
+    // performSync(auto: true) WITHOUT re-checking autoSyncEnabled, so a timer
+    // scheduled by a write just before the reset would otherwise still fire and
+    // race the DB wipe (or re-pull). Flipping autoSyncEnabled below only stops
+    // NEW timers from being scheduled.
+    _autoSyncTimer?.cancel();
+
     // Two independent guards against the post-reset re-pull: disabling
     // auto-sync closes the launch/resume sync, and signing out disconnects the
     // provider so a manual sync cannot pull either. Attempt BOTH even if one

--- a/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
@@ -80,7 +80,7 @@ class _SyncConnectStepState extends ConsumerState<SyncConnectStep> {
       // hasAnyDiversProvider read reflects the freshly pulled rows.
       ref.invalidate(allDiversProvider);
       final hasDivers =
-          (await ref.read(diverRepositoryProvider).getAllDivers()).isNotEmpty;
+          (await ref.read(diverRepositoryProvider).getDiverCount()) > 0;
       if (mounted) {
         setState(() => _phase = hasDivers ? _PullPhase.done : _PullPhase.empty);
       }

--- a/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
@@ -74,8 +74,9 @@ class _SyncConnectStepState extends ConsumerState<SyncConnectStep> {
       // directly for the "did a library arrive?" decision: the cached diver
       // providers can still report empty here because their pause-aware
       // self-invalidation (Ref.invalidateSelfWhen) does not fire while nothing
-      // is listening to them in the wizard, so ref.read(hasAnyDiversProvider)
-      // would return the stale startup value and wrongly show "no library".
+      // is listening to them in the wizard, so ref.read(hasAnyDiversProvider
+      // .future) would return the stale startup value and wrongly show
+      // "no library".
       // Invalidate the cache too, so the dashboard redirect's later
       // hasAnyDiversProvider read reflects the freshly pulled rows.
       ref.invalidate(allDiversProvider);

--- a/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
@@ -70,6 +70,9 @@ class _SyncConnectStepState extends ConsumerState<SyncConnectStep> {
       await realignActiveDiverAfterDataReplace(
         ref.read(sharedPreferencesProvider),
       );
+      // The step can be disposed mid-pull (user backs out during the spinner);
+      // touching ref after that throws, so bail before invalidating/reading.
+      if (!mounted) return;
       // The pull wrote divers straight into the DB. Consult the repository
       // directly for the "did a library arrive?" decision: the cached diver
       // providers can still report empty here because their pause-aware

--- a/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
@@ -70,7 +70,17 @@ class _SyncConnectStepState extends ConsumerState<SyncConnectStep> {
       await realignActiveDiverAfterDataReplace(
         ref.read(sharedPreferencesProvider),
       );
-      final hasDivers = await ref.read(hasAnyDiversProvider.future);
+      // The pull wrote divers straight into the DB. Consult the repository
+      // directly for the "did a library arrive?" decision: the cached diver
+      // providers can still report empty here because their pause-aware
+      // self-invalidation (Ref.invalidateSelfWhen) does not fire while nothing
+      // is listening to them in the wizard, so ref.read(hasAnyDiversProvider)
+      // would return the stale startup value and wrongly show "no library".
+      // Invalidate the cache too, so the dashboard redirect's later
+      // hasAnyDiversProvider read reflects the freshly pulled rows.
+      ref.invalidate(allDiversProvider);
+      final hasDivers =
+          (await ref.read(diverRepositoryProvider).getAllDivers()).isNotEmpty;
       if (mounted) {
         setState(() => _phase = hasDivers ? _PullPhase.done : _PullPhase.empty);
       }

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -29,6 +29,9 @@ class _DrivableSyncNotifier extends StateNotifier<SyncState>
   Future<void> performSync({bool auto = false}) async {}
 
   @override
+  Future<void> disableForDatabaseReset() async {}
+
+  @override
   Future<FirstSyncMergeInfo?> firstSyncMergeInfo() async => null;
 
   @override

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -10,6 +10,9 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart'
+    as domain;
 
 class _FakeLocation implements DatabaseLocationService {
   _FakeLocation(this.path);
@@ -179,6 +182,27 @@ void main() {
       expect(diveTypes.read<int>('c'), greaterThan(0));
     },
   );
+
+  test('resetDatabase wipes user rows (divers), not just re-seeds', () async {
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(dbPath),
+    );
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+
+    final now = DateTime.now();
+    await DiverRepository().createDiver(
+      domain.Diver(id: '', name: 'Old Profile', createdAt: now, updatedAt: now),
+    );
+    expect(await DiverRepository().getAllDivers(), isNotEmpty);
+
+    final backupPath = p.join(tempDir.path, 'reset-backup.db');
+    await DatabaseService.instance.resetDatabase(backupPath: backupPath);
+
+    // After a reset the old profiles must be gone.
+    expect(await DiverRepository().getAllDivers(), isEmpty);
+  });
 
   test('a failing migration ladder closes the migrator and rethrows', () async {
     // Seed a current-schema file, then rewind user_version far back so the

--- a/test/features/divers/data/repositories/diver_repository_error_test.dart
+++ b/test/features/divers/data/repositories/diver_repository_error_test.dart
@@ -57,6 +57,9 @@ void main() {
         throwsA(anything),
       );
 
+      // getDiverCount - rethrows
+      await expectLater(repository.getDiverCount(), throwsA(anything));
+
       // getTotalBottomTimeForDiver - rethrows
       await expectLater(
         repository.getTotalBottomTimeForDiver('d1'),

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -163,6 +163,9 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> performSync({bool auto = false}) async => performSyncCalls++;
 
   @override
+  Future<void> disableForDatabaseReset() async {}
+
+  @override
   Future<FirstSyncMergeInfo?> firstSyncMergeInfo() async => firstSyncInfo;
 
   @override

--- a/test/features/settings/presentation/pages/storage_settings_reset_test.dart
+++ b/test/features/settings/presentation/pages/storage_settings_reset_test.dart
@@ -58,17 +58,28 @@ class _FakeStorageConfig extends StateNotifier<StorageConfigState>
 
 void main() {
   late SharedPreferences prefs;
+  late Directory tempDir;
 
   setUp(() async {
     await setUpTestDatabase();
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
-    PathProviderPlatform.instance = _FakePathProvider(
-      Directory.systemTemp.createTempSync('storage_reset_test').path,
-    );
+    tempDir = Directory.systemTemp.createTempSync('storage_reset_test');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
   });
 
-  tearDown(() => DatabaseService.instance.resetForTesting());
+  tearDown(() async {
+    // The reset can swap in an on-disk DB; close whatever is open (best-effort
+    // -- it may be null if the reset failed), reset the service, then drop the
+    // temp docs directory the reset may have written a fresh DB into.
+    try {
+      await DatabaseService.instance.database.close();
+    } catch (_) {}
+    DatabaseService.instance.resetForTesting();
+    try {
+      tempDir.deleteSync(recursive: true);
+    } catch (_) {}
+  });
 
   /// Pumps the storage page and drives the Reset Database confirm flow with
   /// [spy] wired in as the sync notifier.
@@ -98,6 +109,7 @@ void main() {
         currentDatabasePathProvider.overrideWith((ref) async => '/tmp/db'),
       ],
       child: const MaterialApp(
+        locale: Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: StorageSettingsPage(),

--- a/test/features/settings/presentation/pages/storage_settings_reset_test.dart
+++ b/test/features/settings/presentation/pages/storage_settings_reset_test.dart
@@ -30,12 +30,16 @@ class _FakePathProvider extends PathProviderPlatform
 /// Records whether the reset handler asked to turn cloud sync off.
 class _SpySyncNotifier extends StateNotifier<SyncState>
     implements SyncNotifier {
-  _SpySyncNotifier() : super(const SyncState());
+  _SpySyncNotifier({this.throwOnDisable = false}) : super(const SyncState());
 
+  final bool throwOnDisable;
   bool disableCalled = false;
 
   @override
-  Future<void> disableForDatabaseReset() async => disableCalled = true;
+  Future<void> disableForDatabaseReset() async {
+    disableCalled = true;
+    if (throwOnDisable) throw StateError('sync off failed');
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -54,7 +58,6 @@ class _FakeStorageConfig extends StateNotifier<StorageConfigState>
 
 void main() {
   late SharedPreferences prefs;
-  late _SpySyncNotifier spySync;
 
   setUp(() async {
     await setUpTestDatabase();
@@ -63,14 +66,13 @@ void main() {
     PathProviderPlatform.instance = _FakePathProvider(
       Directory.systemTemp.createTempSync('storage_reset_test').path,
     );
-    spySync = _SpySyncNotifier();
   });
 
   tearDown(() => DatabaseService.instance.resetForTesting());
 
-  testWidgets('Reset Database turns cloud sync off before wiping', (
-    tester,
-  ) async {
+  /// Pumps the storage page and drives the Reset Database confirm flow with
+  /// [spy] wired in as the sync notifier.
+  Future<void> tapReset(WidgetTester tester, _SpySyncNotifier spy) async {
     tester.view.physicalSize = const Size(1400, 3200);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(() {
@@ -81,7 +83,7 @@ void main() {
     final app = ProviderScope(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
-        syncStateProvider.overrideWith((ref) => spySync),
+        syncStateProvider.overrideWith((ref) => spy),
         storageConfigNotifierProvider.overrideWith(
           (ref) => _FakeStorageConfig(),
         ),
@@ -121,7 +123,23 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
     });
     await tester.pumpAndSettle();
+  }
 
-    expect(spySync.disableCalled, isTrue);
+  testWidgets('Reset Database turns cloud sync off before wiping', (
+    tester,
+  ) async {
+    final spy = _SpySyncNotifier();
+    await tapReset(tester, spy);
+    expect(spy.disableCalled, isTrue);
+  });
+
+  testWidgets('reset proceeds even if turning sync off throws', (tester) async {
+    // The sync-disable is best-effort: a failure must be swallowed (logged),
+    // not abort the reset.
+    final spy = _SpySyncNotifier(throwOnDisable: true);
+    await tapReset(tester, spy);
+    expect(spy.disableCalled, isTrue);
+    // The page did not crash; the reset flow continued past the failure.
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/features/settings/presentation/pages/storage_settings_reset_test.dart
+++ b/test/features/settings/presentation/pages/storage_settings_reset_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/domain/entities/storage_config.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/settings/presentation/pages/storage_settings_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/storage_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Routes getApplicationDocumentsDirectory to a temp dir so the reset handler's
+/// backup-path computation resolves inside the sandbox.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.docsPath);
+  final String docsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => docsPath;
+}
+
+/// Records whether the reset handler asked to turn cloud sync off.
+class _SpySyncNotifier extends StateNotifier<SyncState>
+    implements SyncNotifier {
+  _SpySyncNotifier() : super(const SyncState());
+
+  bool disableCalled = false;
+
+  @override
+  Future<void> disableForDatabaseReset() async => disableCalled = true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeStorageConfig extends StateNotifier<StorageConfigState>
+    implements StorageConfigNotifier {
+  _FakeStorageConfig()
+    : super(
+        const StorageConfigState(config: StorageConfig(), isLoading: false),
+      );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late _SpySyncNotifier spySync;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    PathProviderPlatform.instance = _FakePathProvider(
+      Directory.systemTemp.createTempSync('storage_reset_test').path,
+    );
+    spySync = _SpySyncNotifier();
+  });
+
+  tearDown(() => DatabaseService.instance.resetForTesting());
+
+  testWidgets('Reset Database turns cloud sync off before wiping', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 3200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final app = ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        syncStateProvider.overrideWith((ref) => spySync),
+        storageConfigNotifierProvider.overrideWith(
+          (ref) => _FakeStorageConfig(),
+        ),
+        storagePlatformCapabilitiesProvider.overrideWithValue(
+          const StoragePlatformCapabilities(
+            supportsCustomFolder: false,
+            supportsICloud: false,
+            supportsGoogleDrive: false,
+            isDesktop: true,
+          ),
+        ),
+        currentDatabasePathProvider.overrideWith((ref) async => '/tmp/db'),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: StorageSettingsPage(),
+      ),
+    );
+    // initState does real file I/O (getCurrentDatabaseInfo), which only runs
+    // under runAsync; pumping it there lets the loading spinner clear so the
+    // later pumpAndSettle can settle.
+    await tester.runAsync(() async {
+      await tester.pumpWidget(app);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pumpAndSettle();
+
+    // Open the reset dialog, type the confirmation, and confirm.
+    await tester.tap(find.text('Reset Database'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Delete');
+    await tester.pump();
+
+    await tester.runAsync(() async {
+      await tester.tap(find.widgetWithText(FilledButton, 'Reset'));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(spySync.disableCalled, isTrue);
+  });
+}

--- a/test/features/settings/presentation/providers/sync_providers_reset_disable_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_reset_disable_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
-import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_preferences.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -38,7 +37,7 @@ void main() {
     cloud = FakeCloudStorageProvider();
   });
 
-  tearDown(() => DatabaseService.instance.resetForTesting());
+  tearDown(tearDownTestDatabase);
 
   Future<ProviderContainer> makeContainer() async {
     final container = ProviderContainer(

--- a/test/features/settings/presentation/providers/sync_providers_reset_disable_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_reset_disable_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart'
+    show CloudProviderType;
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_preferences.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Fails when asked to disable auto-sync, to exercise the independent-guard
+/// path in [SyncNotifier.disableForDatabaseReset].
+class _ThrowingBehaviorNotifier extends SyncBehaviorNotifier {
+  _ThrowingBehaviorNotifier(super.prefs);
+
+  @override
+  Future<void> setAutoSyncEnabled(bool value) async =>
+      throw StateError('setAutoSyncEnabled failed');
+}
+
+/// Coverage for the REAL SyncNotifier.disableForDatabaseReset() -- the guard
+/// that stops a database reset from being immediately undone by the launch
+/// sync re-pulling the cloud library. The storage-settings widget tests use a
+/// fake notifier, so the real method is only exercised here.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferences prefs;
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(() => DatabaseService.instance.resetForTesting());
+
+  Future<ProviderContainer> makeContainer() async {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(cloud),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(syncStateProvider);
+    await container.read(syncStateProvider.notifier).refreshState();
+    return container;
+  }
+
+  test(
+    'disables auto-sync and signs out so a reset is not re-pulled',
+    () async {
+      final container = await makeContainer();
+      await container
+          .read(syncBehaviorProvider.notifier)
+          .setAutoSyncEnabled(true);
+      container.read(selectedCloudProviderTypeProvider.notifier).state =
+          CloudProviderType.icloud;
+
+      await container
+          .read(syncStateProvider.notifier)
+          .disableForDatabaseReset();
+
+      // Auto-sync off closes the launch/resume re-pull path...
+      expect(container.read(syncBehaviorProvider).autoSyncEnabled, isFalse);
+      // ...and the provider is disconnected so a manual sync cannot pull.
+      expect(container.read(selectedCloudProviderTypeProvider), isNull);
+    },
+  );
+
+  test(
+    'still signs out (and rethrows) when disabling auto-sync throws',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+          syncBehaviorProvider.overrideWith(
+            (ref) => _ThrowingBehaviorNotifier(SyncPreferences(prefs)),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(syncStateProvider);
+      await container.read(syncStateProvider.notifier).refreshState();
+      container.read(selectedCloudProviderTypeProvider.notifier).state =
+          CloudProviderType.icloud;
+
+      // The first guard throws, but the second must still run, and the failure
+      // must surface so the caller can log it.
+      await expectLater(
+        container.read(syncStateProvider.notifier).disableForDatabaseReset(),
+        throwsA(isA<StateError>()),
+      );
+      expect(container.read(selectedCloudProviderTypeProvider), isNull);
+    },
+  );
+}

--- a/test/features/settings/presentation/s3_config_page_test.dart
+++ b/test/features/settings/presentation/s3_config_page_test.dart
@@ -118,6 +118,9 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> performSync({bool auto = false}) async {}
 
   @override
+  Future<void> disableForDatabaseReset() async {}
+
+  @override
   Future<FirstSyncMergeInfo?> firstSyncMergeInfo() async => null;
 
   @override

--- a/test/features/setup_wizard/presentation/widgets/steps/sync_connect_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/sync_connect_step_test.dart
@@ -109,6 +109,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
+        locale: const Locale('en'),
         overrides: await overrides(),
         child: Builder(
           builder: (context) {
@@ -141,6 +142,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
+        locale: const Locale('en'),
         overrides: await overrides(),
         child: Builder(
           builder: (context) {
@@ -174,6 +176,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
+        locale: const Locale('en'),
         overrides: await overrides(),
         child: Builder(
           builder: (context) {
@@ -213,6 +216,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
+        locale: const Locale('en'),
         overrides: await overrides(failSync: true),
         child: Builder(
           builder: (context) {
@@ -252,6 +256,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
+        locale: const Locale('en'),
         overrides: await overrides(onSync: _writeSyncedDiver),
         child: Builder(
           builder: (context) {
@@ -298,6 +303,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
+        locale: const Locale('en'),
         overrides: [
           ...base,
           isApplePlatformProvider.overrideWithValue(false),
@@ -377,6 +383,7 @@ void main() {
     );
     await tester.pumpWidget(
       testAppRouter(
+        locale: const Locale('en'),
         router: router,
         overrides: await overrides(onSync: _writeSyncedDiver),
       ),

--- a/test/features/setup_wizard/presentation/widgets/steps/sync_connect_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/sync_connect_step_test.dart
@@ -7,6 +7,8 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/sync/sync_initializer.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/setup_wizard/domain/setup_wizard_models.dart';
@@ -35,19 +37,39 @@ class _FakeSyncInit implements SyncInitializer {
 
 class _FakeSyncNotifier extends StateNotifier<SyncState>
     implements SyncNotifier {
-  _FakeSyncNotifier({this.failSync = false}) : super(const SyncState());
+  _FakeSyncNotifier({this.failSync = false, this.onSync})
+    : super(const SyncState());
 
   final bool failSync;
+
+  /// Simulates the side effect of a real pull: writes rows into the live DB.
+  final Future<void> Function()? onSync;
 
   @override
   Future<void> performSync({bool auto = false}) async {
     if (failSync) {
       state = const SyncState(status: SyncStatus.error, message: 'sync boom');
+      return;
     }
+    if (onSync != null) await onSync!();
   }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Writes a diver into the live test DB, mimicking what a real pull persists.
+Future<void> _writeSyncedDiver() async {
+  final now = DateTime.now();
+  await DiverRepository().createDiver(
+    Diver(
+      id: '',
+      name: 'Synced Diver',
+      isDefault: true,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
 }
 
 void main() {
@@ -63,6 +85,7 @@ void main() {
   Future<List<Override>> overrides({
     bool hasDivers = true,
     bool failSync = false,
+    Future<void> Function()? onSync,
   }) async {
     final base = await getBaseOverrides();
     return [
@@ -74,7 +97,7 @@ void main() {
       ),
       syncInitializerProvider.overrideWithValue(syncInit),
       syncStateProvider.overrideWith(
-        (ref) => _FakeSyncNotifier(failSync: failSync),
+        (ref) => _FakeSyncNotifier(failSync: failSync, onSync: onSync),
       ),
       hasAnyDiversProvider.overrideWith((ref) async => hasDivers),
     ];
@@ -229,7 +252,7 @@ void main() {
     late ProviderContainer container;
     await tester.pumpWidget(
       testApp(
-        overrides: await overrides(hasDivers: true),
+        overrides: await overrides(onSync: _writeSyncedDiver),
         child: Builder(
           builder: (context) {
             container = ProviderScope.containerOf(context);
@@ -254,6 +277,66 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Library adopted'), findsOneWidget);
+  });
+
+  testWidgets('pulled divers are adopted even when the diver cache is stale', (
+    tester,
+  ) async {
+    // Reproduces the setup-wizard bug: the pull writes a diver straight into
+    // the DB, but the cached diver providers still report empty because their
+    // pause-aware self-invalidation never fired (nothing is listening to
+    // allDiversProvider in the wizard). The step must consult the live DB, not
+    // the stale cache, or it wrongly shows "No library found" and pivots fresh.
+    syncInit.peers = [
+      CloudFileInfo(
+        id: 'a',
+        name: 'peer.manifest.json',
+        modifiedTime: DateTime(2026),
+      ),
+    ];
+    final base = await getBaseOverrides();
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          iCloudAvailabilityProvider.overrideWith(
+            (ref) async => ICloudAvailability.unsupported,
+          ),
+          syncInitializerProvider.overrideWithValue(syncInit),
+          syncStateProvider.overrideWith(
+            (ref) => _FakeSyncNotifier(onSync: _writeSyncedDiver),
+          ),
+          // Stale cache: the DB has a diver, but the provider reports empty.
+          allDiversProvider.overrideWith((ref) async => <Diver>[]),
+        ],
+        child: Builder(
+          builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return SyncConnectStep(
+              mode: SetupWizardMode.firstRun,
+              onNoLibrary: () {},
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    container
+        .read(setupWizardProvider(SetupWizardMode.firstRun).notifier)
+        .setConnectedProvider(CloudProviderType.s3);
+    await tester.pumpAndSettle();
+
+    await tester.runAsync(() async {
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.text('Library adopted'), findsOneWidget);
+    expect(find.text('No library found'), findsNothing);
   });
 
   testWidgets('adopted screen Continue navigates to the dashboard', (
@@ -293,7 +376,10 @@ void main() {
       ],
     );
     await tester.pumpWidget(
-      testAppRouter(router: router, overrides: await overrides()),
+      testAppRouter(
+        router: router,
+        overrides: await overrides(onSync: _writeSyncedDiver),
+      ),
     );
     await tester.pumpAndSettle();
     container!


### PR DESCRIPTION
## Summary

Fixes two related failures where cloud-synced dive data appeared to be lost.

### 1. Setup-wizard cloud-sync restore reported "no library found"

In a fresh setup, restoring via cloud sync said the library could not be found and pushed the user to create a new profile — even though the pull had actually populated the database.

**Root cause:** after `performSync()` writes the pulled library into the local DB, the wizard's "did data arrive?" gate read `hasAnyDiversProvider`. That derives from `allDiversProvider`, whose pause-aware self-invalidation (`Ref.invalidateSelfWhen`) never fired because nothing was actively listening to it in the wizard, so the read returned the value cached at startup (empty).

**Fix:** read the repository directly for the gate decision and invalidate `allDiversProvider`, so both the decision and the subsequent dashboard redirect reflect the freshly pulled rows.

### 2. Reset Database was undone by cloud sync

"Reset Database" wiped the local DB, but the next launch's auto-sync (`_maybeSyncOnLaunch`) re-pulled the entire cloud library and resurrected the cleared data — so the reset appeared to do nothing.

**Fix:** reset now turns cloud sync off (disconnect provider + disable auto-sync) via a new `SyncNotifier.disableForDatabaseReset()` before wiping, so the reset sticks. The cloud library itself is left intact — a local-only reset that reconnecting sync re-adopts. (A fleet-wide "reset cloud too" variant would instead reuse the restore-style replace intent.)

## Changes

- `sync_connect_step.dart`: gate the post-pull "library adopted vs. no library" decision on a live repository read and invalidate `allDiversProvider` (fixes bug 1).
- `sync_providers.dart`: add `SyncNotifier.disableForDatabaseReset()` (disable auto-sync + sign out).
- `storage_settings_page.dart`: call `disableForDatabaseReset()` from the reset handler before wiping; best-effort so a failure never blocks the reset (fixes bug 2).
- Tests: regression test reproducing the stale-cache restore gate; a test asserting `resetDatabase` clears user rows (not just re-seeds); update the `implements SyncNotifier` test fakes for the new method.

## Test Plan

- [x] `flutter test` passes (affected suites: setup_wizard, settings, divers, backup, core/services — green)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] Manual testing on: macOS. Reset with iCloud sync enabled now leaves the on-disk DB empty (`divers=0`) and `sync_auto_enabled=false`; before the fix the file re-populated to the full library within seconds of the launch sync.

## Screenshots

<!-- Not applicable: behavior/data fix, no UI changes. -->
