### PR TITLE
fix(media): serve the compressed rendition when no original was uploaded

### DIFF
--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -93,9 +93,17 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
     // suffices, since thumbs upload before originals. Rows without any
     // confirmed upload skip the runtime entirely (no keychain read, no
     // store construction). Any store failure keeps the native placeholder.
+    //
+    // The compressed stamp counts as confirmation in its own right: an
+    // upload-quality setting other than "original" uploads a rendition and
+    // leaves remoteUploadedAt null permanently, so gating on the original
+    // alone made every such photo unviewable on other devices even though
+    // MediaStoreResolver.tryResolveRemote can serve the rendition. This
+    // mirrors what MediaRepository already treats as backed up.
     final storeConfirmed =
         widget.item.contentHash != null &&
         (widget.item.remoteUploadedAt != null ||
+            widget.item.remoteCompressedUploadedAt != null ||
             (widget.thumbnail && widget.item.remoteThumbUploadedAt != null));
     if (!storeConfirmed) {
       return native;

--- a/test/features/media/presentation/media_item_view_store_fallback_test.dart
+++ b/test/features/media/presentation/media_item_view_store_fallback_test.dart
@@ -209,6 +209,56 @@ void main() {
     expect(find.byType(UnavailableMediaPlaceholder), findsNothing);
   });
 
+  // Regression: an upload-quality setting that stores a compressed rendition
+  // instead of the original leaves remoteUploadedAt null forever, so gating
+  // the store fallback on that stamp alone made the full-size view report
+  // "File not found" on every other device — while the grid thumbnail beside
+  // it rendered fine off the thumb stamp. MediaStoreResolver has always been
+  // able to serve the rendition; only the gate in front of it was too narrow.
+  testWidgets('renders the compressed rendition when only the compressed '
+      'stamp is present', (tester) async {
+    await tester.runAsync(() async {
+      final bytes = base64Decode(_onePixelPngBase64);
+      final hash = 'c3${'7' * 62}';
+      final uploadedAt = DateTime(2026, 7, 2);
+      store.objects[StoreKeys.renditionKey(hash, ext: 'jpg')] = bytes;
+
+      final runtime = MediaStoreRuntime(
+        storeId: 'store-1',
+        store: store,
+        cache: cache,
+        resolver: MediaStoreResolver(store: store, cache: cache),
+      );
+
+      // Exactly the shape a "small" upload-quality row syncs with: thumb and
+      // rendition uploaded, original never.
+      final compressedRow = MediaItem(
+        id: 'm-compressed',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.platformGallery,
+        platformAssetId: 'asset-from-other-device',
+        originalFilename: 'reef.png',
+        takenAt: DateTime(2026),
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        contentHash: hash,
+        remoteThumbUploadedAt: uploadedAt,
+        remoteCompressedUploadedAt: uploadedAt,
+      );
+      expect(compressedRow.remoteUploadedAt, isNull);
+
+      await tester.pumpWidget(app(compressedRow, runtime: runtime));
+      for (var i = 0; i < 40; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+        if (find.byType(Image).evaluate().isNotEmpty) break;
+      }
+    });
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.byType(UnavailableMediaPlaceholder), findsNothing);
+  });
+
   testWidgets('keeps the native placeholder when no store runtime '
       'exists', (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Summary

A photo linked on one device showed a thumbnail in the grid but **"File not found"** full-screen on every other device, whenever the upload-quality setting stores a compressed rendition instead of the original.

Reported against a laptop → phone sync. The affected row looked like this:

| stamp | value |
|---|---|
| `remote_thumb_uploaded_at` | set |
| `remote_compressed_uploaded_at` | set (`compressed_level = small`, 112 KB) |
| `remote_uploaded_at` | **null** |

## Root cause

`MediaItemView._resolve()` gates the media-store fallback on "is this row confirmed in the store", so rows with nothing uploaded never pay for a keychain read or store construction. That gate counted only `remoteUploadedAt`, plus `remoteThumbUploadedAt` for thumbnail requests.

An upload-quality level other than `original` uploads a rendition and leaves `remoteUploadedAt` null **permanently**, so:

- **grid thumbnail** — `thumbnail: true`, thumb stamp satisfies the gate, renders fine;
- **full-screen** — `thumbnail: false`, no stamp satisfies the gate, returns the native `UnavailableData` and shows "File not found".

`MediaStoreResolver.tryResolveRemote` has handled renditions (`_fetchCompressed`) since the upload-quality work landed — the request simply never reached it.

## Changes

Counts `remoteCompressedUploadedAt` as store confirmation. This aligns `MediaItemView` with every other consumer, all of which already treat that stamp as present-in-the-store:

- `media_upload_pipeline.dart` dedup check
- `media_deletion_coordinator.dart` `_enqueueIntent`
- `media_backup_status.dart` `isBackedUp()`
- `media_store_resolver.dart` `tryResolveRemote` itself

`MediaItemView` was the only holdout, which is why the bug reads as an oversight in the quality work rather than a deliberate policy.

## Testing

- New widget regression test built from the reported row's exact shape (thumb + compressed stamps, original null). It fails on `main` with the "File not found" placeholder and passes with the fix.
- 1014 media + media_store tests pass; `flutter analyze` clean; `dart format` clean.