### PR TITLE
feat(planner): name a saved dive plan on first save

### DIFF
--- a/docs/superpowers/plans/2026-07-25-name-saved-dive-plan.md
+++ b/docs/superpowers/plans/2026-07-25-name-saved-dive-plan.md
@@ -1,0 +1,1080 @@
+# Naming a Saved Dive Plan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prompt the diver for a plan name the first time a dive plan is saved, pre-filled with a generated site + depth + date default, and make renaming discoverable from both the plan canvas and the saved-plans list.
+
+**Architecture:** Presentation layer only. `dive_plans.name` already exists as a non-null synced column, so there is no migration, no sync work, and no repository change. A pure name generator lives in the planner's domain services; a reusable dialog widget lives in the planner's presentation widgets; the plan canvas gates its first save on that dialog; the saved-plans sheet gains a Rename menu entry.
+
+**Tech Stack:** Flutter, Riverpod (`StateNotifier`), Drift (unchanged), `intl` `DateFormat`, `flutter_test` / `flutter gen-l10n`.
+
+## Global Constraints
+
+- Working directory is the worktree `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/name-saved-dive-plan` on branch `worktree-name-saved-dive-plan`. Do not `cd` to the main checkout.
+- Run `dart format .` (whole project, not just changed files) before every commit. CI fails on `dart format --set-exit-if-changed`.
+- Run `flutter analyze` over the whole project with no `| tail`, `| head`, or other pipe. Infos are fatal in CI.
+- No emojis in code, comments, or documentation.
+- Immutability: never mutate entities in place; use `copyWith`.
+- Any user-visible string must come from `context.l10n`, never a hardcoded literal. The one exception preserved by this plan is the pre-existing in-memory placeholder `'New Dive Plan'`.
+- New ARB keys must be added to `lib/l10n/arb/app_en.arb` **and** all ten non-English locales (`ar`, `de`, `es`, `fr`, `he`, `hu`, `it`, `nl`, `pt`, `zh`), then regenerated with `flutter gen-l10n`.
+- Anything displaying a depth must respect the active diver's unit settings via `UnitFormatter`.
+- Files stay 200-400 lines typical, 800 max.
+- Do not bump `DatabaseService.currentSchemaVersion`. This feature requires no migration.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `lib/features/planner/domain/services/plan_name_generator.dart` (create) | Pure composition of a default plan name from site, depth label, date, and fallback. No Flutter or Riverpod imports. |
+| `lib/features/planner/presentation/widgets/plan_name_dialog.dart` (create) | Reusable name-entry dialog. Owns and disposes its `TextEditingController`. Returns trimmed text or `null`. |
+| `lib/features/planner/presentation/pages/plan_canvas_page.dart` (modify) | Uses the dialog for rename, adds the edit affordance to the title, gates first save on the dialog. |
+| `lib/features/dive_planner/presentation/providers/dive_planner_providers.dart` (modify) | Exposes `isPersisted` so the page can tell a first save from a re-save. |
+| `lib/features/planner/presentation/widgets/saved_plans_sheet.dart` (modify) | Adds Rename to the per-plan overflow menu. |
+| `lib/l10n/arb/app_*.arb` (modify, 11 files) | Two new keys. |
+| `test/features/planner/plan_name_generator_test.dart` (create) | Unit tests for the generator. |
+| `test/features/planner/plan_name_dialog_test.dart` (create) | Widget tests for the dialog contract. |
+| `test/features/planner/plan_canvas_first_save_test.dart` (create) | Widget tests for the first-save gate. |
+| `test/features/planner/saved_plans_sheet_test.dart` (modify) | Adds a rename test to the existing suite. |
+
+---
+
+### Task 1: Default plan name generator
+
+**Files:**
+- Create: `lib/features/planner/domain/services/plan_name_generator.dart`
+- Test: `test/features/planner/plan_name_generator_test.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `String generateDefaultPlanName({String? siteName, String? depthLabel, required DateTime date, required String fallbackLabel})` — used by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/planner/plan_name_generator_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/planner/domain/services/plan_name_generator.dart';
+
+void main() {
+  final date = DateTime(2026, 7, 25);
+
+  group('generateDefaultPlanName', () {
+    test('combines site, depth, and date', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: 'Blue Hole',
+          depthLabel: '40m',
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Blue Hole 40m - Jul 25',
+      );
+    });
+
+    test('omits the depth when no depth label is supplied', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: 'Blue Hole',
+          depthLabel: null,
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Blue Hole - Jul 25',
+      );
+    });
+
+    test('omits the site when no site name is supplied', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: null,
+          depthLabel: '40m',
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        '40m - Jul 25',
+      );
+    });
+
+    test('falls back to the supplied label when site and depth are absent', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: null,
+          depthLabel: null,
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Dive Plan - Jul 25',
+      );
+    });
+
+    test('treats a blank site name as absent', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: '   ',
+          depthLabel: null,
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Dive Plan - Jul 25',
+      );
+    });
+
+    test('trims surrounding whitespace on the site name', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: '  Blue Hole  ',
+          depthLabel: '40m',
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Blue Hole 40m - Jul 25',
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/planner/plan_name_generator_test.dart`
+
+Expected: FAIL at compile time with `Target of URI doesn't exist: 'package:submersion/features/planner/domain/services/plan_name_generator.dart'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/features/planner/domain/services/plan_name_generator.dart`:
+
+```dart
+import 'package:intl/intl.dart';
+
+/// Builds the default name offered when a dive plan is saved for the first
+/// time.
+///
+/// Kept free of Flutter and Riverpod so it can be unit tested without a
+/// [ProviderContainer]. Unit conversion happens in the caller: [depthLabel] is
+/// already formatted in the diver's depth unit (for example `40m` or `130ft`),
+/// which means the generated name freezes that unit into the stored string.
+/// That is intentional. The name is a user-editable label, so regenerating it
+/// after a unit switch would overwrite names the diver typed deliberately.
+///
+/// [fallbackLabel] is the localized word for a plan (for example `Dive Plan`)
+/// and is used only when neither a site nor a depth is available.
+String generateDefaultPlanName({
+  String? siteName,
+  String? depthLabel,
+  required DateTime date,
+  required String fallbackLabel,
+}) {
+  final site = siteName?.trim();
+  final depth = depthLabel?.trim();
+
+  final parts = <String>[
+    if (site != null && site.isNotEmpty) site,
+    if (depth != null && depth.isNotEmpty) depth,
+  ];
+  if (parts.isEmpty) parts.add(fallbackLabel);
+
+  return '${parts.join(' ')} - ${DateFormat.MMMd().format(date)}';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/planner/plan_name_generator_test.dart`
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Format and analyze**
+
+Run: `dart format . && flutter analyze`
+
+Expected: `dart format` reports 0 changed files on a second run; `flutter analyze` reports `No issues found!`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/planner/domain/services/plan_name_generator.dart test/features/planner/plan_name_generator_test.dart
+git commit -m "feat(planner): add default plan name generator"
+```
+
+---
+
+### Task 2: Reusable name dialog, and wire the canvas rename to it
+
+**Files:**
+- Create: `lib/features/planner/presentation/widgets/plan_name_dialog.dart`
+- Modify: `lib/features/planner/presentation/pages/plan_canvas_page.dart` (title `InkWell` at `:106-110`; `_showRenameDialog` at `:717-749`)
+- Test: `test/features/planner/plan_name_dialog_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `Future<String?> showPlanNameDialog(BuildContext context, {required String initialName, required String title})` — used by Task 4 and Task 5. Returns the trimmed entered name, or `null` when the user cancels or dismisses.
+
+This task also fixes a real leak: the existing `_showRenameDialog` creates a `TextEditingController` inside the `showDialog` builder closure and never disposes it, so every rename leaks one controller. Extracting the dialog into a `StatefulWidget` gives it a `dispose()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/planner/plan_name_dialog_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart';
+
+import '../../helpers/test_app.dart';
+
+void main() {
+  // Opens the dialog from a button and records what it returned.
+  Future<void> openDialog(
+    WidgetTester tester,
+    String initialName,
+    void Function(String?) onResult,
+  ) async {
+    await tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        child: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  final result = await showPlanNameDialog(
+                    context,
+                    initialName: initialName,
+                    title: 'Name your plan',
+                  );
+                  onResult(result);
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('pre-fills the field with the initial name', (tester) async {
+    await openDialog(tester, 'Blue Hole 40m - Jul 25', (_) {});
+
+    expect(find.text('Name your plan'), findsOneWidget);
+    expect(find.text('Blue Hole 40m - Jul 25'), findsOneWidget);
+  });
+
+  testWidgets('cancel returns null', (tester) async {
+    String? result;
+    var called = false;
+    await openDialog(tester, 'Blue Hole', (value) {
+      result = value;
+      called = true;
+    });
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(called, isTrue);
+    expect(result, isNull);
+  });
+
+  testWidgets('confirm returns the trimmed text', (tester) async {
+    String? result;
+    await openDialog(tester, 'Blue Hole', (value) => result = value);
+
+    await tester.enterText(find.byType(TextField), '  Wreck of the Zenobia  ');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(result, 'Wreck of the Zenobia');
+  });
+
+  testWidgets('an all-whitespace field disables confirm', (tester) async {
+    await openDialog(tester, 'Blue Hole', (_) {});
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+
+    final confirm = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Save'),
+    );
+    expect(confirm.onPressed, isNull);
+  });
+
+  testWidgets('confirm is enabled again once text is restored', (
+    tester,
+  ) async {
+    await openDialog(tester, 'Blue Hole', (_) {});
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+
+    final confirm = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Save'),
+    );
+    expect(confirm.onPressed, isNotNull);
+  });
+}
+```
+
+Note: `Cancel` and `Save` are the English values of `common_action_cancel` and `common_action_save`, which is why the harness pins `locale: const Locale('en')`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/planner/plan_name_dialog_test.dart`
+
+Expected: FAIL at compile time with `Target of URI doesn't exist: 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart'`.
+
+- [ ] **Step 3: Write the dialog**
+
+Create `lib/features/planner/presentation/widgets/plan_name_dialog.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Prompt for a dive plan name, seeded with [initialName].
+///
+/// Resolves to the trimmed entered name, or `null` when the diver cancels or
+/// dismisses the dialog. Confirm stays disabled while the trimmed field is
+/// empty, so an empty name can never be returned.
+Future<String?> showPlanNameDialog(
+  BuildContext context, {
+  required String initialName,
+  required String title,
+}) {
+  return showDialog<String>(
+    context: context,
+    builder: (_) => _PlanNameDialog(initialName: initialName, title: title),
+  );
+}
+
+class _PlanNameDialog extends StatefulWidget {
+  const _PlanNameDialog({required this.initialName, required this.title});
+
+  final String initialName;
+  final String title;
+
+  @override
+  State<_PlanNameDialog> createState() => _PlanNameDialogState();
+}
+
+class _PlanNameDialogState extends State<_PlanNameDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialName);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title),
+      content: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+          labelText: context.l10n.divePlanner_field_planName,
+        ),
+        autofocus: true,
+        textCapitalization: TextCapitalization.sentences,
+        onChanged: (_) => setState(() {}),
+        onSubmitted: (_) => _confirm(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(context.l10n.common_action_cancel),
+        ),
+        FilledButton(
+          onPressed: _controller.text.trim().isEmpty ? null : _confirm,
+          child: Text(context.l10n.common_action_save),
+        ),
+      ],
+    );
+  }
+
+  void _confirm() {
+    final name = _controller.text.trim();
+    if (name.isEmpty) return;
+    Navigator.of(context).pop(name);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/planner/plan_name_dialog_test.dart`
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Replace the canvas rename dialog**
+
+In `lib/features/planner/presentation/pages/plan_canvas_page.dart`, delete the entire `_showRenameDialog` method (currently at `:717-749`) and replace it with:
+
+```dart
+  Future<void> _showRenameDialog(BuildContext context) async {
+    final notifier = ref.read(divePlanNotifierProvider.notifier);
+    final entered = await showPlanNameDialog(
+      context,
+      initialName: ref.read(divePlanNotifierProvider).name,
+      title: context.l10n.divePlanner_action_renamePlan,
+    );
+    if (entered == null) return;
+    notifier.updateName(entered);
+  }
+```
+
+Add the import alongside the other `planner/presentation/widgets` imports:
+
+```dart
+import 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart';
+```
+
+- [ ] **Step 6: Add the edit affordance to the title**
+
+In the same file, replace the title `InkWell` (currently at `:106-110`):
+
+```dart
+            Flexible(
+              child: InkWell(
+                onTap: () => _showRenameDialog(context),
+                child: Text(planState.name),
+              ),
+            ),
+```
+
+with:
+
+```dart
+            Flexible(
+              child: InkWell(
+                onTap: () => _showRenameDialog(context),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Flexible(
+                      child: Text(planState.name, overflow: TextOverflow.ellipsis),
+                    ),
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.edit_outlined,
+                      size: 14,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+```
+
+The inner `Flexible` on the `Text` is what keeps a long plan name ellipsizing instead of overflowing the AppBar once the icon takes fixed width.
+
+- [ ] **Step 7: Run the existing canvas tests to check for regressions**
+
+Run: `flutter test test/features/planner/plan_canvas_page_test.dart test/features/planner/plan_canvas_delete_test.dart test/features/planner/plan_canvas_delete_gate_test.dart`
+
+Expected: PASS. If a test matched the title with `find.text('New Dive Plan')`, it still passes: the plan name is still rendered by a `Text` widget, now nested one level deeper.
+
+- [ ] **Step 8: Format, analyze, and commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/planner/presentation/widgets/plan_name_dialog.dart lib/features/planner/presentation/pages/plan_canvas_page.dart test/features/planner/plan_name_dialog_test.dart
+git commit -m "feat(planner): extract plan name dialog and mark the title editable"
+```
+
+Expected: `flutter analyze` reports `No issues found!` before committing.
+
+---
+
+### Task 3: Localization keys
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb`, `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `context.l10n.plannerCanvas_name_dialogTitle` and `context.l10n.plannerCanvas_name_defaultFallback` — used by Task 4 and Task 5.
+
+The ARB files are not strictly alphabetically sorted, so insert both keys immediately after the existing `plannerCanvas_saved_title` entry in each file. Neither key takes placeholders, so no `@`-prefixed metadata block is needed.
+
+- [ ] **Step 1: Add the English keys**
+
+In `lib/l10n/arb/app_en.arb`, after the `"plannerCanvas_saved_title"` line (currently `:7115`), add:
+
+```json
+  "plannerCanvas_name_dialogTitle": "Name your plan",
+  "plannerCanvas_name_defaultFallback": "Dive Plan",
+```
+
+- [ ] **Step 2: Add the translated keys**
+
+Insert the matching pair after `"plannerCanvas_saved_title"` in each locale file:
+
+`app_ar.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "سمِّ خطتك",
+  "plannerCanvas_name_defaultFallback": "خطة غوص",
+```
+
+`app_de.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Plan benennen",
+  "plannerCanvas_name_defaultFallback": "Tauchplan",
+```
+
+`app_es.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Nombra tu plan",
+  "plannerCanvas_name_defaultFallback": "Plan de buceo",
+```
+
+`app_fr.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Nommez votre plan",
+  "plannerCanvas_name_defaultFallback": "Plan de plongée",
+```
+
+`app_he.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "תן שם לתוכנית",
+  "plannerCanvas_name_defaultFallback": "תוכנית צלילה",
+```
+
+`app_hu.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Nevezze el a tervet",
+  "plannerCanvas_name_defaultFallback": "Merülési terv",
+```
+
+`app_it.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Dai un nome al piano",
+  "plannerCanvas_name_defaultFallback": "Piano di immersione",
+```
+
+`app_nl.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Geef je plan een naam",
+  "plannerCanvas_name_defaultFallback": "Duikplan",
+```
+
+`app_pt.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "Dê um nome ao seu plano",
+  "plannerCanvas_name_defaultFallback": "Plano de mergulho",
+```
+
+`app_zh.arb`:
+```json
+  "plannerCanvas_name_dialogTitle": "为计划命名",
+  "plannerCanvas_name_defaultFallback": "潜水计划",
+```
+
+- [ ] **Step 3: Regenerate the localizations**
+
+Run: `flutter gen-l10n`
+
+Expected: exit 0, and `git status` shows all eleven `lib/l10n/arb/app_localizations*.dart` files modified.
+
+- [ ] **Step 4: Verify the getters exist**
+
+Run: `grep -c "plannerCanvas_name_dialogTitle" lib/l10n/arb/app_localizations_de.dart lib/l10n/arb/app_localizations_zh.dart lib/l10n/arb/app_localizations.dart`
+
+Expected: a non-zero count for each of the three files.
+
+- [ ] **Step 5: Format, analyze, and commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/l10n/
+git commit -m "i18n(planner): add plan name dialog title and fallback label"
+```
+
+Expected: `flutter analyze` reports `No issues found!`.
+
+---
+
+### Task 4: First-save name gate
+
+**Files:**
+- Modify: `lib/features/dive_planner/presentation/providers/dive_planner_providers.dart` (near `_loaded` at `:55` and `save()` at `:499`)
+- Modify: `lib/features/planner/presentation/pages/plan_canvas_page.dart` (`_savePlan` at `:532-547`)
+- Test: `test/features/planner/plan_canvas_first_save_test.dart`
+
+**Interfaces:**
+- Consumes: `generateDefaultPlanName(...)` from Task 1, `showPlanNameDialog(...)` from Task 2, `plannerCanvas_name_dialogTitle` and `plannerCanvas_name_defaultFallback` from Task 3.
+- Produces: `bool get isPersisted` on `DivePlanNotifier`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/planner/plan_canvas_first_save_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
+import 'package:submersion/features/planner/data/repositories/dive_plan_repository.dart';
+import 'package:submersion/features/planner/domain/entities/dive_plan.dart';
+import 'package:submersion/features/planner/presentation/pages/plan_canvas_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../helpers/test_app.dart';
+import '../../helpers/test_database.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late DivePlanRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DivePlanRepository();
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  Widget harness() => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    locale: const Locale('en'),
+    child: const PlanCanvasPage(),
+  );
+
+  Future<void> setSize(WidgetTester tester, Size size) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  ProviderContainer containerOf(WidgetTester tester) =>
+      ProviderScope.containerOf(tester.element(find.byType(PlanCanvasPage)));
+
+  DivePlanNotifier notifierOf(WidgetTester tester) =>
+      containerOf(tester).read(divePlanNotifierProvider.notifier);
+
+  // The save IconButton renders Icons.save while the plan is dirty and
+  // Icons.save_outlined (disabled) once it is clean, so a tap must always
+  // target Icons.save.
+  Future<void> tapSave(WidgetTester tester) async {
+    await tester.tap(find.byIcon(Icons.save));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> seedAndSave(WidgetTester tester) async {
+    notifierOf(tester).addSimplePlan(maxDepth: 30, bottomTimeMinutes: 20);
+    await tester.pumpAndSettle();
+    await tapSave(tester);
+  }
+
+  testWidgets('first save opens the name dialog with a generated default', (
+    tester,
+  ) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    expect(find.text('Name your plan'), findsOneWidget);
+    // No site is set on a bare plan, so the name is depth plus date.
+    expect(find.textContaining('30.0m - '), findsOneWidget);
+  });
+
+  testWidgets('cancelling the first save persists nothing', (tester) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(await repository.getAllPlanSummaries(), isEmpty);
+    // Read the state through the container: StateNotifier.state is @protected,
+    // and reading it directly is an analyzer error that CI treats as fatal.
+    expect(containerOf(tester).read(divePlanNotifierProvider).isDirty, isTrue);
+  });
+
+  testWidgets('confirming the first save persists under the entered name', (
+    tester,
+  ) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries, hasLength(1));
+    expect(summaries.single.name, 'Zenobia');
+  });
+
+  testWidgets('a second save does not re-open the dialog', (tester) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    // A successful save clears isDirty, which disables the save button. Dirty
+    // the plan again so there is something to re-save.
+    notifierOf(tester).updateMode(PlanMode.ccr);
+    await tester.pumpAndSettle();
+    await tapSave(tester);
+
+    expect(find.text('Name your plan'), findsNothing);
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries, hasLength(1));
+    expect(summaries.single.name, 'Zenobia');
+  });
+}
+```
+
+`PlanMode` comes from `package:submersion/features/planner/domain/entities/dive_plan.dart`;
+add that import to the test file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/planner/plan_canvas_first_save_test.dart`
+
+Expected: FAIL. The first test fails with `Expected: exactly one matching candidate / Actual: _TextFinder:<zero widgets with text "Name your plan">`, because save is still silent.
+
+- [ ] **Step 3: Expose the persisted flag on the notifier**
+
+In `lib/features/dive_planner/presentation/providers/dive_planner_providers.dart`, immediately below the `domain.DivePlan? _loaded;` field declaration at `:55`, add:
+
+```dart
+  /// Whether this plan already exists in the database.
+  ///
+  /// `_loaded` is set by [save] and [loadPlanById] and cleared by [newPlan], so
+  /// this is an accurate "has been persisted" signal. The plan canvas uses it
+  /// to prompt for a name on the first save only.
+  ///
+  /// Note that [loadPlan] deliberately does not set `_loaded` and therefore
+  /// reports `false`. That method has no production call sites today; a future
+  /// production caller must set `_loaded` as [loadPlanById] does.
+  bool get isPersisted => _loaded != null;
+```
+
+- [ ] **Step 4: Gate the save on the dialog**
+
+In `lib/features/planner/presentation/pages/plan_canvas_page.dart`, replace `_savePlan` (currently at `:532-547`) with:
+
+```dart
+  Future<void> _savePlan() async {
+    final notifier = ref.read(divePlanNotifierProvider.notifier);
+    final outcome = ref.read(planOutcomeProvider);
+    final summary = PlanSummaryData(
+      maxDepth: outcome.maxDepth,
+      runtimeSeconds: outcome.runtimeSeconds,
+      ttsSeconds: outcome.ttsAtBottom,
+    );
+
+    // Prompt for a name the first time a plan is persisted, so the saved-plans
+    // list is not a wall of identically-named rows. Re-saves stay silent.
+    if (!notifier.isPersisted) {
+      final l10n = context.l10n;
+      final state = ref.read(divePlanNotifierProvider);
+      final units = UnitFormatter(ref.read(settingsProvider));
+      final siteId = state.siteId;
+      final site = siteId == null
+          ? null
+          : await ref.read(siteProvider(siteId).future);
+      if (!mounted) return;
+
+      final entered = await showPlanNameDialog(
+        context,
+        initialName: generateDefaultPlanName(
+          siteName: site?.name,
+          depthLabel: outcome.maxDepth > 0
+              ? units.formatDepth(outcome.maxDepth)
+              : null,
+          date: state.startDateTime ?? DateTime.now(),
+          fallbackLabel: l10n.plannerCanvas_name_defaultFallback,
+        ),
+        title: l10n.plannerCanvas_name_dialogTitle,
+      );
+      // Cancel aborts the save entirely: nothing is written and the plan stays
+      // dirty, so the diver is never surprised by a name they rejected.
+      if (entered == null) return;
+      notifier.updateName(entered);
+    }
+
+    await notifier.save(summary: summary);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(context.l10n.divePlanner_message_planSaved)),
+    );
+  }
+```
+
+Add these imports if not already present:
+
+```dart
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/planner/domain/services/plan_name_generator.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+```
+
+`_savePlan` is a method rather than part of `build`, so it constructs its own `UnitFormatter` from `ref.read(settingsProvider)` the way `_sharePlanSlate` already does at `:518`, instead of reaching for the `units` local built in `build` at `:86`. `PlanOutcome.maxDepth` is a non-null `double`, so `> 0` is the only guard needed. `context.l10n` and the settings read are captured before the `await` on `siteProvider`, and `mounted` is checked after it, matching the async-gap pattern used by `_confirmAndDeletePlan` in `saved_plans_sheet.dart:293`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `flutter test test/features/planner/plan_canvas_first_save_test.dart`
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Run the full planner suites for regressions**
+
+Run: `flutter test test/features/planner/ test/features/dive_planner/`
+
+Expected: PASS. `test/features/planner/convert_to_dive_test.dart` in particular must still pass unchanged, because Convert-to-Dive calls `notifier.save()` directly and is deliberately not gated.
+
+- [ ] **Step 7: Format, analyze, and commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/dive_planner/presentation/providers/dive_planner_providers.dart lib/features/planner/presentation/pages/plan_canvas_page.dart test/features/planner/plan_canvas_first_save_test.dart
+git commit -m "feat(planner): prompt for a plan name on first save"
+```
+
+Expected: `flutter analyze` reports `No issues found!`.
+
+---
+
+### Task 5: Rename from the saved-plans sheet
+
+**Files:**
+- Modify: `lib/features/planner/presentation/widgets/saved_plans_sheet.dart` (`_PlanTile` `PopupMenuButton` at `:252-278`)
+- Test: `test/features/planner/saved_plans_sheet_test.dart` (append)
+
+**Interfaces:**
+- Consumes: `showPlanNameDialog(...)` from Task 2.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test inside the existing `void main() { ... }` block in `test/features/planner/saved_plans_sheet_test.dart`, after the last existing `testWidgets`:
+
+```dart
+  testWidgets('rename from the overflow menu updates the plan name', (
+    tester,
+  ) async {
+    await repository.savePlan(_plan('p1', 'New Dive Plan'));
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename Plan'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries.single.name, 'Zenobia');
+    expect(find.text('Zenobia'), findsOneWidget);
+  });
+```
+
+Add `locale: const Locale('en')` to the existing `harness()` helper if it is not already pinned, so `Rename Plan` and `Save` resolve to their English values.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/planner/saved_plans_sheet_test.dart --plain-name "rename from the overflow menu"`
+
+Expected: FAIL with `Expected: exactly one matching candidate / Actual: _TextFinder:<zero widgets with text "Rename Plan">`, because the menu only has Duplicate and Share.
+
+- [ ] **Step 3: Add the Rename menu entry**
+
+In `lib/features/planner/presentation/widgets/saved_plans_sheet.dart`, inside `_PlanTile`'s `PopupMenuButton`, add a `rename` branch as the first case in `onSelected` and a matching first `PopupMenuItem`:
+
+```dart
+          PopupMenuButton<String>(
+            onSelected: (value) async {
+              final repository = ref.read(divePlanRepositoryProvider);
+              if (value == 'rename') {
+                final plan = await repository.getPlan(summary.id);
+                if (plan == null || !context.mounted) return;
+                final entered = await showPlanNameDialog(
+                  context,
+                  initialName: plan.name,
+                  title: context.l10n.divePlanner_action_renamePlan,
+                );
+                if (entered == null) return;
+                await repository.savePlan(plan.copyWith(name: entered));
+              } else if (value == 'duplicate') {
+                await repository.duplicatePlan(summary.id);
+              } else if (value == 'share') {
+                final plan = await repository.getPlan(summary.id);
+                if (plan == null) return;
+                final safeName = plan.name
+                    .replaceAll(RegExp(r'[^\w\s-]'), '')
+                    .trim()
+                    .replaceAll(RegExp(r'\s+'), '_');
+                await saveAndShareFile(
+                  planToSubplanJson(plan),
+                  '${safeName.isEmpty ? 'dive_plan' : safeName}.$subplanExtension',
+                  'application/json',
+                );
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'rename',
+                child: Text(context.l10n.divePlanner_action_renamePlan),
+              ),
+              PopupMenuItem(
+                value: 'duplicate',
+                child: Text(context.l10n.plannerCanvas_saved_duplicate),
+              ),
+              PopupMenuItem(
+                value: 'share',
+                child: Text(context.l10n.plannerCanvas_share_menu),
+              ),
+            ],
+          ),
+```
+
+Add the import:
+
+```dart
+import 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart';
+```
+
+`repository` is read before the `getPlan` await, matching the existing rule in this file about not using `ref` across an async gap. `savePlan` is called without a `summary`, which leaves `summaryMaxDepth`, `summaryRuntimeSeconds`, and `summaryTtsSeconds` as `Value.absent()` in the companion, so the upsert preserves the existing denormalized values and the tile subtitle keeps its depth and runtime.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/planner/saved_plans_sheet_test.dart`
+
+Expected: PASS, including the pre-existing tests in the file.
+
+- [ ] **Step 5: Format, analyze, and commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/planner/presentation/widgets/saved_plans_sheet.dart test/features/planner/saved_plans_sheet_test.dart
+git commit -m "feat(planner): rename a saved plan from the overflow menu"
+```
+
+Expected: `flutter analyze` reports `No issues found!`.
+
+---
+
+### Task 6: Full verification
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: nothing.
+
+- [ ] **Step 1: Confirm formatting is clean**
+
+Run: `dart format .`
+
+Expected: `Formatted N files (0 changed)`.
+
+- [ ] **Step 2: Confirm analysis is clean**
+
+Run: `flutter analyze`
+
+Expected: `No issues found!`. Do not pipe this command; a pipe masks the exit code.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `flutter test`
+
+Expected: all tests pass. If a failure appears in a suite unrelated to the planner, check it against `main` before assuming this branch caused it.
+
+- [ ] **Step 4: Confirm no schema change slipped in**
+
+Run: `git diff main --stat -- lib/core/database/`
+
+Expected: no output. This feature must not touch the database layer.
+
+- [ ] **Step 5: Commit any formatting drift**
+
+```bash
+git status --short
+```
+
+Expected: clean. If `dart format .` changed files in Step 1, commit them:
+
+```bash
+git add -A && git commit -m "style: apply dart format"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+| --- | --- |
+| `generateDefaultPlanName` signature and four composition rules | Task 1 |
+| Output table (site+depth, site only, depth only, neither) | Task 1, Step 1 |
+| Zero/negative depth suppresses the depth segment | Task 1 rule 2, asserted via Task 4's `outcome.maxDepth > 0` guard |
+| `startDateTime` preferred over now | Task 4, Step 4 |
+| `showPlanNameDialog` signature, null on cancel, empty disables confirm | Task 2 |
+| `TextEditingController` leak fix | Task 2, Step 3 |
+| `isPersisted` getter and the `loadPlan` caveat | Task 4, Step 3 |
+| First-save gate with Cancel aborting | Task 4, Step 4 |
+| Async-gap discipline around `siteProvider` | Task 4, Step 4 |
+| Canvas title edit affordance with ellipsis preserved | Task 2, Step 6 |
+| Saved-plans sheet Rename entry | Task 5 |
+| Two new ARB keys across eleven files plus regeneration | Task 3 |
+| Convert-to-Dive, import, duplicate, undo-restore stay unprompted | Task 4, Step 6 regression run |
+| No migration, no sync change | Task 6, Step 4 |
+
+No spec requirement is unimplemented.
+
+**Placeholder scan:** No TBD, TODO, "add appropriate error handling", or "similar to Task N". Every code step contains complete code. Task 4 Step 1 contains a conditional instruction about the save icon, but it names the exact command to resolve it rather than deferring the decision.
+
+**Type consistency:** `generateDefaultPlanName` is declared in Task 1 with parameters `siteName`, `depthLabel`, `date`, `fallbackLabel` and is called with exactly those names in Task 4. `showPlanNameDialog` is declared in Task 2 with `initialName` and `title` and is called with exactly those names in Tasks 2, 4, and 5. `isPersisted` is declared in Task 4 Step 3 and used in Task 4 Step 4. The l10n getters `plannerCanvas_name_dialogTitle` and `plannerCanvas_name_defaultFallback` are created in Task 3 and consumed in Task 4. `DivePlan.copyWith` used in Task 5 exists at `dive_plan.dart:141`. `PlanSummaryData` and `planOutcomeProvider` are already in scope in `plan_canvas_page.dart`.

--- a/docs/superpowers/specs/2026-07-25-name-saved-dive-plan-design.md
+++ b/docs/superpowers/specs/2026-07-25-name-saved-dive-plan-design.md
@@ -1,0 +1,259 @@
+# Naming a Saved Dive Plan
+
+Date: 2026-07-25
+Status: Approved, ready for implementation planning
+
+## Problem
+
+Saving a dive plan is silent. The save button persists the plan and shows a
+"Plan saved" snackbar; the user is never asked what the plan is called. Every
+new plan therefore carries the hardcoded, non-localized default `New Dive Plan`
+(`lib/features/dive_planner/presentation/providers/dive_planner_providers.dart:73`
+and `lib/features/dive_planner/domain/entities/plan_result.dart:598`). A diver
+who saves three plans gets three identical rows in the saved-plans sheet,
+distinguishable only by the date/depth subtitle.
+
+Renaming is possible but undiscoverable: the plan canvas AppBar title is an
+`InkWell` that opens a rename dialog
+(`lib/features/planner/presentation/pages/plan_canvas_page.dart:106-110`,
+`:717-749`) with no visual affordance indicating it is tappable.
+
+## Scope
+
+This is a presentation-layer feature only.
+
+`dive_plans.name` already exists as a non-null `text()` column
+(`lib/core/database/database.dart:413`) and already carries an `hlc` column
+(`:481`). The table is registered in the sync table map
+(`lib/core/data/repositories/sync_repository.dart:56`) and flagged HLC-capable
+in the sync engine (`lib/core/services/sync/sync_service.dart:1750-1759`).
+
+Consequences:
+
+- No schema migration. The schema version stays where it is.
+- No sync work. A rename propagates through the existing last-writer-wins path.
+- No repository changes. `savePlan` already maps `name`
+  (`lib/features/planner/data/repositories/dive_plan_repository.dart:405`).
+
+The feature has three parts: a name dialog gating first save, a generated
+default name pre-filled into that dialog, and discoverable rename entry points.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| When to prompt | First save only | A never-saved plan is the only case where the name is meaningless. Re-saves stay silent. |
+| Default name shape | Site + depth + date | Most informative at a glance. Accepts that the unit is frozen into the stored string. |
+| Cancel semantics | Cancel aborts the save | The dialog is a gate, not a courtesy. A user who rejects a name never finds a plan under it. |
+| Other save paths | None prompt | Convert-to-Dive, import, duplicate, and undo-restore either already carry meaningful names or should not be interrupted. |
+| Name collisions | Allowed | Names are labels, not identifiers. Uniqueness is unenforceable across synced devices. |
+
+### Frozen units
+
+The generated name embeds a unit-formatted depth (`Blue Hole 40m - Jul 25` for a
+metric diver, `Blue Hole 130ft - Jul 25` for an imperial one). Because the name
+is stored as a literal string, it does not re-render when the diver later
+switches unit systems. This is accepted: the name is a user-editable label, and
+regenerating it would overwrite names the user typed deliberately.
+
+## Architecture
+
+### New: `lib/features/planner/domain/services/plan_name_generator.dart`
+
+A single pure function with no Flutter or Riverpod dependency, so it is testable
+without a `ProviderContainer`:
+
+```dart
+String generateDefaultPlanName({
+  String? siteName,
+  String? depthLabel, // already unit-formatted by the caller
+  required DateTime date,
+  required String fallbackLabel, // localized "Dive Plan"
+});
+```
+
+Composition rules:
+
+1. Join the present values of `siteName` and `depthLabel` with a single space,
+   then append `" - "` and the date.
+2. Omit `depthLabel` when the plan's max depth is null or less than or equal to
+   zero. An empty plan must not be named `Blue Hole 0m - Jul 25`.
+3. When both `siteName` and `depthLabel` are absent, use `fallbackLabel` in the
+   leading slot, yielding `Dive Plan - Jul 25`.
+4. Format `date` with `DateFormat.MMMd()` so the result is locale-aware.
+
+Unit formatting stays outside this function. `UnitFormatter` requires
+`settingsProvider`, and taking it as a dependency would make the generator
+untestable in isolation. The caller formats the depth and passes a string.
+
+Expected outputs:
+
+| Site | Max depth | Result |
+| --- | --- | --- |
+| Blue Hole | 40 m | `Blue Hole 40m - Jul 25` |
+| Blue Hole | null or 0 | `Blue Hole - Jul 25` |
+| null | 40 m | `40m - Jul 25` |
+| null | null or 0 | `Dive Plan - Jul 25` |
+
+The date source is `planState.startDateTime ?? DateTime.now()`.
+
+### New: `lib/features/planner/presentation/widgets/plan_name_dialog.dart`
+
+```dart
+Future<String?> showPlanNameDialog(
+  BuildContext context, {
+  required String initialName,
+  required String title,
+});
+```
+
+Returns the trimmed entered name, or `null` when the user cancels. The confirm
+button is disabled while the trimmed field is empty, so an empty name can never
+be committed.
+
+This replaces the inline `_showRenameDialog` at `plan_canvas_page.dart:717`,
+which creates a `TextEditingController` inside the builder closure and never
+disposes it. The extracted widget is a `StatefulWidget` that disposes its
+controller in `dispose()`.
+
+### Changed: `DivePlanNotifier`
+
+Add a getter exposing whether the plan has been persisted in this editing
+session:
+
+```dart
+bool get isPersisted => _loaded != null;
+```
+
+`_loaded` is set by `save()` (`dive_planner_providers.dart:507`) and by
+`loadPlanById()` (`:116`), and cleared by `newPlan()` (`:101`). It is therefore
+an accurate "this plan exists in the database" signal.
+
+Known gap, deliberately not fixed: `loadPlan(DivePlanState)` (`:106`) sets state
+without setting `_loaded`, so a plan loaded through it would report
+`isPersisted == false`. That method has no production call sites; it is used
+only by `test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart:72`.
+If a production caller is ever added, it must set `_loaded`.
+
+The notifier gains no UI dependency. `save()` stays a pure persistence call, so
+the four other callers (`_convertToDive`, `.subplan` import, duplicate,
+undo-delete restore) are unaffected.
+
+### Changed: `_savePlan()` in `plan_canvas_page.dart`
+
+```
+if (!notifier.isPersisted) {
+  siteName  = state.siteId == null
+      ? null
+      : (await ref.read(siteProvider(state.siteId!).future))?.name;
+  depthLabel = outcome.maxDepth > 0 ? units.formatDepth(outcome.maxDepth) : null;
+  suggested = generateDefaultPlanName(
+    siteName: siteName,
+    depthLabel: depthLabel,
+    date: state.startDateTime ?? DateTime.now(),
+    fallbackLabel: l10n.plannerCanvas_name_defaultFallback,
+  );
+  entered = await showPlanNameDialog(
+    context,
+    initialName: suggested,
+    title: l10n.plannerCanvas_name_dialogTitle,
+  );
+  if (entered == null) return;  // Cancel: persist nothing, plan stays dirty
+  notifier.updateName(entered);
+}
+await notifier.save(summary: ...);
+```
+
+Because `siteProvider` is a `FutureProvider.family`
+(`lib/features/dive_sites/presentation/providers/site_providers.dart:273`),
+resolving the site name is an `await` that runs before the dialog opens. On a
+cold cache this introduces a brief gap between tapping Save and the dialog
+appearing. This is accepted rather than mitigated with a loading indicator: the
+read is a single indexed row lookup.
+
+The `context` and `ref` reads that cross the `await` must be captured before it,
+and `mounted` checked after, following the pattern already used in
+`_confirmAndDeletePlan` (`saved_plans_sheet.dart:293`).
+
+`_savePlan` is a method rather than part of `build`, so it constructs its own
+`UnitFormatter(ref.read(settingsProvider))` the way `_sharePlanSlate` already
+does at `plan_canvas_page.dart:518`, rather than reaching for the `units` local
+built in `build` at `:86`. `PlanOutcome.maxDepth` is a non-null `double`
+(`plan_result.dart:318`), so the `> 0` guard is the only check needed.
+
+### Changed: canvas title affordance
+
+The existing title `InkWell` (`plan_canvas_page.dart:106-110`) wraps its `Text`
+in a `Row` with a trailing `Icon(Icons.edit_outlined, size: 14)` tinted
+`colorScheme.onSurfaceVariant`. The `Flexible` stays on the `Text` so long plan
+names still ellipsize rather than overflow the AppBar.
+
+### Changed: saved-plans sheet
+
+`_PlanTile` already renders a `PopupMenuButton` with Duplicate and Share
+(`saved_plans_sheet.dart:252-278`). Add a `rename` entry as the first item. On
+selection it loads the plan through `divePlanRepositoryProvider.getPlan`,
+prompts with `showPlanNameDialog` seeded from the current name, and on confirm
+writes back via `savePlan(plan.copyWith(name: entered))`.
+
+The repository read must happen before the dialog `await`, matching the existing
+comment on `_confirmAndDeletePlan` about not using `ref` across an async gap.
+
+## Localization
+
+Two new keys, added to `lib/l10n/arb/app_en.arb` and translated into all ten
+non-English locales, then regenerated:
+
+| Key | English |
+| --- | --- |
+| `plannerCanvas_name_dialogTitle` | Name your plan |
+| `plannerCanvas_name_defaultFallback` | Dive Plan |
+
+Reused without change: `divePlanner_field_planName` ("Plan Name"),
+`divePlanner_action_renamePlan` ("Rename Plan"), `common_action_cancel`,
+`common_action_save`, `plannerCanvas_saved_duplicate`.
+
+The hardcoded `'New Dive Plan'` at `dive_planner_providers.dart:73` and
+`plan_result.dart:598` stays as-is. In the normal flow it is a transient
+in-memory placeholder shown on the canvas until the first-save gate replaces it.
+
+It can still reach the database by one route: Convert-to-Dive on a
+never-persisted plan calls `save()` directly without prompting, so the plan row
+lands as `New Dive Plan`. That is the accepted consequence of the decision not
+to interrupt the convert flow with a modal, and it is recoverable through the
+saved-plans sheet's Rename entry.
+
+## Testing
+
+Unit tests for `generateDefaultPlanName`:
+
+- All four presence combinations from the output table above.
+- Zero and negative max depth suppress the depth segment.
+- `startDateTime` is preferred over the current date when present.
+- Locale-dependent date formatting produces the expected string for `en`.
+
+Widget tests for `showPlanNameDialog`:
+
+- Cancel returns `null`.
+- Confirm returns the trimmed text.
+- An all-whitespace field disables the confirm button.
+
+Widget tests for the canvas save flow:
+
+- First save on a never-persisted plan opens the dialog pre-filled with the
+  generated name.
+- Cancelling that dialog persists nothing and leaves `isDirty` true.
+- Confirming persists under the entered name.
+- A second save on the same plan does not open the dialog.
+
+Widget test for the saved-plans sheet:
+
+- The overflow menu exposes Rename, and confirming it updates the tile title.
+
+## Out of scope
+
+- Renaming from the planning page's recent-plans tiles
+  (`lib/features/planning/presentation/pages/planning_page.dart:117-134`). Those
+  are a read-only preview; the saved-plans sheet is the management surface.
+- Regenerating stored names when the diver switches unit systems.
+- Any uniqueness constraint or auto-numbering of names.

--- a/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
+++ b/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
@@ -54,6 +54,17 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
   /// preserves fields the legacy state does not carry across a save cycle.
   domain.DivePlan? _loaded;
 
+  /// Whether this plan already exists in the database.
+  ///
+  /// [_loaded] is set by [save] and [loadPlanById] and cleared by [newPlan], so
+  /// this is an accurate "has been persisted" signal. The plan canvas uses it
+  /// to prompt for a name on the first save only.
+  ///
+  /// Note that [loadPlan] deliberately does not set [_loaded] and therefore
+  /// reports `false`. That method has no production call sites today; a future
+  /// production caller must set [_loaded] as [loadPlanById] does.
+  bool get isPersisted => _loaded != null;
+
   DivePlanNotifier(
     this._calculator, {
     double reservePressure = DivePlanState.kDefaultReservePressureBar,

--- a/lib/features/planner/domain/services/plan_name_generator.dart
+++ b/lib/features/planner/domain/services/plan_name_generator.dart
@@ -1,0 +1,31 @@
+import 'package:intl/intl.dart';
+
+/// Builds the default name offered when a dive plan is saved for the first
+/// time.
+///
+/// Kept free of Flutter and Riverpod so it can be unit tested without a
+/// provider container. Unit conversion happens in the caller: [depthLabel] is
+/// already formatted in the diver's depth unit (for example `40m` or `130ft`),
+/// which means the generated name freezes that unit into the stored string.
+/// That is intentional. The name is a user-editable label, so regenerating it
+/// after a unit switch would overwrite names the diver typed deliberately.
+///
+/// [fallbackLabel] is the localized word for a plan (for example `Dive Plan`)
+/// and is used only when neither a site nor a depth is available.
+String generateDefaultPlanName({
+  String? siteName,
+  String? depthLabel,
+  required DateTime date,
+  required String fallbackLabel,
+}) {
+  final site = siteName?.trim();
+  final depth = depthLabel?.trim();
+
+  final parts = <String>[
+    if (site != null && site.isNotEmpty) site,
+    if (depth != null && depth.isNotEmpty) depth,
+  ];
+  if (parts.isEmpty) parts.add(fallbackLabel);
+
+  return '${parts.join(' ')} - ${DateFormat.MMMd().format(date)}';
+}

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -571,11 +571,15 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
       // suggested name must describe what the plan is now.
       final planState = ref.read(divePlanNotifierProvider);
       final suggestedDepth = ref.read(planOutcomeProvider).maxDepth;
+      // The lookup was keyed on the pre-await id. If the diver switched sites
+      // while it resolved, the fetched name describes a site the plan no longer
+      // uses, so drop it rather than pair it with fresh depth and date.
+      final siteName = planState.siteId == siteId ? site?.name : null;
 
       final entered = await showPlanNameDialog(
         context,
         initialName: generateDefaultPlanName(
-          siteName: site?.name,
+          siteName: siteName,
           depthLabel: suggestedDepth > 0
               ? units.formatDepth(suggestedDepth)
               : null,

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -552,12 +552,6 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
 
   Future<void> _savePlan() async {
     final notifier = ref.read(divePlanNotifierProvider.notifier);
-    final outcome = ref.read(planOutcomeProvider);
-    final summary = PlanSummaryData(
-      maxDepth: outcome.maxDepth,
-      runtimeSeconds: outcome.runtimeSeconds,
-      ttsSeconds: outcome.ttsAtBottom,
-    );
 
     // Prompt for a name the first time a plan is persisted, so the saved-plans
     // list is not a wall of identically-named rows. Re-saves stay silent, and
@@ -565,20 +559,25 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
     // grow a modal.
     if (!notifier.isPersisted) {
       final l10n = context.l10n;
-      final planState = ref.read(divePlanNotifierProvider);
       final units = UnitFormatter(ref.read(settingsProvider));
-      final siteId = planState.siteId;
+      final siteId = ref.read(divePlanNotifierProvider).siteId;
       final site = siteId == null
           ? null
           : await ref.read(siteProvider(siteId).future);
       if (!mounted) return;
 
+      // Re-read after the site lookup rather than before it. No modal is up
+      // while that read resolves, so the diver can still edit the plan and the
+      // suggested name must describe what the plan is now.
+      final planState = ref.read(divePlanNotifierProvider);
+      final suggestedDepth = ref.read(planOutcomeProvider).maxDepth;
+
       final entered = await showPlanNameDialog(
         context,
         initialName: generateDefaultPlanName(
           siteName: site?.name,
-          depthLabel: outcome.maxDepth > 0
-              ? units.formatDepth(outcome.maxDepth)
+          depthLabel: suggestedDepth > 0
+              ? units.formatDepth(suggestedDepth)
               : null,
           date: planState.startDateTime ?? DateTime.now(),
           fallbackLabel: l10n.plannerCanvas_name_defaultFallback,
@@ -591,7 +590,17 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
       notifier.updateName(entered);
     }
 
-    await notifier.save(summary: summary);
+    // Build the summary last so the denormalized depth/runtime always describe
+    // the plan actually being persisted, never whatever it looked like before
+    // the naming flow's async gaps.
+    final outcome = ref.read(planOutcomeProvider);
+    await notifier.save(
+      summary: PlanSummaryData(
+        maxDepth: outcome.maxDepth,
+        runtimeSeconds: outcome.runtimeSeconds,
+        ttsSeconds: outcome.ttsAtBottom,
+      ),
+    );
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(context.l10n.divePlanner_message_planSaved)),

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/plan_tank_list.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/segment_list.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/simple_plan_dialog.dart';
@@ -16,6 +17,7 @@ import 'package:submersion/features/planner/data/services/plan_slate_pdf_service
 import 'package:submersion/features/planner/domain/entities/dive_plan.dart'
     as domain;
 import 'package:submersion/features/planner/domain/services/dive_plan_state_mapper.dart';
+import 'package:submersion/features/planner/domain/services/plan_name_generator.dart';
 import 'package:submersion/features/planner/presentation/chart/plan_profile_chart.dart';
 import 'package:submersion/features/planner/presentation/panes/plan_editor_pane.dart';
 import 'package:submersion/features/planner/presentation/panes/plan_results_pane.dart';
@@ -549,16 +551,47 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
   }
 
   Future<void> _savePlan() async {
+    final notifier = ref.read(divePlanNotifierProvider.notifier);
     final outcome = ref.read(planOutcomeProvider);
-    await ref
-        .read(divePlanNotifierProvider.notifier)
-        .save(
-          summary: PlanSummaryData(
-            maxDepth: outcome.maxDepth,
-            runtimeSeconds: outcome.runtimeSeconds,
-            ttsSeconds: outcome.ttsAtBottom,
-          ),
-        );
+    final summary = PlanSummaryData(
+      maxDepth: outcome.maxDepth,
+      runtimeSeconds: outcome.runtimeSeconds,
+      ttsSeconds: outcome.ttsAtBottom,
+    );
+
+    // Prompt for a name the first time a plan is persisted, so the saved-plans
+    // list is not a wall of identically-named rows. Re-saves stay silent, and
+    // so does Convert to Dive: that flow is already multi-step and should not
+    // grow a modal.
+    if (!notifier.isPersisted) {
+      final l10n = context.l10n;
+      final planState = ref.read(divePlanNotifierProvider);
+      final units = UnitFormatter(ref.read(settingsProvider));
+      final siteId = planState.siteId;
+      final site = siteId == null
+          ? null
+          : await ref.read(siteProvider(siteId).future);
+      if (!mounted) return;
+
+      final entered = await showPlanNameDialog(
+        context,
+        initialName: generateDefaultPlanName(
+          siteName: site?.name,
+          depthLabel: outcome.maxDepth > 0
+              ? units.formatDepth(outcome.maxDepth)
+              : null,
+          date: planState.startDateTime ?? DateTime.now(),
+          fallbackLabel: l10n.plannerCanvas_name_defaultFallback,
+        ),
+        title: l10n.plannerCanvas_name_dialogTitle,
+      );
+      // Cancel aborts the save entirely: nothing is written and the plan stays
+      // dirty, so the diver is never surprised by a name they rejected.
+      if (entered == null) return;
+      notifier.updateName(entered);
+    }
+
+    await notifier.save(summary: summary);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(context.l10n.divePlanner_message_planSaved)),

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -25,6 +25,7 @@ import 'package:submersion/features/planner/presentation/providers/plan_reposito
 import 'package:submersion/features/planner/presentation/providers/planner_layout_providers.dart';
 import 'package:submersion/features/planner/presentation/widgets/contingency_chips.dart';
 import 'package:submersion/features/planner/presentation/widgets/follow_dive_sheet.dart';
+import 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart';
 import 'package:submersion/features/planner/presentation/widgets/plan_status_chips.dart';
 import 'package:submersion/features/planner/presentation/widgets/saved_plans_sheet.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -106,7 +107,25 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
             Flexible(
               child: InkWell(
                 onTap: () => _showRenameDialog(context),
-                child: Text(planState.name),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // The inner Flexible is what keeps a long plan name
+                    // ellipsizing once the pencil takes fixed width.
+                    Flexible(
+                      child: Text(
+                        planState.name,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.edit_outlined,
+                      size: 14,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
               ),
             ),
             const SizedBox(width: 8),
@@ -714,37 +733,14 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
     );
   }
 
-  void _showRenameDialog(BuildContext context) {
-    final controller = TextEditingController(
-      text: ref.read(divePlanNotifierProvider).name,
+  Future<void> _showRenameDialog(BuildContext context) async {
+    final notifier = ref.read(divePlanNotifierProvider.notifier);
+    final entered = await showPlanNameDialog(
+      context,
+      initialName: ref.read(divePlanNotifierProvider).name,
+      title: context.l10n.divePlanner_action_renamePlan,
     );
-    showDialog<void>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(context.l10n.divePlanner_action_renamePlan),
-        content: TextField(
-          controller: controller,
-          decoration: InputDecoration(
-            labelText: context.l10n.divePlanner_field_planName,
-          ),
-          autofocus: true,
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: Text(context.l10n.common_action_cancel),
-          ),
-          FilledButton(
-            onPressed: () {
-              ref
-                  .read(divePlanNotifierProvider.notifier)
-                  .updateName(controller.text);
-              Navigator.pop(dialogContext);
-            },
-            child: Text(context.l10n.common_action_save),
-          ),
-        ],
-      ),
-    );
+    if (entered == null) return;
+    notifier.updateName(entered);
   }
 }

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -550,7 +550,27 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
     );
   }
 
+  /// Guards [_savePlan] against re-entry.
+  ///
+  /// The save button stays enabled across the naming flow's async gaps - the
+  /// site lookup and the write itself both run with no modal up and isDirty
+  /// still true - so a second tap could start a concurrent save. Worse than
+  /// stacked dialogs: [DivePlanNotifier.save] only sets its loaded plan after
+  /// the write completes, so a concurrent call still reads isPersisted as false
+  /// and prompts for a name on a plan that is already being saved.
+  bool _saveInFlight = false;
+
   Future<void> _savePlan() async {
+    if (_saveInFlight) return;
+    _saveInFlight = true;
+    try {
+      await _runSavePlan();
+    } finally {
+      _saveInFlight = false;
+    }
+  }
+
+  Future<void> _runSavePlan() async {
     final notifier = ref.read(divePlanNotifierProvider.notifier);
 
     // Prompt for a name the first time a plan is persisted, so the saved-plans

--- a/lib/features/planner/presentation/widgets/plan_name_dialog.dart
+++ b/lib/features/planner/presentation/widgets/plan_name_dialog.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Prompt for a dive plan name, seeded with [initialName].
+///
+/// Resolves to the trimmed entered name, or `null` when the diver cancels or
+/// dismisses the dialog. Confirm stays disabled while the trimmed field is
+/// empty, so an empty name can never be returned.
+Future<String?> showPlanNameDialog(
+  BuildContext context, {
+  required String initialName,
+  required String title,
+}) {
+  return showDialog<String>(
+    context: context,
+    builder: (_) => _PlanNameDialog(initialName: initialName, title: title),
+  );
+}
+
+class _PlanNameDialog extends StatefulWidget {
+  const _PlanNameDialog({required this.initialName, required this.title});
+
+  final String initialName;
+  final String title;
+
+  @override
+  State<_PlanNameDialog> createState() => _PlanNameDialogState();
+}
+
+class _PlanNameDialogState extends State<_PlanNameDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialName);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title),
+      content: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+          labelText: context.l10n.divePlanner_field_planName,
+        ),
+        autofocus: true,
+        textCapitalization: TextCapitalization.sentences,
+        onChanged: (_) => setState(() {}),
+        onSubmitted: (_) => _confirm(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(context.l10n.common_action_cancel),
+        ),
+        FilledButton(
+          onPressed: _controller.text.trim().isEmpty ? null : _confirm,
+          child: Text(context.l10n.common_action_save),
+        ),
+      ],
+    );
+  }
+
+  void _confirm() {
+    final name = _controller.text.trim();
+    if (name.isEmpty) return;
+    Navigator.of(context).pop(name);
+  }
+}

--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/planner/data/services/plan_file_codec.dart';
 import 'package:submersion/features/planner/domain/entities/dive_plan.dart';
 import 'package:submersion/features/planner/presentation/providers/plan_repository_providers.dart';
+import 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -251,7 +252,20 @@ class _PlanTile extends ConsumerWidget {
           PopupMenuButton<String>(
             onSelected: (value) async {
               final repository = ref.read(divePlanRepositoryProvider);
-              if (value == 'duplicate') {
+              if (value == 'rename') {
+                final plan = await repository.getPlan(summary.id);
+                if (plan == null || !context.mounted) return;
+                final entered = await showPlanNameDialog(
+                  context,
+                  initialName: plan.name,
+                  title: context.l10n.divePlanner_action_renamePlan,
+                );
+                if (entered == null) return;
+                // No summary is passed, so the denormalized depth/runtime
+                // columns stay absent in the companion and the upsert
+                // preserves them along with the tile's subtitle.
+                await repository.savePlan(plan.copyWith(name: entered));
+              } else if (value == 'duplicate') {
                 await repository.duplicatePlan(summary.id);
               } else if (value == 'share') {
                 final plan = await repository.getPlan(summary.id);
@@ -268,6 +282,10 @@ class _PlanTile extends ConsumerWidget {
               }
             },
             itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'rename',
+                child: Text(context.l10n.divePlanner_action_renamePlan),
+              ),
               PopupMenuItem(
                 value: 'duplicate',
                 child: Text(context.l10n.plannerCanvas_saved_duplicate),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -3890,6 +3890,8 @@
   "plannerCanvas_saved_duplicate": "تكرار",
   "plannerCanvas_saved_empty": "لا توجد خطط محفوظة بعد",
   "plannerCanvas_saved_title": "الخطط المحفوظة",
+  "plannerCanvas_name_dialogTitle": "سمِّ خطتك",
+  "plannerCanvas_name_defaultFallback": "خطة غوص",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "استيراد",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -3890,6 +3890,8 @@
   "plannerCanvas_saved_duplicate": "Duplizieren",
   "plannerCanvas_saved_empty": "Noch keine gespeicherten Pläne",
   "plannerCanvas_saved_title": "Gespeicherte Pläne",
+  "plannerCanvas_name_dialogTitle": "Plan benennen",
+  "plannerCanvas_name_defaultFallback": "Tauchplan",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importieren",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7113,6 +7113,8 @@
   "plannerCanvas_saved_duplicate": "Duplicate",
   "plannerCanvas_saved_empty": "No saved plans yet",
   "plannerCanvas_saved_title": "Saved plans",
+  "plannerCanvas_name_dialogTitle": "Name your plan",
+  "plannerCanvas_name_defaultFallback": "Dive Plan",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "@plannerCanvas_scrub_bailout": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -3890,6 +3890,8 @@
   "plannerCanvas_saved_duplicate": "Duplicar",
   "plannerCanvas_saved_empty": "Aún no hay planes guardados",
   "plannerCanvas_saved_title": "Planes guardados",
+  "plannerCanvas_name_dialogTitle": "Nombra tu plan",
+  "plannerCanvas_name_defaultFallback": "Plan de buceo",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importar",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -3820,6 +3820,8 @@
   "plannerCanvas_saved_duplicate": "Dupliquer",
   "plannerCanvas_saved_empty": "Aucun plan enregistré",
   "plannerCanvas_saved_title": "Plans enregistrés",
+  "plannerCanvas_name_dialogTitle": "Nommez votre plan",
+  "plannerCanvas_name_defaultFallback": "Plan de plongée",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importer",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -3820,6 +3820,8 @@
   "plannerCanvas_saved_duplicate": "שכפול",
   "plannerCanvas_saved_empty": "אין עדיין תוכניות שמורות",
   "plannerCanvas_saved_title": "תוכניות שמורות",
+  "plannerCanvas_name_dialogTitle": "תן שם לתוכנית",
+  "plannerCanvas_name_defaultFallback": "תוכנית צלילה",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "ייבוא",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -3820,6 +3820,8 @@
   "plannerCanvas_saved_duplicate": "Duplikálás",
   "plannerCanvas_saved_empty": "Még nincsenek mentett tervek",
   "plannerCanvas_saved_title": "Mentett tervek",
+  "plannerCanvas_name_dialogTitle": "Nevezze el a tervet",
+  "plannerCanvas_name_defaultFallback": "Merülési terv",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importálás",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -3820,6 +3820,8 @@
   "plannerCanvas_saved_duplicate": "Duplica",
   "plannerCanvas_saved_empty": "Nessun piano salvato",
   "plannerCanvas_saved_title": "Piani salvati",
+  "plannerCanvas_name_dialogTitle": "Dai un nome al piano",
+  "plannerCanvas_name_defaultFallback": "Piano di immersione",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importa",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -20960,6 +20960,18 @@ abstract class AppLocalizations {
   /// **'Saved plans'**
   String get plannerCanvas_saved_title;
 
+  /// No description provided for @plannerCanvas_name_dialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Name your plan'**
+  String get plannerCanvas_name_dialogTitle;
+
+  /// No description provided for @plannerCanvas_name_defaultFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Dive Plan'**
+  String get plannerCanvas_name_defaultFallback;
+
   /// No description provided for @plannerCanvas_scrub_bailout.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -12119,6 +12119,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get plannerCanvas_saved_title => 'الخطط المحفوظة';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'سمِّ خطتك';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'خطة غوص';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -12335,6 +12335,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Gespeicherte Pläne';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Plan benennen';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Tauchplan';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -12142,6 +12142,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Saved plans';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Name your plan';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Dive Plan';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -12332,6 +12332,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Planes guardados';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Nombra tu plan';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Plan de buceo';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -12382,6 +12382,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Plans enregistrés';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Nommez votre plan';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Plan de plongée';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -12038,6 +12038,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get plannerCanvas_saved_title => 'תוכניות שמורות';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'תן שם לתוכנית';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'תוכנית צלילה';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -12305,6 +12305,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Mentett tervek';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Nevezze el a tervet';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Merülési terv';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -12342,6 +12342,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Piani salvati';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Dai un nome al piano';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Piano di immersione';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -12246,6 +12246,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Opgeslagen plannen';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Geef je plan een naam';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Duikplan';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -12347,6 +12347,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get plannerCanvas_saved_title => 'Planos salvos';
 
   @override
+  String get plannerCanvas_name_dialogTitle => 'Dê um nome ao seu plano';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => 'Plano de mergulho';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -11780,6 +11780,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get plannerCanvas_saved_title => '已保存的计划';
 
   @override
+  String get plannerCanvas_name_dialogTitle => '为计划命名';
+
+  @override
+  String get plannerCanvas_name_defaultFallback => '潜水计划';
+
+  @override
   String plannerCanvas_scrub_bailout(String minutes) {
     return 'BO $minutes′';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -3890,6 +3890,8 @@
   "plannerCanvas_saved_duplicate": "Dupliceren",
   "plannerCanvas_saved_empty": "Nog geen opgeslagen plannen",
   "plannerCanvas_saved_title": "Opgeslagen plannen",
+  "plannerCanvas_name_dialogTitle": "Geef je plan een naam",
+  "plannerCanvas_name_defaultFallback": "Duikplan",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importeren",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -3890,6 +3890,8 @@
   "plannerCanvas_saved_duplicate": "Duplicar",
   "plannerCanvas_saved_empty": "Ainda não há planos salvos",
   "plannerCanvas_saved_title": "Planos salvos",
+  "plannerCanvas_name_dialogTitle": "Dê um nome ao seu plano",
+  "plannerCanvas_name_defaultFallback": "Plano de mergulho",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "Importar",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4041,6 +4041,8 @@
   "plannerCanvas_saved_duplicate": "复制",
   "plannerCanvas_saved_empty": "尚无已保存的计划",
   "plannerCanvas_saved_title": "已保存的计划",
+  "plannerCanvas_name_dialogTitle": "为计划命名",
+  "plannerCanvas_name_defaultFallback": "潜水计划",
   "plannerCanvas_scrub_bailout": "BO {minutes}′",
   "plannerCanvas_scrub_readout": "RT {minutes}′ · {depth}",
   "plannerCanvas_share_import": "导入",

--- a/test/features/planner/plan_canvas_first_save_test.dart
+++ b/test/features/planner/plan_canvas_first_save_test.dart
@@ -114,6 +114,28 @@ void main() {
     expect(summaries.single.name, 'Zenobia');
   });
 
+  testWidgets('the stored summary reflects edits made during the naming flow', (
+    tester,
+  ) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    // Deepen the plan while the naming flow is still in flight. The dialog
+    // blocks the diver, but the site lookup that precedes it does not, so the
+    // summary must describe the plan as it is when save() actually runs.
+    notifierOf(tester).addSimplePlan(maxDepth: 45, bottomTimeMinutes: 10);
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries.single.maxDepth, 45);
+  });
+
   testWidgets('a second save does not re-open the dialog', (tester) async {
     await setSize(tester, const Size(420, 900));
     await tester.pumpWidget(harness());

--- a/test/features/planner/plan_canvas_first_save_test.dart
+++ b/test/features/planner/plan_canvas_first_save_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
+import 'package:submersion/features/planner/data/repositories/dive_plan_repository.dart';
+import 'package:submersion/features/planner/domain/entities/dive_plan.dart';
+import 'package:submersion/features/planner/presentation/pages/plan_canvas_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../helpers/test_app.dart';
+import '../../helpers/test_database.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late DivePlanRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DivePlanRepository();
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+  });
+
+  Widget harness() => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    locale: const Locale('en'),
+    child: const PlanCanvasPage(),
+  );
+
+  Future<void> setSize(WidgetTester tester, Size size) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  ProviderContainer containerOf(WidgetTester tester) =>
+      ProviderScope.containerOf(tester.element(find.byType(PlanCanvasPage)));
+
+  DivePlanNotifier notifierOf(WidgetTester tester) =>
+      containerOf(tester).read(divePlanNotifierProvider.notifier);
+
+  // The save IconButton renders Icons.save while the plan is dirty and
+  // Icons.save_outlined (disabled) once it is clean, so a tap must always
+  // target Icons.save.
+  Future<void> tapSave(WidgetTester tester) async {
+    await tester.tap(find.byIcon(Icons.save));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> seedAndSave(WidgetTester tester) async {
+    notifierOf(tester).addSimplePlan(maxDepth: 30, bottomTimeMinutes: 20);
+    await tester.pumpAndSettle();
+    await tapSave(tester);
+  }
+
+  testWidgets('first save opens the name dialog with a generated default', (
+    tester,
+  ) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    expect(find.text('Name your plan'), findsOneWidget);
+    // No site is set on a bare plan, so the name is depth plus date.
+    expect(find.textContaining('30.0m - '), findsOneWidget);
+  });
+
+  testWidgets('cancelling the first save persists nothing', (tester) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(await repository.getAllPlanSummaries(), isEmpty);
+    // Read the state through the container: StateNotifier.state is @protected,
+    // and reading it directly is an analyzer error that CI treats as fatal.
+    expect(containerOf(tester).read(divePlanNotifierProvider).isDirty, isTrue);
+  });
+
+  testWidgets('confirming the first save persists under the entered name', (
+    tester,
+  ) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries, hasLength(1));
+    expect(summaries.single.name, 'Zenobia');
+  });
+
+  testWidgets('a second save does not re-open the dialog', (tester) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(harness());
+    await seedAndSave(tester);
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    // A successful save clears isDirty, which disables the save button. Dirty
+    // the plan again so there is something to re-save.
+    notifierOf(tester).updateMode(PlanMode.ccr);
+    await tester.pumpAndSettle();
+    await tapSave(tester);
+
+    expect(find.text('Name your plan'), findsNothing);
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries, hasLength(1));
+    expect(summaries.single.name, 'Zenobia');
+  });
+}

--- a/test/features/planner/plan_canvas_first_save_test.dart
+++ b/test/features/planner/plan_canvas_first_save_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/map_style.dart';
@@ -169,6 +171,42 @@ void main() {
     // not be paired with the plan's current depth and date.
     expect(find.textContaining('Blue Hole'), findsNothing);
     expect(find.textContaining('30.0m - '), findsOneWidget);
+  });
+
+  testWidgets('a second tap during the site lookup does not stack dialogs', (
+    tester,
+  ) async {
+    // Hold the site lookup open so both taps land inside the async gap. The
+    // save button stays enabled there because isDirty is still true and no
+    // modal is up yet.
+    final gate = Completer<void>();
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          siteProvider.overrideWith((ref, id) async {
+            await gate.future;
+            return const DiveSite(id: 'blue-hole', name: 'Blue Hole');
+          }),
+        ],
+        locale: const Locale('en'),
+        child: const PlanCanvasPage(),
+      ),
+    );
+    notifierOf(tester).addSimplePlan(maxDepth: 30, bottomTimeMinutes: 20);
+    notifierOf(tester).updateSite('blue-hole');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.save));
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.save));
+    await tester.pump();
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Name your plan'), findsOneWidget);
   });
 
   testWidgets('a second save does not re-open the dialog', (tester) async {

--- a/test/features/planner/plan_canvas_first_save_test.dart
+++ b/test/features/planner/plan_canvas_first_save_test.dart
@@ -4,6 +4,8 @@ import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/planner/data/repositories/dive_plan_repository.dart';
 import 'package:submersion/features/planner/domain/entities/dive_plan.dart';
 import 'package:submersion/features/planner/presentation/pages/plan_canvas_page.dart';
@@ -134,6 +136,39 @@ void main() {
 
     final summaries = await repository.getAllPlanSummaries();
     expect(summaries.single.maxDepth, 45);
+  });
+
+  testWidgets('a site change during the lookup drops the stale site name', (
+    tester,
+  ) async {
+    await setSize(tester, const Size(420, 900));
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          // Switch the plan to a different site while the lookup for the
+          // original one is still in flight. No modal is up during that await,
+          // so this is something the diver can really do.
+          siteProvider.overrideWith((ref, id) async {
+            await Future<void>.delayed(Duration.zero);
+            ref.read(divePlanNotifierProvider.notifier).updateSite('elsewhere');
+            return const DiveSite(id: 'blue-hole', name: 'Blue Hole');
+          }),
+        ],
+        locale: const Locale('en'),
+        child: const PlanCanvasPage(),
+      ),
+    );
+    notifierOf(tester).addSimplePlan(maxDepth: 30, bottomTimeMinutes: 20);
+    notifierOf(tester).updateSite('blue-hole');
+    await tester.pumpAndSettle();
+    await tapSave(tester);
+
+    expect(find.text('Name your plan'), findsOneWidget);
+    // The fetched name describes a site the plan no longer uses, so it must
+    // not be paired with the plan's current depth and date.
+    expect(find.textContaining('Blue Hole'), findsNothing);
+    expect(find.textContaining('30.0m - '), findsOneWidget);
   });
 
   testWidgets('a second save does not re-open the dialog', (tester) async {

--- a/test/features/planner/plan_canvas_page_test.dart
+++ b/test/features/planner/plan_canvas_page_test.dart
@@ -160,6 +160,12 @@ void main() {
     await tester.tap(find.byIcon(Icons.save));
     await tester.pumpAndSettle();
 
+    // The first save of a never-persisted plan is gated on the name dialog.
+    // Confirming it lets the save through; see plan_canvas_first_save_test.dart
+    // for the gate's own coverage.
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
     expect(container.read(divePlanNotifierProvider).isDirty, isFalse);
   });
 

--- a/test/features/planner/plan_name_dialog_test.dart
+++ b/test/features/planner/plan_name_dialog_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/planner/presentation/widgets/plan_name_dialog.dart';
+
+import '../../helpers/test_app.dart';
+
+void main() {
+  // Opens the dialog from a button and records what it returned.
+  Future<void> openDialog(
+    WidgetTester tester,
+    String initialName,
+    void Function(String?) onResult,
+  ) async {
+    await tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        child: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () async {
+                final result = await showPlanNameDialog(
+                  context,
+                  initialName: initialName,
+                  title: 'Name your plan',
+                );
+                onResult(result);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('pre-fills the field with the initial name', (tester) async {
+    await openDialog(tester, 'Blue Hole 40m - Jul 25', (_) {});
+
+    expect(find.text('Name your plan'), findsOneWidget);
+    expect(find.text('Blue Hole 40m - Jul 25'), findsOneWidget);
+  });
+
+  testWidgets('cancel returns null', (tester) async {
+    String? result;
+    var called = false;
+    await openDialog(tester, 'Blue Hole', (value) {
+      result = value;
+      called = true;
+    });
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(called, isTrue);
+    expect(result, isNull);
+  });
+
+  testWidgets('confirm returns the trimmed text', (tester) async {
+    String? result;
+    await openDialog(tester, 'Blue Hole', (value) => result = value);
+
+    await tester.enterText(find.byType(TextField), '  Wreck of the Zenobia  ');
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(result, 'Wreck of the Zenobia');
+  });
+
+  testWidgets('an all-whitespace field disables confirm', (tester) async {
+    await openDialog(tester, 'Blue Hole', (_) {});
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+
+    final confirm = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Save'),
+    );
+    expect(confirm.onPressed, isNull);
+  });
+
+  testWidgets('confirm is enabled again once text is restored', (tester) async {
+    await openDialog(tester, 'Blue Hole', (_) {});
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+
+    final confirm = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Save'),
+    );
+    expect(confirm.onPressed, isNotNull);
+  });
+}

--- a/test/features/planner/plan_name_generator_test.dart
+++ b/test/features/planner/plan_name_generator_test.dart
@@ -19,8 +19,10 @@ void main() {
     // this is a pure unit test, so it has to ask.
     late String? previousLocale;
 
-    setUp(() async {
-      await initializeDateFormatting('en');
+    // Symbol data does not depend on per-test state, so load it once.
+    setUpAll(() => initializeDateFormatting('en'));
+
+    setUp(() {
       previousLocale = Intl.defaultLocale;
       Intl.defaultLocale = 'en';
     });

--- a/test/features/planner/plan_name_generator_test.dart
+++ b/test/features/planner/plan_name_generator_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/planner/domain/services/plan_name_generator.dart';
+
+void main() {
+  final date = DateTime(2026, 7, 25);
+
+  group('generateDefaultPlanName', () {
+    test('combines site, depth, and date', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: 'Blue Hole',
+          depthLabel: '40m',
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Blue Hole 40m - Jul 25',
+      );
+    });
+
+    test('omits the depth when no depth label is supplied', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: 'Blue Hole',
+          depthLabel: null,
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Blue Hole - Jul 25',
+      );
+    });
+
+    test('omits the site when no site name is supplied', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: null,
+          depthLabel: '40m',
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        '40m - Jul 25',
+      );
+    });
+
+    test('falls back to the supplied label when site and depth are absent', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: null,
+          depthLabel: null,
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Dive Plan - Jul 25',
+      );
+    });
+
+    test('treats a blank site name as absent', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: '   ',
+          depthLabel: null,
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Dive Plan - Jul 25',
+      );
+    });
+
+    test('trims surrounding whitespace on the site name', () {
+      expect(
+        generateDefaultPlanName(
+          siteName: '  Blue Hole  ',
+          depthLabel: '40m',
+          date: date,
+          fallbackLabel: 'Dive Plan',
+        ),
+        'Blue Hole 40m - Jul 25',
+      );
+    });
+  });
+}

--- a/test/features/planner/plan_name_generator_test.dart
+++ b/test/features/planner/plan_name_generator_test.dart
@@ -1,10 +1,32 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/features/planner/domain/services/plan_name_generator.dart';
 
 void main() {
   final date = DateTime(2026, 7, 25);
 
   group('generateDefaultPlanName', () {
+    // The generator dates the name with DateFormat.MMMd(), which resolves
+    // against Intl.defaultLocale - a process global that app.dart sets from
+    // the app locale. Pin it so the "Jul 25" assertions state their real
+    // dependency instead of riding on intl's implicit en_US fallback, and
+    // restore it so the global stays contained.
+    //
+    // Setting the global explicitly means intl stops using its built-in
+    // fallback and demands real symbol data, so the locale must be initialized
+    // first. Widget tests get that for free from GlobalMaterialLocalizations;
+    // this is a pure unit test, so it has to ask.
+    late String? previousLocale;
+
+    setUp(() async {
+      await initializeDateFormatting('en');
+      previousLocale = Intl.defaultLocale;
+      Intl.defaultLocale = 'en';
+    });
+
+    tearDown(() => Intl.defaultLocale = previousLocale);
+
     test('combines site, depth, and date', () {
       expect(
         generateDefaultPlanName(

--- a/test/features/planner/saved_plans_sheet_test.dart
+++ b/test/features/planner/saved_plans_sheet_test.dart
@@ -54,6 +54,7 @@ void main() {
     overrides: [
       settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
     ],
+    locale: const Locale('en'),
     child: const SavedPlansSheet(),
   );
 
@@ -283,5 +284,27 @@ void main() {
     // The FormatException is caught and surfaced, not thrown out of the sheet.
     expect(find.byType(SnackBar), findsOneWidget);
     expect(await repository.getAllPlanSummaries(), isEmpty);
+  });
+
+  testWidgets('rename from the overflow menu updates the plan name', (
+    tester,
+  ) async {
+    await repository.savePlan(_plan('p1', 'New Dive Plan'));
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename Plan'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'Zenobia');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    final summaries = await repository.getAllPlanSummaries();
+    expect(summaries.single.name, 'Zenobia');
+    expect(find.text('Zenobia'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Problem

Saving a dive plan was silent, so every new plan kept the hardcoded, non-localized default `New Dive Plan`. A diver who saved three plans got three identical rows in the saved-plans sheet, separable only by the date/depth subtitle. Renaming was possible but undiscoverable: the canvas AppBar title was a bare `InkWell` with no affordance suggesting it could be tapped.

## What changed

**Prompt on first save.** The first time a never-persisted plan is saved, a dialog asks for a name, pre-filled with a generated default. Cancel aborts the save entirely, so nothing is written and the plan stays dirty. Re-saves stay silent.

**Generated default name.** `Blue Hole 40m - Jul 25`, composed from the plan's site, its unit-formatted max depth, and its start date. Absent parts drop out (`Blue Hole - Jul 25`, `40m - Jul 25`), and when neither a site nor a depth is available it falls back to `Dive Plan - Jul 25`. An empty plan never produces `0m`.

**Discoverable rename.** The canvas title gains a small pencil icon, and the saved-plans overflow menu gains a Rename entry alongside Duplicate and Share.

Also fixes a real leak: the old inline rename dialog created a `TextEditingController` inside its builder closure and never disposed it. The extracted `_PlanNameDialog` is a `StatefulWidget` that disposes it properly.

## Scope

Presentation layer only. `dive_plans.name` already existed as a non-null column carrying an `hlc` and was already registered in the sync table map, so a rename propagates through the existing last-writer-wins path. **No migration, no schema-version bump, no sync change** — verified by `git diff main --stat -- lib/core/database/` returning empty.

## Design decisions

| Decision | Choice |
| --- | --- |
| When to prompt | First save only |
| Cancel semantics | Aborts the save; the dialog is a gate, not a courtesy |
| Other save paths | Convert-to-Dive, import, duplicate, and undo-restore stay unprompted |
| Name collisions | Allowed; names are labels, not identifiers, and uniqueness is unenforceable across synced devices |

The generated name embeds a unit-formatted depth, which freezes that unit into the stored string. That is deliberate: the name is a user-editable label, and regenerating it after a unit switch would overwrite names the diver typed.

One accepted consequence of not gating Convert-to-Dive: converting a never-persisted plan still writes a row named `New Dive Plan`. That is recoverable through the new Rename entry.

## Testing

- 6 unit tests for `generateDefaultPlanName` covering all four presence combinations, blank-site handling, and whitespace trimming
- 5 widget tests for the dialog: pre-fill, cancel-returns-null, trimmed confirm, whitespace-disables-confirm, and re-enable
- 4 widget tests for the first-save gate: dialog opens with the generated default, cancel persists nothing and leaves the plan dirty, confirm persists under the entered name, and a second save does not re-prompt
- 1 widget test for rename from the overflow menu
- One pre-existing test (`save action clears the dirty flag`) was updated to confirm the dialog, since the first-save contract deliberately changed

Full suite: 14,051 passing, 14 skipped. `flutter analyze` clean, `dart format .` clean.

## Localization

Two new keys (`plannerCanvas_name_dialogTitle`, `plannerCanvas_name_defaultFallback`) added to `app_en.arb` and all ten non-English locales, then regenerated.

## Docs

Design spec and implementation plan are committed under `docs/superpowers/`.
