### PR TITLE
fix(media-store): stop reporting parked transfers as work in progress

### DIFF
--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media_store/data/media_delete_processor.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
@@ -46,6 +48,13 @@ class MediaStoreWorker {
   final _log = LoggerService.forClass(MediaStoreWorker);
   bool _running = false;
   Future<void>? _activeDrain;
+  Timer? _wakeup;
+  Duration? _wakeupDelay;
+
+  /// The delay the currently armed retry wakeup will wait, or null when no
+  /// row is deferred. Lets a test assert scheduling without waiting it out.
+  @visibleForTesting
+  Duration? get wakeupDelayForTesting => _wakeupDelay;
 
   /// The drain kicked by [enqueueAndKick], if any. Completes only when the
   /// queue has been fully drained, including each entry's post-upload cleanup.
@@ -92,7 +101,50 @@ class MediaStoreWorker {
       }
     } finally {
       _running = false;
+      await _armWakeup();
     }
+  }
+
+  /// Arms a single timer for the soonest deferred row, so a retry that comes
+  /// due mid-session actually fires.
+  ///
+  /// Every other drain trigger is an external event: app start, a
+  /// connectivity change, an explicit user action. Without this, a row that
+  /// markFailed parked behind a long retryAfter - 25 hours for a
+  /// source-unavailable failure - sat untouched for the rest of the
+  /// session, and the settings page kept reporting it as outstanding work
+  /// the entire time.
+  ///
+  /// Runs in drain's finally and must never throw: an exception here would
+  /// replace whatever the drain itself was reporting.
+  Future<void> _armWakeup() async {
+    _wakeup?.cancel();
+    _wakeup = null;
+    _wakeupDelay = null;
+    try {
+      // One clock reading for both the query and the delay, so the timer
+      // cannot be handed a negative duration by the query's own latency.
+      final now = DateTime.now();
+      final due = await _queue.earliestPendingWakeup(now);
+      if (due == null) return;
+      final delay = due.difference(now);
+      _wakeupDelay = delay;
+      _wakeup = Timer(delay, () => unawaited(drain()));
+    } on Object catch (e) {
+      _log.warning('Could not schedule the next transfer retry: $e');
+    }
+  }
+
+  /// Cancels the retry wakeup. Called when the runtime that owns this
+  /// worker is disposed (disconnect, or a connect that rebuilds it).
+  ///
+  /// Deliberately does not touch an in-flight drain: a rebuild does not
+  /// cancel one, and a half-cancelled transfer is worse than one that runs
+  /// to completion against a store it already opened.
+  void dispose() {
+    _wakeup?.cancel();
+    _wakeup = null;
+    _wakeupDelay = null;
   }
 
   Future<void> enqueueAndKick(String mediaId) async {

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -47,6 +47,7 @@ class MediaStoreWorker {
 
   final _log = LoggerService.forClass(MediaStoreWorker);
   bool _running = false;
+  bool _disposed = false;
   Future<void>? _activeDrain;
   Timer? _wakeup;
   Duration? _wakeupDelay;
@@ -63,7 +64,7 @@ class MediaStoreWorker {
   Future<void>? get activeDrain => _activeDrain;
 
   Future<void> drain() async {
-    if (_running) return;
+    if (_disposed || _running) return;
     _running = true;
     try {
       while (true) {
@@ -121,6 +122,11 @@ class MediaStoreWorker {
     _wakeup?.cancel();
     _wakeup = null;
     _wakeupDelay = null;
+    // A rebuild disposes this worker without cancelling a drain it already
+    // started, so dispose can land while one is in flight and this runs
+    // afterwards. Re-arming then would leave a superseded worker waking
+    // itself forever behind the runtime that replaced it.
+    if (_disposed) return;
     try {
       // One clock reading for both the query and the delay, so the timer
       // cannot be handed a negative duration by the query's own latency.
@@ -135,13 +141,18 @@ class MediaStoreWorker {
     }
   }
 
-  /// Cancels the retry wakeup. Called when the runtime that owns this
-  /// worker is disposed (disconnect, or a connect that rebuilds it).
+  /// Retires this worker. Called when the runtime that owns it is disposed
+  /// (disconnect, or a connect that rebuilds it). Cancels the retry wakeup
+  /// and blocks any further drain, including one a still-armed timer or a
+  /// late caller would otherwise start.
   ///
   /// Deliberately does not touch an in-flight drain: a rebuild does not
   /// cancel one, and a half-cancelled transfer is worse than one that runs
-  /// to completion against a store it already opened.
+  /// to completion against a store it already opened. That drain's finally
+  /// still calls _armWakeup, which is why the flag - not just the cancel -
+  /// is what makes disposal stick.
   void dispose() {
+    _disposed = true;
     _wakeup?.cancel();
     _wakeup = null;
     _wakeupDelay = null;

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -394,31 +394,32 @@ class MediaTransferQueueRepository {
     final nowMs = now.millisecondsSinceEpoch;
     var transferring = 0;
     var queued = 0;
-    final deferred = <MediaTransferQueueEntry>[];
+    var waiting = 0;
+    String? reason;
+    int? reasonAt;
+    // Single pass, no intermediate list: this re-runs on every queue write,
+    // and a backfill writes once per row transition over the whole library.
     for (final row in rows) {
       final until = row.nextAttemptAt;
       if (row.state == 'transferring') {
         transferring++;
       } else if (until != null && until > nowMs) {
-        deferred.add(row);
+        waiting++;
+        // Newest wins: of several parked rows, the freshest failure is the
+        // one someone opening this page is looking for.
+        final error = row.errorMessage;
+        if (error != null && (reasonAt == null || row.updatedAt > reasonAt)) {
+          reason = error;
+          reasonAt = row.updatedAt;
+        }
       } else {
         queued++;
-      }
-    }
-    // Newest first: of several parked rows, the freshest failure is the one
-    // someone opening this page is looking for.
-    deferred.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
-    String? reason;
-    for (final row in deferred) {
-      if (row.errorMessage != null) {
-        reason = row.errorMessage;
-        break;
       }
     }
     return MediaTransferSummary(
       transferring: transferring,
       queued: queued,
-      waiting: deferred.length,
+      waiting: waiting,
       waitingReason: reason,
     );
   }

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 
 import 'package:submersion/core/database/local_cache_database.dart';
 import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/features/media_store/domain/media_transfer_summary.dart';
 
 /// Row type alias so callers do not depend on the Drift-generated name.
 typedef MediaTransferQueueEntry = MediaTransferQueueData;
@@ -371,13 +372,80 @@ class MediaTransferQueueRepository {
     _db.mediaTransferQueue,
   )..where((t) => t.state.equals('done'))).go();
 
-  /// Pending + transferring, for backfill progress display.
-  Stream<int> watchActiveCount() {
-    final count = _db.mediaTransferQueue.id.count();
+  /// Live split of the outstanding queue for the settings page.
+  ///
+  /// Replaces a plain pending+transferring count, which reported a row
+  /// parked in a multi-hour retry backoff as work in progress. Due-ness is
+  /// evaluated per emission against [now]; a row that becomes due purely by
+  /// the passage of time does not re-emit on its own, which is why the
+  /// worker arms a timer at [earliestPendingWakeup] - that drain writes,
+  /// and the write is what refreshes this stream.
+  Stream<MediaTransferSummary> watchSummary({DateTime Function()? now}) {
+    final clock = now ?? DateTime.now;
+    final query = _db.select(_db.mediaTransferQueue)
+      ..where((t) => t.state.isIn(['pending', 'transferring']));
+    return query.watch().map((rows) => _summarize(rows, clock()));
+  }
+
+  static MediaTransferSummary _summarize(
+    List<MediaTransferQueueEntry> rows,
+    DateTime now,
+  ) {
+    final nowMs = now.millisecondsSinceEpoch;
+    var transferring = 0;
+    var queued = 0;
+    final deferred = <MediaTransferQueueEntry>[];
+    for (final row in rows) {
+      final until = row.nextAttemptAt;
+      if (row.state == 'transferring') {
+        transferring++;
+      } else if (until != null && until > nowMs) {
+        deferred.add(row);
+      } else {
+        queued++;
+      }
+    }
+    // Newest first: of several parked rows, the freshest failure is the one
+    // someone opening this page is looking for.
+    deferred.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    String? reason;
+    for (final row in deferred) {
+      if (row.errorMessage != null) {
+        reason = row.errorMessage;
+        break;
+      }
+    }
+    return MediaTransferSummary(
+      transferring: transferring,
+      queued: queued,
+      waiting: deferred.length,
+      waitingReason: reason,
+    );
+  }
+
+  /// The soonest future attempt time among pending rows, or null when no
+  /// pending row is waiting on one. Drives the worker's retry wakeup.
+  ///
+  /// Deliberately excludes rows that are already due. Those are the drain's
+  /// own job, and a drain that left one behind did so because it was
+  /// suspended - offline, or a failed preflight - both of which have their
+  /// own triggers. Arming a timer for an already-due row would spin a tight
+  /// loop against a drain that keeps declining to run.
+  Future<DateTime?> earliestPendingWakeup(DateTime now) async {
+    final soonest = _db.mediaTransferQueue.nextAttemptAt.min();
     final query = _db.selectOnly(_db.mediaTransferQueue)
-      ..addColumns([count])
-      ..where(_db.mediaTransferQueue.state.isIn(['pending', 'transferring']));
-    return query.watchSingle().map((row) => row.read(count) ?? 0);
+      ..addColumns([soonest])
+      ..where(
+        _db.mediaTransferQueue.state.equals('pending') &
+            // A null nextAttemptAt fails this comparison in SQL, which is
+            // exactly right: an undeferred row is due, not a wakeup.
+            _db.mediaTransferQueue.nextAttemptAt.isBiggerThanValue(
+              now.millisecondsSinceEpoch,
+            ),
+      );
+    final row = await query.getSingleOrNull();
+    final ms = row?.read(soonest);
+    return ms == null ? null : DateTime.fromMillisecondsSinceEpoch(ms);
   }
 
   Future<List<MediaTransferQueueEntry>> allForTesting() =>

--- a/lib/features/media_store/domain/media_transfer_summary.dart
+++ b/lib/features/media_store/domain/media_transfer_summary.dart
@@ -1,0 +1,62 @@
+/// A snapshot of the media transfer queue, split by what the queue is
+/// actually doing rather than by raw row state.
+///
+/// The table's 'pending' covers two very different situations: a row the
+/// drainer takes on its next pass, and a row markFailed parked behind a
+/// future nextAttemptAt - a wait that reaches 25 hours for a
+/// source-unavailable failure. nextPending deliberately refuses to select
+/// the second kind, so counting them together reports parked work as work
+/// in progress: the settings page animated an indeterminate progress bar
+/// for a day while the worker sat idle.
+class MediaTransferSummary {
+  /// Rows whose bytes are moving right now.
+  final int transferring;
+
+  /// Rows the drainer can take on its next pass: due, or never deferred.
+  final int queued;
+
+  /// Rows deferred to a future attempt - retry backoff after a failure, or
+  /// a policy/connectivity deferral. Nothing happens for these until their
+  /// nextAttemptAt passes.
+  final int waiting;
+
+  /// The most recently recorded failure among the [waiting] rows, when any
+  /// carries one. Null when the deferral is purely policy-driven (a
+  /// cellular or offline hold consumes no attempt and records no error).
+  final String? waitingReason;
+
+  const MediaTransferSummary({
+    this.transferring = 0,
+    this.queued = 0,
+    this.waiting = 0,
+    this.waitingReason,
+  });
+
+  int get total => transferring + queued + waiting;
+
+  /// Whether the queue is working or about to. Deliberately excludes
+  /// [waiting]: parked work is not progress, and must never drive a
+  /// progress indicator.
+  bool get isBusy => transferring > 0 || queued > 0;
+
+  bool get isEmpty => total == 0;
+
+  // Value equality so a stream emission that changes nothing does not
+  // rebuild the settings page. The queue writes updatedAt on every state
+  // transition, so identical successive snapshots are common.
+  @override
+  bool operator ==(Object other) =>
+      other is MediaTransferSummary &&
+      other.transferring == transferring &&
+      other.queued == queued &&
+      other.waiting == waiting &&
+      other.waitingReason == waitingReason;
+
+  @override
+  int get hashCode => Object.hash(transferring, queued, waiting, waitingReason);
+
+  @override
+  String toString() =>
+      'MediaTransferSummary(transferring: $transferring, queued: $queued, '
+      'waiting: $waiting, waitingReason: $waitingReason)';
+}

--- a/lib/features/media_store/presentation/pages/media_storage_page.dart
+++ b/lib/features/media_store/presentation/pages/media_storage_page.dart
@@ -12,6 +12,7 @@ import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/features/media_store/data/media_store_service.dart';
 import 'package:submersion/features/media_store/domain/media_upload_quality.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/features/media_store/presentation/widgets/media_transfer_summary_row.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -732,23 +733,7 @@ class _MediaStoragePageState extends ConsumerState<MediaStoragePage> {
                   padding: EdgeInsets.only(top: 8),
                   child: LinearProgressIndicator(),
                 ),
-              Consumer(
-                builder: (context, ref, _) {
-                  final active =
-                      ref.watch(mediaTransferActiveCountProvider).value ?? 0;
-                  if (active == 0) return const SizedBox.shrink();
-                  return Padding(
-                    padding: const EdgeInsets.only(top: 8),
-                    child: Row(
-                      children: [
-                        const Expanded(child: LinearProgressIndicator()),
-                        const SizedBox(width: 12),
-                        Text('$active'),
-                      ],
-                    ),
-                  );
-                },
-              ),
+              const MediaTransferSummaryRow(),
               ListTile(
                 key: const Key('media-s3-transfers'),
                 leading: const Icon(Icons.swap_vert),

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -31,6 +31,7 @@ import 'package:submersion/features/media_store/data/media_verify_service.dart';
 import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
 import 'package:submersion/features/media_store/data/platform_video_transcoder.dart';
 import 'package:submersion/features/media_store/domain/media_backup_status.dart';
+import 'package:submersion/features/media_store/domain/media_transfer_summary.dart';
 import 'package:submersion/features/media_store/domain/media_upload_quality.dart';
 import 'package:submersion/features/media_store/presentation/widgets/media_store_badge.dart';
 
@@ -144,9 +145,10 @@ final mediaBackfillServiceProvider = Provider<MediaBackfillService>(
   ),
 );
 
-/// Pending + transferring count, for the backfill progress row.
-final mediaTransferActiveCountProvider = StreamProvider<int>(
-  (ref) => ref.watch(mediaTransferQueueRepositoryProvider).watchActiveCount(),
+/// Outstanding transfer work, split into moving / due / parked so the
+/// settings page can tell progress from a retry backoff.
+final mediaTransferSummaryProvider = StreamProvider<MediaTransferSummary>(
+  (ref) => ref.watch(mediaTransferQueueRepositoryProvider).watchSummary(),
 );
 
 /// Transfers view feed.
@@ -393,6 +395,10 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         if (kind != NetworkKind.offline) unawaited(worker.drain());
       });
       ref.onDispose(connectivitySub.cancel);
+      // Cancels only the retry wakeup, not an in-flight drain: a rebuild
+      // has never cancelled one, and a superseded worker's timer must not
+      // keep re-draining behind the runtime that replaced it.
+      ref.onDispose(worker.dispose);
       unawaited(worker.drain());
 
       // Opportunistic Verify Library sweep (orphan-prevention spec 6.4):

--- a/lib/features/media_store/presentation/widgets/media_transfer_summary_row.dart
+++ b/lib/features/media_store/presentation/widgets/media_transfer_summary_row.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Outstanding transfer work on the Media Storage page.
+///
+/// The indeterminate bar is reserved for bytes actually moving. Work the
+/// queue is merely holding renders as text, because an animating bar reads
+/// as "this is happening now" - and a row parked in markFailed's retry
+/// backoff waits up to 25 hours. Reporting that as progress left the page
+/// spinning for a full day against an idle worker.
+///
+/// Matches how the Transfers page has always drawn the same rows: a
+/// progress bar only for 'transferring', a schedule icon for everything
+/// still waiting.
+class MediaTransferSummaryRow extends ConsumerWidget {
+  const MediaTransferSummaryRow({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final summary = ref.watch(mediaTransferSummaryProvider).value;
+    if (summary == null || summary.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (summary.transferring > 0)
+          Padding(
+            key: const Key('media-transfer-progress'),
+            padding: const EdgeInsets.only(top: 8),
+            child: Row(
+              children: [
+                const Expanded(child: LinearProgressIndicator()),
+                const SizedBox(width: 12),
+                Text('${summary.transferring + summary.queued}'),
+              ],
+            ),
+          )
+        else if (summary.queued > 0)
+          Padding(
+            key: const Key('media-transfer-queued'),
+            padding: const EdgeInsets.only(top: 8, left: 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                l10n.settings_mediaStorage_transfers_queued(summary.queued),
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          ),
+        if (summary.waiting > 0)
+          ListTile(
+            key: const Key('media-transfer-waiting'),
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(Icons.schedule, color: theme.colorScheme.tertiary),
+            title: Text(
+              l10n.settings_mediaStorage_transfers_waitingRetry(
+                summary.waiting,
+              ),
+            ),
+            // The raw queue error, exactly as the Transfers page shows it.
+            // Not localized: these are diagnostic strings the pipeline
+            // writes, and translating them would lose the wording anyone
+            // searching for the problem would recognize.
+            subtitle: summary.waitingReason == null
+                ? null
+                : Text(summary.waitingReason!, maxLines: 2),
+            trailing: const Icon(Icons.chevron_right),
+            // Retry lives on the Transfers page, which offers it for a
+            // still-pending row precisely so nobody has to wait out a
+            // multi-hour backoff they are looking at right now.
+            onTap: () => context.push('/settings/media-storage/transfers'),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "جارٍ الإزالة من السحابة",
   "settings_mediaStorage_transfers_state_done": "تم",
   "settings_mediaStorage_transfers_state_failed": "فشل",
+  "settings_mediaStorage_transfers_queued": "{count} في قائمة الانتظار",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} في انتظار إعادة المحاولة",
   "settings_mediaStorage_verify_action": "التحقق من المكتبة",
   "settings_mediaStorage_verify_running": "جارٍ التحقق من مكتبة الوسائط...",
   "settings_mediaStorage_verify_summary": "تم فحص {checked} عنصرًا: أزيل {removed} يتيمًا، وأُدرج {repaired} إصلاحًا في قائمة الانتظار، وأُلغي {aborted} رفعًا قديمًا",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Wird aus der Cloud entfernt",
   "settings_mediaStorage_transfers_state_done": "Fertig",
   "settings_mediaStorage_transfers_state_failed": "Fehlgeschlagen",
+  "settings_mediaStorage_transfers_queued": "{count} in Warteschlange",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} warten auf Wiederholung",
   "settings_mediaStorage_verify_action": "Bibliothek überprüfen",
   "settings_mediaStorage_verify_running": "Medienbibliothek wird überprüft...",
   "settings_mediaStorage_verify_summary": "{checked} Objekte geprüft: {removed} verwaiste entfernt, {repaired} Reparaturen eingereiht, {aborted} veraltete Uploads abgebrochen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12828,6 +12828,22 @@
   "settings_mediaStorage_transfers_state_deleting": "Removing from cloud",
   "settings_mediaStorage_transfers_state_done": "Done",
   "settings_mediaStorage_transfers_state_failed": "Failed",
+  "settings_mediaStorage_transfers_queued": "{count} queued",
+  "@settings_mediaStorage_transfers_queued": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_mediaStorage_transfers_waitingRetry": "{count} waiting to retry",
+  "@settings_mediaStorage_transfers_waitingRetry": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "settings_mediaStorage_verify_action": "Verify library",
   "settings_mediaStorage_verify_running": "Verifying media library...",
   "settings_mediaStorage_verify_summary": "Checked {checked} objects: removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Eliminando de la nube",
   "settings_mediaStorage_transfers_state_done": "Completado",
   "settings_mediaStorage_transfers_state_failed": "Fallido",
+  "settings_mediaStorage_transfers_queued": "{count} en cola",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} esperando para reintentar",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",
   "settings_mediaStorage_verify_running": "Verificando la biblioteca multimedia...",
   "settings_mediaStorage_verify_summary": "Se comprobaron {checked} objetos: {removed} huérfanos eliminados, {repaired} reparaciones en cola, {aborted} subidas obsoletas canceladas",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Suppression du cloud",
   "settings_mediaStorage_transfers_state_done": "Terminé",
   "settings_mediaStorage_transfers_state_failed": "Échec",
+  "settings_mediaStorage_transfers_queued": "{count} en file",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} en attente de nouvelle tentative",
   "settings_mediaStorage_verify_action": "Vérifier la bibliothèque",
   "settings_mediaStorage_verify_running": "Vérification de la médiathèque...",
   "settings_mediaStorage_verify_summary": "{checked} objets vérifiés : {removed} orphelins supprimés, {repaired} réparations en file, {aborted} envois périmés annulés",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "מסיר מהענן",
   "settings_mediaStorage_transfers_state_done": "הושלם",
   "settings_mediaStorage_transfers_state_failed": "נכשל",
+  "settings_mediaStorage_transfers_queued": "{count} בתור",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} ממתינים לניסיון חוזר",
   "settings_mediaStorage_verify_action": "אימות הספרייה",
   "settings_mediaStorage_verify_running": "מאמת את ספריית המדיה...",
   "settings_mediaStorage_verify_summary": "נבדקו {checked} אובייקטים: הוסרו {removed} יתומים, {repaired} תיקונים נוספו לתור, {aborted} העלאות ישנות בוטלו",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Eltávolítás a felhőből",
   "settings_mediaStorage_transfers_state_done": "Kész",
   "settings_mediaStorage_transfers_state_failed": "Sikertelen",
+  "settings_mediaStorage_transfers_queued": "{count} sorban áll",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} újrapróbálkozásra vár",
   "settings_mediaStorage_verify_action": "Könyvtár ellenőrzése",
   "settings_mediaStorage_verify_running": "Médiatár ellenőrzése...",
   "settings_mediaStorage_verify_summary": "{checked} objektum ellenőrizve: {removed} árva eltávolítva, {repaired} javítás sorba állítva, {aborted} elavult feltöltés megszakítva",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Rimozione dal cloud",
   "settings_mediaStorage_transfers_state_done": "Completato",
   "settings_mediaStorage_transfers_state_failed": "Non riuscito",
+  "settings_mediaStorage_transfers_queued": "{count} in coda",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} in attesa di riprovare",
   "settings_mediaStorage_verify_action": "Verifica libreria",
   "settings_mediaStorage_verify_running": "Verifica della libreria multimediale...",
   "settings_mediaStorage_verify_summary": "Controllati {checked} oggetti: {removed} orfani rimossi, {repaired} riparazioni in coda, {aborted} caricamenti obsoleti annullati",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -34164,6 +34164,18 @@ abstract class AppLocalizations {
   /// **'Failed'**
   String get settings_mediaStorage_transfers_state_failed;
 
+  /// No description provided for @settings_mediaStorage_transfers_queued.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} queued'**
+  String settings_mediaStorage_transfers_queued(int count);
+
+  /// No description provided for @settings_mediaStorage_transfers_waitingRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} waiting to retry'**
+  String settings_mediaStorage_transfers_waitingRetry(int count);
+
   /// No description provided for @settings_mediaStorage_verify_action.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -20080,6 +20080,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'فشل';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count في قائمة الانتظار';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count في انتظار إعادة المحاولة';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'التحقق من المكتبة';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20418,6 +20418,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Fehlgeschlagen';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count in Warteschlange';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count warten auf Wiederholung';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Bibliothek überprüfen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -20103,6 +20103,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Failed';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count queued';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count waiting to retry';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Verify library';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20465,6 +20465,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Fallido';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count en cola';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count esperando para reintentar';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Verificar biblioteca';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20523,6 +20523,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Échec';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count en file';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count en attente de nouvelle tentative';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Vérifier la bibliothèque';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -19934,6 +19934,16 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'נכשל';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count בתור';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count ממתינים לניסיון חוזר';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'אימות הספרייה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20393,6 +20393,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Sikertelen';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count sorban áll';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count újrapróbálkozásra vár';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Könyvtár ellenőrzése';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20452,6 +20452,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Non riuscito';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count in coda';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count in attesa di riprovare';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Verifica libreria';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20284,6 +20284,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Mislukt';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count in wachtrij';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count wachten op nieuwe poging';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Bibliotheek verifiëren';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20457,6 +20457,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Falhou';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count na fila';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count aguardando nova tentativa';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => 'Verificar biblioteca';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19405,6 +19405,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => '失败';
 
   @override
+  String settings_mediaStorage_transfers_queued(int count) {
+    return '$count 个排队中';
+  }
+
+  @override
+  String settings_mediaStorage_transfers_waitingRetry(int count) {
+    return '$count 个等待重试';
+  }
+
+  @override
   String get settings_mediaStorage_verify_action => '验证媒体库';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Verwijderen uit de cloud",
   "settings_mediaStorage_transfers_state_done": "Klaar",
   "settings_mediaStorage_transfers_state_failed": "Mislukt",
+  "settings_mediaStorage_transfers_queued": "{count} in wachtrij",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} wachten op nieuwe poging",
   "settings_mediaStorage_verify_action": "Bibliotheek verifiëren",
   "settings_mediaStorage_verify_running": "Mediabibliotheek wordt geverifieerd...",
   "settings_mediaStorage_verify_summary": "{checked} objecten gecontroleerd: {removed} wezen verwijderd, {repaired} reparaties in wachtrij, {aborted} verouderde uploads afgebroken",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Removendo da nuvem",
   "settings_mediaStorage_transfers_state_done": "Concluído",
   "settings_mediaStorage_transfers_state_failed": "Falhou",
+  "settings_mediaStorage_transfers_queued": "{count} na fila",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} aguardando nova tentativa",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",
   "settings_mediaStorage_verify_running": "Verificando a biblioteca de mídia...",
   "settings_mediaStorage_verify_summary": "{checked} objetos verificados: {removed} órfãos removidos, {repaired} reparos na fila, {aborted} envios obsoletos cancelados",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5822,6 +5822,8 @@
   "settings_mediaStorage_transfers_state_deleting": "正在从云端移除",
   "settings_mediaStorage_transfers_state_done": "已完成",
   "settings_mediaStorage_transfers_state_failed": "失败",
+  "settings_mediaStorage_transfers_queued": "{count} 个排队中",
+  "settings_mediaStorage_transfers_waitingRetry": "{count} 个等待重试",
   "settings_mediaStorage_verify_action": "验证媒体库",
   "settings_mediaStorage_verify_running": "正在验证媒体库...",
   "settings_mediaStorage_verify_summary": "已检查 {checked} 个对象：移除 {removed} 个孤立文件，排队 {repaired} 个修复，中止 {aborted} 个过期上传",

--- a/test/features/media_store/media_storage_page_test.dart
+++ b/test/features/media_store/media_storage_page_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/media_store/data/media_store_service.dart';
 import 'package:submersion/features/media_store/data/media_verify_service.dart';
 import 'package:submersion/features/media_store/data/media_stores_repository.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/domain/media_transfer_summary.dart';
 import 'package:submersion/features/media_store/presentation/pages/media_storage_page.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -126,7 +127,7 @@ void main() {
   Widget app({
     bool apple = true,
     String? statusHint,
-    int activeCount = 0,
+    MediaTransferSummary summary = const MediaTransferSummary(),
     // Riverpod 3 does not export the Override type; mirror the
     // weight_planner_page_test precedent.
     List<dynamic> extraOverrides = const [],
@@ -139,9 +140,7 @@ void main() {
       mediaStoreServiceProvider.overrideWithValue(service),
       mediaBackfillServiceProvider.overrideWithValue(backfill),
       mediaStoreStatusHintProvider.overrideWith((ref) async => statusHint),
-      mediaTransferActiveCountProvider.overrideWith(
-        (ref) => Stream.value(activeCount),
-      ),
+      mediaTransferSummaryProvider.overrideWith((ref) => Stream.value(summary)),
       isApplePlatformProvider.overrideWithValue(apple),
       // Last, so callers can genuinely override any of the defaults above.
       // (Plain spread: dynamic elements implicitly cast, and Riverpod 3
@@ -405,7 +404,10 @@ void main() {
     addTearDown(tester.view.reset);
     await tester.runAsync(() async {
       await tester.pumpWidget(
-        app(statusHint: 'dive-media @ minio', activeCount: 3),
+        app(
+          statusHint: 'dive-media @ minio',
+          summary: const MediaTransferSummary(transferring: 3),
+        ),
       );
       // Pump until the active-count stream has propagated.
       for (var i = 0; i < 20; i++) {
@@ -974,8 +976,8 @@ void main() {
             mediaStoreStatusHintProvider.overrideWith(
               (ref) async => 'dive-media @ minio',
             ),
-            mediaTransferActiveCountProvider.overrideWith(
-              (ref) => Stream.value(0),
+            mediaTransferSummaryProvider.overrideWith(
+              (ref) => Stream.value(const MediaTransferSummary()),
             ),
             isApplePlatformProvider.overrideWithValue(false),
             isLinuxPlatformProvider.overrideWithValue(true),

--- a/test/features/media_store/media_storage_page_transfer_summary_test.dart
+++ b/test/features/media_store/media_storage_page_transfer_summary_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/services/media_store/media_store_credentials_store.dart';
+import 'package:submersion/features/media_store/domain/media_transfer_summary.dart';
+import 'package:submersion/features/media_store/presentation/pages/media_storage_page.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../support/fake_keychain_storage.dart';
+
+/// The Media Storage page's transfer indicator. Regression cover for a
+/// spinning indeterminate progress bar shown while the queue was idle: rows
+/// parked in markFailed's multi-hour retry backoff are 'pending' in the
+/// table, but nextPending will not select them, so nothing is transferring.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Widget app(MediaTransferSummary summary) => ProviderScope(
+    overrides: [
+      mediaStoreRuntimeProvider.overrideWith((ref) async => null),
+      mediaStoreCredentialsStoreProvider.overrideWithValue(
+        MediaStoreCredentialsStore(storage: InMemoryKeychain()),
+      ),
+      mediaStoreStatusHintProvider.overrideWith(
+        (ref) async => 'dive-media @ minio',
+      ),
+      mediaTransferSummaryProvider.overrideWith((ref) => Stream.value(summary)),
+    ],
+    child: const MaterialApp(
+      locale: Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: MediaStoragePage(),
+    ),
+  );
+
+  Future<void> settle(WidgetTester tester, MediaTransferSummary summary) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.runAsync(() async {
+      await tester.pumpWidget(app(summary));
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+      }
+    });
+  }
+
+  testWidgets('work parked in retry backoff shows no progress bar', (
+    tester,
+  ) async {
+    await settle(
+      tester,
+      const MediaTransferSummary(
+        transferring: 0,
+        queued: 0,
+        waiting: 4,
+        waitingReason: 'source unavailable on this device',
+      ),
+    );
+
+    expect(
+      find.byType(LinearProgressIndicator),
+      findsNothing,
+      reason: 'nothing is transferring, so nothing may animate',
+    );
+    expect(find.byKey(const Key('media-transfer-waiting')), findsOneWidget);
+    expect(find.text('4 waiting to retry'), findsOneWidget);
+    expect(find.text('source unavailable on this device'), findsOneWidget);
+  });
+
+  testWidgets('the waiting row routes into Transfers', (tester) async {
+    await settle(
+      tester,
+      const MediaTransferSummary(transferring: 0, queued: 0, waiting: 4),
+    );
+
+    final tile = tester.widget<ListTile>(
+      find.byKey(const Key('media-transfer-waiting')),
+    );
+    expect(tile.onTap, isNotNull);
+  });
+
+  testWidgets('an in-flight transfer shows the progress bar and count', (
+    tester,
+  ) async {
+    await settle(
+      tester,
+      const MediaTransferSummary(transferring: 1, queued: 2, waiting: 0),
+    );
+
+    expect(find.byKey(const Key('media-transfer-progress')), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.text('3'), findsOneWidget);
+    expect(find.byKey(const Key('media-transfer-waiting')), findsNothing);
+  });
+
+  testWidgets('due-but-not-started work reads as queued, not moving', (
+    tester,
+  ) async {
+    await settle(
+      tester,
+      const MediaTransferSummary(transferring: 0, queued: 3, waiting: 0),
+    );
+
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(find.text('3 queued'), findsOneWidget);
+  });
+
+  testWidgets('an empty queue renders no indicator at all', (tester) async {
+    await settle(tester, const MediaTransferSummary());
+
+    expect(find.byKey(const Key('media-transfer-progress')), findsNothing);
+    expect(find.byKey(const Key('media-transfer-waiting')), findsNothing);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+  });
+}

--- a/test/features/media_store/media_store_providers_test.dart
+++ b/test/features/media_store/media_store_providers_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/media/domain/entities/media_source_type.dart
 import 'package:submersion/features/media_store/data/media_backfill_service.dart';
 import 'package:submersion/features/media_store/data/media_stores_repository.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/domain/media_transfer_summary.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_enqueue_provider.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/media_store/presentation/widgets/media_store_badge.dart';
@@ -100,20 +101,22 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final subA = container.listen(mediaTransferActiveCountProvider, (_, _) {});
+    final subA = container.listen(mediaTransferSummaryProvider, (_, _) {});
     final subB = container.listen(mediaTransferEntriesProvider, (_, _) {});
     addTearDown(subA.close);
     addTearDown(subB.close);
 
-    // Enqueue one row; the active-count stream should reach 1.
+    // Enqueue one row; the summary stream should report it as queued.
     await repo.enqueueUpload(mediaId: 'm1');
-    var count = 0;
+    var summary = const MediaTransferSummary();
     for (var i = 0; i < 100; i++) {
-      count = container.read(mediaTransferActiveCountProvider).value ?? 0;
-      if (count == 1) break;
+      summary =
+          container.read(mediaTransferSummaryProvider).value ??
+          const MediaTransferSummary();
+      if (summary.queued == 1) break;
       await Future<void>.delayed(const Duration(milliseconds: 10));
     }
-    expect(count, 1);
+    expect(summary.queued, 1);
     expect(container.read(mediaTransferEntriesProvider).hasValue, isTrue);
   });
 }

--- a/test/features/media_store/media_store_worker_wakeup_test.dart
+++ b/test/features/media_store/media_store_worker_wakeup_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/native.dart';
@@ -27,9 +28,15 @@ class _RecordingPipeline extends MediaUploadPipeline {
   final MediaTransferQueueRepository queueRef;
   final processed = <String>[];
 
+  /// When set, process() parks here until completed, holding the drain
+  /// open so a test can act while it is in flight.
+  Completer<void>? gate;
+
   @override
   Future<UploadOutcome> process(MediaTransferQueueEntry entry) async {
     processed.add(entry.mediaId);
+    final held = gate;
+    if (held != null) await held.future;
     await queueRef.markDone(entry.id);
     return UploadOutcome.uploaded;
   }
@@ -149,6 +156,45 @@ void main() {
     worker.dispose();
 
     await Future<void>.delayed(const Duration(milliseconds: 250));
+    expect(pipeline.processed, isEmpty);
+    expect(worker.wakeupDelayForTesting, isNull);
+  });
+
+  // A runtime rebuild disposes this worker without cancelling a drain it
+  // already started - that invariant predates the wakeup. So dispose can
+  // land mid-drain, and the drain's finally would then arm a fresh timer
+  // AFTER disposal, leaving a superseded worker re-draining forever behind
+  // the runtime that replaced it.
+  test('dispose during an in-flight drain does not re-arm a wakeup', () async {
+    await queue.enqueueUpload(mediaId: 'due');
+    final parked = await queue.enqueueUpload(mediaId: 'parked');
+    await queue.defer(parked, DateTime.now().add(const Duration(minutes: 10)));
+    pipeline.gate = Completer<void>();
+
+    final draining = worker.drain();
+    expect(
+      await _waitFor(() => pipeline.processed.isNotEmpty),
+      isTrue,
+      reason: 'the drain should be parked inside process()',
+    );
+
+    worker.dispose();
+    pipeline.gate!.complete();
+    await draining;
+
+    expect(
+      worker.wakeupDelayForTesting,
+      isNull,
+      reason: 'a disposed worker must not arm a wakeup on drain completion',
+    );
+  });
+
+  test('a disposed worker refuses to start a new drain', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    worker.dispose();
+
+    await worker.drain();
+
     expect(pipeline.processed, isEmpty);
     expect(worker.wakeupDelayForTesting, isNull);
   });

--- a/test/features/media_store/media_store_worker_wakeup_test.dart
+++ b/test/features/media_store/media_store_worker_wakeup_test.dart
@@ -1,0 +1,155 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_store_worker.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+class _RecordingPipeline extends MediaUploadPipeline {
+  _RecordingPipeline({
+    required this.queueRef,
+    required super.mediaRepository,
+    required super.queue,
+    required super.store,
+    required super.registry,
+    required super.cache,
+  });
+
+  final MediaTransferQueueRepository queueRef;
+  final processed = <String>[];
+
+  @override
+  Future<UploadOutcome> process(MediaTransferQueueEntry entry) async {
+    processed.add(entry.mediaId);
+    await queueRef.markDone(entry.id);
+    return UploadOutcome.uploaded;
+  }
+}
+
+/// Polls [condition] until true or [within] elapses. Condition-based rather
+/// than a fixed sleep: the wakeup fires on a real timer, and a fixed delay
+/// either flakes under load or pads every run.
+Future<bool> _waitFor(
+  bool Function() condition, {
+  Duration within = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(within);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return true;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return condition();
+}
+
+void main() {
+  late MediaRepository mediaRepository;
+  late LocalCacheDatabase cacheDb;
+  late Directory root;
+  late MediaTransferQueueRepository queue;
+  late _RecordingPipeline pipeline;
+  late MediaStoreWorker worker;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    mediaRepository = MediaRepository();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('worker_wakeup');
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    pipeline = _RecordingPipeline(
+      queueRef: queue,
+      mediaRepository: mediaRepository,
+      queue: queue,
+      store: InMemoryMediaObjectStore(),
+      registry: MediaSourceResolverRegistry({}),
+      cache: MediaCacheStore(database: cacheDb, root: root),
+    );
+    worker = MediaStoreWorker(queue: queue, pipeline: pipeline);
+  });
+
+  tearDown(() async {
+    // Dispose first: a wakeup that fires after the databases close would
+    // drain against a closed connection.
+    worker.dispose();
+    await cacheDb.close();
+    if (root.existsSync()) await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  test('a drain with nothing deferred arms no wakeup', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    await worker.drain();
+    expect(pipeline.processed, ['m1']);
+    expect(worker.wakeupDelayForTesting, isNull);
+  });
+
+  test('drain arms a wakeup for the soonest deferred row', () async {
+    final id = await queue.enqueueUpload(mediaId: 'm1');
+    await queue.defer(id, DateTime.now().add(const Duration(hours: 25)));
+
+    await worker.drain();
+
+    expect(pipeline.processed, isEmpty, reason: 'row is not due yet');
+    final armed = worker.wakeupDelayForTesting;
+    expect(armed, isNotNull);
+    // Within a minute of 25h: the exact value depends on wall clock drift
+    // between defer() and the drain.
+    expect(armed!.inMinutes, closeTo(25 * 60, 1));
+  });
+
+  // The regression this fixes: before the wakeup existed, a row deferred by
+  // markFailed's multi-hour retryAfter sat untouched for the whole session.
+  // Only an unrelated event (app restart, connectivity flap) ever picked it
+  // up, so the settings page count stayed stale indefinitely.
+  test('the armed wakeup re-drains once the backoff expires', () async {
+    final id = await queue.enqueueUpload(mediaId: 'm1');
+    await queue.defer(id, DateTime.now().add(const Duration(milliseconds: 80)));
+
+    await worker.drain();
+    expect(pipeline.processed, isEmpty, reason: 'not due at drain time');
+
+    expect(
+      await _waitFor(() => pipeline.processed.isNotEmpty),
+      isTrue,
+      reason: 'wakeup timer should have re-drained the row',
+    );
+    expect(pipeline.processed, ['m1']);
+  });
+
+  test(
+    'a later drain replaces the armed wakeup rather than stacking',
+    () async {
+      final id = await queue.enqueueUpload(mediaId: 'm1');
+      await queue.defer(id, DateTime.now().add(const Duration(hours: 25)));
+      await worker.drain();
+      final first = worker.wakeupDelayForTesting;
+
+      await queue.defer(id, DateTime.now().add(const Duration(minutes: 10)));
+      await worker.drain();
+
+      expect(first!.inMinutes, closeTo(25 * 60, 1));
+      expect(worker.wakeupDelayForTesting!.inMinutes, closeTo(10, 1));
+    },
+  );
+
+  test('dispose cancels the armed wakeup', () async {
+    final id = await queue.enqueueUpload(mediaId: 'm1');
+    await queue.defer(id, DateTime.now().add(const Duration(milliseconds: 80)));
+    await worker.drain();
+
+    worker.dispose();
+
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    expect(pipeline.processed, isEmpty);
+    expect(worker.wakeupDelayForTesting, isNull);
+  });
+}

--- a/test/features/media_store/media_transfer_queue_repository_test.dart
+++ b/test/features/media_store/media_transfer_queue_repository_test.dart
@@ -213,13 +213,13 @@ void main() {
     );
   });
 
-  test('deleteDone removes only completed rows and watchActiveCount tracks '
-      'pending plus transferring', () async {
+  test('deleteDone removes only completed rows, which the summary already '
+      'excludes', () async {
     final a = await repo.enqueueUpload(mediaId: 'a');
     final b = await repo.enqueueUpload(mediaId: 'b');
     await repo.markDone(a);
     await repo.markTransferring(b);
-    expect(await repo.watchActiveCount().first, 1);
+    expect((await repo.watchSummary().first).transferring, 1);
     expect(await repo.deleteDone(), 1);
     expect((await repo.allForTesting()).length, 1);
   });

--- a/test/features/media_store/media_transfer_summary_test.dart
+++ b/test/features/media_store/media_transfer_summary_test.dart
@@ -1,0 +1,111 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/domain/media_transfer_summary.dart';
+
+void main() {
+  late LocalCacheDatabase db;
+  late MediaTransferQueueRepository repo;
+
+  setUp(() {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    repo = MediaTransferQueueRepository(database: db);
+  });
+
+  tearDown(() => db.close());
+
+  test('watchSummary splits in-flight, due, and deferred work', () async {
+    final now = DateTime.now();
+    final inFlight = await repo.enqueueUpload(mediaId: 'in-flight');
+    await repo.enqueueUpload(mediaId: 'due');
+    final deferred = await repo.enqueueUpload(mediaId: 'deferred');
+    await repo.markTransferring(inFlight);
+    await repo.defer(deferred, now.add(const Duration(hours: 25)));
+
+    final summary = await repo.watchSummary().first;
+    expect(summary.transferring, 1);
+    expect(summary.queued, 1);
+    expect(summary.waiting, 1);
+  });
+
+  // The reported bug: four rows parked in the 25h source-unavailable backoff
+  // read as active work, so the settings page spun an indeterminate progress
+  // bar for a day with an idle worker. A backed-off row is 'pending' in the
+  // table but nextPending refuses to select it, so it must never count as
+  // in-flight.
+  test('a row in retry backoff is waiting, never transferring', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    await repo.markFailed(
+      id,
+      'source unavailable on this device',
+      retryAfter: const Duration(hours: 25),
+    );
+
+    final summary = await repo.watchSummary().first;
+    expect(summary.transferring, 0);
+    expect(summary.queued, 0);
+    expect(summary.waiting, 1);
+    expect(summary.waitingReason, 'source unavailable on this device');
+    expect(summary.isBusy, isFalse);
+  });
+
+  test('terminal and completed rows are excluded entirely', () async {
+    final done = await repo.enqueueUpload(mediaId: 'done');
+    await repo.markDone(done);
+    final failed = await repo.enqueueUpload(mediaId: 'failed');
+    for (var i = 0; i < 5; i++) {
+      await repo.markFailed(failed, 'boom');
+    }
+
+    final summary = await repo.watchSummary().first;
+    expect(summary.isEmpty, isTrue);
+    expect(summary.total, 0);
+  });
+
+  test('summary re-emits as rows change state', () async {
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    final emissions = <MediaTransferSummary>[];
+    final sub = repo.watchSummary().listen(emissions.add);
+    await pumpEventQueue();
+    await repo.markTransferring(id);
+    await pumpEventQueue();
+    await sub.cancel();
+
+    expect(emissions.first.queued, 1);
+    expect(emissions.last.transferring, 1);
+    expect(emissions.last.queued, 0);
+  });
+
+  test(
+    'earliestPendingWakeup returns the soonest future retry, skipping due rows',
+    () async {
+      final now = DateTime.now();
+      await repo.enqueueUpload(mediaId: 'due-now');
+      final soon = await repo.enqueueUpload(mediaId: 'soon');
+      final later = await repo.enqueueUpload(mediaId: 'later');
+      await repo.defer(soon, now.add(const Duration(minutes: 10)));
+      await repo.defer(later, now.add(const Duration(hours: 25)));
+
+      final wakeup = await repo.earliestPendingWakeup(now);
+      expect(wakeup, isNotNull);
+      expect(
+        wakeup!.millisecondsSinceEpoch,
+        now.add(const Duration(minutes: 10)).millisecondsSinceEpoch,
+      );
+    },
+  );
+
+  test('earliestPendingWakeup is null when nothing is deferred', () async {
+    await repo.enqueueUpload(mediaId: 'm1');
+    expect(await repo.earliestPendingWakeup(DateTime.now()), isNull);
+  });
+
+  test('earliestPendingWakeup ignores non-pending rows', () async {
+    final now = DateTime.now();
+    final id = await repo.enqueueUpload(mediaId: 'm1');
+    await repo.defer(id, now.add(const Duration(hours: 1)));
+    await repo.markTransferring(id);
+    expect(await repo.earliestPendingWakeup(now), isNull);
+  });
+}

--- a/test/features/media_store/media_transfer_summary_test.dart
+++ b/test/features/media_store/media_transfer_summary_test.dart
@@ -50,6 +50,35 @@ void main() {
     expect(summary.isBusy, isFalse);
   });
 
+  test(
+    'waitingReason is the newest failure among several parked rows',
+    () async {
+      final older = await repo.enqueueUpload(mediaId: 'older');
+      await repo.markFailed(
+        older,
+        'older failure',
+        retryAfter: const Duration(hours: 25),
+      );
+      // markFailed stamps updatedAt from the wall clock; two calls can land in
+      // the same millisecond, so force a distinct tick.
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      final newer = await repo.enqueueUpload(mediaId: 'newer');
+      await repo.markFailed(
+        newer,
+        'newer failure',
+        retryAfter: const Duration(hours: 25),
+      );
+      // Parked with no error at all: the newest row overall, and still not a
+      // reason. A policy deferral consumes no attempt and records nothing.
+      final quiet = await repo.enqueueUpload(mediaId: 'quiet');
+      await repo.defer(quiet, DateTime.now().add(const Duration(hours: 25)));
+
+      final summary = await repo.watchSummary().first;
+      expect(summary.waiting, 3);
+      expect(summary.waitingReason, 'newer failure');
+    },
+  );
+
   test('terminal and completed rows are excluded entirely', () async {
     final done = await repo.enqueueUpload(mediaId: 'done');
     await repo.markDone(done);


### PR DESCRIPTION
## Summary

Settings > Media Storage showed a spinning indeterminate progress bar with a
count beside it on every app launch, for a full day, while nothing was
uploading.

The bar was not measuring progress. `watchActiveCount()` counted rows in
`state IN ('pending','transferring')`, but `nextPending()` only ever selects
rows that are **due** (`next_attempt_at IS NULL OR <= now`). A row that
`markFailed` parked behind a retry backoff is `'pending'` in the table yet
structurally invisible to the drainer — and `_sourceUnavailableRetryAfter`
is 25 hours, deliberately chosen to outlast the asset resolver's own
negative-cache lockout. Four such rows (`source unavailable on this device`)
were therefore counted as active work while the worker sat completely idle.

The Transfers page, drawing the same rows, already got this right: it gates
its progress bar on `state == 'transferring'` and shows everything else with
a `schedule` icon. Two views of one table disagreeing about what `'pending'`
means was the tell.

A second gap compounded it: **nothing re-kicked a drain when a backoff
expired.** Every `drain()` call site is an external event — runtime
construction, a connectivity change, a verify sweep, an explicit tap — so a
25-hour retry coming due mid-session never fired, and the stale count
survived until an unrelated restart.

## Changes

- Add `MediaTransferSummary` (`transferring` / `queued` / `waiting` +
  `waitingReason`), replacing the conflated `watchActiveCount()` with
  `watchSummary()`. Due-ness is evaluated per emission.
- Extract `MediaTransferSummaryRow`. The indeterminate bar now renders only
  while bytes are actually moving; due-but-not-started work reads as
  "N queued", and parked work as "N waiting to retry" with the queue's own
  error text.
- The waiting row routes into Transfers, which already offers Retry for a
  still-pending row with an error — precisely so nobody has to wait out a
  multi-hour backoff they are looking at right now.
- Add `MediaTransferQueueRepository.earliestPendingWakeup()` and
  `MediaStoreWorker._armWakeup()`: after each drain the worker arms a timer
  for the soonest deferred row. Restricted to **future-dated** rows by
  construction — arming for an already-due row would tight-loop against a
  drain that is declining to run (offline, failed preflight), and those
  cases already have their own triggers.
- `MediaStoreWorker.dispose()` cancels the wakeup, wired to the runtime
  provider's `onDispose`. It deliberately does not touch an in-flight drain,
  matching the existing invariant that a runtime rebuild never cancels one.
- New l10n keys `settings_mediaStorage_transfers_queued` and
  `..._waitingRetry` across all 11 locales.

## Test Plan

- [x] `flutter test` passes — 13,876 passed, 0 failed
- [x] `flutter analyze` passes — no issues (run unpiped; a piped analyze
      masks its exit code)
- [x] 17 new tests, including the exact reported state: `waiting: 4` with
      `waitingReason: 'source unavailable on this device'` renders **no**
      `LinearProgressIndicator`
- [x] Worker wakeup covered end-to-end: a row deferred 80 ms out is
      re-drained by the armed timer; `dispose()` cancels it; a later drain
      replaces rather than stacks the timer
- [x] Manual testing: not re-run against the original state. The reporting
      device's four rows came due at 14:58 on 2026-07-24, so the condition no
      longer exists in that database and reproducing it would have meant
      mutating live data. The widget test covers it instead.

## Notes

Incidentally, the four queued media IDs no longer exist in that device's
`media` table. Per `media_upload_pipeline.dart` a missing media row hits
`markDone`, so the drain clears them on its own once due — that is those
rows resolving, not the defect being fixed. The defect was the reporting.
