### PR TITLE
fix(dive-log): keep large dive numbers inside the list-tile badge

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -839,12 +839,21 @@ class DiveListTile extends ConsumerWidget {
                             )
                           : CircleAvatar(
                               backgroundColor: colorScheme.primaryContainer,
-                              child: Text(
-                                '#$diveNumber',
-                                style: TextStyle(
-                                  color: colorScheme.onPrimaryContainer,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 12,
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 4,
+                                ),
+                                child: FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  child: Text(
+                                    '#$diveNumber',
+                                    maxLines: 1,
+                                    style: TextStyle(
+                                      color: colorScheme.onPrimaryContainer,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 12,
+                                    ),
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
@@ -283,12 +283,17 @@ class CompactDiveListTile extends ConsumerWidget {
                               ),
                             ),
                             if (!isSelectionMode)
-                              Text(
-                                '#$diveNumber',
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 12,
-                                  color: accentColor,
+                              FittedBox(
+                                fit: BoxFit.scaleDown,
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  '#$diveNumber',
+                                  maxLines: 1,
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 12,
+                                    color: accentColor,
+                                  ),
                                 ),
                               ),
                           ],

--- a/lib/features/dive_log/presentation/widgets/dense_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/dense_dive_list_tile.dart
@@ -307,12 +307,17 @@ class DenseDiveListTile extends ConsumerWidget {
                         ),
                       ),
                       if (!isSelectionMode)
-                        Text(
-                          '#$diveNumber',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 12,
-                            color: accentColor,
+                        FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            '#$diveNumber',
+                            maxLines: 1,
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12,
+                              color: accentColor,
+                            ),
                           ),
                         ),
                     ],

--- a/test/features/dive_log/presentation/pages/dive_list_tile_slots_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_list_tile_slots_test.dart
@@ -139,4 +139,41 @@ void main() {
       expect(find.textContaining('2024'), findsNothing);
     });
   });
+
+  group('DiveListTile dive number badge', () {
+    testWidgets('large dive number stays on one line and scales to fit', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            settingsProvider.overrideWith(
+              (ref) => _TestSettingsNotifier(const AppSettings()),
+            ),
+            detailedCardConfigProvider.overrideWith(
+              (ref) =>
+                  _TestCardConfigNotifier(CardViewConfig.defaultDetailed()),
+            ),
+          ],
+          child: DiveListTile(
+            diveId: 'd1',
+            diveNumber: 88888,
+            dateTime: DateTime(2024, 6, 1),
+            siteName: 'Blue Hole',
+            summary: summary(siteName: 'Blue Hole'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final badge = find.text('#88888');
+      expect(badge, findsOneWidget);
+      expect(tester.widget<Text>(badge).maxLines, 1);
+      expect(
+        find.ancestor(of: badge, matching: find.byType(FittedBox)),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
@@ -49,6 +49,36 @@ void main() {
       expect(find.textContaining('52'), findsWidgets);
     });
 
+    testWidgets('large dive number stays on one line and scales to fit', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          ],
+          child: CompactDiveListTile(
+            diveId: 'test-id',
+            diveNumber: 88888,
+            dateTime: DateTime(2026, 3, 15, 9, 30),
+            siteName: 'Blue Corner Wall',
+            maxDepth: 28.5,
+            duration: const Duration(minutes: 52),
+            onTap: () {},
+          ),
+        ),
+      );
+
+      final badge = find.text('#88888');
+      expect(badge, findsOneWidget);
+      expect(tester.widget<Text>(badge).maxLines, 1);
+      expect(
+        find.ancestor(of: badge, matching: find.byType(FittedBox)),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('shows a safety finding badge when the summary has findings', (
       tester,
     ) async {

--- a/test/features/dive_log/presentation/widgets/dense_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/dense_dive_list_tile_test.dart
@@ -51,6 +51,36 @@ void main() {
       expect(find.textContaining('Mar'), findsWidgets);
     });
 
+    testWidgets('large dive number stays on one line and scales to fit', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          ],
+          child: DenseDiveListTile(
+            diveId: 'test-id',
+            diveNumber: 88888,
+            dateTime: DateTime(2026, 3, 15, 9, 30),
+            siteName: 'Blue Corner Wall',
+            maxDepth: 28.5,
+            duration: const Duration(minutes: 52),
+            onTap: () {},
+          ),
+        ),
+      );
+
+      final badge = find.text('#88888');
+      expect(badge, findsOneWidget);
+      expect(tester.widget<Text>(badge).maxLines, 1);
+      expect(
+        find.ancestor(of: badge, matching: find.byType(FittedBox)),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('shows checkbox in selection mode', (tester) async {
       await tester.pumpWidget(
         testApp(


### PR DESCRIPTION
## Problem

On both macOS and iOS, the dive number badge in the dive list tiles doesn't fit once the number gets large. The badge renders a fixed 12px bold `#<n>` in a fixed-size slot:

- detailed mode: a 40x40 `CircleAvatar`
- compact / dense mode: a 36px-wide leading slot

At four or five digits (e.g. **#2845**) the text no longer fits, wraps to two lines and overflows the circle. Reported on the dashboard Recent dives list, but it affects the Dives tab too since both reuse these tiles.

## Fix

Wrap the badge text in `FittedBox(fit: BoxFit.scaleDown)` with `maxLines: 1` in all three tile variants (`dive_list_page.dart` `DiveListTile`, `compact_dive_list_tile.dart`, `dense_dive_list_tile.dart`). Long numbers scale down to fit on a single line; short numbers keep the original 12px size (`scaleDown` never enlarges).

## Tests

Added a regression test to each tile's test file: rendering a 5-digit dive number keeps the badge on one line (`maxLines == 1`), wrapped in a `FittedBox`, with no layout exception.

Verified locally against Flutter 3.44.8 / Dart 3.12.2: `flutter test` on the three tile tests passes (41 tests), `flutter analyze` clean, `dart format` clean.

## Note

The same `#<n>` marker is also drawn on map pins (`dive_map_content.dart`, `dive_activity_map_page.dart`) and in `dive_profile_panel.dart`. Those are a different visual context and out of scope here; can follow up if they show the same clipping.