### PR TITLE
fix(dive-log): persist picked buddy role in bulk edit

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -881,6 +881,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
 
   Map<String, int> _buddyCounts = {};
   final Map<String, Buddy> _buddyById = {};
+  final Map<String, DiveRole> _buddyRoleById = {};
   List<BulkMembershipItem> _buddyMembers = [];
   MembershipDelta _buddyDelta = MembershipDelta.empty;
 
@@ -3303,6 +3304,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       final existing = _buddyMembers.map((e) => e.id).toSet();
       for (final bwr in buddies) {
         _buddyById[bwr.buddy.id] = bwr.buddy;
+        _buddyRoleById[bwr.buddy.id] = bwr.role;
       }
       _buddyMembers = [
         ..._buddyMembers,
@@ -3326,7 +3328,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-    role: DiveRole.builtInBuddy(),
+    role: _buddyRoleById[id] ?? DiveRole.builtInBuddy(),
   );
 
   void _saveEquipmentAsSet() {

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -9,6 +11,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/bulk_field_gat
 import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
@@ -106,6 +109,89 @@ void main() {
       await tester.pump();
       expect(find.text('adding to all 2'), findsOneWidget);
     });
+
+    testWidgets(
+      'bulk-adding a buddy with a picked role persists that role, not the '
+      'default',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final buddy = await BuddyRepository().createBuddy(
+          Buddy(
+            id: '',
+            name: 'Casey Diver',
+            createdAt: DateTime(2026, 1, 1),
+            updatedAt: DateTime(2026, 1, 1),
+          ),
+        );
+        final d1 = await repository.createDive(
+          createTestDiveWithBottomTime().copyWith(id: 'buddy-role-1'),
+        );
+        final overrides = await getBaseOverrides();
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: buildOverrides(overrides).cast(),
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: DiveEditPage(bulkDiveIds: [d1.id], embedded: true),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final buddiesSection = find.ancestor(
+          of: find.text('Buddies'),
+          matching: find.byType(BulkMembershipEditor),
+        );
+        final addToBuddies = find.descendant(
+          of: buddiesSection,
+          matching: find.byIcon(Icons.add),
+        );
+        await tester.ensureVisible(addToBuddies);
+        await tester.tap(addToBuddies);
+        await tester.pumpAndSettle();
+
+        // Open the BuddyPicker's own selection sheet (inside the dialog).
+        await tester.tap(
+          find.descendant(
+            of: find.byType(AlertDialog),
+            matching: find.byIcon(Icons.add),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(buddy.name));
+        await tester.pumpAndSettle();
+
+        // Role selector: pick Instructor instead of the default Buddy role.
+        await tester.tap(find.text('Instructor'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Done'));
+        await tester.pumpAndSettle();
+
+        // Confirm the add in the outer bulk-edit dialog.
+        await tester.tap(find.widgetWithText(FilledButton, 'Add').last);
+        await tester.pumpAndSettle();
+
+        await tester.ensureVisible(find.text('Save'));
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        final saved = await BuddyRepository().getBuddiesForDive(d1.id);
+        expect(saved, hasLength(1));
+        expect(saved.single.role.id, DiveRole.instructorId);
+      },
+    );
 
     testWidgets('toggling a gate enables its checkbox', (tester) async {
       await pumpBulk(tester);

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -137,6 +137,7 @@ void main() {
           ProviderScope(
             overrides: buildOverrides(overrides).cast(),
             child: MaterialApp(
+              locale: const Locale('en'),
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(


### PR DESCRIPTION
## Summary

Bulk-editing multiple dives and adding a buddy let you pick a role (Divemaster, Instructor, etc.) via the picker, but the pick was discarded — every newly-added buddy was always saved with the default "Buddy" role.

Fixes #699
Related to #700

## Changes

- `_addBuddyMembers` now records the picked role in a new `_buddyRoleById` map (alongside the existing `_buddyById`), instead of only capturing `id`/`label`/`icon`.
- `_buddyWithRole` looks up the picked role from that map when building the save payload, falling back to the default `Buddy` role only when unknown.
- New regression test drives the actual bulk-edit UI end-to-end (pick a buddy, choose Instructor in the role sheet, confirm, Save, Apply) and verifies the persisted role via `BuddyRepository.getBuddiesForDive`.

**Known limitation, filed separately:** this fix covers adding a *new* buddy to the selection. Re-picking a buddy who's already on some/all of the selected dives with a different role still doesn't update it — see #700 for that follow-up.

## Test Plan

- [x] `flutter test` passes (full suite: `dive_edit_page_test.dart`, `bulk_dive_edit_page_test.dart`, `bulk_dive_edit_service_test.dart`, `bulk_dive_edit_provider_test.dart`, `buddies/` tree — 240 tests)
- [x] `flutter analyze` passes
- [x] Manual testing on: macOS