### PR TITLE
fix(dashboard): make the insurance gauge chip tappable

### DIFF
--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -109,6 +109,7 @@ class GaugeStrip extends ConsumerWidget {
             icon: Icons.health_and_safety_outlined,
             label: l10n.dashboard_gauges_noInsurance,
             tone: _Tone.neutral,
+            onTap: () => context.go('/settings/diver-profile/insurance'),
           ),
         );
       } else if (insurance.isExpired) {
@@ -118,6 +119,7 @@ class GaugeStrip extends ConsumerWidget {
             icon: Icons.health_and_safety_outlined,
             label: l10n.dashboard_gauges_insuranceExpired,
             tone: _Tone.alert,
+            onTap: () => context.go('/settings/diver-profile/insurance'),
           ),
         );
       } else if (insurance.isExpiringSoon) {
@@ -131,6 +133,7 @@ class GaugeStrip extends ConsumerWidget {
               ).format(insurance.expiryDate!),
             ),
             tone: _Tone.warn,
+            onTap: () => context.go('/settings/diver-profile/insurance'),
           ),
         );
       } else {
@@ -140,6 +143,7 @@ class GaugeStrip extends ConsumerWidget {
             icon: Icons.health_and_safety_outlined,
             label: l10n.dashboard_gauges_insuranceOk,
             tone: _Tone.ok,
+            onTap: () => context.go('/settings/diver-profile/insurance'),
           ),
         );
       }

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -284,8 +284,10 @@ void main() {
       expect(find.text('No insurance on file'), findsOneWidget);
     });
 
-    testWidgets('expired insurance', (tester) async {
-      await pumpStrip(
+    testWidgets('expired insurance chip navigates to the insurance record', (
+      tester,
+    ) async {
+      final spy = await pumpStrip(
         tester,
         DashboardGauges(
           gearGauges: const [],
@@ -299,10 +301,14 @@ void main() {
         ),
       );
       expect(find.text('Insurance expired'), findsOneWidget);
+      await tapChip(tester, 'Insurance expired');
+      expect(spy.location, '/settings/diver-profile/insurance');
     });
 
-    testWidgets('insurance expiring soon shows the date', (tester) async {
-      await pumpStrip(
+    testWidgets('expiring-soon insurance chip navigates to the record', (
+      tester,
+    ) async {
+      final spy = await pumpStrip(
         tester,
         DashboardGauges(
           gearGauges: const [],
@@ -315,7 +321,12 @@ void main() {
           daysSinceLastDive: null,
         ),
       );
-      expect(find.textContaining('Insurance expires'), findsOneWidget);
+      // The label carries a formatted date, so match on its prefix.
+      final chip = find.textContaining('Insurance expires');
+      expect(chip, findsOneWidget);
+      await tester.tap(find.ancestor(of: chip, matching: find.byType(InkWell)));
+      await tester.pumpAndSettle();
+      expect(spy.location, '/settings/diver-profile/insurance');
     });
 
     testWidgets('valid insurance chip navigates to the insurance record', (

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -75,6 +75,10 @@ Future<NavSpy> pumpStrip(
         path: '/settings/data-quality',
         builder: (_, _) => stub('/settings/data-quality'),
       ),
+      GoRoute(
+        path: '/settings/diver-profile/insurance',
+        builder: (_, _) => stub('/settings/diver-profile/insurance'),
+      ),
     ],
   );
   await tester.pumpWidget(
@@ -255,9 +259,13 @@ void main() {
   });
 
   group('insurance chip', () {
-    testWidgets('missing insurance', (tester) async {
-      await pumpStrip(tester, _emptyGauges);
+    testWidgets('missing insurance chip navigates to the insurance record', (
+      tester,
+    ) async {
+      final spy = await pumpStrip(tester, _emptyGauges);
       expect(find.text('No insurance on file'), findsOneWidget);
+      await tapChip(tester, 'No insurance on file');
+      expect(spy.location, '/settings/diver-profile/insurance');
     });
 
     testWidgets('insurance without an expiry date reads as missing', (
@@ -310,8 +318,10 @@ void main() {
       expect(find.textContaining('Insurance expires'), findsOneWidget);
     });
 
-    testWidgets('valid insurance', (tester) async {
-      await pumpStrip(
+    testWidgets('valid insurance chip navigates to the insurance record', (
+      tester,
+    ) async {
+      final spy = await pumpStrip(
         tester,
         DashboardGauges(
           gearGauges: const [],
@@ -325,6 +335,8 @@ void main() {
         ),
       );
       expect(find.text('Insurance OK'), findsOneWidget);
+      await tapChip(tester, 'Insurance OK');
+      expect(spy.location, '/settings/diver-profile/insurance');
     });
   });
 


### PR DESCRIPTION
## Problem

On the home dashboard, the insurance gauge chip (**No insurance on file**, and likewise the expired / expiring-soon / valid states) is not tappable. Unlike the gear, certifications, trip and backup chips next to it, the insurance chip has no `onTap`, so:

- tapping it does nothing, and
- there is no discoverable path from the dashboard to add insurance.

## Fix

`lib/features/dashboard/presentation/widgets/gauge_strip.dart`: wire all four insurance states to `/settings/diver-profile/insurance` (the `InsuranceEditPage`) — the same destination the overdue-insurance urgent banner already navigates to.

## Tests

`test/features/dashboard/presentation/widgets/gauge_strip_test.dart`:

- added the `/settings/diver-profile/insurance` stub route to the test router;
- the "missing insurance" test now taps the chip and asserts it navigates (previously it only checked the label);
- the "valid insurance" test does the same.

Verified locally against Flutter 3.44.8 / Dart 3.12.2: `flutter test` on the file passes, `flutter analyze` clean, `dart format` clean.

## Note

Touches the same file as #740 (gear chip routing) but different lines; they should merge independently.