### PR TITLE
fix(profile): stop over-detecting safety stops on wavy shallow phases

### DIFF
--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -1053,8 +1053,16 @@ class ProfileAnalysisService {
     const minDiveDepth = 10.0;
     const minStopDepth = 3.0;
     const maxStopDepth = 6.0;
+    // Once a stop has opened, brief drifts just outside the 3-6 m band
+    // (buoyancy wobble, small level changes) must not end it. The stop closes
+    // only on a *clear* departure: surfacing (shallower than [stopExitShallow])
+    // or descending back down (deeper than [stopExitDeep]). Without this
+    // hysteresis a long, gently varying shallow phase gets chopped into many
+    // spurious start/end pairs as the depth repeatedly crosses 3 m or 6 m.
+    const stopExitShallow = 1.5; // m -- heading to the surface
+    const stopExitDeep = 8.0; // m -- descending away from the stop
     const minStopDuration = 120; // 2 minutes
-    const maxConsolidationGap = 30; // seconds
+    const maxConsolidationGap = 120; // seconds -- bridge brief clear departures
 
     // Layer 1: Skip shallow dives
     if (depths[maxDepthIndex] < minDiveDepth) return;
@@ -1065,47 +1073,42 @@ class ProfileAnalysisService {
           ({int startIndex, int startTimestamp, int endIndex, int endTimestamp})
         >[];
 
+    void addRawStop(int startIndex, int startTimestamp, int endIndex) {
+      final duration = timestamps[endIndex] - startTimestamp;
+      if (duration >= minStopDuration) {
+        rawStops.add((
+          startIndex: startIndex,
+          startTimestamp: startTimestamp,
+          endIndex: endIndex,
+          endTimestamp: timestamps[endIndex],
+        ));
+      }
+    }
+
     int? stopStartIndex;
     int? stopStartTimestamp;
 
     // Layer 2: Only scan ascent phase (after max depth point)
     for (int i = maxDepthIndex + 1; i < depths.length; i++) {
       final depth = depths[i];
-      final timestamp = timestamps[i];
 
-      if (depth >= minStopDepth && depth <= maxStopDepth) {
-        if (stopStartIndex == null) {
+      if (stopStartIndex == null) {
+        // Open a stop when the diver settles into the safety-stop band.
+        if (depth >= minStopDepth && depth <= maxStopDepth) {
           stopStartIndex = i;
-          stopStartTimestamp = timestamp;
+          stopStartTimestamp = timestamps[i];
         }
-      } else {
-        if (stopStartIndex != null && stopStartTimestamp != null) {
-          final duration = timestamps[i - 1] - stopStartTimestamp;
-          if (duration >= minStopDuration) {
-            rawStops.add((
-              startIndex: stopStartIndex,
-              startTimestamp: stopStartTimestamp,
-              endIndex: i - 1,
-              endTimestamp: timestamps[i - 1],
-            ));
-          }
-          stopStartIndex = null;
-          stopStartTimestamp = null;
-        }
+      } else if (depth < stopExitShallow || depth > stopExitDeep) {
+        // Clear departure: close at the previous in-range sample.
+        addRawStop(stopStartIndex, stopStartTimestamp!, i - 1);
+        stopStartIndex = null;
+        stopStartTimestamp = null;
       }
     }
 
     // Handle stop that extends to end of profile
-    if (stopStartIndex != null && stopStartTimestamp != null) {
-      final duration = timestamps.last - stopStartTimestamp;
-      if (duration >= minStopDuration) {
-        rawStops.add((
-          startIndex: stopStartIndex,
-          startTimestamp: stopStartTimestamp,
-          endIndex: depths.length - 1,
-          endTimestamp: timestamps.last,
-        ));
-      }
+    if (stopStartIndex != null) {
+      addRawStop(stopStartIndex, stopStartTimestamp!, depths.length - 1);
     }
 
     if (rawStops.isEmpty) return;

--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -1040,8 +1040,11 @@ class ProfileAnalysisService {
   ///
   /// Three-layer detection:
   /// 1. Max depth gate: skip dives shallower than 10m
-  /// 2. Ascent-phase restriction: only scan after max depth point
-  /// 3. Consolidation: merge stops separated by gaps <= 30s
+  /// 2. Ascent-phase scan with hysteresis: only samples after the max depth
+  ///    point are considered; a stop opens when depth enters the 3-6m band
+  ///    and closes only on a clear departure (shallower than 1.5m or deeper
+  ///    than 8m), so small drifts across the band edges do not split it
+  /// 3. Consolidation: merge stops separated by gaps <= 120s
   void _detectSafetyStops(
     String diveId,
     List<double> depths,
@@ -1099,7 +1102,8 @@ class ProfileAnalysisService {
           stopStartTimestamp = timestamps[i];
         }
       } else if (depth < stopExitShallow || depth > stopExitDeep) {
-        // Clear departure: close at the previous in-range sample.
+        // Clear departure: close at the previous sample (which may sit
+        // between the band edge and the hysteresis threshold, e.g. 7m).
         addRawStop(stopStartIndex, stopStartTimestamp!, i - 1);
         stopStartIndex = null;
         stopStartTimestamp = null;

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -685,12 +685,18 @@ void main() {
         return (depths: depths, timestamps: timestamps);
       }
 
-      test('two stops separated by 10s gap are merged into one', () {
+      test('in-band drift (7m / 2m) keeps a single stop', () {
+        // Small drifts just outside the 3-6m band are buoyancy wobble, not a
+        // new stop: hysteresis keeps them within one continuous stop, even
+        // when they last longer than the consolidation window.
         final profile = buildDiveWithGaps(
-          gaps: [(durationSeconds: 10, depth: 7.0)],
+          gaps: [
+            (durationSeconds: 31, depth: 7.0),
+            (durationSeconds: 45, depth: 2.0),
+          ],
         );
         final result = service.analyze(
-          diveId: 'merge-short-gap',
+          diveId: 'in-band-drift',
           depths: profile.depths,
           timestamps: profile.timestamps,
         );
@@ -700,33 +706,34 @@ void main() {
         expect(stops[1].eventType, ProfileEventType.safetyStopEnd);
       });
 
-      test('two stops separated by 31s gap remain separate', () {
+      test('brief clear departure below the band is bridged into one', () {
+        // A short re-descent past the hysteresis band (>8m) still consolidates
+        // when the gap is within maxConsolidationGap.
         final profile = buildDiveWithGaps(
-          gaps: [(durationSeconds: 31, depth: 7.0)],
+          gaps: [(durationSeconds: 60, depth: 10.0)],
         );
         final result = service.analyze(
-          diveId: 'keep-long-gap',
+          diveId: 'merge-brief-departure',
+          depths: profile.depths,
+          timestamps: profile.timestamps,
+        );
+        final stops = safetyStopEvents(result);
+        expect(stops.length, equals(2)); // merged into one
+      });
+
+      test('long clear departure splits into separate stops', () {
+        // A sustained re-descent past the hysteresis band, beyond the
+        // consolidation window, is genuinely two separate stops.
+        final profile = buildDiveWithGaps(
+          gaps: [(durationSeconds: 150, depth: 10.0)],
+        );
+        final result = service.analyze(
+          diveId: 'split-long-departure',
           depths: profile.depths,
           timestamps: profile.timestamps,
         );
         final stops = safetyStopEvents(result);
         expect(stops.length, equals(4)); // two starts + two ends
-      });
-
-      test('three consecutive stops with short gaps merge into one', () {
-        final profile = buildDiveWithGaps(
-          gaps: [
-            (durationSeconds: 10, depth: 7.0),
-            (durationSeconds: 15, depth: 2.0),
-          ],
-        );
-        final result = service.analyze(
-          diveId: 'merge-three',
-          depths: profile.depths,
-          timestamps: profile.timestamps,
-        );
-        final stops = safetyStopEvents(result);
-        expect(stops.length, equals(2)); // all merged into one
       });
 
       test('single stop with no neighbors is unchanged', () {
@@ -785,6 +792,61 @@ void main() {
           reason:
               'Shallow dive at safety stop depths should not trigger '
               'safety stop detection (max depth gate: < 10m)',
+        );
+      });
+
+      test('long wavy shallow phase after a deep dive is one stop', () {
+        // Reproduces the reported issue: after a proper deep phase the diver
+        // spends a long shallow stretch gently oscillating across the 3m and
+        // 6m band edges. This must read as a single safety stop, not a string
+        // of spurious start/end pairs.
+        final depths = <double>[];
+        final timestamps = <int>[];
+        var t = 0;
+
+        // Descent to 20m: 1 minute
+        for (var s = 0; s <= 60; s++) {
+          timestamps.add(t);
+          depths.add(20.0 * s / 60.0);
+          t++;
+        }
+        // Bottom at 20m: 5 minutes
+        for (var s = 0; s < 300; s++) {
+          timestamps.add(t);
+          depths.add(20.0);
+          t++;
+        }
+        // Ascent to ~4.5m: 1 minute
+        for (var s = 0; s <= 60; s++) {
+          timestamps.add(t);
+          depths.add(20.0 - 15.5 * s / 60.0);
+          t++;
+        }
+        // 15 minutes oscillating 2.5m..6.5m (crossing both band edges)
+        for (var s = 0; s < 15 * 60; s++) {
+          timestamps.add(t);
+          final phase = (s % 120) / 120.0; // 2-minute period
+          final tri = phase < 0.5 ? phase * 2 : 2 - phase * 2; // 0..1..0
+          depths.add(2.5 + 4.0 * tri); // 2.5m .. 6.5m
+          t++;
+        }
+        // Surface: 30 seconds
+        for (var s = 0; s <= 30; s++) {
+          timestamps.add(t);
+          depths.add(2.5 * (1 - s / 30.0));
+          t++;
+        }
+
+        final result = service.analyze(
+          diveId: 'wavy-shallow',
+          depths: depths,
+          timestamps: timestamps,
+        );
+        final stops = safetyStopEvents(result);
+        expect(
+          stops.length,
+          equals(2),
+          reason: 'an oscillating shallow phase should be a single safety stop',
         );
       });
     });

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -687,8 +687,9 @@ void main() {
 
       test('in-band drift (7m / 2m) keeps a single stop', () {
         // Small drifts just outside the 3-6m band are buoyancy wobble, not a
-        // new stop: hysteresis keeps them within one continuous stop, even
-        // when they last longer than the consolidation window.
+        // new stop: hysteresis keeps the segment open through them, so the
+        // stop never splits. (Under the previous 30s consolidation window,
+        // these 31s/45s excursions each broke the stop in two.)
         final profile = buildDiveWithGaps(
           gaps: [
             (durationSeconds: 31, depth: 7.0),


### PR DESCRIPTION
## Problem

On a dive with a long, gently varying shallow phase, the profile chart shows **many** "Safety Stop Start" / "Safety Stop End" markers (7-8 pairs) where there should be one.

## Cause

`ProfileAnalysisService._detectSafetyStops` detects stops from the depth profile. A stop segment closed the instant depth left the fixed 3-6 m band, and only gaps ≤ 30 s were consolidated. A diver hovering in the shallow phase repeatedly drifts just across the 3 m or 6 m edge for more than 30 s, so each excursion closes the current segment and the next in-band period opens a fresh one — producing a string of spurious start/end pairs.

## Fix

Add **hysteresis** to the segment state machine: a stop still *opens* when depth enters the 3-6 m band, but now *closes* only on a clear departure — surfacing (`< 1.5 m`) or descending back down (`> 8 m`). Small drifts within the band (buoyancy wobble, minor level changes) no longer split the stop. The consolidation gap is also widened from 30 s to 120 s to bridge brief genuine departures.

## Tests

- Reworked the `consolidation` group to the new model: in-band drift (7 m / 2 m, even for 31-45 s) stays one stop; a brief clear departure below the band is bridged into one; a long clear departure stays two separate stops.
- Added an `integration` regression test: a proper deep dive followed by a 15-minute shallow phase oscillating across the 3 m and 6 m edges now yields exactly **one** safety stop.

Verified locally against Flutter 3.44.8 / Dart 3.12.2: the safety-stop, deco-stop, safety-review and profile-event suites pass; `flutter analyze` clean; `dart format` clean.