### PR TITLE
fix(media-store): recover orphaned 'transferring' uploads on drain

### DIFF
--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -49,13 +49,6 @@ class MediaStoreWorker {
     if (_running) return;
     _running = true;
     try {
-      // Crash recovery: a row left 'transferring' by a previous run (app
-      // killed or backgrounded mid-upload) is invisible to nextPending and
-      // stuck forever. We hold the single-flight lock and no transfer is
-      // active yet, so any such row is provably orphaned - return it to
-      // 'pending' before draining. The pipeline's head() dedup guard means
-      // already-uploaded bytes short-circuit to done on the re-run.
-      await _queue.requeueStale();
       while (true) {
         // Re-checked per entry, not once per drain: a store wipe or user
         // disconnect mid-drain must suspend the rest of the queue.

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -49,6 +49,13 @@ class MediaStoreWorker {
     if (_running) return;
     _running = true;
     try {
+      // Crash recovery: a row left 'transferring' by a previous run (app
+      // killed or backgrounded mid-upload) is invisible to nextPending and
+      // stuck forever. We hold the single-flight lock and no transfer is
+      // active yet, so any such row is provably orphaned - return it to
+      // 'pending' before draining. The pipeline's head() dedup guard means
+      // already-uploaded bytes short-circuit to done on the re-run.
+      await _queue.requeueStale();
       while (true) {
         // Re-checked per entry, not once per drain: a store wipe or user
         // disconnect mid-drain must suspend the rest of the queue.

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -215,20 +215,22 @@ class MediaTransferQueueRepository {
   /// Crash recovery: returns rows stranded in 'transferring' back to
   /// 'pending'. A drain can be interrupted (app killed or backgrounded
   /// mid-upload) after markTransferring but before markDone/markFailed, and
-  /// nextPending only selects 'pending' - so such a row is invisible to the
+  /// nextPending only selects 'pending', so such a row is invisible to the
   /// drainer forever and can be neither retried (failed-only) nor cleared
-  /// (done-only) from the Transfers UI. Callers MUST invoke this only when
-  /// no transfer is actively running - it is driven once per process by
-  /// mediaTransferQueueReclaimProvider, before any worker drains, where any
-  /// 'transferring' row is provably orphaned by a dead prior process.
-  /// Running it while a worker is live could flip that worker's in-flight
-  /// row and cause double processing. Stale progress is cleared and the
-  /// entry is made immediately
-  /// due; the resume point is preserved so a resumable adapter can pick up
-  /// where it left off, and attempts are untouched - an interruption is not
-  /// a failed attempt (contrast markFailed) but must still count toward the
-  /// cap of a genuinely broken item (contrast retry). Returns the number of
-  /// rows reclaimed.
+  /// (done-only) from the Transfers UI.
+  ///
+  /// Callers MUST invoke this only when no transfer is actively running:
+  /// it is driven once per process by mediaTransferQueueReclaimProvider,
+  /// before any worker drains, where every 'transferring' row is provably
+  /// orphaned by a dead prior process. Running it while a worker is live
+  /// could flip that worker's in-flight row and cause double processing.
+  ///
+  /// A reclaimed row is made immediately due with its stale progress
+  /// cleared, but keeps its resume point so a resumable adapter can pick up
+  /// where it left off. Attempts are untouched: an interruption is not a
+  /// failed attempt (contrast markFailed), yet a genuinely broken item must
+  /// still count toward its cap (contrast retry). Returns the number of rows
+  /// reclaimed.
   Future<int> requeueStale() {
     return (_db.update(
       _db.mediaTransferQueue,

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -218,9 +218,12 @@ class MediaTransferQueueRepository {
   /// nextPending only selects 'pending' - so such a row is invisible to the
   /// drainer forever and can be neither retried (failed-only) nor cleared
   /// (done-only) from the Transfers UI. Callers MUST invoke this only when
-  /// no transfer is actively running (e.g. at the start of a fresh
-  /// single-flight drain), where any 'transferring' row is provably
-  /// orphaned. Stale progress is cleared and the entry is made immediately
+  /// no transfer is actively running - it is driven once per process by
+  /// mediaTransferQueueReclaimProvider, before any worker drains, where any
+  /// 'transferring' row is provably orphaned by a dead prior process.
+  /// Running it while a worker is live could flip that worker's in-flight
+  /// row and cause double processing. Stale progress is cleared and the
+  /// entry is made immediately
   /// due; the resume point is preserved so a resumable adapter can pick up
   /// where it left off, and attempts are untouched - an interruption is not
   /// a failed attempt (contrast markFailed) but must still count toward the

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -227,10 +227,14 @@ class MediaTransferQueueRepository {
   ///
   /// A reclaimed row is made immediately due with its stale progress
   /// cleared, but keeps its resume point so a resumable adapter can pick up
-  /// where it left off. Attempts are untouched: an interruption is not a
-  /// failed attempt (contrast markFailed), yet a genuinely broken item must
-  /// still count toward its cap (contrast retry). Returns the number of rows
-  /// reclaimed.
+  /// where it left off. Any leftover error message is cleared too: a row can
+  /// reach 'transferring' still carrying an earlier attempt's error (markFailed
+  /// sets it, markTransferring does not clear it), and the Transfers UI shows
+  /// errorMessage whenever it is non-null - a row reclaimed after an
+  /// interruption must not display a failure it recovered from. Attempts are
+  /// untouched: an interruption is not a failed attempt (contrast markFailed),
+  /// yet a genuinely broken item must still count toward its cap (contrast
+  /// retry). Returns the number of rows reclaimed.
   Future<int> requeueStale() {
     return (_db.update(
       _db.mediaTransferQueue,
@@ -240,6 +244,7 @@ class MediaTransferQueueRepository {
         progressBytes: const Value(null),
         totalBytes: const Value(null),
         nextAttemptAt: const Value(null),
+        errorMessage: const Value(null),
         updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
       ),
     );

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -212,6 +212,34 @@ class MediaTransferQueueRepository {
     );
   }
 
+  /// Crash recovery: returns rows stranded in 'transferring' back to
+  /// 'pending'. A drain can be interrupted (app killed or backgrounded
+  /// mid-upload) after markTransferring but before markDone/markFailed, and
+  /// nextPending only selects 'pending' - so such a row is invisible to the
+  /// drainer forever and can be neither retried (failed-only) nor cleared
+  /// (done-only) from the Transfers UI. Callers MUST invoke this only when
+  /// no transfer is actively running (e.g. at the start of a fresh
+  /// single-flight drain), where any 'transferring' row is provably
+  /// orphaned. Stale progress is cleared and the entry is made immediately
+  /// due; the resume point is preserved so a resumable adapter can pick up
+  /// where it left off, and attempts are untouched - an interruption is not
+  /// a failed attempt (contrast markFailed) but must still count toward the
+  /// cap of a genuinely broken item (contrast retry). Returns the number of
+  /// rows reclaimed.
+  Future<int> requeueStale() {
+    return (_db.update(
+      _db.mediaTransferQueue,
+    )..where((t) => t.state.equals('transferring'))).write(
+      MediaTransferQueueCompanion(
+        state: const Value('pending'),
+        progressBytes: const Value(null),
+        totalBytes: const Value(null),
+        nextAttemptAt: const Value(null),
+        updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+      ),
+    );
+  }
+
   /// Connectivity/policy postponement: unlike markFailed, no attempt is
   /// consumed - the entry is simply not due until [until].
   Future<void> defer(int id, DateTime until) async {

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -234,16 +234,20 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
           return WorkerGate.proceed;
         },
       );
+      // Recover orphaned 'transferring' rows once per process, and do it
+      // BEFORE any drain can start - including a connectivity-triggered one.
+      // Awaited before the network subscription is attached so a network
+      // event during the await cannot kick a drain that marks a row
+      // 'transferring' while requeueStale is still running. Driven via the
+      // cached provider (not inside drain()) so a connect/disconnect rebuild
+      // cannot reclaim a row a still-running worker from the previous runtime
+      // owns; the cache makes it run only once.
+      await ref.read(mediaTransferQueueReclaimProvider.future);
+
       final connectivitySub = network.changes.listen((kind) {
         if (kind != NetworkKind.offline) unawaited(worker.drain());
       });
       ref.onDispose(connectivitySub.cancel);
-
-      // Recover orphaned 'transferring' rows once per process, before this
-      // (or any) worker drains. Awaited here rather than inside drain() so a
-      // connect/disconnect rebuild cannot reclaim a row a still-running
-      // worker from the previous runtime owns. Cached, so it runs only once.
-      await ref.read(mediaTransferQueueReclaimProvider.future);
       unawaited(worker.drain());
 
       return MediaStoreRuntime(

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -78,10 +78,12 @@ final mediaTransferQueueRepositoryProvider =
 /// at process start, so running reclamation once before the first drain
 /// recovers every real orphan without ever touching a live worker's row.
 /// This provider is never invalidated: its cached result makes the reclaim
-/// idempotent for the process lifetime.
+/// idempotent for the process lifetime. Uses ref.read, not ref.watch, so an
+/// invalidation/override of the repository provider (e.g. in a nested test
+/// scope) cannot recompute this future and trigger a second reclaim pass.
 final FutureProvider<void> mediaTransferQueueReclaimProvider =
     FutureProvider<void>((ref) async {
-      await ref.watch(mediaTransferQueueRepositoryProvider).requeueStale();
+      await ref.read(mediaTransferQueueRepositoryProvider).requeueStale();
     });
 
 final mediaBackfillServiceProvider = Provider<MediaBackfillService>(

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -65,6 +65,25 @@ final mediaTransferQueueRepositoryProvider =
       (ref) => MediaTransferQueueRepository(),
     );
 
+/// Recovers media transfer rows stranded in 'transferring' by a previous
+/// process (app killed or backgrounded mid-upload) back to 'pending'.
+///
+/// Deliberately separate from [mediaStoreRuntimeProvider] and run exactly
+/// once per process. The runtime is rebuilt on every connect/disconnect,
+/// and a rebuild can spawn a fresh worker while a worker from the previous
+/// runtime is still mid-upload (nothing cancels its in-flight drain).
+/// Reclaiming on each rebuild - or inside drain() - would flip that live
+/// transfer's row back to 'pending' and let two workers process it at once.
+/// A row is only ever orphaned by process death, which is observable only
+/// at process start, so running reclamation once before the first drain
+/// recovers every real orphan without ever touching a live worker's row.
+/// This provider is never invalidated: its cached result makes the reclaim
+/// idempotent for the process lifetime.
+final FutureProvider<void> mediaTransferQueueReclaimProvider =
+    FutureProvider<void>((ref) async {
+      await ref.watch(mediaTransferQueueRepositoryProvider).requeueStale();
+    });
+
 final mediaBackfillServiceProvider = Provider<MediaBackfillService>(
   (ref) => MediaBackfillService(
     mediaRepository: ref.watch(mediaRepositoryProvider),
@@ -219,6 +238,12 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         if (kind != NetworkKind.offline) unawaited(worker.drain());
       });
       ref.onDispose(connectivitySub.cancel);
+
+      // Recover orphaned 'transferring' rows once per process, before this
+      // (or any) worker drains. Awaited here rather than inside drain() so a
+      // connect/disconnect rebuild cannot reclaim a row a still-running
+      // worker from the previous runtime owns. Cached, so it runs only once.
+      await ref.read(mediaTransferQueueReclaimProvider.future);
       unawaited(worker.drain());
 
       return MediaStoreRuntime(

--- a/test/features/media_store/media_store_worker_reclaim_test.dart
+++ b/test/features/media_store/media_store_worker_reclaim_test.dart
@@ -58,7 +58,7 @@ void main() {
     await tearDownTestDatabase();
   });
 
-  test('drain reclaims an orphaned transferring row and uploads it', () async {
+  test('a reclaimed orphan row drains to done end-to-end', () async {
     final f = await cache.stagingFile();
     await f.writeAsBytes(
       img.encodePng(img.Image(width: 4000, height: 3000)),
@@ -83,7 +83,9 @@ void main() {
     await queue.markTransferring(id);
     expect(await queue.nextPending(DateTime.now()), isNull);
 
-    // A fresh drain must recover it, not ignore it.
+    // Recovery path: the once-per-process reclaim returns the orphan to
+    // 'pending', then the worker drains it to completion.
+    await queue.requeueStale();
     await worker.drain();
 
     final got = await mediaRepository.getMediaById('m1');

--- a/test/features/media_store/media_store_worker_reclaim_test.dart
+++ b/test/features/media_store/media_store_worker_reclaim_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_store_worker.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
+import 'support/fake_local_file_resolver.dart';
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+void main() {
+  late MediaRepository mediaRepository;
+  late LocalCacheDatabase cacheDb;
+  late Directory root;
+  late InMemoryMediaObjectStore fakeStore;
+  late MediaCacheStore cache;
+  late MediaTransferQueueRepository queue;
+  late FakeLocalFileResolver resolver;
+  late MediaUploadPipeline pipeline;
+  late MediaStoreWorker worker;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    mediaRepository = MediaRepository();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('worker_reclaim');
+    fakeStore = InMemoryMediaObjectStore();
+    cache = MediaCacheStore(database: cacheDb, root: root);
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    resolver = FakeLocalFileResolver();
+    final registry = MediaSourceResolverRegistry({
+      MediaSourceType.localFile: resolver,
+    });
+    pipeline = MediaUploadPipeline(
+      mediaRepository: mediaRepository,
+      queue: queue,
+      store: fakeStore,
+      registry: registry,
+      cache: cache,
+      now: () => DateTime(2026, 7, 20, 12),
+    );
+    worker = MediaStoreWorker(queue: queue, pipeline: pipeline);
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  test('drain reclaims an orphaned transferring row and uploads it', () async {
+    final f = await cache.stagingFile();
+    await f.writeAsBytes(
+      img.encodePng(img.Image(width: 4000, height: 3000)),
+      flush: true,
+    );
+    resolver.data = FileData(file: f);
+    await mediaRepository.createMedia(
+      MediaItem(
+        id: 'm1',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.localFile,
+        originalFilename: 'shot.png',
+        takenAt: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+
+    // Simulate a previous drain interrupted mid-upload: the row is stranded
+    // in 'transferring' and is invisible to nextPending forever.
+    final id = await queue.enqueueUpload(mediaId: 'm1');
+    await queue.markTransferring(id);
+    expect(await queue.nextPending(DateTime.now()), isNull);
+
+    // A fresh drain must recover it, not ignore it.
+    await worker.drain();
+
+    final got = await mediaRepository.getMediaById('m1');
+    expect(got!.remoteUploadedAt, isNotNull);
+    final row = (await queue.allForTesting()).single;
+    expect(row.state, 'done');
+  });
+}

--- a/test/features/media_store/media_transfer_queue_reclaim_provider_test.dart
+++ b/test/features/media_store/media_transfer_queue_reclaim_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+void main() {
+  late LocalCacheDatabase db;
+  late MediaTransferQueueRepository repo;
+  late ProviderContainer container;
+
+  setUp(() {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    repo = MediaTransferQueueRepository(database: db);
+    container = ProviderContainer(
+      overrides: [mediaTransferQueueRepositoryProvider.overrideWithValue(repo)],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await db.close();
+  });
+
+  test('reclaim returns a stranded transferring row to pending', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    await repo.markTransferring(id);
+    // Stuck: nextPending never selects 'transferring'.
+    expect(await repo.nextPending(DateTime.now()), isNull);
+
+    await container.read(mediaTransferQueueReclaimProvider.future);
+
+    expect((await repo.allForTesting()).single.state, 'pending');
+    expect(await repo.nextPending(DateTime.now()), isNotNull);
+  });
+
+  test('reclaim runs once per process and never re-runs to clobber a live '
+      'transfer', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    await repo.markTransferring(id);
+    await container.read(mediaTransferQueueReclaimProvider.future);
+    expect((await repo.allForTesting()).single.state, 'pending');
+
+    // A worker now legitimately picks the row up and marks it transferring.
+    // A second read (e.g. the runtime rebuilt on connect/disconnect) must NOT
+    // reclaim it again: the provider is cached, so requeueStale does not fire
+    // and the live transfer is left alone.
+    await repo.markTransferring(id);
+    await container.read(mediaTransferQueueReclaimProvider.future);
+
+    expect(
+      (await repo.allForTesting()).single.state,
+      'transferring',
+      reason: 'cached reclaim must not re-run and flip a live transfer',
+    );
+  });
+}

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -253,6 +253,55 @@ void main() {
     expect(kept.data['media_id'], 'm1');
   });
 
+  test('requeueStale returns an orphaned transferring row to pending so the '
+      'drainer can see it again', () async {
+    // An interrupted drain (app killed/backgrounded after markTransferring
+    // but before markDone/markFailed) strands a row in 'transferring'.
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    await repo.updateResumeState(id, '{"uploadId":"u1"}');
+    await repo.updateProgress(id, transferredBytes: 60, totalBytes: 64);
+    await repo.markTransferring(id);
+    // Proof of the bug: nextPending never selects 'transferring'.
+    expect(await repo.nextPending(DateTime.now()), isNull);
+
+    final reclaimed = await repo.requeueStale();
+    expect(reclaimed, 1);
+
+    final row = (await repo.allForTesting()).single;
+    expect(row.state, 'pending');
+    expect(row.attempts, 0, reason: 'interruption is not a failed attempt');
+    expect(row.nextAttemptAt, isNull, reason: 'reclaimed rows are due now');
+    expect(row.progressBytes, isNull, reason: 'stale progress is cleared');
+    expect(row.totalBytes, isNull);
+    expect(
+      row.resumeStateJson,
+      '{"uploadId":"u1"}',
+      reason: 'a resumable adapter must keep its resume point',
+    );
+    expect(await repo.nextPending(DateTime.now()), isNotNull);
+  });
+
+  test(
+    'requeueStale leaves pending, done, and failed rows untouched',
+    () async {
+      final pending = await repo.enqueueUpload(mediaId: 'p');
+      final done = await repo.enqueueUpload(mediaId: 'd');
+      await repo.markDone(done);
+      final failed = await repo.enqueueUpload(mediaId: 'f');
+      for (var i = 0; i < 5; i++) {
+        await repo.markFailed(failed, 'boom');
+      }
+
+      expect(await repo.requeueStale(), 0);
+
+      final byId = {for (final r in await repo.allForTesting()) r.id: r};
+      expect(byId[pending]!.state, 'pending');
+      expect(byId[done]!.state, 'done');
+      expect(byId[failed]!.state, 'failed');
+      expect(byId[failed]!.attempts, 5);
+    },
+  );
+
   test('resume state persists through markFailed and retry, and clears on '
       'markDone', () async {
     final id = await repo.enqueueUpload(mediaId: 'm1');

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -256,9 +256,12 @@ void main() {
   test('requeueStale returns an orphaned transferring row to pending so the '
       'drainer can see it again', () async {
     // An interrupted drain (app killed/backgrounded after markTransferring
-    // but before markDone/markFailed) strands a row in 'transferring'.
+    // but before markDone/markFailed) strands a row in 'transferring'. Here
+    // it had already failed once (attempt consumed, error + backoff set) and
+    // was mid-retry when it stranded, so it carries a stale error message.
     final id = await repo.enqueueUpload(mediaId: 'm1');
     await repo.updateResumeState(id, '{"uploadId":"u1"}');
+    await repo.markFailed(id, 'network blip');
     await repo.updateProgress(id, transferredBytes: 60, totalBytes: 64);
     await repo.markTransferring(id);
     // Proof of the bug: nextPending never selects 'transferring'.
@@ -269,7 +272,12 @@ void main() {
 
     final row = (await repo.allForTesting()).single;
     expect(row.state, 'pending');
-    expect(row.attempts, 0, reason: 'interruption is not a failed attempt');
+    expect(row.attempts, 1, reason: 'reclaim preserves the attempt budget');
+    expect(
+      row.errorMessage,
+      isNull,
+      reason: 'a reclaimed row was interrupted, not failed - no stale error',
+    );
     expect(row.nextAttemptAt, isNull, reason: 'reclaimed rows are due now');
     expect(row.progressBytes, isNull, reason: 'stale progress is cleared');
     expect(row.totalBytes, isNull);


### PR DESCRIPTION
## Problem

Four media transfers were stuck showing **"Uploading"** forever on the Transfers screen, surviving a full **Reset Database + iCloud resync**.

Root cause: the upload queue lives in `MediaTransferQueue` inside the per-device `submersion_local.db` (Application Support), which is deliberately never synced and is **not** deleted by `DatabaseService.resetDatabase()` (that only wipes `submersion.db`). If a drain is interrupted after `markTransferring` but before `markDone`/`markFailed` — the app killed or backgrounded mid-upload — the row is stranded in `state='transferring'`. From there it is unreachable:

- `nextPending` selects only `'pending'`, so the drainer never sees it again.
- The Transfers UI renders **Retry** only for `'failed'` and **Clear completed** only for `'done'`.
- `enqueueUpload` treats an existing `'transferring'` row as live, so re-import cannot recreate it either.

The queue had a `pending → transferring → done/failed` lifecycle with no crash-recovery edge back to `pending`.

## Fix

Add `MediaTransferQueueRepository.requeueStale()`, which returns orphaned `'transferring'` rows to `'pending'` (stale progress cleared, made immediately due, resume point preserved, `attempts` untouched).

Reclamation is driven **once per process**, not per drain. A row is only ever orphaned by process death, which is observable only at process start; running reclaim on every drain (or every runtime rebuild) could flip a *live* worker's in-flight row back to `'pending'`, because a connect/disconnect rebuild of `mediaStoreRuntimeProvider` can spawn a second worker while a worker from the previous runtime is still mid-upload (nothing cancels its in-flight drain).

So `requeueStale()` is invoked by a new cached `mediaTransferQueueReclaimProvider`, awaited by `mediaStoreRuntimeProvider` **before** the connectivity subscription is attached and before the first drain — so no drain, initial or connectivity-triggered, can start until reclamation has finished. The provider is never invalidated, so its cached result runs reclaim exactly once for the process lifetime and a runtime rebuild can never reclaim a row a live worker owns.

Per-row leases / heartbeats were considered and rejected as unnecessary: object keys are content-addressed (`StoreKeys.objectKey(sha256)`) and the remote-upload stamps are idempotent, so the once-per-process invariant is sufficient without tracking per-row ownership.

On the re-run the pipeline's `head()` dedup guard short-circuits already-uploaded bytes straight to `done`, and a missing/ineligible media resolves to `done` (skip) or a retryable `failed` — so a reclaimed row can never re-strand.

## Tests

- `requeueStale` returns an orphaned `transferring` row to `pending` (clears progress, preserves resume point, keeps attempts, becomes due).
- `requeueStale` leaves `pending`/`done`/`failed` rows untouched.
- Provider: reclaim flips a stranded row to `pending`; a second read does not re-run and clobber a live transfer (once-per-process guarantee).
- Worker integration: the recovery sequence (reclaim then drain) uploads a previously-stranded row end-to-end.

Full `media_store` suite passes; analyze and format clean. No schema change.