### PR TITLE
fix(profile): drop Computer source toggle from the ceiling line (#755)

### DIFF
--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -928,9 +928,8 @@ Future<ProfileAnalysis?> computeAnalysisForProfile(
     final ndlSource = ref.watch(
       profileLegendProvider.select((s) => s.ndlSource),
     );
-    final ceilingSource = ref.watch(
-      profileLegendProvider.select((s) => s.ceilingSource),
-    );
+    // The ceiling line has no source toggle; it always uses the calculated
+    // (exact, continuous) curve, so no ceilingSource is read here (issue #755).
     final ttsSource = ref.watch(
       profileLegendProvider.select((s) => s.ttsSource),
     );
@@ -1035,7 +1034,8 @@ Future<ProfileAnalysis?> computeAnalysisForProfile(
       analysis,
       profile,
       ndlSource: ndlSource,
-      ceilingSource: ceilingSource,
+      // ceilingSource omitted: defaults to calculated so the ceiling line is
+      // always the exact continuous curve (issue #755).
       ttsSource: ttsSource,
       cnsSource: cnsSource,
       decoStopSource: decoStopSource,

--- a/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
@@ -54,9 +54,12 @@ class ProfileLegendState {
   final bool showCns;
   final bool showOtu;
 
-  // Per-metric data source preferences (session overrides)
+  // Per-metric data source preferences (session overrides).
+  // The ceiling line has no source toggle: every import path stores only the
+  // computer's stepped stop depth in `ceiling`, so a "computer" ceiling line
+  // would duplicate the deco-stop band. The ceiling line therefore always
+  // renders the exact, continuous calculated curve (see issue #755).
   final MetricDataSource ndlSource;
-  final MetricDataSource ceilingSource;
   final MetricDataSource ttsSource;
   final MetricDataSource cnsSource;
   final MetricDataSource decoStopSource;
@@ -99,7 +102,6 @@ class ProfileLegendState {
     this.showCns = false,
     this.showOtu = false,
     this.ndlSource = MetricDataSource.calculated,
-    this.ceilingSource = MetricDataSource.calculated,
     this.ttsSource = MetricDataSource.calculated,
     this.cnsSource = MetricDataSource.calculated,
     this.decoStopSource = MetricDataSource.calculated,
@@ -178,7 +180,6 @@ class ProfileLegendState {
     bool? showCns,
     bool? showOtu,
     MetricDataSource? ndlSource,
-    MetricDataSource? ceilingSource,
     MetricDataSource? ttsSource,
     MetricDataSource? cnsSource,
     MetricDataSource? decoStopSource,
@@ -217,7 +218,6 @@ class ProfileLegendState {
       showCns: showCns ?? this.showCns,
       showOtu: showOtu ?? this.showOtu,
       ndlSource: ndlSource ?? this.ndlSource,
-      ceilingSource: ceilingSource ?? this.ceilingSource,
       ttsSource: ttsSource ?? this.ttsSource,
       cnsSource: cnsSource ?? this.cnsSource,
       decoStopSource: decoStopSource ?? this.decoStopSource,
@@ -260,7 +260,6 @@ class ProfileLegendState {
           showCns == other.showCns &&
           showOtu == other.showOtu &&
           ndlSource == other.ndlSource &&
-          ceilingSource == other.ceilingSource &&
           ttsSource == other.ttsSource &&
           cnsSource == other.cnsSource &&
           decoStopSource == other.decoStopSource &&
@@ -298,7 +297,6 @@ class ProfileLegendState {
     showCns,
     showOtu,
     ndlSource,
-    ceilingSource,
     ttsSource,
     cnsSource,
     decoStopSource,
@@ -354,7 +352,6 @@ class ProfileLegend extends _$ProfileLegend {
           defaultShowCns: s.defaultShowCns,
           defaultShowOtu: s.defaultShowOtu,
           defaultNdlSource: s.defaultNdlSource,
-          defaultCeilingSource: s.defaultCeilingSource,
           defaultTtsSource: s.defaultTtsSource,
           defaultCnsSource: s.defaultCnsSource,
           defaultDecoStopSource: s.defaultDecoStopSource,
@@ -390,7 +387,6 @@ class ProfileLegend extends _$ProfileLegend {
       showCns: settings.defaultShowCns,
       showOtu: settings.defaultShowOtu,
       ndlSource: settings.defaultNdlSource,
-      ceilingSource: settings.defaultCeilingSource,
       ttsSource: settings.defaultTtsSource,
       cnsSource: settings.defaultCnsSource,
       decoStopSource: settings.defaultDecoStopSource,
@@ -523,10 +519,6 @@ class ProfileLegend extends _$ProfileLegend {
   }
 
   // Data source set methods (for SegmentedButton)
-  void setCeilingSource(MetricDataSource source) {
-    state = state.copyWith(ceilingSource: source);
-  }
-
   void setDecoStopSource(MetricDataSource source) {
     state = state.copyWith(decoStopSource: source);
   }

--- a/lib/features/dive_log/presentation/widgets/dive_profile_legend.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_legend.dart
@@ -642,14 +642,17 @@ class _ChartOptionsDialog extends StatelessWidget {
           isAreaSwatch: true,
         ),
       if (config.hasCeilingCurve)
-        _buildToggleWithSource(
+        // No source toggle: the ceiling line always shows the exact, continuous
+        // calculated curve. Every import stores only the computer's stepped stop
+        // depth, so a "computer" ceiling would duplicate the deco-stop band
+        // (issue #755). The Computer/Calculated comparison lives on the deco
+        // stops above.
+        _buildToggleItem(
           context,
           label: context.l10n.diveLog_legend_label_ceiling,
           color: const Color(0xFFD32F2F),
           isEnabled: legendState.showCeiling,
           onTap: legendNotifier.toggleCeiling,
-          currentSource: legendState.ceilingSource,
-          onSourceChanged: legendNotifier.setCeilingSource,
         ),
       if (config.hasNdlData)
         _buildToggleWithSource(

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -961,15 +961,9 @@ class _DecompressionSectionContent extends ConsumerWidget {
                       .setDefaultNdlSource(source),
                 ),
                 const Divider(height: 1),
-                _buildSourceDropdownTile(
-                  context,
-                  title: 'Ceiling Source',
-                  value: settings.defaultCeilingSource,
-                  onChanged: (source) => ref
-                      .read(settingsProvider.notifier)
-                      .setDefaultCeilingSource(source),
-                ),
-                const Divider(height: 1),
+                // No Ceiling Source tile: the ceiling line always renders the
+                // exact calculated curve (issue #755). The Computer/Calculated
+                // choice remains meaningful for the deco stop schedule below.
                 _buildSourceDropdownTile(
                   context,
                   title: 'Deco Stop Source',

--- a/test/features/dive_log/presentation/providers/profile_legend_deco_stop_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_deco_stop_test.dart
@@ -17,12 +17,14 @@ void main() {
     expect(updated.showCeiling, state.showCeiling);
   });
 
-  test('deco stop source is independent of the ceiling source', () {
+  test('deco stop source is independent of other metric sources', () {
     const state = ProfileLegendState();
     final updated = state.copyWith(decoStopSource: MetricDataSource.computer);
 
     expect(updated.decoStopSource, MetricDataSource.computer);
-    expect(updated.ceilingSource, MetricDataSource.calculated);
+    // The ceiling line has no source toggle (issue #755); other metric sources
+    // are untouched when only the deco stop source changes.
+    expect(updated.ndlSource, MetricDataSource.calculated);
   });
 
   test('equality accounts for the deco stop fields', () {

--- a/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
@@ -89,15 +89,8 @@ void main() {
 
   group('ProfileLegend notifier methods (via state)', () {
     group('explicit source set methods', () {
-      test('setCeilingSource sets to computer', () {
-        const state = ProfileLegendState();
-        expect(state.ceilingSource, MetricDataSource.calculated);
-        final updated = state.copyWith(
-          ceilingSource: MetricDataSource.computer,
-        );
-        expect(updated.ceilingSource, MetricDataSource.computer);
-      });
-
+      // The ceiling line has no source toggle (issue #755); it always uses the
+      // calculated curve, so there is no ceilingSource field or setter to test.
       test('setNdlSource sets to computer', () {
         const state = ProfileLegendState();
         expect(state.ndlSource, MetricDataSource.calculated);

--- a/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_legend_test.dart
@@ -221,8 +221,26 @@ void main() {
 
     testWidgets('source-capable metrics have SegmentedButtons', (tester) async {
       await openDialog(tester);
-      // 4 metrics with source selectors: Ceiling, NDL, TTS, CNS%
-      expect(find.byType(SegmentedButton<MetricDataSource>), findsNWidgets(4));
+      // 3 metrics with source selectors: NDL, TTS, CNS%. The ceiling line has
+      // no source toggle (issue #755) -- it always shows the calculated curve.
+      expect(find.byType(SegmentedButton<MetricDataSource>), findsNWidgets(3));
+    });
+
+    testWidgets('Ceiling row has no source SegmentedButton', (tester) async {
+      await openDialog(tester);
+      // The ceiling line always renders the exact calculated curve, so its
+      // legend row is a plain visibility toggle with no Computer/Calculated
+      // selector (issue #755).
+      final ceilingRow = find
+          .ancestor(of: find.text('Ceiling'), matching: find.byType(Row))
+          .first;
+      expect(
+        find.descendant(
+          of: ceilingRow,
+          matching: find.byType(SegmentedButton<MetricDataSource>),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('tapping SegmentedButton changes source state', (tester) async {


### PR DESCRIPTION
Every import path stores only the dive computer's stepped stop depth in dive_profiles.ceiling, so a "Computer" ceiling line rendered the same stepped data as the deco-stop band (Computer) - redundant. The only thing the ceiling line uniquely contributes is the exact, continuous curve, which is inherently a calculated value.

The ceiling line now always renders the computed (calculated) ceiling. The Computer/Calculated toggle stays on the deco stops, where the computer's stepped schedule genuinely differs from the app's recomputation.

- Ceiling legend row is now a plain visibility toggle (no source selector)
- Removed the ceilingSource session field and setCeilingSource from the profile legend provider
- Interactive analysis no longer reads a ceiling source; the ceiling always resolves to the calculated curve
- Removed the now-inert "Ceiling Source" tile from settings

The defaultCeilingSource column, settings model, and sync remain in place (retiring them is a separate schema-migration follow-up). The generic overlayComputerDecoData keeps its ceilingSource parameter for other callers.

<img width="2098" height="1241" alt="image" src="https://github.com/user-attachments/assets/4d6a259e-cc97-4747-ae46-80cd7c30e688" />


Closes #755 