### PR TITLE
feat(dive): dive deletion cascades to media + orphan backlog sweep

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -379,19 +379,30 @@ class _StartupWrapperState extends State<StartupWrapper>
     // now-open databases, and self-guards with a persisted flag that is
     // only set on success (a failed run retries next launch).
     final mediaRepository = MediaRepository();
-    unawaited(
-      MediaOrphanBacklogSweep(
+    final sweep = MediaOrphanBacklogSweep(
+      mediaRepository: mediaRepository,
+      coordinator: MediaDeletionCoordinator(
         mediaRepository: mediaRepository,
-        coordinator: MediaDeletionCoordinator(
-          mediaRepository: mediaRepository,
-          queue: () => MediaTransferQueueRepository(),
-        ),
-        prefs: SharedPreferences.getInstance,
-      ).runIfNeeded().catchError((Object e) {
-        debugPrint('Orphaned-media backlog sweep failed (will retry): $e');
-        return 0;
-      }),
+        queue: () => MediaTransferQueueRepository(),
+      ),
+      prefs: SharedPreferences.getInstance,
     );
+    // An async closure rather than `.catchError` on the Future<int>: it
+    // hands `unawaited` a genuine Future<void> instead of a swept-row count
+    // nobody reads, and it keeps the stack trace. Nothing surfaces this
+    // failure to the user and the retry is a whole launch away, so the
+    // trace is the only diagnostic there will be. Untyped catch on purpose:
+    // an uninitialized local cache database throws StateError, not
+    // Exception, and a failed sweep must never take down startup.
+    unawaited(() async {
+      try {
+        await sweep.runIfNeeded();
+      } catch (e, stackTrace) {
+        debugPrint(
+          'Orphaned-media backlog sweep failed (will retry): $e\n$stackTrace',
+        );
+      }
+    }());
     // coverage:ignore-end
   }
 

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show unawaited;
 import 'dart:io';
 
 import 'package:flutter/foundation.dart' show kReleaseMode;
@@ -25,6 +26,10 @@ import 'package:submersion/features/backup/data/services/pre_migration_backup_se
 import 'package:submersion/features/backup/domain/exceptions/backup_failed_exception.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/data/media_orphan_backlog_sweep.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/main.dart' show SubmersionRestart;
 
 /// Callback signature for the service initializer used by [StartupWrapper].
@@ -368,6 +373,25 @@ class _StartupWrapperState extends State<StartupWrapper>
       final speciesRepository = SpeciesRepository();
       await speciesRepository.seedBuiltInSpecies();
     });
+
+    // One-time orphaned-media backlog sweep (orphan-prevention spec 4.3).
+    // Fire-and-forget: it must not delay first frame, runs against the
+    // now-open databases, and self-guards with a persisted flag that is
+    // only set on success (a failed run retries next launch).
+    final mediaRepository = MediaRepository();
+    unawaited(
+      MediaOrphanBacklogSweep(
+        mediaRepository: mediaRepository,
+        coordinator: MediaDeletionCoordinator(
+          mediaRepository: mediaRepository,
+          queue: () => MediaTransferQueueRepository(),
+        ),
+        prefs: SharedPreferences.getInstance,
+      ).runIfNeeded().catchError((Object e) {
+        debugPrint('Orphaned-media backlog sweep failed (will retry): $e');
+        return 0;
+      }),
+    );
     // coverage:ignore-end
   }
 

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -52,20 +52,33 @@ class DiveRepository {
   /// The media dependencies drive the dive-deletion cascade
   /// (orphan-prevention spec 4.2); injectable for tests, self-constructed
   /// otherwise so every existing zero-arg construction site cascades too.
-  DiveRepository({
+  ///
+  /// A factory rather than a generative constructor so the default
+  /// [MediaRepository] is built ONCE and shared with the coordinator: an
+  /// initializer list cannot bind a local, so the obvious
+  /// `mediaRepository ?? MediaRepository()` written twice would hand the
+  /// cascade a different instance than the one this repository partitions
+  /// with.
+  factory DiveRepository({
     MediaRepository? mediaRepository,
     MediaDeletionCoordinator? mediaDeletionCoordinator,
-  }) : _mediaRepository = mediaRepository ?? MediaRepository(),
-       _mediaDeletionCoordinator =
-           mediaDeletionCoordinator ??
-           MediaDeletionCoordinator(
-             mediaRepository: mediaRepository ?? MediaRepository(),
-             queue: () => MediaTransferQueueRepository(),
-             // No worker kick from the data layer (provider cycles):
-             // queued intents drain on the next connectivity event, app
-             // start, or any other kick; the Verify Library sweep is the
-             // backstop.
-           );
+  }) {
+    final media = mediaRepository ?? MediaRepository();
+    return DiveRepository._(
+      media,
+      mediaDeletionCoordinator ??
+          MediaDeletionCoordinator(
+            mediaRepository: media,
+            queue: () => MediaTransferQueueRepository(),
+            // No worker kick from the data layer (provider cycles):
+            // queued intents drain on the next connectivity event, app
+            // start, or any other kick; the Verify Library sweep is the
+            // backstop.
+          ),
+    );
+  }
+
+  DiveRepository._(this._mediaRepository, this._mediaDeletionCoordinator);
 
   final MediaRepository _mediaRepository;
   final MediaDeletionCoordinator _mediaDeletionCoordinator;

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1519,9 +1519,9 @@ class DiveRepository {
   Future<void> _cascadeMediaForDiveDeletion(List<String> ids) async {
     final split = await _mediaRepository.partitionMediaForDiveDeletion(ids);
     if (split.doomed.isNotEmpty) {
-      await _mediaDeletionCoordinator.deleteMultipleMedia(
-        split.doomed.map((m) => m.id).toList(),
-      );
+      // Items, not ids: the partition already read these rows, and the
+      // blob-delete intent needs exactly the fields it carries.
+      await _mediaDeletionCoordinator.deleteMediaItems(split.doomed);
     }
     if (split.unlinkIds.isNotEmpty) {
       await _mediaRepository.unlinkMediaFromDeletedDives(split.unlinkIds);

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -33,6 +33,9 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     as domain;
 import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_custom_field.dart'
     as domain;
 import 'package:submersion/features/dive_log/data/repositories/dive_custom_field_repository.dart';
@@ -46,6 +49,26 @@ import 'package:submersion/features/buddies/domain/entities/buddy.dart'
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 
 class DiveRepository {
+  /// The media dependencies drive the dive-deletion cascade
+  /// (orphan-prevention spec 4.2); injectable for tests, self-constructed
+  /// otherwise so every existing zero-arg construction site cascades too.
+  DiveRepository({
+    MediaRepository? mediaRepository,
+    MediaDeletionCoordinator? mediaDeletionCoordinator,
+  }) : _mediaRepository = mediaRepository ?? MediaRepository(),
+       _mediaDeletionCoordinator =
+           mediaDeletionCoordinator ??
+           MediaDeletionCoordinator(
+             mediaRepository: mediaRepository ?? MediaRepository(),
+             queue: () => MediaTransferQueueRepository(),
+             // No worker kick from the data layer (provider cycles):
+             // queued intents drain on the next connectivity event, app
+             // start, or any other kick; the Verify Library sweep is the
+             // backstop.
+           );
+
+  final MediaRepository _mediaRepository;
+  final MediaDeletionCoordinator _mediaDeletionCoordinator;
   AppDatabase get _db => DatabaseService.instance.database;
   final SyncRepository _syncRepository = SyncRepository();
   final _uuid = const Uuid();
@@ -1469,10 +1492,39 @@ class DiveRepository {
     }
   }
 
-  /// Delete a dive
-  Future<void> deleteDive(String id) async {
+  /// Cascade a dying dive's media (orphan-prevention spec 4.2): dive-only
+  /// non-library rows die with the dive (rows + tombstones + blob-delete
+  /// intents via the coordinator's enqueue-before-delete path); site-linked
+  /// and library-level rows survive with diveId nulled and HLC-stamped.
+  ///
+  /// Deliberately NOT wrapped in a transaction with the dive delete: the
+  /// coordinator's queue writes live in another database, and every step is
+  /// individually idempotent/tombstoned - a crash between cascade and dive
+  /// delete leaves a re-deletable dive, never an orphan. Merge and
+  /// consolidation services reassign media to the surviving dive BEFORE
+  /// deleting sources, so this sees no doomed media for merged-away dives.
+  Future<void> _cascadeMediaForDiveDeletion(List<String> ids) async {
+    final split = await _mediaRepository.partitionMediaForDiveDeletion(ids);
+    if (split.doomed.isNotEmpty) {
+      await _mediaDeletionCoordinator.deleteMultipleMedia(
+        split.doomed.map((m) => m.id).toList(),
+      );
+    }
+    if (split.unlinkIds.isNotEmpty) {
+      await _mediaRepository.unlinkMediaFromDeletedDives(split.unlinkIds);
+    }
+  }
+
+  /// Delete a dive.
+  ///
+  /// [cascadeMedia] is true for user-intent deletions (the dive's media
+  /// goes with the dive). Restore/undo flows that re-point media
+  /// afterwards (e.g. merge undo) pass false so the cascade cannot eat
+  /// rows they are about to restore.
+  Future<void> deleteDive(String id, {bool cascadeMedia = true}) async {
     try {
       _log.info('Deleting dive: $id');
+      if (cascadeMedia) await _cascadeMediaForDiveDeletion([id]);
       await (_db.delete(_db.dives)..where((t) => t.id.equals(id))).go();
       await _syncRepository.logDeletion(entityType: 'dives', recordId: id);
       SyncEventBus.notifyLocalChange();
@@ -1489,11 +1541,15 @@ class DiveRepository {
 
   /// Bulk delete multiple dives
   /// Returns the list of deleted dive IDs for potential undo
-  Future<List<String>> bulkDeleteDives(List<String> ids) async {
+  Future<List<String>> bulkDeleteDives(
+    List<String> ids, {
+    bool cascadeMedia = true,
+  }) async {
     if (ids.isEmpty) return [];
 
     try {
       _log.info('Bulk deleting ${ids.length} dives');
+      if (cascadeMedia) await _cascadeMediaForDiveDeletion(ids);
       await (_db.delete(_db.dives)..where((t) => t.id.isIn(ids))).go();
       for (final id in ids) {
         await _syncRepository.logDeletion(entityType: 'dives', recordId: id);

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -488,7 +488,10 @@ class DiveMergeService {
         );
         batch.deleteWhere(_db.tideRecords, (t) => t.diveId.equals(mergedId));
       });
-      await _diveRepo.deleteDive(mergedId);
+      // cascadeMedia: false - this undo re-points the merged dive's media
+      // back to the restored sources below; the cascade would delete (and
+      // tombstone) those rows before the restore could reach them.
+      await _diveRepo.deleteDive(mergedId, cascadeMedia: false);
 
       // Re-insert dives with ORIGINAL ids; newer HLC beats the tombstones.
       //

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -930,6 +930,14 @@ class MediaRepository {
   /// survive as site-linked or library-level rows with diveId nulled.
   Future<({List<domain.MediaItem> doomed, List<String> unlinkIds})>
   partitionMediaForDiveDeletion(List<String> diveIds) async {
+    // Not a correctness guard - SQLite accepts the `IN ()` an empty list
+    // compiles to and matches nothing - but bulk callers legitimately hand
+    // over empty collections (e.g. consolidation's secondary-dive set), and
+    // there is no reason to make the database prove that nothing matches.
+    // Matches [unlinkMediaFromDeletedDives]'s guard below.
+    if (diveIds.isEmpty) {
+      return (doomed: const <domain.MediaItem>[], unlinkIds: const <String>[]);
+    }
     final rows = await (_db.select(
       _db.media,
     )..where((t) => t.diveId.isIn(diveIds))).get();

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -913,6 +913,83 @@ class MediaRepository {
   static Expression<bool> isLinkedToDiveOrSite($MediaTable m) =>
       m.diveId.isNotNull() | m.siteId.isNotNull();
 
+  /// Source types whose rows are legitimate as library-level media with no
+  /// dive/site linkage (orphan-prevention spec section 3, gate audit
+  /// 2026-07-23): URL-tab and manifest-subscription imports. Auto-match is
+  /// additive for them, so unlinkedness is a normal permanent state - the
+  /// dive-deletion cascade unlinks instead of deleting, and the backlog
+  /// sweep never touches them.
+  static const List<String> libraryLevelSourceTypes = [
+    'networkUrl',
+    'manifestEntry',
+  ];
+
+  /// Splits a dying dive's media (orphan-prevention spec 4.2): `doomed`
+  /// rows die with the dive (dive-only, non-library; full items because
+  /// the blob-delete intent needs contentHash/filename/type), `unlinkIds`
+  /// survive as site-linked or library-level rows with diveId nulled.
+  Future<({List<domain.MediaItem> doomed, List<String> unlinkIds})>
+  partitionMediaForDiveDeletion(List<String> diveIds) async {
+    final rows = await (_db.select(
+      _db.media,
+    )..where((t) => t.diveId.isIn(diveIds))).get();
+    final doomed = <domain.MediaItem>[];
+    final unlinkIds = <String>[];
+    for (final row in rows) {
+      final keep =
+          row.siteId != null ||
+          libraryLevelSourceTypes.contains(row.sourceType);
+      if (keep) {
+        unlinkIds.add(row.id);
+      } else {
+        doomed.add(_mapRowToMediaItem(row));
+      }
+    }
+    return (doomed: doomed, unlinkIds: unlinkIds);
+  }
+
+  /// Explicitly unlinks surviving media from deleted dives, with the HLC
+  /// stamp the old silent FK SET NULL never produced - so the unlink
+  /// propagates to other devices instead of diverging.
+  Future<void> unlinkMediaFromDeletedDives(List<String> mediaIds) async {
+    if (mediaIds.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _db.transaction(() async {
+      await (_db.update(_db.media)..where((t) => t.id.isIn(mediaIds))).write(
+        MediaCompanion(diveId: const Value(null), updatedAt: Value(now)),
+      );
+      for (final id in mediaIds) {
+        await _syncRepository.markRecordPending(
+          entityType: 'media',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+    });
+    SyncEventBus.notifyLocalChange();
+  }
+
+  /// Backlog-sweep candidates (orphan-prevention spec 4.3): unlinked,
+  /// non-library, and created before [olderThan] (the 24h age guard
+  /// protects any future add-then-link creator the gate audit could not
+  /// foresee).
+  Future<List<String>> getSweepableOrphanIds({
+    required DateTime olderThan,
+  }) async {
+    final id = _db.media.id;
+    final query = _db.selectOnly(_db.media)
+      ..addColumns([id])
+      ..where(
+        isLinkedToDiveOrSite(_db.media).not() &
+            _db.media.sourceType.isNotIn(libraryLevelSourceTypes) &
+            _db.media.createdAt.isSmallerThanValue(
+              olderThan.millisecondsSinceEpoch,
+            ),
+      );
+    final rows = await query.get();
+    return rows.map((r) => r.read(id)!).toList();
+  }
+
   /// Backfill candidates (design spec section 9): device-resident photos
   /// not yet confirmed in the media store, newest first so recent dives
   /// gain protection soonest. Scoped to rows linked to a dive or site so

--- a/lib/features/media_store/data/media_deletion_coordinator.dart
+++ b/lib/features/media_store/data/media_deletion_coordinator.dart
@@ -31,7 +31,22 @@ class MediaDeletionCoordinator {
 
   Future<void> deleteMedia(String id) => deleteMultipleMedia([id]);
 
-  Future<void> deleteMultipleMedia(List<String> ids) async {
+  /// Deletes by id, reading each row back to build its blob-delete intent.
+  Future<void> deleteMultipleMedia(List<String> ids) =>
+      _delete(ids, const <String, MediaItem>{});
+
+  /// [deleteMultipleMedia] for callers that already hold the rows. The
+  /// dive-deletion cascade partitions its doomed set out of a single
+  /// select, so re-reading each row by id here would be duplicate work
+  /// proportional to the number of photos on the dives being deleted.
+  Future<void> deleteMediaItems(List<MediaItem> items) => _delete(
+    [for (final item in items) item.id],
+    {for (final item in items) item.id: item},
+  );
+
+  /// [known] short-circuits the per-id read for callers that already hold
+  /// the row; ids absent from it are read back as before.
+  Future<void> _delete(List<String> ids, Map<String, MediaItem> known) async {
     var enqueued = false;
     for (final id in ids) {
       // Untyped catch on purpose: an uninitialized
@@ -39,7 +54,7 @@ class MediaDeletionCoordinator {
       // Exception), and no media-store problem may ever block the user's
       // deletion.
       try {
-        if (await _enqueueIntent(id)) enqueued = true;
+        if (await _enqueueIntent(id, known[id])) enqueued = true;
       } catch (e, stackTrace) {
         _log.warning(
           'Could not enqueue remote delete for media $id '
@@ -63,8 +78,8 @@ class MediaDeletionCoordinator {
     }
   }
 
-  Future<bool> _enqueueIntent(String id) async {
-    final item = await _mediaRepository.getMediaById(id);
+  Future<bool> _enqueueIntent(String id, MediaItem? known) async {
+    final item = known ?? await _mediaRepository.getMediaById(id);
     final hash = item?.contentHash;
     if (item == null || hash == null || hash.isEmpty) return false;
     final everUploaded =

--- a/lib/features/media_store/data/media_orphan_backlog_sweep.dart
+++ b/lib/features/media_store/data/media_orphan_backlog_sweep.dart
@@ -1,0 +1,49 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+
+/// One-time cleanup of the orphaned-media-row backlog (orphan-prevention
+/// spec 4.3): rows unlinked from any dive or site by past dive deletions
+/// (the FK's silent SET NULL), which the dive-deletion cascade now
+/// prevents going forward. Library-level source types and rows younger
+/// than 24 hours are never touched (spec section 3, gate audit).
+///
+/// Runs through the repository layer, not a schema migration: tombstones
+/// need the live sync clock, and the coordinator's enqueue-before-delete
+/// path needs the transfer queue. The persisted flag is set only on
+/// success, giving at-least-once execution; every step is idempotent, so
+/// at-least-once is safe.
+class MediaOrphanBacklogSweep {
+  MediaOrphanBacklogSweep({
+    required MediaRepository mediaRepository,
+    required MediaDeletionCoordinator coordinator,
+    required Future<SharedPreferences> Function() prefs,
+  }) : _mediaRepository = mediaRepository,
+       _coordinator = coordinator,
+       _prefs = prefs;
+
+  static const flagKey = 'media_orphan_backlog_swept_v1';
+
+  final MediaRepository _mediaRepository;
+  final MediaDeletionCoordinator _coordinator;
+  final Future<SharedPreferences> Function() _prefs;
+  final _log = LoggerService.forClass(MediaOrphanBacklogSweep);
+
+  /// Runs at most once per device (persisted flag). Returns the number of
+  /// rows swept (0 on skip). Throws on repository failure so the flag
+  /// stays unset and the next launch retries.
+  Future<int> runIfNeeded({DateTime? now}) async {
+    final p = await _prefs();
+    if (p.getBool(flagKey) ?? false) return 0;
+    final cutoff = (now ?? DateTime.now()).subtract(const Duration(hours: 24));
+    final ids = await _mediaRepository.getSweepableOrphanIds(olderThan: cutoff);
+    if (ids.isNotEmpty) {
+      _log.info('Sweeping ${ids.length} orphaned media rows');
+      await _coordinator.deleteMultipleMedia(ids);
+    }
+    await p.setBool(flagKey, true);
+    return ids.length;
+  }
+}

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -486,82 +486,85 @@ void main() {
       );
     });
 
-    test('a library-level photo whose dive was deleted is preserved '
-        '(unlinked), not lost and not resurrected with a dangling link',
-        () async {
-      final serializer = SyncDataSerializer();
-      final diveRepo = DiveRepository();
-      final db = DatabaseService.instance.database;
+    test(
+      'a library-level photo whose dive was deleted is preserved '
+      '(unlinked), not lost and not resurrected with a dangling link',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+        final db = DatabaseService.instance.database;
 
-      await diveRepo.createDive(
-        createTestDiveWithBottomTime(id: 'dive-61', diveNumber: 61),
-      );
-      await db
-          .into(db.media)
-          .insert(
-            MediaCompanion.insert(
-              id: 'media-61',
-              diveId: const Value('dive-61'),
-              filePath: '/photo.jpg',
-              sourceType: const Value('networkUrl'),
-              createdAt: 1000,
-              updatedAt: 1000,
-            ),
-          );
-      await buildService().performSync();
-      final diveJson = await serializer.fetchRecord('dives', 'dive-61');
-      final mediaJson = await serializer.fetchRecord('media', 'media-61');
-      expect(mediaJson, isNotNull);
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-61', diveNumber: 61),
+        );
+        await db
+            .into(db.media)
+            .insert(
+              MediaCompanion.insert(
+                id: 'media-61',
+                diveId: const Value('dive-61'),
+                filePath: '/photo.jpg',
+                sourceType: const Value('networkUrl'),
+                createdAt: 1000,
+                updatedAt: 1000,
+              ),
+            );
+        await buildService().performSync();
+        final diveJson = await serializer.fetchRecord('dives', 'dive-61');
+        final mediaJson = await serializer.fetchRecord('media', 'media-61');
+        expect(mediaJson, isNotNull);
 
-      // Library-level source types (networkUrl/manifestEntry) revert to
-      // library on dive deletion instead of dying (orphan-prevention spec
-      // section 3): auto-match was additive, so the import must survive.
-      await diveRepo.deleteDive('dive-61');
-      expect(await serializer.fetchRecord('dives', 'dive-61'), isNull);
-      final localMedia = await serializer.fetchRecord('media', 'media-61');
-      expect(
-        localMedia,
-        isNotNull,
-        reason: 'the library import must survive the delete',
-      );
-      expect(localMedia!['diveId'], isNull);
+        // Library-level source types (networkUrl/manifestEntry) revert to
+        // library on dive deletion instead of dying (orphan-prevention spec
+        // section 3): auto-match was additive, so the import must survive.
+        await diveRepo.deleteDive('dive-61');
+        expect(await serializer.fetchRecord('dives', 'dive-61'), isNull);
+        final localMedia = await serializer.fetchRecord('media', 'media-61');
+        expect(
+          localMedia,
+          isNotNull,
+          reason: 'the library import must survive the delete',
+        );
+        expect(localMedia!['diveId'], isNull);
 
-      // Peer still has the live dive AND the photo still linked to it.
-      final peerData = SyncData(
-        dives: [
-          {...diveJson!, 'updatedAt': 1000},
-        ],
-        media: [mediaJson!],
-      );
-      final checksum = sha256
-          .convert(utf8.encode(jsonEncode(peerData.toJson())))
-          .toString();
-      final payload = SyncPayload(
-        version: syncFormatVersion,
-        exportedAt: 2000,
-        deviceId: 'peer-dev',
-        checksum: checksum,
-        data: peerData,
-        deletions: const {},
-      );
-      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+        // Peer still has the live dive AND the photo still linked to it.
+        final peerData = SyncData(
+          dives: [
+            {...diveJson!, 'updatedAt': 1000},
+          ],
+          media: [mediaJson!],
+        );
+        final checksum = sha256
+            .convert(utf8.encode(jsonEncode(peerData.toJson())))
+            .toString();
+        final payload = SyncPayload(
+          version: syncFormatVersion,
+          exportedAt: 2000,
+          deviceId: 'peer-dev',
+          checksum: checksum,
+          data: peerData,
+          deletions: const {},
+        );
+        await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
 
-      final result = await buildService().performSync();
+        final result = await buildService().performSync();
 
-      expect(result.status, isNot(SyncResultStatus.error));
-      expect(await serializer.fetchRecord('dives', 'dive-61'), isNull);
-      final afterMedia = await serializer.fetchRecord('media', 'media-61');
-      expect(
-        afterMedia,
-        isNotNull,
-        reason: 'the library import must NOT be lost when its dive is deleted',
-      );
-      expect(
-        afterMedia!['diveId'],
-        isNull,
-        reason: 'the dangling dive link is cleared, not resurrected',
-      );
-    });
+        expect(result.status, isNot(SyncResultStatus.error));
+        expect(await serializer.fetchRecord('dives', 'dive-61'), isNull);
+        final afterMedia = await serializer.fetchRecord('media', 'media-61');
+        expect(
+          afterMedia,
+          isNotNull,
+          reason:
+              'the library import must NOT be lost when its dive is deleted',
+        );
+        expect(
+          afterMedia!['diveId'],
+          isNull,
+          reason: 'the dangling dive link is cleared, not resurrected',
+        );
+      },
+    );
 
     test(
       'applying a peer deletion of a SITE a local dive still references does '

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -419,8 +419,8 @@ void main() {
       );
     });
 
-    test('a photo whose dive was deleted is preserved (set-null), not lost '
-        'and not resurrected with a dangling link', () async {
+    test('a dive-only photo dies with its dive (cascade) and is not '
+        'resurrected by a peer live copy', () async {
       final serializer = SyncDataSerializer();
       final diveRepo = DiveRepository();
       final db = DatabaseService.instance.database;
@@ -444,15 +444,85 @@ void main() {
       final mediaJson = await serializer.fetchRecord('media', 'media-60');
       expect(mediaJson, isNotNull);
 
-      // Deleting the dive set-nulls the photo's diveId locally; the photo
-      // survives (Media.diveId is nullable / onDelete: setNull).
+      // The dive's photo goes with the dive (orphan-prevention spec 4.2):
+      // deleting the dive cascades to its dive-only media, tombstoned so
+      // the deletion syncs.
       await diveRepo.deleteDive('dive-60');
       expect(await serializer.fetchRecord('dives', 'dive-60'), isNull);
-      final localMedia = await serializer.fetchRecord('media', 'media-60');
+      expect(
+        await serializer.fetchRecord('media', 'media-60'),
+        isNull,
+        reason: 'dive-only media dies with the dive',
+      );
+
+      // Peer still has the live dive AND the photo still linked to it.
+      final peerData = SyncData(
+        dives: [
+          {...diveJson!, 'updatedAt': 1000},
+        ],
+        media: [mediaJson!],
+      );
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(peerData.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 2000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: peerData,
+        deletions: const {},
+      );
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+
+      expect(result.status, isNot(SyncResultStatus.error));
+      expect(await serializer.fetchRecord('dives', 'dive-60'), isNull);
+      expect(
+        await serializer.fetchRecord('media', 'media-60'),
+        isNull,
+        reason: 'the media tombstone beats the peer live copy',
+      );
+    });
+
+    test('a library-level photo whose dive was deleted is preserved '
+        '(unlinked), not lost and not resurrected with a dangling link',
+        () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final db = DatabaseService.instance.database;
+
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-61', diveNumber: 61),
+      );
+      await db
+          .into(db.media)
+          .insert(
+            MediaCompanion.insert(
+              id: 'media-61',
+              diveId: const Value('dive-61'),
+              filePath: '/photo.jpg',
+              sourceType: const Value('networkUrl'),
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          );
+      await buildService().performSync();
+      final diveJson = await serializer.fetchRecord('dives', 'dive-61');
+      final mediaJson = await serializer.fetchRecord('media', 'media-61');
+      expect(mediaJson, isNotNull);
+
+      // Library-level source types (networkUrl/manifestEntry) revert to
+      // library on dive deletion instead of dying (orphan-prevention spec
+      // section 3): auto-match was additive, so the import must survive.
+      await diveRepo.deleteDive('dive-61');
+      expect(await serializer.fetchRecord('dives', 'dive-61'), isNull);
+      final localMedia = await serializer.fetchRecord('media', 'media-61');
       expect(
         localMedia,
         isNotNull,
-        reason: 'the photo must survive the delete',
+        reason: 'the library import must survive the delete',
       );
       expect(localMedia!['diveId'], isNull);
 
@@ -479,12 +549,12 @@ void main() {
       final result = await buildService().performSync();
 
       expect(result.status, isNot(SyncResultStatus.error));
-      expect(await serializer.fetchRecord('dives', 'dive-60'), isNull);
-      final afterMedia = await serializer.fetchRecord('media', 'media-60');
+      expect(await serializer.fetchRecord('dives', 'dive-61'), isNull);
+      final afterMedia = await serializer.fetchRecord('media', 'media-61');
       expect(
         afterMedia,
         isNotNull,
-        reason: 'the photo must NOT be lost when its dive is deleted',
+        reason: 'the library import must NOT be lost when its dive is deleted',
       );
       expect(
         afterMedia!['diveId'],

--- a/test/features/dive_log/data/dive_deletion_cascade_test.dart
+++ b/test/features/dive_log/data/dive_deletion_cascade_test.dart
@@ -1,0 +1,181 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart' hide Dive;
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+import '../../../helpers/test_database.dart';
+
+void main() {
+  late LocalCacheDatabase cacheDb;
+  late MediaTransferQueueRepository queue;
+  late MediaRepository mediaRepository;
+  late DiveRepository diveRepository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    mediaRepository = MediaRepository();
+    diveRepository = DiveRepository(
+      mediaRepository: mediaRepository,
+      mediaDeletionCoordinator: MediaDeletionCoordinator(
+        mediaRepository: mediaRepository,
+        queue: () => queue,
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    await tearDownTestDatabase();
+  });
+
+  Future<Dive> makeDive() =>
+      diveRepository.createDive(Dive(id: '', dateTime: DateTime(2026, 6, 1)));
+
+  Future<String> insertSite() async {
+    final db = DatabaseService.instance.database;
+    final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.diveSites)
+        .insert(
+          DiveSitesCompanion(
+            id: const Value('site-1'),
+            name: const Value('Reef'),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
+    return 'site-1';
+  }
+
+  MediaItem item(
+    String name, {
+    String? diveId,
+    String? siteId,
+    String? hash,
+    DateTime? uploadedAt,
+    MediaSourceType sourceType = MediaSourceType.platformGallery,
+  }) => MediaItem(
+    id: '',
+    mediaType: MediaType.photo,
+    sourceType: sourceType,
+    filePath: '/tmp/$name',
+    localPath: '/tmp/$name',
+    originalFilename: name,
+    diveId: diveId,
+    siteId: siteId,
+    contentHash: hash,
+    remoteUploadedAt: uploadedAt,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  Future<List<String>> mediaTombstones() async {
+    final db = DatabaseService.instance.database;
+    final rows = await (db.select(
+      db.deletionLog,
+    )..where((t) => t.entityType.equals('media'))).get();
+    return rows.map((r) => r.recordId).toList();
+  }
+
+  test('deleteDive deletes dive-only media with tombstone and blob intent',
+      () async {
+    final dive = await makeDive();
+    final doomed = await mediaRepository.createMedia(
+      item(
+        'a.jpg',
+        diveId: dive.id,
+        hash: 'h1',
+        uploadedAt: DateTime(2026, 2),
+      ),
+    );
+
+    await diveRepository.deleteDive(dive.id);
+
+    expect(await mediaRepository.getMediaById(doomed.id), isNull);
+    expect(await mediaTombstones(), contains(doomed.id));
+    final entry = (await queue.allForTesting()).single;
+    expect(entry.direction, 'delete');
+    expect(entry.contentHash, 'h1');
+  });
+
+  test('site-linked media survives with diveId nulled', () async {
+    final dive = await makeDive();
+    final site = await insertSite();
+    final kept = await mediaRepository.createMedia(
+      item('b.jpg', diveId: dive.id, siteId: site),
+    );
+
+    await diveRepository.deleteDive(dive.id);
+
+    final got = await mediaRepository.getMediaById(kept.id);
+    expect(got, isNotNull);
+    expect(got!.diveId, isNull);
+    expect(got.siteId, site);
+    expect(await queue.allForTesting(), isEmpty);
+  });
+
+  test('library-level media reverts to library instead of dying', () async {
+    final dive = await makeDive();
+    final kept = await mediaRepository.createMedia(
+      item(
+        'c.jpg',
+        diveId: dive.id,
+        sourceType: MediaSourceType.networkUrl,
+      ),
+    );
+
+    await diveRepository.deleteDive(dive.id);
+
+    final got = await mediaRepository.getMediaById(kept.id);
+    expect(got, isNotNull);
+    expect(got!.diveId, isNull);
+    expect(await queue.allForTesting(), isEmpty);
+  });
+
+  test('bulkDeleteDives cascades across all deleted dives', () async {
+    final d1 = await makeDive();
+    final d2 = await makeDive();
+    final m1 = await mediaRepository.createMedia(
+      item('a.jpg', diveId: d1.id, hash: 'h1', uploadedAt: DateTime(2026, 2)),
+    );
+    final m2 = await mediaRepository.createMedia(
+      item('b.jpg', diveId: d2.id, hash: 'h2', uploadedAt: DateTime(2026, 2)),
+    );
+
+    await diveRepository.bulkDeleteDives([d1.id, d2.id]);
+
+    expect(await mediaRepository.getMediaById(m1.id), isNull);
+    expect(await mediaRepository.getMediaById(m2.id), isNull);
+    expect(await mediaTombstones(), containsAll([m1.id, m2.id]));
+    final hashes = (await queue.allForTesting())
+        .map((e) => e.contentHash)
+        .toSet();
+    expect(hashes, {'h1', 'h2'});
+  });
+
+  test('never-uploaded dive-only media dies without a blob intent',
+      () async {
+    final dive = await makeDive();
+    final doomed = await mediaRepository.createMedia(
+      item('plain.jpg', diveId: dive.id),
+    );
+
+    await diveRepository.deleteDive(dive.id);
+
+    expect(await mediaRepository.getMediaById(doomed.id), isNull);
+    expect(await mediaTombstones(), contains(doomed.id));
+    expect(await queue.allForTesting(), isEmpty);
+  });
+}

--- a/test/features/dive_log/data/dive_deletion_cascade_test.dart
+++ b/test/features/dive_log/data/dive_deletion_cascade_test.dart
@@ -89,26 +89,28 @@ void main() {
     return rows.map((r) => r.recordId).toList();
   }
 
-  test('deleteDive deletes dive-only media with tombstone and blob intent',
-      () async {
-    final dive = await makeDive();
-    final doomed = await mediaRepository.createMedia(
-      item(
-        'a.jpg',
-        diveId: dive.id,
-        hash: 'h1',
-        uploadedAt: DateTime(2026, 2),
-      ),
-    );
+  test(
+    'deleteDive deletes dive-only media with tombstone and blob intent',
+    () async {
+      final dive = await makeDive();
+      final doomed = await mediaRepository.createMedia(
+        item(
+          'a.jpg',
+          diveId: dive.id,
+          hash: 'h1',
+          uploadedAt: DateTime(2026, 2),
+        ),
+      );
 
-    await diveRepository.deleteDive(dive.id);
+      await diveRepository.deleteDive(dive.id);
 
-    expect(await mediaRepository.getMediaById(doomed.id), isNull);
-    expect(await mediaTombstones(), contains(doomed.id));
-    final entry = (await queue.allForTesting()).single;
-    expect(entry.direction, 'delete');
-    expect(entry.contentHash, 'h1');
-  });
+      expect(await mediaRepository.getMediaById(doomed.id), isNull);
+      expect(await mediaTombstones(), contains(doomed.id));
+      final entry = (await queue.allForTesting()).single;
+      expect(entry.direction, 'delete');
+      expect(entry.contentHash, 'h1');
+    },
+  );
 
   test('site-linked media survives with diveId nulled', () async {
     final dive = await makeDive();
@@ -129,11 +131,7 @@ void main() {
   test('library-level media reverts to library instead of dying', () async {
     final dive = await makeDive();
     final kept = await mediaRepository.createMedia(
-      item(
-        'c.jpg',
-        diveId: dive.id,
-        sourceType: MediaSourceType.networkUrl,
-      ),
+      item('c.jpg', diveId: dive.id, sourceType: MediaSourceType.networkUrl),
     );
 
     await diveRepository.deleteDive(dive.id);
@@ -165,8 +163,7 @@ void main() {
     expect(hashes, {'h1', 'h2'});
   });
 
-  test('never-uploaded dive-only media dies without a blob intent',
-      () async {
+  test('never-uploaded dive-only media dies without a blob intent', () async {
     final dive = await makeDive();
     final doomed = await mediaRepository.createMedia(
       item('plain.jpg', diveId: dive.id),

--- a/test/features/media/data/media_repository_cascade_test.dart
+++ b/test/features/media/data/media_repository_cascade_test.dart
@@ -83,8 +83,7 @@ void main() {
     expect(split.unlinkIds.toSet(), {siteLinked.id, library.id});
   });
 
-  test('unlinkMediaFromDeletedDives nulls diveId and keeps the row',
-      () async {
+  test('unlinkMediaFromDeletedDives nulls diveId and keeps the row', () async {
     await insertDive('d1');
     final m = await repo.createMedia(item('a.jpg', diveId: 'd1'));
     await repo.unlinkMediaFromDeletedDives([m.id]);
@@ -93,8 +92,7 @@ void main() {
     expect(got!.diveId, isNull);
   });
 
-  test('getSweepableOrphanIds honours linkage, source type, and age',
-      () async {
+  test('getSweepableOrphanIds honours linkage, source type, and age', () async {
     await insertDive('d1');
     final orphan = await repo.createMedia(item('old.jpg'));
     final libraryOrphan = await repo.createMedia(

--- a/test/features/media/data/media_repository_cascade_test.dart
+++ b/test/features/media/data/media_repository_cascade_test.dart
@@ -95,10 +95,13 @@ void main() {
   test('getSweepableOrphanIds honours linkage, source type, and age', () async {
     await insertDive('d1');
     final orphan = await repo.createMedia(item('old.jpg'));
-    final libraryOrphan = await repo.createMedia(
-      item('lib.jpg', sourceType: MediaSourceType.manifestEntry),
-    );
+    // The two library-level source types, named for the import that creates
+    // them: both are born unlinked and stay that way when auto-match is off
+    // or finds no confident dive, so neither is ever sweepable.
     final manifestOrphan = await repo.createMedia(
+      item('manifest.jpg', sourceType: MediaSourceType.manifestEntry),
+    );
+    final urlOrphan = await repo.createMedia(
       item('url.jpg', sourceType: MediaSourceType.networkUrl),
     );
     final linked = await repo.createMedia(item('linked.jpg', diveId: 'd1'));
@@ -110,8 +113,8 @@ void main() {
 
     final sweepable = await repo.getSweepableOrphanIds(olderThan: future);
     expect(sweepable, [orphan.id]);
-    expect(sweepable, isNot(contains(libraryOrphan.id)));
     expect(sweepable, isNot(contains(manifestOrphan.id)));
+    expect(sweepable, isNot(contains(urlOrphan.id)));
     expect(sweepable, isNot(contains(linked.id)));
 
     expect(await repo.getSweepableOrphanIds(olderThan: past), isEmpty);

--- a/test/features/media/data/media_repository_cascade_test.dart
+++ b/test/features/media/data/media_repository_cascade_test.dart
@@ -1,0 +1,121 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+
+  Future<void> insertDive(String id) => db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(epoch),
+          createdAt: Value(epoch),
+          updatedAt: Value(epoch),
+        ),
+      );
+
+  Future<void> insertSite(String id) => db
+      .into(db.diveSites)
+      .insert(
+        DiveSitesCompanion(
+          id: Value(id),
+          name: const Value('Reef'),
+          createdAt: Value(epoch),
+          updatedAt: Value(epoch),
+        ),
+      );
+
+  MediaItem item(
+    String name, {
+    String? diveId,
+    String? siteId,
+    String? hash,
+    MediaType mediaType = MediaType.photo,
+    MediaSourceType sourceType = MediaSourceType.platformGallery,
+  }) => MediaItem(
+    id: '',
+    mediaType: mediaType,
+    sourceType: sourceType,
+    filePath: '/tmp/$name',
+    localPath: '/tmp/$name',
+    originalFilename: name,
+    diveId: diveId,
+    siteId: siteId,
+    contentHash: hash,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  test('partitionMediaForDiveDeletion splits doomed from unlink', () async {
+    await insertDive('d1');
+    await insertSite('s1');
+    final doomed = await repo.createMedia(
+      item('a.jpg', diveId: 'd1', hash: 'h1'), // dive-only gallery photo
+    );
+    final siteLinked = await repo.createMedia(
+      item('b.jpg', diveId: 'd1', siteId: 's1'),
+    );
+    final library = await repo.createMedia(
+      item('c.jpg', diveId: 'd1', sourceType: MediaSourceType.networkUrl),
+    );
+    await repo.createMedia(item('other.jpg')); // unrelated row
+
+    final split = await repo.partitionMediaForDiveDeletion(['d1']);
+    expect(split.doomed.map((m) => m.id), [doomed.id]);
+    expect(split.doomed.single.contentHash, 'h1');
+    expect(split.unlinkIds.toSet(), {siteLinked.id, library.id});
+  });
+
+  test('unlinkMediaFromDeletedDives nulls diveId and keeps the row',
+      () async {
+    await insertDive('d1');
+    final m = await repo.createMedia(item('a.jpg', diveId: 'd1'));
+    await repo.unlinkMediaFromDeletedDives([m.id]);
+    final got = await repo.getMediaById(m.id);
+    expect(got, isNotNull);
+    expect(got!.diveId, isNull);
+  });
+
+  test('getSweepableOrphanIds honours linkage, source type, and age',
+      () async {
+    await insertDive('d1');
+    final orphan = await repo.createMedia(item('old.jpg'));
+    final libraryOrphan = await repo.createMedia(
+      item('lib.jpg', sourceType: MediaSourceType.manifestEntry),
+    );
+    final manifestOrphan = await repo.createMedia(
+      item('url.jpg', sourceType: MediaSourceType.networkUrl),
+    );
+    final linked = await repo.createMedia(item('linked.jpg', diveId: 'd1'));
+
+    // createMedia stamps createdAt with the current wall clock, so a future
+    // cutoff includes the fixtures and a past cutoff excludes them.
+    final future = DateTime.now().add(const Duration(days: 1));
+    final past = DateTime.now().subtract(const Duration(days: 1));
+
+    final sweepable = await repo.getSweepableOrphanIds(olderThan: future);
+    expect(sweepable, [orphan.id]);
+    expect(sweepable, isNot(contains(libraryOrphan.id)));
+    expect(sweepable, isNot(contains(manifestOrphan.id)));
+    expect(sweepable, isNot(contains(linked.id)));
+
+    expect(await repo.getSweepableOrphanIds(olderThan: past), isEmpty);
+  });
+}

--- a/test/features/media/data/media_repository_cascade_test.dart
+++ b/test/features/media/data/media_repository_cascade_test.dart
@@ -83,6 +83,23 @@ void main() {
     expect(split.unlinkIds.toSet(), {siteLinked.id, library.id});
   });
 
+  test(
+    'partitionMediaForDiveDeletion short-circuits an empty dive list',
+    () async {
+      // Bulk callers hand over collections that can be empty (consolidation's
+      // secondary-dive set, an empty multi-select), and must get empty buckets
+      // rather than every unlinked row in the library.
+      await insertDive('d1');
+      await repo.createMedia(item('a.jpg', diveId: 'd1'));
+      await repo.createMedia(item('unlinked.jpg'));
+
+      final split = await repo.partitionMediaForDiveDeletion([]);
+
+      expect(split.doomed, isEmpty);
+      expect(split.unlinkIds, isEmpty);
+    },
+  );
+
   test('unlinkMediaFromDeletedDives nulls diveId and keeps the row', () async {
     await insertDive('d1');
     final m = await repo.createMedia(item('a.jpg', diveId: 'd1'));

--- a/test/features/media_store/media_deletion_coordinator_test.dart
+++ b/test/features/media_store/media_deletion_coordinator_test.dart
@@ -96,6 +96,35 @@ void main() {
     expect((await queue.allForTesting()).single.direction, 'delete');
   });
 
+  test('deleteMediaItems builds the intent from the caller\'s row', () async {
+    await repo.createMedia(
+      photo('m5', hash: 'dd', uploadedAt: DateTime(2026, 2)),
+    );
+    final held = (await repo.getMediaById('m5'))!;
+
+    await coordinator.deleteMediaItems([held]);
+
+    expect(await repo.getMediaById('m5'), isNull);
+    final row = (await queue.allForTesting()).single;
+    expect(row.direction, 'delete');
+    expect(row.contentHash, 'dd');
+    expect(kicks, 1);
+  });
+
+  test('deleteMediaItems does not read the row back', () async {
+    // The dive-deletion cascade hands over rows it already selected, so the
+    // per-id read must be skipped rather than merely redundant. Proven by
+    // an item with no row behind it: the read-back path would find nothing
+    // and enqueue nothing, so an intent here can only have come from the
+    // caller's copy.
+    await coordinator.deleteMediaItems([
+      photo('ghost', hash: 'ee', uploadedAt: DateTime(2026, 2)),
+    ]);
+
+    final row = (await queue.allForTesting()).single;
+    expect(row.contentHash, 'ee');
+  });
+
   test('queue failure never blocks row deletion', () async {
     await repo.createMedia(
       photo('m4', hash: 'cc', uploadedAt: DateTime(2026, 2)),

--- a/test/features/media_store/media_orphan_backlog_sweep_test.dart
+++ b/test/features/media_store/media_orphan_backlog_sweep_test.dart
@@ -108,21 +108,23 @@ void main() {
     expect(await sweep.runIfNeeded(now: sweepTime), 0);
   });
 
-  test('flag stays unset when the sweep fails, so it retries next launch',
-      () async {
-    final broken = MediaOrphanBacklogSweep(
-      mediaRepository: _ThrowingMediaRepository(),
-      coordinator: MediaDeletionCoordinator(
-        mediaRepository: repo,
-        queue: () => queue,
-      ),
-      prefs: SharedPreferences.getInstance,
-    );
-    await expectLater(broken.runIfNeeded(now: sweepTime), throwsStateError);
-    final p = await SharedPreferences.getInstance();
-    expect(p.getBool(MediaOrphanBacklogSweep.flagKey), isNot(true));
-    // The healthy sweep still runs afterwards.
-    expect(await sweep.runIfNeeded(now: sweepTime), 0);
-    expect(p.getBool(MediaOrphanBacklogSweep.flagKey), isTrue);
-  });
+  test(
+    'flag stays unset when the sweep fails, so it retries next launch',
+    () async {
+      final broken = MediaOrphanBacklogSweep(
+        mediaRepository: _ThrowingMediaRepository(),
+        coordinator: MediaDeletionCoordinator(
+          mediaRepository: repo,
+          queue: () => queue,
+        ),
+        prefs: SharedPreferences.getInstance,
+      );
+      await expectLater(broken.runIfNeeded(now: sweepTime), throwsStateError);
+      final p = await SharedPreferences.getInstance();
+      expect(p.getBool(MediaOrphanBacklogSweep.flagKey), isNot(true));
+      // The healthy sweep still runs afterwards.
+      expect(await sweep.runIfNeeded(now: sweepTime), 0);
+      expect(p.getBool(MediaOrphanBacklogSweep.flagKey), isTrue);
+    },
+  );
 }

--- a/test/features/media_store/media_orphan_backlog_sweep_test.dart
+++ b/test/features/media_store/media_orphan_backlog_sweep_test.dart
@@ -1,0 +1,128 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/data/media_orphan_backlog_sweep.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+import '../../helpers/test_database.dart';
+
+class _ThrowingMediaRepository extends MediaRepository {
+  @override
+  Future<List<String>> getSweepableOrphanIds({required DateTime olderThan}) {
+    throw StateError('db unavailable');
+  }
+}
+
+void main() {
+  late AppDatabase db;
+  late LocalCacheDatabase cacheDb;
+  late MediaTransferQueueRepository queue;
+  late MediaRepository repo;
+  late MediaOrphanBacklogSweep sweep;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    repo = MediaRepository();
+    sweep = MediaOrphanBacklogSweep(
+      mediaRepository: repo,
+      coordinator: MediaDeletionCoordinator(
+        mediaRepository: repo,
+        queue: () => queue,
+      ),
+      prefs: SharedPreferences.getInstance,
+    );
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    await tearDownTestDatabase();
+  });
+
+  MediaItem item(
+    String name, {
+    String? diveId,
+    String? hash,
+    DateTime? uploadedAt,
+    MediaSourceType sourceType = MediaSourceType.platformGallery,
+  }) => MediaItem(
+    id: '',
+    mediaType: MediaType.photo,
+    sourceType: sourceType,
+    filePath: '/tmp/$name',
+    localPath: '/tmp/$name',
+    originalFilename: name,
+    diveId: diveId,
+    contentHash: hash,
+    remoteUploadedAt: uploadedAt,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  // createMedia stamps createdAt with the real wall clock, so the sweep's
+  // 24h age guard is satisfied by running "two days in the future".
+  final sweepTime = DateTime.now().add(const Duration(days: 2));
+
+  test('sweeps old unlinked non-library rows exactly once', () async {
+    final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diveDateTime: Value(epoch),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
+    final orphan = await repo.createMedia(
+      item('orphan.jpg', hash: 'h1', uploadedAt: DateTime(2026, 2)),
+    );
+    final library = await repo.createMedia(
+      item('lib.jpg', sourceType: MediaSourceType.networkUrl),
+    );
+    final linked = await repo.createMedia(item('linked.jpg', diveId: 'd1'));
+
+    final swept = await sweep.runIfNeeded(now: sweepTime);
+    expect(swept, 1);
+    expect(await repo.getMediaById(orphan.id), isNull);
+    expect(await repo.getMediaById(library.id), isNotNull);
+    expect(await repo.getMediaById(linked.id), isNotNull);
+    // The uploaded orphan produced a blob-delete intent.
+    final entry = (await queue.allForTesting()).single;
+    expect(entry.direction, 'delete');
+    expect(entry.contentHash, 'h1');
+
+    // Second run is a no-op: the flag persisted.
+    await repo.createMedia(item('later-orphan.jpg'));
+    expect(await sweep.runIfNeeded(now: sweepTime), 0);
+  });
+
+  test('flag stays unset when the sweep fails, so it retries next launch',
+      () async {
+    final broken = MediaOrphanBacklogSweep(
+      mediaRepository: _ThrowingMediaRepository(),
+      coordinator: MediaDeletionCoordinator(
+        mediaRepository: repo,
+        queue: () => queue,
+      ),
+      prefs: SharedPreferences.getInstance,
+    );
+    await expectLater(broken.runIfNeeded(now: sweepTime), throwsStateError);
+    final p = await SharedPreferences.getInstance();
+    expect(p.getBool(MediaOrphanBacklogSweep.flagKey), isNot(true));
+    // The healthy sweep still runs afterwards.
+    expect(await sweep.runIfNeeded(now: sweepTime), 0);
+    expect(p.getBool(MediaOrphanBacklogSweep.flagKey), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Dive deletion previously deleted only the dive row; the `media.dive_id` FK's `ON DELETE SET NULL` silently unlinked its media, which then accumulated as orphan rows (369 in one debug DB), got uploaded by backfill, and HLC-stamped into sync. This PR makes dive deletion cascade to its media - honoring the amended safe predicate from the design's verification gate - and sweeps the existing backlog once per device.

PR 3 of 4 from `docs/superpowers/specs/2026-07-23-media-store-orphan-prevention-design.md` (sections 3, 4.2, 4.3 as amended; plan: `docs/superpowers/plans/2026-07-23-media-orphan-prevention-pr3-cascade-backlog.md`). **Stacked on #702** (which stacks on #697); merge bottom-up.

## The verification gate (spec section 3, resolved)

A codebase audit before this PR found that bare `dive_id IS NULL AND site_id IS NULL` would delete legitimate data: URL-tab (`networkUrl`) and manifest-subscription (`manifestEntry`) imports are deliberately library-level - created unlinked, auto-matched additively, and permanently unlinked when auto-match is off or no confident match exists. Both the cascade and the sweep therefore protect those source types. Every other creator always sets `diveId` at creation, so a null/null non-library row can only be past-dive-deletion residue. A 24h age guard covers unforeseen future add-then-link creators.

## Changes

- **Cascade** (`DiveRepository.deleteDive` / `bulkDeleteDives`): dive-only non-library media dies with the dive - rows + tombstones + remote-blob delete intents via #702's `MediaDeletionCoordinator` (enqueue-before-delete). Site-linked and library-level media survives with `dive_id` explicitly nulled AND HLC-stamped - fixing a latent sync divergence: the FK's silent SET NULL never propagated the unlink to other devices.
- **`cascadeMedia: false` opt-out** for restore flows: merge-undo re-points media back to restored sources after deleting the merged dive; the cascade would have eaten those rows first (caught by the existing merge-undo byte-for-byte test).
- **`MediaRepository`** gains the shared partition (`partitionMediaForDiveDeletion`), the synced unlink (`unlinkMediaFromDeletedDives`), the `libraryLevelSourceTypes` constant, and `getSweepableOrphanIds` (unlinked + non-library + 24h age guard), all built on PR 1's `isLinkedToDiveOrSite`.
- **One-time backlog sweep** (`MediaOrphanBacklogSweep`): runs fire-and-forget at startup after DB init (mirroring the `AccountStartupMigration` precedent), guarded by a SharedPreferences flag set only on success; sweeps existing orphans through the coordinator so uploaded ones also get blob-delete intents. Repository-layer, not `onUpgrade`: tombstones need the live sync clock.
- **Sync contract tests updated**: dive-only media now dies with its dive and its tombstone beats a peer's live copy; library-level media keeps the original preserved-not-resurrected guarantee.
- Merge/consolidation regression: those services reassign media to the surviving dive before deleting sources, so the cascade sees no doomed media there - covered by the existing suites plus the merge-undo opt-out.

## Testing

- New suites: repository partition/unlink/sweepable (3), dive-deletion cascade (5: tombstone + blob intent, site-linked survival, library revert, bulk, never-uploaded), backlog sweep (2: selective one-shot sweep with intent, flag-unset-on-failure retry).
- `flutter analyze`: no issues. `dart format .`: clean. Mocks regenerated for the new deletion signatures.
- Full suite: 13769 passed / 0 failed (14 skipped).