### PR TITLE
fix(sync): replicate linked media depth/time association (media_enrichment)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-media-enrichment-sync.md
+++ b/docs/superpowers/plans/2026-07-20-media-enrichment-sync.md
@@ -1,0 +1,830 @@
+# Media Enrichment Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a linked photo/video's depth/time association (the `MediaEnrichment` row) replicate through sync so it is no longer lost on a second device or after a restore.
+
+**Architecture:** `MediaEnrichment` is depth/temperature/elapsed data projected onto the dive profile at the media's capture time. Today it is computed once at import and stored only in the local DB — it is not a synced entity (absent from `SyncService.entityHasUpdatedAt`, no serializer case, no `hlc` column), even though `MediaRepository.saveEnrichment` already calls `markRecordPending('mediaEnrichment', …)`. We complete that half-finished wiring: add an `hlc` column (schema v130), register `mediaEnrichment` as a first-class HLC-synced child entity across the sync engine (mirroring `mediaStores`), and run a one-time runtime backfill so pre-v130 rows (which carry `hlc = NULL` and are invisible to the incremental export) get a fresh HLC and heal already-affected peers.
+
+**Tech Stack:** Flutter, Drift ORM (SQLite), Riverpod. HLC (Hybrid Logical Clock) based incremental sync.
+
+## Global Constraints
+
+- **Schema version:** bump `AppDatabase.currentSchemaVersion` from `129` to `130`. Parallel open PRs may also claim v130; on a merge conflict in `database.dart`, keep BOTH idempotent migration blocks inside the single `if (from < 130)` step (precedent: the v103 media-store / dive-roles collision). `currentSchemaVersion` stays `130`.
+- **Codegen:** after any change to a Drift `Table` class, run `dart run build_runner build --delete-conflicting-outputs` before compiling/testing.
+- **Formatting:** run `dart format .` (whole project) before committing; CI treats `prefer_const`-class infos as fatal, so run `flutter analyze` on the WHOLE project and keep it clean.
+- **No new l10n:** this change is engine/schema-only; no user-facing strings.
+- **Commits/PR:** no `Co-Authored-By` line, no Claude Code attribution, no session URL in commit messages or the PR body.
+- **Entity naming:** the sync entity key is the camelCase string `'mediaEnrichment'`; the SQL table is `media_enrichment`; the Drift getter is `_db.mediaEnrichment`; the generated row class is `MediaEnrichmentData`; the companion is `MediaEnrichmentCompanion`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `lib/core/database/database.dart` | Schema, migrations, beforeOpen backstops | Add `hlc` column to `MediaEnrichment`; bump version; add v130 migration + backstop helper |
+| `lib/core/database/database.g.dart` | Generated Drift code | Regenerated (never hand-edited) |
+| `lib/core/services/sync/sync_data_serializer.dart` | `SyncData` model + per-entity (de)serialization, export, upsert, delete | Add `mediaEnrichment` field + all serializer cases + `_exportMediaEnrichment` |
+| `lib/core/services/sync/sync_service.dart` | Sync orchestration, entity registry, merge order, FK guards | Register `mediaEnrichment` in `entityHasUpdatedAt`, `mergeOrder`, `parentRefs`; call backfill |
+| `lib/core/data/repositories/sync_repository.dart` | HLC stamping, mark-pending, backfill | Add `_hlcTargets` entry; add `backfillMediaEnrichmentHlc()` |
+| `test/core/database/migration_v130_media_enrichment_hlc_test.dart` | Migration coverage + version tripwire | Create |
+| `test/core/database/migration_v129_quality_findings_test.dart` | Old tripwire | Relax exact `==129` to `>=129` |
+| `test/core/services/sync/sync_media_enrichment_test.dart` | End-to-end sync replication for enrichment | Create |
+| `test/core/services/sync/sync_parent_refs_completeness_test.dart` | FK-guard completeness | Add `media_enrichment` to `syncedTables`, `media` to `deletableParents` |
+
+---
+
+## Task 1: Schema v130 — add `hlc` column to `media_enrichment`
+
+**Files:**
+- Modify: `lib/core/database/database.dart` (table def; `currentSchemaVersion`; `migrationVersions`; new `_assertMediaEnrichmentHlcColumn()` helper; onUpgrade block; beforeOpen call)
+- Regenerate: `lib/core/database/database.g.dart`
+- Create: `test/core/database/migration_v130_media_enrichment_hlc_test.dart`
+- Modify: `test/core/database/migration_v129_quality_findings_test.dart`
+
+**Interfaces:**
+- Produces: `media_enrichment.hlc` column (nullable TEXT); `AppDatabase.currentSchemaVersion == 130`; `_assertMediaEnrichmentHlcColumn()` idempotent helper. Task 2/3 rely on the `hlc` column existing.
+
+- [ ] **Step 1: Write the failing migration test**
+
+Create `test/core/database/migration_v130_media_enrichment_hlc_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+import '../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = createTestDatabase();
+  });
+
+  tearDown(() => db.close());
+
+  test('media_enrichment has an hlc column', () async {
+    final rows = await db
+        .customSelect("PRAGMA table_info('media_enrichment')")
+        .get();
+    final cols = [for (final r in rows) r.read<String>('name')];
+    expect(
+      cols,
+      containsAll([
+        'id',
+        'media_id',
+        'dive_id',
+        'depth_meters',
+        'temperature_celsius',
+        'elapsed_seconds',
+        'match_confidence',
+        'timestamp_offset_seconds',
+        'created_at',
+        'hlc',
+      ]),
+    );
+  });
+
+  test('v130 is the current schema version (exact-latest tripwire)', () {
+    expect(AppDatabase.currentSchemaVersion, 130);
+    expect(AppDatabase.migrationVersions, contains(130));
+  });
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `flutter test test/core/database/migration_v130_media_enrichment_hlc_test.dart`
+Expected: FAIL — `hlc` not in columns and `currentSchemaVersion` is 129.
+
+- [ ] **Step 3: Add the `hlc` column to the table**
+
+In `lib/core/database/database.dart`, in `class MediaEnrichment extends Table`, after the `createdAt` getter and before `@override Set<Column> get primaryKey`, add:
+
+```dart
+  IntColumn get createdAt => integer()();
+  // v130: sync replication. media_enrichment is the depth/time association
+  // for a linked photo; without an hlc it never travelled through sync and
+  // was lost on other devices / after restore.
+  TextColumn get hlc => text().nullable()();
+```
+
+- [ ] **Step 4: Bump the schema version and register the migration version**
+
+Change `static const int currentSchemaVersion = 129;` to `= 130;`.
+
+In the `static const List<int> migrationVersions = [ … ]` list, append `130,` after the existing final `129,` entry.
+
+- [ ] **Step 5: Add the idempotent backstop helper**
+
+In `lib/core/database/database.dart`, next to the other `_assert…` helpers (e.g. beside `_assertMediaStoreSchema`), add:
+
+```dart
+  /// v130: media_enrichment.hlc column. Self-guarding when the table is
+  /// absent (partial-schema migration tests) and PRAGMA-guarded so it is safe
+  /// to call from both onUpgrade and the beforeOpen backstop (parallel-branch
+  /// collision self-heal).
+  Future<void> _assertMediaEnrichmentHlcColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('media_enrichment')",
+    ).get();
+    final hasColumn = cols.any((c) => c.read<String>('name') == 'hlc');
+    if (cols.isNotEmpty && !hasColumn) {
+      await customStatement(
+        'ALTER TABLE media_enrichment ADD COLUMN hlc TEXT',
+      );
+    }
+  }
+```
+
+- [ ] **Step 6: Wire the onUpgrade step**
+
+In the `onUpgrade` chain, after the `if (from < 129) await reportProgress();` line, add:
+
+```dart
+      // v130: media_enrichment.hlc so the depth/time association syncs.
+      if (from < 130) {
+        await _assertMediaEnrichmentHlcColumn();
+      }
+      if (from < 130) await reportProgress();
+```
+
+- [ ] **Step 7: Wire the beforeOpen backstop**
+
+In the `beforeOpen` block, next to the `await _assertMediaStoreSchema();` call, add:
+
+```dart
+        await _assertMediaEnrichmentHlcColumn();
+```
+
+- [ ] **Step 8: Regenerate Drift code**
+
+Run: `dart run build_runner build --delete-conflicting-outputs`
+Expected: `MediaEnrichmentData` gains an `hlc` field; its `fromJson`/`toJson`/`toCompanion` include `hlc`.
+
+- [ ] **Step 9: Relax the old tripwire**
+
+In `test/core/database/migration_v129_quality_findings_test.dart`, change:
+
+```dart
+    expect(AppDatabase.currentSchemaVersion, 129);
+    expect(AppDatabase.migrationVersions, contains(129));
+```
+
+to:
+
+```dart
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(129));
+    expect(AppDatabase.migrationVersions, contains(129));
+```
+
+- [ ] **Step 10: Run both migration tests**
+
+Run: `flutter test test/core/database/migration_v130_media_enrichment_hlc_test.dart test/core/database/migration_v129_quality_findings_test.dart`
+Expected: PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add lib/core/database/database.dart lib/core/database/database.g.dart \
+  test/core/database/migration_v130_media_enrichment_hlc_test.dart \
+  test/core/database/migration_v129_quality_findings_test.dart
+git commit -m "feat(sync): add hlc column to media_enrichment (schema v130)"
+```
+
+---
+
+## Task 2: Register `mediaEnrichment` as a synced entity
+
+Drive this task with the end-to-end sync test; it exercises export, upsert, batch, `deleteAllRecords`, `recordIdsFor`, `SyncData.fromJson`, and `performSync`, plus the two parity/completeness tests fail until every site is wired. Land all sites together (the parity tests require the `SyncData` field and the `entityHasUpdatedAt` key to move as a pair).
+
+**Files:**
+- Create: `test/core/services/sync/sync_media_enrichment_test.dart`
+- Modify: `lib/core/services/sync/sync_data_serializer.dart`
+- Modify: `lib/core/services/sync/sync_service.dart`
+- Modify: `lib/core/data/repositories/sync_repository.dart`
+- Modify: `test/core/services/sync/sync_parent_refs_completeness_test.dart`
+
+**Interfaces:**
+- Consumes: `media_enrichment.hlc` column (Task 1).
+- Produces: `SyncData.mediaEnrichment` (`List<Map<String, dynamic>>`); serializer handling for the `'mediaEnrichment'` entity key; `_hlcTargets['mediaEnrichment']` (Task 3 relies on this so `markRecordPending` stamps the HLC).
+
+- [ ] **Step 1: Write the failing sync test**
+
+Create `test/core/services/sync/sync_media_enrichment_test.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/changeset_test_helpers.dart';
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Sync replication for `media_enrichment` (the depth/time association for a
+/// linked photo). Like `media_stores`/`buddy_roles`, this table carries its
+/// own `hlc` column, so its export uses the simple hlc-filter pattern. Unlike
+/// them it is a child of both `media` and `dives`, so each fixture seeds those
+/// parent rows first.
+void main() {
+  group('media_enrichment sync', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    String hlcAt(int physical, String node) =>
+        '${physical.toString().padLeft(15, '0')}:000000:$node';
+
+    Map<String, dynamic> diveRow(String id) => {
+      'id': id,
+      'diveNumber': 1,
+      'diveDateTime': 1000,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    };
+
+    Map<String, dynamic> mediaRow(String id, String diveId) => {
+      'id': id,
+      'diveId': diveId,
+      'filePath': '/photos/$id.jpg',
+      'fileType': 'photo',
+      'sourceType': 'platformGallery',
+      'isFavorite': false,
+      'isOrphaned': false,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    };
+
+    Map<String, dynamic> enrichmentRow(
+      String id, {
+      required String mediaId,
+      required String diveId,
+      required String hlc,
+    }) => {
+      'id': id,
+      'mediaId': mediaId,
+      'diveId': diveId,
+      'depthMeters': 18.3,
+      'temperatureCelsius': 21.0,
+      'elapsedSeconds': 600,
+      'matchConfidence': 'exact',
+      'timestampOffsetSeconds': 0,
+      'createdAt': 1000,
+      'hlc': hlc,
+    };
+
+    Future<void> seedParents(
+      SyncDataSerializer s, {
+      required String diveId,
+      required String mediaId,
+    }) async {
+      await s.upsertRecord('dives', diveRow(diveId));
+      await s.upsertRecord('media', mediaRow(mediaId, diveId));
+    }
+
+    test('full export includes a media_enrichment row', () async {
+      final s = SyncDataSerializer();
+      await seedParents(s, diveId: 'd1', mediaId: 'm1');
+      await s.upsertRecord(
+        'mediaEnrichment',
+        enrichmentRow('e1', mediaId: 'm1', diveId: 'd1',
+            hlc: hlcAt(1000, 'dev-a')),
+      );
+
+      final payload = await s.exportData(deviceId: 'dev-a', deletions: const []);
+
+      expect(
+        payload.data.mediaEnrichment.map((r) => r['id']).toSet(),
+        contains('e1'),
+      );
+    });
+
+    test('round trip: wipe and re-import restores depth and confidence',
+        () async {
+      final s = SyncDataSerializer();
+      await seedParents(s, diveId: 'd1', mediaId: 'm1');
+      await s.upsertRecord(
+        'mediaEnrichment',
+        enrichmentRow('e1', mediaId: 'm1', diveId: 'd1',
+            hlc: hlcAt(1000, 'dev-a')),
+      );
+
+      final payload = await s.exportData(deviceId: 'dev-a', deletions: const []);
+      final exported =
+          payload.data.mediaEnrichment.singleWhere((r) => r['id'] == 'e1');
+
+      final db = DatabaseService.instance.database;
+      await s.deleteAllRecords('mediaEnrichment');
+      expect(
+        await (db.select(db.mediaEnrichment)
+              ..where((t) => t.id.equals('e1')))
+            .getSingleOrNull(),
+        isNull,
+        reason: 'sanity: the wipe actually removed the row',
+      );
+
+      await s.upsertRecord('mediaEnrichment', exported);
+
+      final restored = await (db.select(db.mediaEnrichment)
+            ..where((t) => t.id.equals('e1')))
+          .getSingle();
+      expect(restored.depthMeters, 18.3);
+      expect(restored.matchConfidence, 'exact');
+      expect(restored.diveId, 'd1');
+    });
+
+    test('incremental export: only rows with hlc > watermark are included',
+        () async {
+      final s = SyncDataSerializer();
+      await seedParents(s, diveId: 'd1', mediaId: 'm1');
+      await s.upsertRecord('media', mediaRow('m2', 'd1'));
+      await s.upsertRecord(
+        'mediaEnrichment',
+        enrichmentRow('e-old', mediaId: 'm1', diveId: 'd1',
+            hlc: hlcAt(1000, 'dev-a')),
+      );
+      await s.upsertRecord(
+        'mediaEnrichment',
+        enrichmentRow('e-new', mediaId: 'm2', diveId: 'd1',
+            hlc: hlcAt(9000, 'dev-a')),
+      );
+
+      final changeset = await s.exportChangeset(
+        deviceId: 'dev-a',
+        hlcWatermark: hlcAt(5000, 'dev-a'),
+        deletions: const [],
+      );
+
+      final ids = changeset.data.mediaEnrichment.map((r) => r['id']).toSet();
+      expect(ids, contains('e-new'));
+      expect(ids, isNot(contains('e-old')));
+    });
+
+    test('per-record plumbing: recordIdsFor, deleteRecord, SyncData.fromJson',
+        () async {
+      final s = SyncDataSerializer();
+      await seedParents(s, diveId: 'd1', mediaId: 'm1');
+      await s.upsertRecord(
+        'mediaEnrichment',
+        enrichmentRow('e1', mediaId: 'm1', diveId: 'd1',
+            hlc: hlcAt(1000, 'dev-a')),
+      );
+
+      expect(await s.recordIdsFor('mediaEnrichment'), {'e1'});
+
+      final payload = await s.exportData(deviceId: 'dev-a', deletions: const []);
+      final rehydrated = SyncData.fromJson(payload.data.toJson());
+      expect(
+        rehydrated.mediaEnrichment.map((r) => r['id']),
+        contains('e1'),
+      );
+
+      await s.deleteRecord('mediaEnrichment', 'e1');
+      expect(await s.recordIdsFor('mediaEnrichment'), isEmpty);
+    });
+
+    test('end to end: a peer-published enrichment replicates via performSync',
+        () async {
+      final cloud = FakeCloudStorageProvider();
+      final data = SyncData(
+        dives: [diveRow('d1')],
+        media: [mediaRow('m1', 'd1')],
+        mediaEnrichment: [
+          enrichmentRow('e1', mediaId: 'm1', diveId: 'd1',
+              hlc: hlcAt(1000, 'peer-dev')),
+        ],
+      );
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 9000,
+        deviceId: 'peer-dev',
+        checksum: sha256
+            .convert(utf8.encode(jsonEncode(data.toJson())))
+            .toString(),
+        data: data,
+        deletions: const {},
+      );
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+      ).performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final db = DatabaseService.instance.database;
+      final restored = await (db.select(db.mediaEnrichment)
+            ..where((t) => t.id.equals('e1')))
+          .getSingleOrNull();
+      expect(restored, isNotNull);
+      expect(restored!.depthMeters, 18.3);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `flutter test test/core/services/sync/sync_media_enrichment_test.dart`
+Expected: FAIL to COMPILE — `SyncData` has no `mediaEnrichment` member.
+
+> NOTE on the fixtures: the `diveRow`/`mediaRow` maps use the JSON keys Drift's `fromJson` expects (camelCase getter names). If a required non-null column is missing for your generated schema, the `upsertRecord` insert will throw — add the missing key using the column's Drift getter name. Keep the enrichment JSON keys exactly as the generated `MediaEnrichmentData.toJson()` emits them (verify by printing `payload.data.mediaEnrichment.first` once).
+
+- [ ] **Step 3: Add the `SyncData` field, ctor param, toJson, fromJson**
+
+In `lib/core/services/sync/sync_data_serializer.dart`, in `class SyncData`:
+- After the field `final List<Map<String, dynamic>> mediaStores;` add:
+  ```dart
+  final List<Map<String, dynamic>> mediaEnrichment;
+  ```
+- In the constructor, after `this.mediaStores = const [],` add:
+  ```dart
+  this.mediaEnrichment = const [],
+  ```
+- In `toJson()`, after `'mediaStores': mediaStores,` add:
+  ```dart
+  'mediaEnrichment': mediaEnrichment,
+  ```
+- In `fromJson()`, after `mediaStores: _parseList(json['mediaStores']),` add:
+  ```dart
+  mediaEnrichment: _parseList(json['mediaEnrichment']),
+  ```
+
+- [ ] **Step 4: Add the base-snapshot table entry and the export call**
+
+In `_baseTables`, after `(key: 'media', table: _db.media, blob: true, full: null),` add:
+
+```dart
+    (
+      key: 'mediaEnrichment',
+      table: _db.mediaEnrichment,
+      blob: false,
+      full: null,
+    ),
+```
+
+In `_buildSyncData(String? hlcSince)`, after the `media: await _safeExport('media', () => _exportMedia(hlcSince)),` line add:
+
+```dart
+      mediaEnrichment: await _safeExport(
+        'mediaEnrichment',
+        () => _exportMediaEnrichment(hlcSince),
+      ),
+```
+
+- [ ] **Step 5: Add the `_exportMediaEnrichment` method**
+
+Next to `_exportMediaStores`, add:
+
+```dart
+  Future<List<Map<String, dynamic>>> _exportMediaEnrichment(
+    String? hlcSince,
+  ) async {
+    final query = _db.select(_db.mediaEnrichment);
+    if (hlcSince != null) {
+      query.where((t) => t.hlc.isBiggerThanValue(hlcSince));
+    }
+    final rows = await query.get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+```
+
+- [ ] **Step 6: Add the per-entity switch cases**
+
+Mirror the adjacent `case 'mediaStores':` in each switch, swapping table/class. Add to each:
+
+`fetchRecord`:
+```dart
+      case 'mediaEnrichment':
+        final row = await (_db.select(_db.mediaEnrichment)
+              ..where((t) => t.id.equals(recordId)))
+            .getSingleOrNull();
+        return row?.toJson();
+```
+
+`fetchRecords` (use whatever the local id-list param is named — it is the same one the `'mediaStores'` case uses):
+```dart
+      case 'mediaEnrichment':
+        final rows = await (_db.select(_db.mediaEnrichment)
+              ..where((t) => t.id.isIn(idList)))
+            .get();
+        return {for (final r in rows) r.id: r.toJson()};
+```
+
+`upsertRecord`:
+```dart
+      case 'mediaEnrichment':
+        await _db
+            .into(_db.mediaEnrichment)
+            .insertOnConflictUpdate(
+              MediaEnrichmentData.fromJson(data).toCompanion(false),
+            );
+        return;
+```
+
+`upsertRecords`:
+```dart
+      case 'mediaEnrichment':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.mediaEnrichment,
+            records
+                .map((r) => MediaEnrichmentData.fromJson(r).toCompanion(false))
+                .toList(),
+          ),
+        );
+        return;
+```
+
+`recordIdsFor`:
+```dart
+      case 'mediaEnrichment':
+        return plain(_db.mediaEnrichment, _db.mediaEnrichment.id);
+```
+
+`_syncTableFor`:
+```dart
+      case 'mediaEnrichment':
+        return _db.mediaEnrichment;
+```
+
+`deleteRecord`:
+```dart
+      case 'mediaEnrichment':
+        await (_db.delete(_db.mediaEnrichment)
+              ..where((t) => t.id.equals(recordId)))
+            .go();
+        return;
+```
+
+- [ ] **Step 7: Register in `sync_service.dart`**
+
+In `entityHasUpdatedAt`, after `'media': false,` add:
+```dart
+    'mediaEnrichment': false,
+```
+
+In `mergeOrder`, after `(type: 'media', records: data.media, hasUpdatedAt: false),` add:
+```dart
+          (
+            type: 'mediaEnrichment',
+            records: data.mediaEnrichment,
+            hasUpdatedAt: false,
+          ),
+```
+
+In `parentRefs`, add a new entry (place it near the other dive-child entries):
+```dart
+    'mediaEnrichment': [
+      (field: 'mediaId', parent: 'media', nullable: false),
+      (field: 'diveId', parent: 'dives', nullable: false),
+    ],
+```
+
+- [ ] **Step 8: Register the HLC target in `sync_repository.dart`**
+
+In `_hlcTargets`, after `'media': (table: 'media', pk: 'id'),` add:
+```dart
+    'mediaEnrichment': (table: 'media_enrichment', pk: 'id'),
+```
+
+- [ ] **Step 9: Update the parent-refs completeness test**
+
+In `test/core/services/sync/sync_parent_refs_completeness_test.dart`:
+- In the `syncedTables` map, after `'media': 'media',` add:
+  ```dart
+    'media_enrichment': 'mediaEnrichment',
+  ```
+- In the `deletableParents` map, add (so the test verifies the `mediaId` guard too):
+  ```dart
+    'media': 'media',
+  ```
+
+- [ ] **Step 10: Run the new test + the parity/completeness guards**
+
+Run:
+```bash
+flutter test \
+  test/core/services/sync/sync_media_enrichment_test.dart \
+  test/core/services/sync/sync_parent_refs_completeness_test.dart \
+  test/core/services/sync/sync_data_serializer_record_ids_test.dart
+```
+Expected: PASS. (The record-ids guard and the `entityHasUpdatedAt covers exactly the SyncData entities` parity test now include `mediaEnrichment` automatically.)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add lib/core/services/sync/sync_data_serializer.dart \
+  lib/core/services/sync/sync_service.dart \
+  lib/core/data/repositories/sync_repository.dart \
+  test/core/services/sync/sync_media_enrichment_test.dart \
+  test/core/services/sync/sync_parent_refs_completeness_test.dart
+git commit -m "feat(sync): replicate media_enrichment as a first-class HLC entity"
+```
+
+---
+
+## Task 3: One-time self-heal backfill for pre-v130 rows
+
+**Files:**
+- Modify: `lib/core/data/repositories/sync_repository.dart` (add `backfillMediaEnrichmentHlc()`)
+- Modify: `lib/core/services/sync/sync_service.dart` (call it in `performSync`)
+- Create: `test/core/services/sync/sync_enrichment_backfill_test.dart`
+
+**Interfaces:**
+- Consumes: `_hlcTargets['mediaEnrichment']` (Task 2) so `markRecordPending` stamps the HLC; `media_enrichment.hlc` column (Task 1).
+- Produces: `SyncRepository.backfillMediaEnrichmentHlc()`.
+
+- [ ] **Step 1: Write the failing backfill test**
+
+Create `test/core/services/sync/sync_enrichment_backfill_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Pre-v130 media_enrichment rows have hlc = NULL and are invisible to the
+/// incremental export. The backfill stamps a fresh HLC so they replicate.
+void main() {
+  setUp(() async => setUpTestDatabase());
+  tearDown(() async => tearDownTestDatabase());
+
+  test('stamps hlc + a pending sync record on null-hlc enrichment rows',
+      () async {
+    final db = DatabaseService.instance.database;
+    // A parent dive + media (FK) and an enrichment row with NO hlc, as written
+    // by a pre-v130 build.
+    await db.customStatement(
+      "INSERT INTO dives (id, dive_number, dive_date_time, created_at, "
+      "updated_at) VALUES ('d1', 1, 1000, 1000, 1000)",
+    );
+    await db.customStatement(
+      "INSERT INTO media (id, dive_id, file_path, file_type, source_type, "
+      "is_favorite, is_orphaned, created_at, updated_at) "
+      "VALUES ('m1', 'd1', '/p.jpg', 'photo', 'platformGallery', 0, 0, "
+      "1000, 1000)",
+    );
+    await db.customStatement(
+      "INSERT INTO media_enrichment (id, media_id, dive_id, depth_meters, "
+      "match_confidence, created_at) "
+      "VALUES ('e1', 'm1', 'd1', 12.5, 'exact', 1000)",
+    );
+
+    await SyncRepository().backfillMediaEnrichmentHlc();
+
+    final row = await (db.select(db.mediaEnrichment)
+          ..where((t) => t.id.equals('e1')))
+        .getSingle();
+    expect(row.hlc, isNotNull);
+
+    final pending = await (db.select(db.syncRecords)
+          ..where((t) => t.entityType.equals('mediaEnrichment')))
+        .get();
+    expect(pending.map((r) => r.recordId), contains('e1'));
+  });
+
+  test('is a no-op the second time (self-limiting)', () async {
+    final db = DatabaseService.instance.database;
+    await db.customStatement(
+      "INSERT INTO dives (id, dive_number, dive_date_time, created_at, "
+      "updated_at) VALUES ('d1', 1, 1000, 1000, 1000)",
+    );
+    await db.customStatement(
+      "INSERT INTO media (id, dive_id, file_path, file_type, source_type, "
+      "is_favorite, is_orphaned, created_at, updated_at) "
+      "VALUES ('m1', 'd1', '/p.jpg', 'photo', 'platformGallery', 0, 0, "
+      "1000, 1000)",
+    );
+    await db.customStatement(
+      "INSERT INTO media_enrichment (id, media_id, dive_id, match_confidence, "
+      "created_at) VALUES ('e1', 'm1', 'd1', 'exact', 1000)",
+    );
+
+    await SyncRepository().backfillMediaEnrichmentHlc();
+    final first = (await (db.select(db.mediaEnrichment)
+              ..where((t) => t.id.equals('e1')))
+            .getSingle())
+        .hlc;
+    await SyncRepository().backfillMediaEnrichmentHlc();
+    final second = (await (db.select(db.mediaEnrichment)
+              ..where((t) => t.id.equals('e1')))
+            .getSingle())
+        .hlc;
+
+    expect(second, first, reason: 'row already had an hlc; not re-stamped');
+  });
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `flutter test test/core/services/sync/sync_enrichment_backfill_test.dart`
+Expected: FAIL — `backfillMediaEnrichmentHlc` is undefined.
+
+- [ ] **Step 3: Implement the backfill in `sync_repository.dart`**
+
+Add to `class SyncRepository`:
+
+```dart
+  /// One-time self-heal for enrichment rows written before schema v130, when
+  /// media_enrichment had no `hlc` column and never synced. Such rows carry
+  /// `hlc IS NULL` and are invisible to the incremental export (which filters
+  /// `hlc > watermark`; SQL `NULL > x` is false). markRecordPending stamps a
+  /// fresh HLC (above every peer watermark) so they replicate on the next
+  /// sync and heal peers that lost the depth/time association.
+  ///
+  /// Self-limiting: rows written by saveEnrichment always get an HLC, so once
+  /// every legacy row is stamped this finds nothing.
+  Future<void> backfillMediaEnrichmentHlc() async {
+    final rows = await _db
+        .customSelect(
+          'SELECT id, created_at FROM media_enrichment WHERE hlc IS NULL',
+        )
+        .get();
+    for (final row in rows) {
+      await markRecordPending(
+        entityType: 'mediaEnrichment',
+        recordId: row.read<String>('id'),
+        localUpdatedAt: row.read<int>('created_at'),
+      );
+    }
+  }
+```
+
+- [ ] **Step 4: Call it from `performSync`**
+
+In `lib/core/services/sync/sync_service.dart`, in `performSync`, immediately after `await _syncRepository.ensureSyncClockConfigured();`, add:
+
+```dart
+      // Self-heal: stamp an HLC on pre-v130 enrichment rows so the depth/time
+      // association replicates and repairs peers that lost it.
+      await _syncRepository.backfillMediaEnrichmentHlc();
+```
+
+- [ ] **Step 5: Run the backfill test**
+
+Run: `flutter test test/core/services/sync/sync_enrichment_backfill_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/data/repositories/sync_repository.dart \
+  lib/core/services/sync/sync_service.dart \
+  test/core/services/sync/sync_enrichment_backfill_test.dart
+git commit -m "feat(sync): backfill hlc on legacy media_enrichment rows (self-heal)"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole sync + database + media test suites**
+
+Run:
+```bash
+flutter test test/core/services/sync/ test/core/database/ test/features/media/
+```
+Expected: PASS (no regressions). Investigate any failure before proceeding.
+
+- [ ] **Step 2: Analyze the whole project**
+
+Run: `flutter analyze`
+Expected: no errors, no new infos (CI treats infos as fatal).
+
+- [ ] **Step 3: Format the whole project**
+
+Run: `dart format .`
+Expected: no files changed (if any change, re-stage and amend the relevant commit).
+
+- [ ] **Step 4: Run the full test suite once**
+
+Run: `flutter test`
+Expected: PASS.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** depth/time now (a) travels in base + incremental payloads (`_baseTables`, `_exportMediaEnrichment`), (b) applies on peers (`upsertRecord`/`upsertRecords`, `mergeOrder`), (c) survives Replace-adopt (re-inserted from the cloud union like any synced entity), (d) heals already-broken libraries (`backfillMediaEnrichmentHlc`), and (e) is FK-safe under deferred-FK COMMIT (`parentRefs`).
+- **Deletion:** enrichment needs no tombstones — it cascade-deletes with its parent `media`/`dive` locally, and applying the parent's synced deletion cascades on peers too.
+- **Type consistency:** entity key `'mediaEnrichment'`, table `media_enrichment`, getter `_db.mediaEnrichment`, row class `MediaEnrichmentData`, companion `MediaEnrichmentCompanion` are used identically everywhere above.
+- **Placeholder scan:** none — every step carries concrete code or an exact command.

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -77,6 +77,7 @@ class SyncRepository {
     'csvPresets': (table: 'csv_presets', pk: 'id'),
     'viewConfigs': (table: 'view_configs', pk: 'id'),
     'media': (table: 'media', pk: 'id'),
+    'mediaEnrichment': (table: 'media_enrichment', pk: 'id'),
     'species': (table: 'species', pk: 'id'),
     'fieldPresets': (table: 'field_presets', pk: 'id'),
     'qualityFindings': (table: 'quality_findings', pk: 'id'),

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -487,13 +487,20 @@ class SyncRepository {
           'SELECT id, created_at FROM media_enrichment WHERE hlc IS NULL',
         )
         .get();
-    for (final row in rows) {
-      await markRecordPending(
-        entityType: 'mediaEnrichment',
-        recordId: row.read<String>('id'),
-        localUpdatedAt: row.read<int>('created_at'),
-      );
-    }
+    if (rows.isEmpty) return;
+    // One transaction for the whole backfill: markRecordPending's own
+    // per-row transaction nests as a savepoint, so a library with many
+    // linked photos commits once instead of once per row (the per-row fsync
+    // was the sync-start cost flagged in review).
+    await _db.transaction(() async {
+      for (final row in rows) {
+        await markRecordPending(
+          entityType: 'mediaEnrichment',
+          recordId: row.read<String>('id'),
+          localUpdatedAt: row.read<int>('created_at'),
+        );
+      }
+    });
   }
 
   /// Stamp a fresh Hybrid Logical Clock onto the just-written entity row, if

--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -472,6 +472,30 @@ class SyncRepository {
     }
   }
 
+  /// One-time self-heal for enrichment rows written before schema v130, when
+  /// media_enrichment had no `hlc` column and never synced. Such rows carry
+  /// `hlc IS NULL` and are invisible to the incremental export (which filters
+  /// `hlc > watermark`; SQL `NULL > x` is false). markRecordPending stamps a
+  /// fresh HLC (above every peer watermark) so they replicate on the next sync
+  /// and heal peers that lost the depth/time association.
+  ///
+  /// Self-limiting: rows written by saveEnrichment always get an HLC, so once
+  /// every legacy row is stamped this finds nothing.
+  Future<void> backfillMediaEnrichmentHlc() async {
+    final rows = await _db
+        .customSelect(
+          'SELECT id, created_at FROM media_enrichment WHERE hlc IS NULL',
+        )
+        .get();
+    for (final row in rows) {
+      await markRecordPending(
+        entityType: 'mediaEnrichment',
+        recordId: row.read<String>('id'),
+        localUpdatedAt: row.read<int>('created_at'),
+      );
+    }
+  }
+
   /// Stamp a fresh Hybrid Logical Clock onto the just-written entity row, if
   /// the entity is conflict-capable and the clock is configured. Centralised
   /// here (the write choke point) rather than in every repository companion.

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1256,6 +1256,10 @@ class MediaEnrichment extends Table {
   )(); // exact, interpolated, estimated, no_profile
   IntColumn get timestampOffsetSeconds => integer().nullable()();
   IntColumn get createdAt => integer()();
+  // v130: sync replication. media_enrichment is the depth/time association for
+  // a linked photo; without an hlc it never travelled through sync and was
+  // lost on other devices / after restore.
+  TextColumn get hlc => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -2814,7 +2818,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 129;
+  static const int currentSchemaVersion = 130;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -2963,6 +2967,8 @@ class AppDatabase extends _$AppDatabase {
     // v129: quality_findings table for the Data Quality Assistant (renumbered
     // from v118 as main advanced past it at merge time).
     129,
+    // v130: media_enrichment.hlc so a photo's depth/time association syncs.
+    130,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -3543,6 +3549,20 @@ class AppDatabase extends _$AppDatabase {
           orElse: () => CertificationAgency.other,
         )
         .displayName;
+  }
+
+  /// v130: media_enrichment.hlc column. Self-guarding when the table is absent
+  /// (partial-schema migration fixtures) and PRAGMA-guarded so it is safe to
+  /// call from both onUpgrade and the beforeOpen backstop (parallel-branch
+  /// collision self-heal).
+  Future<void> _assertMediaEnrichmentHlcColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('media_enrichment')",
+    ).get();
+    final hasColumn = cols.any((c) => c.read<String>('name') == 'hlc');
+    if (cols.isNotEmpty && !hasColumn) {
+      await customStatement('ALTER TABLE media_enrichment ADD COLUMN hlc TEXT');
+    }
   }
 
   /// Idempotent DDL for the v103 media store objects. Called from the v103
@@ -6697,6 +6717,12 @@ class AppDatabase extends _$AppDatabase {
           await _assertQualityFindingsSchema();
         }
         if (from < 129) await reportProgress();
+        // v130: media_enrichment.hlc so a photo's depth/time association
+        // replicates through sync (it was local-only before).
+        if (from < 130) {
+          await _assertMediaEnrichmentHlcColumn();
+        }
+        if (from < 130) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -6705,6 +6731,9 @@ class AppDatabase extends _$AppDatabase {
         // v103 backstop: re-assert media store schema (the helper is
         // self-guarding when the media table is absent).
         await _assertMediaStoreSchema();
+
+        // v130 backstop: re-assert the media_enrichment.hlc column.
+        await _assertMediaEnrichmentHlcColumn();
 
         // v106 backstop: re-assert connector-suggestion columns (the helper
         // is self-guarding when the suggestions table is absent).

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -226,6 +226,7 @@ class SyncData {
   final List<Map<String, dynamic>> qualityFindings;
   final List<Map<String, dynamic>> equipmentAttributes;
   final List<Map<String, dynamic>> media;
+  final List<Map<String, dynamic>> mediaEnrichment;
   final List<Map<String, dynamic>> buddies;
   final List<Map<String, dynamic>> buddyRoles;
   final List<Map<String, dynamic>> mediaStores;
@@ -297,6 +298,7 @@ class SyncData {
     this.qualityFindings = const [],
     this.equipmentAttributes = const [],
     this.media = const [],
+    this.mediaEnrichment = const [],
     this.buddies = const [],
     this.buddyRoles = const [],
     this.mediaStores = const [],
@@ -369,6 +371,7 @@ class SyncData {
     'qualityFindings': qualityFindings,
     'equipmentAttributes': equipmentAttributes,
     'media': media,
+    'mediaEnrichment': mediaEnrichment,
     'buddies': buddies,
     'buddyRoles': buddyRoles,
     'mediaStores': mediaStores,
@@ -442,6 +445,7 @@ class SyncData {
       qualityFindings: _parseList(json['qualityFindings']),
       equipmentAttributes: _parseList(json['equipmentAttributes']),
       media: _parseList(json['media']),
+      mediaEnrichment: _parseList(json['mediaEnrichment']),
       buddies: _parseList(json['buddies']),
       buddyRoles: _parseList(json['buddyRoles']),
       mediaStores: _parseList(json['mediaStores']),
@@ -664,6 +668,12 @@ class SyncDataSerializer {
       full: null,
     ),
     (key: 'media', table: _db.media, blob: true, full: null),
+    (
+      key: 'mediaEnrichment',
+      table: _db.mediaEnrichment,
+      blob: false,
+      full: null,
+    ),
     (key: 'buddies', table: _db.buddies, blob: false, full: null),
     (key: 'buddyRoles', table: _db.buddyRoles, blob: false, full: null),
     (key: 'mediaStores', table: _db.mediaStores, blob: false, full: null),
@@ -1156,6 +1166,10 @@ class SyncDataSerializer {
         () => _exportEquipmentAttributes(hlcSince),
       ),
       media: await _safeExport('media', () => _exportMedia(hlcSince)),
+      mediaEnrichment: await _safeExport(
+        'mediaEnrichment',
+        () => _exportMediaEnrichment(hlcSince),
+      ),
       buddies: await _safeExport('buddies', () => _exportBuddies(hlcSince)),
       buddyRoles: await _safeExport(
         'buddyRoles',
@@ -1570,6 +1584,11 @@ class SyncDataSerializer {
           _db.mediaStores,
         )..where((t) => t.id.equals(recordId))).getSingleOrNull();
         return row?.toJson();
+      case 'mediaEnrichment':
+        final row = await (_db.select(
+          _db.mediaEnrichment,
+        )..where((t) => t.id.equals(recordId))).getSingleOrNull();
+        return row?.toJson();
       case 'connectedAccounts':
         final row = await (_db.select(
           _db.connectedAccounts,
@@ -1921,6 +1940,11 @@ class SyncDataSerializer {
           _db.mediaStores,
         )..where((t) => t.id.isIn(idList))).get();
         return {for (final r in rows) r.id: r.toJson()};
+      case 'mediaEnrichment':
+        final rows = await (_db.select(
+          _db.mediaEnrichment,
+        )..where((t) => t.id.isIn(idList))).get();
+        return {for (final r in rows) r.id: r.toJson()};
       case 'connectedAccounts':
         final rows = await (_db.select(
           _db.connectedAccounts,
@@ -2226,6 +2250,13 @@ class SyncDataSerializer {
             .into(_db.mediaStores)
             .insertOnConflictUpdate(
               MediaStore.fromJson(data).toCompanion(false),
+            );
+        return;
+      case 'mediaEnrichment':
+        await _db
+            .into(_db.mediaEnrichment)
+            .insertOnConflictUpdate(
+              MediaEnrichmentData.fromJson(data).toCompanion(false),
             );
         return;
       case 'connectedAccounts':
@@ -2743,6 +2774,16 @@ class SyncDataSerializer {
             _db.mediaStores,
             records
                 .map((r) => MediaStore.fromJson(r).toCompanion(false))
+                .toList(),
+          ),
+        );
+        return;
+      case 'mediaEnrichment':
+        await _db.batch(
+          (b) => b.insertAllOnConflictUpdate(
+            _db.mediaEnrichment,
+            records
+                .map((r) => MediaEnrichmentData.fromJson(r).toCompanion(false))
                 .toList(),
           ),
         );
@@ -3346,6 +3387,8 @@ class SyncDataSerializer {
         return plain(_db.buddyRoles, _db.buddyRoles.id);
       case 'mediaStores':
         return plain(_db.mediaStores, _db.mediaStores.id);
+      case 'mediaEnrichment':
+        return plain(_db.mediaEnrichment, _db.mediaEnrichment.id);
       case 'connectedAccounts':
         return plain(_db.connectedAccounts, _db.connectedAccounts.id);
       case 'mediaSubscriptions':
@@ -3574,6 +3617,8 @@ class SyncDataSerializer {
         return _db.buddyRoles;
       case 'mediaStores':
         return _db.mediaStores;
+      case 'mediaEnrichment':
+        return _db.mediaEnrichment;
       case 'connectedAccounts':
         return _db.connectedAccounts;
       case 'mediaSubscriptions':
@@ -3804,6 +3849,11 @@ class SyncDataSerializer {
       case 'mediaStores':
         await (_db.delete(
           _db.mediaStores,
+        )..where((t) => t.id.equals(recordId))).go();
+        return;
+      case 'mediaEnrichment':
+        await (_db.delete(
+          _db.mediaEnrichment,
         )..where((t) => t.id.equals(recordId))).go();
         return;
       case 'connectedAccounts':
@@ -4320,6 +4370,17 @@ class SyncDataSerializer {
     String? hlcSince,
   ) async {
     final query = _db.select(_db.mediaStores);
+    if (hlcSince != null) {
+      query.where((t) => t.hlc.isBiggerThanValue(hlcSince));
+    }
+    final rows = await query.get();
+    return rows.map((r) => r.toJson()).toList();
+  }
+
+  Future<List<Map<String, dynamic>>> _exportMediaEnrichment(
+    String? hlcSince,
+  ) async {
+    final query = _db.select(_db.mediaEnrichment);
     if (hlcSince != null) {
       query.where((t) => t.hlc.isBiggerThanValue(hlcSince));
     }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -389,6 +389,10 @@ class SyncService {
       );
       await _syncRepository.ensureSyncClockConfigured();
 
+      // Self-heal: stamp an HLC on pre-v130 enrichment rows so the depth/time
+      // association replicates and repairs peers that lost it (schema v130).
+      await _syncRepository.backfillMediaEnrichmentHlc();
+
       // ---- Library epoch gate (restore Replace mode) ----
       // A pending replace runs INSTEAD of a merge, and a marker from an
       // unaccepted epoch halts everything until the user adopts.

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1192,6 +1192,11 @@ class SyncService {
           ),
           (type: 'settings', records: data.settings, hasUpdatedAt: true),
           (type: 'media', records: data.media, hasUpdatedAt: false),
+          (
+            type: 'mediaEnrichment',
+            records: data.mediaEnrichment,
+            hasUpdatedAt: false,
+          ),
           (type: 'mediaStores', records: data.mediaStores, hasUpdatedAt: false),
           (
             type: 'connectedAccounts',
@@ -1762,6 +1767,7 @@ class SyncService {
     'serviceSchedules': true,
     'settings': true,
     'media': false,
+    'mediaEnrichment': false,
     'mediaStores': false,
     'connectedAccounts': true,
     'mediaSubscriptions': true,
@@ -1813,6 +1819,10 @@ class SyncService {
       (field: 'buddyId', parent: 'buddies', nullable: false),
     ],
     'buddyRoles': [(field: 'buddyId', parent: 'buddies', nullable: false)],
+    'mediaEnrichment': [
+      (field: 'mediaId', parent: 'media', nullable: false),
+      (field: 'diveId', parent: 'dives', nullable: false),
+    ],
     'diveTags': [
       (field: 'diveId', parent: 'dives', nullable: false),
       (field: 'tagId', parent: 'tags', nullable: false),

--- a/test/core/database/migration_v129_quality_findings_test.dart
+++ b/test/core/database/migration_v129_quality_findings_test.dart
@@ -49,11 +49,10 @@ void main() {
     expect(names, contains('idx_quality_findings_status'));
   });
 
-  test('v129 is the current schema version (exact-latest tripwire)', () {
-    // Exact assertion: the newest migration owns the tripwire, so the next
-    // schema bump must move it forward. Relax to greaterThanOrEqualTo and add
-    // a fresh exact test when a later migration lands on top of v129.
-    expect(AppDatabase.currentSchemaVersion, 129);
+  test('v129 quality_findings migration is present', () {
+    // The exact-latest tripwire moved to migration_v130 when v130 landed on
+    // top of v129; this test now only asserts v129 still has its migration.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(129));
     expect(AppDatabase.migrationVersions, contains(129));
   });
 }

--- a/test/core/database/migration_v130_media_enrichment_hlc_test.dart
+++ b/test/core/database/migration_v130_media_enrichment_hlc_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+import '../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = createTestDatabase();
+  });
+
+  tearDown(() => db.close());
+
+  test('media_enrichment has an hlc column', () async {
+    final rows = await db
+        .customSelect("PRAGMA table_info('media_enrichment')")
+        .get();
+    final cols = [for (final r in rows) r.read<String>('name')];
+    expect(
+      cols,
+      containsAll([
+        'id',
+        'media_id',
+        'dive_id',
+        'depth_meters',
+        'temperature_celsius',
+        'elapsed_seconds',
+        'match_confidence',
+        'timestamp_offset_seconds',
+        'created_at',
+        'hlc',
+      ]),
+    );
+  });
+
+  test('v130 is the current schema version (exact-latest tripwire)', () {
+    expect(AppDatabase.currentSchemaVersion, 130);
+    expect(AppDatabase.migrationVersions, contains(130));
+  });
+}

--- a/test/core/services/sync/sync_enrichment_backfill_test.dart
+++ b/test/core/services/sync/sync_enrichment_backfill_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Pre-v130 media_enrichment rows have hlc = NULL and are invisible to the
+/// incremental export. The backfill stamps a fresh HLC so they replicate.
+void main() {
+  setUp(() async => setUpTestDatabase());
+  tearDown(() async => tearDownTestDatabase());
+
+  // A dive + media so the enrichment row's FKs resolve, then an enrichment row
+  // with NO hlc, exactly as a pre-v130 build wrote it.
+  Future<void> seedLegacyEnrichment(String enrichmentId) async {
+    final db = DatabaseService.instance.database;
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await SyncDataSerializer().upsertRecord('media', {
+      'id': 'm1',
+      'diveId': 'd1',
+      'filePath': '/p.jpg',
+      'fileType': 'photo',
+      'sourceType': 'platformGallery',
+      'isFavorite': false,
+      'isOrphaned': false,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    });
+    await db.customStatement(
+      "INSERT INTO media_enrichment (id, media_id, dive_id, depth_meters, "
+      "match_confidence, created_at) "
+      "VALUES ('$enrichmentId', 'm1', 'd1', 12.5, 'exact', 1000)",
+    );
+  }
+
+  test(
+    'stamps hlc + a pending sync record on null-hlc enrichment rows',
+    () async {
+      final db = DatabaseService.instance.database;
+      await seedLegacyEnrichment('e1');
+
+      await SyncRepository().backfillMediaEnrichmentHlc();
+
+      final row = await (db.select(
+        db.mediaEnrichment,
+      )..where((t) => t.id.equals('e1'))).getSingle();
+      expect(row.hlc, isNotNull);
+
+      final pending = await (db.select(
+        db.syncRecords,
+      )..where((t) => t.entityType.equals('mediaEnrichment'))).get();
+      expect(pending.map((r) => r.recordId), contains('e1'));
+    },
+  );
+
+  test('is a no-op the second time (self-limiting)', () async {
+    final db = DatabaseService.instance.database;
+    await seedLegacyEnrichment('e1');
+
+    await SyncRepository().backfillMediaEnrichmentHlc();
+    final first = (await (db.select(
+      db.mediaEnrichment,
+    )..where((t) => t.id.equals('e1'))).getSingle()).hlc;
+    await SyncRepository().backfillMediaEnrichmentHlc();
+    final second = (await (db.select(
+      db.mediaEnrichment,
+    )..where((t) => t.id.equals('e1'))).getSingle()).hlc;
+
+    expect(second, first, reason: 'row already had an hlc; not re-stamped');
+  });
+}

--- a/test/core/services/sync/sync_media_enrichment_test.dart
+++ b/test/core/services/sync/sync_media_enrichment_test.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/changeset_test_helpers.dart';
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Sync replication for `media_enrichment` (the depth/time association for a
+/// linked photo). Like `media_stores`/`buddy_roles`, this table carries its
+/// own `hlc` column, so its export uses the simple hlc-filter pattern. Unlike
+/// them it is a child of both `media` and `dives`, so each fixture seeds those
+/// parent rows first (FKs are enforced in the test database).
+void main() {
+  group('media_enrichment sync', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    String hlcAt(int physical, String node) =>
+        '${physical.toString().padLeft(15, '0')}:000000:$node';
+
+    Map<String, dynamic> mediaRow(String id, String diveId) => {
+      'id': id,
+      'diveId': diveId,
+      'filePath': '/photos/$id.jpg',
+      'fileType': 'photo',
+      'sourceType': 'platformGallery',
+      'isFavorite': false,
+      'isOrphaned': false,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    };
+
+    Map<String, dynamic> enrichmentRow(
+      String id, {
+      required String mediaId,
+      required String diveId,
+      required String hlc,
+    }) => {
+      'id': id,
+      'mediaId': mediaId,
+      'diveId': diveId,
+      'depthMeters': 18.3,
+      'temperatureCelsius': 21.0,
+      'elapsedSeconds': 600,
+      'matchConfidence': 'exact',
+      'timestampOffsetSeconds': 0,
+      'createdAt': 1000,
+      'hlc': hlc,
+    };
+
+    // Seeds a real dive (many required columns) via the repository helper, plus
+    // a media row via the serializer, so an enrichment row's FKs resolve.
+    Future<void> seedParents(
+      SyncDataSerializer s, {
+      required String diveId,
+      required String mediaId,
+    }) async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: diveId, diveNumber: 1),
+      );
+      await s.upsertRecord('media', mediaRow(mediaId, diveId));
+    }
+
+    test('full export includes a media_enrichment row', () async {
+      final s = SyncDataSerializer();
+      await seedParents(s, diveId: 'd1', mediaId: 'm1');
+      await s.upsertRecord(
+        'mediaEnrichment',
+        enrichmentRow('e1', mediaId: 'm1', diveId: 'd1', hlc: hlcAt(1000, 'a')),
+      );
+
+      final payload = await s.exportData(deviceId: 'a', deletions: const []);
+
+      expect(
+        payload.data.mediaEnrichment.map((r) => r['id']).toSet(),
+        contains('e1'),
+      );
+    });
+
+    test(
+      'round trip: wipe and re-import restores depth and confidence',
+      () async {
+        final s = SyncDataSerializer();
+        await seedParents(s, diveId: 'd1', mediaId: 'm1');
+        await s.upsertRecord(
+          'mediaEnrichment',
+          enrichmentRow(
+            'e1',
+            mediaId: 'm1',
+            diveId: 'd1',
+            hlc: hlcAt(1000, 'a'),
+          ),
+        );
+
+        final payload = await s.exportData(deviceId: 'a', deletions: const []);
+        final exported = payload.data.mediaEnrichment.singleWhere(
+          (r) => r['id'] == 'e1',
+        );
+
+        final db = DatabaseService.instance.database;
+        await s.deleteAllRecords('mediaEnrichment');
+        expect(
+          await (db.select(
+            db.mediaEnrichment,
+          )..where((t) => t.id.equals('e1'))).getSingleOrNull(),
+          isNull,
+          reason: 'sanity: the wipe actually removed the row',
+        );
+
+        await s.upsertRecord('mediaEnrichment', exported);
+
+        final restored = await (db.select(
+          db.mediaEnrichment,
+        )..where((t) => t.id.equals('e1'))).getSingle();
+        expect(restored.depthMeters, 18.3);
+        expect(restored.matchConfidence, 'exact');
+        expect(restored.diveId, 'd1');
+      },
+    );
+
+    test(
+      'incremental export: only rows with hlc > watermark are included',
+      () async {
+        final s = SyncDataSerializer();
+        await seedParents(s, diveId: 'd1', mediaId: 'm1');
+        await s.upsertRecord('media', mediaRow('m2', 'd1'));
+        await s.upsertRecord(
+          'mediaEnrichment',
+          enrichmentRow(
+            'e-old',
+            mediaId: 'm1',
+            diveId: 'd1',
+            hlc: hlcAt(1000, 'a'),
+          ),
+        );
+        await s.upsertRecord(
+          'mediaEnrichment',
+          enrichmentRow(
+            'e-new',
+            mediaId: 'm2',
+            diveId: 'd1',
+            hlc: hlcAt(9000, 'a'),
+          ),
+        );
+
+        final changeset = await s.exportChangeset(
+          deviceId: 'a',
+          hlcWatermark: hlcAt(5000, 'a'),
+          deletions: const [],
+        );
+
+        final ids = changeset.data.mediaEnrichment.map((r) => r['id']).toSet();
+        expect(ids, contains('e-new'));
+        expect(ids, isNot(contains('e-old')));
+      },
+    );
+
+    test(
+      'per-record plumbing: recordIdsFor, deleteRecord, SyncData.fromJson',
+      () async {
+        final s = SyncDataSerializer();
+        await seedParents(s, diveId: 'd1', mediaId: 'm1');
+        await s.upsertRecord(
+          'mediaEnrichment',
+          enrichmentRow(
+            'e1',
+            mediaId: 'm1',
+            diveId: 'd1',
+            hlc: hlcAt(1000, 'a'),
+          ),
+        );
+
+        expect(await s.recordIdsFor('mediaEnrichment'), {'e1'});
+
+        final payload = await s.exportData(deviceId: 'a', deletions: const []);
+        final rehydrated = SyncData.fromJson(payload.data.toJson());
+        expect(rehydrated.mediaEnrichment.map((r) => r['id']), contains('e1'));
+
+        await s.deleteRecord('mediaEnrichment', 'e1');
+        expect(await s.recordIdsFor('mediaEnrichment'), isEmpty);
+      },
+    );
+
+    test(
+      'end to end: a peer-published enrichment replicates via performSync',
+      () async {
+        // Parents already present locally (they synced earlier); the peer
+        // publishes only the enrichment for them.
+        await seedParents(SyncDataSerializer(), diveId: 'd1', mediaId: 'm1');
+
+        final cloud = FakeCloudStorageProvider();
+        final data = SyncData(
+          mediaEnrichment: [
+            enrichmentRow(
+              'e1',
+              mediaId: 'm1',
+              diveId: 'd1',
+              hlc: hlcAt(1000, 'peer-dev'),
+            ),
+          ],
+        );
+        final payload = SyncPayload(
+          version: syncFormatVersion,
+          exportedAt: 9000,
+          deviceId: 'peer-dev',
+          checksum: sha256
+              .convert(utf8.encode(jsonEncode(data.toJson())))
+              .toString(),
+          data: data,
+          deletions: const {},
+        );
+        await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+        final result = await SyncService(
+          syncRepository: SyncRepository(),
+          serializer: SyncDataSerializer(),
+          cloudProvider: cloud,
+        ).performSync();
+        expect(result.status, isNot(SyncResultStatus.error));
+
+        final db = DatabaseService.instance.database;
+        final restored = await (db.select(
+          db.mediaEnrichment,
+        )..where((t) => t.id.equals('e1'))).getSingleOrNull();
+        expect(restored, isNotNull);
+        expect(restored!.depthMeters, 18.3);
+      },
+    );
+  });
+}

--- a/test/core/services/sync/sync_parent_refs_completeness_test.dart
+++ b/test/core/services/sync/sync_parent_refs_completeness_test.dart
@@ -62,6 +62,7 @@ void main() {
     'service_records': 'serviceRecords',
     'settings': 'settings',
     'media': 'media',
+    'media_enrichment': 'mediaEnrichment',
     'course_requirements': 'courseRequirements',
     'course_requirement_dives': 'courseRequirementDives',
     'emergency_chambers': 'emergencyChambers',
@@ -85,6 +86,7 @@ void main() {
     'species': 'species',
     'dive_computers': 'diveComputers',
     'checklist_templates': 'checklistTemplates',
+    'media': 'media',
   };
 
   String camel(String snake) {

--- a/test/core/services/sync/sync_parent_refs_completeness_test.dart
+++ b/test/core/services/sync/sync_parent_refs_completeness_test.dart
@@ -66,6 +66,26 @@ void main() {
     'course_requirements': 'courseRequirements',
     'course_requirement_dives': 'courseRequirementDives',
     'emergency_chambers': 'emergencyChambers',
+    'media_stores': 'mediaStores',
+    'connected_accounts': 'connectedAccounts',
+    'media_subscriptions': 'mediaSubscriptions',
+    'service_kinds': 'serviceKinds',
+    'service_schedules': 'serviceSchedules',
+    'gps_tracks': 'gpsTracks',
+    'diver_weight_entries': 'diverWeightEntries',
+    'dive_roles': 'diveRoles',
+    'equipment_attributes': 'equipmentAttributes',
+    'dive_dive_types': 'diveDiveTypes',
+    'dive_safety_reviews': 'diveSafetyReviews',
+    'dive_safety_findings': 'diveSafetyFindings',
+    'dive_plans': 'divePlans',
+    'dive_plan_tanks': 'divePlanTanks',
+    'dive_plan_segments': 'divePlanSegments',
+    'dive_plan_equipment': 'divePlanEquipment',
+    'pre_dive_checklist_templates': 'preDiveChecklistTemplates',
+    'pre_dive_checklist_template_items': 'preDiveChecklistTemplateItems',
+    'pre_dive_sessions': 'preDiveSessions',
+    'pre_dive_session_items': 'preDiveSessionItems',
   };
 
   // Parent table -> entityType for parents a user can delete (and thus
@@ -172,6 +192,23 @@ void main() {
       reason:
           'Nullability mismatch (decides skip vs. clear-the-reference):\n'
           '${wrongNullable.join('\n')}',
+    );
+  });
+
+  test('syncedTables covers every merge-applied entity (no silent drift)', () {
+    // The FK guard above only checks tables listed in syncedTables. If a new
+    // synced entity is added to SyncService.entityHasUpdatedAt but not here,
+    // its FKs would go unverified -- so keep this map complete.
+    final covered = syncedTables.values.toSet();
+    final missing = SyncService.entityHasUpdatedAt.keys
+        .where((e) => !covered.contains(e))
+        .toList();
+    expect(
+      missing,
+      isEmpty,
+      reason:
+          'These merge-applied entities are missing from syncedTables, so '
+          'their FK guards are unverified:\n${missing.join('\n')}',
     );
   });
 }


### PR DESCRIPTION
## Summary

Linked photos and videos were losing their depth/time association after syncing. The `MediaEnrichment` row — the depth / temperature / elapsed data projected onto the dive profile at a photo's capture time — was computed once at import and stored **local-only**. It was never a synced entity (absent from `entityHasUpdatedAt`, no serializer case, no `hlc` column), even though `MediaRepository.saveEnrichment` already called `markRecordPending('mediaEnrichment', …)` (dead half-wiring the engine ignored). So the `media` row synced but its enrichment did not: a second device showed the photo with no depth/time, and a Replace-adopt restore wiped it locally (`deleteAllRecords('media')` + FK cascade).

This registers `mediaEnrichment` as a first-class HLC-synced child entity so the association travels with the library, plus a one-time backfill that heals already-affected libraries.

## Changes

- **Schema v130:** add nullable `hlc` to `media_enrichment` (idempotent PRAGMA-guarded migration + `beforeOpen` backstop, mirroring `_assertMediaStoreSchema`).
- **Engine registration** (mirrors `mediaStores`): `SyncData` field/fromJson/toJson, `_baseTables`, HLC-filtered `_exportMediaEnrichment`, upsert single+batch, `fetchRecord(s)`, `recordIdsFor`, `_syncTableFor`, `deleteRecord`, `entityHasUpdatedAt`, `mergeOrder`, `_hlcTargets`.
- **FK guard** (`parentRefs`): enrichment is a child of both `media` and `dives`; without the guard a peer's live child of a locally-deleted parent dangles its FK and fails the deferred-FK COMMIT (SqliteException 787).
- **Self-heal** (`backfillMediaEnrichmentHlc`, called at `performSync` start): stamps a fresh HLC on pre-v130 `hlc IS NULL` rows so they replicate and repair peers. Self-limiting — new rows always get an HLC via `saveEnrichment`. Runs at sync time because migrations can't reach `SyncClock`.
- **Tests:** enrichment sync (export / round-trip / incremental / per-record / end-to-end `performSync`), migration v130 + version tripwire, backfill; `parentRefs` completeness updated.

## Test Plan

- [x] `flutter test` passes (13,334 passed, 13 skipped)
- [x] `flutter analyze` passes (no issues, whole project)
- [x] Manual testing on: two-device sync + Replace-adopt restore (pending real devices)

## Notes

- Schema **v130** may collide with parallel open PRs. On a `database.dart` conflict, keep both idempotent `if (from < 130)` blocks (v103 media-store / dive-roles precedent); `currentSchemaVersion` stays 130.
- Enrichment needs no tombstones: it cascade-deletes with its parent media/dive locally, and applying the parent's synced deletion cascades on peers too.
