### PR TITLE
feat(sites): discoverable "Select sites" menu entry for merging duplicates

### DIFF
--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -441,7 +441,9 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                 PopupMenuButton<String>(
                   icon: const Icon(Icons.more_vert),
                   onSelected: (value) {
-                    if (value == 'import') {
+                    if (value == 'select') {
+                      _enterSelectionMode(null);
+                    } else if (value == 'import') {
                       context.push('/sites/import');
                     } else if (value.startsWith('view_')) {
                       final mode = ListViewMode.fromName(
@@ -463,6 +465,14 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                         ],
                       ),
                       const PopupMenuDivider(),
+                      PopupMenuItem(
+                        value: 'select',
+                        child: ListTile(
+                          leading: const Icon(Icons.checklist),
+                          title: Text(context.l10n.diveSites_list_menu_select),
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                      ),
                       PopupMenuItem(
                         value: 'import',
                         child: ListTile(
@@ -637,7 +647,9 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
           PopupMenuButton<String>(
             icon: const Icon(Icons.more_vert, size: 20),
             onSelected: (value) {
-              if (value == 'import') {
+              if (value == 'select') {
+                _enterSelectionMode(null);
+              } else if (value == 'import') {
                 context.push('/sites/import');
               } else if (value.startsWith('view_')) {
                 final mode = ListViewMode.fromName(
@@ -659,6 +671,10 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                   ],
                 ),
                 const PopupMenuDivider(),
+                PopupMenuItem(
+                  value: 'select',
+                  child: Text(context.l10n.diveSites_list_menu_select),
+                ),
                 PopupMenuItem(
                   value: 'import',
                   child: Text(context.l10n.diveSites_list_menu_import),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "تحديد المواقع",
   "diveLog_edit_geofenceSuggestion_near": "بالقرب من {location}",
   "diveLog_edit_geofenceSuggestion_title": "اقتراح المعدات",
   "diveLog_edit_geofenceSuggestion_body": "تطبيق مجموعة \"{setName}\"؟",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Tauchplätze auswählen",
   "diveLog_edit_geofenceSuggestion_near": "In der Nähe von {location}",
   "diveLog_edit_geofenceSuggestion_title": "Ausrüstungsvorschlag",
   "diveLog_edit_geofenceSuggestion_body": "Set \"{setName}\" übernehmen?",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -4553,6 +4553,7 @@
   "diveSites_list_error_loadingSites": "Error loading sites: {error}",
   "diveSites_list_error_retry": "Retry",
   "diveSites_list_menu_import": "Import",
+  "diveSites_list_menu_select": "Select sites",
   "diveSites_list_search_backTooltip": "Back",
   "diveSites_list_search_clearTooltip": "Clear Search",
   "diveSites_list_search_emptyHint": "Search by site name, country, or region",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Seleccionar puntos",
   "diveLog_edit_geofenceSuggestion_near": "Cerca de {location}",
   "diveLog_edit_geofenceSuggestion_title": "Sugerencia de equipo",
   "diveLog_edit_geofenceSuggestion_body": "¿Aplicar tu conjunto \"{setName}\"?",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Sélectionner des sites",
   "diveLog_edit_geofenceSuggestion_near": "Près de {location}",
   "diveLog_edit_geofenceSuggestion_title": "Suggestion d'équipement",
   "diveLog_edit_geofenceSuggestion_body": "Appliquer l'ensemble \"{setName}\" ?",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "בחירת אתרים",
   "diveLog_edit_geofenceSuggestion_near": "ליד {location}",
   "diveLog_edit_geofenceSuggestion_title": "הצעת ציוד",
   "diveLog_edit_geofenceSuggestion_body": "להחיל את ערכת \"{setName}\"?",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Merülőhelyek kiválasztása",
   "diveLog_edit_geofenceSuggestion_near": "{location} közelében",
   "diveLog_edit_geofenceSuggestion_title": "Felszerelési javaslat",
   "diveLog_edit_geofenceSuggestion_body": "Alkalmazza a(z) \"{setName}\" készletet?",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Seleziona siti",
   "diveLog_edit_geofenceSuggestion_near": "Vicino a {location}",
   "diveLog_edit_geofenceSuggestion_title": "Suggerimento attrezzatura",
   "diveLog_edit_geofenceSuggestion_body": "Applicare il set \"{setName}\"?",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -14059,6 +14059,12 @@ abstract class AppLocalizations {
   /// **'Import'**
   String get diveSites_list_menu_import;
 
+  /// No description provided for @diveSites_list_menu_select.
+  ///
+  /// In en, this message translates to:
+  /// **'Select sites'**
+  String get diveSites_list_menu_select;
+
   /// No description provided for @diveSites_list_search_backTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -8150,6 +8150,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveSites_list_menu_import => 'استيراد';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'رجوع';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -8150,7 +8150,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveSites_list_menu_import => 'استيراد';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'تحديد المواقع';
 
   @override
   String get diveSites_list_search_backTooltip => 'رجوع';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -8306,6 +8306,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importieren';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Zurück';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -8306,7 +8306,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importieren';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Tauchplätze auswählen';
 
   @override
   String get diveSites_list_search_backTooltip => 'Zurück';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -8169,6 +8169,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveSites_list_menu_import => 'Import';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Back';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -8310,6 +8310,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importar';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Atras';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -8310,7 +8310,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importar';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Seleccionar puntos';
 
   @override
   String get diveSites_list_search_backTooltip => 'Atras';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -8341,6 +8341,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importer';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Retour';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -8341,7 +8341,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importer';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Sélectionner des sites';
 
   @override
   String get diveSites_list_search_backTooltip => 'Retour';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -8100,6 +8100,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveSites_list_menu_import => 'ייבא';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'חזרה';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -8100,7 +8100,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveSites_list_menu_import => 'ייבא';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'בחירת אתרים';
 
   @override
   String get diveSites_list_search_backTooltip => 'חזרה';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -8289,6 +8289,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importalas';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Vissza';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -8289,7 +8289,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importalas';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Merülőhelyek kiválasztása';
 
   @override
   String get diveSites_list_search_backTooltip => 'Vissza';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -8308,6 +8308,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importa';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Indietro';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -8308,7 +8308,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importa';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Seleziona siti';
 
   @override
   String get diveSites_list_search_backTooltip => 'Indietro';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -8242,6 +8242,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importeren';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Terug';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -8242,7 +8242,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importeren';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Duikstekken selecteren';
 
   @override
   String get diveSites_list_search_backTooltip => 'Terug';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -8312,6 +8312,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importar';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => 'Voltar';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -8312,7 +8312,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveSites_list_menu_import => 'Importar';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => 'Selecionar pontos';
 
   @override
   String get diveSites_list_search_backTooltip => 'Voltar';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -7910,6 +7910,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveSites_list_menu_import => '导入';
 
   @override
+  String get diveSites_list_menu_select => 'Select sites';
+
+  @override
   String get diveSites_list_search_backTooltip => '返回';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -7910,7 +7910,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveSites_list_menu_import => '导入';
 
   @override
-  String get diveSites_list_menu_select => 'Select sites';
+  String get diveSites_list_menu_select => '选择潜水点';
 
   @override
   String get diveSites_list_search_backTooltip => '返回';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Duikstekken selecteren",
   "diveLog_edit_geofenceSuggestion_near": "Bij {location}",
   "diveLog_edit_geofenceSuggestion_title": "Uitrustingssuggestie",
   "diveLog_edit_geofenceSuggestion_body": "Set \"{setName}\" toepassen?",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "Selecionar pontos",
   "diveLog_edit_geofenceSuggestion_near": "Perto de {location}",
   "diveLog_edit_geofenceSuggestion_title": "Sugestão de equipamento",
   "diveLog_edit_geofenceSuggestion_body": "Aplicar o conjunto \"{setName}\"?",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,4 +1,5 @@
 {
+  "diveSites_list_menu_select": "选择潜水点",
   "diveLog_edit_geofenceSuggestion_near": "靠近 {location}",
   "diveLog_edit_geofenceSuggestion_title": "装备建议",
   "diveLog_edit_geofenceSuggestion_body": "应用\"{setName}\"套装？",

--- a/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
@@ -172,6 +172,74 @@ void main() {
   );
 
   // ---------------------------------------------------------------------------
+  // Overflow-menu entry into selection mode (discoverable merge)
+  // ---------------------------------------------------------------------------
+
+  group('overflow menu "Select sites"', () {
+    testWidgets('enters selection mode from the compact app bar', (
+      tester,
+    ) async {
+      _setMobileTestSurfaceSize(tester);
+      final overrides = await _buildPhoneOverrides(
+        sites: [
+          _makeSite(id: 's1', name: 'Alpha Site'),
+          _makeSite(id: 's2', name: 'Bravo Site'),
+        ],
+        viewMode: ListViewMode.detailed,
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const SiteListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // No selection UI before opening the menu.
+      expect(find.byIcon(Icons.select_all), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Select sites'));
+      await tester.pumpAndSettle();
+
+      // Selection app bar is now shown (select-all affordance present).
+      expect(find.byIcon(Icons.select_all), findsOneWidget);
+    });
+
+    testWidgets('enters selection mode from the wide app bar', (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(1200, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final overrides = await _buildPhoneOverrides(
+        sites: [
+          _makeSite(id: 's1', name: 'Alpha Site'),
+          _makeSite(id: 's2', name: 'Bravo Site'),
+        ],
+        viewMode: ListViewMode.detailed,
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const SiteListContent(showAppBar: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.select_all), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Select sites'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.select_all), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Phone-mode highlight
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Motivation

Merging duplicate dive sites is already fully implemented — multi-select two or more sites and the selection app bar's **Merge** action opens `SiteMergePage` (pick the survivor, dives are re-linked, with an undo snapshot). But the **only** way to enter selection mode is a **long-press** on a site tile. That's undiscoverable — especially on desktop/macOS, where long-pressing with a mouse is unintuitive — so users with duplicate sites (e.g. two "Cossi" entries) can't find the merge flow at all.

## Change

Add a **"Select sites"** entry to the Dive Sites overflow (⋮) menu, in **both** the wide and compact app bars. Selecting it enters the existing multi-select mode; everything downstream (select-all, Merge, delete, the merge page, undo) is unchanged.

Because both app bars get the entry, the path is available on every platform (iPhone/Android compact bar and iPad/macOS/desktop wide bar), not just desktop. Long-press still works as before.

## Details

- `site_list_content.dart`: new `PopupMenuItem(value: 'select')` in both overflow menus, wired to the existing `_enterSelectionMode(null)`.
- New localization key `diveSites_list_menu_select` ("Select sites"); localizations regenerated. Untranslated locales fall back to English pending translation.

## Tests

Added widget tests asserting that choosing "Select sites" from the overflow menu enters selection mode (the selection app bar appears) from **both** the compact and wide app bars.

Verified locally against Flutter 3.44.8 / Dart 3.12.2: `flutter test` on the site-list-content suite passes, `flutter analyze` clean, `dart format` clean, `flutter gen-l10n` run.