### PR TITLE
Read HEIC/HEIF capture time on desktop

### DIFF
--- a/lib/features/media/data/services/capture_time_reader.dart
+++ b/lib/features/media/data/services/capture_time_reader.dart
@@ -84,7 +84,7 @@ DateTime? _readHeicExifDate(File file) {
 
     raf.setPositionSync(extent.offset);
     final item = raf.readSync(extent.length);
-    final tiff = _findTiffHeader(item);
+    final tiff = _tiffHeaderOffset(item);
     if (tiff == null) return null;
 
     final exif = img.ExifData.fromInputBuffer(
@@ -115,16 +115,15 @@ int? _heicExifItemId(Uint8List b, int start, int end) {
   for (var i = 0; i < count && p + 8 <= end; i++) {
     final size = _beU32(b, p);
     if (size < 8 || p + size > end) return null;
+    final infeEnd = p + size;
     final infeVersion = b[p + 8];
-    var q = p + 12; // skip infe box header (8) + version+flags (4)
-    if (infeVersion >= 3) {
-      q += 4; // item_ID uint32
-    } else {
-      q += 2; // item_ID uint16
-    }
+    final idBytes = infeVersion >= 3 ? 4 : 2; // item_ID width
     final itemId = infeVersion >= 3 ? _beU32(b, p + 12) : _beU16(b, p + 12);
-    q += 2; // item_protection_index
-    if (q + 4 <= end && _fourCC(b, q) == 'Exif') return itemId;
+    // item_type follows: infe header (8) + version/flags (4) + item_ID +
+    // item_protection_index (2). Bound the read to THIS infe box so a corrupt
+    // size can't match an 'Exif' fourCC that belongs to a following entry.
+    final typePos = p + 12 + idBytes + 2;
+    if (typePos + 4 <= infeEnd && _fourCC(b, typePos) == 'Exif') return itemId;
     p += size;
   }
   return null;
@@ -176,18 +175,29 @@ _Extent? _heicExifExtent(Uint8List b, int start, int end, int wantId) {
   return null;
 }
 
-/// Locates the TIFF header (`II*\0` or `MM\0*`) that begins the EXIF block
-/// inside a HEIC `Exif` item (which is prefixed by a small offset header).
-int? _findTiffHeader(Uint8List b) {
+/// The HEIC `Exif` item begins with a 4-byte big-endian offset to the TIFF
+/// header (counted from just past that field). Use it directly; fall back to a
+/// bounded scan only when the declared offset is out of range or does not point
+/// at a TIFF signature, so malformed input degrades gracefully instead of
+/// mis-locating an earlier byte sequence.
+int? _tiffHeaderOffset(Uint8List b) {
+  if (b.length >= 8) {
+    final declared = 4 + _beU32(b, 0);
+    if (declared + 4 <= b.length && _isTiffHeader(b, declared)) return declared;
+  }
   for (var i = 0; i + 4 <= b.length; i++) {
-    final a = b[i], c = b[i + 1], d = b[i + 2], e = b[i + 3];
-    if ((a == 0x49 && c == 0x49 && d == 0x2a && e == 0x00) ||
-        (a == 0x4d && c == 0x4d && d == 0x00 && e == 0x2a)) {
-      return i;
-    }
+    if (_isTiffHeader(b, i)) return i;
   }
   return null;
 }
+
+/// A TIFF header is `II*\0` (little-endian) or `MM\0*` (big-endian).
+bool _isTiffHeader(Uint8List b, int o) =>
+    (b[o] == 0x49 &&
+        b[o + 1] == 0x49 &&
+        b[o + 2] == 0x2a &&
+        b[o + 3] == 0x00) ||
+    (b[o] == 0x4d && b[o + 1] == 0x4d && b[o + 2] == 0x00 && b[o + 3] == 0x2a);
 
 /// Byte-buffer twin of [_findBox], for walking sub-boxes already read into
 /// memory (e.g. inside a `meta` box).

--- a/lib/features/media/data/services/capture_time_reader.dart
+++ b/lib/features/media/data/services/capture_time_reader.dart
@@ -57,6 +57,10 @@ DateTime? _dateFromExif(img.ExifData exif) {
   return parseExifDateTimeOriginal(raw?.toString());
 }
 
+// Upper bound on a HEIC `Exif` item read. Real items are a few KB (tens of KB
+// with an embedded thumbnail); this only exists to cap a corrupt/crafted length.
+const _maxExifItemBytes = 64 * 1024 * 1024;
+
 /// Reads EXIF from a HEIC/HEIF file. HEIC is ISO-BMFF: the EXIF lives in a
 /// metadata item declared by the `meta > iinf` box (type `Exif`) and located
 /// by `meta > iloc`. We read only the `meta` box and the Exif item's extent
@@ -81,6 +85,15 @@ DateTime? _readHeicExifDate(File file) {
     if (itemId == null) return null;
     final extent = _heicExifExtent(metaBytes, iloc.start, iloc.end, itemId);
     if (extent == null) return null;
+    // Reject a corrupt/crafted extent that points past EOF or advertises an
+    // absurd length, so we fall back to mtime instead of attempting a huge
+    // read/allocation. Real EXIF items are a few KB.
+    if (extent.offset < 0 ||
+        extent.length <= 0 ||
+        extent.length > _maxExifItemBytes ||
+        extent.offset + extent.length > end) {
+      return null;
+    }
 
     raf.setPositionSync(extent.offset);
     final item = raf.readSync(extent.length);

--- a/lib/features/media/data/services/capture_time_reader.dart
+++ b/lib/features/media/data/services/capture_time_reader.dart
@@ -57,8 +57,10 @@ DateTime? _dateFromExif(img.ExifData exif) {
   return parseExifDateTimeOriginal(raw?.toString());
 }
 
-// Upper bound on a HEIC `Exif` item read. Real items are a few KB (tens of KB
-// with an embedded thumbnail); this only exists to cap a corrupt/crafted length.
+// Upper bounds on HEIC reads. Real `meta` boxes and `Exif` items are tens of KB
+// (the meta box carries no pixel data); these caps only exist to reject a
+// corrupt/crafted length before it triggers a large allocation.
+const _maxMetaBytes = 64 * 1024 * 1024;
 const _maxExifItemBytes = 64 * 1024 * 1024;
 
 /// Reads EXIF from a HEIC/HEIF file. HEIC is ISO-BMFF: the EXIF lives in a
@@ -74,8 +76,14 @@ DateTime? _readHeicExifDate(File file) {
     final meta = _findBox(raf, 0, end, 'meta');
     if (meta == null) return null;
     // `meta` is a FullBox: its child boxes start 4 (version+flags) bytes in.
+    // Bound the read: reject a too-small box (nothing to parse / underflow) or
+    // an absurdly large one (a crafted meta could be huge yet within EOF) so we
+    // fall back to mtime rather than risk a large allocation. The meta box holds
+    // only metadata, never pixel data, so it is small in practice.
+    final metaLen = meta.end - meta.start - 4;
+    if (metaLen <= 0 || metaLen > _maxMetaBytes) return null;
     raf.setPositionSync(meta.start + 4);
-    final metaBytes = raf.readSync(meta.end - meta.start - 4);
+    final metaBytes = raf.readSync(metaLen);
 
     final iinf = _findBoxInBytes(metaBytes, 0, metaBytes.length, 'iinf');
     final iloc = _findBoxInBytes(metaBytes, 0, metaBytes.length, 'iloc');

--- a/lib/features/media/data/services/capture_time_reader.dart
+++ b/lib/features/media/data/services/capture_time_reader.dart
@@ -14,12 +14,18 @@ import 'package:submersion/features/media/data/services/exif_date_parser.dart';
 ///
 /// - JPEG: EXIF `DateTimeOriginal` (via `package:image`, EXIF-only, no pixel
 ///   decode).
+/// - HEIC/HEIF: EXIF from the ISO-BMFF `meta` box's `Exif` item (iPhone's
+///   default photo format; `package:image` cannot decode HEIC pixels, but the
+///   embedded EXIF is a standard TIFF block once located).
 /// - MP4/MOV/M4V: the `moov > mvhd` `creation_time` from the ISO-BMFF/QuickTime
 ///   container.
 DateTime? readLocalCaptureTime(File file, String mime) {
   switch (mime) {
     case 'image/jpeg':
       return _readJpegExifDate(file);
+    case 'image/heic':
+    case 'image/heif':
+      return _readHeicExifDate(file);
     case 'video/mp4':
     case 'video/quicktime':
     case 'video/x-m4v':
@@ -33,19 +39,188 @@ DateTime? _readJpegExifDate(File file) {
   try {
     final exif = img.decodeJpgExif(file.readAsBytesSync());
     if (exif == null) return null;
-    // EXIF date tags are ASCII "YYYY:MM:DD HH:MM:SS". Prefer the shutter time
-    // (DateTimeOriginal), then when it was digitized, then the basic file
-    // DateTime, so files that omit the richer tags still get a real date.
-    final raw =
-        exif.exifIfd['DateTimeOriginal'] ??
-        exif.exifIfd['DateTimeDigitized'] ??
-        exif.imageIfd['DateTime'];
-    return parseExifDateTimeOriginal(raw?.toString());
+    return _dateFromExif(exif);
   } on Object {
     // Truncated/corrupt JPEG or an unreadable file: fall back to mtime.
     return null;
   }
 }
+
+/// Pulls a wall-clock-UTC date from a parsed [img.ExifData]. EXIF date tags are
+/// ASCII "YYYY:MM:DD HH:MM:SS"; prefer the shutter time (DateTimeOriginal),
+/// then when it was digitized, then the basic file DateTime.
+DateTime? _dateFromExif(img.ExifData exif) {
+  final raw =
+      exif.exifIfd['DateTimeOriginal'] ??
+      exif.exifIfd['DateTimeDigitized'] ??
+      exif.imageIfd['DateTime'];
+  return parseExifDateTimeOriginal(raw?.toString());
+}
+
+/// Reads EXIF from a HEIC/HEIF file. HEIC is ISO-BMFF: the EXIF lives in a
+/// metadata item declared by the `meta > iinf` box (type `Exif`) and located
+/// by `meta > iloc`. We read only the `meta` box and the Exif item's extent
+/// (not the multi-MB image data), then hand the embedded TIFF block to
+/// `package:image`'s EXIF parser.
+DateTime? _readHeicExifDate(File file) {
+  RandomAccessFile? raf;
+  try {
+    raf = file.openSync();
+    final end = raf.lengthSync();
+    final meta = _findBox(raf, 0, end, 'meta');
+    if (meta == null) return null;
+    // `meta` is a FullBox: its child boxes start 4 (version+flags) bytes in.
+    raf.setPositionSync(meta.start + 4);
+    final metaBytes = raf.readSync(meta.end - meta.start - 4);
+
+    final iinf = _findBoxInBytes(metaBytes, 0, metaBytes.length, 'iinf');
+    final iloc = _findBoxInBytes(metaBytes, 0, metaBytes.length, 'iloc');
+    if (iinf == null || iloc == null) return null;
+
+    final itemId = _heicExifItemId(metaBytes, iinf.start, iinf.end);
+    if (itemId == null) return null;
+    final extent = _heicExifExtent(metaBytes, iloc.start, iloc.end, itemId);
+    if (extent == null) return null;
+
+    raf.setPositionSync(extent.offset);
+    final item = raf.readSync(extent.length);
+    final tiff = _findTiffHeader(item);
+    if (tiff == null) return null;
+
+    final exif = img.ExifData.fromInputBuffer(
+      img.InputBuffer(item.sublist(tiff)),
+    );
+    return _dateFromExif(exif);
+  } on Object {
+    return null;
+  } finally {
+    raf?.closeSync();
+  }
+}
+
+/// Finds the `Exif` item's id in an `iinf` box's content range. Each `infe`
+/// entry carries the item id (uint16 in v<3, uint32 in v3+) followed by the
+/// protection index and a four-char item type.
+int? _heicExifItemId(Uint8List b, int start, int end) {
+  final version = b[start];
+  var p = start + 4; // skip version + flags
+  final int count;
+  if (version == 0) {
+    count = _beU16(b, p);
+    p += 2;
+  } else {
+    count = _beU32(b, p);
+    p += 4;
+  }
+  for (var i = 0; i < count && p + 8 <= end; i++) {
+    final size = _beU32(b, p);
+    if (size < 8 || p + size > end) return null;
+    final infeVersion = b[p + 8];
+    var q = p + 12; // skip infe box header (8) + version+flags (4)
+    if (infeVersion >= 3) {
+      q += 4; // item_ID uint32
+    } else {
+      q += 2; // item_ID uint16
+    }
+    final itemId = infeVersion >= 3 ? _beU32(b, p + 12) : _beU16(b, p + 12);
+    q += 2; // item_protection_index
+    if (q + 4 <= end && _fourCC(b, q) == 'Exif') return itemId;
+    p += size;
+  }
+  return null;
+}
+
+/// Resolves the byte extent (absolute offset + length) of item [wantId] from an
+/// `iloc` box's content range.
+_Extent? _heicExifExtent(Uint8List b, int start, int end, int wantId) {
+  final version = b[start];
+  var p = start + 4; // skip version + flags
+  final offsetSize = b[p] >> 4;
+  final lengthSize = b[p] & 0xf;
+  final baseOffsetSize = b[p + 1] >> 4;
+  final indexSize = b[p + 1] & 0xf;
+  p += 2;
+  final int itemCount;
+  if (version < 2) {
+    itemCount = _beU16(b, p);
+    p += 2;
+  } else {
+    itemCount = _beU32(b, p);
+    p += 4;
+  }
+
+  int readSized(int n) {
+    var v = 0;
+    for (var i = 0; i < n; i++) {
+      v = (v << 8) | b[p + i];
+    }
+    p += n;
+    return v;
+  }
+
+  for (var i = 0; i < itemCount && p < end; i++) {
+    final id = version < 2 ? _beU16(b, p) : _beU32(b, p);
+    p += version < 2 ? 2 : 4;
+    if (version == 1 || version == 2) p += 2; // construction_method
+    p += 2; // data_reference_index
+    final baseOffset = readSized(baseOffsetSize);
+    final extentCount = _beU16(b, p);
+    p += 2;
+    for (var e = 0; e < extentCount; e++) {
+      if ((version == 1 || version == 2) && indexSize > 0) readSized(indexSize);
+      final off = readSized(offsetSize);
+      final len = readSized(lengthSize);
+      if (id == wantId) return _Extent(baseOffset + off, len);
+    }
+  }
+  return null;
+}
+
+/// Locates the TIFF header (`II*\0` or `MM\0*`) that begins the EXIF block
+/// inside a HEIC `Exif` item (which is prefixed by a small offset header).
+int? _findTiffHeader(Uint8List b) {
+  for (var i = 0; i + 4 <= b.length; i++) {
+    final a = b[i], c = b[i + 1], d = b[i + 2], e = b[i + 3];
+    if ((a == 0x49 && c == 0x49 && d == 0x2a && e == 0x00) ||
+        (a == 0x4d && c == 0x4d && d == 0x00 && e == 0x2a)) {
+      return i;
+    }
+  }
+  return null;
+}
+
+/// Byte-buffer twin of [_findBox], for walking sub-boxes already read into
+/// memory (e.g. inside a `meta` box).
+_BoxRange? _findBoxInBytes(Uint8List b, int start, int end, String type) {
+  var pos = start;
+  while (pos + 8 <= end) {
+    var size = _beU32(b, pos);
+    var headerLen = 8;
+    if (size == 1) {
+      if (pos + 16 > end) return null;
+      size = _beU64(b, pos + 8);
+      headerLen = 16;
+    } else if (size == 0) {
+      size = end - pos;
+    }
+    if (size < headerLen || pos + size > end) return null;
+    if (_fourCC(b, pos + 4) == type) {
+      return _BoxRange(pos + headerLen, pos + size);
+    }
+    pos += size;
+  }
+  return null;
+}
+
+class _Extent {
+  const _Extent(this.offset, this.length);
+  final int offset;
+  final int length;
+}
+
+int _beU16(Uint8List b, int o) => (b[o] << 8) | b[o + 1];
+
+String _fourCC(Uint8List b, int o) => String.fromCharCodes(b, o, o + 4);
 
 // Seconds between the QuickTime/ISO-BMFF epoch (1904-01-01) and the Unix epoch.
 // This is a whole number of days, so the epoch shift preserves the time-of-day

--- a/test/features/media/data/services/capture_time_reader_test.dart
+++ b/test/features/media/data/services/capture_time_reader_test.dart
@@ -145,7 +145,11 @@ void main() {
     // Minimal HEIC: ftyp, mdat holding the Exif payload, then meta whose
     // iinf declares an 'Exif' item and iloc points at the payload's absolute
     // offset (base_offset_size 0, construction_method 0).
-    List<int> heicFile(String date, {int declaredOffset = 6}) {
+    List<int> heicFile(
+      String date, {
+      int declaredOffset = 6,
+      int ilocVersion = 1,
+    }) {
       final ftyp = _box('ftyp', 'heic'.codeUnits);
       final payload = exifItemPayload(date, declaredOffset: declaredOffset);
       final mdat = _box('mdat', payload);
@@ -159,13 +163,16 @@ void main() {
         0, // item_name (empty)
       ]);
       final iinf = _box('iinf', [0, 0, 0, 0, ...u16(1), ...infe]);
+      // iloc v2 widens item_count and item_ID to 32-bit (v0/v1 use 16-bit).
+      final countAndId = ilocVersion >= 2
+          ? [..._u32(1), ..._u32(1)]
+          : [...u16(1), ...u16(1)];
       final iloc = _box('iloc', [
-        1, 0, 0, 0, // version 1 + flags
+        ilocVersion, 0, 0, 0, // version + flags
         0x44, // offset_size=4, length_size=4
         0x00, // base_offset_size=0, index_size=0
-        ...u16(1), // item_count
-        ...u16(1), // item_ID
-        ...u16(0), // construction_method
+        ...countAndId, // item_count + item_ID
+        ...u16(0), // construction_method (v1/v2)
         ...u16(0), // data_reference_index
         ...u16(1), // extent_count
         ..._u32(payloadOffset), // extent_offset
@@ -178,6 +185,17 @@ void main() {
     test('reads DateTimeOriginal from a HEIC Exif item', () async {
       final f = File('${tempDir.path}/photo.heic')
         ..writeAsBytesSync(heicFile('2026:05:06 17:35:39'));
+      expect(
+        readLocalCaptureTime(f, 'image/heic'),
+        DateTime.utc(2026, 5, 6, 17, 35, 39),
+      );
+    });
+
+    test('reads DateTimeOriginal from an iloc v2 container', () async {
+      // iloc v2 widens item_count and item_ID to 32-bit (per ISO 14496-12;
+      // v3 is an infe concept, not iloc). Confirms the version branch.
+      final f = File('${tempDir.path}/v2.heic')
+        ..writeAsBytesSync(heicFile('2026:05:06 17:35:39', ilocVersion: 2));
       expect(
         readLocalCaptureTime(f, 'image/heic'),
         DateTime.utc(2026, 5, 6, 17, 35, 39),

--- a/test/features/media/data/services/capture_time_reader_test.dart
+++ b/test/features/media/data/services/capture_time_reader_test.dart
@@ -125,14 +125,18 @@ void main() {
     // A real TIFF/EXIF block: encode a JPEG with the tag, then lift its APP1
     // payload. `image` can't encode HEIC, but a HEIC `Exif` item carries the
     // same "Exif\0\0" + TIFF payload, prefixed by a 4-byte tiff-header offset.
-    List<int> exifItemPayload(String date) {
+    List<int> exifItemPayload(String date, {int declaredOffset = 6}) {
       final image = img.Image(width: 2, height: 2);
       image.exif.exifIfd['DateTimeOriginal'] = date;
       final jpg = img.encodeJpg(image);
       for (var i = 0; i + 3 < jpg.length; i++) {
         if (jpg[i] == 0xFF && jpg[i + 1] == 0xE1) {
           final segLen = (jpg[i + 2] << 8) | jpg[i + 3];
-          return [0, 0, 0, 6, ...jpg.sublist(i + 4, i + 2 + segLen)];
+          // 4-byte tiff-header offset (6 skips the "Exif\0\0" prefix) + payload.
+          return [
+            ..._u32(declaredOffset),
+            ...jpg.sublist(i + 4, i + 2 + segLen),
+          ];
         }
       }
       throw StateError('no APP1 EXIF segment in encoded JPEG');
@@ -141,9 +145,9 @@ void main() {
     // Minimal HEIC: ftyp, mdat holding the Exif payload, then meta whose
     // iinf declares an 'Exif' item and iloc points at the payload's absolute
     // offset (base_offset_size 0, construction_method 0).
-    List<int> heicFile(String date) {
+    List<int> heicFile(String date, {int declaredOffset = 6}) {
       final ftyp = _box('ftyp', 'heic'.codeUnits);
-      final payload = exifItemPayload(date);
+      final payload = exifItemPayload(date, declaredOffset: declaredOffset);
       final mdat = _box('mdat', payload);
       final payloadOffset = ftyp.length + 8; // just past the mdat box header
 
@@ -194,6 +198,22 @@ void main() {
         ..writeAsBytesSync([0, 1, 2, 3]);
       expect(readLocalCaptureTime(f, 'image/heic'), isNull);
     });
+
+    test(
+      'falls back to scanning when the declared TIFF offset is bogus',
+      () async {
+        // Out-of-range declared offset: the reader must still find the TIFF via
+        // its bounded scan rather than give up.
+        final f = File('${tempDir.path}/badoffset.heic')
+          ..writeAsBytesSync(
+            heicFile('2026:05:06 17:35:39', declaredOffset: 99999),
+          );
+        expect(
+          readLocalCaptureTime(f, 'image/heic'),
+          DateTime.utc(2026, 5, 6, 17, 35, 39),
+        );
+      },
+    );
   });
 
   group('JPEG EXIF (shared reader)', () {

--- a/test/features/media/data/services/capture_time_reader_test.dart
+++ b/test/features/media/data/services/capture_time_reader_test.dart
@@ -119,6 +119,83 @@ void main() {
     });
   });
 
+  group('HEIC/HEIF EXIF', () {
+    List<int> u16(int v) => [(v >> 8) & 0xff, v & 0xff];
+
+    // A real TIFF/EXIF block: encode a JPEG with the tag, then lift its APP1
+    // payload. `image` can't encode HEIC, but a HEIC `Exif` item carries the
+    // same "Exif\0\0" + TIFF payload, prefixed by a 4-byte tiff-header offset.
+    List<int> exifItemPayload(String date) {
+      final image = img.Image(width: 2, height: 2);
+      image.exif.exifIfd['DateTimeOriginal'] = date;
+      final jpg = img.encodeJpg(image);
+      for (var i = 0; i + 3 < jpg.length; i++) {
+        if (jpg[i] == 0xFF && jpg[i + 1] == 0xE1) {
+          final segLen = (jpg[i + 2] << 8) | jpg[i + 3];
+          return [0, 0, 0, 6, ...jpg.sublist(i + 4, i + 2 + segLen)];
+        }
+      }
+      throw StateError('no APP1 EXIF segment in encoded JPEG');
+    }
+
+    // Minimal HEIC: ftyp, mdat holding the Exif payload, then meta whose
+    // iinf declares an 'Exif' item and iloc points at the payload's absolute
+    // offset (base_offset_size 0, construction_method 0).
+    List<int> heicFile(String date) {
+      final ftyp = _box('ftyp', 'heic'.codeUnits);
+      final payload = exifItemPayload(date);
+      final mdat = _box('mdat', payload);
+      final payloadOffset = ftyp.length + 8; // just past the mdat box header
+
+      final infe = _box('infe', [
+        2, 0, 0, 0, // version 2 + flags
+        ...u16(1), // item_ID
+        ...u16(0), // protection_index
+        ...'Exif'.codeUnits, // item_type
+        0, // item_name (empty)
+      ]);
+      final iinf = _box('iinf', [0, 0, 0, 0, ...u16(1), ...infe]);
+      final iloc = _box('iloc', [
+        1, 0, 0, 0, // version 1 + flags
+        0x44, // offset_size=4, length_size=4
+        0x00, // base_offset_size=0, index_size=0
+        ...u16(1), // item_count
+        ...u16(1), // item_ID
+        ...u16(0), // construction_method
+        ...u16(0), // data_reference_index
+        ...u16(1), // extent_count
+        ..._u32(payloadOffset), // extent_offset
+        ..._u32(payload.length), // extent_length
+      ]);
+      final meta = _box('meta', [0, 0, 0, 0, ...iinf, ...iloc]);
+      return [...ftyp, ...mdat, ...meta];
+    }
+
+    test('reads DateTimeOriginal from a HEIC Exif item', () async {
+      final f = File('${tempDir.path}/photo.heic')
+        ..writeAsBytesSync(heicFile('2026:05:06 17:35:39'));
+      expect(
+        readLocalCaptureTime(f, 'image/heic'),
+        DateTime.utc(2026, 5, 6, 17, 35, 39),
+      );
+    });
+
+    test('image/heif mime is also handled', () async {
+      final f = File('${tempDir.path}/photo.heif')
+        ..writeAsBytesSync(heicFile('2026:05:06 17:35:39'));
+      expect(
+        readLocalCaptureTime(f, 'image/heif'),
+        DateTime.utc(2026, 5, 6, 17, 35, 39),
+      );
+    });
+
+    test('non-HEIC bytes for a heic mime return null (no throw)', () async {
+      final f = File('${tempDir.path}/bad.heic')
+        ..writeAsBytesSync([0, 1, 2, 3]);
+      expect(readLocalCaptureTime(f, 'image/heic'), isNull);
+    });
+  });
+
   group('JPEG EXIF (shared reader)', () {
     test('reads DateTimeOriginal from JPEG bytes', () async {
       final image = img.Image(width: 4, height: 4);

--- a/test/features/media/data/services/capture_time_reader_test.dart
+++ b/test/features/media/data/services/capture_time_reader_test.dart
@@ -217,6 +217,17 @@ void main() {
       expect(readLocalCaptureTime(f, 'image/heic'), isNull);
     });
 
+    test('meta box too small to hold version/flags returns null', () async {
+      // An 8-byte meta box has no room for the 4 version/flags bytes; the
+      // reader must reject it (no negative-length read) and fall back.
+      final bytes = [
+        ..._box('ftyp', 'heic'.codeUnits),
+        ..._box('meta', <int>[]),
+      ];
+      final f = File('${tempDir.path}/tinymeta.heic')..writeAsBytesSync(bytes);
+      expect(readLocalCaptureTime(f, 'image/heic'), isNull);
+    });
+
     test(
       'falls back to scanning when the declared TIFF offset is bogus',
       () async {


### PR DESCRIPTION
## Summary

Follow-up to #660. That PR enabled the local file/folder media picker to accept
`.heic/.heif`, but the pure-Dart capture-time reader only parsed JPEG EXIF — so
on desktop (where `native_exif` has no implementation) iPhone HEIC photos fell
back to filesystem mtime and did not auto-match dives. This closes that gap, the
last of the documented follow-ups from #660.

## Changes

- **HEIC/HEIF EXIF reader** in `capture_time_reader.dart`. HEIC is ISO-BMFF: the
  EXIF lives in a metadata item declared by `meta > iinf` (type `Exif`) and
  located by `meta > iloc`. The reader parses those boxes to find the item's
  byte extent, reads **only** the `meta` box and that extent (not the multi-MB
  image data), locates the embedded TIFF block, and hands it to `package:image`'s
  `ExifData` parser. Reuses the ISO-BMFF box-walking already added for MP4/MOV.
- Extracted the shared EXIF date-tag precedence (`DateTimeOriginal` →
  `DateTimeDigitized` → `DateTime`) into `_dateFromExif`, now used by both the
  JPEG and HEIC paths.

No new dependencies (`package:image` is already used for JPEG EXIF).

## Test Plan

- [x] `flutter test` passes (full media suite green; 3 new HEIC unit tests built
      on a synthetic HEIC container embedding a real TIFF/EXIF block)
- [x] `flutter analyze` passes (clean, whole project)
- [x] Validated end-to-end against a **real iPhone HEIC** (`IMG_5905.HEIC`):
      `readLocalCaptureTime` returns the correct `2026-05-06 17:35:39` capture
      time via the production path
- [x] macOS: pick/link a HEIC from a known dive and confirm it auto-matches

### Note on testing

`package:image` can't *encode* HEIC, so the unit tests build a minimal HEIC
container (`ftyp` + `mdat` + `meta{iinf, iloc}`) in-code and embed a genuine
TIFF/EXIF block lifted from an encoded JPEG's APP1 segment — the same payload a
real HEIC `Exif` item carries. The real-file validation above covers the parts a
synthetic fixture can't (actual iPhone box layout).
