### PR TITLE
fix(media): hydrate media taken_at as wall-clock-UTC

### DIFF
--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -1066,8 +1066,9 @@ class MediaRepository {
       longitude: row.longitude,
       // taken_at is stored as wall-clock-UTC millis (see the write path and the
       // dive side, which reads entry_time with isUtc: true). Hydrate it as UTC
-      // so downstream normalisation (EnrichmentService.toWallClockUtc) is a
-      // no-op instead of shifting the photo time by the host's UTC offset.
+      // so downstream normalisation (TripMediaScanner.toWallClockUtc, invoked by
+      // EnrichmentService.calculateEnrichment) is a no-op instead of shifting the
+      // photo time by the host's UTC offset.
       takenAt: row.takenAt != null
           ? DateTime.fromMillisecondsSinceEpoch(row.takenAt!, isUtc: true)
           : _defaultTakenAt(row.id),

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -1064,8 +1064,12 @@ class MediaRepository {
       mediaType: _parseMediaType(row.fileType),
       latitude: row.latitude,
       longitude: row.longitude,
+      // taken_at is stored as wall-clock-UTC millis (see the write path and the
+      // dive side, which reads entry_time with isUtc: true). Hydrate it as UTC
+      // so downstream normalisation (EnrichmentService.toWallClockUtc) is a
+      // no-op instead of shifting the photo time by the host's UTC offset.
       takenAt: row.takenAt != null
-          ? DateTime.fromMillisecondsSinceEpoch(row.takenAt!)
+          ? DateTime.fromMillisecondsSinceEpoch(row.takenAt!, isUtc: true)
           : _defaultTakenAt(row.id),
       width: row.width,
       height: row.height,

--- a/test/features/media/data/repositories/media_repository_test.dart
+++ b/test/features/media/data/repositories/media_repository_test.dart
@@ -150,6 +150,40 @@ void main() {
         expect(fetched.isFavorite, isTrue);
       });
 
+      test(
+        'hydrates takenAt as wall-clock-UTC so enrichment is not TZ-skewed',
+        () async {
+          // taken_at is persisted as wall-clock-UTC millis (the same convention
+          // the dive side uses: dive_repository_impl reads entry_time with
+          // isUtc: true, and the media write path stores the ms of an already-
+          // UTC DateTime). It must be read back as a *UTC* DateTime. If it is
+          // hydrated as local, EnrichmentService.calculateEnrichment's
+          // toWallClockUtc() reinterprets the shifted local digits as UTC and
+          // displaces the photo time by the host's UTC offset relative to the
+          // (correctly UTC) dive start — pinning every item to the first
+          // profile point (surface depth). Regression guard for that skew.
+          final takenAt = DateTime.utc(2025, 12, 27, 11, 47, 48);
+          final media = createTestMediaItem(
+            filePath: '/photos/reef.jpg',
+            takenAt: takenAt,
+          );
+
+          final created = await repository.createMedia(media);
+          final fetched = await repository.getMediaById(created.id);
+
+          expect(fetched, isNotNull);
+          expect(
+            fetched!.takenAt.isUtc,
+            isTrue,
+            reason:
+                'takenAt must round-trip as UTC to match the wall-clock-UTC '
+                'storage convention; a local value skews enrichment by the '
+                'host UTC offset.',
+          );
+          expect(fetched.takenAt, equals(takenAt));
+        },
+      );
+
       test('should create media linked to a dive', () async {
         final dive = await createTestDiveInDb(diveNumber: 1);
         final media = createTestMediaItem(

--- a/test/features/media/data/repositories/media_repository_test.dart
+++ b/test/features/media/data/repositories/media_repository_test.dart
@@ -157,11 +157,12 @@ void main() {
           // the dive side uses: dive_repository_impl reads entry_time with
           // isUtc: true, and the media write path stores the ms of an already-
           // UTC DateTime). It must be read back as a *UTC* DateTime. If it is
-          // hydrated as local, EnrichmentService.calculateEnrichment's
-          // toWallClockUtc() reinterprets the shifted local digits as UTC and
-          // displaces the photo time by the host's UTC offset relative to the
-          // (correctly UTC) dive start — pinning every item to the first
-          // profile point (surface depth). Regression guard for that skew.
+          // hydrated as local, the TripMediaScanner.toWallClockUtc() call inside
+          // EnrichmentService.calculateEnrichment reinterprets the shifted local
+          // digits as UTC and displaces the photo time by the host's UTC offset
+          // relative to the (correctly UTC) dive start — pinning every item to
+          // the first profile point (surface depth). Regression guard for that
+          // skew.
           final takenAt = DateTime.utc(2025, 12, 27, 11, 47, 48);
           final media = createTestMediaItem(
             filePath: '/photos/reef.jpg',


### PR DESCRIPTION
## Problem

Photos and videos added via **Add photo or video → Files** (folder pick) were all pinned to the first dive-profile point — surface depth, e.g. "2ft" — with the wrong time/depth association. The **gallery scan** path was unaffected.

This is distinct from #660, which fixed timestamp *extraction* on desktop. Extraction is correct here: the stored `media.taken_at` values match the source metadata (JPG EXIF and GoPro `mvhd`). The skew is introduced at **enrichment** time.

## Root cause

`MediaRepository._mapRowToMediaItem` hydrated `taken_at` with `DateTime.fromMillisecondsSinceEpoch(ms)` **without `isUtc: true`**, producing a local `DateTime`.

`taken_at` is persisted as **wall-clock-UTC** millis — the write path stores the epoch ms of an already-UTC `DateTime`, and the dive side reads `entry_time` with `isUtc: true` (`dive_repository_impl.dart:2237`). On a host with a non-zero UTC offset, the local hydration shows shifted digits (e.g. `11:47 UTC` → `06:47` on US-Eastern). `EnrichmentService.calculateEnrichment` then calls `toWallClockUtc()`, which reinterprets those shifted digits as UTC. The photo time is displaced by the host offset relative to the (correct, UTC) dive start, yielding a negative elapsed time so every item resolves to the first profile point.

Observed in a real DB: 11 enrichment rows all had `elapsed_seconds ≈ −16692` (−5h = host December offset) and `depth_meters = 0.4572` (≈ "2ft"), while the `taken_at` values themselves were correct.

## Fix

Hydrate `taken_at` with `isUtc: true` so downstream normalisation is a no-op.

- **Safe for `asset_resolution_service`**: it compares timestamps with `.difference()`/`.subtract()`, which operate on absolute instants and ignore the `isUtc` flag.
- **Corrects the photo viewer**: `DateFormat` now reads UTC components, showing the true wall-clock capture time instead of a host-offset-shifted one.

## Tests

- New repository round-trip guard asserting `fetched.takenAt.isUtc` (fails before the fix).
- Full media suite (725) + analyzer green.

## Notes

- Items imported *before* this fix keep their stale enrichment rows (the backfill only enriches rows that are missing); unlink + re-add to correct them.
- Local-file video thumbnails still render a movie-icon placeholder (no poster frame generated) — a separate, pre-existing gap; depth badges on videos are corrected by this change.
- Sibling `media_repository.dart:698` (GPS tuple) also omits `isUtc: true`; left unchanged as its use is instant-based, but worth a follow-up audit.