### PR TITLE
fix(dive-log): draw every profile curve from t=0 instead of the first sample

### DIFF
--- a/lib/features/dive_log/data/services/profile_surface_lead_in.dart
+++ b/lib/features/dive_log/data/services/profile_surface_lead_in.dart
@@ -1,0 +1,39 @@
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+/// Whether a profile chart should be extended back to the surface at t=0.
+///
+/// Dive computers do not sample at t=0, so a profile whose first sample sits
+/// one interval in leaves a gap between the chart's t=0 origin and the start of
+/// every plotted line. Closing it is truthful: the diver was at the surface
+/// before the first reading was taken (issue #684).
+///
+/// Deliberately limited to a gap of at most one sample interval. A profile that
+/// starts later than that has been trimmed or merged, and drawing across it
+/// would fabricate dive time that was never recorded -- worse than the gap it
+/// would close.
+///
+/// Shared by the full profile chart and the compact profile widgets so they
+/// cannot disagree about where a dive begins.
+bool shouldDrawSurfaceLeadIn(List<DiveProfilePoint> profile) {
+  if (profile.length < 2) return false;
+  final firstSample = profile.first.timestamp;
+  if (firstSample <= 0) return false;
+  final interval = profile[1].timestamp - firstSample;
+  return interval > 0 && firstSample <= interval;
+}
+
+/// Ambient pressure in bar at [depthMeters]: 1 bar at the surface, plus 1 bar
+/// per 10 m of seawater.
+double ambientPressureBar(double depthMeters) => 1.0 + depthMeters / 10.0;
+
+/// The surface value of a quantity proportional to ambient pressure -- partial
+/// pressures and gas density -- given its value at [depthMeters].
+///
+/// These lead-ins are calculated rather than held flat, because they are a
+/// deterministic function of depth: at the surface the ambient pressure is
+/// 1 bar, so each reduces to its gas fraction. Dividing by the ambient pressure
+/// at the sample recovers that fraction without resolving which cylinder was
+/// breathed. Reduces to the sampled value when the diver is still at the
+/// surface, which is the usual case one sample into a dive.
+double surfaceValueAtOneBar(double valueAtDepth, double depthMeters) =>
+    valueAtDepth / ambientPressureBar(depthMeters);

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1254,7 +1254,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         rows.add(
           TooltipRow(
             label: 'ppHe',
-            value: '${ppHe.toStringAsFixed(2)} bar',
+            value: '${_readoutValue(ppHe, onLeadIn).toStringAsFixed(2)} bar',
             bulletColor: Colors.pink.shade300,
           ),
         );
@@ -1285,7 +1285,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         TooltipRow(
           label: 'Density',
           value:
-              '${widget.densityCurve![spot.spotIndex].toStringAsFixed(2)} g/L',
+              '${_readoutValue(widget.densityCurve![spot.spotIndex], onLeadIn).toStringAsFixed(2)} g/L',
           bulletColor: Colors.brown,
         ),
       );
@@ -2622,6 +2622,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                       depthIndex >= 0 &&
                       depthIndex < widget.profile.length;
 
+                  // The cursor is on the lead-in vertex when the resolved bar's
+                  // start is negative and the touched spot is its first: the
+                  // readout must describe t=0, not repeat the first sample.
+                  final onLeadIn =
+                      depthSpot != null &&
+                      depthSpot.spotIndex == 0 &&
+                      depthBarStarts[depthSpot.barIndex] < 0 &&
+                      shouldDrawSurfaceLeadIn(widget.profile);
+
                   // Return cached result if the same sample is touched again.
                   // The cache is keyed on the resolved depth index, but the
                   // cached list length equals the number of touched bars when it
@@ -2648,7 +2657,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     }
                     final spot = (spotIndex: depthIndex);
 
-                    final point = widget.profile[spot.spotIndex];
+                    final point = onLeadIn
+                        ? _surfaceReadoutPoint()
+                        : widget.profile[spot.spotIndex];
                     final minutes = point.timestamp ~/ 60;
                     final seconds = point.timestamp % 60;
 
@@ -2899,7 +2910,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                       String ppO2Value = '—';
                       if (widget.ppO2Curve != null &&
                           spot.spotIndex < widget.ppO2Curve!.length) {
-                        final ppO2 = widget.ppO2Curve![spot.spotIndex];
+                        final ppO2 = _readoutValue(
+                          widget.ppO2Curve![spot.spotIndex],
+                          onLeadIn,
+                        );
                         ppO2Value = '${ppO2.toStringAsFixed(2)} bar';
                       }
                       addRow(
@@ -2930,7 +2944,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                       String ppN2Value = '—';
                       if (widget.ppN2Curve != null &&
                           spot.spotIndex < widget.ppN2Curve!.length) {
-                        final ppN2 = widget.ppN2Curve![spot.spotIndex];
+                        final ppN2 = _readoutValue(
+                          widget.ppN2Curve![spot.spotIndex],
+                          onLeadIn,
+                        );
                         ppN2Value = '${ppN2.toStringAsFixed(2)} bar';
                       }
                       addRow(
@@ -2947,7 +2964,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                           spot.spotIndex < widget.ppHeCurve!.length) {
                         final ppHe = widget.ppHeCurve![spot.spotIndex];
                         if (ppHe > 0.001) {
-                          ppHeValue = '${ppHe.toStringAsFixed(2)} bar';
+                          ppHeValue =
+                              '${_readoutValue(ppHe, onLeadIn).toStringAsFixed(2)} bar';
                         }
                       }
                       addRow(
@@ -2979,7 +2997,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                       String densityValue = '—';
                       if (widget.densityCurve != null &&
                           spot.spotIndex < widget.densityCurve!.length) {
-                        final density = widget.densityCurve![spot.spotIndex];
+                        final density = _readoutValue(
+                          widget.densityCurve![spot.spotIndex],
+                          onLeadIn,
+                        );
                         densityValue = '${density.toStringAsFixed(2)} g/L';
                       }
                       addRow(
@@ -3170,10 +3191,35 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                       }
                     }
 
+                    // On the lead-in, mark every carried-over value so a held
+                    // reading is never shown as measured. Exact and computed
+                    // rows (time, depth, the partial pressures, MOD, density)
+                    // are left untouched -- same set as the overlay readout.
+                    final displayRows = onLeadIn
+                        ? [
+                            for (final row in tooltipRows)
+                              if (_exactAtSurfaceLabels(
+                                    context,
+                                  ).contains(row.label) ||
+                                  row.label.startsWith(
+                                    context.l10n.diveLog_tooltip_depth,
+                                  ))
+                                row
+                              else
+                                (
+                                  label: row.label,
+                                  value: '${row.value} (interpolated)',
+                                  bulletColor: row.bulletColor,
+                                  bullet: row.bullet,
+                                  bulletSize: row.bulletSize,
+                                ),
+                          ]
+                        : tooltipRows;
+
                     const rowWidth = labelWidth + valueWidth;
                     final rowFiller = List.filled(rowWidth, '0').join();
                     final lines = <TextSpan>[];
-                    for (final row in tooltipRows) {
+                    for (final row in displayRows) {
                       if (lines.isNotEmpty) {
                         lines.add(const TextSpan(text: '\n'));
                       }
@@ -3799,12 +3845,20 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// Built at the call site because some labels are localized: matching
   /// hardcoded English would silently mark them interpolated in other locales.
   Set<String> _exactAtSurfaceLabels(BuildContext context) => {
+    // The overlay readout uses hardcoded labels; the inline (fl_chart) readout
+    // uses localized ones. Both forms are exempt so neither is mislabelled.
     'Time',
     'Depth',
     'ppN2',
     'ppHe',
     'Density',
     'MOD',
+    context.l10n.diveLog_tooltip_time,
+    context.l10n.diveLog_tooltip_depth,
+    context.l10n.diveLog_tooltip_ppN2,
+    context.l10n.diveLog_tooltip_ppHe,
+    context.l10n.diveLog_tooltip_mod,
+    context.l10n.diveLog_tooltip_density,
     context.l10n.diveLog_tooltip_ppO2,
     '${context.l10n.diveLog_tooltip_ppO2} '
         '${context.l10n.diveLog_tooltip_avgCalculated}',

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -3757,6 +3757,33 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     return lines;
   }
 
+  /// Extend a curve back to the t=0 axis origin with a lead-in vertex at
+  /// [surfaceY] (already in chart y-space, i.e. negated/normalised the same way
+  /// the curve's own points are).
+  ///
+  /// Computers do not sample at t=0, so without this every line starts one
+  /// sample interval inside the chart and the left edge reads as ragged
+  /// (issue #684). No-ops when the profile already starts at zero, when the gap
+  /// is too wide to attribute to the sampling rate, or when the curve drew no
+  /// points at all.
+  List<FlSpot> _withSurfaceLeadIn(List<FlSpot> spots, double surfaceY) {
+    if (spots.isEmpty) return spots;
+    if (!DiveProfileChart.shouldDrawSurfaceLeadIn(widget.profile)) return spots;
+    // A curve that is only drawn where it has data (the ceiling line skips
+    // ceiling <= 0) may legitimately start mid-dive; only bridge a curve whose
+    // own first point is the dive's first sample.
+    if (spots.first.x != widget.profile.first.timestamp.toDouble()) {
+      return spots;
+    }
+    return [FlSpot(0, surfaceY), ...spots];
+  }
+
+  /// Lead-in for curves that barely change across one sample interval
+  /// (temperature, partial pressures, MOD, density, SAC, tank pressure, heart
+  /// rate): hold the first reading flat back to t=0.
+  List<FlSpot> _withFlatSurfaceLeadIn(List<FlSpot> spots) =>
+      spots.isEmpty ? spots : _withSurfaceLeadIn(spots, spots.first.y);
+
   /// Build a single depth line segment with the given color
   LineChartBarData _buildSingleDepthSegment(
     Color color,
@@ -3879,21 +3906,23 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     UnitFormatter units,
   ) {
     return LineChartBarData(
-      spots: widget.profile
-          .where((p) => p.temperature != null)
-          .map(
-            (p) => FlSpot(
-              p.timestamp.toDouble(),
-              // Convert temp to user's unit, then map to depth axis
-              -_mapTempToDepth(
-                units.convertTemperature(p.temperature!),
-                chartMaxDepth,
-                minTemp,
-                maxTemp,
+      spots: _withFlatSurfaceLeadIn(
+        widget.profile
+            .where((p) => p.temperature != null)
+            .map(
+              (p) => FlSpot(
+                p.timestamp.toDouble(),
+                // Convert temp to user's unit, then map to depth axis
+                -_mapTempToDepth(
+                  units.convertTemperature(p.temperature!),
+                  chartMaxDepth,
+                  minTemp,
+                  maxTemp,
+                ),
               ),
-            ),
-          )
-          .toList(),
+            )
+            .toList(),
+      ),
       isCurved: true,
       curveSmoothness: 0.2,
       color: colorScheme.tertiary,
@@ -3968,19 +3997,23 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
       lines.add(
         LineChartBarData(
-          spots: pressurePoints
-              .map(
-                (p) => FlSpot(
-                  p.timestamp.toDouble(),
-                  -_mapValueToDepth(
-                    p.pressure,
-                    chartMaxDepth,
-                    minPressure,
-                    maxPressure,
+          // A tank first breathed mid-dive keeps its own start: the lead-in
+          // only bridges a series that begins at the dive's first sample.
+          spots: _withFlatSurfaceLeadIn(
+            pressurePoints
+                .map(
+                  (p) => FlSpot(
+                    p.timestamp.toDouble(),
+                    -_mapValueToDepth(
+                      p.pressure,
+                      chartMaxDepth,
+                      minPressure,
+                      maxPressure,
+                    ),
                   ),
-                ),
-              )
-              .toList(),
+                )
+                .toList(),
+          ),
           // Synthesized estimates are straight (flat-drop-flat); curve
           // smoothing would round their corners. Real AI data stays curved.
           isCurved: !(widget.estimatedTankIds?.contains(tankId) ?? false),
@@ -4052,7 +4085,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.3,
       color: sacColor,
@@ -4087,7 +4120,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       );
     }
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: Colors.lime,
@@ -4165,7 +4198,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: ceilingColor,
@@ -4202,7 +4235,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      // Held flat, not forced to maximum: on a repetitive dive the NDL at the
+      // surface is already cut short by residual loading, which the first
+      // sample reflects and a synthetic maximum would not.
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       preventCurveOverShooting: true,
@@ -4232,7 +4268,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: ppO2Color,
@@ -4260,7 +4296,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: ppN2Color,
@@ -4296,7 +4332,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: ppHeColor,
@@ -4361,7 +4397,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: densityColor,
@@ -4390,7 +4426,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: gfColor,
@@ -4419,7 +4455,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: surfaceGfColor,
@@ -4446,7 +4482,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: meanDepthColor,
@@ -4477,7 +4513,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: ttsColor,
@@ -4518,7 +4554,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: cnsColor,
@@ -4545,7 +4581,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
       color: otuColor,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -15,6 +15,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
 import 'package:submersion/features/dive_log/data/services/profile_markers_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_surface_lead_in.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
@@ -402,24 +403,6 @@ class DiveProfileChart extends ConsumerStatefulWidget {
 
   /// Whether the depth line should be extended back to the surface at t=0.
   ///
-  /// Dive computers do not sample at t=0, so a profile whose first sample sits
-  /// one interval in leaves a gap between the chart's t=0 origin and the start
-  /// of the trace. Drawing the descent from `(0, 0m)` closes it truthfully: the
-  /// diver was at the surface before the first sample was taken (issue #684).
-  ///
-  /// Deliberately limited to a gap of at most one sample interval. A profile
-  /// that starts later than that has been trimmed or merged, and inventing a
-  /// descent across it would fabricate dive time that was never recorded --
-  /// worse than the gap it would close.
-  @visibleForTesting
-  static bool shouldDrawSurfaceLeadIn(List<DiveProfilePoint> profile) {
-    if (profile.length < 2) return false;
-    final firstSample = profile.first.timestamp;
-    if (firstSample <= 0) return false;
-    final interval = profile[1].timestamp - firstSample;
-    return interval > 0 && firstSample <= interval;
-  }
-
   /// Resolve a touched depth spot to an index into [profile].
   ///
   /// fl_chart reports a touched spot as `(barIndex, spotIndex)`, where
@@ -3566,9 +3549,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     // The surface lead-in prepends one synthetic spot to the bar that owns the
     // first sample, shifting that bar's local spotIndex by one. Reporting a
     // start of -1 keeps `start + spotIndex` addressing the right sample.
-    final leadIn = DiveProfileChart.shouldDrawSurfaceLeadIn(widget.profile)
-        ? 1
-        : 0;
+    final leadIn = shouldDrawSurfaceLeadIn(widget.profile) ? 1 : 0;
     final ascentRates = widget.ascentRates;
     if (_showAscentRateColors &&
         ascentRates != null &&
@@ -3768,7 +3749,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// points at all.
   List<FlSpot> _withSurfaceLeadIn(List<FlSpot> spots, double surfaceY) {
     if (spots.isEmpty) return spots;
-    if (!DiveProfileChart.shouldDrawSurfaceLeadIn(widget.profile)) return spots;
+    if (!shouldDrawSurfaceLeadIn(widget.profile)) return spots;
     // A curve that is only drawn where it has data (the ceiling line skips
     // ceiling <= 0) may legitimately start mid-dive; only bridge a curve whose
     // own first point is the dive's first sample.
@@ -3781,6 +3762,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// Lead-in for curves that barely change across one sample interval
   /// (temperature, partial pressures, MOD, density, SAC, tank pressure, heart
   /// rate): hold the first reading flat back to t=0.
+  /// [surfaceValueAtOneBar] applied at the dive's first sample.
+  double _surfaceValueOf(double valueAtFirstSample) => widget.profile.isEmpty
+      ? valueAtFirstSample
+      : surfaceValueAtOneBar(valueAtFirstSample, widget.profile.first.depth);
+
   List<FlSpot> _withFlatSurfaceLeadIn(List<FlSpot> spots) =>
       spots.isEmpty ? spots : _withSurfaceLeadIn(spots, spots.first.y);
 
@@ -3797,8 +3783,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         // Close the gap between the t=0 axis origin and the first sample by
         // descending from the surface. Only the bar that owns the first sample
         // carries it, so the later velocity-band bars are untouched.
-        if (startIndex == 0 &&
-            DiveProfileChart.shouldDrawSurfaceLeadIn(widget.profile))
+        if (startIndex == 0 && shouldDrawSurfaceLeadIn(widget.profile))
           const FlSpot(0, 0),
         ...widget.profile
             .sublist(startIndex, endIndex)
@@ -3809,6 +3794,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       ],
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: color,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -3925,6 +3915,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       ),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: colorScheme.tertiary,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4018,6 +4013,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           // smoothing would round their corners. Real AI data stays curved.
           isCurved: !(widget.estimatedTankIds?.contains(tankId) ?? false),
           curveSmoothness: 0.2,
+          // The lead-in vertex is a sharp direction change; without this the
+          // spline overshoots it and hooks below the curve at the left edge.
+          preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
           color: color,
           barWidth: 2,
           isStrokeCapRound: true,
@@ -4088,6 +4086,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.3,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: sacColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4123,6 +4126,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: Colors.lime,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4201,6 +4209,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: ceilingColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4268,9 +4281,24 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: _withFlatSurfaceLeadIn(spots),
+      // ppO2 scales with ambient pressure, so its surface value is computed,
+      // not held flat: at 1 bar it is simply the oxygen fraction.
+      spots: _withSurfaceLeadIn(
+        spots,
+        -_mapValueToDepth(
+          _surfaceValueOf(ppO2Data.first).clamp(minPpO2, maxPpO2),
+          chartMaxDepth,
+          minPpO2,
+          maxPpO2,
+        ),
+      ),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: ppO2Color,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4296,9 +4324,23 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: _withFlatSurfaceLeadIn(spots),
+      // Computed, not held flat: at 1 bar ppN2 is the nitrogen fraction.
+      spots: _withSurfaceLeadIn(
+        spots,
+        -_mapValueToDepth(
+          _surfaceValueOf(ppN2Data.first).clamp(minPpN2, maxPpN2),
+          chartMaxDepth,
+          minPpN2,
+          maxPpN2,
+        ),
+      ),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: ppN2Color,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4332,9 +4374,25 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: _withFlatSurfaceLeadIn(spots),
+      // Computed, not held flat: at 1 bar ppHe is the helium fraction. The
+      // ppHe > 0.001 filter above means a non-trimix dive draws nothing at all,
+      // and the lead-in is skipped with it.
+      spots: _withSurfaceLeadIn(
+        spots,
+        -_mapValueToDepth(
+          _surfaceValueOf(ppHeData.first).clamp(minPpHe, maxPpHe),
+          chartMaxDepth,
+          minPpHe,
+          maxPpHe,
+        ),
+      ),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: ppHeColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4364,7 +4422,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: spots,
+      // Held flat, and that is the calculated value: MOD is a property of the
+      // gas, not of depth, so it does not change between the surface and the
+      // first sample. Only a gas switch moves it.
+      spots: _withFlatSurfaceLeadIn(spots),
       isCurved: false,
       color: modColor,
       barWidth: 2,
@@ -4397,9 +4458,24 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
 
     return LineChartBarData(
-      spots: _withFlatSurfaceLeadIn(spots),
+      // Gas density scales with ambient pressure, so the surface value is
+      // computed rather than held flat.
+      spots: _withSurfaceLeadIn(
+        spots,
+        -_mapValueToDepth(
+          _surfaceValueOf(densityData.first).clamp(minDensity, maxDensity),
+          chartMaxDepth,
+          minDensity,
+          maxDensity,
+        ),
+      ),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: densityColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4429,6 +4505,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: gfColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4458,6 +4539,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: surfaceGfColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4485,6 +4571,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: meanDepthColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4516,6 +4607,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: ttsColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4557,6 +4653,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: cnsColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4584,6 +4685,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       spots: _withFlatSurfaceLeadIn(spots),
       isCurved: true,
       curveSmoothness: 0.2,
+      // Only while a lead-in is drawn: that vertex is a sharp direction
+      // change and the spline would otherwise overshoot it and hook below
+      // the curve at the left edge. Dives already starting at t=0 keep
+      // their existing smoothing untouched.
+      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
       color: otuColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -5067,11 +5173,14 @@ class DiveProfileMiniChart extends StatelessWidget {
           lineTouchData: const LineTouchData(enabled: false),
           lineBarsData: [
             LineChartBarData(
-              spots: profile
-                  .map(
-                    (p) => FlSpot(p.timestamp.toDouble(), -p.depth),
-                  ) // Negate for inverted axis
-                  .toList(),
+              spots: [
+                // Descend from the surface so the silhouette reaches the left
+                // edge, matching the full chart (issue #684).
+                if (shouldDrawSurfaceLeadIn(profile)) const FlSpot(0, 0),
+                ...profile.map(
+                  (p) => FlSpot(p.timestamp.toDouble(), -p.depth),
+                ), // Negate for inverted axis
+              ],
               // Straight segments preserve the actual sample-to-sample shape
               // (safety stops, multilevel ledges, abrupt descents). Catmull-
               // Rom smoothing flattens those short features into rounded

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -330,6 +330,11 @@ class DiveProfileChart extends ConsumerStatefulWidget {
   /// ([_DiveProfileChartState._buildVelocityColoredDepthLines]) and mapping a
   /// touched depth spot back to its global profile index: a spot on bar `b` at
   /// local `spotIndex` addresses profile point `runs[b].start + spotIndex`.
+  ///
+  /// [_DiveProfileChartState._depthBarStartIndices] applies one further
+  /// adjustment on top of these runs: when a surface lead-in vertex is drawn
+  /// (see [shouldDrawSurfaceLeadIn]) the first run's start is decremented to
+  /// absorb it, so the identity above continues to hold.
   @visibleForTesting
   static List<({int start, int end, AscentRateCategory category})>
   velocityBandRuns(int profileLength, List<AscentRatePoint> ascentRates) {
@@ -395,6 +400,26 @@ class DiveProfileChart extends ConsumerStatefulWidget {
         .toList();
   }
 
+  /// Whether the depth line should be extended back to the surface at t=0.
+  ///
+  /// Dive computers do not sample at t=0, so a profile whose first sample sits
+  /// one interval in leaves a gap between the chart's t=0 origin and the start
+  /// of the trace. Drawing the descent from `(0, 0m)` closes it truthfully: the
+  /// diver was at the surface before the first sample was taken (issue #684).
+  ///
+  /// Deliberately limited to a gap of at most one sample interval. A profile
+  /// that starts later than that has been trimmed or merged, and inventing a
+  /// descent across it would fabricate dive time that was never recorded --
+  /// worse than the gap it would close.
+  @visibleForTesting
+  static bool shouldDrawSurfaceLeadIn(List<DiveProfilePoint> profile) {
+    if (profile.length < 2) return false;
+    final firstSample = profile.first.timestamp;
+    if (firstSample <= 0) return false;
+    final interval = profile[1].timestamp - firstSample;
+    return interval > 0 && firstSample <= interval;
+  }
+
   /// Resolve a touched depth spot to an index into [profile].
   ///
   /// fl_chart reports a touched spot as `(barIndex, spotIndex)`, where
@@ -423,7 +448,10 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     required bool multiComputer,
   }) {
     if (!multiComputer) {
-      return depthBarStarts[barIndex] + spotIndex;
+      // A surface lead-in vertex makes the first bar's start -1 (see
+      // [shouldDrawSurfaceLeadIn]); touching that synthetic vertex resolves to
+      // the first real sample rather than a negative index.
+      return math.max(0, depthBarStarts[barIndex] + spotIndex);
     }
     if (profile.isEmpty) return -1;
     var best = 0;
@@ -984,9 +1012,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     final touched = touchedSpots
         .where((s) => s.barIndex < starts.length)
         .firstOrNull;
+    // Clamped for the same reason as [DiveProfileChart.depthSpotProfileIndex]:
+    // the surface lead-in makes the first bar's start -1, and hovering that
+    // synthetic vertex should read the first sample, not suppress the tooltip.
     final index = touched == null
         ? -1
-        : starts[touched.barIndex] + touched.spotIndex;
+        : math.max(0, starts[touched.barIndex] + touched.spotIndex);
     if (touched == null || index < 0 || index >= widget.profile.length) {
       widget.onTooltipData!(null);
       return;
@@ -3532,17 +3563,25 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// colouring splits it into one bar per band. Mirrors the branching in
   /// [_buildGasColoredDepthLines].
   List<int> _depthBarStartIndices() {
+    // The surface lead-in prepends one synthetic spot to the bar that owns the
+    // first sample, shifting that bar's local spotIndex by one. Reporting a
+    // start of -1 keeps `start + spotIndex` addressing the right sample.
+    final leadIn = DiveProfileChart.shouldDrawSurfaceLeadIn(widget.profile)
+        ? 1
+        : 0;
     final ascentRates = widget.ascentRates;
     if (_showAscentRateColors &&
         ascentRates != null &&
         ascentRates.length == widget.profile.length &&
         widget.profile.length >= 2) {
-      return DiveProfileChart.velocityBandRuns(
+      final runs = DiveProfileChart.velocityBandRuns(
         widget.profile.length,
         ascentRates,
       ).map((run) => run.start).toList();
+      if (leadIn > 0 && runs.isNotEmpty) runs[0] -= leadIn;
+      return runs;
     }
-    return const [0];
+    return [0 - leadIn];
   }
 
   /// Whether the built-in focus indicator for [barData]'s spot at [index]
@@ -3727,12 +3766,20 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     bool showFill = false,
   }) {
     return LineChartBarData(
-      spots: widget.profile
-          .sublist(startIndex, endIndex)
-          .map(
-            (p) => FlSpot(p.timestamp.toDouble(), -units.convertDepth(p.depth)),
-          )
-          .toList(),
+      spots: [
+        // Close the gap between the t=0 axis origin and the first sample by
+        // descending from the surface. Only the bar that owns the first sample
+        // carries it, so the later velocity-band bars are untouched.
+        if (startIndex == 0 &&
+            DiveProfileChart.shouldDrawSurfaceLeadIn(widget.profile))
+          const FlSpot(0, 0),
+        ...widget.profile
+            .sublist(startIndex, endIndex)
+            .map(
+              (p) =>
+                  FlSpot(p.timestamp.toDouble(), -units.convertDepth(p.depth)),
+            ),
+      ],
       isCurved: true,
       curveSmoothness: 0.2,
       color: color,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -3670,17 +3670,31 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         overlay.points,
         (p) => p.depth,
       );
+      // Keyed on the overlay's OWN points, not the active profile: an overlaid
+      // computer has its own first sample and sampling interval, so the active
+      // dive cannot decide whether this trace needs a lead-in. Without that,
+      // an overlay starting at t=10 stays gapped whenever the active profile
+      // starts at t=0.
+      final overlayDepthSpots = [
+        for (final i in depthKeep)
+          FlSpot(
+            overlay.points[i].timestamp.toDouble(),
+            -units.convertDepth(overlay.points[i].depth),
+          ),
+      ];
       lines.add(
         LineChartBarData(
-          spots: [
-            for (final i in depthKeep)
-              FlSpot(
-                overlay.points[i].timestamp.toDouble(),
-                -units.convertDepth(overlay.points[i].depth),
-              ),
-          ],
+          spots: _withSurfaceLeadIn(
+            overlayDepthSpots,
+            0,
+            owner: overlay.points,
+          ),
           isCurved: true,
           curveSmoothness: 0.2,
+          preventCurveOverShooting: _seriesGetsLeadIn(
+            overlayDepthSpots,
+            overlay.points,
+          ),
           color: overlay.color,
           barWidth: 2,
           isStrokeCapRound: true,
@@ -3807,15 +3821,30 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// (issue #684). No-ops when the profile already starts at zero, when the gap
   /// is too wide to attribute to the sampling rate, or when the curve drew no
   /// points at all.
-  List<FlSpot> _withSurfaceLeadIn(List<FlSpot> spots, double surfaceY) {
-    if (spots.isEmpty) return spots;
-    if (!shouldDrawSurfaceLeadIn(widget.profile)) return spots;
-    // A curve that is only drawn where it has data (the ceiling line skips
-    // ceiling <= 0) may legitimately start mid-dive; only bridge a curve whose
-    // own first point is the dive's first sample.
-    if (spots.first.x != widget.profile.first.timestamp.toDouble()) {
-      return spots;
-    }
+  /// Whether [spots] is eligible for a lead-in against [owner], the profile the
+  /// series was built from.
+  ///
+  /// [owner] is passed rather than assumed to be [widget.profile]: an overlaid
+  /// source has its own samples and its own sampling interval, so keying an
+  /// overlay's lead-in off the active profile would test the wrong dive.
+  ///
+  /// A curve that is only drawn where it has data (the ceiling line skips
+  /// ceiling <= 0, a deco bottle's pressure starts when it is first breathed)
+  /// may legitimately start mid-dive; only a curve whose own first point is its
+  /// profile's first sample is bridged back to t=0.
+  bool _seriesGetsLeadIn(List<FlSpot> spots, List<DiveProfilePoint> owner) =>
+      spots.isNotEmpty &&
+      owner.isNotEmpty &&
+      shouldDrawSurfaceLeadIn(owner) &&
+      spots.first.x == owner.first.timestamp.toDouble();
+
+  List<FlSpot> _withSurfaceLeadIn(
+    List<FlSpot> spots,
+    double surfaceY, {
+    List<DiveProfilePoint>? owner,
+  }) {
+    final source = owner ?? widget.profile;
+    if (!_seriesGetsLeadIn(spots, source)) return spots;
     return [FlSpot(0, surfaceY), ...spots];
   }
 
@@ -3892,8 +3921,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       ? valueAtFirstSample
       : surfaceValueAtOneBar(valueAtFirstSample, widget.profile.first.depth);
 
-  List<FlSpot> _withFlatSurfaceLeadIn(List<FlSpot> spots) =>
-      spots.isEmpty ? spots : _withSurfaceLeadIn(spots, spots.first.y);
+  List<FlSpot> _withFlatSurfaceLeadIn(
+    List<FlSpot> spots, {
+    List<DiveProfilePoint>? owner,
+  }) => spots.isEmpty
+      ? spots
+      : _withSurfaceLeadIn(spots, spots.first.y, owner: owner);
 
   /// Build a single depth line segment with the given color
   LineChartBarData _buildSingleDepthSegment(
@@ -3923,7 +3956,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting:
+          startIndex == 0 && shouldDrawSurfaceLeadIn(widget.profile),
       color: color,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4020,31 +4054,33 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     double maxTemp,
     UnitFormatter units,
   ) {
+    // Built first so the smoothing flag below can ask whether this series
+    // actually receives a lead-in: samples without a temperature are skipped,
+    // so the curve can legitimately start after the dive's first sample.
+    final tempSpots = widget.profile
+        .where((p) => p.temperature != null)
+        .map(
+          (p) => FlSpot(
+            p.timestamp.toDouble(),
+            // Convert temp to user's unit, then map to depth axis
+            -_mapTempToDepth(
+              units.convertTemperature(p.temperature!),
+              chartMaxDepth,
+              minTemp,
+              maxTemp,
+            ),
+          ),
+        )
+        .toList();
     return LineChartBarData(
-      spots: _withFlatSurfaceLeadIn(
-        widget.profile
-            .where((p) => p.temperature != null)
-            .map(
-              (p) => FlSpot(
-                p.timestamp.toDouble(),
-                // Convert temp to user's unit, then map to depth axis
-                -_mapTempToDepth(
-                  units.convertTemperature(p.temperature!),
-                  chartMaxDepth,
-                  minTemp,
-                  maxTemp,
-                ),
-              ),
-            )
-            .toList(),
-      ),
+      spots: _withFlatSurfaceLeadIn(tempSpots),
       isCurved: true,
       curveSmoothness: 0.2,
       // Only while a lead-in is drawn: that vertex is a sharp direction
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(tempSpots, widget.profile),
       color: colorScheme.tertiary,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4115,32 +4151,35 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           : _getTankColor(i);
       final dashPattern = _getTankDashPattern(i);
 
+      // A tank first breathed mid-dive keeps its own start: the lead-in only
+      // bridges a series that begins at the dive's first sample. Built first so
+      // the smoothing flag below reflects whether THIS tank got one.
+      final tankSpots = pressurePoints
+          .map(
+            (p) => FlSpot(
+              p.timestamp.toDouble(),
+              -_mapValueToDepth(
+                p.pressure,
+                chartMaxDepth,
+                minPressure,
+                maxPressure,
+              ),
+            ),
+          )
+          .toList();
       lines.add(
         LineChartBarData(
-          // A tank first breathed mid-dive keeps its own start: the lead-in
-          // only bridges a series that begins at the dive's first sample.
-          spots: _withFlatSurfaceLeadIn(
-            pressurePoints
-                .map(
-                  (p) => FlSpot(
-                    p.timestamp.toDouble(),
-                    -_mapValueToDepth(
-                      p.pressure,
-                      chartMaxDepth,
-                      minPressure,
-                      maxPressure,
-                    ),
-                  ),
-                )
-                .toList(),
-          ),
+          spots: _withFlatSurfaceLeadIn(tankSpots),
           // Synthesized estimates are straight (flat-drop-flat); curve
           // smoothing would round their corners. Real AI data stays curved.
           isCurved: !(widget.estimatedTankIds?.contains(tankId) ?? false),
           curveSmoothness: 0.2,
           // The lead-in vertex is a sharp direction change; without this the
           // spline overshoots it and hooks below the curve at the left edge.
-          preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+          preventCurveOverShooting: _seriesGetsLeadIn(
+            tankSpots,
+            widget.profile,
+          ),
           color: color,
           barWidth: 2,
           isStrokeCapRound: true,
@@ -4215,7 +4254,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: sacColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4255,7 +4294,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: Colors.lime,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4338,7 +4377,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: ceilingColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4423,7 +4462,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: ppO2Color,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4465,7 +4504,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: ppN2Color,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4517,7 +4556,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: ppHeColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4600,7 +4639,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: densityColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4634,7 +4673,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: gfColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4668,7 +4707,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: surfaceGfColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4700,7 +4739,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: meanDepthColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4736,7 +4775,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: ttsColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4782,7 +4821,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: cnsColor,
       barWidth: 2,
       isStrokeCapRound: true,
@@ -4814,7 +4853,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // change and the spline would otherwise overshoot it and hook below
       // the curve at the left edge. Dives already starting at t=0 keep
       // their existing smoothing untouched.
-      preventCurveOverShooting: shouldDrawSurfaceLeadIn(widget.profile),
+      preventCurveOverShooting: _seriesGetsLeadIn(spots, widget.profile),
       color: otuColor,
       barWidth: 2,
       isStrokeCapRound: true,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1007,7 +1007,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
     final spot = (spotIndex: index);
 
-    final point = widget.profile[spot.spotIndex];
+    // On the lead-in vertex the cursor is before the first sample, so the
+    // readout must describe t=0 rather than repeat the first sample's values.
+    final onLeadIn =
+        touched.spotIndex == 0 &&
+        starts[touched.barIndex] < 0 &&
+        shouldDrawSurfaceLeadIn(widget.profile);
+    final point = onLeadIn
+        ? _surfaceReadoutPoint()
+        : widget.profile[spot.spotIndex];
     final rows = <TooltipRow>[];
     final onSurface = colorScheme.onInverseSurface;
 
@@ -1200,7 +1208,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           label: widget.ppO2FromSensorAverage
               ? '${context.l10n.diveLog_tooltip_ppO2} ${context.l10n.diveLog_tooltip_avgCalculated}'
               : context.l10n.diveLog_tooltip_ppO2,
-          value: '${widget.ppO2Curve![spot.spotIndex].toStringAsFixed(2)} bar',
+          value:
+              '${_readoutValue(widget.ppO2Curve![spot.spotIndex], onLeadIn).toStringAsFixed(2)} bar',
           bulletColor: const Color(0xFF00ACC1),
         ),
       );
@@ -1229,7 +1238,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       rows.add(
         TooltipRow(
           label: 'ppN2',
-          value: '${widget.ppN2Curve![spot.spotIndex].toStringAsFixed(2)} bar',
+          value:
+              '${_readoutValue(widget.ppN2Curve![spot.spotIndex], onLeadIn).toStringAsFixed(2)} bar',
           bulletColor: Colors.indigo,
         ),
       );
@@ -1424,7 +1434,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       }
     }
 
-    widget.onTooltipData!(rows);
+    widget.onTooltipData!(
+      onLeadIn
+          ? _markInterpolatedRows(rows, _exactAtSurfaceLabels(context))
+          : rows,
+    );
   }
 
   /// The plot-rect insets (reserved axis gutters) for the current build, so a
@@ -3762,6 +3776,63 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// Lead-in for curves that barely change across one sample interval
   /// (temperature, partial pressures, MOD, density, SAC, tank pressure, heart
   /// rate): hold the first reading flat back to t=0.
+  /// The sample the readout describes when the cursor sits on the lead-in.
+  ///
+  /// Time and depth are exact rather than interpolated: the dive begins at
+  /// t=0 with the diver at the surface. Temperature carries over from the
+  /// first reading and is marked interpolated by [_markInterpolatedRows].
+  DiveProfilePoint _surfaceReadoutPoint() => DiveProfilePoint(
+    timestamp: 0,
+    depth: 0,
+    temperature: widget.profile.isEmpty
+        ? null
+        : widget.profile.first.temperature,
+  );
+
+  /// Labels whose value at t=0 is known or calculated rather than carried over
+  /// from the first sample, and so must not be marked interpolated.
+  ///
+  /// Time and depth are exact. The partial pressures and gas density are
+  /// computed from the ambient pressure at the surface (see
+  /// [surfaceValueAtOneBar]). MOD is a property of the gas, so it does not
+  /// change between the surface and the first sample.
+  /// Built at the call site because some labels are localized: matching
+  /// hardcoded English would silently mark them interpolated in other locales.
+  Set<String> _exactAtSurfaceLabels(BuildContext context) => {
+    'Time',
+    'Depth',
+    'ppN2',
+    'ppHe',
+    'Density',
+    'MOD',
+    context.l10n.diveLog_tooltip_ppO2,
+    '${context.l10n.diveLog_tooltip_ppO2} '
+        '${context.l10n.diveLog_tooltip_avgCalculated}',
+  };
+
+  /// Mark every readout row whose value was carried over from the first sample
+  /// rather than known or calculated at t=0, so the lead-in never presents a
+  /// held value as if it had been measured there.
+  List<TooltipRow> _markInterpolatedRows(
+    List<TooltipRow> rows,
+    Set<String> exactLabels,
+  ) => [
+    for (final row in rows)
+      if (exactLabels.contains(row.label) || row.label.startsWith('Depth ·'))
+        row
+      else
+        TooltipRow(
+          label: row.label,
+          value: '${row.value} (interpolated)',
+          bulletColor: row.bulletColor,
+        ),
+  ];
+
+  /// A readout value for a pressure-proportional quantity: computed at the
+  /// surface while on the lead-in, otherwise the sampled value as-is.
+  double _readoutValue(double sampled, bool onLeadIn) =>
+      onLeadIn ? _surfaceValueOf(sampled) : sampled;
+
   /// [surfaceValueAtOneBar] applied at the dive's first sample.
   double _surfaceValueOf(double valueAtFirstSample) => widget.profile.isEmpty
       ? valueAtFirstSample

--- a/lib/features/media/presentation/widgets/mini_dive_profile_overlay.dart
+++ b/lib/features/media/presentation/widgets/mini_dive_profile_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/data/services/profile_surface_lead_in.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -137,9 +138,13 @@ class MiniDiveProfileOverlay extends StatelessWidget {
 
     // Create depth line spots with NEGATED depths for proper orientation
     // (fl_chart Y-axis goes up, but we want depth to increase downward)
-    final depthSpots = sortedProfile
-        .map((p) => FlSpot(p.timestamp.toDouble(), -p.depth))
-        .toList();
+    // The x-axis starts at 0 but computers do not sample there, so descend
+    // from the surface to close the gap (issue #684). Same one-sample-interval
+    // rule as the full profile chart.
+    final depthSpots = <FlSpot>[
+      if (shouldDrawSurfaceLeadIn(sortedProfile)) const FlSpot(0, 0),
+      ...sortedProfile.map((p) => FlSpot(p.timestamp.toDouble(), -p.depth)),
+    ];
 
     // Find the depth at the photo timestamp for the marker
     final photoDepth = _interpolateDepth(sortedProfile, photoElapsedSeconds);

--- a/test/features/dive_log/data/services/profile_surface_lead_in_test.dart
+++ b/test/features/dive_log/data/services/profile_surface_lead_in_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/profile_surface_lead_in.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+List<DiveProfilePoint> _profile(List<int> timestamps) => [
+  for (final t in timestamps) DiveProfilePoint(timestamp: t, depth: 1.0),
+];
+
+void main() {
+  group('shouldDrawSurfaceLeadIn', () {
+    test('true when the first sample sits one interval in', () {
+      expect(shouldDrawSurfaceLeadIn(_profile([10, 20, 30])), isTrue);
+    });
+
+    test('false when the profile already starts at zero', () {
+      expect(shouldDrawSurfaceLeadIn(_profile([0, 1, 2])), isFalse);
+    });
+
+    test('false when the gap exceeds one sample interval', () {
+      expect(shouldDrawSurfaceLeadIn(_profile([600, 610, 620])), isFalse);
+    });
+
+    test('boundary: one interval yes, one second more no', () {
+      expect(shouldDrawSurfaceLeadIn(_profile([10, 20])), isTrue);
+      expect(shouldDrawSurfaceLeadIn(_profile([11, 21])), isFalse);
+    });
+
+    test('false for profiles too short to establish an interval', () {
+      expect(shouldDrawSurfaceLeadIn(const []), isFalse);
+      expect(shouldDrawSurfaceLeadIn(_profile([10])), isFalse);
+    });
+
+    test('false when the first two samples share a timestamp', () {
+      expect(shouldDrawSurfaceLeadIn(_profile([10, 10, 20])), isFalse);
+    });
+  });
+
+  group('ambientPressureBar', () {
+    test('1 bar at the surface', () {
+      expect(ambientPressureBar(0), 1.0);
+    });
+
+    test('adds 1 bar per 10 m of seawater', () {
+      expect(ambientPressureBar(10), 2.0);
+      expect(ambientPressureBar(20), 3.0);
+      expect(ambientPressureBar(25), closeTo(3.5, 1e-9));
+    });
+  });
+
+  group('surfaceValueAtOneBar', () {
+    test('recovers the gas fraction from a partial pressure at depth', () {
+      // Air ppO2 of 0.63 bar at 20 m (3 bar ambient) is 0.21 at the surface.
+      expect(surfaceValueAtOneBar(0.63, 20), closeTo(0.21, 1e-9));
+      // ppN2 0.79 * 3 = 2.37 at 20 m recovers 0.79.
+      expect(surfaceValueAtOneBar(2.37, 20), closeTo(0.79, 1e-9));
+    });
+
+    test('is a no-op when the first sample is already at the surface', () {
+      expect(surfaceValueAtOneBar(0.21, 0), 0.21);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -523,6 +523,42 @@ void main() {
       expect(depthBar.spots.first.x, 0);
     });
 
+    testWidgets('analysis curves are extended to t=0 at their first value', (
+      tester,
+    ) async {
+      // Held flat rather than zeroed: on a repetitive dive the first sample
+      // already carries residual loading (CNS here starts at 12%), and forcing
+      // a synthetic 0 would draw it as a first dive of the day.
+      final profile = [
+        for (var i = 1; i <= 8; i++)
+          DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+      ];
+      final cns = [for (var i = 0; i < 8; i++) 12.0 + i];
+      final ndl = [for (var i = 0; i < 8; i++) 1080 - i * 10];
+
+      await tester.pumpWidget(
+        _buildChart(profile: profile, cnsCurve: cns, ndlCurve: ndl),
+      );
+      await tester.pumpAndSettle();
+
+      final bars = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineBarsData;
+
+      // Bar 0 is depth, which descends from the surface rather than holding
+      // flat; the analysis curves after it hold their first value.
+      expect(bars.first.spots.first, const FlSpot(0, 0));
+
+      final analysisLeadIns = bars
+          .skip(1)
+          .where((b) => b.spots.length > 1 && b.spots.first.x == 0);
+      expect(analysisLeadIns, isNotEmpty);
+      for (final bar in analysisLeadIns) {
+        expect(bar.spots.first.y, bar.spots[1].y);
+      }
+    });
+
     testWidgets('a trimmed profile keeps its gap rather than inventing a '
         'descent', (tester) async {
       // First sample far beyond one interval: drawing from the surface would

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -722,6 +722,119 @@ void main() {
     );
 
     testWidgets(
+      'an overlay gets its lead-in from its own samples, not the active dive',
+      (tester) async {
+        // The case the hard-wired predicate missed: the active profile starts
+        // at t=0 (so it needs no lead-in) while the overlaid computer starts at
+        // t=10 and does. Keying off the active dive would leave the overlay
+        // gapped.
+        final active = [
+          for (var i = 0; i < 8; i++)
+            DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+        ];
+        final other = [
+          for (var i = 1; i <= 8; i++)
+            DiveProfilePoint(timestamp: i * 10, depth: i * 1.5),
+        ];
+
+        await tester.pumpWidget(
+          _buildChart(
+            profile: active,
+            activeComputerId: 'comp-a',
+            overlays: [overlay(color: Colors.purple, points: other)],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final bars = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data
+            .lineBarsData;
+
+        // Active depth bar: starts at t=0 already, so no synthetic vertex.
+        expect(bars.first.spots.length, active.length);
+        expect(bars.first.spots.first.x, 0);
+
+        // Overlay depth bar is appended last and DOES get one.
+        final overlayBar = bars.last;
+        expect(overlayBar.color, Colors.purple);
+        expect(overlayBar.spots.first, const FlSpot(0, 0));
+        expect(overlayBar.spots.length, other.length + 1);
+        expect(overlayBar.spots[1].x, 10);
+      },
+    );
+
+    testWidgets(
+      'a tank first breathed mid-dive keeps its smoothing untouched',
+      (tester) async {
+        // A deco bottle's pressure trace legitimately starts mid-dive, so it
+        // receives no lead-in -- and must not have its smoothing changed by
+        // the dive-level flag either.
+        final profile = [
+          for (var i = 1; i <= 10; i++)
+            DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+        ];
+        const tanks = [
+          DiveTank(id: 'back', gasMix: GasMix(o2: 21), order: 0),
+          DiveTank(id: 'deco', gasMix: GasMix(o2: 50), order: 1),
+        ];
+        const pressures = {
+          'back': [
+            TankPressurePoint(
+              id: 'b0',
+              tankId: 'back',
+              timestamp: 10,
+              pressure: 200,
+            ),
+            TankPressurePoint(
+              id: 'b1',
+              tankId: 'back',
+              timestamp: 100,
+              pressure: 80,
+            ),
+          ],
+          'deco': [
+            TankPressurePoint(
+              id: 'd0',
+              tankId: 'deco',
+              timestamp: 60,
+              pressure: 200,
+            ),
+            TankPressurePoint(
+              id: 'd1',
+              tankId: 'deco',
+              timestamp: 100,
+              pressure: 150,
+            ),
+          ],
+        };
+
+        await tester.pumpWidget(
+          _buildChart(profile: profile, tanks: tanks, tankPressures: pressures),
+        );
+        await tester.pumpAndSettle();
+
+        final bars = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data
+            .lineBarsData;
+
+        // The deco series starts at t=60: no lead-in, and no smoothing change.
+        final decoBar = bars.firstWhere(
+          (b) => b.spots.length == 2 && b.spots.first.x == 60,
+        );
+        expect(decoBar.preventCurveOverShooting, isFalse);
+
+        // The back-gas series starts at the dive's first sample, so it does
+        // get a lead-in and the overshoot guard with it.
+        final backBar = bars.firstWhere(
+          (b) => b.spots.length == 3 && b.spots.first.x == 0,
+        );
+        expect(backBar.preventCurveOverShooting, isTrue);
+      },
+    );
+
+    testWidgets(
       'inline tooltip on the lead-in computes pressures and marks held values',
       (tester) async {
         // First sample at 10s and 20 m depth => 3 bar ambient. A ppO2 of

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -671,6 +671,102 @@ void main() {
     );
 
     testWidgets(
+      'touching the lead-in vertex reports t=0 and marks held values',
+      (tester) async {
+        // First sample at 10s, so bar 0 carries a synthetic (0, 0m) lead-in
+        // vertex at spotIndex 0 (issue #684). Touching it must describe t=0,
+        // not repeat the first sample.
+        final profile = [
+          for (var i = 1; i <= 8; i++)
+            DiveProfilePoint(
+              timestamp: i * 10,
+              depth: i * 2.0,
+              temperature: 25.0,
+            ),
+        ];
+        List<TooltipRow>? rows;
+        await tester.pumpWidget(
+          _buildChart(
+            profile: profile,
+            tooltipBelow: true,
+            onTooltipData: (r) => rows = r,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final data = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data;
+        final depthBar = data.lineBarsData.first;
+        // The lead-in vertex: bar 0, spotIndex 0, at x=0.
+        expect(depthBar.spots.first, const FlSpot(0, 0));
+        data.lineTouchData.touchCallback!(
+          FlPanDownEvent(DragDownDetails()),
+          LineTouchResponse(
+            touchLocation: Offset.zero,
+            touchChartCoordinate: Offset.zero,
+            lineBarSpots: <TouchLineBarSpot>[
+              TouchLineBarSpot(depthBar, 0, depthBar.spots.first, 0),
+            ],
+          ),
+        );
+
+        expect(rows, isNotNull);
+        final byLabel = {for (final r in rows!) r.label: r.value};
+        // Time and depth are exact at the surface, never marked.
+        expect(byLabel['Time'], '0:00');
+        expect(byLabel['Depth'], isNot(contains('interpolated')));
+        // Temperature is carried over from the first sample, so it is marked.
+        expect(byLabel['Temp'], contains('(interpolated)'));
+      },
+    );
+
+    testWidgets(
+      'inline tooltip on the lead-in computes pressures and marks held values',
+      (tester) async {
+        // First sample at 10s and 20 m depth => 3 bar ambient. A ppO2 of
+        // 0.63 bar there is 0.21 at the surface, so the lead-in readout must
+        // compute it, not repeat 0.63. Temperature is held and marked.
+        final profile = [
+          for (var i = 1; i <= 8; i++)
+            DiveProfilePoint(timestamp: i * 10, depth: 20.0, temperature: 25.0),
+        ];
+        await tester.pumpWidget(
+          _buildChartAllMetrics(
+            profile: profile,
+            ppO2Curve: [for (var i = 0; i < 8; i++) 0.63],
+            ppN2Curve: [for (var i = 0; i < 8; i++) 2.37],
+            ppHeCurve: [for (var i = 0; i < 8; i++) 0.9],
+            densityCurve: [for (var i = 0; i < 8; i++) 3.6],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final data = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data;
+        final depthBar = data.lineBarsData.first;
+        expect(depthBar.spots.first, const FlSpot(0, 0));
+
+        // Drive fl_chart's own tooltip builder with the lead-in vertex.
+        final items = data.lineTouchData.touchTooltipData.getTooltipItems(
+          <LineBarSpot>[TouchLineBarSpot(depthBar, 0, depthBar.spots.first, 0)],
+        );
+        final plain = items
+            .whereType<LineTooltipItem>()
+            .expand(
+              (it) => [it.text, ...?it.children?.map((c) => c.toPlainText())],
+            )
+            .join();
+
+        expect(plain, contains('0:00')); // t=0, not 0:10
+        expect(plain, contains('0.21 bar')); // computed ppO2, not 0.63
+        expect(plain, isNot(contains('0.63 bar')));
+        expect(plain, contains('(interpolated)')); // temperature held
+      },
+    );
+
+    testWidgets(
       'touch on the active depth bar resolves the active profile sample '
       'even with a denser overlay present',
       (tester) async {
@@ -3851,6 +3947,52 @@ void main() {
         expect(b.spots, isNotEmpty);
         expect(b.spots.length, lessThanOrEqualTo(2008));
       }
+    });
+  });
+
+  group('DiveProfileMiniChart', () {
+    Widget host(List<DiveProfilePoint> profile) => MaterialApp(
+      home: Scaffold(body: DiveProfileMiniChart(profile: profile)),
+    );
+
+    LineChartBarData bar(WidgetTester tester) => tester
+        .widget<LineChart>(find.byType(LineChart))
+        .data
+        .lineBarsData
+        .first;
+
+    testWidgets('empty profile renders no chart', (tester) async {
+      await tester.pumpWidget(host(const []));
+      await tester.pumpAndSettle();
+      expect(find.byType(LineChart), findsNothing);
+    });
+
+    testWidgets('a profile starting after t=0 descends from the surface', (
+      tester,
+    ) async {
+      final profile = [
+        for (var i = 1; i <= 8; i++)
+          DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+      ];
+      await tester.pumpWidget(host(profile));
+      await tester.pumpAndSettle();
+
+      final b = bar(tester);
+      expect(b.spots.first, const FlSpot(0, 0));
+      expect(b.spots.length, profile.length + 1);
+    });
+
+    testWidgets('a profile starting at t=0 gains no lead-in', (tester) async {
+      final profile = [
+        for (var i = 0; i < 8; i++)
+          DiveProfilePoint(timestamp: i * 10, depth: i.toDouble()),
+      ];
+      await tester.pumpWidget(host(profile));
+      await tester.pumpAndSettle();
+
+      final b = bar(tester);
+      expect(b.spots.length, profile.length);
+      expect(b.spots.first.x, 0);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/profile_metrics.dart';
 import 'package:submersion/core/deco/ascent_rate_calculator.dart';
+import 'package:submersion/features/dive_log/data/services/profile_surface_lead_in.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_colors.dart';
 
@@ -521,6 +522,39 @@ void main() {
 
       expect(depthBar.spots.length, profile.length);
       expect(depthBar.spots.first.x, 0);
+    });
+
+    testWidgets('a profile starting at t=0 keeps its original smoothing', (
+      tester,
+    ) async {
+      // The lead-in changes curve smoothing to stop the spline overshooting
+      // that vertex. A dive that needs no lead-in must be rendered exactly as
+      // before, so the fix cannot alter dives it does not apply to.
+      final atZero = _makeProfile(points: 8);
+      expect(atZero.first.timestamp, 0);
+
+      await tester.pumpWidget(_buildChart(profile: atZero));
+      await tester.pumpAndSettle();
+      final zeroBars = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineBarsData;
+      for (final bar in zeroBars) {
+        expect(bar.preventCurveOverShooting, isFalse);
+      }
+
+      // The same chart on a profile that does need one turns it on.
+      final offset = [
+        for (var i = 1; i <= 8; i++)
+          DiveProfilePoint(timestamp: i * 30, depth: i * 2.0),
+      ];
+      await tester.pumpWidget(_buildChart(profile: offset));
+      await tester.pumpAndSettle();
+      final offsetBars = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineBarsData;
+      expect(offsetBars.any((b) => b.preventCurveOverShooting), isTrue);
     });
 
     testWidgets('analysis curves are extended to t=0 at their first value', (
@@ -1820,69 +1854,46 @@ void main() {
     });
   });
 
-  group('DiveProfileChart.shouldDrawSurfaceLeadIn', () {
+  group('shouldDrawSurfaceLeadIn', () {
     List<DiveProfilePoint> profileFrom(List<int> timestamps) => [
       for (final t in timestamps) DiveProfilePoint(timestamp: t, depth: 1.0),
     ];
 
     test('true when the first sample sits one interval in', () {
       // The Subsurface/DC-XML case from #679: 10s sampling, first sample at 10.
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10, 20, 30, 40])),
-        isTrue,
-      );
+      expect(shouldDrawSurfaceLeadIn(profileFrom([10, 20, 30, 40])), isTrue);
     });
 
     test('false when the profile already starts at zero', () {
       // Garmin FIT samples at t=0, so there is no gap to close.
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([0, 1, 2, 3])),
-        isFalse,
-      );
+      expect(shouldDrawSurfaceLeadIn(profileFrom([0, 1, 2, 3])), isFalse);
     });
 
     test('true for a one-second sampling computer', () {
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([1, 2, 3, 4])),
-        isTrue,
-      );
+      expect(shouldDrawSurfaceLeadIn(profileFrom([1, 2, 3, 4])), isTrue);
     });
 
     test('false when the gap exceeds one sample interval', () {
       // A trimmed or merged profile starting well after t=0: drawing a descent
       // across that span would fabricate dive time that was never recorded.
       expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(
-          profileFrom([600, 610, 620, 630]),
-        ),
+        shouldDrawSurfaceLeadIn(profileFrom([600, 610, 620, 630])),
         isFalse,
       );
     });
 
     test('boundary: exactly one interval yes, one second more no', () {
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10, 20, 30])),
-        isTrue,
-      );
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([11, 21, 31])),
-        isFalse,
-      );
+      expect(shouldDrawSurfaceLeadIn(profileFrom([10, 20, 30])), isTrue);
+      expect(shouldDrawSurfaceLeadIn(profileFrom([11, 21, 31])), isFalse);
     });
 
     test('false for profiles too short to establish an interval', () {
-      expect(DiveProfileChart.shouldDrawSurfaceLeadIn(const []), isFalse);
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10])),
-        isFalse,
-      );
+      expect(shouldDrawSurfaceLeadIn(const []), isFalse);
+      expect(shouldDrawSurfaceLeadIn(profileFrom([10])), isFalse);
     });
 
     test('false when samples share a timestamp (no usable interval)', () {
-      expect(
-        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10, 10, 20])),
-        isFalse,
-      );
+      expect(shouldDrawSurfaceLeadIn(profileFrom([10, 10, 20])), isFalse);
     });
   });
 

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -478,6 +478,73 @@ void main() {
     });
 
     testWidgets(
+      'a profile starting after t=0 draws the depth line from the surface',
+      (tester) async {
+        // Subsurface/DC-XML profiles begin at the first sample (10s), leaving a
+        // gap against the t=0 axis origin (issue #684).
+        final profile = [
+          for (var i = 1; i <= 8; i++)
+            DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+        ];
+        await tester.pumpWidget(_buildChart(profile: profile));
+        await tester.pumpAndSettle();
+
+        final depthBar = tester
+            .widget<LineChart>(find.byType(LineChart).first)
+            .data
+            .lineBarsData
+            .first;
+
+        expect(depthBar.spots.first.x, 0);
+        expect(depthBar.spots.first.y, 0);
+        // The synthetic vertex is additive: every real sample is still drawn.
+        expect(depthBar.spots.length, profile.length + 1);
+        expect(depthBar.spots[1].x, 10);
+      },
+    );
+
+    testWidgets('a profile already starting at t=0 gains no extra vertex', (
+      tester,
+    ) async {
+      // Garmin FIT samples at zero, so there is no gap and nothing to add.
+      final profile = _makeProfile(points: 8);
+      expect(profile.first.timestamp, 0);
+
+      await tester.pumpWidget(_buildChart(profile: profile));
+      await tester.pumpAndSettle();
+
+      final depthBar = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineBarsData
+          .first;
+
+      expect(depthBar.spots.length, profile.length);
+      expect(depthBar.spots.first.x, 0);
+    });
+
+    testWidgets('a trimmed profile keeps its gap rather than inventing a '
+        'descent', (tester) async {
+      // First sample far beyond one interval: drawing from the surface would
+      // fabricate dive time that was never recorded.
+      final profile = [
+        for (var i = 0; i < 8; i++)
+          DiveProfilePoint(timestamp: 600 + i * 10, depth: 20.0 + i),
+      ];
+      await tester.pumpWidget(_buildChart(profile: profile));
+      await tester.pumpAndSettle();
+
+      final depthBar = tester
+          .widget<LineChart>(find.byType(LineChart).first)
+          .data
+          .lineBarsData
+          .first;
+
+      expect(depthBar.spots.length, profile.length);
+      expect(depthBar.spots.first.x, 600);
+    });
+
+    testWidgets(
       'tooltip rows label overlay depth and temperature with the metric',
       (tester) async {
         final active = [
@@ -1672,6 +1739,113 @@ void main() {
           multiComputer: true,
         ),
         -1,
+      );
+    });
+
+    test('a surface lead-in vertex does not shift the sample mapping', () {
+      // With a lead-in, bar 0's spots are [synthetic, p0, p1, ...], so
+      // _depthBarStartIndices reports -1 for that bar to keep
+      // `start + spotIndex` addressing the right sample. The synthetic vertex
+      // itself resolves to the first sample rather than a negative index.
+      const starts = [-1];
+      expect(
+        DiveProfileChart.depthSpotProfileIndex(
+          profile: profile,
+          depthBarStarts: starts,
+          barIndex: 0,
+          spotIndex: 0, // the synthetic (0, 0m) vertex
+          spotX: 0.0,
+          multiComputer: false,
+        ),
+        0,
+      );
+      expect(
+        DiveProfileChart.depthSpotProfileIndex(
+          profile: profile,
+          depthBarStarts: starts,
+          barIndex: 0,
+          spotIndex: 1, // the first real sample
+          spotX: 0.0,
+          multiComputer: false,
+        ),
+        0,
+      );
+      expect(
+        DiveProfileChart.depthSpotProfileIndex(
+          profile: profile,
+          depthBarStarts: starts,
+          barIndex: 0,
+          spotIndex: 3,
+          spotX: 20.0,
+          multiComputer: false,
+        ),
+        2,
+      );
+    });
+  });
+
+  group('DiveProfileChart.shouldDrawSurfaceLeadIn', () {
+    List<DiveProfilePoint> profileFrom(List<int> timestamps) => [
+      for (final t in timestamps) DiveProfilePoint(timestamp: t, depth: 1.0),
+    ];
+
+    test('true when the first sample sits one interval in', () {
+      // The Subsurface/DC-XML case from #679: 10s sampling, first sample at 10.
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10, 20, 30, 40])),
+        isTrue,
+      );
+    });
+
+    test('false when the profile already starts at zero', () {
+      // Garmin FIT samples at t=0, so there is no gap to close.
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([0, 1, 2, 3])),
+        isFalse,
+      );
+    });
+
+    test('true for a one-second sampling computer', () {
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([1, 2, 3, 4])),
+        isTrue,
+      );
+    });
+
+    test('false when the gap exceeds one sample interval', () {
+      // A trimmed or merged profile starting well after t=0: drawing a descent
+      // across that span would fabricate dive time that was never recorded.
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(
+          profileFrom([600, 610, 620, 630]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('boundary: exactly one interval yes, one second more no', () {
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10, 20, 30])),
+        isTrue,
+      );
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([11, 21, 31])),
+        isFalse,
+      );
+    });
+
+    test('false for profiles too short to establish an interval', () {
+      expect(DiveProfileChart.shouldDrawSurfaceLeadIn(const []), isFalse);
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10])),
+        isFalse,
+      );
+    });
+
+    test('false when samples share a timestamp (no usable interval)', () {
+      expect(
+        DiveProfileChart.shouldDrawSurfaceLeadIn(profileFrom([10, 10, 20])),
+        isFalse,
       );
     });
   });

--- a/test/features/media/presentation/widgets/mini_dive_profile_overlay_test.dart
+++ b/test/features/media/presentation/widgets/mini_dive_profile_overlay_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/presentation/widgets/mini_dive_profile_overlay.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+Widget _host(Widget child) => MaterialApp(
+  locale: const Locale('en'),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: Center(child: child)),
+);
+
+LineChartBarData _depthBar(WidgetTester tester) =>
+    tester.widget<LineChart>(find.byType(LineChart)).data.lineBarsData.first;
+
+void main() {
+  const settings = AppSettings();
+
+  testWidgets('empty profile renders nothing', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        const MiniDiveProfileOverlay(
+          profile: [],
+          photoElapsedSeconds: 0,
+          settings: settings,
+        ),
+      ),
+    );
+    expect(find.byType(LineChart), findsNothing);
+  });
+
+  testWidgets('a profile starting after t=0 descends from the surface', (
+    tester,
+  ) async {
+    // Subsurface/DC-XML sampling: first sample at 10s, so the sparkline must
+    // reach the left edge rather than starting one interval in (issue #684).
+    final profile = [
+      for (var i = 1; i <= 8; i++)
+        DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+    ];
+    await tester.pumpWidget(
+      _host(
+        MiniDiveProfileOverlay(
+          profile: profile,
+          photoElapsedSeconds: 30,
+          photoDepthMeters: 6.0,
+          settings: settings,
+        ),
+      ),
+    );
+
+    final bar = _depthBar(tester);
+    expect(bar.spots.first, const FlSpot(0, 0));
+    // Additive: every real sample is still drawn after the lead-in.
+    expect(bar.spots.length, profile.length + 1);
+    expect(bar.spots[1].x, 10);
+  });
+
+  testWidgets('a profile already starting at t=0 gains no lead-in', (
+    tester,
+  ) async {
+    final profile = [
+      for (var i = 0; i < 8; i++)
+        DiveProfilePoint(timestamp: i * 10, depth: i.toDouble()),
+    ];
+    await tester.pumpWidget(
+      _host(
+        MiniDiveProfileOverlay(
+          profile: profile,
+          photoElapsedSeconds: 20,
+          settings: settings,
+        ),
+      ),
+    );
+
+    final bar = _depthBar(tester);
+    expect(bar.spots.length, profile.length);
+    expect(bar.spots.first.x, 0);
+  });
+
+  testWidgets('a trimmed profile keeps its gap', (tester) async {
+    // First sample far past one interval: no fabricated descent.
+    final profile = [
+      for (var i = 0; i < 8; i++)
+        DiveProfilePoint(timestamp: 600 + i * 10, depth: 20.0 + i),
+    ];
+    await tester.pumpWidget(
+      _host(
+        MiniDiveProfileOverlay(
+          profile: profile,
+          photoElapsedSeconds: 620,
+          settings: settings,
+        ),
+      ),
+    );
+
+    final bar = _depthBar(tester);
+    expect(bar.spots.length, profile.length);
+    expect(bar.spots.first.x, 600);
+  });
+}


### PR DESCRIPTION
Fixes #684.

## Symptom

Nothing on the profile chart reached the left edge. The x-axis starts at `t = 0`, but every line — depth, NDL, TTS, ceiling, ppO2, CNS, temperature, tank pressure — began at the dive's first sample, leaving a ragged gap one sample interval wide.

Most visible on Subsurface/DC-XML imports (first sample at `t = 10`). Garmin FIT samples at `t = 0`, so there was never a gap there.

Found while investigating #679 — the spurious gas sliver in that report sat in exactly this gap. The two are separate: #679 was about *which gas* fills `0 .. firstSample`; this is about nothing being drawn there at all.

## Cause

The axis domain starts at zero (`minX` is the viewport offset, `0` at default zoom), but every curve plots its points at raw sample timestamps.

## Fix

| Line | Lead-in value at `t = 0` | |
| --- | --- | --- |
| Depth | `0 m` — the diver was at the surface | known |
| ppO2, ppN2, ppHe, gas density | computed at 1 bar ambient, where each reduces to its gas fraction | calculated |
| MOD | unchanged — a property of the gas, not of depth | calculated |
| Everything else | its first reading, held flat | interpolated |

Anything calculable is calculated rather than stubbed flat. Dividing a reading by the ambient pressure at its sample recovers the gas fraction — its value at the surface — and collapses to the sampled value when the diver is still at the surface, the usual case one sample in.

**Held flat rather than zeroed, because of repetitive dives.** A diver entering the water on their second dive of the day already carries CNS, OTU and tissue loading, and their NDL is already cut short by residual nitrogen. The first sample reflects that. Forcing a semantic zero — or a maximum NDL — would render a repetitive dive as though it were the first of the day: full no-deco time and no accumulated oxygen exposure, neither of which is true. That is a wrong number on a chart read for gas and deco decisions, not a cosmetic difference. Holding the first value is at most one sample interval stale and never contradicts the dive's history.

Two guards keep the lead-in honest:

1. **Gap of at most one sample interval.** That is the only gap the sampling rate can explain. A profile starting later has been trimmed or merged, and drawing a descent across it would fabricate dive time that was never recorded — worse than the gap it closes. Those keep their gap.
2. **The curve's own first point must be the dive's first sample.** A ceiling that only appears once deco is owed, or a deco bottle's pressure trace, keeps its real mid-dive start rather than being dragged back to zero.

## Two knock-on effects

**Smoothing.** The lead-in is a sharp direction change, and Catmull-Rom smoothing overshot it, hooking curves below themselves at the left edge. `preventCurveOverShooting` is enabled *only* while a lead-in is drawn, so dives already starting at `t = 0` render byte-identically to before — there is a test asserting exactly that.

**The readout.** Hovering the lead-in previously resolved to the first sample and claimed `Time 0:10` while the cursor sat at 0. It now describes `t = 0`: time and depth are exact, pressure-based values are computed, and everything carried over is labelled `(interpolated)` so a held number is never presented as measured. The exempt-label set is built from the same l10n expressions that produce the rows — `ppO2`'s label is localized, and matching hardcoded English would have mislabelled it in every non-English locale.

**Compact charts.** The dive-list sparkline and the video-overlay mini profile had the same `minX: 0` with raw-timestamp spots and are covered too. The predicate now lives in a shared service rather than on the chart widget, so the three cannot disagree about where a dive begins — `media` importing a `dive_log` chart widget to reach it was the wrong dependency.

## The non-obvious part

The depth line's spot indices are wired to the tooltip through a documented contract: a hovered point resolves as `depthBarStarts[bar] + spotIndex`. Prepending a vertex shifts that by one and would have made every tooltip on the first depth bar silently read one sample late. `_depthBarStartIndices` now reports `-1` for that bar to absorb it, and both resolution points clamp at zero so the synthetic vertex reads the first sample rather than a negative index.

## Screenshots

### Before
<img width="998" height="815" alt="image" src="https://github.com/user-attachments/assets/96a514e6-6df8-4190-b265-bc9cdb6638b1" />


### After 
<img width="1295" height="800" alt="after" src="https://github.com/user-attachments/assets/c74312ca-6dcf-4389-9926-4f2af8fbeb90" />

## Tests

Behavioural tests, verified to fail against the old code (the rendering test failed with `Expected: <0>  Actual: <10.0>` — the trace starting at the first sample):

- a profile starting after `t = 0` draws the depth line from `(0, 0m)`, with every real sample still present
- analysis curves reach `x = 0` holding their first value, with a residual CNS of 12% preserved rather than zeroed
- a profile already starting at `t = 0` (Garmin FIT) gains no extra vertex
- a trimmed profile keeps its gap
- the lead-in does not shift the tooltip's spot-to-sample mapping

Plus predicate coverage across sample intervals (0, 1, 10, 600s), the one-interval boundary, short profiles and duplicate timestamps.

Both tooltip readouts get the `t = 0` treatment: the floating overlay box (`_emitExternalTooltip`) and fl_chart's inline `getTooltipItems`. Each has its own copy of every row, and the two label the same rows differently — one hardcoded, one localized — so the exempt-label set carries both forms. All four pressure-based rows (ppO2, ppN2, ppHe, density) are computed in both.

`flutter analyze` clean; `dart format` applied. Chart + shared-service suites 151/151. Full suite result to follow in a comment.


