### PR TITLE
fix(dive-centers): fix imported-center View action (route + lingering snackbar)

### DIFF
--- a/lib/features/dive_centers/presentation/pages/dive_center_import_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_import_page.dart
@@ -63,7 +63,10 @@ class _DiveCenterImportPageState extends ConsumerState<DiveCenterImportPage> {
           action: SnackBarAction(
             label: context.l10n.diveCenters_action_view,
             onPressed: () {
-              context.push('/centers/${importedCenter.id}');
+              // Dismiss before navigating so the bar can't linger on the
+              // destination screen if this page is disposed mid-animation.
+              ScaffoldMessenger.of(context).hideCurrentSnackBar();
+              context.push('/dive-centers/${importedCenter.id}');
             },
           ),
         ),
@@ -405,7 +408,7 @@ class _LocalCenterCard extends StatelessWidget {
           center.name,
         ),
         child: InkWell(
-          onTap: () => context.push('/centers/${center.id}'),
+          onTap: () => context.push('/dive-centers/${center.id}'),
           borderRadius: BorderRadius.circular(12),
           child: Padding(
             padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Problem

On the dive center import page (`/dive-centers/import`), after importing a center:

1. the **View** action in the "imported \"...\"" snackbar, and
2. tapping a **saved-center card** (`_LocalCenterCard`)

both navigate to `/centers/<id>`, which is not a registered route. The detail page is registered at `/dive-centers/:centerId`, so both taps fail to open it. The identical dive-**site** import uses the valid `/sites/<id>` and works; this page was the only place using the `/centers/...` prefix.

A follow-on symptom (reported on iOS): after importing, the "imported" snackbar stayed stuck at the bottom of the screen and didn't dismiss, even after navigating back to Home.

## Fix

`lib/features/dive_centers/presentation/pages/dive_center_import_page.dart`:

- Use the real `/dive-centers/<id>` path in both spots.
- Dismiss the snackbar (`hideCurrentSnackBar`) before navigating from the View action, so it can't linger on the destination screen if this page is disposed mid-animation.

## Note on the stuck snackbar

I could not reproduce the lingering snackbar in a widget test (navigating from the action to either a valid or invalid route dismisses it cleanly there), so it appears to be an iOS-runtime interaction with the broken route. The correct route (matching the working site import) plus the explicit dismiss should resolve it; the dismiss is standard belt-and-suspenders for actions that navigate away.

## Testing

Verified locally against Flutter 3.44.8 / Dart 3.12.2:

- `flutter test test/features/dive_centers/` -> all pass (145 tests)
- `flutter analyze` on the changed file -> no issues
- `dart format` -> clean

## Unrelated finding

The audit that surfaced this also found `lib/features/tools/presentation/pages/tools_page.dart`, which is orphaned (not registered in the router, never navigated to) and points at non-existent `/tools/deco-calculator` and `/tools/gas-calculators` routes. Left untouched here; happy to remove it or wire it up separately.