### PR TITLE
fix(dive-log): treat a gas change at the first sample as the initial gas (#679)

### DIFF
--- a/lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
+++ b/lib/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart
@@ -22,6 +22,7 @@ EstimatedTankPressures synthesizeEstimatedTankPressures({
   required List<DiveTank> tanks,
   required List<GasSwitchWithTank> gasSwitches,
   required int diveDurationSeconds,
+  int firstSampleSeconds = 0,
 }) {
   final pressures = <String, List<TankPressurePoint>>{...existing};
   final estimated = <String>{};
@@ -33,6 +34,7 @@ EstimatedTankPressures synthesizeEstimatedTankPressures({
     tanks: tanks,
     gasSwitches: gasSwitches,
     diveDurationSeconds: diveDurationSeconds,
+    firstSampleSeconds: firstSampleSeconds,
   );
 
   for (final tank in tanks) {

--- a/lib/features/dive_log/data/services/gas_usage_segments_service.dart
+++ b/lib/features/dive_log/data/services/gas_usage_segments_service.dart
@@ -28,12 +28,20 @@ class GasUsageSegment {
 /// Algorithm:
 /// 1. Pick the starting tank (lowest [DiveTank.order], or the first tank).
 /// 2. Sort gas switches by timestamp and clamp to dive bounds.
-/// 3. The initial segment runs from t=0 to the first switch's timestamp
-///    (skipped if the first switch is exactly at t=0).
-/// 4. Each subsequent segment runs from one switch to the next, ending at
+/// 3. A switch at or before [firstSampleSeconds] is the dive's initial-gas
+///    declaration rather than a mid-dive switch, and owns the window from t=0.
+/// 4. Otherwise the initial segment runs from t=0 to the first switch, filled
+///    from the starting tank.
+/// 5. Each subsequent segment runs from one switch to the next, ending at
 ///    [diveDurationSeconds] for the final switch.
-/// 5. Adjacent segments with identical gas mixes are merged so a switch back
+/// 6. Adjacent segments with identical gas mixes are merged so a switch back
 ///    to the same gas does not produce a visible seam.
+///
+/// [firstSampleSeconds] is the timestamp of the dive's first profile sample.
+/// Dive computers do not sample at t=0, and importers record the starting gas
+/// as a gas-change event at that first sample; without it a phantom leading
+/// segment is invented from the lowest-order tank, which renders a sliver of
+/// the wrong gas whenever that tank holds a different mix (issue #679).
 ///
 /// Returns an empty list when there are no tanks or the dive has no
 /// duration — the caller should hide the strip in that case.
@@ -41,6 +49,7 @@ List<GasUsageSegment> buildGasUsageSegments({
   required List<DiveTank> tanks,
   required List<GasSwitchWithTank> gasSwitches,
   required int diveDurationSeconds,
+  int firstSampleSeconds = 0,
 }) {
   if (tanks.isEmpty || diveDurationSeconds <= 0) {
     return const <GasUsageSegment>[];
@@ -70,12 +79,16 @@ List<GasUsageSegment> buildGasUsageSegments({
 
   final segments = <GasUsageSegment>[];
 
-  final firstSwitch = inBoundsSwitches.first;
-  if (firstSwitch.timestamp > 0) {
+  final initialIndex = _initialGasDeclarationIndex(
+    inBoundsSwitches,
+    firstSampleSeconds,
+  );
+
+  if (initialIndex == null) {
     segments.add(
       GasUsageSegment(
         startSeconds: 0,
-        endSeconds: firstSwitch.timestamp,
+        endSeconds: inBoundsSwitches.first.timestamp,
         gasMix: startingTank.gasMix,
         label: startingTank.gasMix.name,
         tankName: startingTank.name,
@@ -83,17 +96,18 @@ List<GasUsageSegment> buildGasUsageSegments({
     );
   }
 
-  for (var i = 0; i < inBoundsSwitches.length; i++) {
+  for (var i = initialIndex ?? 0; i < inBoundsSwitches.length; i++) {
     final cur = inBoundsSwitches[i];
+    final startSec = i == initialIndex ? 0 : cur.timestamp;
     final endSec = i + 1 < inBoundsSwitches.length
         ? inBoundsSwitches[i + 1].timestamp
         : diveDurationSeconds;
-    if (cur.timestamp >= endSec) continue;
+    if (startSec >= endSec) continue;
     final tank = tankById[cur.tankId];
     final gasMix = GasMix(o2: cur.o2Fraction * 100, he: cur.heFraction * 100);
     segments.add(
       GasUsageSegment(
-        startSeconds: cur.timestamp,
+        startSeconds: startSec,
         endSeconds: endSec,
         gasMix: gasMix,
         label: gasMix.name,
@@ -103,6 +117,25 @@ List<GasUsageSegment> buildGasUsageSegments({
   }
 
   return _mergeAdjacentSameGas(segments);
+}
+
+/// Index into [sorted] of the switch that declares the dive's starting gas, or
+/// null when the first switch is a genuine mid-dive change.
+///
+/// Importers write the starting gas as a gas-change event at the first profile
+/// sample, so any switch at or before [firstSampleSeconds] is a declaration,
+/// not a change. When several land in that window the last one wins — it is the
+/// gas actually carried into the dive.
+int? _initialGasDeclarationIndex(
+  List<GasSwitchWithTank> sorted,
+  int firstSampleSeconds,
+) {
+  int? index;
+  for (var i = 0; i < sorted.length; i++) {
+    if (sorted[i].timestamp > firstSampleSeconds) break;
+    index = i;
+  }
+  return index;
 }
 
 List<GasUsageSegment> _mergeAdjacentSameGas(List<GasUsageSegment> segments) {
@@ -133,14 +166,16 @@ List<GasUsageSegment> _mergeAdjacentSameGas(List<GasUsageSegment> segments) {
 ///
 /// Uses the same starting-tank + switch-walk rules as [buildGasUsageSegments]
 /// (starting tank = lowest [DiveTank.order]; switches sorted and clamped to
-/// [0, diveDurationSeconds]; the initial window runs from t=0 to the first
-/// switch), but keys by tankId with no gas-mix merging.
+/// [0, diveDurationSeconds]; a switch at or before [firstSampleSeconds] is the
+/// initial-gas declaration and owns the window from t=0, otherwise that window
+/// goes to the starting tank), but keys by tankId with no gas-mix merging.
 ///
 /// Returns an empty map when there are no tanks or the dive has no duration.
 Map<String, List<({int start, int end})>> buildActiveTankIntervals({
   required List<DiveTank> tanks,
   required List<GasSwitchWithTank> gasSwitches,
   required int diveDurationSeconds,
+  int firstSampleSeconds = 0,
 }) {
   final result = <String, List<({int start, int end})>>{};
   if (tanks.isEmpty || diveDurationSeconds <= 0) return result;
@@ -164,14 +199,19 @@ Map<String, List<({int start, int end})>> buildActiveTankIntervals({
     return result;
   }
 
-  if (inBounds.first.timestamp > 0) {
+  final initialIndex = _initialGasDeclarationIndex(
+    inBounds,
+    firstSampleSeconds,
+  );
+
+  if (initialIndex == null) {
     add(startingTank.id, 0, inBounds.first.timestamp);
   }
-  for (var i = 0; i < inBounds.length; i++) {
+  for (var i = initialIndex ?? 0; i < inBounds.length; i++) {
     final end = i + 1 < inBounds.length
         ? inBounds[i + 1].timestamp
         : diveDurationSeconds;
-    add(inBounds[i].tankId, inBounds[i].timestamp, end);
+    add(inBounds[i].tankId, i == initialIndex ? 0 : inBounds[i].timestamp, end);
   }
   return result;
 }

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1677,6 +1677,8 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                                     gasSwitchesAsync.valueOrNull ?? const [],
                                 diveDurationSeconds:
                                     chartProfile.last.timestamp,
+                                firstSampleSeconds:
+                                    chartProfile.first.timestamp,
                               ),
                         diveDurationSeconds: chartProfile.isEmpty
                             ? null

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -381,6 +381,8 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                                   gasSwitches: gasSwitches ?? const [],
                                   diveDurationSeconds:
                                       chartProfile.last.timestamp,
+                                  firstSampleSeconds:
+                                      chartProfile.first.timestamp,
                                 ),
                           diveDurationSeconds: chartProfile.isEmpty
                               ? null

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -1045,6 +1045,9 @@ final estimatedTankPressuresProvider =
         diveDurationSeconds: dive.profile.isEmpty
             ? 0
             : dive.profile.last.timestamp,
+        firstSampleSeconds: dive.profile.isEmpty
+            ? 0
+            : dive.profile.first.timestamp,
       );
     });
 

--- a/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
@@ -403,6 +403,7 @@ class _DiveProfilePanelContentState
                           tanks: dive.tanks,
                           gasSwitches: gasSwitches ?? const [],
                           diveDurationSeconds: dive.profile.last.timestamp,
+                          firstSampleSeconds: dive.profile.first.timestamp,
                         ),
                   diveDurationSeconds: dive.profile.isEmpty
                       ? null

--- a/lib/features/media/presentation/widgets/perdix_overlay/perdix_face_resolver.dart
+++ b/lib/features/media/presentation/widgets/perdix_overlay/perdix_face_resolver.dart
@@ -58,6 +58,7 @@ class PerdixFaceResolver {
                tanks: tanks,
                gasSwitches: gasSwitches,
                diveDurationSeconds: profile.last.timestamp,
+               firstSampleSeconds: profile.first.timestamp,
              ),
        _activeTankIntervals = profile.isEmpty
            ? const {}
@@ -65,6 +66,7 @@ class PerdixFaceResolver {
                tanks: tanks,
                gasSwitches: gasSwitches,
                diveDurationSeconds: profile.last.timestamp,
+               firstSampleSeconds: profile.first.timestamp,
              );
 
   final List<DiveProfilePoint> _profile;

--- a/test/features/dive_log/data/services/gas_usage_segments_service_test.dart
+++ b/test/features/dive_log/data/services/gas_usage_segments_service_test.dart
@@ -199,6 +199,71 @@ void main() {
       expect(segments.single.gasMix.he, 45);
       expect(segments.single.label, 'Tx 18/45');
     });
+
+    test(
+      'gas change at the first sample declares the initial gas, not a switch',
+      () {
+        // Subsurface writes the starting gas as a gaschange event at the first
+        // sample (t=10), never at t=0, and it may name a cylinder other than
+        // the lowest-order one (fixtures 002 and 003 do exactly this).
+        final deco = _tank(id: 'deco', o2: 32, name: 'Deco');
+        final back = _tank(id: 'back', o2: 21, name: 'Back', order: 1);
+        final segments = buildGasUsageSegments(
+          tanks: [deco, back],
+          gasSwitches: [
+            _switch(tankId: 'back', timestamp: 10, o2Fraction: 0.21),
+          ],
+          diveDurationSeconds: 1800,
+          firstSampleSeconds: 10,
+        );
+        expect(segments, hasLength(1));
+        expect(segments.single.startSeconds, 0);
+        expect(segments.single.endSeconds, 1800);
+        expect(segments.single.gasMix.o2, 21);
+        expect(segments.single.tankName, 'Back');
+      },
+    );
+
+    test('a genuine mid-dive switch still gets its own segment', () {
+      final deco = _tank(id: 'deco', o2: 50, name: 'Deco');
+      final back = _tank(id: 'back', o2: 21, name: 'Back', order: 1);
+      final segments = buildGasUsageSegments(
+        tanks: [deco, back],
+        gasSwitches: [
+          _switch(tankId: 'back', timestamp: 10, o2Fraction: 0.21),
+          _switch(tankId: 'deco', timestamp: 1500, o2Fraction: 0.50),
+        ],
+        diveDurationSeconds: 3000,
+        firstSampleSeconds: 10,
+      );
+      expect(segments, hasLength(2));
+      expect(segments[0].startSeconds, 0);
+      expect(segments[0].endSeconds, 1500);
+      expect(segments[0].gasMix.o2, 21);
+      expect(segments[1].startSeconds, 1500);
+      expect(segments[1].endSeconds, 3000);
+      expect(segments[1].gasMix.o2, 50);
+    });
+
+    test(
+      'a switch after the first sample still gets a starting-tank segment',
+      () {
+        final back = _tank(id: 'back', o2: 32, name: 'Back');
+        final deco = _tank(id: 'deco', o2: 80, order: 1);
+        final segments = buildGasUsageSegments(
+          tanks: [back, deco],
+          gasSwitches: [
+            _switch(tankId: 'deco', timestamp: 600, o2Fraction: 0.80),
+          ],
+          diveDurationSeconds: 1800,
+          firstSampleSeconds: 10,
+        );
+        expect(segments, hasLength(2));
+        expect(segments[0].startSeconds, 0);
+        expect(segments[0].endSeconds, 600);
+        expect(segments[0].gasMix.o2, 32);
+      },
+    );
   });
 
   group('buildActiveTankIntervals', () {
@@ -295,6 +360,21 @@ void main() {
           _switch(tankId: 'deco', timestamp: 9000, o2Fraction: 0.50),
         ],
         diveDurationSeconds: 1800,
+      );
+      expect(result['back'], [(start: 0, end: 1800)]);
+      expect(result.containsKey('deco'), isFalse);
+    });
+
+    test('gas change at the first sample owns the window from t=0, not the '
+        'lowest-order tank', () {
+      final result = buildActiveTankIntervals(
+        tanks: [
+          _tank(id: 'deco', o2: 32),
+          _tank(id: 'back', o2: 21, order: 1),
+        ],
+        gasSwitches: [_switch(tankId: 'back', timestamp: 10, o2Fraction: 0.21)],
+        diveDurationSeconds: 1800,
+        firstSampleSeconds: 10,
       );
       expect(result['back'], [(start: 0, end: 1800)]);
       expect(result.containsKey('deco'), isFalse);

--- a/test/features/dive_log/data/services/gas_usage_segments_service_test.dart
+++ b/test/features/dive_log/data/services/gas_usage_segments_service_test.dart
@@ -264,6 +264,47 @@ void main() {
         expect(segments[0].gasMix.o2, 32);
       },
     );
+
+    // Sample intervals vary by computer: 1s and 2s on Shearwater, 4s/5s on
+    // Suunto, 10s in Subsurface's default export, 20s/30s on older units. The
+    // rule keys off the dive's own first sample, never a fixed constant.
+    for (final firstSample in const [0, 1, 2, 4, 5, 10, 20, 30, 60]) {
+      test('initial-gas declaration is recognised at a first sample of '
+          '${firstSample}s', () {
+        final deco = _tank(id: 'deco', o2: 32, name: 'Deco');
+        final back = _tank(id: 'back', o2: 21, name: 'Back', order: 1);
+        final segments = buildGasUsageSegments(
+          tanks: [deco, back],
+          gasSwitches: [
+            _switch(tankId: 'back', timestamp: firstSample, o2Fraction: 0.21),
+          ],
+          diveDurationSeconds: 1800,
+          firstSampleSeconds: firstSample,
+        );
+        expect(segments, hasLength(1));
+        expect(segments.single.startSeconds, 0);
+        expect(segments.single.endSeconds, 1800);
+        expect(segments.single.gasMix.o2, 21);
+        expect(segments.single.tankName, 'Back');
+      });
+    }
+
+    test('a switch one second after the first sample is a real switch', () {
+      final back = _tank(id: 'back', o2: 21, name: 'Back');
+      final deco = _tank(id: 'deco', o2: 50, name: 'Deco', order: 1);
+      final segments = buildGasUsageSegments(
+        tanks: [back, deco],
+        gasSwitches: [_switch(tankId: 'deco', timestamp: 5, o2Fraction: 0.50)],
+        diveDurationSeconds: 1800,
+        firstSampleSeconds: 4,
+      );
+      expect(segments, hasLength(2));
+      expect(segments[0].startSeconds, 0);
+      expect(segments[0].endSeconds, 5);
+      expect(segments[0].gasMix.o2, 21);
+      expect(segments[1].startSeconds, 5);
+      expect(segments[1].gasMix.o2, 50);
+    });
   });
 
   group('buildActiveTankIntervals', () {


### PR DESCRIPTION
Fixes #679.

## Symptom

Imported dives render a short segment of the wrong gas at the very start of the gas-usage strip — green Nitrox ahead of the orange Air actually breathed.

## Root cause

`buildGasUsageSegments` treats any gas change at `t > 0` as a mid-dive switch and synthesises a leading segment from the **lowest-`order` tank**. But most dive computers do not sample at `t = 0`, and importers record the starting gas as a gas-change event at the **first sample**. Whenever the lowest-`order` tank holds a different mix than that event names, the invented segment renders as a sliver of a gas that was never breathed.

The condition is precisely **first sample != 0**. Dumping the parsed fixtures gives a clean controlled comparison:

| Fixture | Source | First sample | Initial declaration | Lowest-`order` tank | Sliver |
| --- | --- | --- | --- | --- | --- |
| 001 / 004 | Subsurface | `10` | cyl 0, Air | cyl 0, Air | hidden by merge |
| 002 | Subsurface | `10` | cyl 2, **Tx 16/48** | cyl 0, **EAN50** | **visible** |
| 003 | Subsurface | `10` | cyl 1, **Air** | cyl 0, **EAN40** | **visible** |
| 005 | Garmin FIT | **`0`** | `t=0` | Tx 19/34 | none |

003 is exactly the reported artefact: a green EAN40 sliver ahead of orange Air. Garmin samples at zero, so its declaration lands at `t = 0`, the original `> 0` guard is already false, and the FIT path was never affected.

Tank ordering does not cause the bug — it only decides whether the phantom segment is *hidden* (001/004, where `_mergeAdjacentSameGas` absorbs it) or *wrong-coloured* (002/003).

The screenshot in the issue corroborates this: the sliver spans exactly from `x = 0` to where the depth trace begins, and the orange gas starts at the same instant as the first sample.

## Why it surfaced only recently

The flaw is original to the gas strip (`36692d5cd`) — the file is otherwise byte-identical to that commit — but it was **unreachable**. `gas_switches` was empty for these dives, so the function took its `if (inBoundsSwitches.isEmpty)` early return and produced one correct full-dive segment. `cfcd956eb` ("persist gas switches on multi-gas dive-computer dives") started populating the table, and the buggy branch woke up.

Note `cfcd956eb` got the convention right for the dive-computer download path: `resolveGasSwitches` explicitly drops the baseline ("the first observed gas is the baseline... not a switch"). The file-import parsers never adopted it. That split convention is the underlying defect.

## Fix

Treat a switch at or before the first profile sample as the initial-gas declaration: it owns the window from `t = 0`, and no leading segment is invented. When several land in that window the last one wins. The same rule is applied in `buildActiveTankIntervals`, which drives per-tank pressure interpolation, so the two stay consistent.

`firstSampleSeconds` defaults to `0`, so behaviour is unchanged for callers without profile data — and provably identical on the FIT path, where `timestamp <= 0` is the old `> 0` guard inverted. Threaded through all call sites plus `synthesizeEstimatedTankPressures`.

Because the strip's axis starts at `viewMin = 0`, letting the declaration own `0 .. firstSample` keeps the strip starting at zero with no gap, rather than merely suppressing the sliver. The dive does start at `t = 0` — the computer simply has not sampled yet — so that window is real dive time and belongs to the gas carried in from the surface.

## Tests

Three behavioural tests, each verified to fail against the old behaviour (spurious extra segment; interval starting at `10` instead of `0`) and pass with the fix:

- a gas change at the first sample produces no leading segment of a different gas, even when the lowest-`order` tank is a different mix
- a genuine mid-dive switch still gets its own segment
- `buildActiveTankIntervals` attributes the `0 .. firstSample` window to the tank named by the declaration

Plus generality coverage, since the rule keys off each dive's own first sample rather than the 10s interval the Subsurface fixtures happen to use: first samples of 0, 1, 2, 4, 5, 10, 20, 30 and 60 seconds (Shearwater 1s/2s, Suunto 4s/5s, older units 20s/30s), and a boundary case confirming a switch one second past the first sample is still a real mid-dive switch.

`flutter analyze` clean; `dart format` applied. Full suite: 13571 pass, 27 skipped, 4 fail — three of those four fail identically on `main` at 3b6cc74d9 (pre-existing, unrelated: backup, equipment, media), and the fourth (`setup_apply_service`) passes in isolation on this branch and at base, so it is order-dependent flake in a feature this change does not touch.

## Scope and follow-ups (deliberately not in this PR)

This is a read-side fix. Nothing persisted changes, so no migration or re-import is needed — all consumers of the estimated-pressure path are chart widgets, and `synthesizeEstimatedTankPressures` is pure and never persists.

Known related items left alone:

1. `gas_analysis_service._getActiveTankAtTimestamp` has its own independent pre-first-switch fallback (`role == backGas`, else `tanks.first`) and mis-attributes the same `0 .. firstSample` window, feeding SAC segmentation. The error is ~10s of a ~40min dive, so numerically negligible, but it is the same root cause outside the display path.
2. Having the Subsurface parser stop emitting the initial declaration as a switch row — matching `resolveGasSwitches` — is the deeper consistency fix, but it only helps on re-import. The service-level fix is what repairs already-imported dives.
3. The depth trace itself still starts at the first sample while the axis starts at `0`, leaving a few pixels of empty space at the left edge. That is a separate rendering decision from gas attribution.
