### PR TITLE
fix(accounts): stop Connected Accounts accumulating duplicate rows

### DIFF
--- a/docs/superpowers/plans/2026-07-24-connected-accounts-dedup.md
+++ b/docs/superpowers/plans/2026-07-24-connected-accounts-dedup.md
@@ -1,0 +1,1528 @@
+# Connected Accounts Deduplication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `connected_accounts` from accumulating duplicate rows for the same endpoint, and collapse the duplicates that already exist.
+
+**Architecture:** Give accounts a deterministic UUIDv5 id derived from `kind` plus a natural key (S3: host/bucket/prefix; managed kinds: the kind name). The primary key then becomes the uniqueness constraint, so two devices connecting the same endpoint compute the same id and sync's upsert-by-id merges them. A repository `ensure()` replaces every unguarded `create()` call site, and a startup pass migrates the rows that sync metadata and the media-store pref actually point at onto their canonical ids, then deletes the inert leftovers.
+
+**Tech Stack:** Dart / Flutter, Drift ORM, Riverpod, `uuid` package, `flutter_secure_storage`, `shared_preferences`, `flutter_test`.
+
+Spec: `docs/superpowers/specs/2026-07-24-connected-accounts-dedup-design.md`
+
+## Global Constraints
+
+- No database schema change and no schema version bump. No new column, no unique index.
+- `AccountKind.adobeLightroom` is excluded from every part of this work. Lightroom ids were preserved by the v107 migration because scan state and suggestion rows key on them.
+- `kConnectedAccountNamespace` is `'c622faae-974f-4310-a5e7-36c2fb773684'` and must never change.
+- Never delete legacy keychain blobs. Migration copies rather than moves (rollback safety), matching `AccountStartupMigration`.
+- All Dart code must pass `dart format .` with no changes.
+- No emojis in code, comments, or documentation.
+- Run `dart format .` and `flutter analyze` before every commit. `flutter analyze` must be run on the whole project and must not be piped through `tail` or `head`.
+- Commit messages must not contain a `Co-Authored-By:` trailer.
+
+## File Structure
+
+| File | Responsibility |
+| ---- | -------------- |
+| `lib/core/services/accounts/account_identity.dart` (create) | Namespace constant, natural-key builders, deterministic id function. Pure, no I/O. |
+| `lib/core/data/repositories/connected_accounts_repository.dart` (modify) | Add `ensure()`. No other behaviour change. |
+| `lib/features/media_store/data/media_store_service.dart` (modify) | Route the two account-creating paths through `ensure()`. |
+| `lib/features/settings/presentation/providers/sync_providers.dart` (modify) | Route `ensureAccountForProviderType` through `ensure()`. |
+| `lib/core/services/accounts/account_startup_migration.dart` (modify) | Route its three `create()` calls through `ensure()`. |
+| `lib/core/services/accounts/account_deduplicator.dart` (create) | One-purpose startup pass: canonicalize anchors, delete inert rows. |
+| `lib/core/presentation/pages/startup_page.dart` (modify) | Run the deduplicator after the account migration. |
+
+---
+
+### Task 1: Deterministic account identity
+
+**Files:**
+- Create: `lib/core/services/accounts/account_identity.dart`
+- Test: `test/core/services/accounts/account_identity_test.dart`
+
+**Interfaces:**
+- Consumes: `AccountKind` from `lib/core/services/accounts/account_kind.dart`, `S3Config` from `lib/core/services/cloud_storage/s3/s3_config.dart`.
+- Produces:
+  - `const String kConnectedAccountNamespace`
+  - `String s3NaturalKey(S3Config config)`
+  - `String? naturalKeyForKind(AccountKind kind)` — returns null for `s3` (needs a config) and `adobeLightroom` (excluded)
+  - `String accountIdFor({required AccountKind kind, required String naturalKey})`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/services/accounts/account_identity_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+
+void main() {
+  S3Config config({
+    String endpoint = 'https://minio.local',
+    String region = 'us-east-1',
+    String bucket = 'dive-media',
+    String prefix = 'submersion-sync/',
+  }) => S3Config(
+    endpoint: endpoint,
+    region: region,
+    bucket: bucket,
+    prefix: prefix,
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+  );
+
+  String idFor(S3Config c) =>
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(c));
+
+  test('same endpoint yields the same id', () {
+    expect(idFor(config()), idFor(config()));
+  });
+
+  test('id is stable across credential rotation', () {
+    final rotated = S3Config(
+      endpoint: 'https://minio.local',
+      bucket: 'dive-media',
+      prefix: 'submersion-sync/',
+      accessKeyId: 'ROTATED',
+      secretAccessKey: 'ROTATED',
+    );
+    expect(idFor(config()), idFor(rotated));
+  });
+
+  test('a different prefix is a different account', () {
+    expect(idFor(config()), isNot(idFor(config(prefix: 'media/'))));
+  });
+
+  test('a different bucket is a different account', () {
+    expect(idFor(config()), isNot(idFor(config(bucket: 'other'))));
+  });
+
+  test('AWS-proper and an explicit AWS endpoint agree', () {
+    final implicit = config(endpoint: '', region: 'eu-west-1');
+    final explicit = config(
+      endpoint: 'https://s3.eu-west-1.amazonaws.com',
+      region: 'eu-west-1',
+    );
+    expect(idFor(implicit), idFor(explicit));
+  });
+
+  test('a trailing slash on the endpoint does not change the id', () {
+    expect(idFor(config()), idFor(config(endpoint: 'https://minio.local/')));
+  });
+
+  test('managed kinds are single-instance per kind', () {
+    for (final kind in [
+      AccountKind.icloud,
+      AccountKind.dropbox,
+      AccountKind.googledrive,
+    ]) {
+      final key = naturalKeyForKind(kind);
+      expect(key, isNotNull, reason: '$kind must have a natural key');
+      expect(
+        accountIdFor(kind: kind, naturalKey: key!),
+        accountIdFor(kind: kind, naturalKey: key),
+      );
+    }
+  });
+
+  test('different kinds never collide', () {
+    final ids = {
+      for (final kind in [
+        AccountKind.icloud,
+        AccountKind.dropbox,
+        AccountKind.googledrive,
+      ])
+        accountIdFor(kind: kind, naturalKey: naturalKeyForKind(kind)!),
+    };
+    expect(ids.length, 3);
+  });
+
+  test('s3 and lightroom have no kind-only natural key', () {
+    expect(naturalKeyForKind(AccountKind.s3), isNull);
+    expect(naturalKeyForKind(AccountKind.adobeLightroom), isNull);
+  });
+
+  test('the namespace constant is frozen', () {
+    expect(kConnectedAccountNamespace, 'c622faae-974f-4310-a5e7-36c2fb773684');
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/core/services/accounts/account_identity_test.dart`
+Expected: FAIL — `Error: Error when reading 'lib/core/services/accounts/account_identity.dart': No such file or directory`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/core/services/accounts/account_identity.dart`:
+
+```dart
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+
+/// Namespace for deterministic connected-account ids. Frozen: every device
+/// must derive the same id from the same endpoint, so changing this would
+/// fork the roster across the fleet.
+const String kConnectedAccountNamespace =
+    'c622faae-974f-4310-a5e7-36c2fb773684';
+
+/// Endpoint identity for an S3 account.
+///
+/// Uses [S3Config.displayHost] rather than the raw endpoint so AWS-proper
+/// (empty endpoint, host derived from the region) and an explicit AWS
+/// endpoint for one bucket resolve to a single account. Includes the prefix
+/// so the sync and media-store roles stay separate accounts when they share
+/// a bucket. Credentials are deliberately excluded: rotating a key must not
+/// mint a new account.
+String s3NaturalKey(S3Config config) =>
+    '${config.displayHost}|${config.bucket}|${config.prefix}';
+
+/// Natural key for a kind that can only have one instance per library.
+///
+/// Null for [AccountKind.s3] (an instance kind: use [s3NaturalKey]) and for
+/// [AccountKind.adobeLightroom], whose ids are preserved from the v107
+/// migration because Lightroom scan state and suggestion rows key on them.
+String? naturalKeyForKind(AccountKind kind) => switch (kind) {
+  AccountKind.icloud ||
+  AccountKind.dropbox ||
+  AccountKind.googledrive => kind.name,
+  AccountKind.s3 || AccountKind.adobeLightroom => null,
+};
+
+/// The deterministic id for an endpoint.
+///
+/// Two devices computing this for the same endpoint get the same primary
+/// key, so sync's upsert-by-id merges them instead of unioning two rows.
+/// This is why no unique index is needed: a unique constraint on a
+/// replicated table would make an inbound sync insert throw rather than
+/// merge.
+String accountIdFor({required AccountKind kind, required String naturalKey}) =>
+    const Uuid().v5(kConnectedAccountNamespace, '${kind.name}:$naturalKey');
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/core/services/accounts/account_identity_test.dart`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/core/services/accounts/account_identity.dart test/core/services/accounts/account_identity_test.dart
+git commit -m "feat(accounts): add deterministic connected-account identity
+
+Derives an account id from kind plus a natural key (S3 host/bucket/prefix,
+kind name for single-instance managed kinds) via UUIDv5 under a frozen
+namespace, so every device computes the same primary key for the same
+endpoint. Lightroom is excluded: its ids are preserved from v107."
+```
+
+---
+
+### Task 2: Repository `ensure()`
+
+**Files:**
+- Modify: `lib/core/data/repositories/connected_accounts_repository.dart`
+- Test: `test/core/data/repositories/connected_accounts_repository_test.dart` (exists, append)
+
+**Interfaces:**
+- Consumes: `accountIdFor` from Task 1.
+- Produces: `Future<ConnectedAccount> ConnectedAccountsRepository.ensure({required AccountKind kind, required String naturalKey, required String label})`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `main()` in `test/core/data/repositories/connected_accounts_repository_test.dart`, after the last existing `test(...)` block:
+
+```dart
+  test('ensure is idempotent: two calls yield one row', () async {
+    final first = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'dive-media @ minio.local',
+    );
+    final second = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'dive-media @ minio.local',
+    );
+    expect(second.id, first.id);
+    expect((await repo.getAll()).length, 1);
+  });
+
+  test('ensure uses the deterministic id', () async {
+    final account = await repo.ensure(
+      kind: AccountKind.icloud,
+      naturalKey: 'icloud',
+      label: 'iCloud',
+    );
+    expect(
+      account.id,
+      accountIdFor(kind: AccountKind.icloud, naturalKey: 'icloud'),
+    );
+  });
+
+  test('ensure refreshes a drifted label in place', () async {
+    final first = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'old label',
+    );
+    final second = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'new label',
+    );
+    expect(second.id, first.id);
+    expect(second.label, 'new label');
+    final all = await repo.getAll();
+    expect(all.length, 1);
+    expect(all.single.label, 'new label');
+  });
+
+  test('ensure separates two prefixes in one bucket', () async {
+    final sync = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|shared|submersion-sync/',
+      label: 'shared @ minio.local',
+    );
+    final media = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|shared|media/',
+      label: 'shared @ minio.local',
+    );
+    expect(media.id, isNot(sync.id));
+    expect((await repo.getAll()).length, 2);
+  });
+```
+
+Add this import to the test file's import block:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/core/data/repositories/connected_accounts_repository_test.dart`
+Expected: FAIL — `The method 'ensure' isn't defined for the class 'ConnectedAccountsRepository'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/core/data/repositories/connected_accounts_repository.dart`, add this import next to the existing account imports:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+```
+
+Then insert this method immediately after `create()`:
+
+```dart
+  /// Find-or-create by deterministic id.
+  ///
+  /// The id IS the dedup mechanism: it collides for the same endpoint on
+  /// every device, so sync's upsert-by-id merges rather than duplicating.
+  /// Callers on write paths must use this instead of [create]; [getByKind]
+  /// is a local-only query and cannot dedup a replicated table.
+  ///
+  /// A drifted [label] (renamed bucket, changed host spelling) is refreshed
+  /// in place rather than minting a row.
+  Future<domain.ConnectedAccount> ensure({
+    required AccountKind kind,
+    required String naturalKey,
+    required String label,
+  }) async {
+    final id = accountIdFor(kind: kind, naturalKey: naturalKey);
+    final existing = await getById(id);
+    if (existing == null) {
+      return create(kind: kind, label: label, id: id);
+    }
+    if (existing.label == label) return existing;
+    await updateLabels(id, label: label);
+    return existing.copyWith(label: label);
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/core/data/repositories/connected_accounts_repository_test.dart`
+Expected: PASS, including the pre-existing tests.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/core/data/repositories/connected_accounts_repository.dart test/core/data/repositories/connected_accounts_repository_test.dart
+git commit -m "feat(accounts): add ConnectedAccountsRepository.ensure
+
+Find-or-create keyed on the deterministic id, refreshing a drifted label in
+place. Write paths use this instead of create so the primary key does the
+deduplication."
+```
+
+---
+
+### Task 3: Route the media store through `ensure()`
+
+**Files:**
+- Modify: `lib/features/media_store/data/media_store_service.dart:206-214` (S3) and `:277-279` (managed)
+- Test: `test/features/media_store/media_store_service_test.dart` (exists, modify one test and append two)
+
+**Interfaces:**
+- Consumes: `ensure()` from Task 2, `s3NaturalKey` / `naturalKeyForKind` from Task 1.
+- Produces: no new public API. `connectS3` and `_connectManaged` keep their existing signatures and return types.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/features/media_store/media_store_service_test.dart`, replace the existing test named `connectS3 against an existing store adopts its storeId` with:
+
+```dart
+  test('connectS3 against an existing store adopts its storeId', () async {
+    final first = await service.connectS3(config);
+    await service.disconnect();
+    final second = await service.connectS3(config);
+    expect(second.createdNewStore, isFalse);
+    expect(second.storeId, first.storeId);
+  });
+
+  test('connectS3 twice reuses one account row', () async {
+    await service.connectS3(config);
+    await service.connectS3(config);
+    final accounts = await accountsRepository.getAll();
+    expect(accounts.length, 1);
+    expect(accounts.single.kind, AccountKind.s3);
+  });
+
+  test('connectS3 uses the deterministic account id', () async {
+    await service.connectS3(config);
+    final accounts = await accountsRepository.getAll();
+    expect(
+      accounts.single.id,
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(config)),
+    );
+  });
+
+  test('connectS3 keeps two prefixes in one bucket separate', () async {
+    await service.connectS3(config);
+    final otherPrefix = S3Config(
+      endpoint: config.endpoint,
+      region: config.region,
+      bucket: config.bucket,
+      prefix: 'a-different-prefix/',
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    );
+    await service.connectS3(otherPrefix);
+    expect((await accountsRepository.getAll()).length, 2);
+  });
+```
+
+Add these imports to the test file if not already present:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/media_store/media_store_service_test.dart`
+Expected: `connectS3 twice reuses one account row` FAILS with `Expected: <1> Actual: <2>`; `connectS3 uses the deterministic account id` FAILS on a random UUID.
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/features/media_store/data/media_store_service.dart`, add the import:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+```
+
+Replace the account resolution inside `connectS3` (currently lines 206-214) with:
+
+```dart
+      // Reuse the given account (only when it really is an S3 account:
+      // attaching S3 credentials under another kind's keychain key would
+      // corrupt that account), else resolve the endpoint to its
+      // deterministic account. The endpoint key includes the prefix, so a
+      // bare connect still never adopts the sync S3 account when sync uses
+      // a different prefix in the same bucket.
+      final requested = accountId == null
+          ? null
+          : await _accounts.getById(accountId);
+      final account = (requested != null && requested.kind == AccountKind.s3)
+          ? requested
+          : await _accounts.ensure(
+              kind: AccountKind.s3,
+              naturalKey: s3NaturalKey(config),
+              label: '${config.bucket} @ ${config.displayHost}',
+            );
+```
+
+Replace the account resolution inside `_connectManaged` (currently lines 276-279) with:
+
+```dart
+    final kind = AccountKind.fromCloudProviderType(type);
+    // Single-instance per kind, resolved to the deterministic id so two
+    // devices connecting the same provider converge on one row instead of
+    // each minting its own (getByKind dedups only locally).
+    final account = await _accounts.ensure(
+      kind: kind,
+      naturalKey: naturalKeyForKind(kind)!,
+      label: displayHint,
+    );
+```
+
+The `!` is safe here: `_connectManaged` is only reached for `dropbox`, `googledrive` and `icloud`, all of which `naturalKeyForKind` answers non-null. S3 uses `connectS3`, and Lightroom has no `CloudProviderType`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/media_store/media_store_service_test.dart`
+Expected: PASS, all tests including the pre-existing ones.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/media_store/data/media_store_service.dart test/features/media_store/media_store_service_test.dart
+git commit -m "fix(media-store): stop minting a new account on every connect
+
+connectS3 created an account row unconditionally, so every connect to the
+same bucket added a duplicate; _connectManaged deduped via getByKind, which
+is local-only and cannot converge a sync-replicated table. Both now resolve
+the endpoint to its deterministic account id."
+```
+
+---
+
+### Task 4: Route sync provider selection through `ensure()`
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart:257-280`
+- Test: `test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ensure()` from Task 2, `s3NaturalKey` / `naturalKeyForKind` from Task 1, `S3CredentialsStore` from `lib/core/services/cloud_storage/s3/s3_credentials_store.dart`.
+- Produces: `ensureAccountForProviderType` gains one optional named parameter, `S3CredentialsStore? s3Credentials`. Full signature after this task:
+
+```dart
+Future<domain.ConnectedAccount> ensureAccountForProviderType(
+  CloudProviderType type,
+  ConnectedAccountsRepository repo, {
+  SyncRepository? syncRepository,
+  S3CredentialsStore? s3Credentials,
+})
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+import '../../../../support/fake_keychain_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late ConnectedAccountsRepository repo;
+  late InMemoryKeychain keychain;
+  late S3CredentialsStore s3Credentials;
+
+  final config = S3Config(
+    endpoint: 'https://minio.local',
+    bucket: 'dive-sync',
+    prefix: 'submersion-sync/',
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+  );
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = ConnectedAccountsRepository();
+    keychain = InMemoryKeychain();
+    s3Credentials = S3CredentialsStore(storage: keychain);
+    await SyncRepository().getOrCreateMetadata();
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  test('flipping S3 to iCloud and back reuses one S3 row', () async {
+    await s3Credentials.save(config);
+
+    final s3First = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    await SyncRepository().setSyncAccount(
+      accountId: s3First.id,
+      providerType: CloudProviderType.s3,
+    );
+
+    final icloud = await ensureAccountForProviderType(
+      CloudProviderType.icloud,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    await SyncRepository().setSyncAccount(
+      accountId: icloud.id,
+      providerType: CloudProviderType.icloud,
+    );
+
+    final s3Second = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+
+    expect(s3Second.id, s3First.id);
+    final all = await repo.getAll();
+    expect(all.where((a) => a.kind == AccountKind.s3).length, 1);
+    expect(all.where((a) => a.kind == AccountKind.icloud).length, 1);
+  });
+
+  test('the S3 account uses the deterministic id', () async {
+    await s3Credentials.save(config);
+    final account = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    expect(
+      account.id,
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(config)),
+    );
+  });
+
+  test('an unreadable S3 config still yields an account', () async {
+    final account = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    expect(account.kind, AccountKind.s3);
+    expect((await repo.getAll()).length, 1);
+  });
+
+  test('iCloud selected twice reuses one row', () async {
+    final first = await ensureAccountForProviderType(
+      CloudProviderType.icloud,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    final second = await ensureAccountForProviderType(
+      CloudProviderType.icloud,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    expect(second.id, first.id);
+    expect((await repo.getAll()).length, 1);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart`
+Expected: FAIL — `No named parameter with the name 's3Credentials'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/features/settings/presentation/providers/sync_providers.dart`, add the import:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+```
+
+Replace the whole of `ensureAccountForProviderType` (currently lines 257-280) with:
+
+```dart
+Future<domain.ConnectedAccount> ensureAccountForProviderType(
+  CloudProviderType type,
+  ConnectedAccountsRepository repo, {
+  SyncRepository? syncRepository,
+  S3CredentialsStore? s3Credentials,
+}) async {
+  final kind = AccountKind.fromCloudProviderType(type);
+  final persistedId = await (syncRepository ?? SyncRepository())
+      .getSyncAccountId();
+  if (persistedId != null) {
+    final persisted = await repo.getById(persistedId);
+    if (persisted != null && persisted.kind == kind) return persisted;
+  }
+  if (kind == AccountKind.s3) {
+    // S3 accounts are instances, so the endpoint identifies them. Read the
+    // legacy config (the source of truth on this path, mirrored by
+    // _mirrorLegacyCredentials) to derive that identity. Without it, fall
+    // back to a fresh row: an account with no resolvable endpoint cannot be
+    // matched to any other, and the deduplicator will canonicalize it once
+    // the config is readable.
+    final config = await (s3Credentials ?? S3CredentialsStore()).load();
+    if (config == null) {
+      return repo.create(
+        kind: kind,
+        label: cloudProviderInstanceFor(type).providerName,
+      );
+    }
+    return repo.ensure(
+      kind: kind,
+      naturalKey: s3NaturalKey(config),
+      label: '${config.bucket} @ ${config.displayHost}',
+    );
+  }
+  return repo.ensure(
+    kind: kind,
+    naturalKey: naturalKeyForKind(kind)!,
+    label: cloudProviderInstanceFor(type).providerName,
+  );
+}
+```
+
+Note the deliberate label change on the S3 branch: it now matches the media store's `bucket @ host` form, which is what already appears in existing rows, instead of the generic provider name.
+
+Update the one caller inside `selectedSyncAccountProvider` (currently line 305) to pass nothing new — it keeps working unchanged because `s3Credentials` is optional and defaults to the real store.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart`
+Expected: PASS, 4 tests.
+
+Then run the neighbouring suites to confirm nothing regressed:
+
+Run: `flutter test test/features/settings/presentation/providers/`
+Expected: PASS.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/settings/presentation/providers/sync_providers.dart test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart
+git commit -m "fix(sync): reuse the S3 account when the provider type flips
+
+ensureAccountForProviderType created a fresh S3 row whenever the persisted
+sync account was of another kind, so every S3 to iCloud and back round trip
+added a duplicate. It now derives the endpoint identity from the legacy S3
+config and resolves to the deterministic account id."
+```
+
+---
+
+### Task 5: Route the startup migration through `ensure()`
+
+**Files:**
+- Modify: `lib/core/services/accounts/account_startup_migration.dart:87`, `:137-140`, `:147-148`
+- Test: `test/core/services/accounts/account_startup_migration_test.dart` (exists, append)
+
+**Interfaces:**
+- Consumes: `ensure()` from Task 2, `s3NaturalKey` / `naturalKeyForKind` from Task 1.
+- Produces: no signature change. `AccountStartupMigration({required SharedPreferences prefs, AppDatabase? database, ConnectedAccountsRepository? accounts, AccountCredentialsStore? credentials, SyncRepository? syncRepository, EstablishedProviderStore? established})` is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `main()` in `test/core/services/accounts/account_startup_migration_test.dart`:
+
+```dart
+  test('migrated iCloud sync account lands on the deterministic id', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await SyncRepository().setCloudProvider(CloudProviderType.icloud);
+
+    await (await migration(prefs)).run();
+
+    final accounts = await ConnectedAccountsRepository().getAll();
+    expect(accounts.length, 1);
+    expect(
+      accounts.single.id,
+      accountIdFor(kind: AccountKind.icloud, naturalKey: 'icloud'),
+    );
+  });
+
+  test('a fresh connect after migration reuses the migrated row', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await SyncRepository().setCloudProvider(CloudProviderType.icloud);
+    await (await migration(prefs)).run();
+
+    await accounts.ensure(
+      kind: AccountKind.icloud,
+      naturalKey: 'icloud',
+      label: 'iCloud',
+    );
+
+    expect((await ConnectedAccountsRepository().getAll()).length, 1);
+  });
+```
+
+Add these imports to the test file if not already present:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/core/services/accounts/account_startup_migration_test.dart`
+Expected: `migrated iCloud sync account lands on the deterministic id` FAILS — the id is a random UUIDv4.
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/core/services/accounts/account_startup_migration.dart`, add the imports:
+
+```dart
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+```
+
+Add this private helper to the class, immediately above `_labelFor`:
+
+```dart
+  /// Create-or-reuse an account at its deterministic id. Falls back to the
+  /// legacy random-id create only when the endpoint is not resolvable (an S3
+  /// config this device cannot read); the deduplicator canonicalizes those
+  /// later.
+  Future<domain.ConnectedAccount> _ensure({
+    required AccountKind kind,
+    required String label,
+    S3Config? s3,
+  }) async {
+    final naturalKey = kind == AccountKind.s3
+        ? (s3 == null ? null : s3NaturalKey(s3))
+        : naturalKeyForKind(kind);
+    if (naturalKey == null) {
+      return _accounts.create(kind: kind, label: label);
+    }
+    return _accounts.ensure(kind: kind, naturalKey: naturalKey, label: label);
+  }
+```
+
+In `_migrateSyncProvider`, replace line 87:
+
+```dart
+    account ??= await _accounts.create(kind: kind, label: _labelFor(kind));
+```
+
+with:
+
+```dart
+    final syncS3 = kind == AccountKind.s3
+        ? await S3CredentialsStore(storageKey: 'sync_s3_config').load()
+        : null;
+    account ??= await _ensure(kind: kind, label: _labelFor(kind), s3: syncS3);
+```
+
+In `_migrateMediaStoreAttachment`, replace the S3 branch (currently lines 136-140):
+
+```dart
+      final account = await _accounts.create(
+        kind: AccountKind.s3,
+        label: 'S3 media storage',
+      );
+```
+
+with:
+
+```dart
+      final mediaS3 = await S3CredentialsStore(
+        storageKey: 'media_store_s3_config',
+      ).load();
+      final account = await _ensure(
+        kind: AccountKind.s3,
+        label: mediaS3 == null
+            ? 'S3 media storage'
+            : '${mediaS3.bucket} @ ${mediaS3.displayHost}',
+        s3: mediaS3,
+      );
+```
+
+and replace the managed branch (currently lines 147-148):
+
+```dart
+      var account = await _accounts.getByKind(kind);
+      account ??= await _accounts.create(kind: kind, label: _labelFor(kind));
+      accountId = account.id;
+```
+
+with:
+
+```dart
+      final account = await _ensure(kind: kind, label: _labelFor(kind));
+      accountId = account.id;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/core/services/accounts/account_startup_migration_test.dart`
+Expected: PASS, including all pre-existing tests.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/core/services/accounts/account_startup_migration.dart test/core/services/accounts/account_startup_migration_test.dart
+git commit -m "refactor(accounts): seed the migration at deterministic ids
+
+Routes the migration's three create calls through ensure so an upgrading
+install and a fresh install land on identical account ids, instead of the
+upgrade keeping a random id that a peer would later duplicate."
+```
+
+---
+
+### Task 6: Startup deduplicator
+
+**Files:**
+- Create: `lib/core/services/accounts/account_deduplicator.dart`
+- Test: `test/core/services/accounts/account_deduplicator_test.dart`
+
+**Interfaces:**
+- Consumes: `accountIdFor` / `s3NaturalKey` / `naturalKeyForKind` (Task 1), `ensure` (Task 2), `ConnectedAccountsRepository`, `AccountCredentialsStore`, `SyncRepository`, `EstablishedProviderStore`, `MediaStoreAttachState` pref key `media_store_account_id`, `S3CredentialsStore`.
+- Produces:
+
+```dart
+class AccountDeduplicator {
+  AccountDeduplicator({
+    required SharedPreferences prefs,
+    AppDatabase? database,
+    ConnectedAccountsRepository? accounts,
+    AccountCredentialsStore? credentials,
+    SyncRepository? syncRepository,
+    EstablishedProviderStore? established,
+    S3CredentialsStore? syncS3,
+    S3CredentialsStore? mediaS3,
+  });
+
+  Future<void> run();
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/services/accounts/account_deduplicator_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_deduplicator.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+
+import '../../../helpers/test_database.dart';
+import '../../../support/fake_keychain_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late ConnectedAccountsRepository accounts;
+  late InMemoryKeychain keychain;
+  late AccountCredentialsStore credentials;
+  late S3CredentialsStore syncS3;
+  late S3CredentialsStore mediaS3;
+
+  final syncConfig = S3Config(
+    endpoint: 'https://149b84f6.r2.cloudflarestorage.com',
+    bucket: 'submersion-sync',
+    prefix: 'submersion-sync/',
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+  );
+
+  String syncCanonicalId() => accountIdFor(
+    kind: AccountKind.s3,
+    naturalKey: s3NaturalKey(syncConfig),
+  );
+
+  Future<AccountDeduplicator> dedup(SharedPreferences prefs) async =>
+      AccountDeduplicator(
+        prefs: prefs,
+        database: db,
+        accounts: accounts,
+        credentials: credentials,
+        syncRepository: SyncRepository(),
+        established: EstablishedProviderStore(prefs),
+        syncS3: syncS3,
+        mediaS3: mediaS3,
+      );
+
+  Future<int> deletionCount() async {
+    final rows = await db
+        .customSelect(
+          "SELECT COUNT(*) AS c FROM deletion_log "
+          "WHERE entity_type = 'connectedAccounts'",
+        )
+        .getSingle();
+    return rows.data['c'] as int;
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    accounts = ConnectedAccountsRepository();
+    keychain = InMemoryKeychain();
+    credentials = AccountCredentialsStore(storage: keychain);
+    syncS3 = S3CredentialsStore(storage: keychain, storageKey: 'sync_s3_config');
+    mediaS3 = S3CredentialsStore(
+      storage: keychain,
+      storageKey: 'media_store_s3_config',
+    );
+    await SyncRepository().getOrCreateMetadata();
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  test('collapses the observed duplicate roster', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+
+    const label = 'submersion-sync @ 149b84f6.r2.cloudflarestorage.com';
+    final s3Ids = <String>[];
+    for (var i = 0; i < 9; i++) {
+      final a = await accounts.create(kind: AccountKind.s3, label: label);
+      s3Ids.add(a.id);
+    }
+    for (var i = 0; i < 2; i++) {
+      await accounts.create(kind: AccountKind.icloud, label: 'iCloud');
+    }
+    await credentials.write(s3Ids.first, '{"blob":"sync"}');
+    await SyncRepository().setSyncAccount(
+      accountId: s3Ids.first,
+      providerType: CloudProviderType.s3,
+    );
+
+    await (await dedup(prefs)).run();
+
+    final remaining = await accounts.getAll();
+    expect(remaining.length, 1);
+    expect(remaining.single.id, syncCanonicalId());
+    expect(remaining.single.label, label);
+    expect(await SyncRepository().getSyncAccountId(), syncCanonicalId());
+    expect(await credentials.read(syncCanonicalId()), '{"blob":"sync"}');
+    expect(await deletionCount(), 10);
+  });
+
+  test('is a no-op on a second run', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+    final a = await accounts.create(kind: AccountKind.s3, label: 'x');
+    await SyncRepository().setSyncAccount(
+      accountId: a.id,
+      providerType: CloudProviderType.s3,
+    );
+
+    await (await dedup(prefs)).run();
+    final afterFirst = await deletionCount();
+    await (await dedup(prefs)).run();
+
+    expect(await deletionCount(), afterFirst);
+    expect((await accounts.getAll()).length, 1);
+  });
+
+  test('keeps a sync and a media anchor that differ by prefix', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+    final mediaConfig = S3Config(
+      endpoint: syncConfig.endpoint,
+      bucket: syncConfig.bucket,
+      prefix: 'media/',
+      accessKeyId: 'AK',
+      secretAccessKey: 'SK',
+    );
+    await mediaS3.save(mediaConfig);
+
+    const label = 'submersion-sync @ 149b84f6.r2.cloudflarestorage.com';
+    final syncRow = await accounts.create(kind: AccountKind.s3, label: label);
+    final mediaRow = await accounts.create(kind: AccountKind.s3, label: label);
+    await SyncRepository().setSyncAccount(
+      accountId: syncRow.id,
+      providerType: CloudProviderType.s3,
+    );
+    await prefs.setString('media_store_account_id', mediaRow.id);
+
+    await (await dedup(prefs)).run();
+
+    final remaining = await accounts.getAll();
+    expect(remaining.length, 2);
+    expect(
+      remaining.map((a) => a.id).toSet(),
+      {
+        syncCanonicalId(),
+        accountIdFor(
+          kind: AccountKind.s3,
+          naturalKey: s3NaturalKey(mediaConfig),
+        ),
+      },
+    );
+    expect(prefs.getString('media_store_account_id'), isNot(mediaRow.id));
+  });
+
+  test('leaves Lightroom rows untouched', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final lr = await accounts.create(
+      kind: AccountKind.adobeLightroom,
+      label: 'Lightroom',
+      accountIdentifier: 'catalog-1',
+      id: 'preserved-lightroom-id',
+    );
+    final lr2 = await accounts.create(
+      kind: AccountKind.adobeLightroom,
+      label: 'Lightroom',
+      accountIdentifier: 'catalog-2',
+    );
+
+    await (await dedup(prefs)).run();
+
+    final ids = (await accounts.getAll()).map((a) => a.id).toSet();
+    expect(ids, containsAll([lr.id, lr2.id]));
+    expect(await deletionCount(), 0);
+  });
+
+  test('keeps an anchor whose S3 config is unreadable, drops inert rows',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    const label = 'submersion-sync @ 149b84f6.r2.cloudflarestorage.com';
+    final anchor = await accounts.create(kind: AccountKind.s3, label: label);
+    await accounts.create(kind: AccountKind.s3, label: label);
+    await accounts.create(kind: AccountKind.s3, label: label);
+    await SyncRepository().setSyncAccount(
+      accountId: anchor.id,
+      providerType: CloudProviderType.s3,
+    );
+
+    await (await dedup(prefs)).run();
+
+    final remaining = await accounts.getAll();
+    expect(remaining.length, 1);
+    expect(remaining.single.id, anchor.id);
+    expect(await SyncRepository().getSyncAccountId(), anchor.id);
+    expect(await deletionCount(), 2);
+  });
+
+  test('carries an established marker onto the canonical id', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+    final anchor = await accounts.create(kind: AccountKind.s3, label: 'x');
+    await SyncRepository().setSyncAccount(
+      accountId: anchor.id,
+      providerType: CloudProviderType.s3,
+    );
+    final established = EstablishedProviderStore(prefs);
+    await established.add(anchor.id);
+
+    await (await dedup(prefs)).run();
+
+    expect(established.contains(syncCanonicalId()), isTrue);
+  });
+
+  test('does nothing when there is nothing to collapse', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await (await dedup(prefs)).run();
+    expect(await accounts.getAll(), isEmpty);
+    expect(await deletionCount(), 0);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/core/services/accounts/account_deduplicator_test.dart`
+Expected: FAIL — `Error when reading 'lib/core/services/accounts/account_deduplicator.dart': No such file or directory`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/core/services/accounts/account_deduplicator.dart`:
+
+```dart
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/connected_account.dart'
+    as domain;
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+
+/// Collapses duplicate `connected_accounts` rows onto their deterministic
+/// ids.
+///
+/// Rows created before deterministic ids existed carry random UUIDv4s, so
+/// the same endpoint appears once per connect and once per device. This pass
+/// is anchor-based rather than group-and-elect: legacy labels carry only
+/// `bucket @ host` with no prefix, so grouping on the label would merge a
+/// sync-S3 and a media-S3 account that share a bucket - two accounts the
+/// identity scheme deliberately keeps apart.
+///
+/// An anchor is a row something actually points at. There are at most two:
+/// the sync account (`sync_metadata.sync_account_id`) and the media store
+/// account (`media_store_account_id`). Each is migrated to the canonical id
+/// derived from its own config. Every other non-Lightroom row is referenced
+/// by nothing and its keychain blob is a copy, so it is deleted.
+///
+/// Runs on every launch rather than behind a done flag, so it also heals
+/// rows that arrive later from a device still on an older build. It performs
+/// no writes when there is nothing to collapse.
+class AccountDeduplicator {
+  AccountDeduplicator({
+    required SharedPreferences prefs,
+    AppDatabase? database,
+    ConnectedAccountsRepository? accounts,
+    AccountCredentialsStore? credentials,
+    SyncRepository? syncRepository,
+    EstablishedProviderStore? established,
+    S3CredentialsStore? syncS3,
+    S3CredentialsStore? mediaS3,
+  }) : _prefs = prefs,
+       _database = database,
+       _accounts = accounts ?? ConnectedAccountsRepository(),
+       _credentials = credentials ?? AccountCredentialsStore(),
+       _syncRepository = syncRepository ?? SyncRepository(),
+       _established = established ?? EstablishedProviderStore(prefs),
+       _syncS3 =
+           syncS3 ?? S3CredentialsStore(storageKey: _syncS3Key),
+       _mediaS3 =
+           mediaS3 ?? S3CredentialsStore(storageKey: _mediaS3Key);
+
+  static final _log = LoggerService.forClass(AccountDeduplicator);
+
+  static const String _syncS3Key = 'sync_s3_config';
+  static const String _mediaS3Key = 'media_store_s3_config';
+  static const String _mediaAccountIdKey = 'media_store_account_id';
+
+  final SharedPreferences _prefs;
+  final AppDatabase? _database;
+  final ConnectedAccountsRepository _accounts;
+  final AccountCredentialsStore _credentials;
+  final SyncRepository _syncRepository;
+  final EstablishedProviderStore _established;
+  final S3CredentialsStore _syncS3;
+  final S3CredentialsStore _mediaS3;
+
+  AppDatabase get _db => _database ?? DatabaseService.instance.database;
+
+  Future<void> run() async {
+    try {
+      await _run();
+    } catch (e, stackTrace) {
+      // A dedup failure must never block startup: the duplicates are a
+      // cosmetic and hygiene problem, and the next launch retries.
+      _log.error(
+        'Account deduplication failed; will retry next launch',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _run() async {
+    final all = await _accounts.getAll();
+    final candidates = all
+        .where((a) => a.kind != AccountKind.adobeLightroom)
+        .toList();
+    if (candidates.isEmpty) return;
+
+    // Anchors first, so references are repointed before anything is deleted.
+    final keep = <String>{};
+
+    final syncCanonical = await _canonicalizeSyncAnchor();
+    if (syncCanonical != null) keep.add(syncCanonical);
+
+    final mediaCanonical = await _canonicalizeMediaAnchor();
+    if (mediaCanonical != null) keep.add(mediaCanonical);
+
+    // Everything else is inert: nothing points at it, and its credentials
+    // blob is a copy of an anchor's.
+    for (final account in candidates) {
+      if (keep.contains(account.id)) continue;
+      // The established marker gates sync's first-contact check, so it
+      // carries only onto the SYNC canonical id. The media anchor plays no
+      // part in that gate and must not inherit the marker.
+      if (syncCanonical != null && _established.contains(account.id)) {
+        await _established.add(syncCanonical);
+      }
+      await _accounts.delete(account.id);
+    }
+  }
+
+  /// Migrates the sync account onto its canonical id and repoints
+  /// `sync_metadata`. Returns the id to keep, or null when there is no sync
+  /// anchor.
+  Future<String?> _canonicalizeSyncAnchor() async {
+    final id = await _syncRepository.getSyncAccountId();
+    if (id == null) return null;
+    final row = await _accounts.getById(id);
+    if (row == null || row.kind == AccountKind.adobeLightroom) return null;
+
+    final canonical = await _canonicalIdFor(row, _syncS3);
+    if (canonical == null || canonical == row.id) return row.id;
+
+    await _adopt(row, canonical);
+    final providerType = row.kind.cloudProviderType;
+    if (providerType != null) {
+      await _syncRepository.setSyncAccount(
+        accountId: canonical,
+        providerType: providerType,
+      );
+    }
+    return canonical;
+  }
+
+  /// Migrates the media store account onto its canonical id and repoints the
+  /// attach pref. Returns the id to keep, or null when nothing is attached.
+  Future<String?> _canonicalizeMediaAnchor() async {
+    final id = _prefs.getString(_mediaAccountIdKey);
+    if (id == null) return null;
+    final row = await _accounts.getById(id);
+    if (row == null || row.kind == AccountKind.adobeLightroom) return null;
+
+    final canonical = await _canonicalIdFor(row, _mediaS3);
+    if (canonical == null || canonical == row.id) return row.id;
+
+    await _adopt(row, canonical);
+    await _prefs.setString(_mediaAccountIdKey, canonical);
+    return canonical;
+  }
+
+  /// The deterministic id for [row], or null when this device cannot resolve
+  /// the endpoint (an S3 config it cannot read). Null means "leave it alone":
+  /// a device that can read the config finishes the migration, and the
+  /// deterministic id makes both devices agree afterwards.
+  Future<String?> _canonicalIdFor(
+    domain.ConnectedAccount row,
+    S3CredentialsStore s3Store,
+  ) async {
+    if (row.kind == AccountKind.s3) {
+      final config = await s3Store.load();
+      if (config == null) return null;
+      return accountIdFor(
+        kind: AccountKind.s3,
+        naturalKey: s3NaturalKey(config),
+      );
+    }
+    final key = naturalKeyForKind(row.kind);
+    return key == null
+        ? null
+        : accountIdFor(kind: row.kind, naturalKey: key);
+  }
+
+  /// Copies [row] onto [canonicalId]: credentials first, then the row.
+  ///
+  /// The legacy row is left for the inert sweep to delete, so a crash
+  /// between here and the sweep leaves a harmless extra row rather than a
+  /// reference pointing at a tombstone.
+  Future<void> _adopt(domain.ConnectedAccount row, String canonicalId) async {
+    final blob = await _credentials.read(row.id);
+    if (blob != null) await _credentials.write(canonicalId, blob);
+    if (await _accounts.getById(canonicalId) == null) {
+      await _accounts.create(
+        kind: row.kind,
+        label: row.label,
+        accountIdentifier: row.accountIdentifier,
+        id: canonicalId,
+      );
+    }
+    if (_established.contains(row.id)) {
+      await _established.add(canonicalId);
+    }
+  }
+}
+```
+
+Note: `_db` is retained for symmetry with `AccountStartupMigration` and is used by nothing in this pass. If `flutter analyze` reports it as unused, delete the `_db` getter, the `_database` field and the `database` constructor parameter, and drop the `AppDatabase` and `DatabaseService` imports along with the `database: db` argument in the test helper.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/core/services/accounts/account_deduplicator_test.dart`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/core/services/accounts/account_deduplicator.dart test/core/services/accounts/account_deduplicator_test.dart
+git commit -m "feat(accounts): add the startup account deduplicator
+
+Migrates the sync and media-store anchors onto their deterministic ids,
+repointing sync metadata, the attach pref, the established marker and the
+keychain blob before deleting the inert duplicate rows via tombstones.
+Lightroom is untouched."
+```
+
+---
+
+### Task 7: Run the deduplicator at startup
+
+**Files:**
+- Modify: `lib/core/presentation/pages/startup_page.dart:353-356`
+
+**Interfaces:**
+- Consumes: `AccountDeduplicator` from Task 6.
+- Produces: no new API.
+
+- [ ] **Step 1: Write the implementation**
+
+There is no unit test for `startup_page.dart`'s step sequence; this task is a wiring change verified by the full suite and a manual run.
+
+In `lib/core/presentation/pages/startup_page.dart`, add the import next to the existing `AccountStartupMigration` import:
+
+```dart
+import 'package:submersion/core/services/accounts/account_deduplicator.dart';
+```
+
+Replace the existing `accountMigration` step:
+
+```dart
+    await timeStartupStep('accountMigration', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await AccountStartupMigration(prefs: prefs).run();
+    });
+```
+
+with:
+
+```dart
+    await timeStartupStep('accountMigration', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await AccountStartupMigration(prefs: prefs).run();
+      // After the migration, so rows it seeds are already at their
+      // deterministic ids and the pass finds nothing to do on a fresh
+      // install. Both swallow their own errors: neither can block startup.
+      await AccountDeduplicator(prefs: prefs).run();
+    });
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `flutter test`
+Expected: PASS.
+
+- [ ] **Step 3: Format, analyze**
+
+```bash
+dart format .
+flutter analyze
+```
+
+Expected: no changes from `dart format`, no issues from `flutter analyze`.
+
+- [ ] **Step 4: Verify against the real database**
+
+Back up the development database first, since this pass deletes rows:
+
+```bash
+cp "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db" \
+   "$HOME/Desktop/submersion-before-dedup.db"
+sqlite3 "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db" \
+  "select kind, count(*) from connected_accounts group by kind;"
+```
+
+Expected before: `icloud|2`, `s3|9`.
+
+Run the app: `flutter run -d macos`, open Settings, then Connected Accounts.
+
+Expected after: at most one row per distinct endpoint. Re-run the same `sqlite3` query and confirm the counts dropped, and that `sync_metadata.sync_account_id` names a row that still exists:
+
+```bash
+sqlite3 "$HOME/Library/Containers/app.submersion/Data/Documents/Submersion/submersion.db" \
+  "select count(*) from connected_accounts c
+     join sync_metadata m on m.sync_account_id = c.id;"
+```
+
+Expected: `1`.
+
+Confirm sync still works: open Settings, Cloud Sync, and run a manual sync.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/presentation/pages/startup_page.dart
+git commit -m "feat(startup): run the account deduplicator after the migration
+
+Collapses pre-existing duplicate connected_accounts rows on launch, after
+the migration has seeded any rows it owns."
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the whole suite**
+
+Run: `flutter test`
+Expected: PASS with no skipped or failing tests. Record the totals.
+
+- [ ] **Step 2: Format and analyze the whole project**
+
+```bash
+dart format .
+flutter analyze
+```
+
+Expected: `dart format` reports 0 changed files; `flutter analyze` reports `No issues found!`. Do not pipe either command through `head` or `tail` - that masks the exit status.
+
+- [ ] **Step 3: Confirm no schema change slipped in**
+
+```bash
+git diff main --stat -- lib/core/database/
+```
+
+Expected: empty output. Any change under `lib/core/database/` means the no-schema-change constraint was violated.
+
+- [ ] **Step 4: Confirm every unguarded create is gone**
+
+```bash
+grep -rn "_accounts.create\|repo.create" lib --include="*.dart"
+```
+
+Expected: only the two documented fallbacks remain - `sync_providers.dart` (unreadable S3 config) and `account_startup_migration.dart`'s `_ensure` helper. Any other hit is a missed call site.
+
+- [ ] **Step 5: Push**
+
+```bash
+git push -u origin worktree-connected-accounts-duplicates
+```
+
+The pre-push hook runs `dart format --set-exit-if-changed`, `flutter analyze` and `flutter test`. If it rejects the push, fix the cause rather than bypassing with `--no-verify`.

--- a/docs/superpowers/specs/2026-07-24-connected-accounts-dedup-design.md
+++ b/docs/superpowers/specs/2026-07-24-connected-accounts-dedup-design.md
@@ -1,0 +1,210 @@
+# Connected Accounts deduplication
+
+Date: 2026-07-24
+
+## Problem
+
+The Connected Accounts page shows the same endpoint many times. The page is
+not at fault: it renders `ConnectedAccountsRepository.getAll()` verbatim, and
+the rows really are duplicated in `connected_accounts`.
+
+Evidence from the development database (11 rows):
+
+| kind | label | count |
+| ---- | ----- | ----- |
+| s3 | `submersion-sync @ 149b84f6...r2.cloudflarestorage.com` | 9 |
+| icloud | `iCloud` | 2 |
+
+Every row carries a distinct UUIDv4, `created_at == updated_at`, and
+`account_identifier` NULL. The HLC column shows two distinct node ids, so
+six S3 rows were minted on one device and three on another; the two iCloud
+rows are one per device.
+
+## Root cause
+
+`connected_accounts` rows have no natural identity. Row identity is a
+per-device random `Uuid().v4()`, and "does this account already exist?" is
+answered either by `getByKind` (kind-only, local-only) or not at all. Two
+consequences, both observed:
+
+1. **S3 has no dedup at all.** `MediaStoreService.connectS3` creates a row on
+   every connect, and `ensureAccountForProviderType`'s S3 branch creates a row
+   whenever the persisted sync account is of another kind - which is exactly
+   what happens each time sync flips S3 to iCloud and back.
+2. **`getByKind` dedup is local-only on a replicated table.** Two devices
+   independently mint different UUIDs for the same logical account, and sync
+   unions them. This is the iCloud pair.
+
+`connected_accounts` already has an `account_identifier` column, populated
+only for Lightroom catalog ids.
+
+## Design
+
+### 1. Deterministic account identity
+
+New `lib/core/services/accounts/account_identity.dart`:
+
+```
+kConnectedAccountNamespace = 'c622faae-974f-4310-a5e7-36c2fb773684'
+
+naturalKeyFor(kind, {S3Config? s3}) ->
+  s3                          : '${s3.displayHost}|${s3.bucket}|${s3.prefix}'
+  icloud, dropbox, googledrive: kind.name
+  adobeLightroom              : null (excluded)
+
+accountIdFor(kind, naturalKey) ->
+  const Uuid().v5(kConnectedAccountNamespace, '${kind.name}:$naturalKey')
+```
+
+This follows the existing UUIDv5 idiom in
+`lib/features/data_quality/domain/entities/quality_finding.dart`.
+
+The primary key becomes the uniqueness constraint. Two devices connecting the
+same endpoint independently compute the same id, so sync's upsert-by-id
+collapses them with no coordination. No DB unique index is added: a unique
+constraint on a replicated table would make an inbound sync insert throw
+rather than merge.
+
+`displayHost` rather than raw `endpoint` is used so that AWS-proper (empty
+endpoint, host derived from region) and an explicit endpoint for the same
+bucket do not split into two accounts.
+
+The S3 key includes `prefix`, which preserves the separation documented at
+`media_store_service.dart:204` ("the media store S3 config is independent
+from sync's by design"): sync defaults to prefix `submersion-sync/` and the
+media store uses its own, so the same bucket yields two accounts.
+
+**Lightroom is excluded.** The v107 DB migration preserved Lightroom ids
+because scan state and suggestion rows key on them, and Lightroom already has
+real per-catalog identity in `account_identifier`. Rewriting those ids would
+orphan that data.
+
+No schema change, so no schema version bump.
+
+### 2. Repository `ensure()` and the creation sites
+
+```dart
+Future<ConnectedAccount> ensure({
+  required AccountKind kind,
+  required String naturalKey,
+  required String label,
+}) async {
+  final id = accountIdFor(kind, naturalKey);
+  final existing = await getById(id);
+  if (existing != null) {
+    if (existing.label != label) await updateLabels(id, label: label);
+    return existing.copyWith(label: label);
+  }
+  return create(id: id, kind: kind, label: label);
+}
+```
+
+`create()` already accepts an injectable `id`, so its signature is unchanged.
+The label refresh keeps a renamed bucket current without minting a row.
+
+Creation sites change as follows:
+
+| Site | Today | After |
+| ---- | ----- | ----- |
+| `media_store_service.dart:211` `connectS3` | unconditional `create` | `ensure(s3, key(config), '$bucket @ $host')`; an explicit `accountId` still wins when it is an S3 account |
+| `media_store_service.dart:279` `_connectManaged` | `getByKind ?? create` | `ensure(kind, kind.name, displayHint)` |
+| `sync_providers.dart:270` S3 branch | unconditional `create` | read `S3CredentialsStore.storageKey`, then `ensure(s3, key(config), ...)`; if the config is unreadable, keep today's behaviour |
+| `sync_providers.dart:276` managed branch | `getByKind ?? create` | `ensure(kind, kind.name, providerName)` |
+| `account_startup_migration.dart:87,137,148` | `create` | route through `ensure()` |
+
+`getByKind()` remains for reads (resolving "the iCloud account") and is
+removed from write paths. A local-only query is fine for answering a
+question and wrong for deciding whether to insert into a replicated table.
+
+The explicit-`accountId` branch in `connectS3` is retained: the media hub
+passes a specific account when re-attaching, and redirecting that to a
+natural-key match would change which endpoint the store attaches to.
+
+`sync_providers.dart`'s S3 branch is the only site needing new data - it
+receives a `CloudProviderType` only. It gains a read of the legacy S3
+credentials blob, already the documented source of truth on that path
+(`_mirrorLegacyCredentials` reads the same key).
+
+### 3. Startup reconciliation of existing duplicates
+
+New `lib/core/services/accounts/account_deduplicator.dart`, run from
+`startup_page.dart:356` immediately after `AccountStartupMigration`. It runs
+every launch rather than being done-flag gated, so it also heals rows that
+arrive later from a device still on an older build, and short-circuits when
+there is nothing to do.
+
+The pass is **anchor-based** rather than group-and-elect. Grouping legacy rows
+by `(kind, label)` is not safe: legacy labels carry only `bucket @ host` with
+no prefix, so a sync-S3 and a media-S3 account sharing one bucket have
+identical labels, and grouping on the label would merge two accounts that
+section 1 deliberately keeps separate.
+
+**Anchors.** An anchor is a row some piece of state actually points at. There
+are at most two non-Lightroom anchors on a device:
+
+| Anchor | Reference | Natural key recomputed from |
+| ------ | --------- | --------------------------- |
+| sync | `sync_metadata.sync_account_id` | the sync S3 config, else `kind.name` for managed kinds |
+| media store | `media_store_account_id` pref | the media store S3 config, else `kind.name` |
+
+Each anchor is migrated to its own canonical deterministic id, computed from
+its own config. Two anchors that resolve to the same natural key (same host,
+bucket and prefix) legitimately collapse into one row; two that differ stay
+two rows. This is what makes the pass correct for a shared bucket.
+
+**Everything else is inert.** Any remaining non-Lightroom row is referenced by
+nothing: not by `sync_metadata`, not by the media pref, and its keychain blob
+is a copy rather than a unique credential. Those rows are deleted. No
+attribution decision is needed for them, which is precisely why the label
+ambiguity above stops mattering once the anchors are handled first.
+
+**Order of operations.** References are repointed before any deletion, so a
+crash mid-pass never strands a reference on a deleted row:
+
+1. copy the anchor's keychain blob to the canonical id
+   (`AccountCredentialsStore.write`)
+2. write the canonical row (`ensure()`, carrying the anchor's label)
+3. `sync_metadata.sync_account_id` to canonical, when the sync anchor moved
+4. `media_store_account_id` pref to canonical, when the media anchor moved
+5. `EstablishedProviderStore.add(canonicalId)` when any row being removed was
+   established
+6. delete every non-canonical, non-Lightroom row via
+   `ConnectedAccountsRepository.delete()`, which already logs tombstones
+
+`delete()` writes a tombstone, and a tombstone for a row `sync_metadata` still
+points at would leave every peer resolving sync to a nonexistent account, so
+this ordering is load-bearing rather than stylistic.
+
+**Rows this device cannot attribute.** If an anchor's S3 config is not
+readable on this device, that anchor keeps its existing id and is left alone;
+its inert siblings are still removed. A device that can read the config
+finishes the migration, and the deterministic id makes both devices agree.
+
+Lightroom rows are skipped entirely, per section 1.
+
+**Idempotence.** A second run finds each anchor already at its canonical id
+and no inert rows, and exits without writes.
+
+## Testing
+
+Tests are written before the implementation, per the project TDD rule.
+
+- `account_identity_test.dart`: same config yields the same id; a prefix change
+  yields a different id; AWS-proper and explicit endpoint for the same bucket
+  yield the same id.
+- `connected_accounts_repository_test.dart`: `ensure()` twice yields one row;
+  label drift updates in place without inserting.
+- `account_deduplicator_test.dart`: seeded with the 11 observed rows, yields
+  1 S3 + 1 iCloud, `sync_metadata` repointed, 10 tombstones logged; a second
+  run is a no-op; Lightroom rows untouched; a sync anchor and a media anchor
+  sharing a bucket but differing in prefix survive as two rows; an anchor
+  whose S3 config is unreadable keeps its id while its inert siblings go.
+- Regression: `connectS3` called twice with an identical config yields one
+  account row.
+
+## Out of scope
+
+- Any change to how Lightroom accounts are identified or deduplicated.
+- A "Merge duplicates" UI action. The startup pass is automatic; a manual
+  trigger can be added later if duplicates are ever observed post-fix.
+- Schema changes. No new column and no unique index are introduced.

--- a/lib/core/data/repositories/connected_accounts_repository.dart
+++ b/lib/core/data/repositories/connected_accounts_repository.dart
@@ -72,11 +72,59 @@ class ConnectedAccountsRepository {
     required AccountKind kind,
     required String naturalKey,
     required String label,
+  }) => ensureById(
+    id: accountIdFor(kind: kind, naturalKey: naturalKey),
+    kind: kind,
+    label: label,
+  );
+
+  /// [ensure] for a caller that already holds the id (the deduplicator
+  /// canonicalizing an anchor), preserving [accountIdentifier].
+  ///
+  /// The insert is `insertOrIgnore` rather than a read-then-insert because
+  /// the two are not atomic and deterministic ids make the collision an
+  /// EXPECTED event, not a freak one: provider re-derivation, a media store
+  /// connect and an inbound sync apply (which upserts this table) all
+  /// compute the same id. Without it the loser throws
+  /// SqliteException(1555). Same reasoning as
+  /// SyncRepository.getOrCreateMetadata's seed.
+  Future<domain.ConnectedAccount> ensureById({
+    required String id,
+    required AccountKind kind,
+    required String label,
+    String? accountIdentifier,
   }) async {
-    final id = accountIdFor(kind: kind, naturalKey: naturalKey);
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final inserted = await _db
+        .into(_db.connectedAccounts)
+        .insertReturningOrNull(
+          ConnectedAccountsCompanion.insert(
+            id: id,
+            kind: kind.name,
+            label: label,
+            accountIdentifier: Value(accountIdentifier),
+            createdAt: now,
+            updatedAt: now,
+          ),
+          mode: InsertMode.insertOrIgnore,
+        );
+    if (inserted != null) {
+      // Only the writer that actually inserted marks pending, so a losing
+      // racer cannot stamp a second HLC on someone else's row.
+      await _markPending(id, now);
+      return _toDomain(inserted);
+    }
+
     final existing = await getById(id);
     if (existing == null) {
-      return create(kind: kind, label: label, id: id);
+      // The row was deleted between the ignored insert and this read (a
+      // tombstone apply landing mid-flight). Nothing holds the id now.
+      return create(
+        kind: kind,
+        label: label,
+        accountIdentifier: accountIdentifier,
+        id: id,
+      );
     }
     if (existing.label == label) return existing;
     await updateLabels(id, label: label);

--- a/lib/core/data/repositories/connected_accounts_repository.dart
+++ b/lib/core/data/repositories/connected_accounts_repository.dart
@@ -3,6 +3,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
@@ -56,6 +57,30 @@ class ConnectedAccountsRepository {
       createdAt: DateTime.fromMillisecondsSinceEpoch(now, isUtc: true),
       updatedAt: DateTime.fromMillisecondsSinceEpoch(now, isUtc: true),
     );
+  }
+
+  /// Find-or-create by deterministic id.
+  ///
+  /// The id IS the dedup mechanism: it collides for the same endpoint on
+  /// every device, so sync's upsert-by-id merges rather than duplicating.
+  /// Callers on write paths must use this instead of [create]; [getByKind]
+  /// is a local-only query and cannot dedup a replicated table.
+  ///
+  /// A drifted [label] (renamed bucket, changed host spelling) is refreshed
+  /// in place rather than minting a row.
+  Future<domain.ConnectedAccount> ensure({
+    required AccountKind kind,
+    required String naturalKey,
+    required String label,
+  }) async {
+    final id = accountIdFor(kind: kind, naturalKey: naturalKey);
+    final existing = await getById(id);
+    if (existing == null) {
+      return create(kind: kind, label: label, id: id);
+    }
+    if (existing.label == label) return existing;
+    await updateLabels(id, label: label);
+    return existing.copyWith(label: label);
   }
 
   Future<List<domain.ConnectedAccount>> getAll() async {

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/core/domain/entities/migration_progress.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
 import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
+import 'package:submersion/core/services/accounts/account_deduplicator.dart';
 import 'package:submersion/core/services/accounts/account_startup_migration.dart';
 import 'package:submersion/core/services/background_service.dart';
 import 'package:submersion/core/services/database_location_service.dart';
@@ -355,6 +356,10 @@ class _StartupWrapperState extends State<StartupWrapper>
     await timeStartupStep('accountMigration', () async {
       final prefs = await SharedPreferences.getInstance();
       await AccountStartupMigration(prefs: prefs).run();
+      // After the migration, so rows it seeds are already at their
+      // deterministic ids and the pass finds nothing to do on a fresh
+      // install. Both swallow their own errors: neither can block startup.
+      await AccountDeduplicator(prefs: prefs).run();
     });
     await timeStartupStep(
       'notifications',

--- a/lib/core/providers/account_providers.dart
+++ b/lib/core/providers/account_providers.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/services/accounts/adapters/google_drive_account_
 import 'package:submersion/core/services/accounts/adapters/icloud_account_adapter.dart';
 import 'package:submersion/core/services/accounts/adapters/lightroom_account_adapter.dart';
 import 'package:submersion/core/services/accounts/adapters/s3_account_adapter.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 
 final connectedAccountsRepositoryProvider =
     Provider<ConnectedAccountsRepository>(
@@ -18,6 +19,15 @@ final connectedAccountsRepositoryProvider =
 /// in-memory keychain (the real one has no platform channel under test).
 final accountCredentialsStoreProvider = Provider<AccountCredentialsStore>(
   (ref) => AccountCredentialsStore(),
+);
+
+/// The LEGACY single-key sync S3 config store, still the source of truth for
+/// the S3 connect UI. Sync account derivation reads it to identify the
+/// endpoint. Overridable for the same reason as
+/// [accountCredentialsStoreProvider]: the real keychain has no platform
+/// channel under test.
+final s3CredentialsStoreProvider = Provider<S3CredentialsStore>(
+  (ref) => S3CredentialsStore(),
 );
 
 /// One adapter instance per kind for the process lifetime (token caches and

--- a/lib/core/services/accounts/account_deduplicator.dart
+++ b/lib/core/services/accounts/account_deduplicator.dart
@@ -1,0 +1,187 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/connected_account.dart'
+    as domain;
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+
+/// Collapses duplicate `connected_accounts` rows onto their deterministic
+/// ids.
+///
+/// Rows created before deterministic ids existed carry random UUIDv4s, so
+/// the same endpoint appears once per connect and once per device. This pass
+/// is anchor-based rather than group-and-elect: legacy labels carry only
+/// `bucket @ host` with no prefix, so grouping on the label would merge a
+/// sync-S3 and a media-S3 account that share a bucket - two accounts the
+/// identity scheme deliberately keeps apart.
+///
+/// An anchor is a row something actually points at. There are at most two:
+/// the sync account (`sync_metadata.sync_account_id`) and the media store
+/// account (`media_store_account_id`). Each is migrated to the canonical id
+/// derived from its own config. Every other non-Lightroom row is referenced
+/// by nothing and its keychain blob is a copy, so it is deleted.
+///
+/// Runs on every launch rather than behind a done flag, so it also heals
+/// rows that arrive later from a device still on an older build. It performs
+/// no writes when there is nothing to collapse.
+class AccountDeduplicator {
+  AccountDeduplicator({
+    required SharedPreferences prefs,
+    ConnectedAccountsRepository? accounts,
+    AccountCredentialsStore? credentials,
+    SyncRepository? syncRepository,
+    EstablishedProviderStore? established,
+    S3CredentialsStore? syncS3,
+    S3CredentialsStore? mediaS3,
+  }) : _prefs = prefs,
+       _accounts = accounts ?? ConnectedAccountsRepository(),
+       _credentials = credentials ?? AccountCredentialsStore(),
+       _syncRepository = syncRepository ?? SyncRepository(),
+       _established = established ?? EstablishedProviderStore(prefs),
+       _syncS3 = syncS3 ?? S3CredentialsStore(storageKey: _syncS3Key),
+       _mediaS3 = mediaS3 ?? S3CredentialsStore(storageKey: _mediaS3Key);
+
+  static final _log = LoggerService.forClass(AccountDeduplicator);
+
+  static const String _syncS3Key = 'sync_s3_config';
+  static const String _mediaS3Key = 'media_store_s3_config';
+  static const String _mediaAccountIdKey = 'media_store_account_id';
+
+  final SharedPreferences _prefs;
+  final ConnectedAccountsRepository _accounts;
+  final AccountCredentialsStore _credentials;
+  final SyncRepository _syncRepository;
+  final EstablishedProviderStore _established;
+  final S3CredentialsStore _syncS3;
+  final S3CredentialsStore _mediaS3;
+
+  Future<void> run() async {
+    try {
+      await _run();
+    } catch (e, stackTrace) {
+      // A dedup failure must never block startup: the duplicates are a
+      // cosmetic and hygiene problem, and the next launch retries.
+      _log.error(
+        'Account deduplication failed; will retry next launch',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _run() async {
+    final all = await _accounts.getAll();
+    final candidates = all
+        .where((a) => a.kind != AccountKind.adobeLightroom)
+        .toList();
+    if (candidates.isEmpty) return;
+
+    // Anchors first, so references are repointed before anything is deleted.
+    final keep = <String>{};
+
+    final syncCanonical = await _canonicalizeSyncAnchor();
+    if (syncCanonical != null) keep.add(syncCanonical);
+
+    final mediaCanonical = await _canonicalizeMediaAnchor();
+    if (mediaCanonical != null) keep.add(mediaCanonical);
+
+    // Everything else is inert: nothing points at it, and its credentials
+    // blob is a copy of an anchor's.
+    for (final account in candidates) {
+      if (keep.contains(account.id)) continue;
+      // The established marker gates sync's first-contact check, so it
+      // carries only onto the SYNC canonical id. The media anchor plays no
+      // part in that gate and must not inherit the marker.
+      if (syncCanonical != null && _established.contains(account.id)) {
+        await _established.add(syncCanonical);
+      }
+      await _accounts.delete(account.id);
+    }
+  }
+
+  /// Migrates the sync account onto its canonical id and repoints
+  /// `sync_metadata`. Returns the id to keep, or null when there is no sync
+  /// anchor.
+  Future<String?> _canonicalizeSyncAnchor() async {
+    final id = await _syncRepository.getSyncAccountId();
+    if (id == null) return null;
+    final row = await _accounts.getById(id);
+    if (row == null || row.kind == AccountKind.adobeLightroom) return null;
+
+    final canonical = await _canonicalIdFor(row, _syncS3);
+    if (canonical == null || canonical == row.id) return row.id;
+
+    await _adopt(row, canonical);
+    final providerType = row.kind.cloudProviderType;
+    if (providerType != null) {
+      await _syncRepository.setSyncAccount(
+        accountId: canonical,
+        providerType: providerType,
+      );
+    }
+    return canonical;
+  }
+
+  /// Migrates the media store account onto its canonical id and repoints the
+  /// attach pref. Returns the id to keep, or null when nothing is attached.
+  Future<String?> _canonicalizeMediaAnchor() async {
+    final id = _prefs.getString(_mediaAccountIdKey);
+    if (id == null) return null;
+    final row = await _accounts.getById(id);
+    if (row == null || row.kind == AccountKind.adobeLightroom) return null;
+
+    final canonical = await _canonicalIdFor(row, _mediaS3);
+    if (canonical == null || canonical == row.id) return row.id;
+
+    await _adopt(row, canonical);
+    await _prefs.setString(_mediaAccountIdKey, canonical);
+    return canonical;
+  }
+
+  /// The deterministic id for [row], or null when this device cannot resolve
+  /// the endpoint (an S3 config it cannot read). Null means "leave it alone":
+  /// a device that can read the config finishes the migration, and the
+  /// deterministic id makes both devices agree afterwards.
+  Future<String?> _canonicalIdFor(
+    domain.ConnectedAccount row,
+    S3CredentialsStore s3Store,
+  ) async {
+    if (row.kind == AccountKind.s3) {
+      final config = await s3Store.load();
+      if (config == null) return null;
+      return accountIdFor(
+        kind: AccountKind.s3,
+        naturalKey: s3NaturalKey(config),
+      );
+    }
+    final key = naturalKeyForKind(row.kind);
+    return key == null ? null : accountIdFor(kind: row.kind, naturalKey: key);
+  }
+
+  /// Copies [row] onto [canonicalId]: credentials first, then the row.
+  ///
+  /// The legacy row is left for the inert sweep to delete, so a crash
+  /// between here and the sweep leaves a harmless extra row rather than a
+  /// reference pointing at a tombstone.
+  Future<void> _adopt(domain.ConnectedAccount row, String canonicalId) async {
+    final blob = await _credentials.read(row.id);
+    if (blob != null) await _credentials.write(canonicalId, blob);
+    if (await _accounts.getById(canonicalId) == null) {
+      await _accounts.create(
+        kind: row.kind,
+        label: row.label,
+        accountIdentifier: row.accountIdentifier,
+        id: canonicalId,
+      );
+    }
+    if (_established.contains(row.id)) {
+      await _established.add(canonicalId);
+    }
+  }
+}

--- a/lib/core/services/accounts/account_deduplicator.dart
+++ b/lib/core/services/accounts/account_deduplicator.dart
@@ -172,14 +172,15 @@ class AccountDeduplicator {
   Future<void> _adopt(domain.ConnectedAccount row, String canonicalId) async {
     final blob = await _credentials.read(row.id);
     if (blob != null) await _credentials.write(canonicalId, blob);
-    if (await _accounts.getById(canonicalId) == null) {
-      await _accounts.create(
-        kind: row.kind,
-        label: row.label,
-        accountIdentifier: row.accountIdentifier,
-        id: canonicalId,
-      );
-    }
+    // ensureById rather than a read-then-create: another device may already
+    // have published this very id (that is the point of deterministic ids),
+    // so an inbound sync apply can land the row mid-pass.
+    await _accounts.ensureById(
+      id: canonicalId,
+      kind: row.kind,
+      label: row.label,
+      accountIdentifier: row.accountIdentifier,
+    );
     if (_established.contains(row.id)) {
       await _established.add(canonicalId);
     }

--- a/lib/core/services/accounts/account_identity.dart
+++ b/lib/core/services/accounts/account_identity.dart
@@ -1,0 +1,43 @@
+import 'package:uuid/uuid.dart';
+
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+
+/// Namespace for deterministic connected-account ids. Frozen: every device
+/// must derive the same id from the same endpoint, so changing this would
+/// fork the roster across the fleet.
+const String kConnectedAccountNamespace =
+    'c622faae-974f-4310-a5e7-36c2fb773684';
+
+/// Endpoint identity for an S3 account.
+///
+/// Uses [S3Config.displayHost] rather than the raw endpoint so AWS-proper
+/// (empty endpoint, host derived from the region) and an explicit AWS
+/// endpoint for one bucket resolve to a single account. Includes the prefix
+/// so the sync and media-store roles stay separate accounts when they share
+/// a bucket. Credentials are deliberately excluded: rotating a key must not
+/// mint a new account.
+String s3NaturalKey(S3Config config) =>
+    '${config.displayHost}|${config.bucket}|${config.prefix}';
+
+/// Natural key for a kind that can only have one instance per library.
+///
+/// Null for [AccountKind.s3] (an instance kind: use [s3NaturalKey]) and for
+/// [AccountKind.adobeLightroom], whose ids are preserved from the v107
+/// migration because Lightroom scan state and suggestion rows key on them.
+String? naturalKeyForKind(AccountKind kind) => switch (kind) {
+  AccountKind.icloud ||
+  AccountKind.dropbox ||
+  AccountKind.googledrive => kind.name,
+  AccountKind.s3 || AccountKind.adobeLightroom => null,
+};
+
+/// The deterministic id for an endpoint.
+///
+/// Two devices computing this for the same endpoint get the same primary
+/// key, so sync's upsert-by-id merges them instead of unioning two rows.
+/// This is why no unique index is needed: a unique constraint on a
+/// replicated table would make an inbound sync insert throw rather than
+/// merge.
+String accountIdFor({required AccountKind kind, required String naturalKey}) =>
+    const Uuid().v5(kConnectedAccountNamespace, '${kind.name}:$naturalKey');

--- a/lib/core/services/accounts/account_startup_migration.dart
+++ b/lib/core/services/accounts/account_startup_migration.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/data/repositories/connected_accounts_repository.
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
     as domain;
@@ -84,7 +85,7 @@ class AccountStartupMigration {
       if (persisted != null && persisted.kind == kind) account = persisted;
     }
     account ??= await _accounts.getByKind(kind);
-    account ??= await _accounts.create(kind: kind, label: _labelFor(kind));
+    account ??= await _ensure(kind: kind, label: _labelFor(kind));
 
     switch (kind) {
       case AccountKind.s3:
@@ -144,8 +145,7 @@ class AccountStartupMigration {
       );
       accountId = account.id;
     } else {
-      var account = await _accounts.getByKind(kind);
-      account ??= await _accounts.create(kind: kind, label: _labelFor(kind));
+      final account = await _ensure(kind: kind, label: _labelFor(kind));
       accountId = account.id;
     }
     await _prefs.setString(_mediaAccountIdKey, accountId);
@@ -181,6 +181,24 @@ class AccountStartupMigration {
         );
       }
     }
+  }
+
+  /// Create-or-reuse at the deterministic id for kinds that have one.
+  ///
+  /// S3 has no kind-only natural key (it is an instance kind, identified by
+  /// its endpoint), and reading that endpoint here would mean plumbing the
+  /// S3 credential stores through this class purely to re-derive what
+  /// [AccountDeduplicator] re-derives moments later on the same launch. So
+  /// S3 keeps the legacy random-id create and is canonicalized by that pass.
+  Future<domain.ConnectedAccount> _ensure({
+    required AccountKind kind,
+    required String label,
+  }) async {
+    final naturalKey = naturalKeyForKind(kind);
+    if (naturalKey == null) {
+      return _accounts.create(kind: kind, label: label);
+    }
+    return _accounts.ensure(kind: kind, naturalKey: naturalKey, label: label);
   }
 
   String _labelFor(AccountKind kind) => switch (kind) {

--- a/lib/features/media_store/data/media_store_service.dart
+++ b/lib/features/media_store/data/media_store_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/account_provider_adapter.dart';
 import 'package:submersion/core/services/accounts/account_provider_registry.dart';
@@ -200,16 +201,18 @@ class MediaStoreService {
       final ensured = await StoreMarkerStore(store: built.store).ensure();
       // Reuse the given account (only when it really is an S3 account:
       // attaching S3 credentials under another kind's keychain key would
-      // corrupt that account) or create a fresh S3 account. A bare connect
-      // never adopts the sync S3 account: the media store S3 config is
-      // independent from sync's by design.
+      // corrupt that account), else resolve the endpoint to its
+      // deterministic account. The endpoint key includes the prefix, so a
+      // bare connect still never adopts the sync S3 account when sync uses
+      // a different prefix in the same bucket.
       final requested = accountId == null
           ? null
           : await _accounts.getById(accountId);
       final account = (requested != null && requested.kind == AccountKind.s3)
           ? requested
-          : await _accounts.create(
+          : await _accounts.ensure(
               kind: AccountKind.s3,
+              naturalKey: s3NaturalKey(config),
               label: '${config.bucket} @ ${config.displayHost}',
             );
       await _accountCredentials.write(account.id, jsonEncode(config.toJson()));
@@ -274,9 +277,14 @@ class MediaStoreService {
     // per-account key is still empty: a user who linked Dropbox sync
     // before the accounts layer existed connects without re-auth.
     final kind = AccountKind.fromCloudProviderType(type);
-    final account =
-        await _accounts.getByKind(kind) ??
-        await _accounts.create(kind: kind, label: displayHint);
+    // Single-instance per kind, resolved to the deterministic id so two
+    // devices connecting the same provider converge on one row instead of
+    // each minting its own (getByKind dedups only locally).
+    final account = await _accounts.ensure(
+      kind: kind,
+      naturalKey: naturalKeyForKind(kind)!,
+      label: displayHint,
+    );
     if (type == CloudProviderType.dropbox) {
       // Refresh (overwrite) so a re-link in Cloud Sync that rotated the
       // legacy blob is reflected here; the runtime reads only the

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -7,6 +7,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
 import 'package:submersion/core/providers/account_providers.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/account_provider_adapter.dart';
 import 'package:submersion/core/services/accounts/connected_account.dart'
@@ -258,6 +259,7 @@ Future<domain.ConnectedAccount> ensureAccountForProviderType(
   CloudProviderType type,
   ConnectedAccountsRepository repo, {
   SyncRepository? syncRepository,
+  S3CredentialsStore? s3Credentials,
 }) async {
   final kind = AccountKind.fromCloudProviderType(type);
   final persistedId = await (syncRepository ?? SyncRepository())
@@ -267,16 +269,30 @@ Future<domain.ConnectedAccount> ensureAccountForProviderType(
     if (persisted != null && persisted.kind == kind) return persisted;
   }
   if (kind == AccountKind.s3) {
-    return repo.create(
-      kind: kind,
-      label: cloudProviderInstanceFor(type).providerName,
-    );
-  }
-  return await repo.getByKind(kind) ??
-      await repo.create(
+    // S3 accounts are instances, so the endpoint identifies them. Read the
+    // legacy config (the source of truth on this path, mirrored by
+    // _mirrorLegacyCredentials) to derive that identity. Without it, fall
+    // back to a fresh row: an account with no resolvable endpoint cannot be
+    // matched to any other, and the deduplicator will canonicalize it once
+    // the config is readable.
+    final config = await (s3Credentials ?? S3CredentialsStore()).load();
+    if (config == null) {
+      return repo.create(
         kind: kind,
         label: cloudProviderInstanceFor(type).providerName,
       );
+    }
+    return repo.ensure(
+      kind: kind,
+      naturalKey: s3NaturalKey(config),
+      label: '${config.bucket} @ ${config.displayHost}',
+    );
+  }
+  return repo.ensure(
+    kind: kind,
+    naturalKey: naturalKeyForKind(kind)!,
+    label: cloudProviderInstanceFor(type).providerName,
+  );
 }
 
 /// File-scoped logger for the top-level sync providers (the provider bodies

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -322,6 +322,7 @@ final selectedSyncAccountProvider = FutureProvider<domain.ConnectedAccount?>((
       type,
       repo,
       syncRepository: ref.read(syncRepositoryProvider),
+      s3Credentials: ref.read(s3CredentialsStoreProvider),
     );
     await ref
         .read(syncRepositoryProvider)

--- a/test/core/data/repositories/connected_accounts_repository_test.dart
+++ b/test/core/data/repositories/connected_accounts_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 
 import '../../../helpers/test_database.dart';
@@ -97,4 +98,64 @@ void main() {
       expect(tombstones, hasLength(1), reason: 'deletions sync via tombstones');
     },
   );
+
+  test('ensure is idempotent: two calls yield one row', () async {
+    final first = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'dive-media @ minio.local',
+    );
+    final second = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'dive-media @ minio.local',
+    );
+    expect(second.id, first.id);
+    expect((await repo.getAll()).length, 1);
+  });
+
+  test('ensure uses the deterministic id', () async {
+    final account = await repo.ensure(
+      kind: AccountKind.icloud,
+      naturalKey: 'icloud',
+      label: 'iCloud',
+    );
+    expect(
+      account.id,
+      accountIdFor(kind: AccountKind.icloud, naturalKey: 'icloud'),
+    );
+  });
+
+  test('ensure refreshes a drifted label in place', () async {
+    final first = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'old label',
+    );
+    final second = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'new label',
+    );
+    expect(second.id, first.id);
+    expect(second.label, 'new label');
+    final all = await repo.getAll();
+    expect(all.length, 1);
+    expect(all.single.label, 'new label');
+  });
+
+  test('ensure separates two prefixes in one bucket', () async {
+    final sync = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|shared|submersion-sync/',
+      label: 'shared @ minio.local',
+    );
+    final media = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|shared|media/',
+      label: 'shared @ minio.local',
+    );
+    expect(media.id, isNot(sync.id));
+    expect((await repo.getAll()).length, 2);
+  });
 }

--- a/test/core/data/repositories/connected_accounts_repository_test.dart
+++ b/test/core/data/repositories/connected_accounts_repository_test.dart
@@ -144,6 +144,57 @@ void main() {
     expect(all.single.label, 'new label');
   });
 
+  test(
+    'concurrent ensure calls do not collide on the deterministic id',
+    () async {
+      // Deterministic ids mean independent writers compute the SAME id, and
+      // ensure's existence check is not atomic with its insert. Provider
+      // re-derivation, a media-store connect and an inbound sync apply can all
+      // be in flight at once; the loser of that race must not throw
+      // SqliteException(1555).
+      final results = await Future.wait([
+        for (var i = 0; i < 4; i++)
+          repo.ensure(
+            kind: AccountKind.s3,
+            naturalKey: 'minio.local|dive-media|media/',
+            label: 'dive-media @ minio.local',
+          ),
+      ]);
+
+      expect(results.map((a) => a.id).toSet(), hasLength(1));
+      expect((await repo.getAll()).length, 1);
+    },
+  );
+
+  test('ensure adopts a row an inbound sync apply already wrote', () async {
+    final id = accountIdFor(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+    );
+    // Mirrors sync_data_serializer's insertOnConflictUpdate for this table.
+    await db
+        .into(db.connectedAccounts)
+        .insertOnConflictUpdate(
+          ConnectedAccountsCompanion.insert(
+            id: id,
+            kind: AccountKind.s3.name,
+            label: 'from peer',
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+
+    final account = await repo.ensure(
+      kind: AccountKind.s3,
+      naturalKey: 'minio.local|dive-media|media/',
+      label: 'dive-media @ minio.local',
+    );
+
+    expect(account.id, id);
+    expect(account.label, 'dive-media @ minio.local');
+    expect((await repo.getAll()).length, 1);
+  });
+
   test('ensure separates two prefixes in one bucket', () async {
     final sync = await repo.ensure(
       kind: AccountKind.s3,

--- a/test/core/services/accounts/account_deduplicator_test.dart
+++ b/test/core/services/accounts/account_deduplicator_test.dart
@@ -7,12 +7,22 @@ import 'package:submersion/core/services/accounts/account_credentials_store.dart
 import 'package:submersion/core/services/accounts/account_deduplicator.dart';
 import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/connected_account.dart'
+    as domain;
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 import 'package:submersion/core/services/sync/established_provider_store.dart';
 
 import '../../../helpers/test_database.dart';
 import '../../../support/fake_keychain_storage.dart';
+
+/// Fails the very first read the pass makes, so run()'s guarantee that a
+/// dedup failure cannot block startup is exercised end to end.
+class _ThrowingAccounts extends ConnectedAccountsRepository {
+  @override
+  Future<List<domain.ConnectedAccount>> getAll() async =>
+      throw StateError('keychain unavailable');
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -220,6 +230,50 @@ void main() {
     await (await dedup(prefs)).run();
 
     expect(established.contains(syncCanonicalId()), isTrue);
+  });
+
+  test('canonicalizes a managed-kind sync anchor', () async {
+    // The observed real-world roster had iCloud as the sync anchor, not S3:
+    // sync_metadata pointed at one of the two duplicate iCloud rows.
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final first = await accounts.create(
+      kind: AccountKind.icloud,
+      label: 'iCloud',
+    );
+    await accounts.create(kind: AccountKind.icloud, label: 'iCloud');
+    await SyncRepository().setSyncAccount(
+      accountId: first.id,
+      providerType: CloudProviderType.icloud,
+    );
+
+    await (await dedup(prefs)).run();
+
+    final canonical = accountIdFor(
+      kind: AccountKind.icloud,
+      naturalKey: 'icloud',
+    );
+    final remaining = await accounts.getAll();
+    expect(remaining.length, 1);
+    expect(remaining.single.id, canonical);
+    expect(await SyncRepository().getSyncAccountId(), canonical);
+  });
+
+  test('a failure never blocks startup', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final failing = AccountDeduplicator(
+      prefs: prefs,
+      accounts: _ThrowingAccounts(),
+      credentials: credentials,
+      syncRepository: SyncRepository(),
+      established: EstablishedProviderStore(prefs),
+      syncS3: syncS3,
+      mediaS3: mediaS3,
+    );
+
+    // Swallowed, not rethrown: startup must proceed.
+    await expectLater(failing.run(), completes);
   });
 
   test('does nothing when there is nothing to collapse', () async {

--- a/test/core/services/accounts/account_deduplicator_test.dart
+++ b/test/core/services/accounts/account_deduplicator_test.dart
@@ -1,0 +1,232 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_deduplicator.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+import 'package:submersion/core/services/sync/established_provider_store.dart';
+
+import '../../../helpers/test_database.dart';
+import '../../../support/fake_keychain_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late ConnectedAccountsRepository accounts;
+  late InMemoryKeychain keychain;
+  late AccountCredentialsStore credentials;
+  late S3CredentialsStore syncS3;
+  late S3CredentialsStore mediaS3;
+
+  final syncConfig = S3Config(
+    endpoint: 'https://149b84f6.r2.cloudflarestorage.com',
+    bucket: 'submersion-sync',
+    prefix: 'submersion-sync/',
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+  );
+
+  String syncCanonicalId() =>
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(syncConfig));
+
+  Future<AccountDeduplicator> dedup(SharedPreferences prefs) async =>
+      AccountDeduplicator(
+        prefs: prefs,
+        accounts: accounts,
+        credentials: credentials,
+        syncRepository: SyncRepository(),
+        established: EstablishedProviderStore(prefs),
+        syncS3: syncS3,
+        mediaS3: mediaS3,
+      );
+
+  Future<int> deletionCount() async {
+    final row = await db
+        .customSelect(
+          "SELECT COUNT(*) AS c FROM deletion_log "
+          "WHERE entity_type = 'connectedAccounts'",
+        )
+        .getSingle();
+    return row.data['c'] as int;
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    accounts = ConnectedAccountsRepository();
+    keychain = InMemoryKeychain();
+    credentials = AccountCredentialsStore(storage: keychain);
+    syncS3 = S3CredentialsStore(
+      storage: keychain,
+      storageKey: 'sync_s3_config',
+    );
+    mediaS3 = S3CredentialsStore(
+      storage: keychain,
+      storageKey: 'media_store_s3_config',
+    );
+    await SyncRepository().getOrCreateMetadata();
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  test('collapses the observed duplicate roster', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+
+    const label = 'submersion-sync @ 149b84f6.r2.cloudflarestorage.com';
+    final s3Ids = <String>[];
+    for (var i = 0; i < 9; i++) {
+      final a = await accounts.create(kind: AccountKind.s3, label: label);
+      s3Ids.add(a.id);
+    }
+    for (var i = 0; i < 2; i++) {
+      await accounts.create(kind: AccountKind.icloud, label: 'iCloud');
+    }
+    await credentials.write(s3Ids.first, '{"blob":"sync"}');
+    await SyncRepository().setSyncAccount(
+      accountId: s3Ids.first,
+      providerType: CloudProviderType.s3,
+    );
+
+    await (await dedup(prefs)).run();
+
+    final remaining = await accounts.getAll();
+    expect(remaining.length, 1);
+    expect(remaining.single.id, syncCanonicalId());
+    expect(remaining.single.label, label);
+    expect(await SyncRepository().getSyncAccountId(), syncCanonicalId());
+    expect(await credentials.read(syncCanonicalId()), '{"blob":"sync"}');
+    // All 11 legacy rows are tombstoned, including the anchor: its id
+    // genuinely changes, so the canonical row is a new row rather than a
+    // rename of the anchor.
+    expect(await deletionCount(), 11);
+  });
+
+  test('is a no-op on a second run', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+    final a = await accounts.create(kind: AccountKind.s3, label: 'x');
+    await SyncRepository().setSyncAccount(
+      accountId: a.id,
+      providerType: CloudProviderType.s3,
+    );
+
+    await (await dedup(prefs)).run();
+    final afterFirst = await deletionCount();
+    await (await dedup(prefs)).run();
+
+    expect(await deletionCount(), afterFirst);
+    expect((await accounts.getAll()).length, 1);
+  });
+
+  test('keeps a sync and a media anchor that differ by prefix', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+    final mediaConfig = S3Config(
+      endpoint: syncConfig.endpoint,
+      bucket: syncConfig.bucket,
+      prefix: 'media/',
+      accessKeyId: 'AK',
+      secretAccessKey: 'SK',
+    );
+    await mediaS3.save(mediaConfig);
+
+    const label = 'submersion-sync @ 149b84f6.r2.cloudflarestorage.com';
+    final syncRow = await accounts.create(kind: AccountKind.s3, label: label);
+    final mediaRow = await accounts.create(kind: AccountKind.s3, label: label);
+    await SyncRepository().setSyncAccount(
+      accountId: syncRow.id,
+      providerType: CloudProviderType.s3,
+    );
+    await prefs.setString('media_store_account_id', mediaRow.id);
+
+    await (await dedup(prefs)).run();
+
+    final remaining = await accounts.getAll();
+    expect(remaining.length, 2);
+    expect(remaining.map((a) => a.id).toSet(), {
+      syncCanonicalId(),
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(mediaConfig)),
+    });
+    expect(prefs.getString('media_store_account_id'), isNot(mediaRow.id));
+  });
+
+  test('leaves Lightroom rows untouched', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final lr = await accounts.create(
+      kind: AccountKind.adobeLightroom,
+      label: 'Lightroom',
+      accountIdentifier: 'catalog-1',
+      id: 'preserved-lightroom-id',
+    );
+    final lr2 = await accounts.create(
+      kind: AccountKind.adobeLightroom,
+      label: 'Lightroom',
+      accountIdentifier: 'catalog-2',
+    );
+
+    await (await dedup(prefs)).run();
+
+    final ids = (await accounts.getAll()).map((a) => a.id).toSet();
+    expect(ids, containsAll([lr.id, lr2.id]));
+    expect(await deletionCount(), 0);
+  });
+
+  test(
+    'keeps an anchor whose S3 config is unreadable, drops inert rows',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      const label = 'submersion-sync @ 149b84f6.r2.cloudflarestorage.com';
+      final anchor = await accounts.create(kind: AccountKind.s3, label: label);
+      await accounts.create(kind: AccountKind.s3, label: label);
+      await accounts.create(kind: AccountKind.s3, label: label);
+      await SyncRepository().setSyncAccount(
+        accountId: anchor.id,
+        providerType: CloudProviderType.s3,
+      );
+
+      await (await dedup(prefs)).run();
+
+      final remaining = await accounts.getAll();
+      expect(remaining.length, 1);
+      expect(remaining.single.id, anchor.id);
+      expect(await SyncRepository().getSyncAccountId(), anchor.id);
+      expect(await deletionCount(), 2);
+    },
+  );
+
+  test('carries an established marker onto the canonical id', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await syncS3.save(syncConfig);
+    final anchor = await accounts.create(kind: AccountKind.s3, label: 'x');
+    await SyncRepository().setSyncAccount(
+      accountId: anchor.id,
+      providerType: CloudProviderType.s3,
+    );
+    final established = EstablishedProviderStore(prefs);
+    await established.add(anchor.id);
+
+    await (await dedup(prefs)).run();
+
+    expect(established.contains(syncCanonicalId()), isTrue);
+  });
+
+  test('does nothing when there is nothing to collapse', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await (await dedup(prefs)).run();
+    expect(await accounts.getAll(), isEmpty);
+    expect(await deletionCount(), 0);
+  });
+}

--- a/test/core/services/accounts/account_identity_test.dart
+++ b/test/core/services/accounts/account_identity_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+
+void main() {
+  S3Config config({
+    String endpoint = 'https://minio.local',
+    String region = 'us-east-1',
+    String bucket = 'dive-media',
+    String prefix = 'submersion-sync/',
+  }) => S3Config(
+    endpoint: endpoint,
+    region: region,
+    bucket: bucket,
+    prefix: prefix,
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+  );
+
+  String idFor(S3Config c) =>
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(c));
+
+  test('same endpoint yields the same id', () {
+    expect(idFor(config()), idFor(config()));
+  });
+
+  test('id is stable across credential rotation', () {
+    final rotated = S3Config(
+      endpoint: 'https://minio.local',
+      bucket: 'dive-media',
+      prefix: 'submersion-sync/',
+      accessKeyId: 'ROTATED',
+      secretAccessKey: 'ROTATED',
+    );
+    expect(idFor(config()), idFor(rotated));
+  });
+
+  test('a different prefix is a different account', () {
+    expect(idFor(config()), isNot(idFor(config(prefix: 'media/'))));
+  });
+
+  test('a different bucket is a different account', () {
+    expect(idFor(config()), isNot(idFor(config(bucket: 'other'))));
+  });
+
+  test('AWS-proper and an explicit AWS endpoint agree', () {
+    final implicit = config(endpoint: '', region: 'eu-west-1');
+    final explicit = config(
+      endpoint: 'https://s3.eu-west-1.amazonaws.com',
+      region: 'eu-west-1',
+    );
+    expect(idFor(implicit), idFor(explicit));
+  });
+
+  test('a trailing slash on the endpoint does not change the id', () {
+    expect(idFor(config()), idFor(config(endpoint: 'https://minio.local/')));
+  });
+
+  test('managed kinds are single-instance per kind', () {
+    for (final kind in [
+      AccountKind.icloud,
+      AccountKind.dropbox,
+      AccountKind.googledrive,
+    ]) {
+      final key = naturalKeyForKind(kind);
+      expect(key, isNotNull, reason: '$kind must have a natural key');
+      expect(
+        accountIdFor(kind: kind, naturalKey: key!),
+        accountIdFor(kind: kind, naturalKey: key),
+      );
+    }
+  });
+
+  test('different kinds never collide', () {
+    final ids = {
+      for (final kind in [
+        AccountKind.icloud,
+        AccountKind.dropbox,
+        AccountKind.googledrive,
+      ])
+        accountIdFor(kind: kind, naturalKey: naturalKeyForKind(kind)!),
+    };
+    expect(ids.length, 3);
+  });
+
+  test('s3 and lightroom have no kind-only natural key', () {
+    expect(naturalKeyForKind(AccountKind.s3), isNull);
+    expect(naturalKeyForKind(AccountKind.adobeLightroom), isNull);
+  });
+
+  test('the namespace constant is frozen', () {
+    expect(kConnectedAccountNamespace, 'c622faae-974f-4310-a5e7-36c2fb773684');
+  });
+}

--- a/test/core/services/accounts/account_startup_migration_test.dart
+++ b/test/core/services/accounts/account_startup_migration_test.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/data/repositories/connected_accounts_repository.
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/accounts/account_startup_migration.dart';
 import 'package:submersion/core/services/sync/established_provider_store.dart';
@@ -250,5 +251,35 @@ void main() {
     await (await migration(prefs)).run();
 
     expect((await accounts.getAll()).length, countAfterFirst);
+  });
+
+  test('migrated iCloud sync account lands on the deterministic id', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await SyncRepository().setCloudProvider(CloudProviderType.icloud);
+
+    await (await migration(prefs)).run();
+
+    final all = await accounts.getAll();
+    expect(all.length, 1);
+    expect(
+      all.single.id,
+      accountIdFor(kind: AccountKind.icloud, naturalKey: 'icloud'),
+    );
+  });
+
+  test('a fresh connect after migration reuses the migrated row', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await SyncRepository().setCloudProvider(CloudProviderType.icloud);
+    await (await migration(prefs)).run();
+
+    await accounts.ensure(
+      kind: AccountKind.icloud,
+      naturalKey: 'icloud',
+      label: 'iCloud',
+    );
+
+    expect((await accounts.getAll()).length, 1);
   });
 }

--- a/test/features/media_store/media_store_service_test.dart
+++ b/test/features/media_store/media_store_service_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/accounts/account_credentials_store.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/core/services/media_store/media_store_attach_state.dart';
@@ -92,6 +93,37 @@ void main() {
     final second = await service.connectS3(config);
     expect(second.createdNewStore, isFalse);
     expect(second.storeId, first.storeId);
+  });
+
+  test('connectS3 twice reuses one account row', () async {
+    await service.connectS3(config);
+    await service.connectS3(config);
+    final accounts = await accountsRepository.getAll();
+    expect(accounts.length, 1);
+    expect(accounts.single.kind, AccountKind.s3);
+  });
+
+  test('connectS3 uses the deterministic account id', () async {
+    await service.connectS3(config);
+    final accounts = await accountsRepository.getAll();
+    expect(
+      accounts.single.id,
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(config)),
+    );
+  });
+
+  test('connectS3 keeps two prefixes in one bucket separate', () async {
+    await service.connectS3(config);
+    final otherPrefix = S3Config(
+      endpoint: config.endpoint,
+      region: config.region,
+      bucket: config.bucket,
+      prefix: 'a-different-prefix/',
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    );
+    await service.connectS3(otherPrefix);
+    expect((await accountsRepository.getAll()).length, 2);
   });
 
   test('testConnection round-trips a probe object and cleans up', () async {

--- a/test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_account_dedup_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/accounts/account_identity.dart';
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+import '../../../../support/fake_keychain_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ConnectedAccountsRepository repo;
+  late InMemoryKeychain keychain;
+  late S3CredentialsStore s3Credentials;
+
+  final config = S3Config(
+    endpoint: 'https://minio.local',
+    bucket: 'dive-sync',
+    prefix: 'submersion-sync/',
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+  );
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repo = ConnectedAccountsRepository();
+    keychain = InMemoryKeychain();
+    s3Credentials = S3CredentialsStore(storage: keychain);
+    await SyncRepository().getOrCreateMetadata();
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  test('flipping S3 to iCloud and back reuses one S3 row', () async {
+    await s3Credentials.save(config);
+
+    final s3First = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    await SyncRepository().setSyncAccount(
+      accountId: s3First.id,
+      providerType: CloudProviderType.s3,
+    );
+
+    final icloud = await ensureAccountForProviderType(
+      CloudProviderType.icloud,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    await SyncRepository().setSyncAccount(
+      accountId: icloud.id,
+      providerType: CloudProviderType.icloud,
+    );
+
+    final s3Second = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+
+    expect(s3Second.id, s3First.id);
+    final all = await repo.getAll();
+    expect(all.where((a) => a.kind == AccountKind.s3).length, 1);
+    expect(all.where((a) => a.kind == AccountKind.icloud).length, 1);
+  });
+
+  test('the S3 account uses the deterministic id', () async {
+    await s3Credentials.save(config);
+    final account = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    expect(
+      account.id,
+      accountIdFor(kind: AccountKind.s3, naturalKey: s3NaturalKey(config)),
+    );
+  });
+
+  test('an unreadable S3 config still yields an account', () async {
+    final account = await ensureAccountForProviderType(
+      CloudProviderType.s3,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    expect(account.kind, AccountKind.s3);
+    expect((await repo.getAll()).length, 1);
+  });
+
+  test('iCloud selected twice reuses one row', () async {
+    final first = await ensureAccountForProviderType(
+      CloudProviderType.icloud,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    final second = await ensureAccountForProviderType(
+      CloudProviderType.icloud,
+      repo,
+      s3Credentials: s3Credentials,
+    );
+    expect(second.id, first.id);
+    expect((await repo.getAll()).length, 1);
+  });
+}

--- a/test/features/settings/sync_account_selection_test.dart
+++ b/test/features/settings/sync_account_selection_test.dart
@@ -55,6 +55,9 @@ void main() {
         accountCredentialsStoreProvider.overrideWithValue(
           AccountCredentialsStore(storage: InMemoryKeychain()),
         ),
+        s3CredentialsStoreProvider.overrideWithValue(
+          S3CredentialsStore(storage: InMemoryKeychain()),
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -91,6 +94,9 @@ void main() {
         accountCredentialsStoreProvider.overrideWithValue(
           AccountCredentialsStore(storage: keychain),
         ),
+        s3CredentialsStoreProvider.overrideWithValue(
+          S3CredentialsStore(storage: keychain),
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -122,6 +128,9 @@ void main() {
       overrides: [
         accountCredentialsStoreProvider.overrideWithValue(
           AccountCredentialsStore(storage: keychain),
+        ),
+        s3CredentialsStoreProvider.overrideWithValue(
+          S3CredentialsStore(storage: keychain),
         ),
       ],
     );
@@ -157,6 +166,9 @@ void main() {
           // so mirrorLegacy throws and the derivation returns null.
           AccountCredentialsStore(storage: FailingKeychain(-25308)),
         ),
+        s3CredentialsStoreProvider.overrideWithValue(
+          S3CredentialsStore(storage: InMemoryKeychain()),
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -180,6 +192,9 @@ void main() {
       overrides: [
         accountCredentialsStoreProvider.overrideWithValue(
           AccountCredentialsStore(storage: keychain),
+        ),
+        s3CredentialsStoreProvider.overrideWithValue(
+          S3CredentialsStore(storage: keychain),
         ),
       ],
     );
@@ -208,6 +223,7 @@ void main() {
       final syncAccount = await ensureAccountForProviderType(
         CloudProviderType.s3,
         repo,
+        s3Credentials: S3CredentialsStore(storage: InMemoryKeychain()),
       );
       expect(
         syncAccount.id,
@@ -218,9 +234,11 @@ void main() {
   );
 
   test('a persisted sync account of the same kind is preferred', () async {
+    final s3Store = S3CredentialsStore(storage: InMemoryKeychain());
     final first = await ensureAccountForProviderType(
       CloudProviderType.s3,
       repo,
+      s3Credentials: s3Store,
     );
     await SyncRepository().setSyncAccount(
       accountId: first.id,
@@ -230,6 +248,7 @@ void main() {
     final second = await ensureAccountForProviderType(
       CloudProviderType.s3,
       repo,
+      s3Credentials: s3Store,
     );
     expect(second.id, first.id, reason: 'no duplicate account per re-derive');
   });


### PR DESCRIPTION
## Summary

The Connected Accounts page showed the same endpoint many times. The page was not
at fault: it renders `ConnectedAccountsRepository.getAll()` verbatim, and the rows
really were duplicated. A development database held 11 rows for 2 real endpoints:

| kind | label | rows |
| ---- | ----- | ---- |
| s3 | `submersion-sync @ 149b84f6...r2.cloudflarestorage.com` | 9 |
| icloud | `iCloud` | 2 |

Every row carried a distinct UUIDv4 with `created_at == updated_at`, and the HLC
column showed two node ids: six S3 rows minted on one device and three on another,
with the two iCloud rows one per device.

**Root cause:** `connected_accounts` rows had no natural identity. Row identity was
a per-device random `Uuid().v4()`, and "does this account already exist?" was
answered either by `getByKind` (kind-only, local-only) or not at all:

1. **S3 had no dedup at all.** `MediaStoreService.connectS3` created a row on every
   connect, and `ensureAccountForProviderType`'s S3 branch created one whenever the
   persisted sync account was of another kind - which is what happens each time sync
   flips S3 to iCloud and back.
2. **`getByKind` dedup is local-only on a replicated table.** Two devices
   independently mint different UUIDs for the same logical account, and sync unions
   them. That is the iCloud pair.

**Fix:** derive the account id deterministically (UUIDv5 over `kind` plus a natural
key) so the primary key becomes the uniqueness constraint. Two devices computing it
for the same endpoint get the same id, and sync's upsert-by-id merges them with no
coordination. A startup pass then collapses the rows that already exist.

No unique index is added on purpose: a unique constraint on a replicated table would
make an inbound sync insert throw rather than merge.

## Changes

- **`account_identity.dart` (new)** - natural keys and deterministic ids. S3 is keyed
  on `displayHost|bucket|prefix`; single-instance managed kinds on the kind name.
  Follows the existing UUIDv5 idiom in `quality_finding.dart`.
  - `displayHost` rather than the raw endpoint, so AWS-proper and an explicit AWS
    endpoint for one bucket do not split into two accounts.
  - `prefix` is included, which preserves the separation documented at
    `media_store_service.dart` ("the media store S3 config is independent from
    sync's by design"): sync defaults to `submersion-sync/`, the media store uses
    its own, so one bucket can legitimately host two accounts.
  - Credentials are excluded, so rotating an access key does not mint a new account.
- **`ConnectedAccountsRepository.ensure()`** - find-or-create keyed on that id,
  refreshing a drifted label in place. `getByKind` stays for reads and is removed
  from write paths.
- **Creation sites routed through it** - `connectS3`, `_connectManaged`,
  `ensureAccountForProviderType`, and the startup migration's managed-kind creates.
- **`account_deduplicator.dart` (new)** - collapses pre-existing duplicates at
  startup, wired in after `AccountStartupMigration`.
- **`s3CredentialsStoreProvider` (new)** - sync account derivation now reads the
  legacy S3 config to identify the endpoint; this makes that store injectable,
  alongside the existing `accountCredentialsStoreProvider`.

### How the deduplicator decides what to keep

It is anchor-based rather than group-and-elect. Grouping legacy rows by
`(kind, label)` would be wrong: legacy labels carry only `bucket @ host` with no
prefix, so a sync-S3 and a media-S3 account sharing a bucket have identical labels,
and grouping on the label would merge two accounts the identity scheme deliberately
keeps apart.

An anchor is a row something actually points at - at most two per device:

| Anchor | Reference | Natural key recomputed from |
| ------ | --------- | --------------------------- |
| sync | `sync_metadata.sync_account_id` | the sync S3 config, else the kind name |
| media store | `media_store_account_id` pref | the media store S3 config, else the kind name |

Each anchor moves to its own canonical id. Every remaining non-Lightroom row is
referenced by nothing and its keychain blob is a copy, so it is deleted.

References are repointed before any deletion: `delete()` writes a tombstone, and a
tombstone for a row `sync_metadata` still points at would leave every peer resolving
sync to a nonexistent account. That ordering is load-bearing rather than stylistic.

If an anchor's S3 config is unreadable on this device, that anchor keeps its id and
is left alone; a device that can read the config finishes the job, and the
deterministic id makes both devices agree afterwards.

The pass runs on every launch rather than behind a done flag, so it also heals rows
arriving later from a device still on an older build. It performs no writes when
there is nothing to collapse.

### Deliberately out of scope

- **Lightroom is excluded everywhere.** Its ids were preserved by the v107 migration
  because scan state and suggestion rows key on them, and it already has real
  per-catalog identity in `account_identifier`. Rewriting those ids would orphan
  that data.
- **The migration's S3 creates keep random ids.** Deriving their endpoint identity
  there would mean plumbing both S3 credential stores through that class to
  re-derive what the deduplicator re-derives moments later on the same launch.
- **No schema change and no version bump.** `git diff` on `lib/core/database/` is
  empty.

## Test Plan

- [x] `flutter test` passes - 13,923 passed, 14 skipped, 0 failures
- [x] `flutter analyze` passes - no issues found
- [x] `dart format .` - 0 files changed
- [x] Manual testing on: macOS

New coverage:

- `account_identity_test.dart` - stability across credential rotation, prefix and
  bucket splitting, AWS-proper vs explicit endpoint agreement, per-kind uniqueness.
- `connected_accounts_repository_test.dart` - `ensure()` idempotence, in-place label
  refresh, two prefixes in one bucket staying separate.
- `account_deduplicator_test.dart` - seeded with the exact 9-S3-plus-2-iCloud roster
  observed above; also covers idempotence, a sync and media anchor differing only by
  prefix, an anchor whose S3 config is unreadable, established-marker carry-over, and
  Lightroom rows being untouched.
- `sync_providers_account_dedup_test.dart` - the S3 to iCloud and back round trip
  that produced most of the duplicates.
- `media_store_service_test.dart` - `connectS3` twice yields one account row.

Manual verification against a real database with the 11 duplicate rows:

- 11 rows collapsed to 2, both at their canonical deterministic ids
- `sync_metadata.sync_account_id` and `media_store_account_id` both repointed and
  still resolving to live rows
- 11 tombstones logged, so peers converge rather than re-importing the duplicates
- a second launch changed nothing: same 2 rows, no new tombstones
