### PR TITLE
ci: shard tests 4→8 to roughly halve test wall-clock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,9 +152,17 @@ jobs:
       fail-fast: false
       matrix:
         # 0-based shard indices; keep TOTAL_SHARDS below in sync with the count.
-        shard: [0, 1, 2, 3]
+        # NOTE: the shard count is coupled to codecov.yml `after_n_builds`, which
+        # must equal (shard count + 1) for the scripts job -- Codecov holds the
+        # patch/project status until every partial lcov arrives (see codecov.yml).
+        # It is also bounded by the account-wide concurrent-job cap: this workflow
+        # already fans out ~9-10 non-test jobs (analyze + 5 builds + scripts +
+        # integration) that share the pool AND gate ci-success, so oversharding
+        # queues the builds and makes total CI slower, not faster. 8 keeps us
+        # under the cap while roughly halving test wall-clock.
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      TOTAL_SHARDS: 4
+      TOTAL_SHARDS: 8
     steps:
       - uses: actions/checkout@v7
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,22 +3,27 @@
 
 codecov:
   notify:
-    # Coverage arrives as 5 separate uploads: the 4 file-sharded test jobs
-    # (flags shard-0..3) plus the scripts job (flag scripts). Tests are sharded
+    # Coverage arrives as 9 separate uploads: the 8 file-sharded test jobs
+    # (flags shard-0..7) plus the scripts job (flag scripts). Tests are sharded
     # BY FILE (ci.yaml), so each shard's lcov only marks the lines its subset
     # executed and Codecov must union them. Without waiting, Codecov computes
     # the patch/project STATUS after the first upload lands -- and a shard that
     # touched only part of a PR's diff then posts a misleadingly low patch %
     # (e.g. 12.5% when the fully-merged coverage is 100%), which sticks. Hold
-    # the status until all 5 uploads arrive, then compute once on the merge.
+    # the status until all 9 uploads arrive, then compute once on the merge.
     # Both upload steps run `if: always()` (empty shards upload an empty lcov),
-    # so exactly 5 uploads occur -- keep this in sync with the shard count.
-    after_n_builds: 5
+    # so exactly 9 uploads occur.
+    #
+    # THIS MUST EQUAL (ci.yaml shard count + 1) for the scripts job. If the
+    # `codecov/patch` status is made a REQUIRED check in branch protection, a
+    # stale count here means the status never settles and NO PR can merge --
+    # so bump this in lockstep whenever you change the shard matrix.
+    after_n_builds: 9
     wait_for_ci: true
 
 comment:
   # Same rationale: don't post/update the PR comment until every upload is in.
-  after_n_builds: 5
+  after_n_builds: 9
 
 coverage:
   status:


### PR DESCRIPTION
## What

Bump the CI test matrix from 4 to 8 file-shards and update codecov's
`after_n_builds` to match.

## Why

The test shards are the CI/CD critical path at ~19 min each, while every
other job finishes in <=12 min. Step-level timing shows ~15-18 min of that
is the `flutter test` step itself; setup/caching is only ~1.5 min. Within a
shard, `flutter test` concurrency is bounded by runner cores, so the only
way to cut wall-clock is more shards. With the suite now ~1420 files, 4
shards (355 files each) no longer divides the work enough.

## Change

- `.github/workflows/ci.yaml`: `shard: [0..7]`, `TOTAL_SHARDS: 8`
- `codecov.yml`: `after_n_builds: 5 -> 9` (8 shards + the scripts job), so
  Codecov holds patch/project status until every partial lcov arrives.

## Expected impact

~19 min -> ~10-11 min on the test critical path. Extra ubuntu runners are
free on this public repo; total concurrent jobs (~18) stay under the
account concurrency cap, so the parallel build jobs aren't queued/starved.

## Notes

- The shard count and `after_n_builds` are coupled: `after_n_builds` must
  equal (shard count + 1) for the scripts job. Both files carry a comment
  to keep them in sync.
- CI-config only; no Dart changes.
