### PR TITLE
Surface a trash button on saved-plan rows

### DIFF
--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -45,6 +45,11 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
     // Render stale data during a reload rather than flashing a spinner.
     final plans = summaries.valueOrNull;
 
+    // The compare-mode toggle only renders with >=2 plans; if an in-mode delete
+    // drops the count below that, fall back to normal rows so the user is never
+    // stranded in a mode whose exit control has disappeared.
+    final selecting = _selecting && (plans?.length ?? 0) >= 2;
+
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
@@ -104,9 +109,10 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
                 child: ListView.builder(
                   shrinkWrap: true,
                   itemCount: plans.length,
-                  itemBuilder: (context, i) => _selecting
+                  itemBuilder: (context, i) => selecting
                       ? CheckboxListTile(
                           contentPadding: EdgeInsets.zero,
+                          controlAffinity: ListTileControlAffinity.leading,
                           title: Text(plans[i].name),
                           value: _selected.contains(plans[i].id),
                           onChanged: (checked) => setState(() {
@@ -118,11 +124,22 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
                               _selected.remove(plans[i].id);
                             }
                           }),
+                          secondary: IconButton(
+                            icon: const Icon(Icons.delete_outline),
+                            color: theme.colorScheme.error,
+                            tooltip: context.l10n.common_action_delete,
+                            onPressed: () => _confirmAndDeletePlan(
+                              context,
+                              ref,
+                              plans[i].id,
+                              plans[i].name,
+                            ),
+                          ),
                         )
                       : _PlanTile(summary: plans[i], units: units),
                 ),
               ),
-            if (_selecting)
+            if (selecting)
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: FilledButton(
@@ -213,66 +230,81 @@ class _PlanTile extends ConsumerWidget {
         context.pop();
         context.go('/planning/dive-planner/${summary.id}');
       },
-      trailing: PopupMenuButton<String>(
-        onSelected: (value) async {
-          final repository = ref.read(divePlanRepositoryProvider);
-          if (value == 'duplicate') {
-            await repository.duplicatePlan(summary.id);
-          } else if (value == 'share') {
-            final plan = await repository.getPlan(summary.id);
-            if (plan == null) return;
-            final safeName = plan.name
-                .replaceAll(RegExp(r'[^\w\s-]'), '')
-                .trim()
-                .replaceAll(RegExp(r'\s+'), '_');
-            await saveAndShareFile(
-              planToSubplanJson(plan),
-              '${safeName.isEmpty ? 'dive_plan' : safeName}.$subplanExtension',
-              'application/json',
-            );
-          } else if (value == 'delete') {
-            final confirmed = await _confirmDelete(context);
-            if (confirmed) await repository.deletePlan(summary.id);
-          }
-        },
-        itemBuilder: (context) => [
-          PopupMenuItem(
-            value: 'duplicate',
-            child: Text(context.l10n.plannerCanvas_saved_duplicate),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            color: Theme.of(context).colorScheme.error,
+            tooltip: context.l10n.common_action_delete,
+            onPressed: () =>
+                _confirmAndDeletePlan(context, ref, summary.id, summary.name),
           ),
-          PopupMenuItem(
-            value: 'share',
-            child: Text(context.l10n.plannerCanvas_share_menu),
-          ),
-          PopupMenuItem(
-            value: 'delete',
-            child: Text(context.l10n.common_action_delete),
+          PopupMenuButton<String>(
+            onSelected: (value) async {
+              final repository = ref.read(divePlanRepositoryProvider);
+              if (value == 'duplicate') {
+                await repository.duplicatePlan(summary.id);
+              } else if (value == 'share') {
+                final plan = await repository.getPlan(summary.id);
+                if (plan == null) return;
+                final safeName = plan.name
+                    .replaceAll(RegExp(r'[^\w\s-]'), '')
+                    .trim()
+                    .replaceAll(RegExp(r'\s+'), '_');
+                await saveAndShareFile(
+                  planToSubplanJson(plan),
+                  '${safeName.isEmpty ? 'dive_plan' : safeName}.$subplanExtension',
+                  'application/json',
+                );
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'duplicate',
+                child: Text(context.l10n.plannerCanvas_saved_duplicate),
+              ),
+              PopupMenuItem(
+                value: 'share',
+                child: Text(context.l10n.plannerCanvas_share_menu),
+              ),
+            ],
           ),
         ],
       ),
     );
   }
+}
 
-  Future<bool> _confirmDelete(BuildContext context) async {
-    final result = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(context.l10n.plannerCanvas_saved_deleteConfirmTitle),
-        content: Text(
-          context.l10n.plannerCanvas_saved_deleteConfirmBody(summary.name),
+/// Confirms deletion of the plan named [name], then removes plan [id].
+///
+/// Shared by the normal row's trash button and the compare-mode row's trash
+/// button so both modes delete through a single confirmation path. The
+/// repository is read before the dialog await to avoid using [ref] across an
+/// async gap.
+Future<void> _confirmAndDeletePlan(
+  BuildContext context,
+  WidgetRef ref,
+  String id,
+  String name,
+) async {
+  final repository = ref.read(divePlanRepositoryProvider);
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(context.l10n.plannerCanvas_saved_deleteConfirmTitle),
+      content: Text(context.l10n.plannerCanvas_saved_deleteConfirmBody(name)),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(context.l10n.common_action_cancel),
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(context.l10n.common_action_cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(context.l10n.common_action_delete),
-          ),
-        ],
-      ),
-    );
-    return result ?? false;
-  }
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Text(context.l10n.common_action_delete),
+        ),
+      ],
+    ),
+  );
+  if (confirmed ?? false) await repository.deletePlan(id);
 }

--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -45,10 +45,18 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
     // Render stale data during a reload rather than flashing a spinner.
     final plans = summaries.valueOrNull;
 
-    // The compare-mode toggle only renders with >=2 plans; if an in-mode delete
-    // drops the count below that, fall back to normal rows so the user is never
-    // stranded in a mode whose exit control has disappeared.
-    final selecting = _selecting && (plans?.length ?? 0) >= 2;
+    // The compare-mode toggle only renders with >=2 plans. If an in-mode delete
+    // drops the count below that, actually leave compare mode (not merely hide
+    // it) so the sheet can't silently re-enter it when the count later climbs
+    // back to >=2 (e.g. via Import while the sheet is still open).
+    ref.listen(divePlanSummariesProvider, (_, next) {
+      if (_selecting && (next.valueOrNull?.length ?? 0) < 2) {
+        setState(() {
+          _selecting = false;
+          _selected.clear();
+        });
+      }
+    });
 
     return SafeArea(
       child: Padding(
@@ -109,7 +117,7 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
                 child: ListView.builder(
                   shrinkWrap: true,
                   itemCount: plans.length,
-                  itemBuilder: (context, i) => selecting
+                  itemBuilder: (context, i) => _selecting
                       ? CheckboxListTile(
                           contentPadding: EdgeInsets.zero,
                           controlAffinity: ListTileControlAffinity.leading,
@@ -139,7 +147,7 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
                       : _PlanTile(summary: plans[i], units: units),
                 ),
               ),
-            if (selecting)
+            if (_selecting)
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: FilledButton(

--- a/test/features/planner/saved_plans_sheet_test.dart
+++ b/test/features/planner/saved_plans_sheet_test.dart
@@ -121,9 +121,7 @@ void main() {
     await tester.pumpWidget(harness());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(PopupMenuButton<String>));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Delete').last);
+    await tester.tap(find.byIcon(Icons.delete_outline));
     await tester.pumpAndSettle();
 
     // Confirmation dialog.
@@ -179,6 +177,28 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('compare-page'), findsOneWidget);
+  });
+
+  testWidgets('delete is reachable from compare mode', (tester) async {
+    await repository.savePlan(_plan('a', 'Reef dive'));
+    await repository.savePlan(_plan('b', 'Wreck dive'));
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    // Enter compare mode -> each checkbox row carries its own trash button.
+    await tester.tap(find.text('Compare'));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.delete_outline), findsNWidgets(2));
+
+    await tester.tap(find.byIcon(Icons.delete_outline).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Delete plan?'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    expect(await repository.getAllPlanSummaries(), hasLength(1));
   });
 
   testWidgets('import reads a .subplan file and opens the imported plan', (

--- a/test/features/planner/saved_plans_sheet_test.dart
+++ b/test/features/planner/saved_plans_sheet_test.dart
@@ -199,6 +199,37 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(await repository.getAllPlanSummaries(), hasLength(1));
+
+    // Dropping to a single plan must actually leave compare mode (not merely
+    // hide the checkboxes): the surviving row renders as a normal tile.
+    expect(find.byType(CheckboxListTile), findsNothing);
+    expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+  });
+
+  testWidgets('compare mode is not silently re-entered after the count '
+      'recovers', (tester) async {
+    await repository.savePlan(_plan('a', 'Reef dive'));
+    await repository.savePlan(_plan('b', 'Wreck dive'));
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    // Enter compare mode, then delete down to one plan so the mode resets.
+    await tester.tap(find.text('Compare'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.delete_outline).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+    expect(find.byType(CheckboxListTile), findsNothing);
+
+    // Adding a plan back climbs the count to >=2 again. The sheet must stay in
+    // normal mode; a stale `_selecting` flag would resurrect the checkboxes.
+    await repository.savePlan(_plan('c', 'Drift dive'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CheckboxListTile), findsNothing);
+    expect(find.text('Compare'), findsOneWidget);
   });
 
   testWidgets('import reads a .subplan file and opens the imported plan', (


### PR DESCRIPTION
## Summary

Deleting a saved dive plan previously required opening each row's overflow (⋮) menu — easy to miss, and unavailable at all in compare/multi-select mode. This surfaces delete directly on the row.

- **Dedicated trash button on every saved-plan row.** Each row in the Saved Plans sheet now has an error-tinted `delete_outline` `IconButton`, so deletion is a single tap. The overflow menu keeps Duplicate and Share.
- **Delete now works in compare mode too.** The compare-mode `CheckboxListTile` moves its checkbox to the leading edge (`controlAffinity: leading`) and places a trash button in the `secondary` (trailing) slot — consistent placement with normal rows.
- **No stranding in compare mode.** The compare toggle only renders at ≥2 plans; deleting below that now auto-exits compare mode via a derived `selecting` flag, so the user can never get stuck in a mode whose exit control has disappeared.
- **Shared confirmation path.** The confirm-then-delete `AlertDialog` is extracted into a single top-level `_confirmAndDeletePlan(context, ref, id, name)` helper used by both the normal and compare-mode rows, replacing the per-widget `_confirmDelete` method.

## Testing

- `dart format` — clean
- `flutter analyze` (changed files) — no issues
- `flutter test test/features/planner/saved_plans_sheet_test.dart` — 9/9 pass, including a new `delete is reachable from compare mode` test. The existing normal-mode delete test was updated to tap the trash icon (`find.byIcon(Icons.delete_outline)`) rather than the removed menu item.