### PR TITLE
fix(signatures): let users draw by disabling sheet drag-to-dismiss

### DIFF
--- a/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
+++ b/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
@@ -333,6 +333,10 @@ Future<void> showBuddySignatureRequestSheet({
   return showModalBottomSheet(
     context: context,
     isScrollControlled: true,
+    // Drawing on the signature canvas uses a pan gesture; the sheet's
+    // drag-to-dismiss would otherwise win the gesture arena and move the
+    // whole sheet instead of drawing. A Cancel button provides dismissal.
+    enableDrag: false,
     builder: (context) => BuddySignatureRequestSheet(
       buddyWithRole: buddyWithRole,
       onSave: onSave,

--- a/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
+++ b/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
@@ -355,6 +355,10 @@ Future<void> showSignatureCaptureSheet({
   return showModalBottomSheet(
     context: context,
     isScrollControlled: true,
+    // Drawing on the signature canvas uses a pan gesture; the sheet's
+    // drag-to-dismiss would otherwise win the gesture arena and move the
+    // whole sheet instead of drawing. A Cancel button provides dismissal.
+    enableDrag: false,
     builder: (context) => SignatureCaptureSheet(
       initialSignerName: initialSignerName,
       onSave: onSave,


### PR DESCRIPTION
## Problem

On iOS, opening the **Signatures** section on a dive and tapping **Ready to Sign** shows a signature pad, but trying to draw with a finger moves/dismisses the whole sheet instead of drawing — the signature can't be captured.

## Cause

Both signature sheets are shown with `showModalBottomSheet(isScrollControlled: true, ...)` and the default `enableDrag: true`. The drawing canvas is a raw `GestureDetector` (pan) over a `CustomPaint`. The sheet's drag-to-dismiss `VerticalDragGestureRecognizer` competes with the canvas's `PanGestureRecognizer` in the gesture arena and wins for any drag with a vertical component, so the pointer is interpreted as "drag the sheet" rather than "draw". It presents as iOS-only because the modal sheet's drag-to-dismiss is the always-on, sensitive interaction there.

## Fix

Pass `enableDrag: false` to both:

- `showBuddySignatureRequestSheet` (`buddy_signature_request_sheet.dart`)
- `showSignatureCaptureSheet` (`signature_capture_widget.dart`)

Both screens already provide a **Cancel** button, so dismissal is unaffected; only the drag-to-dismiss gesture (the one stealing the drawing pan) is removed.

## Testing

Verified locally against Flutter 3.44.8 / Dart 3.12.2: `flutter analyze` on both files is clean, `dart format` clean. No widget-test harness exists for these sheets, and simulating the gesture-arena conflict in a test is brittle, so this is a targeted config fix verified by analysis; happy to add a drag-vs-draw widget test if you'd like.