### PR TITLE
fix(media): scope backfill candidates to linked media

### DIFF
--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -906,27 +906,37 @@ class MediaRepository {
     SyncEventBus.notifyLocalChange();
   }
 
+  /// A media row is linked to the logbook when it references a dive or a
+  /// site (orphan-prevention spec section 3). Single definition shared by
+  /// backfill scoping, the dive-deletion cascade, and the orphan backlog
+  /// sweep so the three predicates cannot drift apart.
+  static Expression<bool> isLinkedToDiveOrSite($MediaTable m) =>
+      m.diveId.isNotNull() | m.siteId.isNotNull();
+
   /// Backfill candidates (design spec section 9): device-resident photos
   /// not yet confirmed in the media store, newest first so recent dives
-  /// gain protection soonest.
+  /// gain protection soonest. Scoped to rows linked to a dive or site so
+  /// orphaned rows are never uploaded (orphan-prevention spec section 4.1).
   Future<List<String>> getBackfillCandidateIds() async {
     final id = _db.media.id;
     final query = _db.selectOnly(_db.media)
       ..addColumns([id])
       ..where(
-        (_db.media.remoteUploadedAt.isNull() &
-                _db.media.remoteCompressedUploadedAt.isNull() &
-                _db.media.fileType.equals('photo') &
-                _db.media.sourceType.isIn([
-                  'platformGallery',
-                  'localFile',
-                  'serviceConnector',
-                ])) |
-            // Connector videos are thumb-only (no original in the store by
-            // design), so their backfill signal is the missing thumb stamp.
-            (_db.media.remoteThumbUploadedAt.isNull() &
-                _db.media.fileType.equals('video') &
-                _db.media.sourceType.equals('serviceConnector')),
+        isLinkedToDiveOrSite(_db.media) &
+            ((_db.media.remoteUploadedAt.isNull() &
+                    _db.media.remoteCompressedUploadedAt.isNull() &
+                    _db.media.fileType.equals('photo') &
+                    _db.media.sourceType.isIn([
+                      'platformGallery',
+                      'localFile',
+                      'serviceConnector',
+                    ])) |
+                // Connector videos are thumb-only (no original in the store
+                // by design), so their backfill signal is the missing thumb
+                // stamp.
+                (_db.media.remoteThumbUploadedAt.isNull() &
+                    _db.media.fileType.equals('video') &
+                    _db.media.sourceType.equals('serviceConnector'))),
       )
       ..orderBy([OrderingTerm.desc(_db.media.takenAt)]);
     final rows = await query.get();

--- a/test/features/media/data/media_repository_backfill_scope_test.dart
+++ b/test/features/media/data/media_repository_backfill_scope_test.dart
@@ -61,29 +61,31 @@ void main() {
     updatedAt: DateTime(2026, 1, 1),
   );
 
-  test('unlinked media are never backfill candidates (orphan regression)',
-      () async {
-    await insertDive('dive-1');
-    await insertSite('site-1');
-    final linkedToDive = await repo.createMedia(
-      item('a.jpg', diveId: 'dive-1'),
-    );
-    final linkedToSite = await repo.createMedia(
-      item('b.jpg', siteId: 'site-1'),
-    );
-    // The observed bug, miniaturized: an orphan gallery photo (dive was
-    // deleted; FK nulled dive_id) must not be uploaded.
-    await repo.createMedia(item('orphan.jpg'));
-    // The video arm has the same hole and must be scoped too.
-    await repo.createMedia(
-      item(
-        'orphan.mp4',
-        mediaType: MediaType.video,
-        sourceType: MediaSourceType.serviceConnector,
-      ),
-    );
+  test(
+    'unlinked media are never backfill candidates (orphan regression)',
+    () async {
+      await insertDive('dive-1');
+      await insertSite('site-1');
+      final linkedToDive = await repo.createMedia(
+        item('a.jpg', diveId: 'dive-1'),
+      );
+      final linkedToSite = await repo.createMedia(
+        item('b.jpg', siteId: 'site-1'),
+      );
+      // The observed bug, miniaturized: an orphan gallery photo (dive was
+      // deleted; FK nulled dive_id) must not be uploaded.
+      await repo.createMedia(item('orphan.jpg'));
+      // The video arm has the same hole and must be scoped too.
+      await repo.createMedia(
+        item(
+          'orphan.mp4',
+          mediaType: MediaType.video,
+          sourceType: MediaSourceType.serviceConnector,
+        ),
+      );
 
-    final ids = await repo.getBackfillCandidateIds();
-    expect(ids.toSet(), {linkedToDive.id, linkedToSite.id});
-  });
+      final ids = await repo.getBackfillCandidateIds();
+      expect(ids.toSet(), {linkedToDive.id, linkedToSite.id});
+    },
+  );
 }

--- a/test/features/media/data/media_repository_backfill_scope_test.dart
+++ b/test/features/media/data/media_repository_backfill_scope_test.dart
@@ -1,0 +1,89 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+
+  Future<void> insertDive(String id) => db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(epoch),
+          createdAt: Value(epoch),
+          updatedAt: Value(epoch),
+        ),
+      );
+
+  Future<void> insertSite(String id) => db
+      .into(db.diveSites)
+      .insert(
+        DiveSitesCompanion(
+          id: Value(id),
+          name: const Value('Reef'),
+          createdAt: Value(epoch),
+          updatedAt: Value(epoch),
+        ),
+      );
+
+  MediaItem item(
+    String name, {
+    String? diveId,
+    String? siteId,
+    MediaType mediaType = MediaType.photo,
+    MediaSourceType sourceType = MediaSourceType.platformGallery,
+  }) => MediaItem(
+    id: '',
+    mediaType: mediaType,
+    sourceType: sourceType,
+    filePath: '/tmp/$name',
+    localPath: '/tmp/$name',
+    originalFilename: name,
+    diveId: diveId,
+    siteId: siteId,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  test('unlinked media are never backfill candidates (orphan regression)',
+      () async {
+    await insertDive('dive-1');
+    await insertSite('site-1');
+    final linkedToDive = await repo.createMedia(
+      item('a.jpg', diveId: 'dive-1'),
+    );
+    final linkedToSite = await repo.createMedia(
+      item('b.jpg', siteId: 'site-1'),
+    );
+    // The observed bug, miniaturized: an orphan gallery photo (dive was
+    // deleted; FK nulled dive_id) must not be uploaded.
+    await repo.createMedia(item('orphan.jpg'));
+    // The video arm has the same hole and must be scoped too.
+    await repo.createMedia(
+      item(
+        'orphan.mp4',
+        mediaType: MediaType.video,
+        sourceType: MediaSourceType.serviceConnector,
+      ),
+    );
+
+    final ids = await repo.getBackfillCandidateIds();
+    expect(ids.toSet(), {linkedToDive.id, linkedToSite.id});
+  });
+}

--- a/test/features/media/data/media_repository_compressed_test.dart
+++ b/test/features/media/data/media_repository_compressed_test.dart
@@ -1,20 +1,24 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import '../../../helpers/test_database.dart';
 
 void main() {
+  late AppDatabase db;
   late MediaRepository repo;
 
   setUp(() async {
-    await setUpTestDatabase();
+    db = await setUpTestDatabase();
     repo = MediaRepository();
   });
   tearDown(tearDownTestDatabase);
 
-  MediaItem photo(String id, {String? hash}) => MediaItem(
+  MediaItem photo(String id, {String? hash, String? diveId}) => MediaItem(
     id: id,
     mediaType: MediaType.photo,
+    diveId: diveId,
     takenAt: DateTime(2026, 1, 1),
     createdAt: DateTime(2026, 1, 1),
     updatedAt: DateTime(2026, 1, 1),
@@ -69,10 +73,24 @@ void main() {
   );
 
   test('compressed-only photo is NOT a backfill candidate', () async {
+    // Linked to a dive so the exclusion below is proven to come from the
+    // compressed stamp, not the linkage scoping.
+    final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('dive-1'),
+            diveDateTime: Value(epoch),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
     await repo.createMedia(
       photo(
         'd',
         hash: 'h3',
+        diveId: 'dive-1',
       ).copyWith(remoteCompressedUploadedAt: DateTime(2026, 1, 3)),
     );
     expect(await repo.getBackfillCandidateIds(), isNot(contains('d')));

--- a/test/features/media_store/media_backfill_service_test.dart
+++ b/test/features/media_store/media_backfill_service_test.dart
@@ -1,5 +1,7 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart'
@@ -11,13 +13,27 @@ import 'package:submersion/features/media_store/data/media_transfer_queue_reposi
 import '../../helpers/test_database.dart';
 
 void main() {
+  late AppDatabase db;
   late MediaRepository mediaRepository;
   late LocalCacheDatabase cacheDb;
   late MediaTransferQueueRepository queue;
   late MediaBackfillService service;
 
   setUp(() async {
-    await setUpTestDatabase();
+    db = await setUpTestDatabase();
+    // Backfill candidates must be linked to a dive or site; every fixture
+    // row in this file hangs off this one dive.
+    final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('dive-1'),
+            diveDateTime: Value(epoch),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
     mediaRepository = MediaRepository();
     cacheDb = LocalCacheDatabase(NativeDatabase.memory());
     queue = MediaTransferQueueRepository(database: cacheDb);
@@ -42,6 +58,7 @@ void main() {
     final created = await mediaRepository.createMedia(
       domain.MediaItem(
         id: '',
+        diveId: 'dive-1',
         mediaType: mediaType,
         sourceType: sourceType,
         filePath: '/tmp/$name',


### PR DESCRIPTION
## Summary

"Upload library" (Settings -> Media Storage) enqueued every media row in the table, including rows linked to neither a dive nor a site. Such orphan rows are mass-produced by dive deletion: the `media.dive_id` FK is `ON DELETE SET NULL`, so deleting a dive silently unlinks its media instead of removing it. In an affected library the backfill then (a) uploads non-logbook bytes to the user's cloud media store and (b) HLC-stamps each orphan row into the sync changeset, propagating it fleet-wide. Observed: a debug DB with 3 dives / 1 linked photo queued 83 transfers.

This is PR 1 of 4 from `docs/superpowers/specs/2026-07-23-media-store-orphan-prevention-design.md` (plan: `docs/superpowers/plans/2026-07-23-media-orphan-prevention-pr1-backfill-scoping.md`): it stops the bleeding at the query. Later PRs add the remote-delete fast path, the dive-deletion cascade + backlog sweep, and the Verify Library reconciliation sweep.

## Changes

- New shared predicate `MediaRepository.isLinkedToDiveOrSite()` (spec section 3) - single definition that the dive-deletion cascade and backlog sweep (PR 3) will reuse so the predicates cannot drift.
- `getBackfillCandidateIds()` ANDs the predicate onto the existing WHERE, scoping both the photo arm and the connector-video arm at once. This also closes the latent widening: broadening the video arm's source types can no longer pull in unlinked gallery videos.
- Regression test `media_repository_backfill_scope_test.dart`: dive-linked and site-linked rows are candidates; unlinked photo and video rows are not.
- Fixture repairs: `media_backfill_service_test.dart` and the compressed-stamp backfill test created unlinked rows and asserted they WERE candidates - they had encoded the bug as expected behavior. Fixtures now link rows to a dive so each test proves its named exclusion reason.

## Testing

- `flutter analyze`: no issues.
- `dart format .`: clean.
- Full suite: 13698 passed / 0 failed (14 skipped).