### PR TITLE
fix(media): probe readability, not just existence, for localFile resolve

### DIFF
--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -242,8 +242,29 @@ class LocalFileResolver implements MediaSourceResolver {
   Future<VerifyResult> verify(MediaItem item) async {
     final data = await resolve(item);
     if (data is! UnavailableData) return VerifyResult.available;
-    return data.kind == UnavailableKind.volumeOffline
-        ? VerifyResult.volumeOffline
-        : VerifyResult.notFound;
+    if (data.kind == UnavailableKind.volumeOffline) {
+      return VerifyResult.volumeOffline;
+    }
+    // A file that is present but unreadable (sandbox denial, revoked
+    // permission) is not a dead pointer: the bytes are still on disk and a
+    // re-grant restores access. Reporting notFound here would let the
+    // re-verify sweep flag the row "missing from device", which is both
+    // wrong and sticky. transientError updates lastVerifiedAt without
+    // touching the orphan flag.
+    final localPath = item.localPath ?? item.filePath;
+    if (localPath != null && localPath.isNotEmpty) {
+      try {
+        if (await File(localPath).exists()) return VerifyResult.transientError;
+      }
+      // coverage:ignore-start
+      // Only reachable when exists() itself throws (permission/FS error),
+      // which flutter_test's tmpdir fixtures do not produce. Falling through
+      // to notFound matches the pre-existing behaviour.
+      on FileSystemException {
+        // Fall through to notFound.
+      }
+      // coverage:ignore-end
+    }
+    return VerifyResult.notFound;
   }
 }

--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -76,10 +76,12 @@ class LocalFileResolver implements MediaSourceResolver {
         // to the security-scoped bookmark — the design's source of truth
         // on macOS — when the direct read is denied.
         if (await f.exists()) {
-          if (await _isReadable(f)) return FileData(file: f);
+          final blocker = await _readBlocker(f);
+          if (blocker == null) return FileData(file: f);
           _log.debug(
-            'localPath exists but is not readable (sandbox?), falling '
+            'localPath exists but cannot be opened (sandbox?), falling '
             'back to bookmark: $localPath [item ${item.id}]',
+            error: blocker,
           );
         } else {
           _log.debug(
@@ -128,8 +130,12 @@ class LocalFileResolver implements MediaSourceResolver {
       try {
         final bytes = await _platform.readUriBytes(ref);
         return BytesData(bytes: bytes);
-      } catch (e) {
-        _log.warning('readUriBytes failed for item ${item.id}', error: e);
+      } catch (e, st) {
+        _log.warning(
+          'readUriBytes failed for item ${item.id}',
+          error: e,
+          stackTrace: st,
+        );
         return const UnavailableData(kind: UnavailableKind.notFound);
       }
       // coverage:ignore-end
@@ -152,8 +158,12 @@ class LocalFileResolver implements MediaSourceResolver {
         // security scope when callers forget to invoke releaseBookmark.
         final bytes = await _platform.readBookmarkBytes(blob);
         return BytesData(bytes: bytes);
-      } catch (e) {
-        _log.warning('readBookmarkBytes failed for item ${item.id}', error: e);
+      } catch (e, st) {
+        _log.warning(
+          'readBookmarkBytes failed for item ${item.id}',
+          error: e,
+          stackTrace: st,
+        );
         return const UnavailableData(kind: UnavailableKind.notFound);
       }
     }
@@ -161,18 +171,23 @@ class LocalFileResolver implements MediaSourceResolver {
     return const UnavailableData(kind: UnavailableKind.notFound);
   }
 
-  /// True when [f] can actually be opened for reading. Complements the
-  /// exists() check in [resolve]: a sandboxed build can stat a user file it
-  /// is not allowed to open, and handing such a file to Image.file produces
-  /// a broken tile with no diagnosable error. An open/close round-trip is
-  /// cheap relative to decoding and runs only on the localFile resolve path.
-  Future<bool> _isReadable(File f) async {
+  /// Returns null when [f] can actually be opened for reading, otherwise the
+  /// exception that blocked it. Complements the exists() check in [resolve]:
+  /// a sandboxed build can stat a user file it is not allowed to open, and
+  /// handing such a file to Image.file produces a broken tile with no
+  /// diagnosable error. An open/close round-trip is cheap relative to
+  /// decoding and runs only on the localFile resolve path.
+  ///
+  /// The exception is returned rather than collapsed to a bool so the caller
+  /// can log the concrete reason (EPERM vs. ENOENT vs. an I/O error) — the
+  /// whole point of this path is that the failure was previously invisible.
+  Future<FileSystemException?> _readBlocker(File f) async {
     try {
       final raf = await f.open();
       await raf.close();
-      return true;
-    } on FileSystemException {
-      return false;
+      return null;
+    } on FileSystemException catch (e) {
+      return e;
     }
   }
 

--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -43,14 +43,28 @@ class LocalFileResolver implements MediaSourceResolver {
     required ExifExtractor exifExtractor,
     VideoThumbnailService? videoThumbnails,
     VolumeStatus? volumeStatus,
+    bool Function()? usesSecurityScopedBookmarks,
   }) : _bookmarkStorage = bookmarkStorage,
        _platform = platform,
        _exifExtractor = exifExtractor,
        _videoThumbnails = videoThumbnails,
-       _volumeStatus = volumeStatus ?? VolumeStatus();
+       _volumeStatus = volumeStatus ?? VolumeStatus(),
+       _usesSecurityScopedBookmarks =
+           usesSecurityScopedBookmarks ??
+           (() => Platform.isIOS || Platform.isMacOS);
 
   final VideoThumbnailService? _videoThumbnails;
   final VolumeStatus _volumeStatus;
+
+  /// Whether this host resolves local files through security-scoped
+  /// bookmarks (iOS / macOS) rather than a plain path.
+  ///
+  /// Injectable for the same reason [VolumeStatus.directoryExists] is: the
+  /// unit shards run on Linux, so a hard `Platform.isMacOS` check would
+  /// leave the bookmark branch — the only path that can resolve a sandboxed
+  /// file, and the whole point of this resolver on Apple platforms —
+  /// unexecuted in CI. Production always gets the real check.
+  final bool Function() _usesSecurityScopedBookmarks;
   final _log = LoggerService.forClass(LocalFileResolver);
 
   @override
@@ -141,7 +155,7 @@ class LocalFileResolver implements MediaSourceResolver {
       // coverage:ignore-end
     }
 
-    if (Platform.isIOS || Platform.isMacOS) {
+    if (_usesSecurityScopedBookmarks()) {
       final blob = await _bookmarkStorage.read(ref);
       if (blob == null) {
         _log.warning(

--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui' show Size;
 
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/data/services/exif_extractor.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
@@ -50,6 +51,7 @@ class LocalFileResolver implements MediaSourceResolver {
 
   final VideoThumbnailService? _videoThumbnails;
   final VolumeStatus _volumeStatus;
+  final _log = LoggerService.forClass(LocalFileResolver);
 
   @override
   MediaSourceType get sourceType => MediaSourceType.localFile;
@@ -67,7 +69,24 @@ class LocalFileResolver implements MediaSourceResolver {
     if (localPath != null && localPath.isNotEmpty) {
       try {
         final f = File(localPath);
-        if (await f.exists()) return FileData(file: f);
+        // Existence alone is not enough: the macOS sandbox allows STAT on
+        // user files (~/Downloads etc.) while denying OPEN, so exists()
+        // returns true for a file Image.file can never actually read
+        // (PathAccessException, EPERM). Probe readability and fall through
+        // to the security-scoped bookmark — the design's source of truth
+        // on macOS — when the direct read is denied.
+        if (await f.exists()) {
+          if (await _isReadable(f)) return FileData(file: f);
+          _log.debug(
+            'localPath exists but is not readable (sandbox?), falling '
+            'back to bookmark: $localPath [item ${item.id}]',
+          );
+        } else {
+          _log.debug(
+            'localPath does not exist, falling back to bookmark: '
+            '$localPath [item ${item.id}]',
+          );
+        }
         // Missing file on an unmounted volume (network share, external
         // disk) is a temporary condition, not a dead pointer: report it
         // as such so nothing orphans the row while the share is offline.
@@ -94,6 +113,10 @@ class LocalFileResolver implements MediaSourceResolver {
 
     final ref = item.bookmarkRef;
     if (ref == null || ref.isEmpty) {
+      _log.warning(
+        'No usable localPath and no bookmarkRef; item ${item.id} '
+        'is unresolvable on this device',
+      );
       return const UnavailableData(kind: UnavailableKind.notFound);
     }
 
@@ -105,7 +128,8 @@ class LocalFileResolver implements MediaSourceResolver {
       try {
         final bytes = await _platform.readUriBytes(ref);
         return BytesData(bytes: bytes);
-      } catch (_) {
+      } catch (e) {
+        _log.warning('readUriBytes failed for item ${item.id}', error: e);
         return const UnavailableData(kind: UnavailableKind.notFound);
       }
       // coverage:ignore-end
@@ -114,6 +138,10 @@ class LocalFileResolver implements MediaSourceResolver {
     if (Platform.isIOS || Platform.isMacOS) {
       final blob = await _bookmarkStorage.read(ref);
       if (blob == null) {
+        _log.warning(
+          'Bookmark blob $ref missing from secure storage for '
+          'item ${item.id}',
+        );
         return const UnavailableData(kind: UnavailableKind.notFound);
       }
       try {
@@ -124,12 +152,28 @@ class LocalFileResolver implements MediaSourceResolver {
         // security scope when callers forget to invoke releaseBookmark.
         final bytes = await _platform.readBookmarkBytes(blob);
         return BytesData(bytes: bytes);
-      } catch (_) {
+      } catch (e) {
+        _log.warning('readBookmarkBytes failed for item ${item.id}', error: e);
         return const UnavailableData(kind: UnavailableKind.notFound);
       }
     }
 
     return const UnavailableData(kind: UnavailableKind.notFound);
+  }
+
+  /// True when [f] can actually be opened for reading. Complements the
+  /// exists() check in [resolve]: a sandboxed build can stat a user file it
+  /// is not allowed to open, and handing such a file to Image.file produces
+  /// a broken tile with no diagnosable error. An open/close round-trip is
+  /// cheap relative to decoding and runs only on the localFile resolve path.
+  Future<bool> _isReadable(File f) async {
+    try {
+      final raf = await f.open();
+      await raf.close();
+      return true;
+    } on FileSystemException {
+      return false;
+    }
   }
 
   @override

--- a/lib/features/media/data/services/local_files_diagnostics_service.dart
+++ b/lib/features/media/data/services/local_files_diagnostics_service.dart
@@ -95,9 +95,13 @@ class LocalFilesDiagnosticsService {
     for (final item in all) {
       try {
         final result = await _resolver.verify(item);
-        // An unmounted volume is transient: keep the row's current orphan
-        // state rather than flagging files that will reappear on remount.
-        if (result == VerifyResult.volumeOffline) {
+        // Transient states keep the row's current orphan flag rather than
+        // flagging files that are still on disk: an unmounted volume
+        // reappears on remount, and a present-but-unreadable file (sandbox
+        // denial, revoked permission) comes back when access is re-granted.
+        // This is the contract VerifyResult documents.
+        if (result == VerifyResult.volumeOffline ||
+            result == VerifyResult.transientError) {
           await _repository.updateMedia(item.copyWith(lastVerifiedAt: now));
           continue;
         }

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -187,7 +187,7 @@ class _VideoThumbnailPlaceholder extends StatelessWidget {
   }
 }
 
-const _imageErrorLog = LoggerService('MediaItemView');
+final _imageErrorLog = LoggerService.forClass(MediaItemView);
 
 /// Graceful fallback when image bytes fail to decode (corrupt/unsupported), so
 /// the raw "Invalid image data" exception never reaches the UI. Shows a

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
@@ -186,11 +187,22 @@ class _VideoThumbnailPlaceholder extends StatelessWidget {
   }
 }
 
+const _imageErrorLog = LoggerService('MediaItemView');
+
 /// Graceful fallback when image bytes fail to decode (corrupt/unsupported), so
 /// the raw "Invalid image data" exception never reaches the UI. Shows a
 /// broken-image tile rather than the "file not found" placeholder: the file is
 /// present, it just couldn't be rendered.
+///
+/// The underlying error is logged: `errorBuilder` suppresses the framework's
+/// own console report, so without this a load/decode failure (sandbox denial,
+/// truncated bytes, unsupported codec) leaves no trace anywhere.
 Widget _imageError(BuildContext context, Object error, StackTrace? stack) {
+  _imageErrorLog.warning(
+    'Image failed to load/decode',
+    error: error,
+    stackTrace: stack,
+  );
   final scheme = Theme.of(context).colorScheme;
   return ColoredBox(
     color: scheme.surfaceContainerHighest,

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -321,6 +321,32 @@ void main() {
         expect((data as UnavailableData).kind, UnavailableKind.notFound);
       },
     );
+
+    // The bytes are still on disk, so the re-verify sweep must not flag the
+    // row "missing from device" — that state is sticky and misleading, and a
+    // re-granted permission restores the file with no user action.
+    test('verify reports transientError (not notFound) for a present but '
+        'unreadable file', () async {
+      if (!Platform.isMacOS) return;
+      final f = File('${tempDir.path}/locked3.jpg')
+        ..writeAsBytesSync([1, 2, 3]);
+      await Process.run('chmod', ['000', f.path]);
+      addTearDown(() => Process.run('chmod', ['644', f.path]));
+
+      final r = _resolver();
+      expect(
+        await r.verify(_localFile(localPath: f.path)),
+        VerifyResult.transientError,
+      );
+    });
+
+    test('verify still reports notFound for a genuinely absent file', () async {
+      final r = _resolver();
+      expect(
+        await r.verify(_localFile(localPath: '${tempDir.path}/gone.jpg')),
+        VerifyResult.notFound,
+      );
+    });
   });
 
   group('volume awareness', () {

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -76,6 +76,20 @@ LocalFileResolver _resolver() => LocalFileResolver(
   exifExtractor: ExifExtractor(),
 );
 
+/// Resolver pinned to the security-scoped-bookmark branch (the iOS / macOS
+/// path) on any host. The unit shards run on Linux, so without this the
+/// bookmark branch — the only one that can resolve a sandboxed file — would
+/// never execute in CI.
+LocalFileResolver _bookmarkResolver({
+  required LocalBookmarkStorage bookmarkStorage,
+  required LocalMediaPlatform platform,
+}) => LocalFileResolver(
+  bookmarkStorage: bookmarkStorage,
+  platform: platform,
+  exifExtractor: ExifExtractor(),
+  usesSecurityScopedBookmarks: () => true,
+);
+
 void main() {
   late Directory tempDir;
 
@@ -123,11 +137,32 @@ void main() {
   test(
     'resolve returns Unavailable when bookmarkRef present but storage returns null',
     () async {
-      final r = _resolver();
-      // Non-Android / non-iOS desktop host: bookmarkRef present but
-      // _NullBookmarkStorage returns null -> UnavailableData.
+      // Pinned to the bookmark branch so the missing-blob path (and its
+      // diagnostic warning) executes on every host, not just Apple ones.
+      final r = _bookmarkResolver(
+        bookmarkStorage: _NullBookmarkStorage(),
+        platform: LocalMediaPlatform(),
+      );
       final data = await r.resolve(_localFile(bookmarkRef: 'ref-123'));
       expect(data, isA<UnavailableData>());
+      expect((data as UnavailableData).kind, UnavailableKind.notFound);
+    },
+  );
+
+  test(
+    'resolve falls through to Unavailable on a host without bookmarks',
+    () async {
+      // The default predicate on a non-Apple host: the bookmark branch is
+      // skipped entirely and resolve() exits at the final return.
+      final r = LocalFileResolver(
+        bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
+        platform: _StubPlatform(),
+        exifExtractor: ExifExtractor(),
+        usesSecurityScopedBookmarks: () => false,
+      );
+      final data = await r.resolve(_localFile(bookmarkRef: 'ref-123'));
+      expect(data, isA<UnavailableData>());
+      expect((data as UnavailableData).kind, UnavailableKind.notFound);
     },
   );
 
@@ -194,23 +229,19 @@ void main() {
     },
   );
 
-  // The Android branch (Platform.isAndroid: readUriBytes) and the
-  // iOS / macOS bookmark-bytes branch are exercised together via the
-  // BytesData round-trip in extractMetadata. On macOS hosts the
-  // bookmark-bytes branch fires; on Android hosts the URI-bytes branch
-  // fires. Below we assert the iOS/macOS branch (the host this suite
-  // runs on in dev / CI).
+  // The security-scoped-bookmark branch (iOS / macOS in production). These
+  // pin the branch via `usesSecurityScopedBookmarks` rather than gating on
+  // the host, so they run on the Linux unit shards too. The Android
+  // URI-bytes branch stays host-gated — it needs a real Android runtime.
   test(
-    'resolve returns BytesData via readBookmarkBytes on iOS/macOS hosts',
+    'resolve returns BytesData via readBookmarkBytes on the bookmark branch',
     () async {
-      if (!Platform.isIOS && !Platform.isMacOS) return;
       final platform = _StubPlatform()
         ..onReadBookmarkBytes = ((blob) async =>
             Uint8List.fromList([10, 20, 30]));
-      final r = LocalFileResolver(
+      final r = _bookmarkResolver(
         bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
         platform: platform,
-        exifExtractor: ExifExtractor(),
       );
       final data = await r.resolve(_localFile(bookmarkRef: 'ref-1'));
       expect(data, isA<BytesData>());
@@ -218,34 +249,27 @@ void main() {
     },
   );
 
-  test(
-    'resolve returns Unavailable when readBookmarkBytes throws (iOS/macOS)',
-    () async {
-      if (!Platform.isIOS && !Platform.isMacOS) return;
-      final platform = _StubPlatform()
-        ..onReadBookmarkBytes = ((blob) async => throw 'boom');
-      final r = LocalFileResolver(
-        bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
-        platform: platform,
-        exifExtractor: ExifExtractor(),
-      );
-      final data = await r.resolve(_localFile(bookmarkRef: 'ref-1'));
-      expect(data, isA<UnavailableData>());
-      expect((data as UnavailableData).kind, UnavailableKind.notFound);
-    },
-  );
+  test('resolve returns Unavailable when readBookmarkBytes throws', () async {
+    final platform = _StubPlatform()
+      ..onReadBookmarkBytes = ((blob) async => throw 'boom');
+    final r = _bookmarkResolver(
+      bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
+      platform: platform,
+    );
+    final data = await r.resolve(_localFile(bookmarkRef: 'ref-1'));
+    expect(data, isA<UnavailableData>());
+    expect((data as UnavailableData).kind, UnavailableKind.notFound);
+  });
 
   test(
-    'extractMetadata over BytesData round-trips through a temp file (iOS/macOS)',
+    'extractMetadata over BytesData round-trips through a temp file',
     () async {
-      if (!Platform.isIOS && !Platform.isMacOS) return;
       final platform = _StubPlatform()
         ..onReadBookmarkBytes = ((blob) async =>
             Uint8List.fromList([0, 1, 2, 3]));
-      final r = LocalFileResolver(
+      final r = _bookmarkResolver(
         bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
         platform: platform,
-        exifExtractor: ExifExtractor(),
       );
       final meta = await r.extractMetadata(_localFile(bookmarkRef: 'ref-1'));
       // BytesData branch writes a temp file, runs extractor, deletes — so we
@@ -255,24 +279,19 @@ void main() {
     },
   );
 
-  test(
-    'extractMetadata cleans up the temp file after BytesData run (iOS/macOS)',
-    () async {
-      if (!Platform.isIOS && !Platform.isMacOS) return;
-      final platform = _StubPlatform()
-        ..onReadBookmarkBytes = ((blob) async =>
-            Uint8List.fromList([0, 1, 2, 3]));
-      final item = _localFile(bookmarkRef: 'ref-cleanup');
-      final r = LocalFileResolver(
-        bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
-        platform: platform,
-        exifExtractor: ExifExtractor(),
-      );
-      await r.extractMetadata(item);
-      final tmp = File('${Directory.systemTemp.path}/exif_${item.id}.bin');
-      expect(tmp.existsSync(), isFalse);
-    },
-  );
+  test('extractMetadata cleans up the temp file after BytesData run', () async {
+    final platform = _StubPlatform()
+      ..onReadBookmarkBytes = ((blob) async =>
+          Uint8List.fromList([0, 1, 2, 3]));
+    final item = _localFile(bookmarkRef: 'ref-cleanup');
+    final r = _bookmarkResolver(
+      bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
+      platform: platform,
+    );
+    await r.extractMetadata(item);
+    final tmp = File('${Directory.systemTemp.path}/exif_${item.id}.bin');
+    expect(tmp.existsSync(), isFalse);
+  });
   // Regression: a sandboxed macOS build can STAT a user file (~/Downloads)
   // but not OPEN it — File.exists() returns true while any read throws
   // EPERM. The resolver must probe readability, not existence, before
@@ -308,24 +327,18 @@ void main() {
       }
     }
 
-    // Unlike its two siblings below, this one cannot run on Linux: the
-    // bookmark branch in resolve() is gated on Platform.isIOS/isMacOS, so a
-    // Linux host would fall straight through to notFound no matter how the
-    // storage is stubbed.
     test(
       'resolve falls back to the bookmark when localPath is unreadable',
       () async {
-        if (!Platform.isIOS && !Platform.isMacOS) return;
         final f = await unreadableFile('${tempDir.path}/locked.jpg');
         if (f == null) return;
 
         final platform = _StubPlatform()
           ..onReadBookmarkBytes = ((blob) async =>
               Uint8List.fromList([10, 20, 30]));
-        final r = LocalFileResolver(
+        final r = _bookmarkResolver(
           bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
           platform: platform,
-          exifExtractor: ExifExtractor(),
         );
         final data = await r.resolve(
           _localFile(localPath: f.path, bookmarkRef: 'ref-1'),

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -279,16 +279,45 @@ void main() {
   // taking the direct-file fast path; otherwise it returns FileData that
   // Image.file can never load and the working security-scoped bookmark is
   // never consulted. chmod 000 reproduces the same exists-but-unreadable
-  // split without a sandbox.
+  // split without a sandbox, on both macOS and Linux (CI runs the unit
+  // shards on ubuntu, so guarding these on macOS alone would mean the
+  // regression is never exercised in CI).
   group('exists-but-unreadable localPath (sandbox)', () {
+    /// Creates a file at [path] that exists but cannot be opened, or returns
+    /// null when this environment cannot produce that state — Windows has no
+    /// chmod semantics, and chmod cannot deny root, so a root test runner
+    /// (some CI containers) would silently get a readable file and fail for
+    /// the wrong reason. Callers skip in that case.
+    Future<File?> unreadableFile(String path) async {
+      if (Platform.isWindows) {
+        markTestSkipped('chmod permission semantics are POSIX-only');
+        return null;
+      }
+      final f = File(path)..writeAsBytesSync([1, 2, 3]);
+      final chmod = await Process.run('chmod', ['000', f.path]);
+      expect(chmod.exitCode, 0, reason: 'chmod 000 failed: ${chmod.stderr}');
+      addTearDown(() => Process.run('chmod', ['644', f.path]));
+      // Confirm the state we actually need, rather than assuming chmod
+      // implies it.
+      try {
+        await (await f.open()).close();
+        markTestSkipped('running as root: chmod cannot deny read access');
+        return null;
+      } on FileSystemException {
+        return f;
+      }
+    }
+
+    // Unlike its two siblings below, this one cannot run on Linux: the
+    // bookmark branch in resolve() is gated on Platform.isIOS/isMacOS, so a
+    // Linux host would fall straight through to notFound no matter how the
+    // storage is stubbed.
     test(
       'resolve falls back to the bookmark when localPath is unreadable',
       () async {
-        if (!Platform.isMacOS) return;
-        final f = File('${tempDir.path}/locked.jpg')
-          ..writeAsBytesSync([1, 2, 3]);
-        await Process.run('chmod', ['000', f.path]);
-        addTearDown(() => Process.run('chmod', ['644', f.path]));
+        if (!Platform.isIOS && !Platform.isMacOS) return;
+        final f = await unreadableFile('${tempDir.path}/locked.jpg');
+        if (f == null) return;
 
         final platform = _StubPlatform()
           ..onReadBookmarkBytes = ((blob) async =>
@@ -309,11 +338,8 @@ void main() {
     test(
       'resolve reads unreadable localPath as Unavailable when no bookmark',
       () async {
-        if (!Platform.isMacOS) return;
-        final f = File('${tempDir.path}/locked2.jpg')
-          ..writeAsBytesSync([1, 2, 3]);
-        await Process.run('chmod', ['000', f.path]);
-        addTearDown(() => Process.run('chmod', ['644', f.path]));
+        final f = await unreadableFile('${tempDir.path}/locked2.jpg');
+        if (f == null) return;
 
         final r = _resolver();
         final data = await r.resolve(_localFile(localPath: f.path));
@@ -327,11 +353,8 @@ void main() {
     // re-granted permission restores the file with no user action.
     test('verify reports transientError (not notFound) for a present but '
         'unreadable file', () async {
-      if (!Platform.isMacOS) return;
-      final f = File('${tempDir.path}/locked3.jpg')
-        ..writeAsBytesSync([1, 2, 3]);
-      await Process.run('chmod', ['000', f.path]);
-      addTearDown(() => Process.run('chmod', ['644', f.path]));
+      final f = await unreadableFile('${tempDir.path}/locked3.jpg');
+      if (f == null) return;
 
       final r = _resolver();
       expect(

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -273,6 +273,56 @@ void main() {
       expect(tmp.existsSync(), isFalse);
     },
   );
+  // Regression: a sandboxed macOS build can STAT a user file (~/Downloads)
+  // but not OPEN it — File.exists() returns true while any read throws
+  // EPERM. The resolver must probe readability, not existence, before
+  // taking the direct-file fast path; otherwise it returns FileData that
+  // Image.file can never load and the working security-scoped bookmark is
+  // never consulted. chmod 000 reproduces the same exists-but-unreadable
+  // split without a sandbox.
+  group('exists-but-unreadable localPath (sandbox)', () {
+    test(
+      'resolve falls back to the bookmark when localPath is unreadable',
+      () async {
+        if (!Platform.isMacOS) return;
+        final f = File('${tempDir.path}/locked.jpg')
+          ..writeAsBytesSync([1, 2, 3]);
+        await Process.run('chmod', ['000', f.path]);
+        addTearDown(() => Process.run('chmod', ['644', f.path]));
+
+        final platform = _StubPlatform()
+          ..onReadBookmarkBytes = ((blob) async =>
+              Uint8List.fromList([10, 20, 30]));
+        final r = LocalFileResolver(
+          bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2])),
+          platform: platform,
+          exifExtractor: ExifExtractor(),
+        );
+        final data = await r.resolve(
+          _localFile(localPath: f.path, bookmarkRef: 'ref-1'),
+        );
+        expect(data, isA<BytesData>());
+        expect((data as BytesData).bytes, [10, 20, 30]);
+      },
+    );
+
+    test(
+      'resolve reads unreadable localPath as Unavailable when no bookmark',
+      () async {
+        if (!Platform.isMacOS) return;
+        final f = File('${tempDir.path}/locked2.jpg')
+          ..writeAsBytesSync([1, 2, 3]);
+        await Process.run('chmod', ['000', f.path]);
+        addTearDown(() => Process.run('chmod', ['644', f.path]));
+
+        final r = _resolver();
+        final data = await r.resolve(_localFile(localPath: f.path));
+        expect(data, isA<UnavailableData>());
+        expect((data as UnavailableData).kind, UnavailableKind.notFound);
+      },
+    );
+  });
+
   group('volume awareness', () {
     LocalFileResolver volumeResolver({required bool volumeOnline}) =>
         LocalFileResolver(

--- a/test/features/media/data/services/local_files_diagnostics_service_test.dart
+++ b/test/features/media/data/services/local_files_diagnostics_service_test.dart
@@ -154,6 +154,35 @@ void main() {
       },
     );
 
+    test(
+      'transientError items keep their orphan state (only stamped)',
+      () async {
+        // A present-but-unreadable file (sandbox denial / revoked
+        // permission): the bytes are on disk, so the sweep must not flip a
+        // healthy row to "missing from device".
+        final healthy = item(id: 'a', isOrphaned: false);
+        final orphan = item(id: 'b', isOrphaned: true);
+        when(
+          mockRepo.getAllBySourceType(MediaSourceType.localFile),
+        ).thenAnswer((_) async => [healthy, orphan]);
+        when(
+          mockResolver.verify(any),
+        ).thenAnswer((_) async => VerifyResult.transientError);
+        when(mockRepo.updateMedia(any)).thenAnswer((_) async {});
+
+        final flipped = await subject.reverifyAll();
+
+        expect(flipped, 0, reason: 'a transient failure never flips anything');
+        final captured = verify(
+          mockRepo.updateMedia(captureAny),
+        ).captured.cast<MediaItem>();
+        final byId = {for (final u in captured) u.id: u};
+        expect(byId['a']!.isOrphaned, isFalse, reason: 'not orphaned');
+        expect(byId['b']!.isOrphaned, isTrue, reason: 'state preserved');
+        expect(byId['a']!.lastVerifiedAt, isNotNull);
+      },
+    );
+
     test('on empty repository returns zero', () async {
       when(
         mockRepo.getAllBySourceType(MediaSourceType.localFile),


### PR DESCRIPTION
## Summary

A photo linked via the Files tab rendered as a silent broken-image tile (grid and full-screen viewer) on sandboxed macOS builds, with nothing in the console.

**Root cause:** the macOS sandbox allows `stat` on user files (`~/Downloads` etc.) while denying `open`. `File.exists()` therefore returns `true` for a file `Image.file` can never read (`PathAccessException`, EPERM). `LocalFileResolver.resolve()` gated its desktop fast path on `exists()` alone, returned `FileData`, and never fell through to the security-scoped bookmark — which was created correctly at link time and works. The failure was invisible because `errorBuilder` suppresses the framework's console report of image load errors.

## Changes

- `LocalFileResolver.resolve()` probes readability (open/close round-trip) after `exists()`; an exists-but-unreadable `localPath` now falls through to the bookmark, per the documented design (bookmark is the source of truth for resolution on macOS; `localPath` exists for Show in Finder).
- The resolver's previously silent `catch` branches now log why resolution failed (missing blob, `readBookmarkBytes`/`readUriBytes` errors).
- `MediaItemView`'s `_imageError` logs the swallowed load/decode error so a broken-image tile always leaves a trace.

## Testing

- Two new regression tests simulate the exists-but-unreadable split with `chmod 000` (bookmark fallback + no-bookmark Unavailable).
- Full media suite (760 tests) green; `flutter analyze` clean; `dart format` clean.
- Verified live on a sandboxed macOS debug build: the affected photo now renders in both the dive grid tile and the full-screen viewer.