### PR TITLE
fix(deco): guard against non-bar surface pressure poisoning Deco Status / Tissue Loading

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2846,7 +2846,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 136;
+  static const int currentSchemaVersion = 137;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -3010,6 +3010,9 @@ class AppDatabase extends _$AppDatabase {
     // Phase A). Renumbered from v130 as main advanced past it at merge time.
     134,
     136,
+    // v137: repair surface_pressure rows stored in millibar/hectopascal
+    // (used verbatim as bar, they poisoned the deco/tissue panels).
+    137,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -3196,6 +3199,34 @@ class AppDatabase extends _$AppDatabase {
   /// for minimal old-schema fixtures. onUpgrade only -- never beforeOpen -- so
   /// a dive a user deliberately left with bottom_time == runtime (and no
   /// profile to prove otherwise) is never re-touched.
+  /// Repairs `dives.surface_pressure` rows stored in the wrong unit.
+  ///
+  /// The column is bar, but some import/legacy paths wrote millibar/
+  /// hectopascal values (e.g. 1013) into it. Used verbatim, a ~1000x-too-large
+  /// surface pressure poisons the decompression model and shows absurd figures
+  /// on the dive detail page. This mirrors [normalizeSurfacePressureBar]:
+  /// convert an obvious mbar/hPa value to bar, then null out anything still
+  /// outside the physically-possible surface range (~0.5-1.1 bar). Since no
+  /// real surface pressure is ever out of that range, only corrupt rows are
+  /// touched. PRAGMA-guarded like every other migration helper.
+  Future<void> _repairSurfacePressure() async {
+    final cols = await customSelect("PRAGMA table_info('dives')").get();
+    final colNames = cols.map((c) => c.read<String>('name')).toSet();
+    if (!colNames.contains('surface_pressure')) return;
+
+    // Obvious mbar/hPa magnitude -> bar.
+    await customStatement(
+      'UPDATE dives SET surface_pressure = surface_pressure / 1000.0 '
+      'WHERE surface_pressure IS NOT NULL AND surface_pressure > 100',
+    );
+    // Anything still physically impossible -> NULL (fall back to standard).
+    await customStatement(
+      'UPDATE dives SET surface_pressure = NULL '
+      'WHERE surface_pressure IS NOT NULL '
+      'AND (surface_pressure < 0.5 OR surface_pressure > 1.1)',
+    );
+  }
+
   Future<void> _backfillBottomTimeFromProfile() async {
     // PRAGMA-guarded like every other migration helper: minimal old-schema
     // test fixtures (and any DB that reached this block through a guarded
@@ -7063,6 +7094,13 @@ class AppDatabase extends _$AppDatabase {
           await _assertMediaStoresLastSweepColumn();
         }
         if (from < 136) await reportProgress();
+        // v137: repair surface_pressure values stored in millibar/hectopascal
+        // (e.g. 1013) in this bar-typed column, which poisoned the deco/tissue
+        // panels and displayed as absurd figures elsewhere.
+        if (from < 137) {
+          await _repairSurfacePressure();
+        }
+        if (from < 137) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/core/deco/entities/dive_environment.dart
+++ b/lib/core/deco/entities/dive_environment.dart
@@ -40,14 +40,16 @@ class DiveEnvironment extends Equatable {
   ///
   /// An explicit [surfacePressureBar] wins over [altitudeMeters]. A null
   /// altitude keeps the legacy 1.0 bar surface so dives without altitude
-  /// data are unchanged.
+  /// data are unchanged. The surface pressure is sanitized first (see
+  /// [_sanitizeSurfacePressureBar]); an implausible value is ignored so we
+  /// fall back to altitude/standard pressure rather than poisoning the model.
   factory DiveEnvironment.forConditions({
     double? altitudeMeters,
     WaterType? waterType,
     double? surfacePressureBar,
   }) {
     final surface =
-        surfacePressureBar ??
+        _sanitizeSurfacePressureBar(surfacePressureBar) ??
         (altitudeMeters != null
             ? AltitudeCalculator.calculateBarometricPressure(altitudeMeters)
             : 1.0);
@@ -61,6 +63,26 @@ class DiveEnvironment extends Equatable {
       surfacePressureBar: surface,
       waterDensityKgM3: density,
     );
+  }
+
+  /// Sanitizes a surface pressure that is nominally in bar.
+  ///
+  /// Atmospheric surface pressure is only ever ~0.5 bar (high altitude) to
+  /// ~1.06 bar (sea level). Some import paths have written millibar/
+  /// hectopascal values (e.g. 1013) straight into the bar-typed field. Used
+  /// verbatim, a ~1000x-too-large surface pressure poisons the whole
+  /// decompression model: tissue tensions of hundreds of bar, gradient
+  /// factors clamped to 0, and NDL saturating at its "unlimited" sentinel.
+  ///
+  /// So: convert an obvious mbar/hPa value to bar, then reject anything still
+  /// physically impossible (returning null) so the caller falls back to the
+  /// altitude-derived or standard 1.0 bar surface instead of garbage.
+  static double? _sanitizeSurfacePressureBar(double? raw) {
+    if (raw == null) return null;
+    var bar = raw;
+    if (bar > 100.0) bar /= 1000.0; // millibar / hectopascal -> bar
+    if (bar < 0.5 || bar > 1.1) return null; // implausible -> ignore
+    return bar;
   }
 
   static const double _gravity = 9.80665;

--- a/lib/core/deco/entities/dive_environment.dart
+++ b/lib/core/deco/entities/dive_environment.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/deco/altitude_calculator.dart';
+import 'package:submersion/core/utils/surface_pressure.dart';
 
 /// Physical environment for decompression calculations.
 ///
@@ -41,7 +42,7 @@ class DiveEnvironment extends Equatable {
   /// An explicit [surfacePressureBar] wins over [altitudeMeters]. A null
   /// altitude keeps the legacy 1.0 bar surface so dives without altitude
   /// data are unchanged. The surface pressure is sanitized first (see
-  /// [_sanitizeSurfacePressureBar]); an implausible value is ignored so we
+  /// [normalizeSurfacePressureBar]); an implausible value is ignored so we
   /// fall back to altitude/standard pressure rather than poisoning the model.
   factory DiveEnvironment.forConditions({
     double? altitudeMeters,
@@ -49,7 +50,7 @@ class DiveEnvironment extends Equatable {
     double? surfacePressureBar,
   }) {
     final surface =
-        _sanitizeSurfacePressureBar(surfacePressureBar) ??
+        normalizeSurfacePressureBar(surfacePressureBar) ??
         (altitudeMeters != null
             ? AltitudeCalculator.calculateBarometricPressure(altitudeMeters)
             : 1.0);
@@ -63,26 +64,6 @@ class DiveEnvironment extends Equatable {
       surfacePressureBar: surface,
       waterDensityKgM3: density,
     );
-  }
-
-  /// Sanitizes a surface pressure that is nominally in bar.
-  ///
-  /// Atmospheric surface pressure is only ever ~0.5 bar (high altitude) to
-  /// ~1.06 bar (sea level). Some import paths have written millibar/
-  /// hectopascal values (e.g. 1013) straight into the bar-typed field. Used
-  /// verbatim, a ~1000x-too-large surface pressure poisons the whole
-  /// decompression model: tissue tensions of hundreds of bar, gradient
-  /// factors clamped to 0, and NDL saturating at its "unlimited" sentinel.
-  ///
-  /// So: convert an obvious mbar/hPa value to bar, then reject anything still
-  /// physically impossible (returning null) so the caller falls back to the
-  /// altitude-derived or standard 1.0 bar surface instead of garbage.
-  static double? _sanitizeSurfacePressureBar(double? raw) {
-    if (raw == null) return null;
-    var bar = raw;
-    if (bar > 100.0) bar /= 1000.0; // millibar / hectopascal -> bar
-    if (bar < 0.5 || bar > 1.1) return null; // implausible -> ignore
-    return bar;
   }
 
   static const double _gravity = 9.80665;

--- a/lib/core/utils/surface_pressure.dart
+++ b/lib/core/utils/surface_pressure.dart
@@ -1,0 +1,22 @@
+/// Normalizes a surface (atmospheric) pressure that is nominally in bar.
+///
+/// Atmospheric surface pressure is only ever ~0.5 bar (high altitude) to
+/// ~1.06 bar (sea level). Some import/legacy paths have stored millibar/
+/// hectopascal values (e.g. 1013) in the bar-typed field. Used verbatim, a
+/// value ~1000x too large poisons the decompression model (tissue tensions of
+/// hundreds of bar, NDL saturating at its "unlimited" sentinel) and shows
+/// absurd figures on the dive detail page.
+///
+/// So: convert an obvious mbar/hPa value to bar, then reject (return null)
+/// anything still physically impossible, so callers fall back to the
+/// altitude-derived or standard 1.0 bar surface instead of garbage.
+///
+/// Because no real surface pressure is ever outside ~0.5-1.1 bar, this only
+/// ever touches corrupt data.
+double? normalizeSurfacePressureBar(double? raw) {
+  if (raw == null) return null;
+  var bar = raw;
+  if (bar > 100.0) bar /= 1000.0; // millibar / hectopascal -> bar
+  if (bar < 0.5 || bar > 1.1) return null; // implausible -> ignore
+  return bar;
+}

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/constants/dive_search.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/performance/perf_timer.dart';
+import 'package:submersion/core/utils/surface_pressure.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -992,7 +993,9 @@ class DiveRepository {
               exitMethod: Value(dive.exitMethod?.name),
               waterType: Value(dive.waterType?.name),
               altitude: Value(dive.altitude),
-              surfacePressure: Value(dive.surfacePressure),
+              surfacePressure: Value(
+                normalizeSurfacePressureBar(dive.surfacePressure),
+              ),
               // Entry/exit GPS (previously dropped on create, so file-imported
               // dives never became eligible for site matching).
               entryLatitude: Value(dive.entryLocation?.latitude),
@@ -1239,7 +1242,9 @@ class DiveRepository {
           exitMethod: Value(dive.exitMethod?.name),
           waterType: Value(dive.waterType?.name),
           altitude: Value(dive.altitude),
-          surfacePressure: Value(dive.surfacePressure),
+          surfacePressure: Value(
+            normalizeSurfacePressureBar(dive.surfacePressure),
+          ),
           // Weather conditions
           windSpeed: Value(dive.windSpeed),
           windDirection: Value(dive.windDirection?.name),
@@ -2949,7 +2954,7 @@ class DiveRepository {
             )
           : null,
       altitude: row.altitude,
-      surfacePressure: row.surfacePressure,
+      surfacePressure: normalizeSurfacePressureBar(row.surfacePressure),
       surfaceInterval: row.surfaceIntervalSeconds != null
           ? Duration(seconds: row.surfaceIntervalSeconds!)
           : null,
@@ -3319,7 +3324,7 @@ class DiveRepository {
             )
           : null,
       altitude: row.altitude,
-      surfacePressure: row.surfacePressure,
+      surfacePressure: normalizeSurfacePressureBar(row.surfacePressure),
       surfaceInterval: row.surfaceIntervalSeconds != null
           ? Duration(seconds: row.surfaceIntervalSeconds!)
           : null,

--- a/test/core/database/migration_v136_media_stores_sweep_test.dart
+++ b/test/core/database/migration_v136_media_stores_sweep_test.dart
@@ -49,13 +49,12 @@ void main() {
     },
   );
 
-  test('v136 is the current schema version (exact-latest tripwire)', () {
-    // Exact assertion: the newest migration owns the tripwire, so the next
-    // schema bump must move it forward. Relax to greaterThanOrEqualTo and
-    // add a fresh exact test when a later migration lands on top of v136.
+  test('v136 media_stores sweep migration is present', () {
+    // The exact-latest tripwire moved to migration_v137_surface_pressure_test
+    // when the surface-pressure repair (v137) landed on top of v136.
     // (v135 is reserved by the in-flight color-accents branch; this claim
     // deliberately skips it, mirroring the v132-over-v131 precedent.)
-    expect(AppDatabase.currentSchemaVersion, 136);
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(136));
     expect(AppDatabase.migrationVersions, contains(136));
   });
 }

--- a/test/core/database/migration_v137_surface_pressure_test.dart
+++ b/test/core/database/migration_v137_surface_pressure_test.dart
@@ -1,0 +1,63 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Minimal pre-v137 shape: a dives table with a surface_pressure column,
+/// stamped at v136 so only the 136->137 repair block runs.
+NativeDatabase _dbAt136({required List<String> inserts}) {
+  return NativeDatabase.memory(
+    setup: (rawDb) {
+      rawDb.execute('PRAGMA user_version = 136');
+      rawDb.execute('''
+        CREATE TABLE dives (
+          id TEXT NOT NULL PRIMARY KEY,
+          surface_pressure REAL
+        )
+      ''');
+      for (final sql in inserts) {
+        rawDb.execute(sql);
+      }
+    },
+  );
+}
+
+void main() {
+  test('v137 repairs surface_pressure stored in the wrong unit', () async {
+    final db = AppDatabase(
+      _dbAt136(
+        inserts: [
+          // millibar written into the bar column -> convert to bar.
+          "INSERT INTO dives (id, surface_pressure) VALUES ('mbar', 1013)",
+          // implausible even as mbar (1.264 bar) -> null out.
+          "INSERT INTO dives (id, surface_pressure) VALUES ('garbage', 1264)",
+          // already a valid bar value -> untouched.
+          "INSERT INTO dives (id, surface_pressure) VALUES ('ok', 1.02)",
+          // no data -> stays null.
+          "INSERT INTO dives (id, surface_pressure) VALUES ('none', NULL)",
+        ],
+      ),
+    );
+    addTearDown(db.close);
+
+    Future<double?> sp(String id) async {
+      final row = await db
+          .customSelect(
+            "SELECT surface_pressure AS sp FROM dives WHERE id = '$id'",
+          )
+          .getSingle();
+      return row.data['sp'] as double?;
+    }
+
+    expect(await sp('mbar'), closeTo(1.013, 1e-9));
+    expect(await sp('garbage'), isNull);
+    expect(await sp('ok'), closeTo(1.02, 1e-9));
+    expect(await sp('none'), isNull);
+  });
+
+  test('v137 is the current schema version (exact-latest tripwire)', () {
+    // The newest migration owns the tripwire; the next schema bump must move
+    // it forward and relax this file's assertion to greaterThanOrEqualTo.
+    expect(AppDatabase.currentSchemaVersion, 137);
+    expect(AppDatabase.migrationVersions, contains(137));
+  });
+}

--- a/test/core/deco/dive_environment_test.dart
+++ b/test/core/deco/dive_environment_test.dart
@@ -74,5 +74,48 @@ void main() {
     test('forConditions: null altitude keeps legacy 1.0 bar', () {
       expect(DiveEnvironment.forConditions().surfacePressureBar, 1.0);
     });
+
+    group('surface pressure sanitization', () {
+      test('millibar value stored in the bar field is converted to bar', () {
+        // Some imports wrote surface pressure as mbar (1013) into the
+        // bar-typed field; it must be converted, not used verbatim.
+        final env = DiveEnvironment.forConditions(surfacePressureBar: 1013.0);
+        expect(env.surfacePressureBar, closeTo(1.013, 1e-9));
+      });
+
+      test('hectopascal value is converted and still wins over altitude', () {
+        final env = DiveEnvironment.forConditions(
+          altitudeMeters: 2000.0,
+          surfacePressureBar: 1005.0,
+        );
+        expect(env.surfacePressureBar, closeTo(1.005, 1e-9));
+      });
+
+      test('implausible value falls back to the altitude pressure', () {
+        // 1264 -> 1.264 bar, still impossible as a surface pressure: ignored.
+        final env = DiveEnvironment.forConditions(
+          altitudeMeters: 2000.0,
+          surfacePressureBar: 1264.0,
+        );
+        expect(env.surfacePressureBar, closeTo(0.7950, 0.001));
+      });
+
+      test('implausible value with no altitude falls back to 1.0 bar', () {
+        final env = DiveEnvironment.forConditions(surfacePressureBar: 1264.0);
+        expect(env.surfacePressureBar, 1.0);
+      });
+
+      test('a valid high-altitude surface pressure is preserved', () {
+        final env = DiveEnvironment.forConditions(surfacePressureBar: 0.75);
+        expect(env.surfacePressureBar, 0.75);
+      });
+
+      test('sanitized surface keeps ambient pressure physical', () {
+        // Regression: surfacePressure 1264 previously made pressureAtDepth(20)
+        // ~1266 bar, driving NDL / tissue loading to nonsense.
+        final env = DiveEnvironment.forConditions(surfacePressureBar: 1264.0);
+        expect(env.pressureAtDepth(20.0), lessThan(4.0));
+      });
+    });
   });
 }

--- a/test/core/utils/surface_pressure_test.dart
+++ b/test/core/utils/surface_pressure_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/utils/surface_pressure.dart';
+
+void main() {
+  group('normalizeSurfacePressureBar', () {
+    test('passes a normal sea-level value through unchanged', () {
+      expect(normalizeSurfacePressureBar(1.013), 1.013);
+    });
+
+    test('keeps a valid high-altitude value', () {
+      expect(normalizeSurfacePressureBar(0.75), 0.75);
+    });
+
+    test('null stays null', () {
+      expect(normalizeSurfacePressureBar(null), isNull);
+    });
+
+    test('converts a millibar value into bar', () {
+      expect(normalizeSurfacePressureBar(1013.0), closeTo(1.013, 1e-9));
+    });
+
+    test('converts a hectopascal value into bar', () {
+      expect(normalizeSurfacePressureBar(1005.0), closeTo(1.005, 1e-9));
+    });
+
+    test('rejects an implausible value (mbar magnitude, out of range)', () {
+      // 1264 -> 1.264 bar, still impossible as a surface pressure.
+      expect(normalizeSurfacePressureBar(1264.0), isNull);
+    });
+
+    test('rejects a small-but-impossible value', () {
+      expect(normalizeSurfacePressureBar(2.5), isNull);
+      expect(normalizeSurfacePressureBar(0.1), isNull);
+    });
+
+    test('keeps the plausible boundaries', () {
+      expect(normalizeSurfacePressureBar(0.5), 0.5);
+      expect(normalizeSurfacePressureBar(1.1), 1.1);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On some dives the **Deco Status** and **Tissue Loading** panels show impossible values for an ordinary shallow dive:

- NDL `998:59`, GF99 `0%`, SurfGF `0%`
- Tissue Loading: Load `30817%`, N2 `998.51 bar`

## Cause

Single upstream cause: the dive's stored **`surfacePressure` is in millibar/hectopascal magnitude (~1013-1264) but the field is typed and consumed as bar**. The deco engine and the panels are correct — they faithfully render a model fed a surface pressure ~1000x too large:

- compartments seed surface-saturated at `(surfaceP - 0.0627)·fN2` ≈ **998.5 bar** with surfaceP ≈ 1264 → the reported N2 `998.51 bar`
- `percentLoading = pN2 / surfaceMValue * 100` ≈ 998.5 / 3.24 ≈ **30817%**
- ambient pressure ≈ 1265 bar ≫ tissue tension → gradient factors clamp to **0%**
- tissues never exceed the (enormous) surface ceiling → NDL saturates at the cap `999*60 - 1` s, printed as **`998:59`** (an "unlimited NDL" sentinel shown literally)

Some import/legacy path stored a mbar/hPa value in this bar-typed field. The two active importers actually convert correctly (`UddfFullImportService` does `pascal / 100000`; the Subsurface parser strips the `bar` suffix), so the corrupt value is most likely legacy data or an unaudited path (MacDive/CSV/DL7/native download, or a non-conformant file), not those importers.

## Fix

Sanitize/repair the surface pressure at the source so every consumer — the deco panels **and** the display paths (the detail page rendered a stored `1264` as `1264000 mbar`; the edit form round-tripped it) — sees a clean value:

- Extract the clamp into a shared `normalizeSurfacePressureBar()` in `core`: convert an obvious mbar/hPa value (`> 100`) to bar, then reject anything still outside the physically-possible surface range (~0.5-1.1 bar).
- Normalize at the `Dive` load/persist boundary in `DiveRepositoryImpl` (both row→entity mappers and both write companions), so reads and writes are clean.
- Add a **v137 migration** that repairs stored `dives.surface_pressure` rows the same way. Since no real surface pressure is ever out of range, only corrupt rows are touched.
- Keep the `DiveEnvironment.forConditions` guard as defense-in-depth, since the planner/deco-calculator feed it user-entered values that never pass the DB boundary.

## Tests

- Unit test for `normalizeSurfacePressureBar` (mbar/hPa conversion, implausible-value rejection, boundary values).
- v137 migration test: a stored `1013` becomes `1.013`, an implausible `1264` becomes `NULL`, a valid `1.02` is untouched.
- `dive_environment_test` still covers `forConditions` behaviour; the v136 exact-version tripwire is relaxed per its own instructions.

Verified locally against Flutter 3.44.8 / Dart 3.12.2: `test/core/deco/`, `test/core/database/`, `test/core/utils/`, and the dive-repository suites pass; `flutter analyze` clean; `dart format` clean.

## Credit

Thanks to @readme42 for the review that corrected the original importer misattribution and prompted moving the fix from read-time to the source.