### PR TITLE
fix(db): make app-exit database close wait for the real SQLite close

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -114,12 +114,14 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
   /// NSApplicationDelegate.applicationShouldTerminate: on macOS) which is
   /// async and fires before the Dart VM begins isolate/FFI teardown. Without
   /// this, the Drift background isolate can outlive the FFI subsystem and
-  /// crash in sqlite3_close_v2 → functionDestroy.
+  /// crash in sqlite3_close_v2 → functionDestroy ("GetFfiCallbackMetadata
+  /// called after shutdown"), which stalls the quit. The close() calls run
+  /// sequentially — awaiting the databases in parallel is not worth racing
+  /// two shutdown sequences, and each one is bounded by its own timeouts
+  /// (see closeDatabaseForAppShutdown).
   Future<AppExitResponse> _closeDatabases() async {
-    await Future.wait([
-      DatabaseService.instance.close(),
-      LocalCacheDatabaseService.instance.close(),
-    ]);
+    await DatabaseService.instance.close();
+    await LocalCacheDatabaseService.instance.close();
     return AppExitResponse.exit;
   }
 

--- a/lib/core/database/background_database_connection.dart
+++ b/lib/core/database/background_database_connection.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:drift/drift.dart';
+import 'package:drift/isolate.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+/// Builds the worker's database opener in its own scope.
+///
+/// Dart closures capture the whole enclosing scope rather than just the
+/// variables they reference, so a closure created next to an unsendable local
+/// (a [ReceivePort], for instance) cannot be sent to an isolate. Minting it
+/// here keeps the capture context down to [path].
+DatabaseConnection Function() _openerFor(String path) {
+  return () => DatabaseConnection(NativeDatabase(File(path)));
+}
+
+/// Closes [db] for process shutdown, tolerating the two ways a plain
+/// `db.close()` fails at exit:
+///
+/// 1. `GeneratedDatabase.close()` awaits `streamQueries.close()` before it
+///    closes the executor, and that await hangs forever while any `watch()`
+///    subscription is paused — which Riverpod 3 does to the streams of
+///    providers nobody is currently listening to. A close that hangs there
+///    never even *asks* SQLite to close.
+/// 2. On a background connection, the executor close resolves when the worker
+///    acknowledges the request, not when SQLite is actually closed.
+///
+/// So: try the graceful close briefly, then close the executor directly
+/// (idempotent — a no-op when the graceful close already did it), then wait
+/// for the worker isolate, killing it if stuck. Skipping the stream-store
+/// cleanup is harmless here because the process is exiting.
+///
+/// Returns true when the database shut down cleanly, false when the worker
+/// had to be killed.
+Future<bool> closeDatabaseForAppShutdown(
+  GeneratedDatabase db, {
+  BackgroundDatabaseConnection? background,
+  Duration gracefulTimeout = const Duration(seconds: 1),
+  Duration executorTimeout = const Duration(seconds: 2),
+  Duration workerTimeout = const Duration(seconds: 5),
+}) async {
+  try {
+    await db.close().timeout(gracefulTimeout, onTimeout: () {});
+  } catch (_) {
+    // Abandoning this connection; errors are irrelevant at exit.
+  }
+
+  try {
+    // For a main-isolate NativeDatabase this IS the real sqlite3 close; for a
+    // background connection it sends the shutdown request the hung graceful
+    // close never got to.
+    await db.executor.close().timeout(executorTimeout, onTimeout: () {});
+  } catch (_) {
+    // Same: exit path, nothing to do about a failed close.
+  }
+
+  if (background == null) return true;
+  try {
+    return await background.awaitWorkerShutdown(
+      timeout: workerTimeout,
+      killIfStuck: true,
+    );
+  } catch (_) {
+    return false;
+  }
+}
+
+/// A drift connection whose SQLite work runs on a background isolate that this
+/// class owns, so shutdown can wait for the worker to *actually* finish.
+///
+/// [NativeDatabase.createInBackground] is the stock way to get this, but it
+/// keeps the spawned isolate private, and closing such a connection does not
+/// wait for SQLite to close: drift's remote server answers the `terminateAll`
+/// request before running `connection.close()`, so `AppDatabase.close()`
+/// completes while the worker is still inside `sqlite3_close_v2`.
+///
+/// That is harmless mid-session but fatal at app exit. Drift registers Dart
+/// implementations of SQL functions (`pow`, `regexp`, ...) on every native
+/// connection, so closing the database calls back into Dart from C via
+/// `functionDestroy`. If macOS has already been told the app may terminate,
+/// the Dart VM tears down its FFI callback metadata first and the worker
+/// aborts with `GetFfiCallbackMetadata called after shutdown`, leaving the
+/// app hanging in the Dock.
+///
+/// Owning the isolate gives shutdown a signal it can trust: the worker exits
+/// only once the drift server is done, which is strictly after SQLite has
+/// been closed.
+class BackgroundDatabaseConnection {
+  BackgroundDatabaseConnection._(
+    this.connection,
+    this._worker,
+    this._exitPort,
+    this._workerExited,
+  );
+
+  /// The executor to hand to a generated drift database.
+  final DatabaseConnection connection;
+
+  final Isolate _worker;
+  final ReceivePort _exitPort;
+  final Future<void> _workerExited;
+  bool _shutdownStarted = false;
+
+  /// Opens [file] on a dedicated worker isolate.
+  ///
+  /// [debugOpener] replaces what the worker opens. It exists so tests can give
+  /// the worker a deliberately slow-closing executor; it must be a closure
+  /// that can be sent to an isolate (see [_openerFor]).
+  static Future<BackgroundDatabaseConnection> open(
+    File file, {
+    @visibleForTesting DatabaseConnection Function()? debugOpener,
+  }) async {
+    final exitPort = ReceivePort('submersion drift worker exit');
+    final exited = Completer<void>();
+    exitPort.listen((_) {
+      if (!exited.isCompleted) exited.complete();
+    });
+
+    Isolate? worker;
+    try {
+      final driftIsolate = await DriftIsolate.spawn(
+        debugOpener ?? _openerFor(file.absolute.path),
+        isolateSpawn: <T>(entrypoint, message) async {
+          final isolate = await Isolate.spawn(
+            entrypoint,
+            message,
+            debugName: 'Submersion drift worker for ${file.path}',
+          );
+          // Registered before the worker can finish any work, so the exit
+          // event cannot be missed.
+          isolate.addOnExitListener(exitPort.sendPort);
+          worker = isolate;
+          return isolate;
+        },
+      );
+
+      final connection = await driftIsolate.connect(singleClientMode: true);
+      return BackgroundDatabaseConnection._(
+        connection,
+        worker!,
+        exitPort,
+        exited.future,
+      );
+    } catch (_) {
+      exitPort.close();
+      worker?.kill(priority: Isolate.immediate);
+      rethrow;
+    }
+  }
+
+  /// Waits for the worker isolate to exit, which happens only after it has
+  /// closed SQLite. Call this *after* closing the drift database.
+  ///
+  /// Returns true when the worker exited on its own. When it does not exit
+  /// within [timeout]:
+  ///
+  /// * with [killIfStuck] (app shutdown), the worker is killed so it cannot
+  ///   run FFI callbacks while the VM is tearing down, and false is returned.
+  ///   The database file is left to SQLite's own crash recovery, which is
+  ///   safe: committed data is already durable in the WAL.
+  /// * without it (close-then-reopen paths such as a storage move or a
+  ///   restore), a [TimeoutException] is thrown instead, because killing the
+  ///   worker would strand an open SQLite handle — and its file locks — in a
+  ///   process that is about to reopen the same file.
+  Future<bool> awaitWorkerShutdown({
+    required Duration timeout,
+    required bool killIfStuck,
+  }) async {
+    if (_shutdownStarted) return true;
+    _shutdownStarted = true;
+
+    try {
+      await _workerExited.timeout(timeout);
+      _exitPort.close();
+      return true;
+    } on TimeoutException {
+      if (!killIfStuck) {
+        _shutdownStarted = false;
+        rethrow;
+      }
+      _worker.kill(priority: Isolate.immediate);
+      try {
+        await _workerExited.timeout(const Duration(seconds: 2));
+      } on TimeoutException {
+        // Nothing further to do: the process is exiting either way.
+      }
+      _exitPort.close();
+      return false;
+    }
+  }
+}

--- a/lib/core/database/background_database_connection.dart
+++ b/lib/core/database/background_database_connection.dart
@@ -102,7 +102,6 @@ class BackgroundDatabaseConnection {
   final Isolate _worker;
   final ReceivePort _exitPort;
   final Future<void> _workerExited;
-  bool _shutdownStarted = false;
 
   /// Opens [file] on a dedicated worker isolate.
   ///
@@ -165,22 +164,21 @@ class BackgroundDatabaseConnection {
   ///   restore), a [TimeoutException] is thrown instead, because killing the
   ///   worker would strand an open SQLite handle — and its file locks — in a
   ///   process that is about to reopen the same file.
+  ///
+  /// Safe to call more than once: every call genuinely waits for the exit
+  /// event (awaiting the already-completed future is a no-op after the worker
+  /// has exited, and closing the port or killing the isolate again does
+  /// nothing).
   Future<bool> awaitWorkerShutdown({
     required Duration timeout,
     required bool killIfStuck,
   }) async {
-    if (_shutdownStarted) return true;
-    _shutdownStarted = true;
-
     try {
       await _workerExited.timeout(timeout);
       _exitPort.close();
       return true;
     } on TimeoutException {
-      if (!killIfStuck) {
-        _shutdownStarted = false;
-        rethrow;
-      }
+      if (!killIfStuck) rethrow;
       _worker.kill(priority: Isolate.immediate);
       try {
         await _workerExited.timeout(const Duration(seconds: 2));

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
+import 'package:submersion/core/database/background_database_connection.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/services/database_location_service.dart';
@@ -26,6 +27,12 @@ class DatabaseService {
   static final DatabaseService instance = DatabaseService._();
 
   AppDatabase? _database;
+
+  /// The worker isolate behind [_database], when it was opened on one. Held so
+  /// [close] can wait for SQLite to actually finish closing rather than just
+  /// for drift's acknowledgement — see [BackgroundDatabaseConnection].
+  BackgroundDatabaseConnection? _background;
+
   DatabaseLocationService? _locationService;
   String? _currentDatabasePath;
   bool _isMigrating = false;
@@ -80,6 +87,7 @@ class DatabaseService {
   @visibleForTesting
   void resetForTesting() {
     _database = null;
+    _background = null;
     _locationService = null;
     _currentDatabasePath = null;
     lastOpenMode = null;
@@ -185,8 +193,10 @@ class DatabaseService {
       lastOpenMode = DatabaseOpenMode.background;
     }
 
+    final background = await BackgroundDatabaseConnection.open(file);
+    _background = background;
     return AppDatabase(
-      NativeDatabase.createInBackground(file),
+      background.connection,
       onMigrationProgress: onMigrationProgress,
     );
   }
@@ -259,20 +269,33 @@ class DatabaseService {
       // keep it so the connection (and its locks) is not leaked and a
       // retry can re-attempt the close before reopening.
       await _database!.close().timeout(const Duration(seconds: 5));
+      // Drift acknowledges the shutdown request before the worker isolate
+      // runs sqlite3_close_v2, so the await above does NOT mean the file is
+      // closed. A caller about to reopen the same file must wait for the
+      // real close, and a stuck worker throws rather than being killed:
+      // killing it would strand an open handle holding the file locks.
+      await _background?.awaitWorkerShutdown(
+        timeout: const Duration(seconds: 5),
+        killIfStuck: false,
+      );
+      _background = null;
       _database = null;
       return;
     }
 
+    // Shutdown/abandon path. Two traps make a plain close() unsafe here:
+    // paused watch() subscriptions (Riverpod 3 auto-pause) hang the graceful
+    // close before it ever reaches the executor, and the background worker
+    // acknowledges the executor close before SQLite is actually closed. If
+    // the app then terminates, the worker's sqlite3_close_v2 calls back into
+    // Dart (drift's SQL function destructors) after the VM tore down its FFI
+    // callback metadata, aborting with "GetFfiCallbackMetadata called after
+    // shutdown" and hanging the app in the Dock. See
+    // closeDatabaseForAppShutdown for how each is handled.
     try {
-      // Shutdown/abandon path: if close times out, drop the connection and
-      // let the OS reclaim the file handles when the app exits.
-      await _database!.close().timeout(
-        const Duration(seconds: 5),
-        onTimeout: () {},
-      );
-    } catch (e) {
-      // Ignore close errors - we're abandoning this connection anyway.
+      await closeDatabaseForAppShutdown(_database!, background: _background);
     } finally {
+      _background = null;
       _database = null;
     }
   }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -276,8 +276,14 @@ class DatabaseService {
       // closed. A caller about to reopen the same file must wait for the
       // real close, and a stuck worker throws rather than being killed:
       // killing it would strand an open handle holding the file locks.
+      //
+      // The budget here is deliberately much longer than the 5s ack wait:
+      // the worker's sqlite3_close_v2 is where a WAL checkpoint-on-close
+      // runs, which on a multi-hundred-MB database can take tens of
+      // seconds. Restore/move callers strongly prefer a slow success over
+      // a fast TimeoutException that aborts the whole operation.
       await _background?.awaitWorkerShutdown(
-        timeout: const Duration(seconds: 5),
+        timeout: const Duration(seconds: 60),
         killIfStuck: false,
       );
       _background = null;

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -134,11 +134,13 @@ class DatabaseService {
   ///    hot-journal recovery are proven there, and closing a background
   ///    executor MID-migration has historically hung. The close happens
   ///    strictly after the ladder finishes.
-  /// 2. Open with [NativeDatabase.createInBackground]: every statement
-  ///    executes on drift's worker isolate. Migration callbacks (onCreate
-  ///    for fresh files, the beforeOpen re-asserts) still run on the main
-  ///    isolate and issue their statements through the remote executor,
-  ///    so their semantics are unchanged.
+  /// 2. Open with [BackgroundDatabaseConnection.open] (a
+  ///    [NativeDatabase.createInBackground] equivalent that owns the worker
+  ///    isolate, so [close] can wait for SQLite to actually finish closing):
+  ///    every statement executes on drift's worker isolate. Migration
+  ///    callbacks (onCreate for fresh files, the beforeOpen re-asserts)
+  ///    still run on the main isolate and issue their statements through
+  ///    the remote executor, so their semantics are unchanged.
   ///
   /// A single synchronous `PRAGMA user_version` read (via
   /// [getStoredSchemaVersion]) drives BOTH the newer-than-app guard and

--- a/lib/core/services/local_cache_database_service.dart
+++ b/lib/core/services/local_cache_database_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'package:submersion/core/database/background_database_connection.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
 
 /// Singleton service managing the local-only cache database.
@@ -60,9 +61,12 @@ class LocalCacheDatabaseService {
   Future<void> close() async {
     if (_database == null) return;
     try {
-      await _database!.close().timeout(const Duration(seconds: 5));
-    } catch (_) {
-      // Ignore close errors
+      // Shutdown path: a plain close() hangs while any watch() subscription
+      // is paused (Riverpod 3 pauses the streams of unlistened providers),
+      // because drift awaits the stream store before closing the executor.
+      // This helper falls back to closing the executor directly, which for
+      // this main-isolate database is the real sqlite3 close.
+      await closeDatabaseForAppShutdown(_database!);
     } finally {
       _database = null;
     }

--- a/test/core/database/background_database_connection_test.dart
+++ b/test/core/database/background_database_connection_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart' show sqlite3;
 import 'package:submersion/core/database/background_database_connection.dart';
 
 /// Minimal drift database used only to drive the remote executor.
@@ -187,7 +188,11 @@ void main() {
       File('${dir.path}/app.db'),
     );
     final db = _TinyDb(connection.connection);
+    // Explicit WAL mode with a write through it, so the durability check
+    // after shutdown exercises a WAL checkpoint-on-close.
+    await db.customStatement('PRAGMA journal_mode = WAL');
     await db.customStatement('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+    await db.customStatement('INSERT INTO t (id) VALUES (1)');
 
     // A live watch() whose subscription is paused makes db.close() hang in
     // streamQueries.close() before the executor is ever asked to close —
@@ -217,8 +222,17 @@ void main() {
       lessThan(const Duration(seconds: 4)),
       reason: 'shutdown must not sit out full timeouts',
     );
-    // The worker really closed SQLite: a completed close removes the WAL.
-    expect(File('${dir.path}/app.db-wal').existsSync(), isFalse);
+    // clean == true is the "SQLite really closed" signal: the worker isolate
+    // exits only after connection.close() has returned. (The -wal sidecar is
+    // NOT a usable signal here — Apple's system SQLite enables PERSIST_WAL,
+    // leaving the file behind even on a clean close.) Reopening and reading
+    // additionally proves the committed write survived the shutdown.
+    final reopened = sqlite3.open('${dir.path}/app.db');
+    try {
+      expect(reopened.select('SELECT id FROM t').single['id'], 1);
+    } finally {
+      reopened.dispose();
+    }
 
     subscription.resume();
     await subscription.cancel();
@@ -235,6 +249,9 @@ void main() {
       );
       final db = _TinyDb(connection.connection);
 
+      // Explicit WAL mode so the post-shutdown read exercises a WAL
+      // checkpoint-on-close.
+      await db.customStatement('PRAGMA journal_mode = WAL');
       await db.customStatement('CREATE TABLE t (id INTEGER PRIMARY KEY)');
       await db.customStatement('INSERT INTO t (id) VALUES (7)');
       final rows = await db.customSelect('SELECT id FROM t').get();
@@ -247,9 +264,16 @@ void main() {
       );
 
       expect(exitedCleanly, isTrue);
-      expect(File('${dir.path}/app.db').existsSync(), isTrue);
-      // A completed SQLite close removes the WAL sidecars.
-      expect(File('${dir.path}/app.db-wal').existsSync(), isFalse);
+      // The worker exits only after connection.close() returns, so a clean
+      // exit means SQLite closed. (WAL-sidecar absence is not assertable:
+      // Apple's system SQLite enables PERSIST_WAL and keeps the file on a
+      // clean close.) The committed write must survive a fresh open.
+      final reopened = sqlite3.open('${dir.path}/app.db');
+      try {
+        expect(reopened.select('SELECT id FROM t').single['id'], 7);
+      } finally {
+        reopened.dispose();
+      }
     },
     timeout: const Timeout(Duration(seconds: 60)),
   );

--- a/test/core/database/background_database_connection_test.dart
+++ b/test/core/database/background_database_connection_test.dart
@@ -192,11 +192,15 @@ void main() {
     // A live watch() whose subscription is paused makes db.close() hang in
     // streamQueries.close() before the executor is ever asked to close —
     // exactly what Riverpod 3 does to unlistened providers' streams.
-    final subscription = db
-        .customSelect('SELECT id FROM t')
-        .watch()
-        .listen((_) {});
-    await Future<void>.delayed(const Duration(milliseconds: 100));
+    final firstSnapshot = Completer<void>();
+    final subscription = db.customSelect('SELECT id FROM t').watch().listen((
+      _,
+    ) {
+      if (!firstSnapshot.isCompleted) firstSnapshot.complete();
+    });
+    // Pause only once the stream is live; a fixed sleep would be flaky on
+    // contended CI.
+    await firstSnapshot.future;
     subscription.pause();
 
     final sw = Stopwatch()..start();

--- a/test/core/database/background_database_connection_test.dart
+++ b/test/core/database/background_database_connection_test.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/background_database_connection.dart';
+
+/// Minimal drift database used only to drive the remote executor.
+class _TinyDb extends GeneratedDatabase {
+  _TinyDb(super.e);
+
+  @override
+  Iterable<TableInfo<Table, dynamic>> get allTables => const [];
+
+  @override
+  int get schemaVersion => 1;
+}
+
+/// Stands in for the real SQLite close, which can take seconds when it has to
+/// checkpoint a large WAL. Everything else forwards to [_inner].
+class _SlowClosingExecutor implements QueryExecutor {
+  _SlowClosingExecutor(this._inner, this._closeDelay);
+
+  final QueryExecutor _inner;
+  final Duration _closeDelay;
+
+  @override
+  Future<void> close() async {
+    await Future<void>.delayed(_closeDelay);
+    await _inner.close();
+  }
+
+  @override
+  SqlDialect get dialect => _inner.dialect;
+
+  @override
+  Future<bool> ensureOpen(QueryExecutorUser user) => _inner.ensureOpen(user);
+
+  @override
+  Future<List<Map<String, Object?>>> runSelect(
+    String statement,
+    List<Object?> args,
+  ) => _inner.runSelect(statement, args);
+
+  @override
+  Future<int> runInsert(String statement, List<Object?> args) =>
+      _inner.runInsert(statement, args);
+
+  @override
+  Future<int> runUpdate(String statement, List<Object?> args) =>
+      _inner.runUpdate(statement, args);
+
+  @override
+  Future<int> runDelete(String statement, List<Object?> args) =>
+      _inner.runDelete(statement, args);
+
+  @override
+  Future<void> runCustom(String statement, [List<Object?>? args]) =>
+      _inner.runCustom(statement, args);
+
+  @override
+  Future<void> runBatched(BatchedStatements statements) =>
+      _inner.runBatched(statements);
+
+  @override
+  TransactionExecutor beginTransaction() => _inner.beginTransaction();
+
+  @override
+  QueryExecutor beginExclusive() => _inner.beginExclusive();
+}
+
+/// Built in its own scope so the closure sent to the worker isolate captures
+/// nothing but the delay.
+DatabaseConnection Function() _slowClosingOpener(int closeDelayMs) {
+  return () => DatabaseConnection(
+    _SlowClosingExecutor(
+      NativeDatabase.memory(),
+      Duration(milliseconds: closeDelayMs),
+    ),
+  );
+}
+
+void main() {
+  const closeDelay = Duration(seconds: 2);
+
+  test('awaitWorkerShutdown does not return until the worker has finished '
+      'closing the database', () async {
+    final connection = await BackgroundDatabaseConnection.open(
+      File('unused-by-the-test-opener.db'),
+      debugOpener: _slowClosingOpener(closeDelay.inMilliseconds),
+    );
+    final db = _TinyDb(connection.connection);
+    await db.customSelect('SELECT 1').get();
+
+    final sw = Stopwatch()..start();
+    await db.close();
+    final afterDbClose = sw.elapsed;
+
+    final exitedCleanly = await connection.awaitWorkerShutdown(
+      timeout: const Duration(seconds: 20),
+      killIfStuck: false,
+    );
+    final afterWorkerShutdown = sw.elapsed;
+
+    // The bug this guards against: drift answers the shutdown request before
+    // the executor is closed, so db.close() alone returns early. Letting the
+    // process exit at that point leaves the worker running FFI callbacks into
+    // a VM that is tearing them down.
+    expect(
+      afterDbClose,
+      lessThan(closeDelay),
+      reason: 'db.close() is expected to return before the executor is closed',
+    );
+    expect(exitedCleanly, isTrue);
+    expect(
+      afterWorkerShutdown,
+      greaterThanOrEqualTo(closeDelay),
+      reason: 'awaitWorkerShutdown must wait for the real close',
+    );
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test(
+    'awaitWorkerShutdown kills a stuck worker when asked to',
+    () async {
+      final connection = await BackgroundDatabaseConnection.open(
+        File('unused-by-the-test-opener.db'),
+        debugOpener: _slowClosingOpener(
+          const Duration(minutes: 5).inMilliseconds,
+        ),
+      );
+      final db = _TinyDb(connection.connection);
+      await db.customSelect('SELECT 1').get();
+      await db.close();
+
+      final exitedCleanly = await connection.awaitWorkerShutdown(
+        timeout: const Duration(milliseconds: 300),
+        killIfStuck: true,
+      );
+
+      expect(
+        exitedCleanly,
+        isFalse,
+        reason: 'the worker was still closing, so it had to be killed',
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'awaitWorkerShutdown throws instead of killing on reopen paths',
+    () async {
+      final connection = await BackgroundDatabaseConnection.open(
+        File('unused-by-the-test-opener.db'),
+        debugOpener: _slowClosingOpener(
+          const Duration(minutes: 5).inMilliseconds,
+        ),
+      );
+      final db = _TinyDb(connection.connection);
+      await db.customSelect('SELECT 1').get();
+      await db.close();
+
+      await expectLater(
+        connection.awaitWorkerShutdown(
+          timeout: const Duration(milliseconds: 300),
+          killIfStuck: false,
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      // Killing is still available afterwards so the test does not leak a
+      // worker isolate that would keep the test process alive.
+      await connection.awaitWorkerShutdown(
+        timeout: const Duration(milliseconds: 100),
+        killIfStuck: true,
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test('closeDatabaseForAppShutdown closes SQLite despite a paused watch() '
+      'subscription (Riverpod 3 auto-pause at quit)', () async {
+    final dir = Directory.systemTemp.createTempSync('bg_conn_paused');
+    addTearDown(() => dir.deleteSync(recursive: true));
+
+    final connection = await BackgroundDatabaseConnection.open(
+      File('${dir.path}/app.db'),
+    );
+    final db = _TinyDb(connection.connection);
+    await db.customStatement('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+
+    // A live watch() whose subscription is paused makes db.close() hang in
+    // streamQueries.close() before the executor is ever asked to close —
+    // exactly what Riverpod 3 does to unlistened providers' streams.
+    final subscription = db
+        .customSelect('SELECT id FROM t')
+        .watch()
+        .listen((_) {});
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    subscription.pause();
+
+    final sw = Stopwatch()..start();
+    final clean = await closeDatabaseForAppShutdown(
+      db,
+      background: connection,
+      gracefulTimeout: const Duration(milliseconds: 300),
+    );
+    sw.stop();
+
+    expect(clean, isTrue, reason: 'the worker must exit without a kill');
+    expect(
+      sw.elapsed,
+      lessThan(const Duration(seconds: 4)),
+      reason: 'shutdown must not sit out full timeouts',
+    );
+    // The worker really closed SQLite: a completed close removes the WAL.
+    expect(File('${dir.path}/app.db-wal').existsSync(), isFalse);
+
+    subscription.resume();
+    await subscription.cancel();
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test(
+    'opens a usable database on the worker isolate',
+    () async {
+      final dir = Directory.systemTemp.createTempSync('bg_conn');
+      addTearDown(() => dir.deleteSync(recursive: true));
+
+      final connection = await BackgroundDatabaseConnection.open(
+        File('${dir.path}/app.db'),
+      );
+      final db = _TinyDb(connection.connection);
+
+      await db.customStatement('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+      await db.customStatement('INSERT INTO t (id) VALUES (7)');
+      final rows = await db.customSelect('SELECT id FROM t').get();
+      expect(rows.single.read<int>('id'), 7);
+
+      await db.close();
+      final exitedCleanly = await connection.awaitWorkerShutdown(
+        timeout: const Duration(seconds: 20),
+        killIfStuck: false,
+      );
+
+      expect(exitedCleanly, isTrue);
+      expect(File('${dir.path}/app.db').existsSync(), isTrue);
+      // A completed SQLite close removes the WAL sidecars.
+      expect(File('${dir.path}/app.db-wal').existsSync(), isFalse);
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+}

--- a/test/core/database/drift_close_paused_stream_test.dart
+++ b/test/core/database/drift_close_paused_stream_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,9 +21,13 @@ void main() {
     await db.customStatement('CREATE TABLE t (id INTEGER PRIMARY KEY)');
 
     final stream = db.customSelect('SELECT id FROM t').watch();
-    final subscription = stream.listen((_) {});
-    // Let the first snapshot arrive so the stream is fully live.
-    await Future<void>.delayed(const Duration(milliseconds: 100));
+    // Wait for the first snapshot so the stream is fully live before pausing;
+    // a fixed sleep here would be timing-dependent on contended CI.
+    final firstSnapshot = Completer<void>();
+    final subscription = stream.listen((_) {
+      if (!firstSnapshot.isCompleted) firstSnapshot.complete();
+    });
+    await firstSnapshot.future;
 
     // What Riverpod 3 does to the streams of providers nobody listens to.
     subscription.pause();

--- a/test/core/database/drift_close_paused_stream_test.dart
+++ b/test/core/database/drift_close_paused_stream_test.dart
@@ -1,0 +1,44 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TinyDb extends GeneratedDatabase {
+  _TinyDb(super.e);
+
+  @override
+  Iterable<TableInfo<Table, dynamic>> get allTables => const [];
+
+  @override
+  int get schemaVersion => 1;
+}
+
+void main() {
+  test('db.close() stalls when a watch() subscription is paused '
+      '(the Riverpod 3 auto-pause scenario)', () async {
+    final db = _TinyDb(NativeDatabase.memory());
+    await db.customStatement('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+
+    final stream = db.customSelect('SELECT id FROM t').watch();
+    final subscription = stream.listen((_) {});
+    // Let the first snapshot arrive so the stream is fully live.
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    // What Riverpod 3 does to the streams of providers nobody listens to.
+    subscription.pause();
+
+    final closed = db
+        .close()
+        .then((_) => 'closed')
+        .timeout(const Duration(seconds: 2), onTimeout: () => 'timed out');
+
+    expect(
+      await closed,
+      'timed out',
+      reason: 'a paused subscription blocks StreamQueryStore.close()',
+    );
+
+    // Cleanup so the test process can exit.
+    subscription.resume();
+    await subscription.cancel();
+  }, timeout: const Timeout(Duration(seconds: 30)));
+}

--- a/test/core/database/drift_close_paused_stream_test.dart
+++ b/test/core/database/drift_close_paused_stream_test.dart
@@ -32,19 +32,22 @@ void main() {
     // What Riverpod 3 does to the streams of providers nobody listens to.
     subscription.pause();
 
-    final closed = db
-        .close()
+    final closeFuture = db.close();
+    final outcome = await closeFuture
         .then((_) => 'closed')
         .timeout(const Duration(seconds: 2), onTimeout: () => 'timed out');
 
     expect(
-      await closed,
+      outcome,
       'timed out',
       reason: 'a paused subscription blocks StreamQueryStore.close()',
     );
 
-    // Cleanup so the test process can exit.
+    // Releasing the subscription must unblock the stalled close. Awaiting it
+    // (bounded) both proves that and releases the native connection, so the
+    // abandoned close cannot leak sqlite state across the suite.
     subscription.resume();
     await subscription.cancel();
+    await closeFuture.timeout(const Duration(seconds: 5));
   }, timeout: const Timeout(Duration(seconds: 30)));
 }


### PR DESCRIPTION
## Problem

Quitting the macOS app intermittently stalled ~10-15 s in the Dock, and the debug console showed the Drift isolate worker aborting with `GetFfiCallbackMetadata called after shutdown` inside `sqlite3_close_v2 → functionDestroy`.

Two stacked causes, both reproduced with instrumentation and pinned by deterministic tests:

1. **`db.close()` hangs while any `watch()` subscription is paused.** Drift's `GeneratedDatabase.close()` awaits `streamQueries.close()` *before* closing the executor, and each query stream awaits `controller.close()` — a future that only completes when the done event is delivered. Riverpod 3 auto-pauses subscriptions of unlistened providers, so at quit time the close could hang forever. The swallowed 5 s timeout per database produced the Dock stall, and the executor close request was never even sent to the worker.
2. **Drift's worker acknowledges shutdown before closing SQLite.** The remote server answers `terminateAll` before running `connection.close()`, so even a successful `close()` returns while the worker is still inside `sqlite3_close_v2`. Once the app exits, the worker's close invokes the FFI destructors of drift's built-in Dart SQL functions after the VM tore down its FFI callback metadata, which aborts.

Intermittency is explained by (1): it depends on which providers happen to be paused at quit.

## Fix

- **`BackgroundDatabaseConnection`** (new): owns the drift worker isolate — replacing `NativeDatabase.createInBackground`, which keeps it private — and registers an `onExit` listener, giving shutdown a signal that fires only after SQLite is actually closed.
- **`closeDatabaseForAppShutdown()`**: brief graceful close (1 s) → direct `executor.close()` (idempotent; sends the request a hung graceful close never did; for the main-isolate local cache DB it *is* the real close) → await worker exit, killing it only as a last resort.
- **Strict/reopen closes** (restore, storage move) now also wait for the real worker exit but **throw** on a stuck worker instead of killing it, since a killed worker would strand the file locks the reopen needs.
- App-exit callers in `app.dart` and the local cache service use the shutdown-safe path.

## Verification

- Window-close quit: 15 s with the crash before → under 0.5 s with no crash after (instrumented `flutter run` sessions).
- 7 new regression tests pin the paused-subscription hang, the ack-before-close gap, and the three shutdown behaviors (clean wait, kill-if-stuck, throw-on-reopen).
- `flutter analyze` clean; full `test/core/database` + `test/core/services` suites pass (1496 tests); pre-push affected-test run passed (1074 tests).