### PR TITLE
Add missing default settings for DiverDetails

### DIFF
--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5208,7 +5208,7 @@ class SyncDataSerializer {
       'showDetailsPaneEquipment': false,
       'showDetailsPaneDiveCenters': false,
       'showDetailsPaneCertifications': false,
-      'showDetailsPaneCourses': false
+      'showDetailsPaneCourses': false,
       // Override with actual data (existing values take precedence)
       ...data,
     };

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5207,6 +5207,8 @@ class SyncDataSerializer {
       'showDetailsPaneTrips': false,
       'showDetailsPaneEquipment': false,
       'showDetailsPaneDiveCenters': false,
+      'showDetailsPaneCertifications': false,
+      'showDetailsPaneCourses': false
       // Override with actual data (existing values take precedence)
       ...data,
     };

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5106,6 +5106,8 @@ class SyncDataSerializer {
       // Theme
       'themeMode': 'system',
       'themePreset': 'submersion',
+      // Locale (language preference: 'system', 'en', 'es', 'fr', etc.)
+      'locale': 'system',
       // Defaults
       'defaultDiveType': 'recreational',
       'defaultTankVolume': 12.0,
@@ -5126,17 +5128,57 @@ class SyncDataSerializer {
       'lastStopDepth': 3.0,
       'decoStopIncrement': 3.0,
       'ascentGasSet': 0,
+      'o2Narcotic': true,
+      'endLimit': 30.0,
+      'useDiveComputerCnsData': false,
+      'defaultNdlSource': 1,
+      'defaultCeilingSource': 1,
+      'defaultTtsSource': 1,
+      'defaultCnsSource': 1,
       // Appearance settings
       'showDepthColoredDiveCards': false,
       'cardColorAttribute': 'none',
       'cardColorGradientPreset': 'ocean',
       'cardColorGradientStart': null,
       'cardColorGradientEnd': null,
+      // Tissue visualization settings
+      'tissueColorScheme': 'classic',
+      'tissueVizMode': 'heatMap',
       'showMapBackgroundOnDiveCards': false,
       'showMapBackgroundOnSiteCards': false,
       // Dive profile markers
       'showMaxDepthMarker': true,
       'showPressureThresholdMarkers': false,
+      // List view modes
+      'diveListViewMode': 'detailed',
+      'siteListViewMode': 'detailed',
+      'tripListViewMode': 'detailed',
+      'equipmentListViewMode': 'detailed',
+      'buddyListViewMode': 'detailed',
+      'diveCenterListViewMode': 'detailed',
+      // Map style
+      'mapStyle': 'openStreetMap',
+      // Auto site matching sensitivity
+      'siteMatchSensitivity': 'balanced',
+      // Dive profile chart defaults
+      'defaultRightAxisMetric': 'temperature',
+      'defaultShowTemperature': true,
+      'defaultShowPressure': true,
+      'defaultShowHeartRate': false,
+      'defaultShowSac': false,
+      'defaultShowEvents': true,
+      'defaultShowPpO2': false,
+      'defaultShowPpN2': false,
+      'defaultShowPpHe': false,
+      'defaultShowGasDensity': false,
+      'defaultShowGf': false,
+      'defaultShowSurfaceGf': false,
+      'defaultShowMeanDepth': false,
+      'defaultShowTts': false,
+      'defaultShowCns': false,
+      'defaultShowOtu': false,
+      'defaultShowGasSwitchMarkers': true,
+      'defaultShowGasTimeline': false,
       // Dive profile default-visible metrics. Non-nullable bool added in v91;
       // seed it so payloads predating the column hydrate instead of throwing in
       // DiverSetting.fromJson.
@@ -5150,6 +5192,21 @@ class SyncDataSerializer {
       // columns hydrate instead of throwing in DiverSetting.fromJson.
       'showDecoStopsOnProfile': true,
       'defaultDecoStopSource': 1,
+      // additional non-nullable
+      'safetyReviewEnabled': true,
+      'noFlyPreset': 'standard',
+      'notificationsEnabled': true,
+      'serviceReminderDays': '[7, 14, 30]',
+      'reminderTime': '09:00',
+      'tripServiceLeadDays': 14,
+      'showDataSourceBadges': true,
+      'showProfilePanelInTableView': true,
+      'showDetailsPaneDives': false,
+      'showDetailsPaneSites': false,
+      'showDetailsPaneBuddies': false,
+      'showDetailsPaneTrips': false,
+      'showDetailsPaneEquipment': false,
+      'showDetailsPaneDiveCenters': false,
       // Override with actual data (existing values take precedence)
       ...data,
     };


### PR DESCRIPTION
When syncing a new device with a backup from dropbox I was getting null errors on the DiverDetails upsert.  After adding a few the list just kept getting longer so I just did a mass search for all non-nullable values that were not getting set with a default value. 

## Summary

Adds default values for all non-nullable columns for diver details 
## Changes

- Introduced defaults for locale, appearance, tissue visualization, list view modes, map style, dive profile chart metrics, and additional non-nullable fields.
-

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [ ] Manual testing on: <!-- list platforms tested -->

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->
