### PR TITLE
fix(safety): refresh safety review after sync and analyze-all

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -103,6 +103,12 @@ class DiveRepository {
   /// + dive_computers, plus dive_sites/dive_centers/trips/courses) so a synced
   /// edit to a tag/buddy/species/equipment/site/center/trip/computer NAME also
   /// refreshes the rendered detail, not just changes to the link rows.
+  ///
+  /// Also watches the two post-dive safety-review tables (dive_safety_reviews +
+  /// dive_safety_findings). They carry no HLC of their own, so a sync imports
+  /// them with a raw insertOnConflictUpdate straight into the tables; the one-
+  /// shot safetyReviewProvider self-invalidates on this stream so a freshly
+  /// synced (or batch-analyzed) review becomes visible without an app restart.
   Stream<void> watchDiveDetailChanges() => _db
       .tableUpdates(
         TableUpdateQuery.allOf([
@@ -127,6 +133,8 @@ class DiveRepository {
           TableUpdateQuery.onTable(_db.species),
           TableUpdateQuery.onTable(_db.media),
           TableUpdateQuery.onTable(_db.tideRecords),
+          TableUpdateQuery.onTable(_db.diveSafetyReviews),
+          TableUpdateQuery.onTable(_db.diveSafetyFindings),
         ]),
       )
       .debounce(changeTickDebounce);

--- a/lib/features/dive_log/presentation/providers/safety_review_providers.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_providers.dart
@@ -2,6 +2,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/domain/services/safety_review_service.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
@@ -20,6 +21,16 @@ final safetyReviewProvider = FutureProvider.family<SafetyReview?, String>((
   diveId,
 ) async {
   final repo = ref.watch(safetyFindingsRepositoryProvider);
+
+  // getReview is a one-shot SELECT, not a Drift stream, so this provider only
+  // re-runs when invalidated. A sync imports safety review/finding rows (and a
+  // batch "Analyze all dives" writes them) directly to the DB, bypassing every
+  // local notifier. Self-invalidate on the dive detail-change stream -- which
+  // now includes both safety tables -- so a freshly synced or batch-analyzed
+  // review appears without an app restart. Mirrors analysisDiveProvider.
+  ref.invalidateSelfWhen(
+    ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+  );
 
   final stored = await repo.getReview(diveId);
   if (stored != null &&

--- a/lib/features/settings/presentation/pages/safety_settings_page.dart
+++ b/lib/features/settings/presentation/pages/safety_settings_page.dart
@@ -164,6 +164,15 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
     for (final diveId in diveIds) {
       if (!mounted) return;
       try {
+        // Force a rebuild before reading: safetyReviewProvider is not
+        // autoDispose, so any dive whose detail page was already opened this
+        // session holds a cached AsyncValue. A bare `ref.read(...future)` would
+        // return that cached value -- including a null cached when the dive was
+        // opened mid-sync before its profile arrived -- and never run the
+        // compute-through-cache, so the review would stay missing until an app
+        // restart. Invalidating first guarantees the engine runs (and persists)
+        // for every dive in the sweep.
+        ref.invalidate(safetyReviewProvider(diveId));
         // Compute-through-cache: already-analyzed dives return after a cheap
         // marker-row read; only unanalyzed dives run the profile replay.
         await ref.read(safetyReviewProvider(diveId).future);

--- a/test/features/dive_log/presentation/providers/safety_review_providers_test.dart
+++ b/test/features/dive_log/presentation/providers/safety_review_providers_test.dart
@@ -1,6 +1,8 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/domain/services/safety_review_service.dart';
@@ -8,6 +10,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_anal
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
+import '../../../../helpers/test_database.dart';
 import '../../domain/services/safety_review_fixtures.dart';
 
 /// In-memory [SafetyFindingsRepository] with no database.
@@ -26,6 +29,29 @@ class _FakeRepo extends SafetyFindingsRepository {
 
 void main() {
   final now = DateTime.utc(2026, 7, 16);
+
+  // A real in-memory DB backs every test: the provider self-invalidates on the
+  // dive repository's detail-change stream, which resolves diveRepositoryProvider
+  // -> DiveRepository -> DatabaseService.instance. Without a wired database that
+  // watch would throw on build.
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    final ts = now.millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diveDateTime: Value(ts),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  });
+
+  tearDown(() => tearDownTestDatabase());
 
   SafetyReview storedReview(int version) => SafetyReview(
     diveId: 'd1',
@@ -105,6 +131,82 @@ void main() {
       expect(result!.engineVersion, SafetyReviewService.engineVersion);
       expect(result.findings, isNotEmpty);
       expect(repo.saved, isNotNull, reason: 'a computed review is persisted');
+    },
+  );
+
+  // Regression: a freshly synced library imports safety review/finding rows
+  // straight into their tables (SyncDataSerializer.insertOnConflictUpdate),
+  // bypassing every local notifier. The one-shot safetyReviewProvider must
+  // still pick them up without an app restart -- it did not before the
+  // self-invalidation hook on the dive detail-change stream (which now
+  // includes the safety tables) was added.
+  test(
+    'a synced safety review row refreshes the provider without a restart',
+    () async {
+      // A real repository over the in-memory DB, not the fake: the point is
+      // that a raw table write becomes visible through the provider.
+      final repo = SafetyFindingsRepository(db: db);
+      final container = ProviderContainer(
+        overrides: [
+          safetyFindingsRepositoryProvider.overrideWithValue(repo),
+          safetyReviewEnabledProvider.overrideWithValue(true),
+          // No profile: the compute path returns null, so the first read
+          // caches null exactly like opening a dive mid-sync.
+          profileAnalysisProvider('d1').overrideWith((ref) async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Keep the provider alive like an on-screen detail widget so an
+      // invalidation actually rebuilds it.
+      final sub = container.listen(safetyReviewProvider('d1'), (_, _) {});
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(safetyReviewProvider('d1').future),
+        isNull,
+        reason: 'nothing analyzed and no profile yet',
+      );
+
+      // Simulate the sync import writing the review + one finding directly.
+      final ts = now.millisecondsSinceEpoch;
+      await db
+          .into(db.diveSafetyReviews)
+          .insertOnConflictUpdate(
+            DiveSafetyReviewsCompanion.insert(
+              diveId: 'd1',
+              engineVersion: SafetyReviewService.engineVersion,
+              reviewedAt: ts,
+            ),
+          );
+      await db
+          .into(db.diveSafetyFindings)
+          .insert(
+            DiveSafetyFindingsCompanion.insert(
+              id: 'f1',
+              diveId: 'd1',
+              ruleId: SafetyRuleId.sawtoothProfile.dbValue,
+              severity: SafetySeverity.caution.dbValue,
+              engineVersion: SafetyReviewService.engineVersion,
+              createdAt: ts,
+              value: const Value(3),
+              startTimestamp: const Value(578),
+              endTimestamp: const Value(2582),
+            ),
+          );
+
+      // Wait past the change-tick debounce so invalidateSelfWhen fires.
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+      await pumpEventQueue();
+
+      final refreshed = await container.read(safetyReviewProvider('d1').future);
+      expect(
+        refreshed,
+        isNotNull,
+        reason: 'the synced review must be visible without an app restart',
+      );
+      expect(refreshed!.findings, hasLength(1));
+      expect(refreshed.findings.single.ruleId, SafetyRuleId.sawtoothProfile);
     },
   );
 }


### PR DESCRIPTION
## Problem

Safety-review findings were invisible after a **fresh iCloud sync** and after tapping **Analyze all dives** — they only appeared after an app restart.

## Root cause

Two compounding defects:

1. **Reactivity gap.** `safetyReviewProvider` is a non-`autoDispose` `FutureProvider.family` backed by a one-shot `getReview()` SELECT (not a Drift `.watch()` stream), with no self-invalidation hook. A sync imports `dive_safety_reviews` / `dive_safety_findings` rows with a raw `insertOnConflictUpdate` (these tables carry no HLC of their own), bypassing every local notifier — and `watchDiveDetailChanges()` did not list the two safety tables. So the imported rows were never re-read, and the cached `null` stuck until a cold `ProviderContainer` (app restart).

2. **Batch analyze-all no-op.** `_analyzeAllDives` did `ref.read(safetyReviewProvider(id).future)`. Because the provider is non-`autoDispose`, any dive whose detail page was already opened held a cached `AsyncValue`; the bare read returned it and never ran the compute-through-cache, so no rows were written for on-screen dives.

## Fix

- Add `dive_safety_reviews` + `dive_safety_findings` to `watchDiveDetailChanges()`.
- `safetyReviewProvider` now `invalidateSelfWhen(...watchDiveDetailChanges())`, mirroring `analysisDiveProvider`.
- `_analyzeAllDives` invalidates each provider before reading so the engine runs and persists for every swept dive, not just untouched ones.

### Why no invalidation storm

Adding the safety tables does not introduce a new re-analysis on dismiss: `setDismissed` / `saveReview` already bump the parent dive's HLC via `markRecordPending('dives', …)` → `UPDATE dives SET hlc`, which already ticks `watchDiveDetailChanges` today. The stream is also 300 ms-debounced, so a multi-changeset sync coalesces into a single refresh on the settled DB state.

## Tests

- New regression test in `safety_review_providers_test.dart` simulates a sync importing safety rows directly into the tables and asserts the provider refreshes **without a restart** (confirmed red before the fix, green after).
- Full safety-feature + reactivity suites pass; `flutter analyze` clean; `dart format` clean.

## Suggested manual smoke

Fresh iCloud sync onto a second device → open a dive with findings → confirm the Safety review section populates without restarting the app.