### PR TITLE
fix(dive-log): paint the ceiling line's shaded fill

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -31,6 +31,17 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
 import 'package:submersion/core/ui/trackpad_zoom_recognizer.dart';
 
+/// Opacity of the shaded region between the ceiling and the surface.
+///
+/// Deliberately lighter than [decoStopFillAlpha]. The stop depth is the
+/// ceiling rounded up, so the ceiling region always sits inside the deco stop
+/// band, and for computer-reported profiles the two curves are the same values
+/// and the regions coincide exactly. The fills composite, so this has to be
+/// read as a pair: 0.10 under the band's 0.18 lands the overlap at 0.26, a
+/// perceptible step up from the band rather than the 0.30 that matching the
+/// band's own weight would produce.
+const double ceilingFillAlpha = 0.10;
+
 /// Structured row emitted via [DiveProfileChart.onTooltipData] so callers
 /// can render the tooltip externally (e.g., below the chart).
 class TooltipRow {
@@ -4101,20 +4112,29 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       0xFFD32F2F,
     ); // Red 700 - distinct from pressure orange
 
-    // Build spots only where ceiling > 0
+    // Build spots only where ceiling > 0, breaking the curve wherever the
+    // obligation clears. fl_chart splits a bar on null spots and gives each
+    // section its own fill, so without the break a profile that re-enters deco
+    // would join its two runs and shade the ceiling-free stretch between them.
+    // The break is deferred to the next real spot so no null leads or trails.
     final spots = <FlSpot>[];
+    var pendingBreak = false;
     for (final i in _decimatedCurveIndices(ceilingData)) {
       final ceiling = ceilingData[i];
-      if (ceiling > 0) {
-        spots.add(
-          FlSpot(
-            widget.profile[i].timestamp.toDouble(),
-            -units.convertDepth(
-              ceiling,
-            ), // Convert and negate for inverted axis
-          ),
-        );
+      if (ceiling <= 0) {
+        if (spots.isNotEmpty) pendingBreak = true;
+        continue;
       }
+      if (pendingBreak) {
+        spots.add(FlSpot.nullSpot);
+        pendingBreak = false;
+      }
+      spots.add(
+        FlSpot(
+          widget.profile[i].timestamp.toDouble(),
+          -units.convertDepth(ceiling), // Convert and negate for inverted axis
+        ),
+      );
     }
 
     return LineChartBarData(
@@ -4126,9 +4146,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       isStrokeCapRound: true,
       dotData: const FlDotData(show: false),
       dashArray: [4, 4],
-      belowBarData: BarAreaData(
+      // The shaded region runs from the ceiling UP to the surface, so it is an
+      // aboveBarData. Negated depths put the surface (y = 0) above the ceiling
+      // (y = -4.2), and a below-bar fill cannot express that: fl_chart's
+      // painter draws the below-bar area and then erases the entire above-line
+      // region to clean up the cut-off overdraw, wiping exactly this fill. Same
+      // defect, and same fix, as the deco stop band in deco_stop_band.dart.
+      aboveBarData: BarAreaData(
         show: true,
-        color: ceilingColor.withValues(alpha: 0.15),
+        color: ceilingColor.withValues(alpha: ceilingFillAlpha),
         cutOffY: 0, // Fill to surface
         applyCutOffY: true,
       ),

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_ceiling_fill_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_ceiling_fill_test.dart
@@ -1,0 +1,156 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _buildChartHarness({
+  required List<DiveProfilePoint> profile,
+  required List<double> ceilingCurve,
+}) {
+  return ProviderScope(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          height: 300,
+          child: DiveProfileChart(profile: profile, ceilingCurve: ceilingCurve),
+        ),
+      ),
+    ),
+  );
+}
+
+/// The dashed red ceiling curve. The deco stop band shares its colour but is
+/// drawn with a transparent stroke, so the stroke colour identifies the line.
+LineChartBarData _ceilingBar(WidgetTester tester) {
+  final chart = tester.widget<LineChart>(find.byType(LineChart));
+  return chart.data.lineBarsData.firstWhere(
+    (b) => b.color == const Color(0xFFD32F2F) && b.dashArray != null,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('DiveProfileChart - ceiling fill', () {
+    testWidgets('shades the region between the ceiling and the surface', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildChartHarness(
+          profile: const [
+            DiveProfilePoint(timestamp: 0, depth: 10.0),
+            DiveProfilePoint(timestamp: 30, depth: 40.0),
+            DiveProfilePoint(timestamp: 60, depth: 40.0),
+            DiveProfilePoint(timestamp: 90, depth: 5.0),
+          ],
+          ceilingCurve: const [0.0, 4.2, 4.2, 0.0],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final bar = _ceilingBar(tester);
+
+      // Depths are negated for the inverted axis, so the surface (y = 0) sits
+      // above the ceiling (y = -4.2) and the shaded region is an above-bar
+      // area. belowBarData cannot express this: fl_chart's painter draws the
+      // below-bar fill and then erases the whole above-line region to clean up
+      // the cut-off overdraw, wiping exactly the area the fill needs.
+      expect(bar.aboveBarData.show, isTrue);
+      expect(bar.aboveBarData.applyCutOffY, isTrue);
+      expect(bar.aboveBarData.cutOffY, 0);
+      expect(bar.belowBarData.show, isFalse);
+    });
+
+    testWidgets('breaks the shaded region where the ceiling clears', (
+      tester,
+    ) async {
+      // A sawtooth profile that incurs an obligation, clears it, then incurs a
+      // second one. Samples with no ceiling are skipped rather than plotted at
+      // the surface, so without an explicit break the curve joins the two runs
+      // and the fill shades the gap as though the diver were still in deco.
+      await tester.pumpWidget(
+        _buildChartHarness(
+          profile: const [
+            DiveProfilePoint(timestamp: 0, depth: 5.0),
+            DiveProfilePoint(timestamp: 30, depth: 40.0),
+            DiveProfilePoint(timestamp: 60, depth: 40.0),
+            DiveProfilePoint(timestamp: 90, depth: 5.0),
+            DiveProfilePoint(timestamp: 120, depth: 40.0),
+            DiveProfilePoint(timestamp: 150, depth: 40.0),
+            DiveProfilePoint(timestamp: 180, depth: 5.0),
+          ],
+          ceilingCurve: const [0.0, 4.2, 4.2, 0.0, 6.0, 6.0, 0.0],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final bar = _ceilingBar(tester);
+
+      // fl_chart splits a bar on null spots and gives each section its own
+      // fill, so one break between the two runs is what keeps the shading off
+      // the ceiling-free stretch.
+      expect(bar.spots.where((s) => s.isNull()).length, 1);
+      expect(
+        bar.spots.indexWhere((s) => s.isNull()),
+        greaterThan(0),
+        reason: 'a leading break would start the curve with an empty section',
+      );
+      expect(
+        bar.spots.last.isNull(),
+        isFalse,
+        reason: 'a trailing break would end the curve with an empty section',
+      );
+    });
+
+    testWidgets('leaves a single uninterrupted obligation unbroken', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildChartHarness(
+          profile: const [
+            DiveProfilePoint(timestamp: 0, depth: 5.0),
+            DiveProfilePoint(timestamp: 30, depth: 40.0),
+            DiveProfilePoint(timestamp: 60, depth: 40.0),
+            DiveProfilePoint(timestamp: 90, depth: 5.0),
+          ],
+          ceilingCurve: const [0.0, 4.2, 4.2, 0.0],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final bar = _ceilingBar(tester);
+
+      expect(bar.spots.any((s) => s.isNull()), isFalse);
+      expect(bar.spots, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
Closes #678

## The fix

`_buildCeilingLine` declared its 0.15-alpha fill as a `belowBarData` cut off at the surface. Depths are negated for the inverted Y axis, so the region between a 6 m ceiling (`y = -6`) and the surface (`y = 0`) lies **above** the bar line.

Confirmed against fl_chart 1.2.0 rather than by inspection alone: `drawBelowBar` paints the below-bar area and then erases `filledAboveBarPath` — the whole above-line region — to clean up cut-off overdraw (`line_chart_painter.dart:818-826`). The fill was painted and immediately wiped every frame. `drawAboveBar` erases only `filledBelowBarPath`, so an `aboveBarData` survives.

Same defect and same fix as the deco stop band in #676.


## Screenshots

### Before
<img width="2589" height="1797" alt="image" src="https://github.com/user-attachments/assets/ce5d48b9-93f7-42a1-a537-a89a17ab56a4" />


### After
<img width="2589" height="1797" alt="image" src="https://github.com/user-attachments/assets/db16e7c8-740c-4a8c-b015-a2d1832242aa" />

### With deco stops
<img width="2589" height="1797" alt="image" src="https://github.com/user-attachments/assets/7477fec9-67d2-4e5f-ae87-3564115988f5" />


## Two consequences of making the fill visible

**The curve now breaks where the obligation clears.** Samples with `ceiling <= 0` were silently skipped, so fl_chart joined the runs of a profile that re-enters deco with a straight segment. Harmless while the fill was broken; with the fill painted it would shade the ceiling-free stretch as though the diver were still in deco. Emitting `FlSpot.nullSpot` at the break gives each run its own fill via `splitByNullSpots`. The break is deferred to the next real spot so no null leads or trails the list.

Checked this does not disturb touch handling: the spot-index-to-profile mapping (`depthSpotProfileIndex`) applies only to depth bars, and fl_chart guards `isNull()` in both hit-testing and `mostTopSpot`.

**The fill drops to 0.10 alpha.** The stop depth is the ceiling rounded up, so the ceiling region always sits inside the deco stop band. For computer-reported profiles it is worse than nested — `profile_analysis_provider.dart:471-488` feeds the same `profile[i].ceiling` to both curves, so the two regions coincide exactly. The fills composite:

| ceiling alpha | alone | over the band (0.18) |
| --- | --- | --- |
| 0.15 (as written) | 0.150 | 0.303 (1.68x) |
| 0.10 (this PR) | 0.100 | 0.262 (1.46x) |

0.10 keeps the narrower, harder constraint a perceptible step up rather than double the band's weight. It is a single named constant (`ceilingFillAlpha`) if it wants retuning against a real dive.

The legend's ceiling swatch stays a line rather than becoming an `isAreaSwatch` like the deco band — the dashed line is still the ceiling's identity.

## Tests

`dive_profile_chart_ceiling_fill_test.dart` covers the `aboveBarData` configuration, the gap break, and the absence of a false break on an uninterrupted obligation. All three were watched failing before the fix.

## Verification

- `flutter analyze` clean
- `dart format` clean
- 2208 `test/features/dive_log/` tests pass

The full-suite run had not finished at the time this was opened, which is part of why it is a draft.

## Not covered

The alpha choice is arithmetic on composited values, not a look at a rendered dive. Worth eyeballing before this comes out of draft.
