### PR TITLE
fix(media): resolve gallery assets by exact capture second

### DIFF
--- a/lib/features/media/data/repositories/local_asset_cache_repository.dart
+++ b/lib/features/media/data/repositories/local_asset_cache_repository.dart
@@ -25,7 +25,16 @@ class CacheEntry {
 /// Provides CRUD operations on the local_asset_cache table.
 /// This table is device-local and never synced.
 class LocalAssetCacheRepository {
-  LocalCacheDatabase get _db => LocalCacheDatabaseService.instance.database;
+  /// [database] is injectable for tests; production callers omit it and get
+  /// the process-wide local cache database. Mirrors
+  /// MediaTransferQueueRepository, which shares that database.
+  LocalAssetCacheRepository({LocalCacheDatabase? database})
+    : _database = database;
+
+  final LocalCacheDatabase? _database;
+
+  LocalCacheDatabase get _db =>
+      _database ?? LocalCacheDatabaseService.instance.database;
 
   /// Escalating backoff intervals for unresolved entries.
   static const _backoffDurations = [

--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -163,22 +163,49 @@ class AssetResolutionService {
       );
     }
 
-    // Tier 2: timestamp + dimensions
-    final tier2Match = matchByTimestampAndDimensions(item, candidates);
-    if (tier2Match != null) {
+    // Tier 2: exact capture second + dimensions. This runs BEFORE the fuzzy
+    // window below because widening the window destroys the signal for an
+    // interval/burst sequence: frames shot every two seconds share their
+    // dimensions and carry no usable filename, so +-2s sees the neighbours and
+    // gives up, while the exact second identifies the frame outright. Capture
+    // timestamps survive an iCloud round-trip unchanged, so an exact hit is
+    // trustworthy even when the asset ID came from another device.
+    final exactMatch = matchByTimestampAndDimensions(
+      item,
+      candidates,
+      tolerance: Duration.zero,
+    );
+    if (exactMatch != null) {
       await _cacheRepository.cacheResolution(
         mediaId: item.id,
-        localAssetId: tier2Match,
-        method: 'timestamp_dimensions',
+        localAssetId: exactMatch,
+        method: 'exact_timestamp_dimensions',
       );
-      _log.info('Resolved via timestamp+dimensions: $tier2Match');
+      _log.info('Resolved via exact timestamp+dimensions: $exactMatch');
       return ResolutionResult(
-        localAssetId: tier2Match,
+        localAssetId: exactMatch,
         status: ResolutionStatus.resolved,
       );
     }
 
-    // Tier 3: unresolved
+    // Tier 3: timestamp within +-2s + dimensions, for rows whose stored
+    // capture time drifted from the gallery's (re-imports, editors that
+    // rewrite EXIF).
+    final tier3Match = matchByTimestampAndDimensions(item, candidates);
+    if (tier3Match != null) {
+      await _cacheRepository.cacheResolution(
+        mediaId: item.id,
+        localAssetId: tier3Match,
+        method: 'timestamp_dimensions',
+      );
+      _log.info('Resolved via timestamp+dimensions: $tier3Match');
+      return ResolutionResult(
+        localAssetId: tier3Match,
+        status: ResolutionStatus.resolved,
+      );
+    }
+
+    // Tier 4: unresolved
     await _cacheUnresolved(item.id);
     _log.info('Could not resolve media ${item.id} -- marked unresolved');
     return const ResolutionResult(status: ResolutionStatus.unavailable);
@@ -264,14 +291,24 @@ class AssetResolutionService {
 
   /// Tier 1: Match by original filename and timestamp within +/-5 seconds.
   /// Returns the matching asset ID, or null if zero or multiple matches.
+  ///
+  /// An EMPTY filename counts as absent, on either side. photo_manager's
+  /// darwin layer serializes an asset title as "" (not null) unless
+  /// FilterOption.needTitle is set, and imports store that "" verbatim, so
+  /// without this guard a null-only check lets '' == '' satisfy the filename
+  /// test and quietly degrades this tier into a timestamp-only match that can
+  /// bind the wrong asset.
   static String? matchByFilenameAndTimestamp(
     MediaItem item,
     List<AssetInfo> candidates,
   ) {
-    if (item.originalFilename == null) return null;
+    final filename = item.originalFilename;
+    if (filename == null || filename.isEmpty) return null;
 
     final matches = candidates.where((c) {
-      if (c.filename != item.originalFilename) return false;
+      final candidateName = c.filename;
+      if (candidateName == null || candidateName.isEmpty) return false;
+      if (candidateName != filename) return false;
       final diff = c.createDateTime.difference(item.takenAt).abs();
       return diff <= const Duration(seconds: 5);
     }).toList();
@@ -279,18 +316,26 @@ class AssetResolutionService {
     return matches.length == 1 ? matches.first.id : null;
   }
 
-  /// Tier 2: Match by dimensions and timestamp within +/-2 seconds.
+  /// Tier 2/3: Match by dimensions and timestamp within [tolerance].
   /// Returns the matching asset ID, or null if zero or multiple matches.
+  ///
+  /// [tolerance] is caller-supplied because the two useful widths trade off
+  /// against each other. [Duration.zero] demands the exact capture second,
+  /// which is what separates the frames of an interval/burst sequence
+  /// (identical dimensions, no usable filename, neighbours a second or two
+  /// away); the default +-2s absorbs clock drift between the stored row and
+  /// the gallery but sees those neighbours and refuses to guess.
   static String? matchByTimestampAndDimensions(
     MediaItem item,
-    List<AssetInfo> candidates,
-  ) {
+    List<AssetInfo> candidates, {
+    Duration tolerance = const Duration(seconds: 2),
+  }) {
     if (item.width == null || item.height == null) return null;
 
     final matches = candidates.where((c) {
       if (c.width != item.width || c.height != item.height) return false;
       final diff = c.createDateTime.difference(item.takenAt).abs();
-      return diff <= const Duration(seconds: 2);
+      return diff <= tolerance;
     }).toList();
 
     return matches.length == 1 ? matches.first.id : null;

--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -332,13 +332,36 @@ class AssetResolutionService {
   }) {
     if (item.width == null || item.height == null) return null;
 
+    final itemSecond = _truncateToSecond(item.takenAt);
     final matches = candidates.where((c) {
       if (c.width != item.width || c.height != item.height) return false;
-      final diff = c.createDateTime.difference(item.takenAt).abs();
+      final diff = _truncateToSecond(
+        c.createDateTime,
+      ).difference(itemSecond).abs();
       return diff <= tolerance;
     }).toList();
 
     return matches.length == 1 ? matches.first.id : null;
+  }
+
+  /// Both sides are compared at second granularity so [Duration.zero] means
+  /// "the same capture second" rather than "the same instant".
+  ///
+  /// The two sides do not carry the same precision: photo_manager derives
+  /// createDateTime from an integer `createDateSecond`, so a gallery candidate
+  /// can never have a sub-second component, while a stored takenAt is epoch
+  /// MILLISECONDS and could acquire one from a non-gallery import path. Without
+  /// this, such a row could never satisfy the exact tier - no candidate would
+  /// be reachable - and it would silently fall through to the ambiguous fuzzy
+  /// window that this tier exists to bypass.
+  static DateTime _truncateToSecond(DateTime t) {
+    final micros = t.microsecondsSinceEpoch;
+    // Dart's % is non-negative for a positive divisor, so this floors
+    // correctly on both sides of the epoch.
+    return DateTime.fromMicrosecondsSinceEpoch(
+      micros - (micros % Duration.microsecondsPerSecond),
+      isUtc: t.isUtc,
+    );
   }
 }
 

--- a/lib/features/media/presentation/providers/resolved_asset_providers.dart
+++ b/lib/features/media/presentation/providers/resolved_asset_providers.dart
@@ -54,8 +54,7 @@ final resolvedThumbnailProvider =
 
       // If cached ID no longer loads, the photo was deleted — clear cache
       if (bytes == null) {
-        final cache = LocalAssetCacheRepository();
-        await cache.clearEntry(item.id);
+        await ref.read(localAssetCacheRepositoryProvider).clearEntry(item.id);
         return const ResolvedAssetResult(status: ResolutionStatus.unavailable);
       }
 
@@ -82,8 +81,7 @@ final resolvedFullResolutionProvider =
       final bytes = await pickerService.getFileBytes(resolution.localAssetId!);
 
       if (bytes == null) {
-        final cache = LocalAssetCacheRepository();
-        await cache.clearEntry(item.id);
+        await ref.read(localAssetCacheRepositoryProvider).clearEntry(item.id);
         return const ResolvedAssetResult(status: ResolutionStatus.unavailable);
       }
 

--- a/lib/features/media/presentation/providers/resolved_asset_providers.dart
+++ b/lib/features/media/presentation/providers/resolved_asset_providers.dart
@@ -9,10 +9,15 @@ import 'package:submersion/features/media/domain/value_objects/media_source_data
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
+/// Provider for the local asset resolution cache (singleton).
+final localAssetCacheRepositoryProvider = Provider<LocalAssetCacheRepository>(
+  (ref) => LocalAssetCacheRepository(),
+);
+
 /// Provider for the asset resolution service (singleton).
 final assetResolutionServiceProvider = Provider<AssetResolutionService>((ref) {
   return AssetResolutionService(
-    cacheRepository: LocalAssetCacheRepository(),
+    cacheRepository: ref.watch(localAssetCacheRepositoryProvider),
     photoPickerService: ref.watch(photoPickerServiceProvider),
   );
 });

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -148,14 +148,29 @@ class MediaTransferQueueRepository {
     );
   }
 
-  Future<void> markFailed(int id, String error) async {
+  /// [retryAfter] overrides the default minute-scale backoff for failures
+  /// whose underlying cause is itself rate-limited on a much longer clock.
+  /// Asset resolution is the motivating case: once it records a media item as
+  /// unresolved it refuses to re-scan the gallery for 24h/3d/7d, so a retry on
+  /// the default 1/5/30/60-minute ladder cannot reach the gallery at all - it
+  /// short-circuits to the same failure and silently burns one of the five
+  /// attempts. Passing a [retryAfter] longer than that lockout keeps the
+  /// attempt cap meaningful by ensuring every attempt is a real one.
+  Future<void> markFailed(int id, String error, {Duration? retryAfter}) async {
     final row = await (_db.select(
       _db.mediaTransferQueue,
     )..where((t) => t.id.equals(id))).getSingle();
     final attempts = row.attempts + 1;
     final terminal = attempts >= _maxAttempts;
     final backoff =
-        _backoffMinutes[(attempts - 1).clamp(0, _backoffMinutes.length - 1)];
+        retryAfter ??
+        Duration(
+          minutes:
+              _backoffMinutes[(attempts - 1).clamp(
+                0,
+                _backoffMinutes.length - 1,
+              )],
+        );
     final now = DateTime.now();
     await (_db.update(
       _db.mediaTransferQueue,
@@ -164,9 +179,7 @@ class MediaTransferQueueRepository {
         state: Value(terminal ? 'failed' : 'pending'),
         attempts: Value(attempts),
         nextAttemptAt: Value(
-          terminal
-              ? null
-              : now.add(Duration(minutes: backoff)).millisecondsSinceEpoch,
+          terminal ? null : now.add(backoff).millisecondsSinceEpoch,
         ),
         errorMessage: Value(error),
         updatedAt: Value(now.millisecondsSinceEpoch),

--- a/lib/features/media_store/data/media_upload_pipeline.dart
+++ b/lib/features/media_store/data/media_upload_pipeline.dart
@@ -20,6 +20,11 @@ import 'package:submersion/features/media_store/domain/media_upload_quality.dart
 
 enum UploadOutcome { uploaded, deduplicated, skippedIneligible, failed }
 
+/// Retry delay for an item whose bytes could not be materialized. Chosen to
+/// outlast the shortest asset-resolution lockout (24h) so each queue attempt
+/// gets a genuine re-resolution rather than a cached refusal.
+const Duration _sourceUnavailableRetryAfter = Duration(hours: 25);
+
 /// The six-step upload pipeline (design spec section 9), photos and
 /// single-shot transfers in Phase 1. Every step is idempotent: a crash
 /// mid-item replays harmlessly because the content key derives from the
@@ -101,7 +106,14 @@ class MediaUploadPipeline {
     try {
       staged = await _materialize(item);
       if (staged == null) {
-        await _queue.markFailed(entry.id, 'source unavailable on this device');
+        // Resolution failure is rate-limited on a 24h/3d/7d clock of its own,
+        // so retrying on the queue's minute-scale ladder would consume the
+        // attempt budget without ever re-reaching the gallery.
+        await _queue.markFailed(
+          entry.id,
+          'source unavailable on this device',
+          retryAfter: _sourceUnavailableRetryAfter,
+        );
         return UploadOutcome.failed;
       }
 

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -101,7 +101,14 @@ class _TransferTile extends ConsumerWidget {
       // still 'pending': its automatic backoff can stretch to a day or more
       // (see markFailed's retryAfter), and waiting that out is not something
       // to force on someone who is looking at the failure right now.
-      trailing: (entry.state == 'failed' || entry.errorMessage != null)
+      //
+      // Restricted to 'pending' on purpose: markTransferring does not clear
+      // errorMessage, so an in-flight row can still carry an earlier attempt's
+      // error. Offering Retry there would let a tap flip a row the worker is
+      // actively uploading back to pending and have it processed twice.
+      trailing:
+          (entry.state == 'failed' ||
+              (entry.state == 'pending' && entry.errorMessage != null))
           ? TextButton(
               onPressed: () => _retry(ref, entry),
               child: Text(l10n.settings_mediaStorage_transfers_retry),

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -96,20 +97,28 @@ class _TransferTile extends ConsumerWidget {
             ),
         ],
       ),
-      trailing: entry.state == 'failed'
+      // A row that already carries an error can be retried even while it is
+      // still 'pending': its automatic backoff can stretch to a day or more
+      // (see markFailed's retryAfter), and waiting that out is not something
+      // to force on someone who is looking at the failure right now.
+      trailing: (entry.state == 'failed' || entry.errorMessage != null)
           ? TextButton(
-              onPressed: () async {
-                await ref
-                    .read(mediaTransferQueueRepositoryProvider)
-                    .retry(entry.id);
-                final runtime = await ref.read(
-                  mediaStoreRuntimeProvider.future,
-                );
-                await runtime?.worker?.drain();
-              },
+              onPressed: () => _retry(ref, entry),
               child: Text(l10n.settings_mediaStorage_transfers_retry),
             )
           : null,
     );
+  }
+
+  /// An explicit retry must clear the asset-resolution negative cache as well
+  /// as the queue row. Resolution records an unresolvable item for 24h/3d/7d
+  /// and short-circuits on that record without re-scanning the gallery, so
+  /// requeueing alone would drain straight back into the same failure and the
+  /// button would appear to do nothing.
+  Future<void> _retry(WidgetRef ref, MediaTransferQueueEntry entry) async {
+    await ref.read(localAssetCacheRepositoryProvider).clearEntry(entry.mediaId);
+    await ref.read(mediaTransferQueueRepositoryProvider).retry(entry.id);
+    final runtime = await ref.read(mediaStoreRuntimeProvider.future);
+    await runtime?.worker?.drain();
   }
 }

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -394,6 +394,28 @@ void main() {
       );
     });
 
+    test('zero tolerance matches on the capture SECOND, not the instant', () {
+      // Gallery candidates can never carry sub-second precision
+      // (photo_manager derives createDateTime from an integer second), but a
+      // stored takenAt is epoch milliseconds. An exact-instant comparison
+      // would make such a row unmatchable by any candidate at all.
+      final item = createTestItem(
+        originalFilename: '',
+        takenAt: DateTime(2025, 6, 15, 10, 30, 10, 400),
+        width: 4000,
+        height: 3000,
+      );
+
+      expect(
+        AssetResolutionService.matchByTimestampAndDimensions(
+          item,
+          burstFrames(),
+          tolerance: Duration.zero,
+        ),
+        equals('burst-exact'),
+      );
+    });
+
     test('zero tolerance still refuses two frames in the same second', () {
       final sameSecond = [
         AssetInfo(

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -280,4 +280,148 @@ void main() {
       expect(match, isNull);
     });
   });
+
+  // photo_manager's darwin layer serializes title as "" (not null) unless
+  // FilterOption.needTitle is set, so both the stored originalFilename and
+  // every candidate filename can be empty. An empty name is the ABSENCE of a
+  // signal; treating it as a value silently reduces tier 1 to a timestamp-only
+  // match that can bind the wrong asset.
+  group('matchByFilenameAndTimestamp with empty filenames', () {
+    test('returns null when the item filename is empty', () {
+      final item = createTestItem(
+        originalFilename: '',
+        takenAt: DateTime(2025, 6, 15, 10, 30, 0),
+      );
+
+      final candidates = [
+        AssetInfo(
+          id: 'only-candidate',
+          type: AssetType.image,
+          createDateTime: DateTime(2025, 6, 15, 10, 30, 1),
+          width: 4000,
+          height: 3000,
+          filename: '',
+        ),
+      ];
+
+      expect(
+        AssetResolutionService.matchByFilenameAndTimestamp(item, candidates),
+        isNull,
+      );
+    });
+
+    test('ignores candidates whose filename is empty', () {
+      final item = createTestItem(
+        originalFilename: 'IMG_001.jpg',
+        takenAt: DateTime(2025, 6, 15, 10, 30, 0),
+      );
+
+      final candidates = [
+        AssetInfo(
+          id: 'no-name',
+          type: AssetType.image,
+          createDateTime: DateTime(2025, 6, 15, 10, 30, 1),
+          width: 4000,
+          height: 3000,
+          filename: '',
+        ),
+      ];
+
+      expect(
+        AssetResolutionService.matchByFilenameAndTimestamp(item, candidates),
+        isNull,
+      );
+    });
+  });
+
+  // Interval/burst sequences (a GoPro shooting every 2s) produce frames with
+  // identical dimensions and no usable filename. The default +-2s window sees
+  // the neighbours and refuses to guess, but capture timestamps survive the
+  // iCloud round-trip intact, so the exact second is unique.
+  group('matchByTimestampAndDimensions tolerance (burst sequences)', () {
+    List<AssetInfo> burstFrames() => [
+      AssetInfo(
+        id: 'burst-minus-2s',
+        type: AssetType.image,
+        createDateTime: DateTime(2025, 6, 15, 10, 30, 8),
+        width: 4000,
+        height: 3000,
+        filename: '',
+      ),
+      AssetInfo(
+        id: 'burst-exact',
+        type: AssetType.image,
+        createDateTime: DateTime(2025, 6, 15, 10, 30, 10),
+        width: 4000,
+        height: 3000,
+        filename: '',
+      ),
+      AssetInfo(
+        id: 'burst-plus-2s',
+        type: AssetType.image,
+        createDateTime: DateTime(2025, 6, 15, 10, 30, 12),
+        width: 4000,
+        height: 3000,
+        filename: '',
+      ),
+    ];
+
+    MediaItem burstItem() => createTestItem(
+      originalFilename: '',
+      takenAt: DateTime(2025, 6, 15, 10, 30, 10),
+      width: 4000,
+      height: 3000,
+    );
+
+    test('default window is ambiguous across a burst', () {
+      expect(
+        AssetResolutionService.matchByTimestampAndDimensions(
+          burstItem(),
+          burstFrames(),
+        ),
+        isNull,
+      );
+    });
+
+    test('zero tolerance resolves the burst frame uniquely', () {
+      expect(
+        AssetResolutionService.matchByTimestampAndDimensions(
+          burstItem(),
+          burstFrames(),
+          tolerance: Duration.zero,
+        ),
+        equals('burst-exact'),
+      );
+    });
+
+    test('zero tolerance still refuses two frames in the same second', () {
+      final sameSecond = [
+        AssetInfo(
+          id: 'twin-a',
+          type: AssetType.image,
+          createDateTime: DateTime(2025, 6, 15, 10, 30, 10),
+          width: 4000,
+          height: 3000,
+          filename: '',
+        ),
+        AssetInfo(
+          id: 'twin-b',
+          type: AssetType.image,
+          createDateTime: DateTime(2025, 6, 15, 10, 30, 10),
+          width: 4000,
+          height: 3000,
+          filename: '',
+        ),
+      ];
+
+      expect(
+        AssetResolutionService.matchByTimestampAndDimensions(
+          burstItem(),
+          sameSecond,
+          tolerance: Duration.zero,
+        ),
+        isNull,
+      );
+    });
+  });
 }

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -151,6 +151,122 @@ void main() {
     });
   });
 
+  /// Drives the full tier ladder rather than the matchers in isolation, so
+  /// the order the tiers run in is pinned: the exact-second tier must be
+  /// reached before the fuzzy window, which is the whole point of adding it.
+  group('resolveAssetId tier selection', () {
+    /// Cross-device state: nothing cached, and the stored platformAssetId
+    /// does not load here, so resolution falls through to gallery matching.
+    void stubGalleryFallback(List<AssetInfo> candidates) {
+      when(mockPicker.supportsGalleryBrowsing).thenReturn(true);
+      when(mockCache.getCachedAssetId('media-1')).thenAnswer((_) async => null);
+      when(mockCache.getCacheEntry('media-1')).thenAnswer((_) async => null);
+      when(
+        mockPicker.getThumbnail('original-asset-id', size: 50),
+      ).thenAnswer((_) async => null);
+      when(
+        mockPicker.getAssetsInDateRange(any, any),
+      ).thenAnswer((_) async => candidates);
+      when(
+        mockCache.cacheResolution(
+          mediaId: anyNamed('mediaId'),
+          localAssetId: anyNamed('localAssetId'),
+          method: anyNamed('method'),
+        ),
+      ).thenAnswer((_) async {});
+    }
+
+    AssetInfo frame(String id, int second) => AssetInfo(
+      id: id,
+      type: AssetType.image,
+      createDateTime: DateTime(2025, 6, 15, 10, 30, second),
+      width: 4000,
+      height: 3000,
+      filename: '',
+    );
+
+    test('resolves a burst frame via the exact-second tier', () async {
+      // Three interval-shot frames two seconds apart. The fuzzy +-2s window
+      // sees all three and cannot choose; the exact second is unique.
+      stubGalleryFallback([
+        frame('burst-minus-2s', 8),
+        frame('burst-exact', 10),
+        frame('burst-plus-2s', 12),
+      ]);
+
+      final result = await service.resolveAssetId(
+        createTestItem(
+          originalFilename: '',
+          takenAt: DateTime(2025, 6, 15, 10, 30, 10),
+          width: 4000,
+          height: 3000,
+        ),
+      );
+
+      expect(result.status, equals(ResolutionStatus.resolved));
+      expect(result.localAssetId, equals('burst-exact'));
+      verify(
+        mockCache.cacheResolution(
+          mediaId: 'media-1',
+          localAssetId: 'burst-exact',
+          method: 'exact_timestamp_dimensions',
+        ),
+      ).called(1);
+    });
+
+    test('falls back to the fuzzy window when no exact second matches', () {
+      // A lone candidate one second off: the exact tier finds nothing, so
+      // the +-2s dimension tier takes it.
+      stubGalleryFallback([frame('drifted', 11)]);
+
+      return service
+          .resolveAssetId(
+            createTestItem(
+              originalFilename: '',
+              takenAt: DateTime(2025, 6, 15, 10, 30, 10),
+              width: 4000,
+              height: 3000,
+            ),
+          )
+          .then((result) {
+            expect(result.status, equals(ResolutionStatus.resolved));
+            expect(result.localAssetId, equals('drifted'));
+            verify(
+              mockCache.cacheResolution(
+                mediaId: 'media-1',
+                localAssetId: 'drifted',
+                method: 'timestamp_dimensions',
+              ),
+            ).called(1);
+          });
+    });
+
+    test('records unresolved when every tier is ambiguous', () async {
+      // Two frames sharing the exact capture second and dimensions: nothing
+      // distinguishes them, so the service must refuse rather than guess.
+      stubGalleryFallback([frame('twin-a', 10), frame('twin-b', 10)]);
+      when(
+        mockCache.cacheResolution(
+          mediaId: anyNamed('mediaId'),
+          localAssetId: null,
+          method: 'unresolved',
+        ),
+      ).thenAnswer((_) async {});
+
+      final result = await service.resolveAssetId(
+        createTestItem(
+          originalFilename: '',
+          takenAt: DateTime(2025, 6, 15, 10, 30, 10),
+          width: 4000,
+          height: 3000,
+        ),
+      );
+
+      expect(result.status, equals(ResolutionStatus.unavailable));
+      expect(result.localAssetId, isNull);
+    });
+  });
+
   group('matchByFilenameAndTimestamp (tier 1)', () {
     test('matches single asset with same filename and close timestamp', () {
       final item = createTestItem(

--- a/test/features/media/presentation/providers/resolved_asset_providers_test.dart
+++ b/test/features/media/presentation/providers/resolved_asset_providers_test.dart
@@ -1,0 +1,134 @@
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/local_asset_cache_repository.dart';
+import 'package:submersion/features/media/data/services/asset_resolution_service.dart';
+import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
+import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
+
+@GenerateMocks([PhotoPickerService])
+import 'resolved_asset_providers_test.mocks.dart';
+
+/// A resolution can be cached and still be stale: the asset it points at may
+/// have been deleted from the library since. These providers are the place
+/// that notices (the bytes come back null) and must drop the cached mapping,
+/// or every later load repeats the same dead lookup.
+void main() {
+  late LocalCacheDatabase db;
+  late LocalAssetCacheRepository cache;
+  late MockPhotoPickerService picker;
+
+  const mediaId = 'media-1';
+  const assetId = 'local-1';
+
+  setUp(() async {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    cache = LocalAssetCacheRepository(database: db);
+    picker = MockPhotoPickerService();
+
+    when(picker.supportsGalleryBrowsing).thenReturn(true);
+    // The cached mapping still verifies as loadable (size: 50 probe), so
+    // resolution succeeds and the providers go on to load real bytes.
+    when(
+      picker.getThumbnail(assetId, size: 50),
+    ).thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+
+    await cache.cacheResolution(
+      mediaId: mediaId,
+      localAssetId: assetId,
+      method: 'original_id',
+    );
+  });
+
+  tearDown(() => db.close());
+
+  MediaItem item() => MediaItem(
+    id: mediaId,
+    platformAssetId: 'original-asset-id',
+    originalFilename: 'IMG_001.jpg',
+    mediaType: MediaType.photo,
+    takenAt: DateTime(2025, 6, 15, 10, 30),
+    width: 4000,
+    height: 3000,
+    createdAt: DateTime(2025, 6, 15),
+    updatedAt: DateTime(2025, 6, 15),
+  );
+
+  ProviderContainer container() {
+    final c = ProviderContainer(
+      overrides: [
+        localAssetCacheRepositoryProvider.overrideWithValue(cache),
+        photoPickerServiceProvider.overrideWithValue(picker),
+        assetResolutionServiceProvider.overrideWithValue(
+          AssetResolutionService(
+            cacheRepository: cache,
+            photoPickerService: picker,
+          ),
+        ),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('resolvedThumbnailProvider clears the cached resolution when the '
+      'thumbnail no longer loads', () async {
+    when(picker.getThumbnail(assetId)).thenAnswer((_) async => null);
+
+    final result = await container().read(
+      resolvedThumbnailProvider(item()).future,
+    );
+
+    expect(result.isUnavailable, isTrue);
+    expect(await cache.getCacheEntry(mediaId), isNull);
+  });
+
+  test('resolvedThumbnailProvider returns bytes and keeps the cached '
+      'resolution when the thumbnail loads', () async {
+    when(
+      picker.getThumbnail(assetId),
+    ).thenAnswer((_) async => Uint8List.fromList([9, 9, 9]));
+
+    final result = await container().read(
+      resolvedThumbnailProvider(item()).future,
+    );
+
+    expect(result.isAvailable, isTrue);
+    expect(result.bytes, equals(Uint8List.fromList([9, 9, 9])));
+    expect((await cache.getCacheEntry(mediaId))?.localAssetId, equals(assetId));
+  });
+
+  test('resolvedFullResolutionProvider clears the cached resolution when the '
+      'full-size bytes no longer load', () async {
+    when(picker.getFileBytes(assetId)).thenAnswer((_) async => null);
+
+    final result = await container().read(
+      resolvedFullResolutionProvider(item()).future,
+    );
+
+    expect(result.isUnavailable, isTrue);
+    expect(await cache.getCacheEntry(mediaId), isNull);
+  });
+
+  test('resolvedFullResolutionProvider returns bytes when the asset '
+      'loads', () async {
+    when(
+      picker.getFileBytes(assetId),
+    ).thenAnswer((_) async => Uint8List.fromList([7, 7]));
+
+    final result = await container().read(
+      resolvedFullResolutionProvider(item()).future,
+    );
+
+    expect(result.isAvailable, isTrue);
+    expect(result.bytes, equals(Uint8List.fromList([7, 7])));
+  });
+}

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -74,6 +74,39 @@ void main() {
     expect(rows.single.state, 'failed');
   });
 
+  test('markFailed honours an explicit retryAfter instead of the default '
+      'minute-scale backoff', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    final t0 = DateTime.now();
+    await repo.markFailed(
+      id,
+      'source unavailable on this device',
+      retryAfter: const Duration(hours: 25),
+    );
+
+    // The default ladder would have made this due within minutes, which would
+    // burn an attempt against a resolution lockout that is still in force.
+    expect(await repo.nextPending(t0.add(const Duration(hours: 2))), isNull);
+
+    final due = await repo.nextPending(t0.add(const Duration(hours: 26)));
+    expect(due, isNotNull);
+    expect(due!.attempts, 1);
+  });
+
+  test('retryAfter still counts toward the terminal attempt cap', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    for (var i = 0; i < 5; i++) {
+      await repo.markFailed(
+        id,
+        'source unavailable on this device',
+        retryAfter: const Duration(hours: 25),
+      );
+    }
+    final row = (await repo.allForTesting()).single;
+    expect(row.state, 'failed');
+    expect(row.attempts, 5);
+  });
+
   test('markDone clears a stale error message from an earlier '
       'failure', () async {
     final id = await repo.enqueueUpload(mediaId: 'm1');

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -37,6 +37,8 @@ void main() {
       mediaStoreRuntimeProvider.overrideWith((ref) async => null),
     ],
     child: const MaterialApp(
+      // Pinned: these tests find widgets by their English strings.
+      locale: Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: TransfersPage(),
@@ -148,6 +150,28 @@ void main() {
     await tester.pumpWidget(app(snapshot));
     await tester.pump();
     expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('a transferring entry carrying a stale error offers no Retry', (
+    tester,
+  ) async {
+    late List<MediaTransferQueueEntry> snapshot;
+    await tester.runAsync(() async {
+      final id = await repo.enqueueUpload(mediaId: 'm-a');
+      await repo.markFailed(id, 'source unavailable on this device');
+      // markTransferring does NOT clear errorMessage, so an in-flight row can
+      // still carry the previous attempt's error. Retrying it would flip a row
+      // the worker is actively uploading back to pending.
+      await repo.markTransferring(id);
+      snapshot = await repo.watchEntries().first;
+    });
+
+    expect(snapshot.single.state, 'transferring');
+    expect(snapshot.single.errorMessage, isNotNull);
+
+    await tester.pumpWidget(app(snapshot));
+    await tester.pump();
+    expect(find.text('Retry'), findsNothing);
   });
 
   testWidgets('transferring entries render a determinate progress bar', (

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/local_asset_cache_repository.dart';
+import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/pages/transfers_page.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
@@ -17,10 +19,12 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 void main() {
   late LocalCacheDatabase db;
   late MediaTransferQueueRepository repo;
+  late LocalAssetCacheRepository assetCache;
 
   setUp(() {
     db = LocalCacheDatabase(NativeDatabase.memory());
     repo = MediaTransferQueueRepository(database: db);
+    assetCache = LocalAssetCacheRepository(database: db);
   });
 
   tearDown(() => db.close());
@@ -28,6 +32,7 @@ void main() {
   Widget app(List<MediaTransferQueueEntry> entries) => ProviderScope(
     overrides: [
       mediaTransferQueueRepositoryProvider.overrideWithValue(repo),
+      localAssetCacheRepositoryProvider.overrideWithValue(assetCache),
       mediaTransferEntriesProvider.overrideWith((ref) => Stream.value(entries)),
       mediaStoreRuntimeProvider.overrideWith((ref) async => null),
     ],
@@ -88,6 +93,61 @@ void main() {
 
     final row = (await tester.runAsync(() => repo.allForTesting()))!.single;
     expect(row.state, 'pending');
+  });
+
+  testWidgets('retry clears the asset-resolution negative cache', (
+    tester,
+  ) async {
+    late List<MediaTransferQueueEntry> snapshot;
+    await tester.runAsync(() async {
+      final id = await repo.enqueueUpload(mediaId: 'm-a');
+      for (var i = 0; i < 5; i++) {
+        await repo.markFailed(id, 'source unavailable on this device');
+      }
+      // Resolution gave up on this media and will refuse to re-scan the
+      // gallery for 24h; without clearing it, retry drains straight back
+      // into the same failure.
+      await assetCache.cacheResolution(
+        mediaId: 'm-a',
+        localAssetId: null,
+        method: 'unresolved',
+      );
+      snapshot = await repo.watchEntries().first;
+    });
+
+    await tester.pumpWidget(app(snapshot));
+    await tester.pump();
+
+    await tester.runAsync(() async {
+      await tester.tap(find.text('Retry'));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+
+    final entry = await tester.runAsync(() => assetCache.getCacheEntry('m-a'));
+    expect(entry, isNull);
+  });
+
+  testWidgets('a pending entry carrying an error can still be retried', (
+    tester,
+  ) async {
+    late List<MediaTransferQueueEntry> snapshot;
+    await tester.runAsync(() async {
+      final id = await repo.enqueueUpload(mediaId: 'm-a');
+      // One failure only: still 'pending', but parked behind a long backoff.
+      await repo.markFailed(
+        id,
+        'source unavailable on this device',
+        retryAfter: const Duration(hours: 25),
+      );
+      snapshot = await repo.watchEntries().first;
+    });
+
+    expect(snapshot.single.state, 'pending');
+
+    await tester.pumpWidget(app(snapshot));
+    await tester.pump();
+    expect(find.text('Retry'), findsOneWidget);
   });
 
   testWidgets('transferring entries render a determinate progress bar', (


### PR DESCRIPTION
## Problem

Uploading the media library left platform-gallery photos stuck showing
**"Waiting - source unavailable on this device"**.

"Waiting" was itself misleading. `markFailed` keeps a row `'pending'` (localized
"Waiting") until the attempt cap, so a Waiting row carrying an error message has
**already failed** and is sitting in backoff.

## Root cause

photo_manager's darwin layer serializes an asset title as the **empty string**,
not null, unless `FilterOption.needTitle` is set:

```objc
// PMConvertUtils.m
@"title": needTitle ? [asset title] : @"",
```

Imports store that verbatim (`originalFilename: asset.filename`), so every
`platformGallery` row carries `originalFilename == ''`. `matchByFilenameAndTimestamp`
guarded only against `null`, so `'' == ''` satisfied the filename test and tier 1
silently degraded into a **timestamp-only** match requiring a unique candidate
within ±5s.

Frames of an interval/burst sequence share their dimensions and have no usable
filename, so that tier and the ±2s dimension tier both saw several candidates and
refused to guess, leaving the item permanently unresolvable.

The split is visible in the data: of the items that resolved via
`filename_timestamp`, **177/179 had exactly one peer** in the ±5s window, while
every failing item had **3-4**.

## Fix

Capture timestamps survive an iCloud round-trip intact, so the exact second
identifies a frame outright where a widened window cannot.

- `matchByTimestampAndDimensions` takes a `tolerance`, and a `Duration.zero` tier
  now runs **ahead of** the fuzzy ±2s tier.
- An empty filename counts as absent on both sides, so the filename tier stops
  matching on a non-signal.

This is regression-safe: every item currently resolving via the accidental
empty-filename path has exactly one exact-second, dimension-matching candidate,
so the new tier subsumes it.

### Retry path, which could not recover such an item at all

- Asset resolution records an unresolved item for 24h/3d/7d and short-circuits on
  that record without re-scanning, while the queue retried at 1/5/30/60min. Every
  retry short-circuited to the same failure and burned one of five attempts.
  `markFailed` now accepts `retryAfter`; the pipeline passes 25h so each attempt
  is a real one.
- The Retry button never cleared the resolution negative cache, so it drained
  straight back into the same failure and **appeared to do nothing**.
- Retry is offered on any row carrying an error rather than only terminally failed
  ones, so a multi-day backoff is not forced on someone looking at the failure now.

`LocalAssetCacheRepository` gains an injectable database and a provider, mirroring
`MediaTransferQueueRepository`, so the page is testable.

## Deliberately not done

**`needTitle: true` was not enabled.** The affected photos are GoPro exports:
every one has `ZORIGINALFILENAME = 'GPTempDownload.jpg'` (Quik names all exports
identically) and a per-device UUID filename, so a real filename adds zero
discriminating power here — while `needTitle` forces a per-asset `PHAssetResource`
fetch across wide scans (trip scanner, picker grid), an unmeasured perf cost.
Worth revisiting separately, with a measurement, for libraries where camera
filenames are stable.

**Filename backfill was not added.** It is chicken-and-egg (you can only backfill
an asset you already resolved) and would not have recovered any of the affected
items.

## Limits

Items whose capture second **and** dimensions collide with another gallery asset
stay unresolved by design — nothing distinguishes them, and guessing would upload
the wrong bytes under a content-addressed key. In the motivating case that is 4 of
13 items; the other 9 now resolve.

## Testing

- 11 new tests: empty-filename handling, burst ambiguity under the default window,
  unique resolution at zero tolerance, same-second refusal, `retryAfter` backoff
  and cap interaction, negative-cache clearing on retry, and retry availability on
  a pending errored row.
- Tests were verified to fail against the old logic, not merely to pass.
- Full suite: 13,677 passed, 14 skipped, 0 failures. `flutter analyze` clean;
  `dart format .` clean.
