### PR TITLE
fix(dashboard): route gear chips to /equipment instead of missing /gear

### DIFF
--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -65,7 +65,7 @@ class GaugeStrip extends ConsumerWidget {
             icon: Icons.add,
             label: l10n.dashboard_gauges_addGear,
             tone: _Tone.neutral,
-            onTap: () => context.go('/gear'),
+            onTap: () => context.push('/equipment/new'),
           ),
         );
       } else {
@@ -93,7 +93,7 @@ class GaugeStrip extends ConsumerWidget {
               icon: Icons.build_outlined,
               label: label,
               tone: tone,
-              onTap: () => context.go('/gear'),
+              onTap: () => context.go('/equipment'),
             ),
           );
         }

--- a/lib/features/dashboard/presentation/widgets/urgent_banner.dart
+++ b/lib/features/dashboard/presentation/widgets/urgent_banner.dart
@@ -40,7 +40,7 @@ class UrgentBanner extends ConsumerWidget {
     // Send the tap where the listed problem is fixed: gear service when
     // any clock is overdue, otherwise the insurance record.
     final destination = overdue.isNotEmpty
-        ? '/gear'
+        ? '/equipment'
         : '/settings/diver-profile/insurance';
     return Card(
       margin: EdgeInsets.zero,

--- a/test/features/dashboard/presentation/pages/dashboard_page_test.dart
+++ b/test/features/dashboard/presentation/pages/dashboard_page_test.dart
@@ -48,7 +48,11 @@ Future<void> pumpDashboard(
     routes: [
       GoRoute(path: '/', builder: (_, _) => const DashboardPage()),
       GoRoute(path: '/dives', builder: (_, _) => const Scaffold()),
-      GoRoute(path: '/gear', builder: (_, _) => const Scaffold()),
+      GoRoute(
+        path: '/equipment',
+        builder: (_, _) => const Scaffold(),
+        routes: [GoRoute(path: 'new', builder: (_, _) => const Scaffold())],
+      ),
     ],
   );
   await tester.pumpWidget(

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -55,7 +55,13 @@ Future<NavSpy> pumpStrip(
         path: '/',
         builder: (_, _) => const Scaffold(body: GaugeStrip()),
       ),
-      GoRoute(path: '/gear', builder: (_, _) => stub('/gear')),
+      GoRoute(
+        path: '/equipment',
+        builder: (_, _) => stub('/equipment'),
+        routes: [
+          GoRoute(path: 'new', builder: (_, _) => stub('/equipment/new')),
+        ],
+      ),
       GoRoute(
         path: '/certifications',
         builder: (_, _) => stub('/certifications'),
@@ -191,7 +197,7 @@ void main() {
       );
       expect(find.text('Add gear'), findsOneWidget);
       await tapChip(tester, 'Add gear');
-      expect(spy.location, '/gear');
+      expect(spy.location, '/equipment/new');
     });
 
     testWidgets('overdue, due-soon and ok gear render their own labels', (
@@ -232,7 +238,7 @@ void main() {
       expect(find.text('Add gear'), findsNothing);
 
       await tapChip(tester, 'Regulator overdue');
-      expect(spy.location, '/gear');
+      expect(spy.location, '/equipment');
     });
 
     testWidgets('due-soon clock without a due date falls back to 0 days', (

--- a/test/features/dashboard/presentation/widgets/urgent_banner_test.dart
+++ b/test/features/dashboard/presentation/widgets/urgent_banner_test.dart
@@ -59,7 +59,7 @@ Future<NavSpy> pumpBanner(WidgetTester tester, DashboardAlerts alerts) async {
         path: '/',
         builder: (_, _) => const Scaffold(body: UrgentBanner()),
       ),
-      GoRoute(path: '/gear', builder: (_, _) => stub('/gear')),
+      GoRoute(path: '/equipment', builder: (_, _) => stub('/equipment')),
       GoRoute(
         path: '/settings/diver-profile/insurance',
         builder: (_, _) => stub('/settings/diver-profile/insurance'),
@@ -130,7 +130,7 @@ void main() {
 
     await tester.tap(find.byType(InkWell));
     await tester.pumpAndSettle();
-    expect(spy.location, '/gear');
+    expect(spy.location, '/equipment');
   });
 
   testWidgets('caps overdue lines and shows a "+N more" overflow', (
@@ -157,7 +157,7 @@ void main() {
     // Tap still opens the gear list.
     await tester.tap(find.byType(InkWell));
     await tester.pumpAndSettle();
-    expect(spy.location, '/gear');
+    expect(spy.location, '/equipment');
   });
 
   testWidgets('expired insurance alone navigates to the insurance record', (
@@ -197,6 +197,6 @@ void main() {
 
     await tester.tap(find.byType(InkWell));
     await tester.pumpAndSettle();
-    expect(spy.location, '/gear');
+    expect(spy.location, '/equipment');
   });
 }


### PR DESCRIPTION
## Problem

On the home dashboard, tapping **+ Add gear** (and the gear service chips / the overdue-service urgent banner) crashes to the **Page Not Found** screen with:

```
GoException: no routes for location: /gear
```

There is no `/gear` route in `app_router.dart` — the gear/equipment section is registered at `/equipment`. The dashboard widgets just navigate to the wrong path.

## Fix

`lib/features/dashboard/presentation/widgets/`:

- **gauge_strip.dart**
  - "Add gear" chip -> `context.push('/equipment/new')` (opens the add-gear form directly, consistent with how gear is added elsewhere, e.g. `equipment_list_content.dart`).
  - Gear service chips -> `context.go('/equipment')` (the gear list).
- **urgent_banner.dart**
  - Overdue-service destination -> `/equipment`.

## Why the tests didn't catch it

`gauge_strip_test.dart` and `urgent_banner_test.dart` built their own stub `GoRouter` that *defined* a `/gear` route, so they asserted navigation against a path the real app router never had. Updated the stub routes and assertions to the real `/equipment` / `/equipment/new` routes so they now guard against this regression.

## Testing

Run locally against Flutter 3.44.8 / Dart 3.12.2:

- `flutter test test/features/dashboard/` -> all pass (43 tests)
- `flutter analyze` on the changed files -> no issues
- `dart format` -> clean