### PR TITLE
fix(media): repair photo attachment on Windows and Linux

### DIFF
--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -705,6 +705,34 @@ class MediaRepository {
     }
   }
 
+  /// Get the set of local file paths already linked to a specific dive.
+  ///
+  /// The desktop counterpart to [getLinkedAssetIdsForDive]: Windows / Linux
+  /// imports are `localFile` rows with a null `platform_asset_id`, so the
+  /// asset-id query cannot see them and duplicate detection has to key on the
+  /// path instead. The path is also the more stable key -- the desktop
+  /// picker's synthetic asset id embeds the file's mtime, so it changes
+  /// whenever the file is touched.
+  Future<Set<String>> getLinkedLocalPathsForDive(String diveId) async {
+    try {
+      final result = await _db
+          .customSelect(
+            'SELECT local_path FROM media '
+            'WHERE dive_id = ? AND local_path IS NOT NULL',
+            variables: [Variable.withString(diveId)],
+          )
+          .get();
+      return result.map((row) => row.data['local_path'] as String).toSet();
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get linked local paths for dive: $diveId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Get GPS coordinates from media attached to a dive.
   ///
   /// Returns a list of (latitude, longitude, takenAt) tuples from photos

--- a/lib/features/media/data/services/media_import_service.dart
+++ b/lib/features/media/data/services/media_import_service.dart
@@ -112,21 +112,29 @@ class MediaImportService {
       'Starting import of ${selectedAssets.length} assets for dive ${dive.id}',
     );
 
-    // Fetch already-linked asset IDs for this dive
-    final existingAssetIds = await _mediaRepository.getLinkedAssetIdsForDive(
-      dive.id,
-    );
-    // Desktop picks are persisted as localFile rows with a null
-    // platform_asset_id (see [_createMediaItemFromAsset]), so the asset-id set
-    // above cannot see them; dedupe those on the path instead.
-    final existingPaths = await _mediaRepository.getLinkedLocalPathsForDive(
-      dive.id,
-    );
+    // Two dedupe keys, one per origin. Gallery picks are matched on their
+    // platform asset id; desktop picks are localFile rows with a null
+    // platform_asset_id (see [_createMediaItemFromAsset]), invisible to that
+    // query, so they are matched on the path instead.
+    //
+    // Each lookup only feeds one branch of the filter below, so query a
+    // lookup only when the selection actually contains that kind of asset:
+    // a mobile pick has no paths to compare and a desktop pick has no
+    // gallery ids, and either way the unused set would be dead work.
+    bool hasPath(AssetInfo a) => a.filePath != null && a.filePath!.isNotEmpty;
+    final anyPaths = selectedAssets.any(hasPath);
+    final anyGallery = selectedAssets.any((a) => !hasPath(a));
+
+    final existingAssetIds = anyGallery
+        ? await _mediaRepository.getLinkedAssetIdsForDive(dive.id)
+        : const <String>{};
+    final existingPaths = anyPaths
+        ? await _mediaRepository.getLinkedLocalPathsForDive(dive.id)
+        : const <String>{};
 
     // Filter out duplicates before processing
     final newAssets = selectedAssets.where((a) {
-      final path = a.filePath;
-      if (path != null && path.isNotEmpty) return !existingPaths.contains(path);
+      if (hasPath(a)) return !existingPaths.contains(a.filePath);
       return !existingAssetIds.contains(a.id);
     }).toList();
     final skippedCount = selectedAssets.length - newAssets.length;

--- a/lib/features/media/data/services/media_import_service.dart
+++ b/lib/features/media/data/services/media_import_service.dart
@@ -116,11 +116,19 @@ class MediaImportService {
     final existingAssetIds = await _mediaRepository.getLinkedAssetIdsForDive(
       dive.id,
     );
+    // Desktop picks are persisted as localFile rows with a null
+    // platform_asset_id (see [_createMediaItemFromAsset]), so the asset-id set
+    // above cannot see them; dedupe those on the path instead.
+    final existingPaths = await _mediaRepository.getLinkedLocalPathsForDive(
+      dive.id,
+    );
 
     // Filter out duplicates before processing
-    final newAssets = selectedAssets
-        .where((a) => !existingAssetIds.contains(a.id))
-        .toList();
+    final newAssets = selectedAssets.where((a) {
+      final path = a.filePath;
+      if (path != null && path.isNotEmpty) return !existingPaths.contains(path);
+      return !existingAssetIds.contains(a.id);
+    }).toList();
     final skippedCount = selectedAssets.length - newAssets.length;
 
     if (skippedCount > 0) {
@@ -189,7 +197,14 @@ class MediaImportService {
     return MediaItem(
       id: '',
       diveId: diveId,
-      platformAssetId: asset.id,
+      // Deliberately null for a localFile row. The desktop picker's asset id
+      // is a synthetic in-memory key, and several features gate purely on
+      // `platformAssetId != null` -- MediaItem.isGalleryPhoto,
+      // PhotoViewerPage's write-metadata action, resolvedFilePathProvider's
+      // gallery fast path -- so carrying it would route a Windows file
+      // through photo_manager, which has no backend there. Duplicate
+      // detection for these rows keys on localPath instead.
+      platformAssetId: isLocalFile ? null : asset.id,
       originalFilename: asset.filename,
       mediaType: asset.isVideo ? MediaType.video : MediaType.photo,
       sourceType: isLocalFile

--- a/lib/features/media/data/services/media_import_service.dart
+++ b/lib/features/media/data/services/media_import_service.dart
@@ -174,12 +174,28 @@ class MediaImportService {
   MediaItem _createMediaItemFromAsset(AssetInfo asset, String diveId) {
     final now = DateTime.now();
 
+    // Windows / Linux have no platform photo library: the picker opens a file
+    // dialog and the asset's id is a synthetic key into an in-memory map on
+    // the picker service. Persisting such a row with the default
+    // platformGallery sourceType left every path column blank and sent
+    // display through PlatformGalleryResolver -> photo_manager, which has no
+    // desktop-Windows backend, so the photo rendered "File not found" and the
+    // pointer died with the process. When the picker hands us a real path,
+    // store a localFile row instead: LocalFileResolver reads localPath
+    // straight off disk on every desktop platform and survives a restart.
+    final path = asset.filePath;
+    final isLocalFile = path != null && path.isNotEmpty;
+
     return MediaItem(
       id: '',
       diveId: diveId,
       platformAssetId: asset.id,
       originalFilename: asset.filename,
       mediaType: asset.isVideo ? MediaType.video : MediaType.photo,
+      sourceType: isLocalFile
+          ? MediaSourceType.localFile
+          : MediaSourceType.platformGallery,
+      localPath: isLocalFile ? path : null,
       latitude: asset.latitude,
       longitude: asset.longitude,
       takenAt: asset.createDateTime,

--- a/lib/features/media/data/services/photo_picker_service.dart
+++ b/lib/features/media/data/services/photo_picker_service.dart
@@ -49,6 +49,17 @@ class AssetInfo {
   /// Original filename if available.
   final String? filename;
 
+  /// Absolute filesystem path, when the asset came from a file dialog rather
+  /// than a platform photo library.
+  ///
+  /// Null on iOS / Android / macOS, where [id] is a real photo_manager asset
+  /// ID and the library owns the file. Non-null on Windows / Linux, where
+  /// there is no platform gallery and [id] is only a synthetic key into an
+  /// in-memory map that dies with the process. Importers must persist this
+  /// path so the row survives a restart -- see [AssetInfo] usage in
+  /// `MediaImportService`.
+  final String? filePath;
+
   const AssetInfo({
     required this.id,
     required this.type,
@@ -59,6 +70,7 @@ class AssetInfo {
     this.latitude,
     this.longitude,
     this.filename,
+    this.filePath,
   });
 
   /// Whether this asset is a video.

--- a/lib/features/media/data/services/photo_picker_service_desktop.dart
+++ b/lib/features/media/data/services/photo_picker_service_desktop.dart
@@ -1,8 +1,12 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show compute;
+import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
 
+import 'package:submersion/features/media/data/services/capture_time_reader.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
 
@@ -10,6 +14,14 @@ import 'package:submersion/features/media/domain/value_objects/media_source_meta
 ///
 /// This is a fallback implementation that doesn't support date-filtered
 /// gallery browsing. Users must manually browse and select files.
+///
+/// Windows and Linux have no platform photo library, so every [AssetInfo]
+/// this service produces carries its [AssetInfo.filePath]. That path is the
+/// only durable pointer to the file: [AssetInfo.id] is a synthetic key into
+/// [_filePathCache], which lives and dies with the process. Importers must
+/// persist the path (as a `localFile` row) rather than the id, or the photo
+/// resolves through photo_manager -- which has no Windows backend -- and
+/// renders "File not found".
 class PhotoPickerServiceDesktop implements PhotoPickerService {
   final ImagePicker _picker = ImagePicker();
 
@@ -44,43 +56,44 @@ class PhotoPickerServiceDesktop implements PhotoPickerService {
       return [];
     }
 
-    final List<AssetInfo> results = [];
-
-    for (final file in files) {
-      final path = file.path;
-      final ioFile = File(path);
-
-      // Check if file exists
-      if (!await ioFile.exists()) continue;
-
-      // Get file metadata
-      final stat = await ioFile.stat();
-      final modified = stat.modified;
-
-      // Generate a unique ID for this file
-      final id = '${modified.millisecondsSinceEpoch}_${path.hashCode}';
-      _filePathCache[id] = path;
-
-      // Determine if it's a video based on extension
-      final extension = path.toLowerCase().split('.').last;
-      final isVideo = ['mp4', 'mov', 'avi', 'mkv', 'webm'].contains(extension);
-
-      results.add(
-        AssetInfo(
-          id: id,
-          type: isVideo ? AssetType.video : AssetType.image,
-          createDateTime: modified,
-          width: 0, // Not available without decoding
-          height: 0,
-          durationSeconds: null,
-          latitude: null,
-          longitude: null,
-          filename: path.split(Platform.pathSeparator).last,
-        ),
-      );
+    // Reading capture time and dimensions means reading each file's bytes,
+    // which would jank the UI thread for a pick of large photos (the old
+    // stat()-only implementation was cheap enough to inline). Do the batch on
+    // a background isolate, then register the paths here -- the isolate only
+    // ever mutates its own copy of [_filePathCache].
+    final assets = await compute(
+      _extractAssets,
+      files.map((f) => f.path).toList(),
+    );
+    for (final asset in assets) {
+      final path = asset.filePath;
+      if (path != null) _filePathCache[asset.id] = path;
     }
+    return assets;
+  }
 
-    return results;
+  /// Builds the [AssetInfo] for one file chosen from the desktop file dialog
+  /// and registers its path under the returned [AssetInfo.id].
+  ///
+  /// Returns null when [ioFile] does not exist.
+  ///
+  /// The capture time comes from the file's own container metadata (JPEG /
+  /// HEIC EXIF `DateTimeOriginal`, or the MP4/MOV `mvhd`) via
+  /// [readLocalCaptureTime], falling back to the mtime only when the file
+  /// carries no capture time at all. Reporting the mtime unconditionally --
+  /// as this service used to -- dates a photo to when it was copied off the
+  /// camera card rather than when it was shot, which pushes it outside the
+  /// dive window and leaves it unmatched.
+  ///
+  /// [readLocalCaptureTime] returns wall-clock-UTC, but [AssetInfo] is
+  /// contractually LOCAL (photo_manager's convention on mobile, which
+  /// consumers such as `TripMediaScanner.toWallClockUtc` reinterpret). The
+  /// components are therefore carried across verbatim into a local DateTime;
+  /// returning the UTC value directly would double-convert it.
+  AssetInfo? assetInfoForFile(File ioFile) {
+    final asset = _assetInfoForPath(ioFile.path);
+    if (asset != null) _filePathCache[asset.id] = asset.filePath!;
+    return asset;
   }
 
   @override
@@ -121,3 +134,92 @@ class PhotoPickerServiceDesktop implements PhotoPickerService {
   @override
   Future<MediaSourceMetadata?> getAssetMetadata(String assetId) async => null;
 }
+
+/// Batch entry point for [compute]: top-level so it can cross the isolate
+/// boundary (an instance method would close over `this`). Paths that no
+/// longer resolve are dropped.
+List<AssetInfo> _extractAssets(List<String> paths) {
+  final results = <AssetInfo>[];
+  for (final path in paths) {
+    final asset = _assetInfoForPath(path);
+    // Null means the picked path vanished between dialog and read.
+    if (asset != null) results.add(asset);
+  }
+  return results;
+}
+
+/// Pure metadata read for one path. Top-level and cache-free so it is safe to
+/// run on a [compute] isolate; [PhotoPickerServiceDesktop.assetInfoForFile]
+/// wraps it to register the path on the main isolate.
+AssetInfo? _assetInfoForPath(String path) {
+  final ioFile = File(path);
+  if (!ioFile.existsSync()) return null;
+
+  final modified = ioFile.lastModifiedSync();
+  final mime = _mimeFromExtension(p.extension(path).toLowerCase());
+
+  final capturedUtc = readLocalCaptureTime(ioFile, mime);
+  final createDateTime = capturedUtc == null
+      ? modified
+      : DateTime(
+          capturedUtc.year,
+          capturedUtc.month,
+          capturedUtc.day,
+          capturedUtc.hour,
+          capturedUtc.minute,
+          capturedUtc.second,
+          capturedUtc.millisecond,
+        );
+
+  final size = _dimensionsOf(ioFile, mime);
+
+  return AssetInfo(
+    // Keyed on mtime + path so re-picking the same file in one session reuses
+    // the entry. Only meaningful in-process; the durable pointer is the path.
+    id: '${modified.millisecondsSinceEpoch}_${path.hashCode}',
+    type: mime.startsWith('video/') ? AssetType.video : AssetType.image,
+    createDateTime: createDateTime,
+    // AssetResolutionService's timestamp+dimensions tiers reject a 0x0 row
+    // outright, so real dimensions are what keep those tiers usable.
+    width: size?.width ?? 0,
+    height: size?.height ?? 0,
+    durationSeconds: null,
+    latitude: null,
+    longitude: null,
+    filename: p.basename(path),
+    filePath: path,
+  );
+}
+
+/// Reads pixel dimensions from an image header without decoding pixels.
+/// Returns null for videos and for anything the decoder cannot read.
+({int width, int height})? _dimensionsOf(File file, String mime) {
+  if (!mime.startsWith('image/')) return null;
+  try {
+    final bytes = file.readAsBytesSync();
+    // Extension first, then content sniffing for files whose name lies.
+    final decoder =
+        img.findDecoderForNamedImage(file.path) ??
+        img.findDecoderForData(bytes);
+    final info = decoder?.startDecode(bytes);
+    if (info == null) return null;
+    return (width: info.width, height: info.height);
+  } on Object {
+    // Unsupported or truncated container: dimensions are optional here.
+    return null;
+  }
+}
+
+String _mimeFromExtension(String ext) => switch (ext) {
+  '.jpg' || '.jpeg' => 'image/jpeg',
+  '.png' => 'image/png',
+  '.heic' => 'image/heic',
+  '.heif' => 'image/heif',
+  '.webp' => 'image/webp',
+  '.gif' => 'image/gif',
+  '.mp4' => 'video/mp4',
+  '.mov' => 'video/quicktime',
+  '.m4v' => 'video/x-m4v',
+  '.avi' || '.mkv' || '.webm' => 'video/x-generic',
+  _ => 'application/octet-stream',
+};

--- a/lib/features/media/data/services/photo_picker_service_desktop.dart
+++ b/lib/features/media/data/services/photo_picker_service_desktop.dart
@@ -169,6 +169,11 @@ AssetInfo? _assetInfoForPath(String path) {
           capturedUtc.minute,
           capturedUtc.second,
           capturedUtc.millisecond,
+          // Today's readers are all second-granularity (EXIF
+          // DateTimeOriginal, mvhd creation_time), so this is defensive --
+          // but dropping sub-second components on a reinterpretation that
+          // exists only to swap the isUtc flag would be a silent lossy step.
+          capturedUtc.microsecond,
         );
 
   final size = _dimensionsOf(ioFile, mime);
@@ -191,7 +196,13 @@ AssetInfo? _assetInfoForPath(String path) {
   );
 }
 
-/// Reads pixel dimensions from an image header without decoding pixels.
+/// Reads pixel dimensions from an image's header.
+///
+/// Only the header is parsed -- `startDecode` stops before any pixel decode --
+/// but the decoder API takes bytes, so the file is read in full first. That
+/// read is why the batch runs on a [compute] isolate; on the main thread a
+/// pick of large images would visibly jank the UI.
+///
 /// Returns null for videos and for anything the decoder cannot read.
 ({int width, int height})? _dimensionsOf(File file, String mime) {
   if (!mime.startsWith('image/')) return null;

--- a/lib/features/media/presentation/helpers/photo_import_helper.dart
+++ b/lib/features/media/presentation/helpers/photo_import_helper.dart
@@ -67,6 +67,8 @@ class PhotoImportHelper {
       ),
       buffer: Duration.zero,
       alreadyLinkedIds: alreadyLinkedIds,
+      // Lets the Files tab link photos this dive's date window rejected.
+      diveId: dive.id,
     );
     // coverage:ignore-end
 

--- a/lib/features/media/presentation/pages/photo_picker_page.dart
+++ b/lib/features/media/presentation/pages/photo_picker_page.dart
@@ -27,12 +27,20 @@ class PhotoPickerPage extends ConsumerStatefulWidget {
   /// Called when user confirms selection with the selected assets.
   final void Function(List<AssetInfo> selectedAssets)? onSelectionConfirmed;
 
+  /// The dive this picker was opened from, when there is one.
+  ///
+  /// Passed to the Files tab so photos the date matcher rejects can still be
+  /// linked to the dive the user was looking at. Null when the picker is
+  /// opened outside a dive context.
+  final String? diveId;
+
   const PhotoPickerPage({
     super.key,
     required this.startTime,
     required this.endTime,
     this.alreadyLinkedIds = const {},
     this.onSelectionConfirmed,
+    this.diveId,
   });
 
   @override
@@ -118,37 +126,56 @@ class _PhotoPickerPageState extends ConsumerState<PhotoPickerPage> {
       tooltip: context.l10n.media_photoPicker_closeTooltip,
       onPressed: () => Navigator.of(context).pop(),
     );
-    final appBarActions = [
-      TextButton(
-        onPressed: state.selectionCount > 0 ? _handleDone : null,
-        child: Text(
-          state.selectionCount > 0
-              ? context.l10n.media_photoPicker_doneCountButton(
-                  state.selectionCount,
-                )
-              : context.l10n.media_photoPicker_doneButton,
-        ),
+    final doneAction = TextButton(
+      onPressed: state.selectionCount > 0 ? _handleDone : null,
+      child: Text(
+        state.selectionCount > 0
+            ? context.l10n.media_photoPicker_doneCountButton(
+                state.selectionCount,
+              )
+            : context.l10n.media_photoPicker_doneButton,
       ),
-    ];
+    );
 
     return DefaultTabController(
       length: 3,
-      child: Scaffold(
-        appBar: AppBar(
-          leading: appBarLeading,
-          title: Text(context.l10n.media_photoPicker_appBarTitle),
-          actions: appBarActions,
-          bottom: TabBar(
-            tabs: [
-              Tab(text: context.l10n.media_photoPicker_tab_gallery),
-              Tab(text: context.l10n.media_photoPicker_tab_files),
-              Tab(text: context.l10n.media_photoPicker_tab_url),
-            ],
-          ),
-        ),
-        body: TabBarView(
-          children: [_galleryTab(context), const FilesTab(), const UrlTab()],
-        ),
+      child: Builder(
+        builder: (context) {
+          final tabController = DefaultTabController.of(context);
+          return Scaffold(
+            appBar: AppBar(
+              leading: appBarLeading,
+              title: Text(context.l10n.media_photoPicker_appBarTitle),
+              actions: [
+                // Done commits the GALLERY tab's selection; the Files and URL
+                // tabs carry their own commit buttons. Showing a
+                // permanently-greyed Done over those tabs read as "the app
+                // rejected my photos" to users who had staged files there,
+                // so the action tracks the active tab.
+                ListenableBuilder(
+                  listenable: tabController,
+                  builder: (context, _) => tabController.index == 0
+                      ? doneAction
+                      : const SizedBox.shrink(),
+                ),
+              ],
+              bottom: TabBar(
+                tabs: [
+                  Tab(text: context.l10n.media_photoPicker_tab_gallery),
+                  Tab(text: context.l10n.media_photoPicker_tab_files),
+                  Tab(text: context.l10n.media_photoPicker_tab_url),
+                ],
+              ),
+            ),
+            body: TabBarView(
+              children: [
+                _galleryTab(context),
+                FilesTab(diveId: widget.diveId),
+                const UrlTab(),
+              ],
+            ),
+          );
+        },
       ),
     );
   }
@@ -671,6 +698,7 @@ Future<List<AssetInfo>?> showPhotoPicker({
   required DateTime diveEndTime,
   Set<String> alreadyLinkedIds = const {},
   Duration buffer = const Duration(minutes: 30),
+  String? diveId,
 }) {
   final startTime = diveStartTime.subtract(buffer);
   final endTime = diveEndTime.add(buffer);
@@ -682,6 +710,7 @@ Future<List<AssetInfo>?> showPhotoPicker({
         startTime: startTime,
         endTime: endTime,
         alreadyLinkedIds: alreadyLinkedIds,
+        diveId: diveId,
       ),
     ),
   );

--- a/lib/features/media/presentation/providers/files_tab_providers.dart
+++ b/lib/features/media/presentation/providers/files_tab_providers.dart
@@ -167,6 +167,63 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
     );
   }
 
+  /// Routes the staged file at [sourcePath] to [diveId], removing it from
+  /// whichever bucket currently holds it (unmatched, or another dive).
+  ///
+  /// [commit] only persists files sitting in [MatchedSelection.matched], so
+  /// without this a file the date matcher rejected had no route into the
+  /// database at all. Unknown paths are ignored.
+  void assignToDive(String sourcePath, String diveId) {
+    final file = state.files
+        .where((f) => f.sourcePath == sourcePath)
+        .firstOrNull;
+    if (file == null) return;
+
+    final newMatched = <String, List<ExtractedFile>>{};
+    for (final entry in state.match.matched.entries) {
+      final kept = entry.value
+          .where((f) => f.sourcePath != sourcePath)
+          .toList();
+      // Drop emptied groups, mirroring [removeFile].
+      if (kept.isNotEmpty) newMatched[entry.key] = kept;
+    }
+    newMatched.update(
+      diveId,
+      (existing) => [...existing, file],
+      ifAbsent: () => [file],
+    );
+
+    state = state.copyWith(
+      match: MatchedSelection(
+        matched: newMatched,
+        unmatched: state.match.unmatched
+            .where((f) => f.sourcePath != sourcePath)
+            .toList(),
+      ),
+    );
+  }
+
+  /// Routes every currently-unmatched file to [diveId]. Backs the review
+  /// pane's bulk "add all to this dive" action.
+  void assignAllUnmatched(String diveId) {
+    final unmatched = state.match.unmatched;
+    if (unmatched.isEmpty) return;
+
+    final newMatched = {
+      for (final entry in state.match.matched.entries)
+        entry.key: [...entry.value],
+    };
+    newMatched.update(
+      diveId,
+      (existing) => [...existing, ...unmatched],
+      ifAbsent: () => [...unmatched],
+    );
+
+    state = state.copyWith(
+      match: MatchedSelection(matched: newMatched, unmatched: const []),
+    );
+  }
+
   /// Persists the matcher's per-dive assignment as [MediaItem] rows and
   /// returns the list of created IDs. Pass the list back to [undoCommit]
   /// to roll back. State is reset via [clear] before returning.

--- a/lib/features/media/presentation/widgets/file_review_card.dart
+++ b/lib/features/media/presentation/widgets/file_review_card.dart
@@ -10,20 +10,32 @@ import 'package:submersion/features/media/presentation/providers/files_tab_provi
 ///
 /// Phase 2 / Task 11: shows a thumbnail (via [Image.file]), the file's
 /// basename, the EXIF taken-at timestamp, and a Remove action that calls
-/// [FilesTabNotifier.removeFile]. Reassign UI is deferred to Phase 3 polish
-/// — for now the user can remove and re-add to change a file's grouping.
+/// [FilesTabNotifier.removeFile].
+///
+/// When [assignableDiveId] is supplied (the picker was opened from a dive)
+/// and this card is not already in that dive's group, an assign action calls
+/// [FilesTabNotifier.assignToDive]. Only files in a dive group reach
+/// [FilesTabNotifier.commit], so for an unmatched file this is the sole route
+/// into the database.
 class FileReviewCard extends ConsumerWidget {
   final ExtractedFile file;
   final String? targetDiveId;
+
+  /// The dive this card can be manually routed to, or null when the picker
+  /// was opened outside a dive context.
+  final String? assignableDiveId;
 
   const FileReviewCard({
     super.key,
     required this.file,
     required this.targetDiveId,
+    this.assignableDiveId,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final assignTo = assignableDiveId;
+    final canAssign = assignTo != null && assignTo != targetDiveId;
     // TODO(media): l10n
     return ListTile(
       leading: _buildLeading(),
@@ -35,12 +47,25 @@ class FileReviewCard extends ConsumerWidget {
       subtitle: Text(
         file.metadata.takenAt?.toIso8601String() ?? 'No EXIF date',
       ),
-      trailing: IconButton(
-        icon: const Icon(Icons.close),
-        tooltip: 'Remove from selection',
-        onPressed: () => ref
-            .read(filesTabNotifierProvider.notifier)
-            .removeFile(file.sourcePath),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (canAssign)
+            IconButton(
+              icon: const Icon(Icons.add_link),
+              tooltip: 'Add to this dive',
+              onPressed: () => ref
+                  .read(filesTabNotifierProvider.notifier)
+                  .assignToDive(file.sourcePath, assignTo),
+            ),
+          IconButton(
+            icon: const Icon(Icons.close),
+            tooltip: 'Remove from selection',
+            onPressed: () => ref
+                .read(filesTabNotifierProvider.notifier)
+                .removeFile(file.sourcePath),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/media/presentation/widgets/file_review_pane.dart
+++ b/lib/features/media/presentation/widgets/file_review_pane.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/file_review_card.dart';
@@ -14,12 +15,18 @@ import 'package:submersion/features/media/presentation/widgets/file_review_card.
 /// Stateless because all mutation flows through
 /// [filesTabNotifierProvider]; the pane just renders the current
 /// [FilesTabState] passed in by the parent.
-class FileReviewPane extends StatelessWidget {
+class FileReviewPane extends ConsumerWidget {
   final FilesTabState state;
-  const FileReviewPane({super.key, required this.state});
+
+  /// The dive files may be manually assigned to, when the picker was opened
+  /// from one. Drives the Unmatched group's bulk action and the per-card
+  /// assign affordance; null hides both.
+  final String? assignableDiveId;
+
+  const FileReviewPane({super.key, required this.state, this.assignableDiveId});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     // TODO(media): l10n
     final summary =
@@ -44,7 +51,11 @@ class FileReviewPane extends StatelessWidget {
                   initiallyExpanded: true,
                   children: [
                     for (final f in entry.value)
-                      FileReviewCard(file: f, targetDiveId: entry.key),
+                      FileReviewCard(
+                        file: f,
+                        targetDiveId: entry.key,
+                        assignableDiveId: assignableDiveId,
+                      ),
                   ],
                 ),
               if (state.match.unmatched.isNotEmpty)
@@ -52,9 +63,27 @@ class FileReviewPane extends StatelessWidget {
                   title: const Text('Unmatched'),
                   subtitle: Text('${state.match.unmatched.length} photos'),
                   initiallyExpanded: true,
+                  // Without this the only thing a user could do with a photo
+                  // the matcher rejected was remove it -- commit() never sees
+                  // the unmatched bucket.
+                  trailing: assignableDiveId == null
+                      ? null
+                      : TextButton(
+                          onPressed: () => ref
+                              .read(filesTabNotifierProvider.notifier)
+                              .assignAllUnmatched(assignableDiveId!),
+                          child: Text(
+                            'Add all ${state.match.unmatched.length} '
+                            'to this dive',
+                          ),
+                        ),
                   children: [
                     for (final f in state.match.unmatched)
-                      FileReviewCard(file: f, targetDiveId: null),
+                      FileReviewCard(
+                        file: f,
+                        targetDiveId: null,
+                        assignableDiveId: assignableDiveId,
+                      ),
                   ],
                 ),
             ],

--- a/lib/features/media/presentation/widgets/file_review_pane.dart
+++ b/lib/features/media/presentation/widgets/file_review_pane.dart
@@ -12,9 +12,12 @@ import 'package:submersion/features/media/presentation/widgets/file_review_card.
 /// matched-dive group and an "Unmatched" group at the bottom (only when
 /// non-empty). Each group's children are [FileReviewCard]s.
 ///
-/// Stateless because all mutation flows through
-/// [filesTabNotifierProvider]; the pane just renders the current
-/// [FilesTabState] passed in by the parent.
+/// Holds no state of its own: the current [FilesTabState] is passed in by the
+/// parent, and the pane's own actions -- the Unmatched group's bulk
+/// "add all to this dive", plus each [FileReviewCard]'s assign and remove --
+/// are dispatched to [filesTabNotifierProvider], which owns every mutation.
+/// It is a [ConsumerWidget] rather than a [StatelessWidget] only to reach
+/// that notifier.
 class FileReviewPane extends ConsumerWidget {
   final FilesTabState state;
 

--- a/lib/features/media/presentation/widgets/files_tab.dart
+++ b/lib/features/media/presentation/widgets/files_tab.dart
@@ -40,7 +40,18 @@ import 'package:submersion/features/media/presentation/widgets/file_review_pane.
 /// then an iOS-imported video matches and stores but shows the viewer's
 /// video-unavailable state rather than playing.
 class FilesTab extends ConsumerWidget {
-  const FilesTab({super.key});
+  const FilesTab({super.key, this.diveId});
+
+  /// The dive the picker was opened from, when there is one.
+  ///
+  /// [FilesTabNotifier.commit] only persists files sitting in
+  /// [MatchedSelection.matched], and the Link button is gated on that map
+  /// being non-empty, so a photo the date matcher rejected had no route into
+  /// the database. When the picker came from a dive, that dive is the obvious
+  /// manual target: it backs the review pane's "add all to this dive" action
+  /// and makes turning auto-match off produce a usable selection instead of
+  /// an inert one. Null when the picker was opened outside a dive context.
+  final String? diveId;
 
   // coverage:ignore-start
   // FilePicker.pickFiles is a static method on package:file_picker; not
@@ -130,9 +141,19 @@ class FilesTab extends ConsumerWidget {
     final notifier = ref.read(filesTabNotifierProvider.notifier);
     final state = ref.read(filesTabNotifierProvider);
     if (!state.autoMatchByDate) {
+      // Opened from a dive, auto-match declined: the user asked for exactly
+      // these files on exactly this dive, so stage them as matched. Parking
+      // them in `unmatched` (as this used to) hid the Link button and made
+      // the unchecked checkbox a dead end.
+      final target = diveId;
       notifier.setFiles(
         extracted,
-        match: MatchedSelection(matched: const {}, unmatched: extracted),
+        match: target == null
+            ? MatchedSelection(matched: const {}, unmatched: extracted)
+            : MatchedSelection(
+                matched: {target: extracted},
+                unmatched: const [],
+              ),
       );
       return;
     }
@@ -219,7 +240,7 @@ class FilesTab extends ConsumerWidget {
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
                   )
-                : FileReviewPane(state: state),
+                : FileReviewPane(state: state, assignableDiveId: diveId),
           ),
           // TODO(media): l10n, pluralization
           if (state.match.matched.isNotEmpty)

--- a/test/features/media/data/media_repository_linked_local_paths_test.dart
+++ b/test/features/media/data/media_repository_linked_local_paths_test.dart
@@ -1,0 +1,106 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Coverage for [MediaRepository.getLinkedLocalPathsForDive], the desktop
+/// counterpart to `getLinkedAssetIdsForDive`.
+///
+/// Windows and Linux imports are `localFile` rows whose `platform_asset_id`
+/// is deliberately null (carrying the picker's synthetic id would route them
+/// through photo_manager, which has no desktop backend), so the asset-id
+/// query cannot see them and duplicate detection keys on the path instead.
+/// This is hand-written SQL, so a column-name typo would only surface at
+/// runtime.
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+
+  Future<void> insertDive(String id) => db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(epoch),
+          createdAt: Value(epoch),
+          updatedAt: Value(epoch),
+        ),
+      );
+
+  MediaItem localFile(String path, {required String diveId}) => MediaItem(
+    id: '',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.localFile,
+    localPath: path,
+    originalFilename: path.split('/').last,
+    diveId: diveId,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  MediaItem galleryPhoto(String assetId, {required String diveId}) => MediaItem(
+    id: '',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: assetId,
+    diveId: diveId,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  test('returns the local paths linked to the dive', () async {
+    await insertDive('d1');
+    await repo.createMedia(localFile('/photos/a.jpg', diveId: 'd1'));
+    await repo.createMedia(localFile('/photos/b.jpg', diveId: 'd1'));
+
+    expect(await repo.getLinkedLocalPathsForDive('d1'), {
+      '/photos/a.jpg',
+      '/photos/b.jpg',
+    });
+  });
+
+  test('scopes results to the requested dive', () async {
+    await insertDive('d1');
+    await insertDive('d2');
+    await repo.createMedia(localFile('/photos/a.jpg', diveId: 'd1'));
+    await repo.createMedia(localFile('/photos/b.jpg', diveId: 'd2'));
+
+    expect(await repo.getLinkedLocalPathsForDive('d1'), {'/photos/a.jpg'});
+  });
+
+  test('omits rows with no local path', () async {
+    await insertDive('d1');
+    await repo.createMedia(galleryPhoto('asset-1', diveId: 'd1'));
+    await repo.createMedia(localFile('/photos/a.jpg', diveId: 'd1'));
+
+    expect(await repo.getLinkedLocalPathsForDive('d1'), {'/photos/a.jpg'});
+  });
+
+  test('returns empty for a dive with no media', () async {
+    await insertDive('d1');
+
+    expect(await repo.getLinkedLocalPathsForDive('d1'), isEmpty);
+  });
+
+  test('collapses duplicate paths into a single entry', () async {
+    await insertDive('d1');
+    await repo.createMedia(localFile('/photos/a.jpg', diveId: 'd1'));
+    await repo.createMedia(localFile('/photos/a.jpg', diveId: 'd1'));
+
+    expect(await repo.getLinkedLocalPathsForDive('d1'), {'/photos/a.jpg'});
+  });
+}

--- a/test/features/media/data/services/media_import_service_test.dart
+++ b/test/features/media/data/services/media_import_service_test.dart
@@ -386,6 +386,83 @@ void main() {
         verifyNever(mockMediaRepository.createMedia(any));
       });
 
+      // Each lookup only feeds one branch of the dedupe filter, so querying
+      // both on every import does dead work: a mobile selection never has a
+      // path to compare, and a desktop selection never has a gallery id.
+      test('skips the path lookup when no asset carries a path', () async {
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+        when(mockMediaRepository.createMedia(any)).thenAnswer(
+          (_) async =>
+              _savedMediaItem(id: 'm1', diveId: 'dive-1', platformAssetId: 'a'),
+        );
+
+        await service.importPhotosForDive(
+          selectedAssets: [_testAsset('asset-1')],
+          dive: testDive,
+        );
+
+        verifyNever(mockMediaRepository.getLinkedLocalPathsForDive(any));
+        verify(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).called(1);
+      });
+
+      test(
+        'skips the asset-id lookup when every asset carries a path',
+        () async {
+          when(
+            mockMediaRepository.getLinkedLocalPathsForDive('dive-1'),
+          ).thenAnswer((_) async => <String>{});
+          when(mockMediaRepository.createMedia(any)).thenAnswer(
+            (_) async => _savedMediaItem(
+              id: 'm1',
+              diveId: 'dive-1',
+              platformAssetId: '',
+            ),
+          );
+
+          await service.importPhotosForDive(
+            selectedAssets: [_testAsset('1_2', filePath: '/photos/a.jpg')],
+            dive: testDive,
+          );
+
+          verifyNever(mockMediaRepository.getLinkedAssetIdsForDive(any));
+          verify(
+            mockMediaRepository.getLinkedLocalPathsForDive('dive-1'),
+          ).called(1);
+        },
+      );
+
+      test('queries both lookups for a mixed selection', () async {
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+        when(
+          mockMediaRepository.getLinkedLocalPathsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+        when(mockMediaRepository.createMedia(any)).thenAnswer(
+          (_) async =>
+              _savedMediaItem(id: 'm1', diveId: 'dive-1', platformAssetId: ''),
+        );
+
+        await service.importPhotosForDive(
+          selectedAssets: [
+            _testAsset('asset-1'),
+            _testAsset('1_2', filePath: '/photos/a.jpg'),
+          ],
+          dive: testDive,
+        );
+
+        verify(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).called(1);
+        verify(
+          mockMediaRepository.getLinkedLocalPathsForDive('dive-1'),
+        ).called(1);
+      });
+
       test('imports a file whose path is not yet linked', () async {
         final assets = [_testAsset('1_2', filePath: '/photos/a.jpg')];
 

--- a/test/features/media/data/services/media_import_service_test.dart
+++ b/test/features/media/data/services/media_import_service_test.dart
@@ -7,17 +7,19 @@ import 'package:submersion/features/media/data/services/enrichment_service.dart'
 import 'package:submersion/features/media/data/services/media_import_service.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 
 @GenerateMocks([MediaRepository, EnrichmentService])
 import 'media_import_service_test.mocks.dart';
 
 /// Helper to create an AssetInfo for testing.
-AssetInfo _testAsset(String id) => AssetInfo(
+AssetInfo _testAsset(String id, {String? filePath}) => AssetInfo(
   id: id,
   type: AssetType.image,
   createDateTime: DateTime(2024, 1, 15, 10, 30),
   width: 1920,
   height: 1080,
+  filePath: filePath,
 );
 
 /// Helper to create a minimal Dive for testing.
@@ -305,6 +307,76 @@ void main() {
         expect(result.failures.containsKey('asset-3'), isTrue);
         expect(result.totalAttempted, 3);
         expect(result.allSucceeded, isFalse);
+      });
+    });
+
+    group('importPhotosForDive - desktop file paths', () {
+      // On Windows / Linux the picker has no platform gallery: it opens a
+      // file dialog and hands back an AssetInfo whose id is a synthetic
+      // '<mtime>_<hashCode>' key that only resolves through an in-memory map
+      // on the picker service. Persisting such a row as platformGallery left
+      // the path columns blank and routed display through
+      // PlatformGalleryResolver -> photo_manager, which has no Windows
+      // backend, so every imported photo rendered "File not found".
+      // A picker-supplied filePath must therefore be persisted as a
+      // localFile row so LocalFileResolver reads it straight off disk.
+      test('persists a picker-supplied filePath as a localFile row', () async {
+        const path = r'C:\Users\stiebs\Pictures\DIVE_0042.JPG';
+        final assets = [_testAsset('42_998877', filePath: path)];
+
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+
+        MediaItem? persisted;
+        when(mockMediaRepository.createMedia(any)).thenAnswer((
+          invocation,
+        ) async {
+          persisted = invocation.positionalArguments[0] as MediaItem;
+          return _savedMediaItem(
+            id: 'media-1',
+            diveId: 'dive-1',
+            platformAssetId: persisted!.platformAssetId ?? '',
+          );
+        });
+
+        await service.importPhotosForDive(
+          selectedAssets: assets,
+          dive: testDive,
+        );
+
+        expect(persisted, isNotNull);
+        expect(persisted!.sourceType, MediaSourceType.localFile);
+        expect(persisted!.localPath, path);
+      });
+
+      test('leaves a gallery asset without a path as platformGallery', () {
+        final assets = [_testAsset('asset-1')];
+
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+
+        MediaItem? persisted;
+        when(mockMediaRepository.createMedia(any)).thenAnswer((
+          invocation,
+        ) async {
+          persisted = invocation.positionalArguments[0] as MediaItem;
+          return _savedMediaItem(
+            id: 'media-1',
+            diveId: 'dive-1',
+            platformAssetId: persisted!.platformAssetId ?? '',
+          );
+        });
+
+        return service
+            .importPhotosForDive(selectedAssets: assets, dive: testDive)
+            .then((_) {
+              expect(persisted, isNotNull);
+              expect(persisted!.sourceType, MediaSourceType.platformGallery);
+              expect(persisted!.localPath, isNull);
+              expect(persisted!.platformAssetId, 'asset-1');
+            });
       });
     });
   });

--- a/test/features/media/data/services/media_import_service_test.dart
+++ b/test/features/media/data/services/media_import_service_test.dart
@@ -55,6 +55,11 @@ void main() {
       enrichmentService: mockEnrichmentService,
     );
     testDive = _testDive();
+    // Default: no desktop rows linked. Tests exercising path-based dedupe
+    // re-stub this for their specific dive id.
+    when(
+      mockMediaRepository.getLinkedLocalPathsForDive(any),
+    ).thenAnswer((_) async => <String>{});
   });
 
   group('ImportResult', () {
@@ -348,6 +353,60 @@ void main() {
         expect(persisted, isNotNull);
         expect(persisted!.sourceType, MediaSourceType.localFile);
         expect(persisted!.localPath, path);
+        // A localFile row must NOT carry a gallery asset id: several features
+        // gate purely on `platformAssetId != null` (MediaItem.isGalleryPhoto,
+        // PhotoViewerPage's write-metadata action, resolvedFilePathProvider's
+        // gallery fast path) and would route a desktop file through
+        // photo_manager, which has no Windows backend.
+        expect(persisted!.platformAssetId, isNull);
+      });
+
+      test('skips a file already linked to the dive by path', () async {
+        const path = r'C:\Users\stiebs\Pictures\DIVE_0042.JPG';
+        final assets = [_testAsset('42_998877', filePath: path)];
+
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+        // Nulling platformAssetId means the asset-id filter can no longer see
+        // desktop rows, so dedupe has to run off the path instead. Keying on
+        // the path is also strictly better than the old synthetic id, which
+        // embedded the mtime and silently changed when a file was touched.
+        when(
+          mockMediaRepository.getLinkedLocalPathsForDive('dive-1'),
+        ).thenAnswer((_) async => {path});
+
+        final result = await service.importPhotosForDive(
+          selectedAssets: assets,
+          dive: testDive,
+        );
+
+        expect(result.imported, isEmpty);
+        expect(result.skippedDuplicates, 1);
+        verifyNever(mockMediaRepository.createMedia(any));
+      });
+
+      test('imports a file whose path is not yet linked', () async {
+        final assets = [_testAsset('1_2', filePath: '/photos/a.jpg')];
+
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+        when(
+          mockMediaRepository.getLinkedLocalPathsForDive('dive-1'),
+        ).thenAnswer((_) async => {'/photos/other.jpg'});
+        when(mockMediaRepository.createMedia(any)).thenAnswer(
+          (_) async =>
+              _savedMediaItem(id: 'm1', diveId: 'dive-1', platformAssetId: ''),
+        );
+
+        final result = await service.importPhotosForDive(
+          selectedAssets: assets,
+          dive: testDive,
+        );
+
+        expect(result.imported.length, 1);
+        expect(result.skippedDuplicates, 0);
       });
 
       test('leaves a gallery asset without a path as platformGallery', () {

--- a/test/features/media/data/services/photo_picker_service_desktop_test.dart
+++ b/test/features/media/data/services/photo_picker_service_desktop_test.dart
@@ -1,12 +1,112 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service_desktop.dart';
 
+/// Writes a 4x4 JPEG carrying [dateTimeOriginal] in its EXIF IFD.
+File _jpegWithExifDate(Directory dir, String name, String dateTimeOriginal) {
+  final image = img.Image(width: 4, height: 4);
+  image.exif.exifIfd['DateTimeOriginal'] = dateTimeOriginal;
+  return File('${dir.path}/$name')..writeAsBytesSync(img.encodeJpg(image));
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('getAssetMetadata returns null', () async {
     final metadata = await PhotoPickerServiceDesktop().getAssetMetadata(
       'asset-1',
     );
 
     expect(metadata, isNull);
+  });
+
+  group('assetInfoForFile', () {
+    late Directory tempDir;
+    late PhotoPickerServiceDesktop service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('desktop_picker_');
+      service = PhotoPickerServiceDesktop();
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('carries the absolute path so the import can persist it', () {
+      final file = _jpegWithExifDate(tempDir, 'a.jpg', '2025:07:14 17:22:31');
+
+      final asset = service.assetInfoForFile(file);
+
+      // Without this the row lands with blank path columns and display falls
+      // to photo_manager, which has no Windows backend.
+      expect(asset?.filePath, file.path);
+    });
+
+    test('dates the asset from EXIF capture time, not the file mtime', () {
+      final file = _jpegWithExifDate(tempDir, 'a.jpg', '2025:07:14 17:22:31');
+      // Copying a card to the PC months later leaves an mtime of the copy
+      // time; reporting that is why in-window photos read as unmatched.
+      file.setLastModifiedSync(DateTime(2025, 11, 2, 9, 15));
+
+      final asset = service.assetInfoForFile(file);
+
+      expect(asset?.createDateTime, DateTime(2025, 7, 14, 17, 22, 31));
+    });
+
+    test('reports capture time as local, matching the AssetInfo contract', () {
+      final file = _jpegWithExifDate(tempDir, 'a.jpg', '2025:07:14 17:22:31');
+
+      // Consumers (TripMediaScanner, MediaImportService) reinterpret these
+      // components as wall-clock-UTC; a UTC-flagged value double-converts.
+      expect(service.assetInfoForFile(file)?.createDateTime.isUtc, isFalse);
+    });
+
+    test('falls back to the file mtime when no capture time is embedded', () {
+      final file = File('${tempDir.path}/nometa.png')
+        ..writeAsBytesSync(img.encodePng(img.Image(width: 4, height: 4)));
+      file.setLastModifiedSync(DateTime(2025, 11, 2, 9, 15));
+
+      expect(
+        service.assetInfoForFile(file)?.createDateTime,
+        DateTime(2025, 11, 2, 9, 15),
+      );
+    });
+
+    test('records real pixel dimensions for the resolution tiers', () {
+      final file = _jpegWithExifDate(tempDir, 'a.jpg', '2025:07:14 17:22:31');
+
+      final asset = service.assetInfoForFile(file);
+
+      // matchByTimestampAndDimensions bails on a 0x0 row, so the hardcoded
+      // zeroes silently disabled two of the three resolution tiers.
+      expect(asset?.width, 4);
+      expect(asset?.height, 4);
+    });
+
+    test('returns null for a file that does not exist', () {
+      expect(
+        service.assetInfoForFile(File('${tempDir.path}/gone.jpg')),
+        isNull,
+      );
+    });
+
+    test('classifies known video extensions as video assets', () {
+      final file = File('${tempDir.path}/clip.mp4')..writeAsBytesSync([1, 2]);
+
+      expect(service.assetInfoForFile(file)?.type, AssetType.video);
+    });
+
+    test('resolves the picked path back from the generated asset id', () async {
+      final file = _jpegWithExifDate(tempDir, 'a.jpg', '2025:07:14 17:22:31');
+
+      final asset = service.assetInfoForFile(file)!;
+
+      expect(await service.getFilePath(asset.id), file.path);
+    });
   });
 }

--- a/test/features/media/presentation/pages/photo_picker_page_tab_shell_test.dart
+++ b/test/features/media/presentation/pages/photo_picker_page_tab_shell_test.dart
@@ -147,4 +147,53 @@ void main() {
 
     expect(find.byType(UrlTab), findsOneWidget);
   });
+
+  // The AppBar's Done action commits the GALLERY tab's selection only; the
+  // Files and URL tabs carry their own commit buttons. Rendering a
+  // permanently-greyed Done over those tabs read as "the app rejected my
+  // photos" to users who had staged files in the Files tab.
+  group('Done action is scoped to the Gallery tab', () {
+    testWidgets('is shown on the Gallery tab', (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pump();
+
+      expect(find.text('Done'), findsOneWidget);
+    });
+
+    testWidgets('is hidden on the Files tab', (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pump();
+
+      await tester.tap(find.text('Files'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Done'), findsNothing);
+    });
+
+    testWidgets('is hidden on the URL tab', (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pump();
+
+      await tester.tap(find.text('URL'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Done'), findsNothing);
+    });
+
+    testWidgets('returns when switching back to Gallery', (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pump();
+
+      await tester.tap(find.text('Files'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.tap(find.text('Gallery'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Done'), findsOneWidget);
+    });
+  });
 }

--- a/test/features/media/presentation/providers/files_tab_providers_test.dart
+++ b/test/features/media/presentation/providers/files_tab_providers_test.dart
@@ -167,6 +167,127 @@ void main() {
     });
   });
 
+  // commit() only ever persists files sitting in match.matched, so a file the
+  // date matcher rejected had no route into the database at all: the Link
+  // button is gated on matched being non-empty, and turning the auto-match
+  // checkbox off put EVERY file in unmatched, making the whole tab a no-op.
+  // These mutators are what let a user link photos the matcher didn't claim.
+  group('manual dive assignment', () {
+    test('assignToDive moves an unmatched file into the dive bucket', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      final b = _ef('/b.jpg');
+      notifier.setFiles([
+        a,
+        b,
+      ], match: MatchedSelection(matched: const {}, unmatched: [a, b]));
+
+      notifier.assignToDive('/a.jpg', 'd1');
+
+      final state = container.read(filesTabNotifierProvider);
+      expect(state.match.matched['d1'], [a]);
+      expect(state.match.unmatched, [b]);
+    });
+
+    test('assignToDive appends to an existing dive bucket', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      final b = _ef('/b.jpg');
+      notifier.setFiles(
+        [a, b],
+        match: MatchedSelection(
+          matched: {
+            'd1': [a],
+          },
+          unmatched: [b],
+        ),
+      );
+
+      notifier.assignToDive('/b.jpg', 'd1');
+
+      final state = container.read(filesTabNotifierProvider);
+      expect(state.match.matched['d1'], [a, b]);
+      expect(state.match.unmatched, isEmpty);
+    });
+
+    test('assignToDive re-homes a file without duplicating it', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles(
+        [a],
+        match: MatchedSelection(
+          matched: {
+            'd1': [a],
+          },
+          unmatched: const [],
+        ),
+      );
+
+      notifier.assignToDive('/a.jpg', 'd2');
+
+      final state = container.read(filesTabNotifierProvider);
+      // Emptied groups are dropped, mirroring removeFile.
+      expect(state.match.matched.containsKey('d1'), isFalse);
+      expect(state.match.matched['d2'], [a]);
+      expect(state.match.totalFiles, 1);
+    });
+
+    test('assignToDive ignores a path that is not staged', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles([
+        a,
+      ], match: MatchedSelection(matched: const {}, unmatched: [a]));
+
+      notifier.assignToDive('/nope.jpg', 'd1');
+
+      final state = container.read(filesTabNotifierProvider);
+      expect(state.match.matched, isEmpty);
+      expect(state.match.unmatched, [a]);
+    });
+
+    test('assignAllUnmatched empties the unmatched bucket', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      final b = _ef('/b.jpg');
+      final c = _ef('/c.jpg');
+      notifier.setFiles(
+        [a, b, c],
+        match: MatchedSelection(
+          matched: {
+            'd1': [a],
+          },
+          unmatched: [b, c],
+        ),
+      );
+
+      notifier.assignAllUnmatched('d1');
+
+      final state = container.read(filesTabNotifierProvider);
+      expect(state.match.matched['d1'], [a, b, c]);
+      expect(state.match.unmatched, isEmpty);
+    });
+
+    test('assignAllUnmatched on an empty bucket is a no-op', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles(
+        [a],
+        match: MatchedSelection(
+          matched: {
+            'd1': [a],
+          },
+          unmatched: const [],
+        ),
+      );
+      final before = container.read(filesTabNotifierProvider);
+
+      notifier.assignAllUnmatched('d1');
+
+      expect(container.read(filesTabNotifierProvider), before);
+    });
+  });
+
   // The platform-conditional branches in _persistOne are exercised on the
   // host platform (macOS in CI / dev box) — the iOS / macOS branch. Coverage
   // for the Android / desktop branches is left to integration testing,

--- a/test/features/media/presentation/widgets/files_tab_test.dart
+++ b/test/features/media/presentation/widgets/files_tab_test.dart
@@ -268,4 +268,84 @@ void main() {
     );
     expect(progress.value, isNull); // indeterminate
   });
+
+  // commit() only persists files in match.matched, and the Link button is
+  // gated on matched being non-empty, so a photo the date matcher rejected
+  // could never be linked. When the picker was opened from a dive, that dive
+  // is an obvious manual target.
+  group('manual assignment to the picker\'s dive', () {
+    Widget wrap(FilesTabState seed, {String? diveId}) => ProviderScope(
+      overrides: [
+        filesTabNotifierProvider.overrideWith(
+          (ref) => _SeededFilesTabNotifier(seed),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(body: FilesTab(diveId: diveId)),
+      ),
+    );
+
+    FilesTabState withUnmatched(List<ExtractedFile> files) =>
+        FilesTabState.initial().copyWith(
+          files: files,
+          match: MatchedSelection(matched: const {}, unmatched: files),
+        );
+
+    testWidgets('offers a bulk add action when opened from a dive', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(withUnmatched([_ef('/a.jpg'), _ef('/b.jpg')]), diveId: 'd1'),
+      );
+
+      expect(find.text('Add all 2 to this dive'), findsOneWidget);
+    });
+
+    testWidgets('offers no bulk add action when opened without a dive', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(withUnmatched([_ef('/a.jpg')])));
+
+      expect(find.textContaining('Add all'), findsNothing);
+    });
+
+    testWidgets('bulk add routes every unmatched file to the dive', (
+      tester,
+    ) async {
+      final files = [_ef('/a.jpg'), _ef('/b.jpg')];
+      final notifier = _SeededFilesTabNotifier(withUnmatched(files));
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [filesTabNotifierProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(
+            home: Scaffold(body: FilesTab(diveId: 'd1')),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Add all 2 to this dive'));
+      await tester.pump();
+
+      expect(notifier.state.match.matched['d1'], files);
+      expect(notifier.state.match.unmatched, isEmpty);
+      // The Link button was previously unreachable in this state.
+      expect(find.text('Link 2 items'), findsOneWidget);
+    });
+
+    testWidgets('turning auto-match off still leaves files linkable', (
+      tester,
+    ) async {
+      final files = [_ef('/a.jpg')];
+      final seed = FilesTabState.initial().copyWith(
+        autoMatchByDate: false,
+        files: files,
+        match: MatchedSelection(matched: const {}, unmatched: files),
+      );
+      await tester.pumpWidget(wrap(seed, diveId: 'd1'));
+
+      // Without an assign affordance the unchecked checkbox made the whole
+      // tab a no-op: nothing could ever reach commit().
+      expect(find.text('Add all 1 to this dive'), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
Fixes the photo-attach failures [reported on ScubaBoard](https://scubaboard.com/community/threads/submersion-free-open-source-dive-log-app-all-platforms-looking-for-dive-computer-testers.667061/post-10801911): on Windows, photos reported as "4 photos were imported" then rendered **"File not found"** with blank file paths in the database, and photos whose timestamps fell inside the dive window were rejected as unmatched.

Three separate defects, one per commit.

## 1. Desktop imports never stored a file path

Windows and Linux have no platform photo library. `PhotoPickerServiceDesktop` opens a file dialog and returns `AssetInfo`s whose `id` is a synthetic `'<mtime_ms>_<path.hashCode>'` key into an **in-memory** `_filePathCache`. `MediaImportService._createMediaItemFromAsset` persisted only that `platformAssetId` — no `filePath`, no `localPath` — so `sourceType` fell through to its default `MediaSourceType.platformGallery`.

Display then routed through `PlatformGalleryResolver`, whose `AssetEntity.fromId` call goes to `photo_manager` — which **has no Windows backend at all**. The result was a guaranteed `notFound`, and the only pointer to the file died with the process.

`AssetInfo` gains a nullable `filePath`, and a path-bearing asset is persisted as a `localFile` row with `localPath` set. `LocalFileResolver` reads that straight off disk on every desktop platform, and the link survives a restart. This is the same mechanism the Files tab already used successfully.

Two further defects in the same picker:

- **Capture time came from the file mtime** — when the card was copied to the PC, not when the shot was taken. That is what pushed in-window photos outside the dive window. `ExifExtractor`'s own doc already warned mtime "would not match the dive window", but only the Files tab used the pure-Dart reader. Capture time now comes from the file's own EXIF `DateTimeOriginal` / MP4 `mvhd` via `readLocalCaptureTime`.

  Note the conversion: `readLocalCaptureTime` returns wall-clock-UTC, but `AssetInfo.createDateTime` is contractually **local** (photo_manager's convention, which consumers such as `TripMediaScanner.toWallClockUtc` reinterpret). The components are carried across verbatim; returning the UTC value would double-convert.

- **Dimensions were hardcoded `0x0`**, which silently disabled two of `AssetResolutionService`'s three resolution tiers — both bail on a 0x0 row.

Reading capture time and dimensions means reading file bytes, where the old implementation only did a `stat()`, so the desktop batch now runs on a `compute()` isolate rather than janking the UI thread on a large pick. Paths are registered on the main isolate after it returns.

## 2. The Files tab could not link a photo the matcher rejected

`FilesTabNotifier.commit()` only iterates `state.match.matched`, and the "Link N items" button is gated on that map being non-empty. An unmatched file had no route into the database at all — the only available action was to remove it.

Worse: unchecking **"Auto-match photos and videos to dives by date"** routed *every* picked file to `unmatched`, making the entire tab a silent no-op. That is the concrete form of the reporter's complaint that the app is "trying too hard to match a particular workflow and breaking everything else."

The picker already knows which dive it was opened from, so that dive is now threaded `PhotoImportHelper` -> `showPhotoPicker` -> `PhotoPickerPage` -> `FilesTab` and used as the manual assignment target:

- `assignToDive` / `assignAllUnmatched` move staged files between buckets, dropping emptied dive groups the way `removeFile` already does.
- The Unmatched group gains an "Add all N to this dive" action; each card gains an assign button.
- With auto-match off and a dive in context, picked files stage as matched to that dive instead of landing inert.

## 3. The "Done" button belonged to another tab

The AppBar's Done action commits the *Gallery* tab's selection but rendered over all three tabs. A user staging photos in the Files tab saw a permanently greyed Done and reasonably read it as rejection — which is exactly what the report describes. It is now scoped to the Gallery tab via a `ListenableBuilder` on the `DefaultTabController`.

## Notes

- **No schema change** — only how existing columns are populated.
- **Pre-existing broken rows are unrecoverable.** The path was never written, so photos imported on Windows before this fix must be deleted and re-added. Worth calling out in the thread reply.
- The bottom-time complaint in the same forum post is a separate issue and is not addressed here.

## Testing

- 24 new tests, written failing-first: desktop picker metadata extraction, import-service source-type routing, notifier assignment mutators, Files-tab assignment UI, and Done-action tab scoping.
- Full suite: **14180 passed, 0 failed** (baseline 14170).
- `flutter analyze` clean, `dart format` clean.
