### PR TITLE
fix(import): map Subsurface stopdepth to the sample ceiling

### DIFF
--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -461,6 +461,7 @@ class SubsurfaceXmlParser implements ImportParser {
     double? lastCns;
     double? lastSetpoint;
     double? lastPpo2;
+    double? lastStopDepth;
     final lastSensor = List<double?>.filled(6, null);
     bool inDeco = false;
 
@@ -523,6 +524,19 @@ class SubsurfaceXmlParser implements ImportParser {
       final inDecoAttr = _parseInt(sample.getAttribute('in_deco'));
       if (inDecoAttr != null) inDeco = inDecoAttr == 1;
       if (inDeco) point['decoType'] = 2;
+
+      // Computer-reported deco stop depth, mapped to the sample ceiling. This
+      // is the stop depth in effect at this sample and changes over the dive.
+      // Subsurface delta-encodes stopdepth (written only when it changes), so
+      // an omitted attribute means "unchanged" - carry the last value forward
+      // like ndl/tts/in_deco. A value of 0.0 m is a real "no stop" signal, not
+      // missing data: it clears the obligation, and that cleared state is
+      // carried forward too. Values are meters (unit suffix stripped by
+      // `_parseDouble`).
+      final stopDepth =
+          _parseDouble(sample.getAttribute('stopdepth')) ?? lastStopDepth;
+      lastStopDepth = stopDepth;
+      if (stopDepth != null && stopDepth > 0) point['ceiling'] = stopDepth;
 
       // Read pressure0, pressure1, ... for each tank
       for (var tankIdx = 0; tankIdx < 10; tankIdx++) {

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -626,6 +626,108 @@ void main() {
       expect(profile[5]['decoType'], isNull);
     });
 
+    test('maps delta-encoded stopdepth to ceiling and carries it forward '
+        'across samples that omit it', () async {
+      // Subsurface writes stopdepth only when the computer's stop depth
+      // changes; omission means "unchanged", so the value is sticky like
+      // ndl/tts/cns/in_deco.
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='4:00 min'>
+  <divecomputer model='Test'>
+  <depth max='40.0 m' mean='30.0 m' />
+  <sample time='1:00 min' depth='40.0 m' />
+  <sample time='2:00 min' depth='40.0 m' in_deco='1' stopdepth='6.0 m' />
+  <sample time='3:00 min' depth='38.0 m' />
+  <sample time='4:00 min' depth='30.0 m' stopdepth='9.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+
+      // Before the first stopdepth the ceiling is genuinely unknown.
+      expect(profile[0]['ceiling'], isNull);
+      // Explicit stop depth maps straight to ceiling (meters).
+      expect(profile[1]['ceiling'], 6.0);
+      // A sample that omits stopdepth inherits the previous value.
+      expect(profile[2]['ceiling'], 6.0);
+      // The next explicit value takes over.
+      expect(profile[3]['ceiling'], 9.0);
+    });
+
+    test(
+      "stopdepth '0.0 m' clears the obligation instead of being skipped",
+      () async {
+        // 0.0 m is a real "no stop" value, not missing data, so it maps to no
+        // ceiling and that cleared state carries forward.
+        final result = await parser.parse(
+          xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='3:00 min'>
+  <divecomputer model='Test'>
+  <depth max='40.0 m' mean='20.0 m' />
+  <sample time='1:00 min' depth='40.0 m' in_deco='1' stopdepth='6.0 m' />
+  <sample time='2:00 min' depth='6.0 m' in_deco='0' stopdepth='0.0 m' />
+  <sample time='3:00 min' depth='3.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+        );
+
+        final dive = result.entitiesOf(ImportEntityType.dives).first;
+        final profile = dive['profile'] as List<Map<String, dynamic>>;
+
+        expect(profile[0]['ceiling'], 6.0);
+        // 0.0 m resolves to no obligation.
+        expect(profile[1]['ceiling'], isNull);
+        // The cleared state carries forward to samples that omit stopdepth.
+        expect(profile[2]['ceiling'], isNull);
+      },
+    );
+
+    test('re-acquires a ceiling after a stopdepth 0.0 clear', () async {
+      // A sawtooth profile can clear the obligation and then incur it again;
+      // an explicit stopdepth after a 0.0 must restore the ceiling rather than
+      // latch the cleared state.
+      final result = await parser.parse(
+        xmlBytes('''
+<divelog program='subsurface' version='3'>
+<dives>
+<dive number='1' date='2025-01-15' time='10:00:00' duration='4:00 min'>
+  <divecomputer model='Test'>
+  <depth max='40.0 m' mean='25.0 m' />
+  <sample time='1:00 min' depth='40.0 m' in_deco='1' stopdepth='6.0 m' />
+  <sample time='2:00 min' depth='5.0 m' in_deco='0' stopdepth='0.0 m' />
+  <sample time='3:00 min' depth='38.0 m' in_deco='1' stopdepth='9.0 m' />
+  <sample time='4:00 min' depth='36.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>
+'''),
+      );
+
+      final dive = result.entitiesOf(ImportEntityType.dives).first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+
+      expect(profile[0]['ceiling'], 6.0);
+      expect(profile[1]['ceiling'], isNull);
+      // Re-acquired after the clear.
+      expect(profile[2]['ceiling'], 9.0);
+      // And the re-acquired value carries forward.
+      expect(profile[3]['ceiling'], 9.0);
+    });
+
     test(
       'maps sample po2 to setpoint (not ppO2) and carries it forward',
       () async {
@@ -2024,6 +2126,30 @@ $diveXml
         expect(profile.any((p) => p.containsKey('ppO2')), isTrue);
         // Individual cells are imported raw.
         expect(profile.any((p) => p.containsKey('o2Sensor1')), isTrue);
+      },
+    );
+
+    test(
+      '003 (deco stop schedule): stopdepth maps to a non-null ceiling from the '
+      'first stop onward with the 6/9/12/15 m schedule intact',
+      () async {
+        final profile = await profileOf(
+          'test/dives/003_ccr_with_setpoint_switch_and_calculated_po2.ssrf.xml',
+        );
+
+        // The opening samples are pre-deco and carry no ceiling.
+        expect(profile.first['ceiling'], isNull);
+        // The computer reports stop depths that reach the app as ceilings.
+        expect(profile.any((p) => p['ceiling'] != null), isTrue);
+        // The full stop schedule survives the import rather than being thrown
+        // away (previously every ceiling was null).
+        final ceilings = profile
+            .map((p) => p['ceiling'] as double?)
+            .whereType<double>()
+            .toSet();
+        expect(ceilings, containsAll(<double>[6.0, 9.0, 12.0, 15.0]));
+        // stopdepth '0.0 m' near the end clears the obligation.
+        expect(profile.last['ceiling'], isNull);
       },
     );
   });


### PR DESCRIPTION
## Summary

Subsurface XML import discarded the dive computer's stop schedule. `SubsurfaceXmlParser` read `in_deco` (mapped to `decoType`) but never read the per-sample `stopdepth`, so `dive_profiles.ceiling` was left null for every Subsurface-imported dive.

## Fix

In `_parseProfile`:

- Read `stopdepth` and map it to the sample `ceiling` (metres, unit suffix stripped by `_parseDouble`).
- Carry it forward across samples that omit it. Subsurface delta-encodes the attribute (written only when it changes), so this matches the existing sticky `lastNdl` / `lastTts` / `in_deco` handling in the same function.
- `stopdepth='0.0 m'` is a real "no stop" value, not missing data: it clears the ceiling, and that cleared state is carried forward too.

## Why it matters

Restores the **Computer** ceiling source and deco-stop band (#676), which previously fell back to **Calculated** because `hasComputerCeiling` was always false for these dives (both settings rendered an identical band, reading as a broken toggle).

## Tests (TDD - written first, watched fail, then implemented)

- Delta-encoded `stopdepth` maps to `ceiling` and carries forward across samples that omit it.
- `stopdepth='0.0 m'` clears the obligation and stays cleared.
- Re-acquires a ceiling after a `0.0` clear (sawtooth profile).
- Real fixture `003_ccr_with_setpoint_switch_and_calculated_po2.ssrf.xml`: full 6 / 9 / 12 / 15 m schedule survives, pre-deco samples are null, and the final `0.0` clears.

77/77 in the Subsurface parser suite pass; `flutter analyze` is clean on the changed files.

## Scope notes

- Subsurface's `stoptime` (stop duration) is intentionally **not** imported: there is no `dive_profiles` column, `DiveProfilePoint` field, or UI consumer for stop time today. It can be added as a feature if a UI need arises.
- The UDDF importer has the same ceiling gap (reads `<decostop>` but ignores `decodepth`), filed separately as #750.

Fixes #677
