### PR TITLE
fix(import): map UDDF decostop depth to the sample ceiling

### DIFF
--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1742,16 +1742,35 @@ class UddfFullImportService {
         final decoStop = waypoint.findElements('decostop').firstOrNull;
         if (decoStop != null) {
           final kind = decoStop.getAttribute('kind')?.trim().toLowerCase();
+          // UDDF 3.2.x specifies `safety` / `mandatory`; some exporters emit
+          // `safetystop` / `decostop`. Accept both spellings and only warn for
+          // a genuinely unknown kind (otherwise a spec-valid `mandatory` file
+          // logs a warning on every in-deco waypoint).
+          const safetyKinds = {'safety', 'safetystop'};
+          const decoKinds = {'mandatory', 'decostop'};
           if (kind != null &&
               kind.isNotEmpty &&
-              kind != 'safetystop' &&
-              kind != 'decostop') {
+              !safetyKinds.contains(kind) &&
+              !decoKinds.contains(kind)) {
             _logger.warning(
               'UDDF import: unsupported decostop kind "$kind"; '
               'mapping to decoType=2 because the sample still indicates a deco stop.',
             );
           }
-          point['decoType'] = kind == 'safetystop' ? 1 : 2;
+          point['decoType'] = safetyKinds.contains(kind) ? 1 : 2;
+
+          // Map the computer's stop depth to the sample ceiling. UDDF is SI, so
+          // `decodepth` is metres and needs no conversion. Unlike Subsurface's
+          // delta-encoded stopdepth, `<decostop>` is present on every in-stop
+          // waypoint, so there is nothing to carry forward: a waypoint with no
+          // decostop is simply no obligation (null ceiling). A non-positive
+          // depth is treated as no stop.
+          final decoDepth = double.tryParse(
+            decoStop.getAttribute('decodepth') ?? '',
+          );
+          if (decoDepth != null && decoDepth > 0) {
+            point['ceiling'] = decoDepth;
+          }
         }
 
         // UDDF exposes both remainingbottomtime and remainingo2time.

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -430,5 +430,95 @@ void main() {
         expect(profile[3]['decoType'], 2);
       },
     );
+
+    test('maps decostop decodepth to the sample ceiling (meters) and leaves it '
+        'null when there is no decostop', () async {
+      const uddfContent = '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-09-01T14:18:24Z</datetime>
+          <divenumber>235</divenumber>
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <depth>30</depth>
+            <divetime>0</divetime>
+          </waypoint>
+          <waypoint>
+            <depth>12</depth>
+            <divetime>600</divetime>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+          </waypoint>
+          <waypoint>
+            <depth>9</depth>
+            <divetime>720</divetime>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+          </waypoint>
+          <waypoint>
+            <depth>6</depth>
+            <divetime>900</divetime>
+            <decostop kind="safetystop" decodepth="6" duration="180" />
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+      final result = await service.importAllDataFromUddf(uddfContent);
+      final dive = result.dives.first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+
+      // A waypoint with no decostop carries no ceiling.
+      expect(profile[0]['ceiling'], isNull);
+      // decodepth (UDDF is SI: metres) maps straight to the ceiling.
+      expect(profile[1]['ceiling'], 12.0);
+      expect(profile[2]['ceiling'], 9.0);
+      // A safety stop still records its stop depth as the ceiling.
+      expect(profile[3]['ceiling'], 6.0);
+    });
+
+    test('recognizes UDDF spec decostop kinds: mandatory -> deco, safety -> '
+        'safety', () async {
+      const uddfContent = '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-09-01T14:18:24Z</datetime>
+          <divenumber>235</divenumber>
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <depth>12</depth>
+            <divetime>60</divetime>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+          </waypoint>
+          <waypoint>
+            <depth>6</depth>
+            <divetime>120</divetime>
+            <decostop kind="safety" decodepth="6" duration="180" />
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+      final result = await service.importAllDataFromUddf(uddfContent);
+      final dive = result.dives.first;
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+
+      // UDDF 3.2.x spec kinds are `mandatory` and `safety`; both must be
+      // recognized (no "unsupported kind" warning spam) and mapped correctly.
+      expect(profile[0]['decoType'], 2);
+      expect(profile[1]['decoType'], 1);
+    });
   });
 }


### PR DESCRIPTION
## Summary

UDDF import discarded the dive computer's stop schedule. `UddfFullImportService` read each waypoint's `<decostop>` only for its `kind` (to set `decoType`) and ignored `decodepth`, so `dive_profiles.ceiling` was left null for every UDDF-imported sample — the UDDF twin of #677.

## Fix

Read `decodepth` in the existing `<decostop>` block and map it to the sample `ceiling`. UDDF is SI, so `decodepth` is metres — no conversion. A non-positive depth is treated as no stop.

Unlike Subsurface's delta-encoded `stopdepth`, UDDF writes `<decostop>` on **every** in-stop waypoint, so there is nothing to carry forward — a waypoint with no `<decostop>` is simply no obligation (null ceiling). Verified against fixture `005_oc-trimix-two-deco-gases--perdix2.uddf`: the 226 in-deco waypoints span a contiguous range with zero gaps.

## Why it matters

Restores the **Computer** ceiling source and the deco-stop band (#676) for UDDF imports, which previously fell back to **Calculated** because `hasComputerCeiling` was always false for these dives.

## Tests (TDD — written first, watched fail, then implemented)

- New test: `decodepth` maps straight to `ceiling` (metres) for both mandatory and safety stops; a waypoint with no `<decostop>` leaves `ceiling` null. Watched it fail (expected `12.0`, got `null`) before implementing.
- 9/9 in the UDDF import suite pass; `dart format` + `flutter analyze` clean.

## Scope note

Stop `duration` stays unmapped: there is no `dive_profiles` column, `DiveProfilePoint` field, or UI consumer for stop time (same call as #677).

Fixes #750
