### PR TITLE
fix(import): stop storing bottom time equal to runtime

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -3178,9 +3178,7 @@ class AppDatabase extends _$AppDatabase {
     // test fixtures (and any DB that reached this block through a guarded
     // path) may lack the tables or the specific columns this reads, in which
     // case there is simply nothing to backfill.
-    final diveCols = await customSelect(
-      "PRAGMA table_info('dives')",
-    ).get();
+    final diveCols = await customSelect("PRAGMA table_info('dives')").get();
     final diveColNames = diveCols.map((c) => c.read<String>('name')).toSet();
     if (!diveColNames.contains('bottom_time') ||
         !diveColNames.contains('runtime')) {
@@ -3192,7 +3190,8 @@ class AppDatabase extends _$AppDatabase {
     final profileColNames = profileCols
         .map((c) => c.read<String>('name'))
         .toSet();
-    if (!profileColNames.contains('is_primary') ||
+    if (!profileColNames.contains('dive_id') ||
+        !profileColNames.contains('is_primary') ||
         !profileColNames.contains('timestamp') ||
         !profileColNames.contains('depth')) {
       return;

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2831,7 +2831,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 130;
+  static const int currentSchemaVersion = 132;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -2982,6 +2982,11 @@ class AppDatabase extends _$AppDatabase {
     129,
     // v130: media_enrichment.hlc so a photo's depth/time association syncs.
     130,
+    // v131 is reserved by an in-flight branch (equipment service clock
+    // unification); this branch's next migration is v132.
+    // v132: backfill dives whose bottom_time was wrongly stored equal to
+    // runtime by older imports, recomputing it from the primary profile.
+    132,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -3153,6 +3158,111 @@ class AppDatabase extends _$AppDatabase {
              weight_kg, 0, created_at, updated_at, NULL
       FROM equipment WHERE weight_kg IS NOT NULL
     ''');
+  }
+
+  /// v132 data fix: older imports (Subsurface/MacDive/CSV routed through the
+  /// UDDF entity importer) seeded `bottom_time` from the total-time `duration`,
+  /// so bottom time was stored equal to `runtime`. For any such dive that also
+  /// carries a profile, recompute bottom time from the PRIMARY profile the same
+  /// way [Dive.calculateBottomTimeFromProfile] does (time at/above 85% of max
+  /// depth) and correct it only when the derived value is shorter than runtime.
+  ///
+  /// Deterministic on every device, so `hlc` is left untouched and no sync
+  /// traffic is needed to converge (LWW falls back to the existing hlc /
+  /// updated_at, exactly like the v124 legacy-attribute copy). PRAGMA-guarded
+  /// for minimal old-schema fixtures. onUpgrade only -- never beforeOpen -- so
+  /// a dive a user deliberately left with bottom_time == runtime (and no
+  /// profile to prove otherwise) is never re-touched.
+  Future<void> _backfillBottomTimeFromProfile() async {
+    // PRAGMA-guarded like every other migration helper: minimal old-schema
+    // test fixtures (and any DB that reached this block through a guarded
+    // path) may lack the tables or the specific columns this reads, in which
+    // case there is simply nothing to backfill.
+    final diveCols = await customSelect(
+      "PRAGMA table_info('dives')",
+    ).get();
+    final diveColNames = diveCols.map((c) => c.read<String>('name')).toSet();
+    if (!diveColNames.contains('bottom_time') ||
+        !diveColNames.contains('runtime')) {
+      return;
+    }
+    final profileCols = await customSelect(
+      "PRAGMA table_info('dive_profiles')",
+    ).get();
+    final profileColNames = profileCols
+        .map((c) => c.read<String>('name'))
+        .toSet();
+    if (!profileColNames.contains('is_primary') ||
+        !profileColNames.contains('timestamp') ||
+        !profileColNames.contains('depth')) {
+      return;
+    }
+
+    final candidates = await customSelect(
+      'SELECT id, runtime FROM dives '
+      'WHERE bottom_time IS NOT NULL AND runtime IS NOT NULL '
+      'AND bottom_time = runtime',
+    ).get();
+
+    for (final candidate in candidates) {
+      final diveId = candidate.read<String>('id');
+      final runtimeSeconds = candidate.read<int>('runtime');
+
+      // Primary profile rows only, mirroring the domain profile hydration in
+      // DiveRepositoryImpl (is_primary = 1); mixing a secondary computer's rows
+      // would compute the wrong bottom window.
+      final points = await customSelect(
+        'SELECT timestamp, depth FROM dive_profiles '
+        'WHERE dive_id = ? AND is_primary = 1 '
+        'ORDER BY timestamp ASC',
+        variables: [Variable<String>(diveId)],
+      ).get();
+
+      final bottomSeconds = _bottomTimeSecondsFromProfileRows(points);
+      if (bottomSeconds != null && bottomSeconds < runtimeSeconds) {
+        await customStatement('UPDATE dives SET bottom_time = ? WHERE id = ?', [
+          bottomSeconds,
+          diveId,
+        ]);
+      }
+    }
+  }
+
+  /// Bottom time in seconds from timestamp-ordered profile rows, replicating
+  /// [Dive.calculateBottomTimeFromProfile]: the span between the first and last
+  /// samples at/above 85% of max depth. Returns null when the profile is too
+  /// small or lacks a clear bottom window.
+  int? _bottomTimeSecondsFromProfileRows(List<QueryRow> points) {
+    if (points.length < 3) return null;
+
+    var maxDepth = 0.0;
+    for (final point in points) {
+      final depth = point.read<double>('depth');
+      if (depth > maxDepth) maxDepth = depth;
+    }
+    if (maxDepth <= 0) return null;
+
+    final threshold = maxDepth * 0.85;
+
+    int? descentEnd;
+    for (final point in points) {
+      if (point.read<double>('depth') >= threshold) {
+        descentEnd = point.read<int>('timestamp');
+        break;
+      }
+    }
+
+    int? ascentStart;
+    for (var i = points.length - 1; i >= 0; i--) {
+      if (points[i].read<double>('depth') >= threshold) {
+        ascentStart = points[i].read<int>('timestamp');
+        break;
+      }
+    }
+
+    if (descentEnd == null || ascentStart == null) return null;
+    if (ascentStart <= descentEnd) return null;
+    return ascentStart - descentEnd;
   }
 
   /// v114: collapse duplicate tombstones (newest deleted_at per entity_type +
@@ -6782,6 +6892,17 @@ class AppDatabase extends _$AppDatabase {
           await _assertMediaEnrichmentHlcColumn();
         }
         if (from < 130) await reportProgress();
+        // v132: correct dives whose bottom_time was stored equal to runtime by
+        // older imports (Subsurface/MacDive/CSV via the UDDF entity importer,
+        // which seeded bottom_time from the total-time `duration`). onUpgrade
+        // only -- a deterministic local recompute, never beforeOpen, so a
+        // profile-less dive a user deliberately left with bottom_time==runtime
+        // is not re-touched on every open. (v131 is reserved by an in-flight
+        // branch.)
+        if (from < 132) {
+          await _backfillBottomTimeFromProfile();
+        }
+        if (from < 132) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1184,8 +1184,16 @@ class UddfEntityImporter {
       final dateTime = diveData['dateTime'] as DateTime? ?? now;
       // CSV imports provide only 'duration' (used as bottomTime); fall back
       // to it for runtime so the total dive time is populated.
-      final runtime =
-          diveData['runtime'] as Duration? ?? diveData['duration'] as Duration?;
+      final durationValue = diveData['duration'] as Duration?;
+      final runtime = diveData['runtime'] as Duration? ?? durationValue;
+      // `duration` is ambiguous across import formats: some parsers (FIT) put a
+      // genuine bottom time here, while others (Subsurface) put total runtime,
+      // which would make bottom time equal runtime. Only trust `duration` as a
+      // real bottom time when it differs from runtime; otherwise leave it null
+      // so the profile-based auto-calculation below can derive it.
+      final bottomTimeSeed = durationValue != null && durationValue != runtime
+          ? durationValue
+          : null;
       final parsedEntryTime = diveData['entryTime'] as DateTime?;
       final entryTime = parsedEntryTime ?? dateTime;
       final exitTime = runtime != null ? dateTime.add(runtime) : null;
@@ -1229,7 +1237,7 @@ class UddfEntityImporter {
         dateTime: dateTime,
         entryTime: entryTime,
         exitTime: exitTime,
-        bottomTime: diveData['duration'] as Duration?,
+        bottomTime: bottomTimeSeed,
         runtime: runtime,
         maxDepth: asDoubleOrNull(diveData['maxDepth']),
         avgDepth: asDoubleOrNull(diveData['avgDepth']),
@@ -1304,6 +1312,12 @@ class UddfEntityImporter {
         if (calculatedBottomTime != null) {
           dive = dive.copyWith(bottomTime: calculatedBottomTime);
         }
+      }
+      // If bottom time still could not be derived (no profile, or a profile the
+      // heuristic could not resolve), fall back to the source duration so the
+      // field is not left empty for minimal imports such as CSV.
+      if (dive.bottomTime == null && durationValue != null) {
+        dive = dive.copyWith(bottomTime: durationValue);
       }
 
       await repos.diveRepository.createDive(dive);

--- a/test/core/database/migration_v130_media_enrichment_hlc_test.dart
+++ b/test/core/database/migration_v130_media_enrichment_hlc_test.dart
@@ -34,8 +34,10 @@ void main() {
     );
   });
 
-  test('v130 is the current schema version (exact-latest tripwire)', () {
-    expect(AppDatabase.currentSchemaVersion, 130);
+  test('v130 is present in the schema-version ladder', () {
+    // Relaxed from an exact-latest tripwire when the v132 bottom-time backfill
+    // superseded v130 as the newest migration (superseded-tripwire convention).
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(130));
     expect(AppDatabase.migrationVersions, contains(130));
   });
 }

--- a/test/core/database/migration_v132_bottom_time_backfill_test.dart
+++ b/test/core/database/migration_v132_bottom_time_backfill_test.dart
@@ -1,0 +1,195 @@
+import 'package:drift/drift.dart' show Variable;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// v132 backfill: earlier imports (Subsurface/MacDive/CSV via the UDDF entity
+/// importer) stored the total dive time in `bottom_time`, making it equal
+/// `runtime`. When a profile exists, the migration recomputes bottom time from
+/// the primary profile the same way [Dive.calculateBottomTimeFromProfile] does.
+void main() {
+  // Builds a pre-v132 database (stamped at main's v130) with just the tables
+  // the backfill touches, then seeds dives + primary/secondary profile rows.
+  NativeDatabase setupDb(void Function(dynamic rawDb) seed) {
+    return NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 130');
+        rawDb.execute('''
+          CREATE TABLE dives (
+            id TEXT NOT NULL PRIMARY KEY,
+            bottom_time INTEGER,
+            runtime INTEGER,
+            hlc TEXT
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE dive_profiles (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            is_primary INTEGER NOT NULL DEFAULT 1,
+            timestamp INTEGER NOT NULL,
+            depth REAL NOT NULL
+          )
+        ''');
+        seed(rawDb);
+      },
+    );
+  }
+
+  void insertDive(
+    dynamic rawDb,
+    String id, {
+    int? bottomTime,
+    int? runtime,
+    String? hlc,
+  }) {
+    rawDb.execute(
+      'INSERT INTO dives (id, bottom_time, runtime, hlc) VALUES (?, ?, ?, ?)',
+      [id, bottomTime, runtime, hlc],
+    );
+  }
+
+  // A clear bottom window: 85% of 30 m = 25.5 m; the diver is at/above it from
+  // t=60 to t=1200, so bottom time is 1140 s.
+  void insertBottomWindowProfile(
+    dynamic rawDb,
+    String diveId, {
+    required bool isPrimary,
+    String prefix = 'p',
+  }) {
+    const points = [
+      [0, 0.0],
+      [60, 30.0],
+      [120, 30.0],
+      [1200, 30.0],
+      [1260, 5.0],
+      [1320, 0.0],
+    ];
+    for (var i = 0; i < points.length; i++) {
+      rawDb.execute(
+        'INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, depth) '
+        'VALUES (?, ?, ?, ?, ?)',
+        [
+          '$prefix-$diveId-$i',
+          diveId,
+          isPrimary ? 1 : 0,
+          points[i][0],
+          points[i][1],
+        ],
+      );
+    }
+  }
+
+  Future<int?> bottomTimeOf(AppDatabase db, String id) async {
+    final row = await db
+        .customSelect(
+          'SELECT bottom_time FROM dives WHERE id = ?',
+          variables: [Variable<String>(id)],
+        )
+        .getSingle();
+    return row.data['bottom_time'] as int?;
+  }
+
+  test(
+    'recomputes bottom time from the primary profile when it equals runtime',
+    () async {
+      final db = AppDatabase(
+        setupDb((rawDb) {
+          insertDive(rawDb, 'd1', bottomTime: 1320, runtime: 1320);
+          insertBottomWindowProfile(rawDb, 'd1', isPrimary: true);
+        }),
+      );
+      addTearDown(db.close);
+
+      expect(await bottomTimeOf(db, 'd1'), 1140);
+    },
+  );
+
+  test(
+    'leaves a profile-less dive untouched (cannot derive bottom time)',
+    () async {
+      final db = AppDatabase(
+        setupDb((rawDb) {
+          insertDive(rawDb, 'd2', bottomTime: 1320, runtime: 1320);
+        }),
+      );
+      addTearDown(db.close);
+
+      expect(await bottomTimeOf(db, 'd2'), 1320);
+    },
+  );
+
+  test(
+    'leaves an already-correct dive untouched (bottom time != runtime)',
+    () async {
+      final db = AppDatabase(
+        setupDb((rawDb) {
+          insertDive(rawDb, 'd3', bottomTime: 1140, runtime: 1320);
+          insertBottomWindowProfile(rawDb, 'd3', isPrimary: true);
+        }),
+      );
+      addTearDown(db.close);
+
+      expect(await bottomTimeOf(db, 'd3'), 1140);
+    },
+  );
+
+  test(
+    'uses only primary profile rows, ignoring secondary computer rows',
+    () async {
+      final db = AppDatabase(
+        setupDb((rawDb) {
+          insertDive(rawDb, 'd4', bottomTime: 1320, runtime: 1320);
+          insertBottomWindowProfile(
+            rawDb,
+            'd4',
+            isPrimary: true,
+            prefix: 'pri',
+          );
+          // Secondary computer rows with an earlier bottom window that would
+          // shift the computed value if wrongly included.
+          rawDb.execute(
+            'INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, depth)'
+            ' VALUES (?, ?, 0, ?, ?)',
+            ['sec-d4-0', 'd4', 30, 30.0],
+          );
+          rawDb.execute(
+            'INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, depth)'
+            ' VALUES (?, ?, 0, ?, ?)',
+            ['sec-d4-1', 'd4', 90, 30.0],
+          );
+        }),
+      );
+      addTearDown(db.close);
+
+      expect(await bottomTimeOf(db, 'd4'), 1140);
+    },
+  );
+
+  test(
+    'does not bump hlc (deterministic local correction, no sync traffic)',
+    () async {
+      final db = AppDatabase(
+        setupDb((rawDb) {
+          insertDive(rawDb, 'd5', bottomTime: 1320, runtime: 1320, hlc: 'H1');
+          insertBottomWindowProfile(rawDb, 'd5', isPrimary: true);
+        }),
+      );
+      addTearDown(db.close);
+
+      expect(await bottomTimeOf(db, 'd5'), 1140);
+      final row = await db
+          .customSelect(
+            'SELECT hlc FROM dives WHERE id = ?',
+            variables: [const Variable<String>('d5')],
+          )
+          .getSingle();
+      expect(row.data['hlc'], 'H1');
+    },
+  );
+
+  test('schema version is at least 132 and the migration list includes it', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(132));
+    expect(AppDatabase.migrationVersions, contains(132));
+  });
+}

--- a/test/core/database/migration_v132_bottom_time_backfill_test.dart
+++ b/test/core/database/migration_v132_bottom_time_backfill_test.dart
@@ -188,6 +188,44 @@ void main() {
     },
   );
 
+  test('no-ops safely when dive_profiles lacks a dive_id column', () async {
+    // An ancient/minimal fixture could have dive_profiles with the read
+    // columns but without dive_id (which the per-dive query filters on). The
+    // guard must include dive_id so the migration no-ops instead of throwing
+    // "no such column: dive_id".
+    final db = AppDatabase(
+      NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA user_version = 130');
+          rawDb.execute('''
+            CREATE TABLE dives (
+              id TEXT NOT NULL PRIMARY KEY,
+              bottom_time INTEGER,
+              runtime INTEGER,
+              hlc TEXT
+            )
+          ''');
+          rawDb.execute('''
+            CREATE TABLE dive_profiles (
+              id TEXT NOT NULL PRIMARY KEY,
+              is_primary INTEGER NOT NULL DEFAULT 1,
+              timestamp INTEGER NOT NULL,
+              depth REAL NOT NULL
+            )
+          ''');
+          rawDb.execute(
+            'INSERT INTO dives (id, bottom_time, runtime) VALUES (?, ?, ?)',
+            ['d6', 1320, 1320],
+          );
+        },
+      ),
+    );
+    addTearDown(db.close);
+
+    // Opening (which runs onUpgrade) must not throw; the dive is untouched.
+    expect(await bottomTimeOf(db, 'd6'), 1320);
+  });
+
   test('schema version is at least 132 and the migration list includes it', () {
     expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(132));
     expect(AppDatabase.migrationVersions, contains(132));

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -713,6 +713,127 @@ void main() {
       expect(dive.diverId, diverId);
     });
 
+    // Subsurface (and similar) parsers set 'duration' and 'runtime' to the same
+    // total-time value; that duration is the runtime, not a distinct bottom
+    // time. When a profile exists, bottom time must be derived from it, not left
+    // equal to runtime. Regression guard for the "bottom time == runtime" bug.
+    test(
+      'derives bottom time from profile when duration equals runtime',
+      () async {
+        when(mockDiveRepo.createDive(any)).thenAnswer(
+          (invocation) async => invocation.positionalArguments[0] as Dive,
+        );
+
+        final data = UddfImportResult(
+          dives: [
+            {
+              'dateTime': now,
+              'maxDepth': 30.0,
+              // Total dive time in both keys, as Subsurface reports it.
+              'duration': const Duration(seconds: 1320),
+              'runtime': const Duration(seconds: 1320),
+              'profile': [
+                {'timestamp': 0, 'depth': 0.0},
+                {'timestamp': 60, 'depth': 30.0},
+                {'timestamp': 120, 'depth': 30.0},
+                {'timestamp': 1200, 'depth': 30.0},
+                {'timestamp': 1260, 'depth': 5.0},
+                {'timestamp': 1320, 'depth': 0.0},
+              ],
+            },
+          ],
+        );
+
+        await importer.import(
+          data: data,
+          selections: const UddfImportSelections(dives: {0}),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        final dive =
+            verify(mockDiveRepo.createDive(captureAny)).captured.single as Dive;
+        // Bottom threshold is 85% of 30 m = 25.5 m; the diver is at/above it from
+        // t=60 to t=1200, so bottom time is 1140 s, not the 1320 s runtime.
+        expect(dive.runtime, const Duration(seconds: 1320));
+        expect(dive.bottomTime, const Duration(seconds: 1140));
+        expect(dive.bottomTime!, lessThan(dive.runtime!));
+      },
+    );
+
+    // FIT parsers put a genuine, device-reported bottom time in 'duration'
+    // (distinct from 'runtime'). That real value must be preserved, not
+    // overwritten by the profile heuristic.
+    test(
+      'keeps a genuine bottom time when duration differs from runtime',
+      () async {
+        when(mockDiveRepo.createDive(any)).thenAnswer(
+          (invocation) async => invocation.positionalArguments[0] as Dive,
+        );
+
+        final data = UddfImportResult(
+          dives: [
+            {
+              'dateTime': now,
+              'maxDepth': 30.0,
+              'duration': const Duration(seconds: 3263), // real bottom time
+              'runtime': const Duration(seconds: 3600), // total elapsed
+              'profile': [
+                {'timestamp': 0, 'depth': 0.0},
+                {'timestamp': 60, 'depth': 30.0},
+                {'timestamp': 1200, 'depth': 30.0},
+                {'timestamp': 1320, 'depth': 0.0},
+              ],
+            },
+          ],
+        );
+
+        await importer.import(
+          data: data,
+          selections: const UddfImportSelections(dives: {0}),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        final dive =
+            verify(mockDiveRepo.createDive(captureAny)).captured.single as Dive;
+        expect(dive.bottomTime, const Duration(seconds: 3263));
+        expect(dive.runtime, const Duration(seconds: 3600));
+      },
+    );
+
+    // Minimal CSV imports carry only a single 'duration' with no profile; that
+    // value must still populate bottom time so the field is not left empty.
+    test(
+      'falls back to duration for bottom time when there is no profile',
+      () async {
+        when(mockDiveRepo.createDive(any)).thenAnswer(
+          (invocation) async => invocation.positionalArguments[0] as Dive,
+        );
+
+        final data = UddfImportResult(
+          dives: [
+            {
+              'dateTime': now,
+              'maxDepth': 18.0,
+              'duration': const Duration(minutes: 42),
+            },
+          ],
+        );
+
+        await importer.import(
+          data: data,
+          selections: const UddfImportSelections(dives: {0}),
+          repositories: repos,
+          diverId: diverId,
+        );
+
+        final dive =
+            verify(mockDiveRepo.createDive(captureAny)).captured.single as Dive;
+        expect(dive.bottomTime, const Duration(minutes: 42));
+      },
+    );
+
     test('links dive to imported site via ID mapping', () async {
       when(mockSiteRepo.createSite(any)).thenAnswer((invocation) async {
         final site = invocation.positionalArguments[0] as DiveSite;


### PR DESCRIPTION
## Problem

Users reported imported dives showing **bottom time equal to runtime**. The value only corrected itself when they tapped the profile "calculate" button next to the bottom time field.

## Root cause

The UDDF entity importer (`uddf_entity_importer.dart`) seeded `bottomTime` directly from `diveData['duration']`. But `duration` is semantically inconsistent across parsers:

- **FIT** (`fit_import_parser.dart`) puts a *genuine, device-reported bottom time* in `duration`.
- **Subsurface / MacDive** (`subsurface_xml_parser.dart`) set `duration` and `runtime` to the *same total-dive-time* value.

So for Subsurface/MacDive/CSV imports, bottom time was stored equal to runtime. And because `bottomTime` was then non-null, the importer's existing profile-based auto-calculation — guarded by `bottomTime == null` — was skipped entirely. The "calculate" button worked only because it force-recomputes from the profile, bypassing the bad stored value.

The two other import paths (`dive_computer_repository_impl.dart`, `imported_dive_converter.dart`) were already correct: they set `runtime = duration` and derive `bottomTime` from the profile.

Because SAC (surface air consumption) divides gas used by bottom time, this bug also silently under-reported gas consumption on affected dives.

## Fix

Trust `duration` as a real bottom time **only when it differs from runtime** (the genuine FIT case). Otherwise seed `bottomTime` null so the existing profile heuristic (`Dive.calculateBottomTimeFromProfile`, the time at/above 85% of max depth) derives it. A final fallback keeps `duration` when there is no profile, preserving minimal-CSV behavior.

## Backfill for already-imported dives

New **v132** `onUpgrade` migration (`_backfillBottomTimeFromProfile`) corrects dives already stored with `bottom_time == runtime` that carry a **primary** profile (`is_primary = 1`, mirroring the domain hydration), recomputing bottom time from the profile and only when the derived value is shorter than runtime.

- Deterministic local recompute, so `hlc` is left untouched — it converges across devices without sync traffic (same pattern as the v124 legacy-attribute copy).
- `onUpgrade`-only (never `beforeOpen`), so a profile-less dive a user deliberately set to `bottom == runtime` is never re-touched.
- PRAGMA-column-guarded so old-schema migration fixtures without `runtime`/`bottom_time` are skipped safely.

v131 is reserved by an in-flight branch (equipment service clock unification), so this claims v132.

## Tests

- New importer tests: derive from profile when `duration == runtime`; keep a genuine bottom time when `duration != runtime` (FIT); fall back to `duration` when there is no profile.
- New `migration_v132_bottom_time_backfill_test.dart`: recompute case, profile-less untouched, already-correct untouched, primary-profile-only (ignores secondary computer rows), and `hlc` untouched.
- Relaxed the superseded v130 exact-version tripwire to `greaterThanOrEqualTo(130)` per the repo's superseded-tripwire convention.
- Full `flutter test` suite passes locally; `flutter analyze` clean on changed files.