### PR TITLE
fix(restore): keep the database open during large-DB restore so pages don't red-screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,9 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_theme_registry.dart';
 import 'package:submersion/core/router/app_router.dart';
 import 'package:submersion/features/auto_update/presentation/providers/update_menu_channel.dart';
+import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
@@ -233,6 +236,21 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     });
   }
 
+  void _onBackupOperationChanged(
+    BackupOperationState? prev,
+    BackupOperationState next,
+  ) {
+    // Fire once, on the transition into restoreComplete.
+    if (next.status != BackupOperationStatus.restoreComplete) return;
+    if (prev?.status == BackupOperationStatus.restoreComplete) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final navContext = rootNavigatorKey.currentContext;
+      if (navContext == null) return;
+      RestoreCompletePage.show(navContext);
+    });
+  }
+
   Future<void> _handleIncomingFile(Uint8List bytes, String fileName) async {
     final router = ref.read(appRouterProvider);
     final location = router.routeInformationProvider.value.uri.path;
@@ -281,6 +299,17 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     // post-restore "syncing" notice, and the replaced-library adopt prompt.
     ref.listen<SyncState>(syncStateProvider, _onSyncStateChanged);
 
+    // App-level restore completion: hand off to RestoreCompletePage from here
+    // rather than from whichever page triggered the restore. That page may be
+    // disposed (the user navigated away) by the time the restore finishes, in
+    // which case its own listener would never fire and the app would be
+    // stranded on a stale screen. Listening at the app root guarantees the
+    // hand-off -- and its restartApp() -- always happens.
+    ref.listen<BackupOperationState>(
+      backupOperationProvider,
+      _onBackupOperationChanged,
+    );
+
     return MaterialApp.router(
       scaffoldMessengerKey: _scaffoldMessengerKey,
       title: 'Submersion',
@@ -297,7 +326,9 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
       routerConfig: router,
       builder: (context, child) {
         Intl.defaultLocale = Localizations.localeOf(context).toLanguageTag();
-        return child!;
+        // Block all interaction while a database restore runs, so no data page
+        // can rebuild against the transient null database mid-restore.
+        return RestoreBarrier(child: child!);
       },
     );
   }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -83,6 +83,9 @@ class DatabaseService {
     _locationService = null;
     _currentDatabasePath = null;
     lastOpenMode = null;
+    // The service is a singleton, so a restore seam set by one test would
+    // otherwise leak into the next and fire unexpectedly.
+    debugOnRestoreWindowOpen = null;
   }
 
   /// Initialize the database with optional location service for custom paths
@@ -368,6 +371,10 @@ class DatabaseService {
   /// closed during [restore] — i.e. when the "database unavailable" window
   /// opens — with the staging path. Lets tests assert the backup was fully
   /// staged BEFORE the window opened.
+  ///
+  /// One-shot: [restore] captures and clears it before firing, and
+  /// [resetForTesting] also clears it, so a callback never leaks across tests
+  /// (the service is a singleton).
   @visibleForTesting
   void Function(String stagingPath)? debugOnRestoreWindowOpen;
 
@@ -405,7 +412,12 @@ class DatabaseService {
     // timed out mid-close and still holds the file must throw here rather than
     // race the rename.
     await close(strict: true);
-    debugOnRestoreWindowOpen?.call(stagingPath);
+    // Fire the test seam one-shot: capture and clear it before invoking so a
+    // callback set by one test cannot leak into a later restore (the service is
+    // a singleton).
+    final onWindowOpen = debugOnRestoreWindowOpen;
+    debugOnRestoreWindowOpen = null;
+    onWindowOpen?.call(stagingPath);
 
     // Safe swap: move the live file ASIDE (never delete it before the new file
     // is in place), move the staged file IN, and only then drop the old copy.

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -450,10 +450,20 @@ class DatabaseService {
       rethrow;
     }
 
-    // Swap succeeded: the pre-restore copy is no longer needed.
-    await _deleteIfExists(asidePath);
-
+    // Reopen on the swapped-in file BEFORE dropping the pre-restore copy, so a
+    // cleanup hiccup can never prevent the reopen.
     await initialize();
+
+    // The database is open again on the restored file; the pre-restore copy is
+    // no longer needed. Its deletion is best-effort — a transient failure (e.g.
+    // a Windows file lock) must NOT fail a restore that already succeeded and
+    // leave the app with a closed database despite a valid file on disk. The
+    // leftover copy is harmless and is cleared at the start of the next restore.
+    try {
+      await _deleteIfExists(asidePath);
+    } catch (_) {
+      // Best-effort: a leftover pre-restore copy is harmless.
+    }
   }
 
   Future<void> _deleteIfExists(String path) async {

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -387,7 +387,13 @@ class DatabaseService {
     // effective no-op that still opened a needless "database unavailable"
     // window — during which a provider rebuild caches a fatal
     // "Database not initialized" error.
-    if (!await backupFile.exists()) return;
+    if (!await backupFile.exists()) {
+      // Still sweep any temp files a prior restore may have stranded (e.g. a
+      // large .pre-restore copy left by a best-effort cleanup that failed), so
+      // they don't accumulate on disk. Best-effort; the live DB is untouched.
+      await _sweepRestoreTempFiles(destinationPath);
+      return;
+    }
 
     // Copy the backup to a staging file NEXT TO the destination while the live
     // database stays open and keeps serving reads. This keeps the database
@@ -457,13 +463,10 @@ class DatabaseService {
     // The database is open again on the restored file; the pre-restore copy is
     // no longer needed. Its deletion is best-effort — a transient failure (e.g.
     // a Windows file lock) must NOT fail a restore that already succeeded and
-    // leave the app with a closed database despite a valid file on disk. The
-    // leftover copy is harmless and is cleared at the start of the next restore.
-    try {
-      await _deleteIfExists(asidePath);
-    } catch (_) {
-      // Best-effort: a leftover pre-restore copy is harmless.
-    }
+    // leave the app with a closed database despite a valid file on disk. A
+    // leftover copy is harmless and is swept by the next restore (including a
+    // no-op one).
+    await _bestEffortDelete(asidePath);
   }
 
   Future<void> _deleteIfExists(String path) async {
@@ -471,6 +474,24 @@ class DatabaseService {
     if (await file.exists()) {
       await file.delete();
     }
+  }
+
+  /// Delete [path] if present, swallowing any error. For cleanup that must not
+  /// abort the caller (a transient file lock on a stale temp file is harmless).
+  Future<void> _bestEffortDelete(String path) async {
+    try {
+      await _deleteIfExists(path);
+    } catch (_) {
+      // Best-effort: a stranded temp file is harmless and swept on a later run.
+    }
+  }
+
+  /// Best-effort removal of the temp files a [restore] may leave behind
+  /// (`.restore-staging`, `.pre-restore`). Safe to call while the live database
+  /// is open — it touches only the sidecar temp files, never the live DB.
+  Future<void> _sweepRestoreTempFiles(String destinationPath) async {
+    await _bestEffortDelete('$destinationPath.restore-staging');
+    await _bestEffortDelete('$destinationPath.pre-restore');
   }
 
   /// Delete all data and recreate a fresh empty database.

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -364,21 +364,91 @@ class DatabaseService {
     }
   }
 
-  Future<void> restore(String backupPath) async {
-    // Strict close: restore overwrites the live database file with the
-    // backup copy and then reopens it, so a connection that timed out
-    // mid-close and still holds the file must throw here rather than race
-    // the copy/reopen.
-    await close(strict: true);
+  /// Test seam: invoked synchronously the instant the live database has been
+  /// closed during [restore] — i.e. when the "database unavailable" window
+  /// opens — with the staging path. Lets tests assert the backup was fully
+  /// staged BEFORE the window opened.
+  @visibleForTesting
+  void Function(String stagingPath)? debugOnRestoreWindowOpen;
 
+  Future<void> restore(String backupPath) async {
     final backupFile = File(backupPath);
     final destinationPath = await databasePath;
 
-    if (await backupFile.exists()) {
-      await backupFile.copy(destinationPath);
+    // No backup to swap in: leave the live database exactly as it is. The old
+    // implementation closed and reopened the same file here, which was an
+    // effective no-op that still opened a needless "database unavailable"
+    // window — during which a provider rebuild caches a fatal
+    // "Database not initialized" error.
+    if (!await backupFile.exists()) return;
+
+    // Copy the backup to a staging file NEXT TO the destination while the live
+    // database stays open and keeps serving reads. This keeps the database
+    // available during the slow part of a restore (copying a potentially large
+    // backup), so provider rebuilds never observe a null database and cache a
+    // fatal error. Same-directory staging also keeps the later rename on one
+    // filesystem, so the swap is an atomic metadata operation rather than a
+    // cross-device copy.
+    final stagingPath = '$destinationPath.restore-staging';
+    await _deleteIfExists(stagingPath);
+    try {
+      await backupFile.copy(stagingPath);
+    } catch (_) {
+      await _deleteIfExists(stagingPath);
+      rethrow;
     }
 
+    // The ONLY window where the database is unavailable: close, swap the file,
+    // reopen. Its duration is a rename + open, not the backup copy.
+    //
+    // Strict close: the swap+reopen immediately follows, so a connection that
+    // timed out mid-close and still holds the file must throw here rather than
+    // race the rename.
+    await close(strict: true);
+    debugOnRestoreWindowOpen?.call(stagingPath);
+
+    // Safe swap: move the live file ASIDE (never delete it before the new file
+    // is in place), move the staged file IN, and only then drop the old copy.
+    // If the move-in fails, roll the old file back so the app is never left
+    // with no database and no data. Renaming into a non-existent destination
+    // works identically on POSIX and Windows, so no per-platform branching.
+    final asidePath = '$destinationPath.pre-restore';
+    await _deleteIfExists(asidePath);
+    final destFile = File(destinationPath);
+    final hadDest = await destFile.exists();
+    try {
+      if (hadDest) await destFile.rename(asidePath);
+      // The old WAL/SHM sidecars belong to the pre-restore database. Left in
+      // place, SQLite would replay them into the swapped-in file and corrupt
+      // it, so they must go before the new file is opened.
+      await _deleteIfExists('$destinationPath-wal');
+      await _deleteIfExists('$destinationPath-shm');
+      await File(stagingPath).rename(destinationPath);
+    } catch (_) {
+      // The swap failed with the database closed. Roll the original file back
+      // into place, drop the orphaned staging copy, and reopen so the app is
+      // never left with a dead (null) database, then surface the error.
+      if (hadDest &&
+          !await destFile.exists() &&
+          await File(asidePath).exists()) {
+        await File(asidePath).rename(destinationPath);
+      }
+      await _deleteIfExists(stagingPath);
+      await initialize();
+      rethrow;
+    }
+
+    // Swap succeeded: the pre-restore copy is no longer needed.
+    await _deleteIfExists(asidePath);
+
     await initialize();
+  }
+
+  Future<void> _deleteIfExists(String path) async {
+    final file = File(path);
+    if (await file.exists()) {
+      await file.delete();
+    }
   }
 
   /// Delete all data and recreate a fresh empty database.

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -11,7 +11,6 @@ import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
-import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/backup_encryption_section.dart';
@@ -29,12 +28,8 @@ class BackupSettingsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(backupSettingsProvider);
     final operationState = ref.watch(backupOperationProvider);
-    ref.listen<BackupOperationState>(backupOperationProvider, (previous, next) {
-      if (next.status == BackupOperationStatus.restoreComplete &&
-          context.mounted) {
-        RestoreCompletePage.show(context);
-      }
-    });
+    // Restore completion (RestoreCompletePage + restartApp) is handled app-wide
+    // in SubmersionApp, so it fires even if this page is disposed mid-restore.
     final historyAsync = ref.watch(backupHistoryProvider);
     final cloudProvider = ref.watch(cloudStorageProviderProvider);
     final isInProgress =

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -172,21 +172,32 @@ class BackupOperationState {
   final String? message;
   final BackupRecord? lastRecord;
 
+  /// True only while a database *restore* is running (a subset of the
+  /// [BackupOperationStatus.inProgress] states). Restore briefly closes and
+  /// reopens the database, so the whole app must be blocked from interaction
+  /// until it finishes — but routine backups/exports/deletes, which also use
+  /// `inProgress`, must NOT block the app. The global restore barrier keys off
+  /// this flag, not `status`.
+  final bool isRestoring;
+
   const BackupOperationState({
     this.status = BackupOperationStatus.idle,
     this.message,
     this.lastRecord,
+    this.isRestoring = false,
   });
 
   BackupOperationState copyWith({
     BackupOperationStatus? status,
     String? message,
     BackupRecord? lastRecord,
+    bool? isRestoring,
   }) {
     return BackupOperationState(
       status: status ?? this.status,
       message: message ?? this.message,
       lastRecord: lastRecord ?? this.lastRecord,
+      isRestoring: isRestoring ?? this.isRestoring,
     );
   }
 }
@@ -247,6 +258,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
     state = const BackupOperationState(
       status: BackupOperationStatus.inProgress,
       message: 'Restoring backup...',
+      isRestoring: true,
     );
 
     try {
@@ -364,6 +376,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
     state = const BackupOperationState(
       status: BackupOperationStatus.inProgress,
       message: 'Validating backup file...',
+      isRestoring: true,
     );
 
     try {
@@ -380,6 +393,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
       state = const BackupOperationState(
         status: BackupOperationStatus.inProgress,
         message: 'Restoring backup...',
+        isRestoring: true,
       );
 
       await _service.restoreFromFile(

--- a/lib/features/backup/presentation/widgets/restore_barrier.dart
+++ b/lib/features/backup/presentation/widgets/restore_barrier.dart
@@ -53,35 +53,43 @@ class _RestoreOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    // The provider already supplies an English progress string; fall back to a
+    // plain one if it is ever absent.
+    final label = message ?? 'Restoring backup...';
 
-    return Stack(
-      children: [
-        // Absorbs every pointer event and paints the scrim, so nothing beneath
-        // can be tapped or scrolled during the restore.
-        const ModalBarrier(dismissible: false, color: Colors.black54),
-        Center(
-          child: Material(
-            color: theme.colorScheme.surface,
-            borderRadius: BorderRadius.circular(12),
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const CircularProgressIndicator(),
-                  const SizedBox(height: 16),
-                  // The provider already supplies an English progress string;
-                  // fall back to a plain one if it is ever absent.
-                  Text(
-                    message ?? 'Restoring backup...',
-                    style: theme.textTheme.bodyMedium,
+    // Announce the busy/restoring state to screen readers as a live region, and
+    // exclude the inner widgets' own semantics so the state is announced once
+    // (not duplicated by the progress indicator and the label Text).
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: label,
+      child: ExcludeSemantics(
+        child: Stack(
+          children: [
+            // Absorbs every pointer event and paints the scrim, so nothing
+            // beneath can be tapped or scrolled during the restore.
+            const ModalBarrier(dismissible: false, color: Colors.black54),
+            Center(
+              child: Material(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const CircularProgressIndicator(),
+                      const SizedBox(height: 16),
+                      Text(label, style: theme.textTheme.bodyMedium),
+                    ],
                   ),
-                ],
+                ),
               ),
             ),
-          ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/features/backup/presentation/widgets/restore_barrier.dart
+++ b/lib/features/backup/presentation/widgets/restore_barrier.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+
+/// True while a database restore is running. Derived (not the whole operation
+/// state) so widgets rebuild only when this specific flag flips, and so tests
+/// can override it with a plain value.
+final restoreInProgressProvider = Provider<bool>(
+  (ref) => ref.watch(backupOperationProvider.select((s) => s.isRestoring)),
+);
+
+/// The current restore progress message (e.g. "Restoring backup...").
+final restoreMessageProvider = Provider<String?>(
+  (ref) => ref.watch(backupOperationProvider.select((s) => s.message)),
+);
+
+/// Wraps the whole app and, while a database restore is running, covers it with
+/// an interaction-blocking overlay.
+///
+/// A restore briefly closes and reopens the database. Without this barrier the
+/// user could navigate to a data page mid-restore, whose providers would build
+/// against the transient null database and cache a fatal "Database not
+/// initialized" error that survives until a full app restart (the DiveCenters
+/// red-screen bug). Blocking all interaction until the restore finishes — and
+/// hands off to RestoreCompletePage — closes that gap.
+class RestoreBarrier extends ConsumerWidget {
+  const RestoreBarrier({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isRestoring = ref.watch(restoreInProgressProvider);
+
+    return Stack(
+      children: [
+        child,
+        if (isRestoring)
+          Positioned.fill(
+            child: _RestoreOverlay(message: ref.watch(restoreMessageProvider)),
+          ),
+      ],
+    );
+  }
+}
+
+class _RestoreOverlay extends StatelessWidget {
+  const _RestoreOverlay({this.message});
+
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Stack(
+      children: [
+        // Absorbs every pointer event and paints the scrim, so nothing beneath
+        // can be tapped or scrolled during the restore.
+        const ModalBarrier(dismissible: false, color: Colors.black54),
+        Center(
+          child: Material(
+            color: theme.colorScheme.surface,
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const CircularProgressIndicator(),
+                  const SizedBox(height: 16),
+                  // The provider already supplies an English progress string;
+                  // fall back to a plain one if it is ever absent.
+                  Text(
+                    message ?? 'Restoring backup...',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/setup_wizard/presentation/widgets/steps/restore_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/restore_step.dart
@@ -7,7 +7,6 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
-import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/encryption_passphrase_dialog.dart';
@@ -93,13 +92,9 @@ class RestoreStep extends ConsumerWidget {
     final l10n = context.l10n;
     final operation = ref.watch(backupOperationProvider);
 
-    ref.listen<BackupOperationState>(backupOperationProvider, (prev, next) {
-      if (next.status == BackupOperationStatus.restoreComplete &&
-          context.mounted) {
-        RestoreCompletePage.show(context);
-      }
-    });
-
+    // Restore completion (RestoreCompletePage + restartApp) is handled app-wide
+    // in SubmersionApp, so the hand-off happens even if this wizard step is
+    // disposed before the restore finishes.
     final inProgress = operation.status == BackupOperationStatus.inProgress;
 
     return SingleChildScrollView(

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -11,6 +11,8 @@ import 'package:submersion/core/services/sync/sync_initializer.dart'
     show DeviceIdentityStatus;
 import 'package:submersion/core/services/sync/sync_service.dart'
     show ConflictResolution;
+import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 
 import 'helpers/mock_providers.dart';
@@ -88,6 +90,18 @@ class _DrivableSyncNotifier extends StateNotifier<SyncState>
   ) async {}
 }
 
+/// A [BackupOperationNotifier] stand-in so a test can drive the app-root
+/// restore-completion listener through real state transitions.
+class _DrivableBackupOp extends StateNotifier<BackupOperationState>
+    implements BackupOperationNotifier {
+  _DrivableBackupOp() : super(const BackupOperationState());
+
+  void emit(BackupOperationState next) => state = next;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 /// Minimal router wired to the real [rootNavigatorKey] so the app-root adopt
 /// dialog (which reads `rootNavigatorKey.currentContext`) can surface.
 GoRouter _testRouter() => GoRouter(
@@ -110,7 +124,11 @@ LibraryEpochMarker _marker() => const LibraryEpochMarker(
 void main() {
   /// Pumps [SubmersionApp] with the providers its build/launch path reads
   /// stubbed out, leaving [sync] as the driver for the app-root listener.
-  Future<void> pumpApp(WidgetTester tester, _DrivableSyncNotifier sync) async {
+  Future<void> pumpApp(
+    WidgetTester tester,
+    _DrivableSyncNotifier sync, {
+    _DrivableBackupOp? backupOp,
+  }) async {
     final base = await getBaseOverrides();
     await tester.pumpWidget(
       ProviderScope(
@@ -118,6 +136,8 @@ void main() {
           ...base,
           appRouterProvider.overrideWithValue(_testRouter()),
           syncStateProvider.overrideWith((ref) => sync),
+          if (backupOp != null)
+            backupOperationProvider.overrideWith((ref) => backupOp),
           reconcileDeviceIdentityProvider.overrideWith(
             (ref) async => DeviceIdentityStatus.unchanged,
           ),
@@ -224,6 +244,27 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Sync is paused'), findsNothing);
+  });
+
+  testWidgets('restore completion routes to RestoreCompletePage app-wide', (
+    tester,
+  ) async {
+    // Even though no page-local listener is involved, a restoreComplete
+    // transition on the operation provider must hand off to RestoreCompletePage
+    // from the app root -- so a restore whose triggering page was disposed
+    // still restarts instead of stranding the user on a stale screen.
+    final sync = _DrivableSyncNotifier(const SyncState());
+    final backupOp = _DrivableBackupOp();
+    await pumpApp(tester, sync, backupOp: backupOp);
+
+    expect(find.byType(RestoreCompletePage), findsNothing);
+
+    backupOp.emit(
+      const BackupOperationState(status: BackupOperationStatus.restoreComplete),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RestoreCompletePage), findsOneWidget);
   });
 
   testWidgets('the banner Review action reopens the adopt dialog', (

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -325,6 +325,31 @@ void main() {
     },
   );
 
+  test(
+    'the restore window seam is one-shot and does not leak across restores',
+    () async {
+      // The service is a singleton, so a seam left set by one restore must not
+      // fire on the next. restore() captures+clears it, so it fires exactly once.
+      final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(defaultPath),
+      );
+      await DatabaseService.instance.database
+          .customSelect('SELECT 1')
+          .getSingle();
+      final backupPath = p.join(tempDir.path, 'backup.db');
+      await DatabaseService.instance.backup(backupPath);
+
+      var fireCount = 0;
+      DatabaseService.instance.debugOnRestoreWindowOpen = (_) => fireCount++;
+
+      await DatabaseService.instance.restore(backupPath);
+      await DatabaseService.instance.restore(backupPath);
+
+      expect(fireCount, 1);
+    },
+  );
+
   test('restore with a missing backup file leaves the live DB open', () async {
     // A restore pointed at a nonexistent file must be a true no-op: it must
     // NOT close the database (which would open an unavailable window for

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -246,4 +246,107 @@ void main() {
         .getSingle();
     expect(one.read<int>('v'), 1);
   });
+
+  test('restore stages the backup BEFORE closing the live database', () async {
+    // Regression guard: a restore must copy the (potentially large) backup to
+    // a staging file while the live database is still open, so the window
+    // where the database is unavailable never spans the slow copy. Otherwise a
+    // provider rebuild during the copy hits a null database and caches a fatal
+    // "Database not initialized" error (the DiveCenters red-screen bug).
+    final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(defaultPath),
+    );
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+    final backupPath = p.join(tempDir.path, 'backup.db');
+    await DatabaseService.instance.backup(backupPath);
+
+    // The seam fires the instant the DB is closed (the unavailable window
+    // opens). By then the staged copy must already exist.
+    var stagingExistedAtWindowOpen = false;
+    DatabaseService.instance.debugOnRestoreWindowOpen = (stagingPath) {
+      stagingExistedAtWindowOpen = File(stagingPath).existsSync();
+    };
+
+    await DatabaseService.instance.restore(backupPath);
+
+    expect(
+      stagingExistedAtWindowOpen,
+      isTrue,
+      reason: 'backup must be staged before the DB is closed',
+    );
+    // The restored DB is fully usable, and no staging file is left behind.
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+    expect(File('$defaultPath.restore-staging').existsSync(), isFalse);
+  });
+
+  test(
+    'a failed swap rolls back to the original database (no data loss)',
+    () async {
+      final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(defaultPath),
+      );
+      await DatabaseService.instance.database
+          .customSelect('SELECT 1')
+          .getSingle();
+      final backupPath = p.join(tempDir.path, 'backup.db');
+      await DatabaseService.instance.backup(backupPath);
+
+      // Written AFTER the backup so the live database is distinguishable from the
+      // backup copy: this row must survive a failed restore.
+      final now = DateTime.now();
+      await DiverRepository().createDiver(
+        domain.Diver(id: '', name: 'Keep Me', createdAt: now, updatedAt: now),
+      );
+
+      // Sabotage the swap: delete the staged file the instant the window opens,
+      // so moving it into place fails and the rollback path runs.
+      DatabaseService.instance.debugOnRestoreWindowOpen = (stagingPath) {
+        File(stagingPath).deleteSync();
+      };
+
+      await expectLater(
+        DatabaseService.instance.restore(backupPath),
+        throwsA(anything),
+      );
+
+      // The original database is reopened and its post-backup row survived.
+      final divers = await DiverRepository().getAllDivers();
+      expect(divers.map((d) => d.name), contains('Keep Me'));
+      // No swap temp files are left behind.
+      expect(File('$defaultPath.restore-staging').existsSync(), isFalse);
+      expect(File('$defaultPath.pre-restore').existsSync(), isFalse);
+    },
+  );
+
+  test('restore with a missing backup file leaves the live DB open', () async {
+    // A restore pointed at a nonexistent file must be a true no-op: it must
+    // NOT close the database (which would open an unavailable window for
+    // nothing). The database stays queryable throughout.
+    final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(defaultPath),
+    );
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+
+    var windowOpened = false;
+    DatabaseService.instance.debugOnRestoreWindowOpen = (_) =>
+        windowOpened = true;
+
+    await DatabaseService.instance.restore(p.join(tempDir.path, 'nope.db'));
+
+    expect(windowOpened, isFalse);
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+  });
 }

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -350,6 +350,37 @@ void main() {
     },
   );
 
+  test(
+    'a no-op restore sweeps restore temp files stranded by a prior run',
+    () async {
+      final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(defaultPath),
+      );
+      await DatabaseService.instance.database
+          .customSelect('SELECT 1')
+          .getSingle();
+
+      // Temp files a prior restore left behind (e.g. a large .pre-restore copy
+      // from a best-effort cleanup that failed) must not accumulate on disk.
+      File('$defaultPath.pre-restore').writeAsStringSync('stale');
+      File('$defaultPath.restore-staging').writeAsStringSync('stale');
+
+      // A restore pointed at a missing file is a no-op, but still sweeps temps.
+      await DatabaseService.instance.restore(
+        p.join(tempDir.path, 'missing.db'),
+      );
+
+      expect(File('$defaultPath.pre-restore').existsSync(), isFalse);
+      expect(File('$defaultPath.restore-staging').existsSync(), isFalse);
+      // The live database was never touched.
+      final one = await DatabaseService.instance.database
+          .customSelect('SELECT 1 AS v')
+          .getSingle();
+      expect(one.read<int>('v'), 1);
+    },
+  );
+
   test('restore with a missing backup file leaves the live DB open', () async {
     // A restore pointed at a nonexistent file must be a true no-op: it must
     // NOT close the database (which would open an unavailable window for

--- a/test/features/backup/presentation/providers/backup_providers_restore_test.dart
+++ b/test/features/backup/presentation/providers/backup_providers_restore_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -48,6 +49,10 @@ class _RecordingBackupService extends BackupService {
   /// [WrongPassphraseException], modelling a wrong passphrase on retry.
   String? correctSecret;
 
+  /// When set, restore awaits this before returning, so a test can observe the
+  /// in-flight (mid-restore) state.
+  Completer<void>? restoreGate;
+
   _RecordingBackupService(BackupPreferences prefs)
     : super(dbAdapter: _NoopAdapter(), preferences: prefs);
 
@@ -74,6 +79,7 @@ class _RecordingBackupService extends BackupService {
     lastMode = mode;
     lastSecret = encryptionSecret;
     _gate(encryptionSecret);
+    if (restoreGate != null) await restoreGate!.future;
   }
 
   @override
@@ -140,6 +146,43 @@ void main() {
       BackupOperationStatus.restoreComplete,
     );
   });
+
+  test(
+    'restore arms isRestoring while in flight and clears it on complete',
+    () async {
+      final container = makeContainer();
+      final gate = Completer<void>();
+      service.restoreGate = gate;
+      final record = BackupRecord(
+        id: 'r-gate',
+        filename: 'b.db',
+        timestamp: DateTime(2026),
+        sizeBytes: 1,
+        location: BackupLocation.local,
+      );
+
+      // Kick off the restore but do not await it: the notifier sets the
+      // in-progress state synchronously before the first await.
+      final future = container
+          .read(backupOperationProvider.notifier)
+          .restoreFromBackup(record);
+
+      // Mid-restore: the global barrier flag is armed (routine backups never
+      // arm it -- only restore does).
+      final midState = container.read(backupOperationProvider);
+      expect(midState.isRestoring, isTrue);
+      expect(midState.status, BackupOperationStatus.inProgress);
+
+      gate.complete();
+      await future;
+
+      // Completed: the flag is cleared and the app hands off to
+      // RestoreCompletePage via the restoreComplete status.
+      final doneState = container.read(backupOperationProvider);
+      expect(doneState.isRestoring, isFalse);
+      expect(doneState.status, BackupOperationStatus.restoreComplete);
+    },
+  );
 
   test('restoreFromBackup threads the mode and completes', () async {
     final container = makeContainer();

--- a/test/features/backup/presentation/widgets/restore_barrier_test.dart
+++ b/test/features/backup/presentation/widgets/restore_barrier_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
+
+void main() {
+  Widget wrap({
+    required bool restoring,
+    String? message,
+    required VoidCallback onTap,
+  }) {
+    return ProviderScope(
+      overrides: [
+        restoreInProgressProvider.overrideWithValue(restoring),
+        restoreMessageProvider.overrideWithValue(message),
+      ],
+      child: MaterialApp(
+        home: RestoreBarrier(
+          child: Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: onTap,
+                child: const Text('Tap me'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('when not restoring, no overlay and the child is interactive', (
+    tester,
+  ) async {
+    var taps = 0;
+    await tester.pumpWidget(wrap(restoring: false, onTap: () => taps++));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    await tester.tap(find.text('Tap me'));
+    expect(taps, 1);
+  });
+
+  testWidgets('while restoring, the overlay shows and blocks interaction', (
+    tester,
+  ) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      wrap(
+        restoring: true,
+        message: 'Restoring backup...',
+        onTap: () => taps++,
+      ),
+    );
+
+    // Progress + message are shown.
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Restoring backup...'), findsOneWidget);
+
+    // The underlying button is still present but taps are absorbed by the
+    // barrier (warnIfMissed: the hit is intentionally swallowed).
+    await tester.tap(find.text('Tap me'), warnIfMissed: false);
+    expect(taps, 0);
+  });
+
+  testWidgets('falls back to a default message when none is provided', (
+    tester,
+  ) async {
+    await tester.pumpWidget(wrap(restoring: true, onTap: () {}));
+    expect(find.text('Restoring backup...'), findsOneWidget);
+  });
+}

--- a/test/features/backup/presentation/widgets/restore_barrier_test.dart
+++ b/test/features/backup/presentation/widgets/restore_barrier_test.dart
@@ -67,4 +67,17 @@ void main() {
     await tester.pumpWidget(wrap(restoring: true, onTap: () {}));
     expect(find.text('Restoring backup...'), findsOneWidget);
   });
+
+  testWidgets(
+    'exposes a semantics label so screen readers announce the state',
+    (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        wrap(restoring: true, message: 'Restoring backup...', onTap: () {}),
+      );
+
+      expect(find.bySemanticsLabel('Restoring backup...'), findsOneWidget);
+      handle.dispose();
+    },
+  );
 }

--- a/test/features/backup/presentation/widgets/restore_barrier_test.dart
+++ b/test/features/backup/presentation/widgets/restore_barrier_test.dart
@@ -1,29 +1,27 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
 
+import '../../../../helpers/test_app.dart';
+
 void main() {
+  // Pin the locale via the shared testApp helper for deterministic string
+  // finders. The barrier's message is a raw (non-localized) string today, but
+  // pinning keeps the test robust if it ever becomes localized.
   Widget wrap({
     required bool restoring,
     String? message,
     required VoidCallback onTap,
   }) {
-    return ProviderScope(
+    return testApp(
+      locale: const Locale('en'),
       overrides: [
         restoreInProgressProvider.overrideWithValue(restoring),
         restoreMessageProvider.overrideWithValue(message),
       ],
-      child: MaterialApp(
-        home: RestoreBarrier(
-          child: Scaffold(
-            body: Center(
-              child: ElevatedButton(
-                onPressed: onTap,
-                child: const Text('Tap me'),
-              ),
-            ),
-          ),
+      child: RestoreBarrier(
+        child: Center(
+          child: ElevatedButton(onPressed: onTap, child: const Text('Tap me')),
         ),
       ),
     );

--- a/test/features/setup_wizard/presentation/widgets/steps/restore_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/restore_step_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
-import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
 import 'package:submersion/features/setup_wizard/presentation/widgets/steps/restore_step.dart';
@@ -176,18 +175,7 @@ void main() {
     expect(fake.secretsSeen, [null, 'correct horse']);
   });
 
-  testWidgets('restoreComplete transition shows the completion page', (
-    tester,
-  ) async {
-    final fake = _FakeBackupOp(const BackupOperationState());
-    await tester.pumpWidget(build(fake));
-    await tester.pumpAndSettle();
-
-    fake.push(
-      const BackupOperationState(status: BackupOperationStatus.restoreComplete),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.byType(RestoreCompletePage), findsOneWidget);
-  });
+  // Restore completion (RestoreCompletePage + restartApp) is now handled at the
+  // app root (SubmersionApp), so it fires even if this wizard step is disposed
+  // mid-restore. That hand-off is covered in test/app_test.dart.
 }


### PR DESCRIPTION
## Problem

Restoring a large backup (~500 MB debug database) left every data page — DiveCenters, Dives, etc. — showing a full red error screen:

> Bad state: Database not initialized. Call initialize() first.

The restored database was completely fine (correct schema version, opens cleanly). The failure was a **timing window**, not a bad file.

## Root cause

`DatabaseService.restore()` did `close() → copy backup → initialize()`. For a large backup the copy takes several seconds, and `_database` is `null` that entire time. Repositories dereference `DatabaseService.instance.database` at Riverpod **build** time (e.g. `watchXChanges()` inside `invalidateSelfWhen(...)`), and Riverpod **caches provider errors** like values — so a single rebuild during the window leaves the page permanently in error. The only recovery is `restartApp()`, which fires only when the user reaches the post-restore "Continue" screen — a listener that lived on the *triggering* page and was lost if the user navigated away mid-restore. ~24 repositories share this eager-`_db` exposure.

## Fix (three layers)

1. **Shrink the window** (`database_service.dart`): `restore()` copies the backup to `<db>.restore-staging` while the live database stays open, then performs a tiny `close → safe-swap → reopen`. The null window shrinks from *seconds* (the copy) to a *rename*. The safe-swap moves the old file aside **before** moving the new one in (rolls back on failure, so no data loss on any platform) and purges stale `-wal`/`-shm` so SQLite can't replay them into the swapped-in file. A missing backup file is now a true no-op instead of a needless close/reopen.
2. **Global barrier** (`restore_barrier.dart`, `app.dart`): a restore-specific `isRestoring` flag drives an app-wide `ModalBarrier` so no page can rebuild against the transient null database mid-restore. Routine backup/export/delete (which also use `inProgress`) do **not** block the app.
3. **App-level completion** (`app.dart`): the `restoreComplete → RestoreCompletePage → restartApp()` hand-off moved to the app root, so it fires even if the page that started the restore was disposed. The two page-local listeners were removed.

## Tests

- `database_service_isolate_test.dart`: stage-before-close, missing-file no-op, and failed-swap rollback (asserts a post-backup row survives — no data loss).
- `backup_providers_restore_test.dart`: `isRestoring` is armed mid-restore and cleared on completion.
- `restore_barrier_test.dart`: overlay shows and blocks interaction only while restoring.
- `app_test.dart`: a `restoreComplete` transition routes to `RestoreCompletePage` from the app root.

388 tests pass across the `database`, `backup`, `app`, and `setup_wizard` suites; `flutter analyze` is clean on the whole project.