### PR TITLE
fix(planner): open saved plan with a single back press

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -249,13 +249,20 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                     name: 'noFly',
                     builder: (context, state) => const NoFlyPage(),
                   ),
-                  GoRoute(
-                    path: ':planId',
-                    name: 'editPlan',
-                    builder: (context, state) =>
-                        PlanCanvasPage(planId: state.pathParameters['planId']),
-                  ),
                 ],
+              ),
+              // Editing a saved plan is a SIBLING of the new-plan canvas, not a
+              // child. Nesting it under 'dive-planner' made go_router build the
+              // parent PlanCanvasPage() *and* the PlanCanvasPage(planId): since
+              // both read the same shared divePlanNotifierProvider, the first
+              // Back press only revealed the identical parent canvas, forcing a
+              // second press. Declared after the divePlanner subtree so its
+              // static children (compare/chart/no-fly) still win route matching.
+              GoRoute(
+                path: 'dive-planner/:planId',
+                name: 'editPlan',
+                builder: (context, state) =>
+                    PlanCanvasPage(planId: state.pathParameters['planId']),
               ),
               GoRoute(
                 path: 'deco-calculator',

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/router/app_router.dart';
 import 'package:submersion/features/checklists/presentation/pages/checklist_template_edit_page.dart';
 import 'package:submersion/features/checklists/presentation/pages/checklist_templates_page.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/planner/presentation/pages/plan_canvas_page.dart';
 import 'package:submersion/features/safety/presentation/pages/incident_edit_page.dart';
 import 'package:submersion/features/safety/presentation/pages/incidents_list_page.dart';
 import 'package:submersion/features/settings/presentation/pages/section_appearance_page.dart';
@@ -542,6 +543,104 @@ void main() {
             editRoute!.builder!(context, editState) as IncidentEditPage;
         expect(editWidget.incidentId, 'inc-1');
         expect(editWidget.diveId, isNull);
+      },
+    );
+  });
+
+  group('dive planner back-navigation (editPlan not nested)', () {
+    // Regression: opening a saved plan navigated to
+    // /planning/dive-planner/:planId, which was declared as a CHILD of the
+    // 'dive-planner' route. go_router builds one page per matched route
+    // segment, so the stack became [PlanningPage, PlanCanvasPage(),
+    // PlanCanvasPage(planId)] -- two canvas pages. Both read the same shared
+    // divePlanNotifierProvider, so the first Back press only revealed the
+    // identical parent canvas, forcing a second press. The fix makes editPlan
+    // a SIBLING of divePlanner (path 'dive-planner/:planId') so exactly one
+    // canvas page is built.
+
+    test('editPlan is a sibling of divePlanner, not a nested child', () {
+      final planning = _findRouteByName(
+        router.configuration.routes,
+        'planning',
+      );
+      expect(planning, isNotNull);
+
+      // editPlan lives directly under /planning (sibling of divePlanner).
+      final editPlan = planning!.routes.whereType<GoRoute>().firstWhere(
+        (r) => r.name == 'editPlan',
+        orElse: () =>
+            throw StateError('editPlan not a direct child of planning'),
+      );
+      expect(editPlan.path, 'dive-planner/:planId');
+
+      // The divePlanner subtree must NOT contain the plan-id route anymore.
+      final divePlanner = _findRouteByName(
+        router.configuration.routes,
+        'divePlanner',
+      );
+      expect(divePlanner, isNotNull);
+      final nestedNames = _collectRouteNames(divePlanner!.routes);
+      expect(nestedNames, isNot(contains('editPlan')));
+      final nestedPaths = _collectRoutePaths(divePlanner.routes);
+      expect(nestedPaths, isNot(contains(':planId')));
+    });
+
+    test('opening a saved plan matches only editPlan (single canvas page)', () {
+      final match = router.configuration.findMatch(
+        Uri.parse('/planning/dive-planner/plan-123'),
+      );
+      expect(match.fullPath, '/planning/dive-planner/:planId');
+    });
+
+    test('static sub-routes still win over the :planId sibling', () {
+      // Precedence guard: 'compare' / 'chart' / 'no-fly' remain children of
+      // divePlanner and must resolve before the dynamic sibling.
+      expect(
+        router.configuration
+            .findMatch(Uri.parse('/planning/dive-planner/compare?ids=a,b'))
+            .fullPath,
+        '/planning/dive-planner/compare',
+      );
+      expect(
+        router.configuration
+            .findMatch(Uri.parse('/planning/dive-planner/chart'))
+            .fullPath,
+        '/planning/dive-planner/chart',
+      );
+    });
+
+    testWidgets(
+      'editPlan builder threads planId; divePlanner builds a new plan',
+      (tester) async {
+        await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+        final context = tester.element(find.byType(SizedBox));
+        final config = router.configuration;
+
+        final editPlan = _findRouteByName(config.routes, 'editPlan');
+        final editState = GoRouterState(
+          config,
+          uri: Uri.parse('/planning/dive-planner/plan-123'),
+          matchedLocation: '/planning/dive-planner/plan-123',
+          fullPath: '/planning/dive-planner/:planId',
+          pathParameters: const {'planId': 'plan-123'},
+          pageKey: const ValueKey('/planning/dive-planner/plan-123'),
+        );
+        final editWidget =
+            editPlan!.builder!(context, editState) as PlanCanvasPage;
+        expect(editWidget.planId, 'plan-123');
+
+        final divePlanner = _findRouteByName(config.routes, 'divePlanner');
+        final newState = GoRouterState(
+          config,
+          uri: Uri.parse('/planning/dive-planner'),
+          matchedLocation: '/planning/dive-planner',
+          fullPath: '/planning/dive-planner',
+          pathParameters: const {},
+          pageKey: const ValueKey('/planning/dive-planner'),
+        );
+        final newWidget =
+            divePlanner!.builder!(context, newState) as PlanCanvasPage;
+        expect(newWidget.planId, isNull);
       },
     );
   });


### PR DESCRIPTION
## Problem

Opening a saved plan from the planner required pressing the back arrow **twice**. The first press slid the page away but only revealed an identical-looking canvas underneath; a second press was needed to actually return to the planning hub.

## Root cause

The "edit saved plan" route (`:planId`) was declared as a **child** of the new-plan `dive-planner` route:

```
dive-planner            -> PlanCanvasPage()          (parent page)
  └─ :planId            -> PlanCanvasPage(planId)     (child page)
```

go_router builds **one page per matched route segment**, so navigating to `/planning/dive-planner/<id>` stacked *two* `PlanCanvasPage` instances: `[PlanningPage, PlanCanvasPage(), PlanCanvasPage(id)]`. Because `PlanCanvasPage` reads its plan from the shared `divePlanNotifierProvider` (not from its constructor), the parent page rendered the *same plan* as the child — hence the phantom first back press. The new-plan flow (no id) matched a single segment, which is why only *saved* plans exhibited the double-back.

## Fix

Make `editPlan` a **sibling** of `divePlanner` with a two-segment path (`dive-planner/:planId`), declared *after* the `divePlanner` subtree so its static children (`compare`/`chart`/`no-fly`) still win route matching. Opening a saved plan now builds a single canvas page → one back press.

## Tests

Added a `dive planner back-navigation` group to `app_router_test.dart`:
- `editPlan` is a sibling of `divePlanner`, not a nested child (fails on the old code)
- `/planning/dive-planner/<id>` resolves to `editPlan`
- static sub-routes (`compare`/`chart`) still resolve ahead of the `:planId` sibling (precedence guard)
- builder threads `planId` through; the new-plan route builds with `planId == null`

All 37 router tests pass; `flutter analyze` and `dart format` clean.