### PR TITLE
feat(media-store): remote blob delete fast path

### DIFF
--- a/lib/core/database/local_cache_database.dart
+++ b/lib/core/database/local_cache_database.dart
@@ -35,6 +35,10 @@ class MediaTransferQueue extends Table {
   IntColumn get totalBytes => integer().nullable()();
   // Adjustable upload quality: a per-item re-upload override level (v4).
   TextColumn get overrideLevel => text().nullable()();
+  // Operation payload for non-upload directions (v6). For 'delete' entries:
+  // {"originalExt": ..., "renditionExt": ...} -- the two facts that cannot
+  // be recovered once the media row is gone.
+  TextColumn get payloadJson => text().nullable()();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 }
@@ -64,7 +68,7 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
   LocalCacheDatabase(super.e);
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -87,6 +91,11 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
       // it; the v1 create path above already includes the current schema.
       if (from >= 2 && from < 5) {
         await m.addColumn(mediaCacheEntries, mediaCacheEntries.sourceVersion);
+      }
+      // v6: delete-intent payload. Only v2..v5 stored schemas lack it; the
+      // v1 create path above already includes the current schema.
+      if (from >= 2 && from < 6) {
+        await m.addColumn(mediaTransferQueue, mediaTransferQueue.payloadJson);
       }
     },
   );

--- a/lib/core/services/media_store/dropbox_media_object_store.dart
+++ b/lib/core/services/media_store/dropbox_media_object_store.dart
@@ -248,6 +248,11 @@ class DropboxMediaObjectStore implements MediaObjectStore {
   }
 
   @override
+  Future<void> abandonResume(String key, String? resumeStateJson) async {
+    // Upload sessions expire server-side; nothing to abort.
+  }
+
+  @override
   Stream<StoreObjectInfo> list(String keyPrefix) async* {
     final List<DropboxFileMetadata> entries;
     try {

--- a/lib/core/services/media_store/google_drive_media_object_store.dart
+++ b/lib/core/services/media_store/google_drive_media_object_store.dart
@@ -235,6 +235,11 @@ class GoogleDriveMediaObjectStore implements MediaObjectStore {
     await _deleteById(found.id);
   }
 
+  @override
+  Future<void> abandonResume(String key, String? resumeStateJson) async {
+    // Upload sessions expire server-side; nothing to abort.
+  }
+
   Future<void> _deleteById(String id) async {
     final response = await _send(
       http.Request('DELETE', Uri.parse('$_apiBase/drive/v3/files/$id')),

--- a/lib/core/services/media_store/icloud_media_object_store.dart
+++ b/lib/core/services/media_store/icloud_media_object_store.dart
@@ -123,6 +123,11 @@ class ICloudMediaObjectStore implements MediaObjectStore {
   }
 
   @override
+  Future<void> abandonResume(String key, String? resumeStateJson) async {
+    // Upload sessions are OS-managed; nothing to abort.
+  }
+
+  @override
   Stream<StoreObjectInfo> list(String keyPrefix) async* {
     final root = await _root();
     await _platform.refreshFolder(root);

--- a/lib/core/services/media_store/media_object_store.dart
+++ b/lib/core/services/media_store/media_object_store.dart
@@ -69,6 +69,13 @@ abstract class MediaObjectStore {
   /// Idempotent delete: absent keys succeed.
   Future<void> delete(String key);
 
+  /// Best-effort abandonment of any provider-side resumable upload session
+  /// recorded in [resumeStateJson] for [key] (orphan-prevention spec 5.5).
+  /// Called when an upload is terminally failed and its resume state will
+  /// never be replayed. Providers whose sessions self-expire (Dropbox,
+  /// Drive, iCloud) no-op; must never throw on malformed or null state.
+  Future<void> abandonResume(String key, String? resumeStateJson);
+
   /// All objects whose key starts with [keyPrefix].
   Stream<StoreObjectInfo> list(String keyPrefix);
 }

--- a/lib/core/services/media_store/s3_media_object_store.dart
+++ b/lib/core/services/media_store/s3_media_object_store.dart
@@ -109,8 +109,9 @@ class S3MediaObjectStore implements MediaObjectStore {
     void Function(String resumeStateJson)? onResumeStateChanged,
   }) async {
     final wireKey = _wire(key);
+    ({String uploadId, List<S3PartInfo> parts})? session;
     try {
-      var session = await _validateResume(wireKey, resumeStateJson);
+      session = await _validateResume(wireKey, resumeStateJson);
       session ??= (
         uploadId: await _client.createMultipartUpload(
           wireKey,
@@ -149,14 +150,41 @@ class S3MediaObjectStore implements MediaObjectStore {
         parts: parts,
       );
     } on CloudStorageException catch (e) {
+      // With no persistence callback, nothing will ever replay this
+      // session's resume state, so the failure must abort it or the
+      // uploaded parts strand and bill until a lifecycle rule (which raw
+      // buckets lack) reaps them (orphan-prevention spec 5.5). With a
+      // callback, the persisted state resumes the session on retry.
+      if (onResumeStateChanged == null) {
+        await _abortQuietly(wireKey, session?.uploadId);
+      }
       throw _map('put', key, e);
     } on FileSystemException catch (e) {
+      if (onResumeStateChanged == null) {
+        await _abortQuietly(wireKey, session?.uploadId);
+      }
       throw MediaStoreException(
         'cannot read source for $key',
         kind: MediaStoreErrorKind.fatal,
         cause: e,
       );
     }
+  }
+
+  @override
+  Future<void> abandonResume(String key, String? resumeStateJson) async {
+    if (resumeStateJson == null) return;
+    String? uploadId;
+    try {
+      final decoded = jsonDecode(resumeStateJson);
+      if (decoded is Map<String, dynamic>) {
+        final id = decoded['uploadId'];
+        if (id is String) uploadId = id;
+      }
+    } on FormatException {
+      return;
+    }
+    await _abortQuietly(_wire(key), uploadId);
   }
 
   /// Parses and server-verifies a previous attempt's resume state. Returns

--- a/lib/core/services/media_store/s3_media_object_store.dart
+++ b/lib/core/services/media_store/s3_media_object_store.dart
@@ -119,6 +119,16 @@ class S3MediaObjectStore implements MediaObjectStore {
         ),
         parts: <S3PartInfo>[],
       );
+      // Publish the session BEFORE the first part goes up. This callback is
+      // the only channel by which a caller ever learns the uploadId, and a
+      // failure on part 1 is the likeliest failure of all - without this,
+      // that session would be nameless: unabortable by abandonResume, absent
+      // from key listings, and billing until a lifecycle rule that raw
+      // buckets lack reaps it (orphan-prevention spec 5.5). Re-emitting a
+      // resumed session's own state is a harmless idempotent write.
+      onResumeStateChanged?.call(
+        _resumeToJson(session.uploadId, session.parts),
+      );
       final parts = [...session.parts];
       final totalParts = (length + partSizeBytes - 1) ~/ partSizeBytes;
       var bytesSent = parts.length * partSizeBytes;

--- a/lib/core/services/media_store/store_keys.dart
+++ b/lib/core/services/media_store/store_keys.dart
@@ -14,7 +14,7 @@ class StoreKeys {
   static final RegExp _extPattern = RegExp(r'^[a-z0-9]{1,8}$');
 
   static String objectKey(String contentHash, {required String extension}) =>
-      'smv1/objects/${contentHash.substring(0, 2)}/$contentHash.$extension';
+      '${objectKeyPrefix(contentHash)}$extension';
 
   static String thumbKey(String contentHash) =>
       'smv1/thumbs/${contentHash.substring(0, 2)}/$contentHash.jpg';
@@ -23,7 +23,21 @@ class StoreKeys {
   /// [ext] is the rendition's own output format (jpg for photos, mp4 for
   /// video), not the original's extension. NOT hash-verified on read.
   static String renditionKey(String contentHash, {required String ext}) =>
-      'smv1/renditions/${contentHash.substring(0, 2)}/$contentHash.$ext';
+      '${renditionKeyPrefix(contentHash)}$ext';
+
+  /// Prefix shared by every extension variant of [contentHash] in the
+  /// originals namespace. [extensionFor] is not injective over content:
+  /// `photo.JPG` and `photo.jpeg` hash identically but key differently, and
+  /// a row with no filename lands on `.bin`. Listing this prefix therefore
+  /// finds variants a single recorded extension would miss. The trailing dot
+  /// keeps a 64-hex hash from ever prefix-matching another one.
+  static String objectKeyPrefix(String contentHash) =>
+      'smv1/objects/${contentHash.substring(0, 2)}/$contentHash.';
+
+  /// Rendition-namespace counterpart of [objectKeyPrefix]: photo and video
+  /// renditions of one hash differ only by their `jpg`/`mp4` extension.
+  static String renditionKeyPrefix(String contentHash) =>
+      'smv1/renditions/${contentHash.substring(0, 2)}/$contentHash.';
 
   /// Lowercased extension of [originalFilename] without the dot, or 'bin'
   /// when absent or unusual. Identical bytes imply identical format, so the

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -1040,6 +1040,18 @@ class MediaRepository {
     return (await query.getSingle()).read(count) ?? 0;
   }
 
+  /// Number of media rows referencing [contentHash] at all - uploaded or
+  /// not. The delete fast path's drain-time refcount (orphan-prevention
+  /// spec 5.3): deliberately broader than [countRowsWithOriginal] because
+  /// skipping a blob delete is free while a wrong delete costs a re-upload.
+  Future<int> countRowsWithHash(String contentHash) async {
+    final count = _db.media.id.count();
+    final query = _db.selectOnly(_db.media)
+      ..addColumns([count])
+      ..where(_db.media.contentHash.equals(contentHash));
+    return (await query.getSingle()).read(count) ?? 0;
+  }
+
   domain.MediaItem _mapRowToMediaItem(
     MediaData row, [
     MediaEnrichmentData? enrichmentRow,

--- a/lib/features/media/presentation/providers/files_tab_providers.dart
+++ b/lib/features/media/presentation/providers/files_tab_providers.dart
@@ -12,6 +12,8 @@ import 'package:submersion/features/media/domain/entities/media_source_type.dart
 import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
 import 'package:submersion/features/media/domain/value_objects/matched_selection.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 
 /// State for the Files tab in the photo picker.
@@ -98,9 +100,15 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
     required this.mediaRepository,
     required this.bookmarkStorage,
     required this.platform,
+    this.deletionCoordinator,
   }) : super(FilesTabState.initial());
 
   final MediaRepository mediaRepository;
+
+  /// Routes undo deletions through the orphan-prevention fast path when
+  /// wired (production); direct-construction tests fall back to the
+  /// repository.
+  final MediaDeletionCoordinator? deletionCoordinator;
   final LocalBookmarkStorage bookmarkStorage;
   final LocalMediaPlatform platform;
 
@@ -173,6 +181,11 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
   /// Reverses a prior [commit] by deleting each row by id. Bookmark blobs
   /// in the keychain are intentionally not cleaned up — see class doc.
   Future<void> undoCommit(List<String> ids) async {
+    final coordinator = deletionCoordinator;
+    if (coordinator != null) {
+      await coordinator.deleteMultipleMedia(ids);
+      return;
+    }
     for (final id in ids) {
       await mediaRepository.deleteMedia(id);
     }
@@ -238,5 +251,6 @@ final filesTabNotifierProvider =
         mediaRepository: ref.read(mediaRepositoryProvider),
         bookmarkStorage: ref.read(localBookmarkStorageProvider),
         platform: ref.read(localMediaPlatformProvider),
+        deletionCoordinator: ref.read(mediaDeletionCoordinatorProvider),
       ),
     );

--- a/lib/features/media/presentation/providers/media_providers.dart
+++ b/lib/features/media/presentation/providers/media_providers.dart
@@ -3,6 +3,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_reposit
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/services/dive_media_enricher.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
 /// Repository provider (singleton)
 final mediaRepositoryProvider = Provider<MediaRepository>((ref) {
@@ -131,15 +132,17 @@ class MediaListNotifier extends StateNotifier<AsyncValue<List<MediaItem>>> {
     _ref.invalidate(mediaByIdProvider(item.id));
   }
 
-  /// Delete a media item
+  /// Delete a media item. Routed through the deletion coordinator so the
+  /// remote-blob delete intent is enqueued before the row dies
+  /// (orphan-prevention spec 5.2).
   Future<void> deleteMedia(String id) async {
-    await _repository.deleteMedia(id);
+    await _ref.read(mediaDeletionCoordinatorProvider).deleteMedia(id);
     await refresh();
   }
 
   /// Delete multiple media items at once
   Future<void> deleteMultipleMedia(List<String> ids) async {
-    await _repository.deleteMultipleMedia(ids);
+    await _ref.read(mediaDeletionCoordinatorProvider).deleteMultipleMedia(ids);
     await refresh();
   }
 

--- a/lib/features/media/presentation/providers/url_tab_providers.dart
+++ b/lib/features/media/presentation/providers/url_tab_providers.dart
@@ -37,6 +37,8 @@ import 'package:submersion/features/media/data/repositories/media_repository.dar
 import 'package:submersion/features/media/data/utils/url_validator.dart';
 import 'package:submersion/features/media/domain/entities/extracted_metadata.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
 /// Two-mode segmented control for the URL tab. URLs is the bulk paste-and-add
 /// flow (Phase 3a). Manifest mode is a Phase 3b placeholder card.
@@ -118,14 +120,21 @@ class UrlTabNotifier extends StateNotifier<UrlTabState> {
     required NetworkFetchPipeline pipeline,
     required NetworkCredentialsService credentials,
     required MediaRepository mediaRepository,
+    MediaDeletionCoordinator? deletionCoordinator,
   }) : _pipeline = pipeline,
        _credentials = credentials,
        _mediaRepository = mediaRepository,
+       _deletionCoordinator = deletionCoordinator,
        super(const UrlTabState());
 
   final NetworkFetchPipeline _pipeline;
   final NetworkCredentialsService _credentials;
   final MediaRepository _mediaRepository;
+
+  /// Routes undo deletions through the orphan-prevention fast path when
+  /// wired (production); direct-construction tests fall back to the
+  /// repository.
+  final MediaDeletionCoordinator? _deletionCoordinator;
 
   void setMode(UrlTabMode mode) {
     state = state.copyWith(mode: mode);
@@ -170,8 +179,13 @@ class UrlTabNotifier extends StateNotifier<UrlTabState> {
   /// `FilesTabNotifier.undoCommit` — the pipeline does not expose a
   /// `deleteIds` helper, so we go through the repository.
   Future<void> undoCommit(List<String> ids) async {
-    for (final id in ids) {
-      await _mediaRepository.deleteMedia(id);
+    final coordinator = _deletionCoordinator;
+    if (coordinator != null) {
+      await coordinator.deleteMultipleMedia(ids);
+    } else {
+      for (final id in ids) {
+        await _mediaRepository.deleteMedia(id);
+      }
     }
     state = state.copyWith(committedIds: const []);
   }
@@ -307,5 +321,6 @@ final urlTabNotifierProvider =
         pipeline: ref.watch(networkFetchPipelineProvider),
         credentials: ref.watch(networkCredentialsServiceProvider),
         mediaRepository: ref.watch(mediaRepositoryProvider),
+        deletionCoordinator: ref.read(mediaDeletionCoordinatorProvider),
       ),
     );

--- a/lib/features/media/presentation/widgets/manifest_mode_panel.dart
+++ b/lib/features/media/presentation/widgets/manifest_mode_panel.dart
@@ -43,9 +43,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/media/presentation/providers/manifest_tab_providers.dart';
-import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/manifest_preview_pane.dart';
 
 /// Standard poll-interval choices surfaced in the dropdown. The plan's
@@ -162,10 +162,9 @@ class _ManifestModePanelState extends ConsumerState<ManifestModePanel> {
     required String subscriptionId,
     required bool deleteSubscription,
   }) async {
-    final mediaRepo = ref.read(mediaRepositoryProvider);
-    for (final id in mediaIds) {
-      await mediaRepo.deleteMedia(id);
-    }
+    await ref
+        .read(mediaDeletionCoordinatorProvider)
+        .deleteMultipleMedia(mediaIds);
     if (deleteSubscription) {
       await ref
           .read(manifestSubscriptionRepositoryProvider)

--- a/lib/features/media_store/data/media_delete_processor.dart
+++ b/lib/features/media_store/data/media_delete_processor.dart
@@ -47,6 +47,11 @@ class MediaDeleteProcessor {
       await _store.delete(
         StoreKeys.renditionKey(hash, ext: payload.renditionExt),
       );
+      // Sweep sibling extension variants last, so a store whose listing
+      // fails still has the three recorded keys gone by then and only
+      // repeats idempotent deletes on retry.
+      await _deleteVariants(StoreKeys.objectKeyPrefix(hash));
+      await _deleteVariants(StoreKeys.renditionKeyPrefix(hash));
       await _queue.markDone(entry.id);
     } on Exception catch (e, stackTrace) {
       _log.warning(
@@ -55,6 +60,22 @@ class MediaDeleteProcessor {
         stackTrace: stackTrace,
       );
       await _queue.markFailed(entry.id, e.toString());
+    }
+  }
+
+  /// Deletes every object under [prefix]. One delete intent carries a
+  /// single recorded extension per tier, but a hash can legitimately hold
+  /// several: `photo.JPG` and `photo.jpeg` are identical bytes under
+  /// different keys, a row with no filename keys on `.bin`, and the
+  /// per-hash enqueue dedupe keeps only the first intent's payload. Safe
+  /// because the caller already established that no media row references
+  /// this hash, so everything under the prefix is unreferenced content for
+  /// it - and the collected-then-deleted order avoids mutating the store
+  /// while its listing is still streaming.
+  Future<void> _deleteVariants(String prefix) async {
+    final keys = await _store.list(prefix).map((info) => info.key).toList();
+    for (final key in keys) {
+      await _store.delete(key);
     }
   }
 

--- a/lib/features/media_store/data/media_delete_processor.dart
+++ b/lib/features/media_store/data/media_delete_processor.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+/// Drains 'delete' transfer-queue entries: removes a dead media row's
+/// remote original, thumb, and rendition objects (orphan-prevention spec
+/// section 5). The refcount re-check happens here at drain time - never at
+/// enqueue time - so references that appear between the two (late sync
+/// pulls, re-imports) win and the delete becomes a no-op.
+class MediaDeleteProcessor {
+  MediaDeleteProcessor({
+    required MediaTransferQueueRepository queue,
+    required MediaObjectStore store,
+    required MediaRepository mediaRepository,
+  }) : _queue = queue,
+       _store = store,
+       _mediaRepository = mediaRepository;
+
+  final MediaTransferQueueRepository _queue;
+  final MediaObjectStore _store;
+  final MediaRepository _mediaRepository;
+  final _log = LoggerService.forClass(MediaDeleteProcessor);
+
+  Future<void> process(MediaTransferQueueEntry entry) async {
+    await _queue.markTransferring(entry.id);
+    try {
+      final hash = entry.contentHash;
+      if (hash == null || hash.isEmpty) {
+        // Unusable intent; nothing safe to delete. The sweep is the
+        // backstop.
+        await _queue.markDone(entry.id);
+        return;
+      }
+      if (await _mediaRepository.countRowsWithHash(hash) > 0) {
+        await _queue.markDone(entry.id);
+        return;
+      }
+      final payload = _parsePayload(entry.payloadJson);
+      await _store.delete(
+        StoreKeys.objectKey(hash, extension: payload.originalExt),
+      );
+      await _store.delete(StoreKeys.thumbKey(hash));
+      await _store.delete(
+        StoreKeys.renditionKey(hash, ext: payload.renditionExt),
+      );
+      await _queue.markDone(entry.id);
+    } on Exception catch (e, stackTrace) {
+      _log.warning(
+        'Remote delete failed for ${entry.contentHash}',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      await _queue.markFailed(entry.id, e.toString());
+    }
+  }
+
+  /// Defensive parse: a corrupt payload degrades to plausible extensions
+  /// rather than failing the entry - deleting a key that never existed is
+  /// an idempotent no-op, and anything missed falls to the sweep.
+  ({String originalExt, String renditionExt}) _parsePayload(String? json) {
+    if (json != null) {
+      try {
+        final decoded = jsonDecode(json);
+        if (decoded is Map<String, dynamic>) {
+          final original = decoded['originalExt'];
+          final rendition = decoded['renditionExt'];
+          if (original is String && rendition is String) {
+            return (originalExt: original, renditionExt: rendition);
+          }
+        }
+      } on FormatException {
+        // fall through to defaults
+      }
+    }
+    return (originalExt: 'bin', renditionExt: 'jpg');
+  }
+}

--- a/lib/features/media_store/data/media_deletion_coordinator.dart
+++ b/lib/features/media_store/data/media_deletion_coordinator.dart
@@ -1,0 +1,83 @@
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+/// Wraps media-row deletion with the remote-blob delete fast path
+/// (orphan-prevention spec 5.2): the delete INTENT is enqueued BEFORE the
+/// row dies - the queue lives in a different database, so no cross-DB
+/// transaction exists, and this ordering makes the only crash window
+/// harmless (an intent whose row survived no-ops on the drain-time
+/// refcount). Enqueue problems never block the deletion itself; missed
+/// intents fall to the Verify Library sweep.
+///
+/// Single-enqueuer rule (spec 5.4): only user-action deletion flows go
+/// through this coordinator. Sync tombstone application deletes rows
+/// directly and must never enqueue remote deletes.
+class MediaDeletionCoordinator {
+  MediaDeletionCoordinator({
+    required MediaRepository mediaRepository,
+    required MediaTransferQueueRepository Function() queue,
+    Future<void> Function()? kickWorker,
+  }) : _mediaRepository = mediaRepository,
+       _queue = queue,
+       _kickWorker = kickWorker;
+
+  final MediaRepository _mediaRepository;
+  final MediaTransferQueueRepository Function() _queue;
+  final Future<void> Function()? _kickWorker;
+  final _log = LoggerService.forClass(MediaDeletionCoordinator);
+
+  Future<void> deleteMedia(String id) => deleteMultipleMedia([id]);
+
+  Future<void> deleteMultipleMedia(List<String> ids) async {
+    var enqueued = false;
+    for (final id in ids) {
+      // Untyped catch on purpose: an uninitialized
+      // LocalCacheDatabaseService throws StateError (an Error, not an
+      // Exception), and no media-store problem may ever block the user's
+      // deletion.
+      try {
+        if (await _enqueueIntent(id)) enqueued = true;
+      } catch (e, stackTrace) {
+        _log.warning(
+          'Could not enqueue remote delete for media $id '
+          '(sweep will reconcile)',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    if (ids.length == 1) {
+      await _mediaRepository.deleteMedia(ids.single);
+    } else {
+      await _mediaRepository.deleteMultipleMedia(ids);
+    }
+    if (enqueued && _kickWorker != null) {
+      try {
+        await _kickWorker();
+      } catch (e) {
+        _log.warning('Worker kick after media delete failed', error: e);
+      }
+    }
+  }
+
+  Future<bool> _enqueueIntent(String id) async {
+    final item = await _mediaRepository.getMediaById(id);
+    final hash = item?.contentHash;
+    if (item == null || hash == null || hash.isEmpty) return false;
+    final everUploaded =
+        item.remoteUploadedAt != null ||
+        item.remoteThumbUploadedAt != null ||
+        item.remoteCompressedUploadedAt != null;
+    if (!everUploaded) return false;
+    await _queue().enqueueDelete(
+      mediaId: id,
+      contentHash: hash,
+      originalExt: StoreKeys.extensionFor(item.originalFilename),
+      renditionExt: item.mediaType == MediaType.video ? 'mp4' : 'jpg',
+    );
+    return true;
+  }
+}

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media_store/data/media_delete_processor.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
 import 'package:submersion/features/media_store/domain/media_upload_quality.dart';
@@ -15,15 +16,22 @@ class MediaStoreWorker {
   MediaStoreWorker({
     required MediaTransferQueueRepository queue,
     required MediaUploadPipeline pipeline,
+    MediaDeleteProcessor? deleteProcessor,
     Future<bool> Function()? preflight,
     Future<WorkerGate> Function(MediaTransferQueueEntry entry)? gate,
   }) : _queue = queue,
        _pipeline = pipeline,
+       _deleteProcessor = deleteProcessor,
        _preflight = preflight,
        _gate = gate;
 
   final MediaTransferQueueRepository _queue;
   final MediaUploadPipeline _pipeline;
+
+  /// Handles direction == 'delete' entries (orphan-prevention spec 5).
+  /// Null in wiring shapes that predate the delete fast path; such
+  /// entries are parked in the defer window instead of processed.
+  final MediaDeleteProcessor? _deleteProcessor;
 
   /// Returns false to suspend the drain (store marker mismatch, design
   /// spec section 13).
@@ -68,6 +76,17 @@ class MediaStoreWorker {
             await _queue.defer(entry.id, DateTime.now().add(deferWindow));
             continue;
           }
+        }
+        if (entry.direction == 'delete') {
+          final deleteProcessor = _deleteProcessor;
+          if (deleteProcessor == null) {
+            // No processor wired: park the entry so the drain terminates;
+            // a properly wired worker picks it up later.
+            await _queue.defer(entry.id, DateTime.now().add(deferWindow));
+            continue;
+          }
+          await deleteProcessor.process(entry);
+          continue;
         }
         await _pipeline.process(entry);
       }

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -205,7 +205,10 @@ class MediaTransferQueueRepository {
   /// short-circuits to the same failure and silently burns one of the five
   /// attempts. Passing a [retryAfter] longer than that lockout keeps the
   /// attempt cap meaningful by ensuring every attempt is a real one.
-  Future<void> markFailed(int id, String error, {Duration? retryAfter}) async {
+  /// Returns true when this failure was the terminal one (attempt budget
+  /// exhausted, state now 'failed') so callers can run terminal-only
+  /// cleanup such as abandoning a resumable upload session.
+  Future<bool> markFailed(int id, String error, {Duration? retryAfter}) async {
     final row = await (_db.select(
       _db.mediaTransferQueue,
     )..where((t) => t.id.equals(id))).getSingle();
@@ -234,6 +237,7 @@ class MediaTransferQueueRepository {
         updatedAt: Value(now.millisecondsSinceEpoch),
       ),
     );
+    return terminal;
   }
 
   /// Transfers view feed: active work first, history last.

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 
 import 'package:submersion/core/database/local_cache_database.dart';
@@ -73,6 +75,53 @@ class MediaTransferQueueRepository {
             MediaTransferQueueCompanion.insert(
               mediaId: mediaId,
               overrideLevel: Value(overrideLevel),
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+    });
+  }
+
+  /// Enqueues a remote-blob delete intent (orphan-prevention spec 5.1).
+  /// One entry covers all tiers (original + thumb + rendition) of one
+  /// content hash. Idempotent per hash for every live state, mirroring
+  /// enqueueUpload's semantics: pending/transferring/failed delete rows
+  /// are reused (the sweep is the backstop for terminal failures); only
+  /// 'done' allows a fresh insert. [originalExt] and [renditionExt] are
+  /// captured here because the media row is gone by drain time.
+  Future<int> enqueueDelete({
+    required String mediaId,
+    required String contentHash,
+    required String originalExt,
+    required String renditionExt,
+  }) {
+    return _db.transaction(() async {
+      final existing =
+          await (_db.select(_db.mediaTransferQueue)
+                ..where(
+                  (t) =>
+                      t.direction.equals('delete') &
+                      t.contentHash.equals(contentHash) &
+                      t.state.isIn(['pending', 'transferring', 'failed']),
+                )
+                ..limit(1))
+              .getSingleOrNull();
+      if (existing != null) return existing.id;
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      return _db
+          .into(_db.mediaTransferQueue)
+          .insert(
+            MediaTransferQueueCompanion.insert(
+              mediaId: mediaId,
+              direction: const Value('delete'),
+              contentHash: Value(contentHash),
+              payloadJson: Value(
+                jsonEncode({
+                  'originalExt': originalExt,
+                  'renditionExt': renditionExt,
+                }),
+              ),
               createdAt: now,
               updatedAt: now,
             ),
@@ -201,10 +250,14 @@ class MediaTransferQueueRepository {
     });
   }
 
-  /// Newest queue row for [mediaId] in any state, or null when none.
+  /// Newest upload row for [mediaId] in any state, or null when none.
+  /// Delete rows are excluded: they describe a dead row's blob, not this
+  /// item's transfer status.
   Stream<MediaTransferQueueEntry?> watchLatestForMedia(String mediaId) {
     return (_db.select(_db.mediaTransferQueue)
-          ..where((t) => t.mediaId.equals(mediaId))
+          ..where(
+            (t) => t.mediaId.equals(mediaId) & t.direction.equals('upload'),
+          )
           ..orderBy([(t) => OrderingTerm.desc(t.id)])
           ..limit(1))
         .watchSingleOrNull();

--- a/lib/features/media_store/data/media_upload_pipeline.dart
+++ b/lib/features/media_store/data/media_upload_pipeline.dart
@@ -103,6 +103,11 @@ class MediaUploadPipeline {
 
     File? staged;
     CompressionResult? rendition;
+    // Freshest resume state and its key, for terminal-failure session
+    // abandonment (orphan-prevention spec 5.5): the queue row's copy can
+    // lag when this very attempt created the session.
+    var latestResumeJson = entry.resumeStateJson;
+    String? resumableUploadKey;
     try {
       staged = await _materialize(item);
       if (staged == null) {
@@ -241,13 +246,16 @@ class MediaUploadPipeline {
         // Resume state survives failures on the queue row; content
         // addressing makes replaying it against a re-materialized staging
         // copy safe (identical bytes, identical part boundaries).
+        resumableUploadKey = key;
         await _store.putFile(
           key,
           staged,
           contentType: StoreKeys.contentTypeFor(extension),
           resumeStateJson: entry.resumeStateJson,
-          onResumeStateChanged: (json) =>
-              unawaited(_queue.updateResumeState(entry.id, json)),
+          onResumeStateChanged: (json) {
+            latestResumeJson = json;
+            unawaited(_queue.updateResumeState(entry.id, json));
+          },
           onProgress: (sent, total) => unawaited(
             _queue.updateProgress(
               entry.id,
@@ -291,7 +299,23 @@ class MediaUploadPipeline {
         error: e,
         stackTrace: stackTrace,
       );
-      await _queue.markFailed(entry.id, e.toString());
+      final terminal = await _queue.markFailed(entry.id, e.toString());
+      // Terminal failure means the resume state will never be replayed:
+      // abandon any provider-side session so its parts cannot strand
+      // (orphan-prevention spec 5.5). retry() re-arms with the preserved
+      // resume state; _validateResume then finds the session gone and
+      // starts fresh - graceful either way.
+      final abandonKey = resumableUploadKey;
+      if (terminal && abandonKey != null && latestResumeJson != null) {
+        try {
+          await _store.abandonResume(abandonKey, latestResumeJson);
+        } on Exception catch (abortError) {
+          _log.warning(
+            'Abandoning upload session failed for $abandonKey',
+            error: abortError,
+          );
+        }
+      }
       // Photos re-compress cheaply, so their rendition staging file is
       // discarded on failure (Phase A leaked it). Video renditions are
       // deterministic and PRESERVED for the retry (spec section 8).

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -52,20 +52,30 @@ class _TransferTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
+    // Delete entries (remote-blob cleanup for deleted media) share the
+    // upload lifecycle but read differently: the active label says what
+    // is actually happening, and every state keeps the delete icon so a
+    // row never looks like an upload.
+    final isDelete = entry.direction == 'delete';
     final (icon, label) = switch (entry.state) {
       'transferring' => (
-        Icons.cloud_upload,
-        l10n.settings_mediaStorage_transfers_state_transferring,
+        isDelete ? Icons.delete_outline : Icons.cloud_upload,
+        isDelete
+            ? l10n.settings_mediaStorage_transfers_state_deleting
+            : l10n.settings_mediaStorage_transfers_state_transferring,
       ),
       'failed' => (
         Icons.error_outline,
         l10n.settings_mediaStorage_transfers_state_failed,
       ),
       'done' => (
-        Icons.cloud_done,
+        isDelete ? Icons.delete_outline : Icons.cloud_done,
         l10n.settings_mediaStorage_transfers_state_done,
       ),
-      _ => (Icons.schedule, l10n.settings_mediaStorage_transfers_state_pending),
+      _ => (
+        isDelete ? Icons.delete_outline : Icons.schedule,
+        l10n.settings_mediaStorage_transfers_state_pending,
+      ),
     };
     return ListTile(
       leading: Icon(

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -53,9 +53,11 @@ class _TransferTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     // Delete entries (remote-blob cleanup for deleted media) share the
-    // upload lifecycle but read differently: the active label says what
-    // is actually happening, and every state keeps the delete icon so a
-    // row never looks like an upload.
+    // upload lifecycle but read differently: the active label says what is
+    // actually happening, and the delete icon replaces every cloud icon so
+    // a row never looks like an upload. 'failed' is the deliberate
+    // exception - what went wrong outranks which direction it was going, so
+    // both directions keep the error icon in the error color.
     final isDelete = entry.direction == 'delete';
     final (icon, label) = switch (entry.state) {
       'transferring' => (

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/media/presentation/providers/media_resolver_
 import 'package:submersion/features/media_store/data/media_backfill_service.dart';
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
 import 'package:submersion/features/media_store/data/media_delete_processor.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
 import 'package:submersion/features/media_store/data/media_store_service.dart';
 import 'package:submersion/features/media_store/data/media_store_worker.dart';
 import 'package:submersion/features/media_store/data/media_stores_repository.dart';
@@ -86,6 +87,23 @@ final FutureProvider<void> mediaTransferQueueReclaimProvider =
     FutureProvider<void>((ref) async {
       await ref.read(mediaTransferQueueRepositoryProvider).requeueStale();
     });
+
+/// Deletion entry point for UI flows: enqueue-before-delete per the
+/// orphan-prevention spec (5.2). The queue and runtime are read lazily
+/// (never watched) so consumer widget tests without a media store runtime
+/// are unaffected, and the coordinator itself swallows enqueue failures.
+final mediaDeletionCoordinatorProvider = Provider<MediaDeletionCoordinator>((
+  ref,
+) {
+  return MediaDeletionCoordinator(
+    mediaRepository: ref.watch(mediaRepositoryProvider),
+    queue: () => ref.read(mediaTransferQueueRepositoryProvider),
+    kickWorker: () async {
+      final runtime = await ref.read(mediaStoreRuntimeProvider.future);
+      await runtime?.worker?.drain();
+    },
+  );
+});
 
 final mediaBackfillServiceProvider = Provider<MediaBackfillService>(
   (ref) => MediaBackfillService(

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/media/presentation/providers/media_providers
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/features/media_store/data/media_backfill_service.dart';
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_delete_processor.dart';
 import 'package:submersion/features/media_store/data/media_store_service.dart';
 import 'package:submersion/features/media_store/data/media_store_worker.dart';
 import 'package:submersion/features/media_store/data/media_stores_repository.dart';
@@ -207,9 +208,15 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         cache: cache,
         videoTranscoder: PlatformVideoTranscoder(),
       );
+      final deleteProcessor = MediaDeleteProcessor(
+        queue: MediaTransferQueueRepository(),
+        store: store,
+        mediaRepository: mediaRepository,
+      );
       final worker = MediaStoreWorker(
         queue: MediaTransferQueueRepository(),
         pipeline: pipeline,
+        deleteProcessor: deleteProcessor,
         preflight: () async {
           // Suspend all transfers when this device detached (attach state
           // re-read, not captured: disconnect can land while a drain is
@@ -225,6 +232,10 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
           // drain; cellular defers anything the policy disallows.
           final kind = await network.current();
           if (kind == NetworkKind.offline) return WorkerGate.stopDraining;
+          // Deletes are tiny API calls with no payload: exempt from the
+          // cellular media policies, gated only by being online
+          // (orphan-prevention spec 5.6).
+          if (entry.direction == 'delete') return WorkerGate.proceed;
           if (kind == NetworkKind.cellular) {
             final item = await mediaRepository.getMediaById(entry.mediaId);
             final isVideo = item?.mediaType == MediaType.video;

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "مسح المكتملة",
   "settings_mediaStorage_transfers_state_pending": "في الانتظار",
   "settings_mediaStorage_transfers_state_transferring": "جارٍ الرفع",
+  "settings_mediaStorage_transfers_state_deleting": "جارٍ الإزالة من السحابة",
   "settings_mediaStorage_transfers_state_done": "تم",
   "settings_mediaStorage_transfers_state_failed": "فشل",
   "settings_mediaStorage_backfill_action": "رفع المكتبة الحالية",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Abgeschlossene entfernen",
   "settings_mediaStorage_transfers_state_pending": "Wartend",
   "settings_mediaStorage_transfers_state_transferring": "Wird hochgeladen",
+  "settings_mediaStorage_transfers_state_deleting": "Wird aus der Cloud entfernt",
   "settings_mediaStorage_transfers_state_done": "Fertig",
   "settings_mediaStorage_transfers_state_failed": "Fehlgeschlagen",
   "settings_mediaStorage_backfill_action": "Vorhandene Bibliothek hochladen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12825,6 +12825,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Clear completed",
   "settings_mediaStorage_transfers_state_pending": "Waiting",
   "settings_mediaStorage_transfers_state_transferring": "Uploading",
+  "settings_mediaStorage_transfers_state_deleting": "Removing from cloud",
   "settings_mediaStorage_transfers_state_done": "Done",
   "settings_mediaStorage_transfers_state_failed": "Failed",
   "settings_mediaStorage_backfill_action": "Upload existing library",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Borrar completadas",
   "settings_mediaStorage_transfers_state_pending": "En espera",
   "settings_mediaStorage_transfers_state_transferring": "Subiendo",
+  "settings_mediaStorage_transfers_state_deleting": "Eliminando de la nube",
   "settings_mediaStorage_transfers_state_done": "Completado",
   "settings_mediaStorage_transfers_state_failed": "Fallido",
   "settings_mediaStorage_backfill_action": "Subir biblioteca existente",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Effacer les terminés",
   "settings_mediaStorage_transfers_state_pending": "En attente",
   "settings_mediaStorage_transfers_state_transferring": "Envoi en cours",
+  "settings_mediaStorage_transfers_state_deleting": "Suppression du cloud",
   "settings_mediaStorage_transfers_state_done": "Terminé",
   "settings_mediaStorage_transfers_state_failed": "Échec",
   "settings_mediaStorage_backfill_action": "Envoyer la bibliothèque existante",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "נקה שהושלמו",
   "settings_mediaStorage_transfers_state_pending": "ממתין",
   "settings_mediaStorage_transfers_state_transferring": "מעלה",
+  "settings_mediaStorage_transfers_state_deleting": "מסיר מהענן",
   "settings_mediaStorage_transfers_state_done": "הושלם",
   "settings_mediaStorage_transfers_state_failed": "נכשל",
   "settings_mediaStorage_backfill_action": "העלה ספריה קיימת",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Befejezettek törlése",
   "settings_mediaStorage_transfers_state_pending": "Várakozik",
   "settings_mediaStorage_transfers_state_transferring": "Feltöltés",
+  "settings_mediaStorage_transfers_state_deleting": "Eltávolítás a felhőből",
   "settings_mediaStorage_transfers_state_done": "Kész",
   "settings_mediaStorage_transfers_state_failed": "Sikertelen",
   "settings_mediaStorage_backfill_action": "Meglévő könyvtár feltöltése",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Rimuovi completati",
   "settings_mediaStorage_transfers_state_pending": "In attesa",
   "settings_mediaStorage_transfers_state_transferring": "Caricamento",
+  "settings_mediaStorage_transfers_state_deleting": "Rimozione dal cloud",
   "settings_mediaStorage_transfers_state_done": "Completato",
   "settings_mediaStorage_transfers_state_failed": "Non riuscito",
   "settings_mediaStorage_backfill_action": "Carica libreria esistente",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -34146,6 +34146,12 @@ abstract class AppLocalizations {
   /// **'Uploading'**
   String get settings_mediaStorage_transfers_state_transferring;
 
+  /// No description provided for @settings_mediaStorage_transfers_state_deleting.
+  ///
+  /// In en, this message translates to:
+  /// **'Removing from cloud'**
+  String get settings_mediaStorage_transfers_state_deleting;
+
   /// No description provided for @settings_mediaStorage_transfers_state_done.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -20070,6 +20070,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'جارٍ الرفع';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'جارٍ الإزالة من السحابة';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'تم';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20408,6 +20408,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wird hochgeladen';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Wird aus der Cloud entfernt';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Fertig';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -20093,6 +20093,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'Uploading';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Removing from cloud';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Done';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20455,6 +20455,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'Subiendo';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Eliminando de la nube';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Completado';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20513,6 +20513,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Envoi en cours';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Suppression du cloud';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Terminé';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -19925,6 +19925,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'מעלה';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting => 'מסיר מהענן';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'הושלם';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20383,6 +20383,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'Feltöltés';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Eltávolítás a felhőből';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Kész';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20442,6 +20442,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Caricamento';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Rimozione dal cloud';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Completato';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20274,6 +20274,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'Uploaden';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Verwijderen uit de cloud';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Klaar';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20447,6 +20447,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => 'Enviando';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting =>
+      'Removendo da nuvem';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => 'Concluído';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19396,6 +19396,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_transferring => '上传中';
 
   @override
+  String get settings_mediaStorage_transfers_state_deleting => '正在从云端移除';
+
+  @override
   String get settings_mediaStorage_transfers_state_done => '已完成';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Voltooide wissen",
   "settings_mediaStorage_transfers_state_pending": "Wachten",
   "settings_mediaStorage_transfers_state_transferring": "Uploaden",
+  "settings_mediaStorage_transfers_state_deleting": "Verwijderen uit de cloud",
   "settings_mediaStorage_transfers_state_done": "Klaar",
   "settings_mediaStorage_transfers_state_failed": "Mislukt",
   "settings_mediaStorage_backfill_action": "Bestaande bibliotheek uploaden",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "Limpar concluídas",
   "settings_mediaStorage_transfers_state_pending": "Aguardando",
   "settings_mediaStorage_transfers_state_transferring": "Enviando",
+  "settings_mediaStorage_transfers_state_deleting": "Removendo da nuvem",
   "settings_mediaStorage_transfers_state_done": "Concluído",
   "settings_mediaStorage_transfers_state_failed": "Falhou",
   "settings_mediaStorage_backfill_action": "Enviar biblioteca existente",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5819,6 +5819,7 @@
   "settings_mediaStorage_transfers_clearCompleted": "清除已完成",
   "settings_mediaStorage_transfers_state_pending": "等待中",
   "settings_mediaStorage_transfers_state_transferring": "上传中",
+  "settings_mediaStorage_transfers_state_deleting": "正在从云端移除",
   "settings_mediaStorage_transfers_state_done": "已完成",
   "settings_mediaStorage_transfers_state_failed": "失败",
   "settings_mediaStorage_backfill_action": "上传现有媒体库",

--- a/test/core/services/media_store/s3_media_object_store_abort_test.dart
+++ b/test/core/services/media_store/s3_media_object_store_abort_test.dart
@@ -48,63 +48,69 @@ void main() {
 
   const key = 'smv1/objects/aa/aabb.mp4';
 
-  test('putFile without resume persistence aborts the session on failure',
-      () async {
-    final store = build();
-    final src = await bigSource();
-    server.failAfterPartUploads = 1;
-    await expectLater(
-      store.putFile(key, src, contentType: 'video/mp4'),
-      throwsA(isA<MediaStoreException>()),
-    );
-    server.failAfterPartUploads = null;
-    expect(server.activeMultipartUploadCount, 0);
-  });
+  test(
+    'putFile without resume persistence aborts the session on failure',
+    () async {
+      final store = build();
+      final src = await bigSource();
+      server.failAfterPartUploads = 1;
+      await expectLater(
+        store.putFile(key, src, contentType: 'video/mp4'),
+        throwsA(isA<MediaStoreException>()),
+      );
+      server.failAfterPartUploads = null;
+      expect(server.activeMultipartUploadCount, 0);
+    },
+  );
 
-  test('putFile WITH resume persistence keeps the session for resume',
-      () async {
-    final store = build();
-    final src = await bigSource();
-    server.failAfterPartUploads = 1;
-    String? resume;
-    await expectLater(
-      store.putFile(
-        key,
-        src,
-        contentType: 'video/mp4',
-        onResumeStateChanged: (json) => resume = json,
-      ),
-      throwsA(isA<MediaStoreException>()),
-    );
-    server.failAfterPartUploads = null;
-    expect(server.activeMultipartUploadCount, 1);
-    expect(resume, isNotNull);
-  });
+  test(
+    'putFile WITH resume persistence keeps the session for resume',
+    () async {
+      final store = build();
+      final src = await bigSource();
+      server.failAfterPartUploads = 1;
+      String? resume;
+      await expectLater(
+        store.putFile(
+          key,
+          src,
+          contentType: 'video/mp4',
+          onResumeStateChanged: (json) => resume = json,
+        ),
+        throwsA(isA<MediaStoreException>()),
+      );
+      server.failAfterPartUploads = null;
+      expect(server.activeMultipartUploadCount, 1);
+      expect(resume, isNotNull);
+    },
+  );
 
-  test('abandonResume aborts the recorded session and tolerates junk',
-      () async {
-    final store = build();
-    final src = await bigSource();
-    server.failAfterPartUploads = 1;
-    String? resume;
-    await expectLater(
-      store.putFile(
-        key,
-        src,
-        contentType: 'video/mp4',
-        onResumeStateChanged: (json) => resume = json,
-      ),
-      throwsA(isA<MediaStoreException>()),
-    );
-    server.failAfterPartUploads = null;
-    expect(server.activeMultipartUploadCount, 1);
+  test(
+    'abandonResume aborts the recorded session and tolerates junk',
+    () async {
+      final store = build();
+      final src = await bigSource();
+      server.failAfterPartUploads = 1;
+      String? resume;
+      await expectLater(
+        store.putFile(
+          key,
+          src,
+          contentType: 'video/mp4',
+          onResumeStateChanged: (json) => resume = json,
+        ),
+        throwsA(isA<MediaStoreException>()),
+      );
+      server.failAfterPartUploads = null;
+      expect(server.activeMultipartUploadCount, 1);
 
-    await store.abandonResume(key, resume);
-    expect(server.activeMultipartUploadCount, 0);
+      await store.abandonResume(key, resume);
+      expect(server.activeMultipartUploadCount, 0);
 
-    // Junk inputs are silently tolerated.
-    await store.abandonResume(key, 'not json');
-    await store.abandonResume(key, '{"noUploadId":true}');
-    await store.abandonResume(key, null);
-  });
+      // Junk inputs are silently tolerated.
+      await store.abandonResume(key, 'not json');
+      await store.abandonResume(key, '{"noUploadId":true}');
+      await store.abandonResume(key, null);
+    },
+  );
 }

--- a/test/core/services/media_store/s3_media_object_store_abort_test.dart
+++ b/test/core/services/media_store/s3_media_object_store_abort_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_api_client.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/core/services/media_store/s3_media_object_store.dart';
+
+import '../../../helpers/fake_s3_server.dart';
+
+void main() {
+  late Directory tmp;
+  late FakeS3Server server;
+
+  S3MediaObjectStore build() {
+    final config = S3Config(
+      endpoint: 'http://localhost:9000',
+      bucket: 'test-bucket',
+      prefix: 'submersion-media/',
+      accessKeyId: 'AKIA_TEST',
+      secretAccessKey: 'secret',
+    );
+    return S3MediaObjectStore(
+      client: S3ApiClient(
+        config,
+        httpClient: server.client,
+        retryDelay: const Duration(milliseconds: 1),
+      ),
+      keyPrefix: config.prefix,
+      partSizeBytes: 64 * 1024,
+      downloadChunkBytes: 64 * 1024,
+    );
+  }
+
+  setUp(() async {
+    server = FakeS3Server();
+    tmp = await Directory.systemTemp.createTemp('s3_abort_test');
+  });
+
+  tearDown(() => tmp.delete(recursive: true));
+
+  Future<File> bigSource() async {
+    // Three 64 KiB parts.
+    final f = File('${tmp.path}/src.mp4');
+    await f.writeAsBytes(List.filled(3 * 64 * 1024, 7), flush: true);
+    return f;
+  }
+
+  const key = 'smv1/objects/aa/aabb.mp4';
+
+  test('putFile without resume persistence aborts the session on failure',
+      () async {
+    final store = build();
+    final src = await bigSource();
+    server.failAfterPartUploads = 1;
+    await expectLater(
+      store.putFile(key, src, contentType: 'video/mp4'),
+      throwsA(isA<MediaStoreException>()),
+    );
+    server.failAfterPartUploads = null;
+    expect(server.activeMultipartUploadCount, 0);
+  });
+
+  test('putFile WITH resume persistence keeps the session for resume',
+      () async {
+    final store = build();
+    final src = await bigSource();
+    server.failAfterPartUploads = 1;
+    String? resume;
+    await expectLater(
+      store.putFile(
+        key,
+        src,
+        contentType: 'video/mp4',
+        onResumeStateChanged: (json) => resume = json,
+      ),
+      throwsA(isA<MediaStoreException>()),
+    );
+    server.failAfterPartUploads = null;
+    expect(server.activeMultipartUploadCount, 1);
+    expect(resume, isNotNull);
+  });
+
+  test('abandonResume aborts the recorded session and tolerates junk',
+      () async {
+    final store = build();
+    final src = await bigSource();
+    server.failAfterPartUploads = 1;
+    String? resume;
+    await expectLater(
+      store.putFile(
+        key,
+        src,
+        contentType: 'video/mp4',
+        onResumeStateChanged: (json) => resume = json,
+      ),
+      throwsA(isA<MediaStoreException>()),
+    );
+    server.failAfterPartUploads = null;
+    expect(server.activeMultipartUploadCount, 1);
+
+    await store.abandonResume(key, resume);
+    expect(server.activeMultipartUploadCount, 0);
+
+    // Junk inputs are silently tolerated.
+    await store.abandonResume(key, 'not json');
+    await store.abandonResume(key, '{"noUploadId":true}');
+    await store.abandonResume(key, null);
+  });
+}

--- a/test/core/services/media_store/s3_media_object_store_abort_test.dart
+++ b/test/core/services/media_store/s3_media_object_store_abort_test.dart
@@ -85,6 +85,60 @@ void main() {
     },
   );
 
+  test('a session failing on its FIRST part is still abandonable', () async {
+    // The persistence branch deliberately does not abort, trusting the
+    // caller to abandon later - which is only possible if the caller was
+    // ever told the uploadId. Emitting resume state at session creation
+    // (not after part 1) is what makes that true in the likeliest
+    // failure position of all.
+    final store = build();
+    final src = await bigSource();
+    server.failAfterPartUploads = 0;
+    String? resume;
+    await expectLater(
+      store.putFile(
+        key,
+        src,
+        contentType: 'video/mp4',
+        onResumeStateChanged: (json) => resume = json,
+      ),
+      throwsA(isA<MediaStoreException>()),
+    );
+    server.failAfterPartUploads = null;
+    expect(server.activeMultipartUploadCount, 1);
+    expect(resume, isNotNull, reason: 'uploadId must reach the caller');
+
+    await store.abandonResume(key, resume);
+    expect(server.activeMultipartUploadCount, 0);
+  });
+
+  test('a zero-part resume state resumes from part 1', () async {
+    final store = build();
+    final src = await bigSource();
+    server.failAfterPartUploads = 0;
+    String? resume;
+    await expectLater(
+      store.putFile(
+        key,
+        src,
+        contentType: 'video/mp4',
+        onResumeStateChanged: (json) => resume = json,
+      ),
+      throwsA(isA<MediaStoreException>()),
+    );
+    server.failAfterPartUploads = null;
+
+    await store.putFile(
+      key,
+      src,
+      contentType: 'video/mp4',
+      resumeStateJson: resume,
+      onResumeStateChanged: (json) => resume = json,
+    );
+    expect(server.activeMultipartUploadCount, 0);
+    expect(server.objects.containsKey('submersion-media/$key'), isTrue);
+  });
+
   test(
     'abandonResume aborts the recorded session and tolerates junk',
     () async {

--- a/test/features/media/data/media_repository_compressed_test.dart
+++ b/test/features/media/data/media_repository_compressed_test.dart
@@ -68,6 +68,19 @@ void main() {
     },
   );
 
+  test(
+    'countRowsWithHash counts every row with the hash, uploaded or not',
+    () async {
+      await repo.createMedia(
+        photo('u1', hash: 'hh').copyWith(remoteUploadedAt: DateTime(2026)),
+      );
+      await repo.createMedia(photo('u2', hash: 'hh')); // never uploaded
+      await repo.createMedia(photo('u3', hash: 'other'));
+      expect(await repo.countRowsWithHash('hh'), 2);
+      expect(await repo.countRowsWithHash('nope'), 0);
+    },
+  );
+
   test('compressed-only photo is NOT a backfill candidate', () async {
     await repo.createMedia(
       photo(

--- a/test/features/media/presentation/providers/files_tab_providers_test.dart
+++ b/test/features/media/presentation/providers/files_tab_providers_test.dart
@@ -422,9 +422,7 @@ void main() {
       final notifier = container.read(filesTabNotifierProvider.notifier);
       await notifier.undoCommit(['id-1', 'id-2', 'id-3']);
 
-      verify(
-        mockRepo.deleteMultipleMedia(['id-1', 'id-2', 'id-3']),
-      ).called(1);
+      verify(mockRepo.deleteMultipleMedia(['id-1', 'id-2', 'id-3'])).called(1);
     });
 
     test('undoCommit on empty list deletes nothing', () async {

--- a/test/features/media/presentation/providers/files_tab_providers_test.dart
+++ b/test/features/media/presentation/providers/files_tab_providers_test.dart
@@ -411,18 +411,24 @@ void main() {
       expect(container.read(filesTabNotifierProvider), FilesTabState.initial());
     });
 
-    test('undoCommit calls deleteMedia for each id', () async {
-      when(mockRepo.deleteMedia(any)).thenAnswer((_) async {});
+    test('undoCommit deletes the committed rows via the deletion '
+        'coordinator', () async {
+      // The provider-wired notifier routes through the deletion
+      // coordinator, which looks each row up (for a possible remote-blob
+      // delete intent) and then batch-deletes.
+      when(mockRepo.getMediaById(any)).thenAnswer((_) async => null);
+      when(mockRepo.deleteMultipleMedia(any)).thenAnswer((_) async {});
 
       final notifier = container.read(filesTabNotifierProvider.notifier);
       await notifier.undoCommit(['id-1', 'id-2', 'id-3']);
 
-      verify(mockRepo.deleteMedia('id-1')).called(1);
-      verify(mockRepo.deleteMedia('id-2')).called(1);
-      verify(mockRepo.deleteMedia('id-3')).called(1);
+      verify(
+        mockRepo.deleteMultipleMedia(['id-1', 'id-2', 'id-3']),
+      ).called(1);
     });
 
-    test('undoCommit on empty list is a no-op', () async {
+    test('undoCommit on empty list deletes nothing', () async {
+      when(mockRepo.deleteMultipleMedia(any)).thenAnswer((_) async {});
       final notifier = container.read(filesTabNotifierProvider.notifier);
       await notifier.undoCommit(const []);
       verifyNever(mockRepo.deleteMedia(any));

--- a/test/features/media_store/media_delete_processor_test.dart
+++ b/test/features/media_store/media_delete_processor_test.dart
@@ -63,6 +63,28 @@ void main() {
     },
   );
 
+  test('deletes extension variants the payload never recorded', () async {
+    // Identical bytes reach the store under different keys: `.JPG` and
+    // `.jpeg` normalize differently and a row with no filename keys on
+    // `.bin`. The per-hash enqueue dedupe keeps only the first intent's
+    // payload, so the recorded extension cannot be the whole truth.
+    store.objects[originalKey] = [1];
+    store.objects[StoreKeys.objectKey(hash, extension: 'jpeg')] = [2];
+    store.objects[StoreKeys.objectKey(hash, extension: 'bin')] = [3];
+    store.objects[thumbKey] = [4];
+    store.objects[renditionKey] = [5];
+    store.objects[StoreKeys.renditionKey(hash, ext: 'mp4')] = [6];
+    // A different hash sharing the same two-character shard must survive.
+    const sibling = 'aaffeedd';
+    final siblingKey = StoreKeys.objectKey(sibling, extension: 'jpg');
+    store.objects[siblingKey] = [9];
+
+    await processor.process(await deleteEntry());
+
+    expect(store.objects.keys, [siblingKey]);
+    expect((await queue.allForTesting()).single.state, 'done');
+  });
+
   test('skips deletion when any row still references the hash', () async {
     await mediaRepository.createMedia(
       MediaItem(

--- a/test/features/media_store/media_delete_processor_test.dart
+++ b/test/features/media_store/media_delete_processor_test.dart
@@ -1,0 +1,121 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media_store/data/media_delete_processor.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+void main() {
+  late LocalCacheDatabase cacheDb;
+  late MediaTransferQueueRepository queue;
+  late MediaRepository mediaRepository;
+  late InMemoryMediaObjectStore store;
+  late MediaDeleteProcessor processor;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    mediaRepository = MediaRepository();
+    store = InMemoryMediaObjectStore();
+    processor = MediaDeleteProcessor(
+      queue: queue,
+      store: store,
+      mediaRepository: mediaRepository,
+    );
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    await tearDownTestDatabase();
+  });
+
+  const hash = 'aabbccdd';
+  final originalKey = StoreKeys.objectKey(hash, extension: 'jpg');
+  final thumbKey = StoreKeys.thumbKey(hash);
+  final renditionKey = StoreKeys.renditionKey(hash, ext: 'jpg');
+
+  Future<MediaTransferQueueEntry> deleteEntry() async {
+    final id = await queue.enqueueDelete(
+      mediaId: 'gone',
+      contentHash: hash,
+      originalExt: 'jpg',
+      renditionExt: 'jpg',
+    );
+    return (await queue.allForTesting()).firstWhere((r) => r.id == id);
+  }
+
+  test('deletes all three tiers and marks done when hash is unreferenced',
+      () async {
+    store.objects[originalKey] = [1, 2, 3];
+    store.objects[thumbKey] = [4];
+    store.objects[renditionKey] = [5];
+    await processor.process(await deleteEntry());
+    expect(store.objects, isEmpty);
+    expect((await queue.allForTesting()).single.state, 'done');
+  });
+
+  test('skips deletion when any row still references the hash', () async {
+    await mediaRepository.createMedia(
+      MediaItem(
+        id: 'still-here',
+        mediaType: MediaType.photo,
+        takenAt: DateTime(2026),
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        contentHash: hash,
+      ),
+    );
+    store.objects[originalKey] = [1];
+    await processor.process(await deleteEntry());
+    expect(store.objects.keys, contains(originalKey));
+    expect((await queue.allForTesting()).single.state, 'done');
+  });
+
+  test('store failure marks the entry failed for retry', () async {
+    store.objects[originalKey] = [1];
+    store.failDeleteWith = Exception('boom');
+    await processor.process(await deleteEntry());
+    final row = (await queue.allForTesting()).single;
+    expect(row.state, 'pending'); // attempt 1 of 5, backoff scheduled
+    expect(row.attempts, 1);
+    expect(row.errorMessage, contains('boom'));
+  });
+
+  test('malformed payload still deletes the thumb via fallback defaults',
+      () async {
+    final entryBefore = await deleteEntry();
+    // Corrupt the payload behind the repository's back.
+    await (cacheDb.update(cacheDb.mediaTransferQueue)
+          ..where((t) => t.id.equals(entryBefore.id)))
+        .write(const MediaTransferQueueCompanion(payloadJson: Value('nope')));
+    store.objects[thumbKey] = [4];
+    final entry = (await queue.allForTesting()).single;
+    await processor.process(entry);
+    expect(store.objects, isEmpty);
+    expect((await queue.allForTesting()).single.state, 'done');
+  });
+
+  test('an entry without a content hash completes without touching the store',
+      () async {
+    final id = await queue.enqueueDelete(
+      mediaId: 'gone',
+      contentHash: 'temp',
+      originalExt: 'jpg',
+      renditionExt: 'jpg',
+    );
+    await (cacheDb.update(cacheDb.mediaTransferQueue)
+          ..where((t) => t.id.equals(id)))
+        .write(const MediaTransferQueueCompanion(contentHash: Value(null)));
+    store.objects[thumbKey] = [4];
+    await processor.process((await queue.allForTesting()).single);
+    expect(store.objects.keys, contains(thumbKey));
+    expect((await queue.allForTesting()).single.state, 'done');
+  });
+}

--- a/test/features/media_store/media_delete_processor_test.dart
+++ b/test/features/media_store/media_delete_processor_test.dart
@@ -51,15 +51,17 @@ void main() {
     return (await queue.allForTesting()).firstWhere((r) => r.id == id);
   }
 
-  test('deletes all three tiers and marks done when hash is unreferenced',
-      () async {
-    store.objects[originalKey] = [1, 2, 3];
-    store.objects[thumbKey] = [4];
-    store.objects[renditionKey] = [5];
-    await processor.process(await deleteEntry());
-    expect(store.objects, isEmpty);
-    expect((await queue.allForTesting()).single.state, 'done');
-  });
+  test(
+    'deletes all three tiers and marks done when hash is unreferenced',
+    () async {
+      store.objects[originalKey] = [1, 2, 3];
+      store.objects[thumbKey] = [4];
+      store.objects[renditionKey] = [5];
+      await processor.process(await deleteEntry());
+      expect(store.objects, isEmpty);
+      expect((await queue.allForTesting()).single.state, 'done');
+    },
+  );
 
   test('skips deletion when any row still references the hash', () async {
     await mediaRepository.createMedia(
@@ -88,34 +90,38 @@ void main() {
     expect(row.errorMessage, contains('boom'));
   });
 
-  test('malformed payload still deletes the thumb via fallback defaults',
-      () async {
-    final entryBefore = await deleteEntry();
-    // Corrupt the payload behind the repository's back.
-    await (cacheDb.update(cacheDb.mediaTransferQueue)
-          ..where((t) => t.id.equals(entryBefore.id)))
-        .write(const MediaTransferQueueCompanion(payloadJson: Value('nope')));
-    store.objects[thumbKey] = [4];
-    final entry = (await queue.allForTesting()).single;
-    await processor.process(entry);
-    expect(store.objects, isEmpty);
-    expect((await queue.allForTesting()).single.state, 'done');
-  });
+  test(
+    'malformed payload still deletes the thumb via fallback defaults',
+    () async {
+      final entryBefore = await deleteEntry();
+      // Corrupt the payload behind the repository's back.
+      await (cacheDb.update(cacheDb.mediaTransferQueue)
+            ..where((t) => t.id.equals(entryBefore.id)))
+          .write(const MediaTransferQueueCompanion(payloadJson: Value('nope')));
+      store.objects[thumbKey] = [4];
+      final entry = (await queue.allForTesting()).single;
+      await processor.process(entry);
+      expect(store.objects, isEmpty);
+      expect((await queue.allForTesting()).single.state, 'done');
+    },
+  );
 
-  test('an entry without a content hash completes without touching the store',
-      () async {
-    final id = await queue.enqueueDelete(
-      mediaId: 'gone',
-      contentHash: 'temp',
-      originalExt: 'jpg',
-      renditionExt: 'jpg',
-    );
-    await (cacheDb.update(cacheDb.mediaTransferQueue)
-          ..where((t) => t.id.equals(id)))
-        .write(const MediaTransferQueueCompanion(contentHash: Value(null)));
-    store.objects[thumbKey] = [4];
-    await processor.process((await queue.allForTesting()).single);
-    expect(store.objects.keys, contains(thumbKey));
-    expect((await queue.allForTesting()).single.state, 'done');
-  });
+  test(
+    'an entry without a content hash completes without touching the store',
+    () async {
+      final id = await queue.enqueueDelete(
+        mediaId: 'gone',
+        contentHash: 'temp',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      await (cacheDb.update(cacheDb.mediaTransferQueue)
+            ..where((t) => t.id.equals(id)))
+          .write(const MediaTransferQueueCompanion(contentHash: Value(null)));
+      store.objects[thumbKey] = [4];
+      await processor.process((await queue.allForTesting()).single);
+      expect(store.objects.keys, contains(thumbKey));
+      expect((await queue.allForTesting()).single.state, 'done');
+    },
+  );
 }

--- a/test/features/media_store/media_deletion_coordinator_test.dart
+++ b/test/features/media_store/media_deletion_coordinator_test.dart
@@ -1,0 +1,112 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+import '../../helpers/test_database.dart';
+
+void main() {
+  late LocalCacheDatabase cacheDb;
+  late MediaTransferQueueRepository queue;
+  late MediaRepository repo;
+  late int kicks;
+  late MediaDeletionCoordinator coordinator;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    repo = MediaRepository();
+    kicks = 0;
+    coordinator = MediaDeletionCoordinator(
+      mediaRepository: repo,
+      queue: () => queue,
+      kickWorker: () async => kicks++,
+    );
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    await tearDownTestDatabase();
+  });
+
+  MediaItem photo(
+    String id, {
+    String? hash,
+    DateTime? uploadedAt,
+    MediaType mediaType = MediaType.photo,
+  }) => MediaItem(
+    id: id,
+    mediaType: mediaType,
+    originalFilename: 'p.jpeg',
+    takenAt: DateTime(2026),
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    contentHash: hash,
+    remoteUploadedAt: uploadedAt,
+  );
+
+  test('enqueues delete intent, then deletes the row, then kicks', () async {
+    await repo.createMedia(
+      photo('m1', hash: 'aa', uploadedAt: DateTime(2026, 2)),
+    );
+    await coordinator.deleteMedia('m1');
+    expect(await repo.getMediaById('m1'), isNull);
+    final row = (await queue.allForTesting()).single;
+    expect(row.direction, 'delete');
+    expect(row.contentHash, 'aa');
+    expect(row.payloadJson, contains('"originalExt":"jpeg"'));
+    expect(row.payloadJson, contains('"renditionExt":"jpg"'));
+    expect(kicks, 1);
+  });
+
+  test('videos record an mp4 rendition extension', () async {
+    await repo.createMedia(
+      photo(
+        'v1',
+        hash: 'bb',
+        uploadedAt: DateTime(2026, 2),
+        mediaType: MediaType.video,
+      ),
+    );
+    await coordinator.deleteMedia('v1');
+    expect(
+      (await queue.allForTesting()).single.payloadJson,
+      contains('"renditionExt":"mp4"'),
+    );
+  });
+
+  test('never-uploaded and hashless rows delete without enqueueing',
+      () async {
+    await repo.createMedia(photo('m2', hash: 'bb')); // hash, no stamp
+    await repo.createMedia(photo('m3')); // no hash
+    await coordinator.deleteMultipleMedia(['m2', 'm3']);
+    expect(await repo.getMediaById('m2'), isNull);
+    expect(await repo.getMediaById('m3'), isNull);
+    expect(await queue.allForTesting(), isEmpty);
+    expect(kicks, 0);
+  });
+
+  test('a thumb-only stamp still triggers the delete intent', () async {
+    await repo.createMedia(photo('t1', hash: 'cc'));
+    await repo.stampRemoteThumbUploaded('t1', uploadedAt: DateTime(2026, 2));
+    await coordinator.deleteMedia('t1');
+    expect((await queue.allForTesting()).single.direction, 'delete');
+  });
+
+  test('queue failure never blocks row deletion', () async {
+    await repo.createMedia(
+      photo('m4', hash: 'cc', uploadedAt: DateTime(2026, 2)),
+    );
+    final broken = MediaDeletionCoordinator(
+      mediaRepository: repo,
+      queue: () => throw StateError('cache db not initialized'),
+      kickWorker: () async => kicks++,
+    );
+    await broken.deleteMedia('m4');
+    expect(await repo.getMediaById('m4'), isNull);
+  });
+}

--- a/test/features/media_store/media_deletion_coordinator_test.dart
+++ b/test/features/media_store/media_deletion_coordinator_test.dart
@@ -79,8 +79,7 @@ void main() {
     );
   });
 
-  test('never-uploaded and hashless rows delete without enqueueing',
-      () async {
+  test('never-uploaded and hashless rows delete without enqueueing', () async {
     await repo.createMedia(photo('m2', hash: 'bb')); // hash, no stamp
     await repo.createMedia(photo('m3')); // no hash
     await coordinator.deleteMultipleMedia(['m2', 'm3']);

--- a/test/features/media_store/media_store_worker_delete_test.dart
+++ b/test/features/media_store/media_store_worker_delete_test.dart
@@ -113,20 +113,22 @@ void main() {
     expect(pipeline.processed, ['alive']);
   });
 
-  test('delete entries are deferred when no delete processor is wired',
-      () async {
-    await queue.enqueueDelete(
-      mediaId: 'dead',
-      contentHash: 'aa',
-      originalExt: 'jpg',
-      renditionExt: 'jpg',
-    );
-    final worker = MediaStoreWorker(queue: queue, pipeline: pipeline);
-    await worker.drain(); // must terminate, not spin
+  test(
+    'delete entries are deferred when no delete processor is wired',
+    () async {
+      await queue.enqueueDelete(
+        mediaId: 'dead',
+        contentHash: 'aa',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      final worker = MediaStoreWorker(queue: queue, pipeline: pipeline);
+      await worker.drain(); // must terminate, not spin
 
-    final row = (await queue.allForTesting()).single;
-    expect(row.state, 'pending');
-    expect(row.nextAttemptAt, isNotNull); // parked in the defer window
-    expect(pipeline.processed, isEmpty);
-  });
+      final row = (await queue.allForTesting()).single;
+      expect(row.state, 'pending');
+      expect(row.nextAttemptAt, isNotNull); // parked in the defer window
+      expect(pipeline.processed, isEmpty);
+    },
+  );
 }

--- a/test/features/media_store/media_store_worker_delete_test.dart
+++ b/test/features/media_store/media_store_worker_delete_test.dart
@@ -1,0 +1,132 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_delete_processor.dart';
+import 'package:submersion/features/media_store/data/media_store_worker.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+class _RecordingPipeline extends MediaUploadPipeline {
+  _RecordingPipeline({
+    required this.queueRef,
+    required super.mediaRepository,
+    required super.queue,
+    required super.store,
+    required super.registry,
+    required super.cache,
+  });
+
+  final MediaTransferQueueRepository queueRef;
+  final processed = <String>[];
+
+  @override
+  Future<UploadOutcome> process(MediaTransferQueueEntry entry) async {
+    processed.add(entry.mediaId);
+    await queueRef.markDone(entry.id);
+    return UploadOutcome.uploaded;
+  }
+}
+
+class _RecordingDeleteProcessor extends MediaDeleteProcessor {
+  _RecordingDeleteProcessor({
+    required this.queueRef,
+    required super.queue,
+    required super.store,
+    required super.mediaRepository,
+  });
+
+  final MediaTransferQueueRepository queueRef;
+  final processed = <int>[];
+
+  @override
+  Future<void> process(MediaTransferQueueEntry entry) async {
+    processed.add(entry.id);
+    await queueRef.markDone(entry.id);
+  }
+}
+
+void main() {
+  late MediaRepository mediaRepository;
+  late LocalCacheDatabase cacheDb;
+  late Directory root;
+  late InMemoryMediaObjectStore store;
+  late MediaTransferQueueRepository queue;
+  late _RecordingPipeline pipeline;
+  late _RecordingDeleteProcessor deleteProcessor;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    mediaRepository = MediaRepository();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('worker_delete');
+    store = InMemoryMediaObjectStore();
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    pipeline = _RecordingPipeline(
+      queueRef: queue,
+      mediaRepository: mediaRepository,
+      queue: queue,
+      store: store,
+      registry: MediaSourceResolverRegistry({}),
+      cache: MediaCacheStore(database: cacheDb, root: root),
+    );
+    deleteProcessor = _RecordingDeleteProcessor(
+      queueRef: queue,
+      queue: queue,
+      store: store,
+      mediaRepository: mediaRepository,
+    );
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  test('drain routes delete entries to the delete processor', () async {
+    final deleteId = await queue.enqueueDelete(
+      mediaId: 'dead',
+      contentHash: 'aa',
+      originalExt: 'jpg',
+      renditionExt: 'jpg',
+    );
+    await queue.enqueueUpload(mediaId: 'alive');
+
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      deleteProcessor: deleteProcessor,
+    );
+    await worker.drain();
+
+    expect(deleteProcessor.processed, [deleteId]);
+    expect(pipeline.processed, ['alive']);
+  });
+
+  test('delete entries are deferred when no delete processor is wired',
+      () async {
+    await queue.enqueueDelete(
+      mediaId: 'dead',
+      contentHash: 'aa',
+      originalExt: 'jpg',
+      renditionExt: 'jpg',
+    );
+    final worker = MediaStoreWorker(queue: queue, pipeline: pipeline);
+    await worker.drain(); // must terminate, not spin
+
+    final row = (await queue.allForTesting()).single;
+    expect(row.state, 'pending');
+    expect(row.nextAttemptAt, isNotNull); // parked in the defer window
+    expect(pipeline.processed, isEmpty);
+  });
+}

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -372,6 +372,80 @@ void main() {
     expect(row.totalBytes, isNull);
   });
 
+  group('enqueueDelete', () {
+    test('inserts a delete row with hash and payload', () async {
+      final id = await repo.enqueueDelete(
+        mediaId: 'm1',
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      final row = (await repo.allForTesting()).single;
+      expect(row.id, id);
+      expect(row.direction, 'delete');
+      expect(row.contentHash, 'aabb');
+      expect(row.state, 'pending');
+      expect(row.payloadJson, '{"originalExt":"jpg","renditionExt":"jpg"}');
+    });
+
+    test('is idempotent per content hash for live and failed rows', () async {
+      final first = await repo.enqueueDelete(
+        mediaId: 'm1',
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      final again = await repo.enqueueDelete(
+        mediaId: 'm2', // different row, same blob
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      expect(again, first);
+      expect((await repo.allForTesting()).length, 1);
+    });
+
+    test('a done delete row allows a fresh enqueue', () async {
+      final first = await repo.enqueueDelete(
+        mediaId: 'm1',
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      await repo.markDone(first);
+      final second = await repo.enqueueDelete(
+        mediaId: 'm1',
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      expect(second, isNot(first));
+    });
+
+    test('upload dedup ignores delete rows for the same mediaId', () async {
+      await repo.enqueueDelete(
+        mediaId: 'm1',
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      final uploadId = await repo.enqueueUpload(mediaId: 'm1');
+      final rows = await repo.allForTesting();
+      expect(rows.length, 2);
+      expect(rows.firstWhere((r) => r.id == uploadId).direction, 'upload');
+    });
+
+    test('watchLatestForMedia ignores delete rows', () async {
+      await repo.enqueueDelete(
+        mediaId: 'm1',
+        contentHash: 'aabb',
+        originalExt: 'jpg',
+        renditionExt: 'jpg',
+      );
+      expect(await repo.watchLatestForMedia('m1').first, isNull);
+    });
+  });
+
   test('v6 migration adds payload_json to an existing v5 database', () async {
     final nativeDb = NativeDatabase.memory(
       setup: (rawDb) {

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -515,9 +515,7 @@ void main() {
     final names = cols.map((c) => c.read<String>('name')).toSet();
     expect(names, contains('payload_json'));
     final kept = await upgraded
-        .customSelect(
-          "SELECT media_id, payload_json FROM media_transfer_queue",
-        )
+        .customSelect("SELECT media_id, payload_json FROM media_transfer_queue")
         .getSingle();
     expect(kept.data['media_id'], 'm1');
     expect(kept.data['payload_json'], isNull);

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -372,6 +372,15 @@ void main() {
     expect(row.totalBytes, isNull);
   });
 
+  test('markFailed reports terminality', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    for (var i = 0; i < 4; i++) {
+      expect(await repo.markFailed(id, 'e'), isFalse);
+    }
+    expect(await repo.markFailed(id, 'e'), isTrue);
+    expect((await repo.allForTesting()).single.state, 'failed');
+  });
+
   group('enqueueDelete', () {
     test('inserts a delete row with hash and payload', () async {
       final id = await repo.enqueueDelete(

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -371,4 +371,72 @@ void main() {
     expect(row.progressBytes, isNull);
     expect(row.totalBytes, isNull);
   });
+
+  test('v6 migration adds payload_json to an existing v5 database', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 5');
+        rawDb.execute('''
+          CREATE TABLE local_asset_cache (
+            media_id TEXT NOT NULL PRIMARY KEY,
+            local_asset_id TEXT,
+            resolved_at INTEGER NOT NULL,
+            resolution_method TEXT NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE media_transfer_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            media_id TEXT NOT NULL,
+            direction TEXT NOT NULL DEFAULT 'upload',
+            object_kind TEXT NOT NULL DEFAULT 'original',
+            content_hash TEXT,
+            state TEXT NOT NULL DEFAULT 'pending',
+            attempts INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at INTEGER,
+            resume_state_json TEXT,
+            error_message TEXT,
+            priority INTEGER NOT NULL DEFAULT 0,
+            progress_bytes INTEGER,
+            total_bytes INTEGER,
+            override_level TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE media_cache_entries (
+            content_hash TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            relative_path TEXT NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            last_accessed_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            source_version INTEGER,
+            PRIMARY KEY (content_hash, kind)
+          )
+        ''');
+        rawDb.execute(
+          "INSERT INTO media_transfer_queue "
+          "(media_id, created_at, updated_at) VALUES ('m1', 1, 1)",
+        );
+      },
+    );
+    final upgraded = LocalCacheDatabase(nativeDb);
+    addTearDown(upgraded.close);
+
+    final cols = await upgraded
+        .customSelect("PRAGMA table_info('media_transfer_queue')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('payload_json'));
+    final kept = await upgraded
+        .customSelect(
+          "SELECT media_id, payload_json FROM media_transfer_queue",
+        )
+        .getSingle();
+    expect(kept.data['media_id'], 'm1');
+    expect(kept.data['payload_json'], isNull);
+  });
 }

--- a/test/features/media_store/transfers_page_delete_tile_test.dart
+++ b/test/features/media_store/transfers_page_delete_tile_test.dart
@@ -35,8 +35,9 @@ void main() {
     ),
   );
 
-  testWidgets('a transferring delete entry shows the removing label',
-      (tester) async {
+  testWidgets('a transferring delete entry shows the removing label', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       app(entry(direction: 'delete', state: 'transferring')),
     );

--- a/test/features/media_store/transfers_page_delete_tile_test.dart
+++ b/test/features/media_store/transfers_page_delete_tile_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media_store/presentation/pages/transfers_page.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  MediaTransferQueueData entry({
+    required String direction,
+    required String state,
+  }) => MediaTransferQueueData(
+    id: 1,
+    mediaId: 'dead-row',
+    direction: direction,
+    objectKind: 'original',
+    contentHash: 'aa',
+    state: state,
+    attempts: 0,
+    priority: 0,
+    createdAt: 0,
+    updatedAt: 0,
+  );
+
+  Widget app(MediaTransferQueueData row) => ProviderScope(
+    overrides: [
+      mediaTransferEntriesProvider.overrideWith((ref) => Stream.value([row])),
+    ],
+    child: const MaterialApp(
+      locale: Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: TransfersPage(),
+    ),
+  );
+
+  testWidgets('a transferring delete entry shows the removing label',
+      (tester) async {
+    await tester.pumpWidget(
+      app(entry(direction: 'delete', state: 'transferring')),
+    );
+    await tester.pump();
+
+    expect(find.text('Removing from cloud'), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    expect(find.byIcon(Icons.cloud_upload), findsNothing);
+  });
+
+  testWidgets('a pending delete entry keeps the delete icon', (tester) async {
+    await tester.pumpWidget(app(entry(direction: 'delete', state: 'pending')));
+    await tester.pump();
+
+    expect(find.text('Waiting'), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+  });
+
+  testWidgets('upload entries are unchanged', (tester) async {
+    await tester.pumpWidget(
+      app(entry(direction: 'upload', state: 'transferring')),
+    );
+    await tester.pump();
+
+    expect(find.text('Uploading'), findsOneWidget);
+    expect(find.byIcon(Icons.cloud_upload), findsOneWidget);
+  });
+}

--- a/test/helpers/fake_s3_server.dart
+++ b/test/helpers/fake_s3_server.dart
@@ -19,6 +19,9 @@ class FakeS3Server {
   final Map<String, Map<int, Uint8List>> _sessions = {};
   int _uploadCounter = 0;
 
+  /// Multipart sessions created but neither completed nor aborted.
+  int get activeMultipartUploadCount => _sessions.length;
+
   /// Successful part uploads seen (across all sessions).
   int partUploadCount = 0;
 

--- a/test/helpers/in_memory_media_object_store.dart
+++ b/test/helpers/in_memory_media_object_store.dart
@@ -105,6 +105,14 @@ class InMemoryMediaObjectStore implements MediaObjectStore {
     modified.remove(key);
   }
 
+  /// (key, resumeStateJson) pairs abandonResume was called with.
+  final abandonResumeCalls = <(String, String?)>[];
+
+  @override
+  Future<void> abandonResume(String key, String? resumeStateJson) async {
+    abandonResumeCalls.add((key, resumeStateJson));
+  }
+
   @override
   Stream<StoreObjectInfo> list(String keyPrefix) async* {
     _maybeFail();


### PR DESCRIPTION
## Summary

Once uploaded, media store objects were immortal: no deletion path ever called `MediaObjectStore.delete()`, so deleting media locally (or via sync) left originals, thumbs, and renditions in the user's cloud storage forever. Separately, a failed S3 multipart upload whose resume state was never persisted stranded its session server-side — raw buckets have no default `AbortIncompleteMultipartUpload` lifecycle rule, so orphaned parts bill indefinitely and are invisible to key listings.

This is PR 2 of 4 from `docs/superpowers/specs/2026-07-23-media-store-orphan-prevention-design.md` (plan: `docs/superpowers/plans/2026-07-23-media-orphan-prevention-pr2-blob-delete-fast-path.md`): deleted media rows now durably delete their remote blobs, and multipart sessions can no longer strand.

## Design (intent-log pattern)

- **Delete intents ride the existing transfer queue** as `direction = 'delete'` rows (the column existed unused since Phase 1). Local cache DB bumps v5 -> v6 adding only `payload_json`, which captures the original + rendition file extensions — the two facts unrecoverable after the media row dies. One entry covers all three tiers of one content hash, idempotent per hash.
- **Enqueue-before-delete** (`MediaDeletionCoordinator`): the intent is enqueued before the row dies; the queue lives in a different database (no cross-DB transaction), and this ordering makes the only crash window harmless. Enqueue failures never block the user's deletion — missed intents fall to the future Verify Library sweep (PR 4).
- **Drain-time refcount** (`MediaDeleteProcessor`): before deleting, the worker re-checks whether ANY media row still references the hash (uploaded or not — deliberately broader than the Phase A stamp-filtered counts). References that appear between enqueue and drain (late sync pulls, re-imports) win.
- **Single-enqueuer rule**: only user-action deletion flows (`MediaListNotifier`, Files/URL tab undo, manifest undo) route through the coordinator. Sync tombstone application is untouched, so N devices cannot storm the store with deletes.
- **Cellular gate exemption**: delete drains are tiny API calls; they proceed on any non-offline network, unaffected by the photo/video cellular policies.
- **Multipart abort**: `_putMultipart` now aborts its session on failure when no resume-persistence callback was provided (nothing could ever replay it); terminally failed queue entries abandon their persisted session via the new `MediaObjectStore.abandonResume` (S3 aborts the uploadId; Dropbox/Drive/iCloud sessions self-expire, so they no-op). `markFailed` now reports terminality to drive this.
- **Transfers page** renders delete entries with a distinct icon and a localized "Removing from cloud" label (all 11 locales).

## Known accepted gap

`enqueueReupload` replaces an existing queue row of any state and can discard a `resumeStateJson` whose S3 session then strands until provider expiry or PR 4's `ListMultipartUploads` reap. The queue repository has no store access; threading one in for this edge was not worth the coupling — the sweep is the designed backstop (spec 6.1).

## Testing

- New suites: delete processor (refcount skip, three-tier delete, retry on store failure, defensive payload parse), deletion coordinator (enqueue-before-delete ordering, video mp4 payload, thumb-only stamp, StateError isolation), worker routing (delete dispatch, defer-when-unwired), S3 multipart abort (abort without persistence, keep with persistence, `abandonResume` incl. junk tolerance), cache DB v6 migration, transfers tile rendering.
- `flutter analyze`: no issues. `dart format .`: clean.
- Full suite: 13757 passed / 0 failed (14 skipped).