### PR TITLE
fix(planning): register no-fly route as a direct child of /planning

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -245,11 +245,6 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                     builder: (context, state) =>
                         const PlanChartFullscreenPage(),
                   ),
-                  GoRoute(
-                    path: 'no-fly',
-                    name: 'noFly',
-                    builder: (context, state) => const NoFlyPage(),
-                  ),
                 ],
               ),
               // Editing a saved plan is a SIBLING of the new-plan canvas, not a
@@ -258,7 +253,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               // both read the same shared divePlanNotifierProvider, the first
               // Back press only revealed the identical parent canvas, forcing a
               // second press. Declared after the divePlanner subtree so its
-              // static children (compare/chart/no-fly) still win route matching.
+              // static children (compare/chart) still win route matching.
               GoRoute(
                 path: 'dive-planner/:planId',
                 name: 'editPlan',
@@ -284,6 +279,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 path: 'surface-interval',
                 name: 'surfaceInterval',
                 builder: (context, state) => const SurfaceIntervalToolPage(),
+              ),
+              GoRoute(
+                path: 'no-fly',
+                name: 'noFly',
+                builder: (context, state) => const NoFlyPage(),
               ),
               // GPS Logger moved to top-level /gps-log; keep old deep
               // links working.

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/planner/presentation/pages/plan_canvas_page.dart';
 import 'package:submersion/features/safety/presentation/pages/incident_edit_page.dart';
 import 'package:submersion/features/safety/presentation/pages/incidents_list_page.dart';
+import 'package:submersion/features/safety/presentation/pages/no_fly_page.dart';
 import 'package:submersion/features/settings/presentation/pages/section_appearance_page.dart';
 import 'package:submersion/features/settings/presentation/pages/column_config_page.dart';
 
@@ -625,8 +626,26 @@ void main() {
         router.configuration.routes,
         'divePlanner',
       );
+      expect(divePlanner, isNotNull);
       final nestedNames = _collectRouteNames(divePlanner!.routes);
       expect(nestedNames, isNot(contains('noFly')));
+    });
+
+    testWidgets('noFly route builds the NoFlyPage', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      final context = tester.element(find.byType(SizedBox));
+
+      final noFly = _findRouteByName(router.configuration.routes, 'noFly');
+      expect(noFly, isNotNull);
+      final state = GoRouterState(
+        router.configuration,
+        uri: Uri.parse('/planning/no-fly'),
+        matchedLocation: '/planning/no-fly',
+        fullPath: '/planning/no-fly',
+        pathParameters: const {},
+        pageKey: const ValueKey('/planning/no-fly'),
+      );
+      expect(noFly!.builder!(context, state), isA<NoFlyPage>());
     });
 
     testWidgets(

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -593,8 +593,8 @@ void main() {
     });
 
     test('static sub-routes still win over the :planId sibling', () {
-      // Precedence guard: 'compare' / 'chart' / 'no-fly' remain children of
-      // divePlanner and must resolve before the dynamic sibling.
+      // Precedence guard: 'compare' / 'chart' remain children of divePlanner
+      // and must resolve before the dynamic sibling.
       expect(
         router.configuration
             .findMatch(Uri.parse('/planning/dive-planner/compare?ids=a,b'))
@@ -607,6 +607,26 @@ void main() {
             .fullPath,
         '/planning/dive-planner/chart',
       );
+    });
+
+    test('no-fly is a direct child of /planning (matches the hub tile)', () {
+      // Regression: the "Flying after diving" hub tile navigates to
+      // '/planning/no-fly'. The route used to live under 'dive-planner'
+      // (so its real path was '/planning/dive-planner/no-fly'), leaving the
+      // tile's target unmatched and throwing "no routes for location".
+      expect(
+        router.configuration.findMatch(Uri.parse('/planning/no-fly')).fullPath,
+        '/planning/no-fly',
+      );
+
+      final noFly = _findRouteByName(router.configuration.routes, 'noFly');
+      expect(noFly, isNotNull);
+      final divePlanner = _findRouteByName(
+        router.configuration.routes,
+        'divePlanner',
+      );
+      final nestedNames = _collectRouteNames(divePlanner!.routes);
+      expect(nestedNames, isNot(contains('noFly')));
     });
 
     testWidgets(


### PR DESCRIPTION
## Problem

On the Planning hub, tapping **Flying after diving** crashes to the **Page Not Found** screen with:

```
GoException: no routes for location: /planning/no-fly
```

The hub tile navigates to `/planning/no-fly` (`planning_page.dart`), but the route was nested under `dive-planner`, so its real path was `/planning/dive-planner/no-fly` — the tile's target never matched.

## Fix

`lib/core/router/app_router.dart`: move the `no-fly` `GoRoute` out of the `dive-planner` subtree and register it as a direct child of `/planning`, alongside the other TOOLS entries (`deco-calculator`, `gas-calculators`, `weight-calculator`, `surface-interval`) that the hub links to the same way. Nothing navigated to the old nested path, so this is safe.

Also updated the precedence comment near `dive-planner/:planId` (it listed no-fly as a static child that must win route matching; only `compare`/`chart` remain).

## Tests

- Added a regression test in `app_router_test.dart`: `/planning/no-fly` resolves to `/planning/no-fly`, and `noFly` is no longer a child of `divePlanner`.
- Updated the stale `static sub-routes still win` comment that mentioned no-fly.

Verified locally against Flutter 3.44.8 / Dart 3.12.2:

- `flutter test test/core/router/app_router_test.dart test/features/planning/planning_page_test.dart` -> all pass
- `flutter analyze` on the changed files -> no issues
- `dart format` -> clean