### PR TITLE
Release channels phase 0: groundwork and data-safety guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,7 +526,7 @@ jobs:
         run: flutter build apk --release --dart-define=UPDATE_CHANNEL=github
 
       - name: Build Android App Bundle
-        run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false
+        run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false --dart-define=UPDATE_CHANNEL=playstore
 
       # Guards against issue #318: a 4 KB-aligned native lib (liblibdc_jni.so)
       # silently shipped in v1.5.5.107 and crashed the app on Android 15+

--- a/docs/superpowers/plans/2026-07-28-release-channels-phase0-groundwork.md
+++ b/docs/superpowers/plans/2026-07-28-release-channels-phase0-groundwork.md
@@ -1,0 +1,847 @@
+# Release Channels Phase 0: Groundwork & Data-Safety Guards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Phase 0 groundwork from the release-channels spec (`docs/superpowers/specs/2026-07-28-release-channels-design.md`): fix the latent `UPDATE_CHANNEL`/asset-suffix bugs and close the data-safety gaps (startup screen dead end, missing sync schema-version gate) that must hold before a beta channel exposes users to newer-schema databases.
+
+**Architecture:** Three independent strands: (1) one-line distribution fixes in `update_providers.dart`, `release.yml`, and the iOS Fastfile; (2) a friendlier newer-database startup screen; (3) a schema-version stamp in sync manifests plus an ingest gate in `ChangesetReader`, surfaced through `SyncResult`, copying the proven library-epoch skip pattern end to end.
+
+**Tech Stack:** Flutter/Dart, Drift/sqlite3, custom changeset-log sync engine, GitHub Actions YAML, fastlane Ruby, `flutter_test`.
+
+## Global Constraints
+
+- All Dart code must pass `dart format .` with no changes (format the whole project, not just edited files).
+- `flutter analyze` must be clean; infos are fatal in CI. Never pipe analyze output through `tail`/`head`.
+- No emojis in code, comments, or documentation. No new hardcoded secrets.
+- Startup-page strings are intentionally hardcoded English (pre-l10n boot phase); match that. Sync result messages are also plain English strings today; match the existing style.
+- Tests run with `flutter test <file>` per task; the executor should run the full suite once at the end (some backup tests are flaky only in the full suite; rerun once before concluding a failure is real).
+- Work in a dedicated git worktree; commit after each task.
+- Current schema version constant: `AppDatabase.currentSchemaVersion` = 136 (`lib/core/database/database.dart:2849`). Never bump it in this plan.
+
+---
+
+### Task 1: Correct the Windows update-asset suffix
+
+The GitHub updater's Windows suffix says `Windows.zip` but releases publish `Submersion-<tag>-Windows-Setup.exe` (`release.yml:955`). Dead code today (Windows uses WinSparkle), but it becomes live if engine selection ever changes, and Plan C builds on this provider.
+
+**Files:**
+- Modify: `lib/features/auto_update/presentation/providers/update_providers.dart:25`
+- Test: `test/features/auto_update/data/services/github_update_service_test.dart`
+
+**Interfaces:**
+- Consumes: `GithubUpdateService(owner:, repo:, currentVersion:, platformSuffix:, httpClient:)` (existing).
+- Produces: nothing new — a corrected constant.
+
+- [ ] **Step 1: Add a Windows-suffix test against the real asset name**
+
+In `test/features/auto_update/data/services/github_update_service_test.dart`, the local `makeRelease` helper builds a fixture asset list that includes `'Submersion-$tagName-Windows.zip'`. First, in that helper, rename the Windows asset entry to `'Submersion-$tagName-Windows-Setup.exe'` so the fixture matches what releases actually publish. Then add this test alongside the existing service tests (same `MockClient` pattern used by its neighbors):
+
+```dart
+    test('finds the Windows installer asset by its real suffix', () async {
+      final client = MockClient(
+        (request) async => http.Response(
+          jsonEncode(makeRelease(tagName: 'v9.9.9.999')),
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      final service = GithubUpdateService(
+        owner: 'submersion-app',
+        repo: 'submersion',
+        currentVersion: '1.0.0',
+        platformSuffix: 'Windows-Setup.exe',
+        httpClient: client,
+      );
+
+      final result = await service.checkForUpdate();
+
+      expect(result, isA<UpdateAvailable>());
+      expect(
+        (result as UpdateAvailable).downloadUrl,
+        endsWith('Windows-Setup.exe'),
+      );
+    });
+```
+
+The `makeRelease` helper takes `tagName` plus optional `assets`/`body`; keep the default assets. `UpdateAvailable.downloadUrl` is the verified field name (`lib/features/auto_update/domain/entities/update_status.dart:28`).
+
+- [ ] **Step 2: Run the test file**
+
+Run: `flutter test test/features/auto_update/data/services/github_update_service_test.dart`
+Expected: the new test PASSES (the service is suffix-agnostic; this documents the contract). All existing tests still pass with the renamed fixture asset.
+
+- [ ] **Step 3: Fix the provider constant**
+
+In `lib/features/auto_update/presentation/providers/update_providers.dart`, change line 25:
+
+```dart
+  if (Platform.isWindows) return 'Windows.zip';
+```
+
+to:
+
+```dart
+  if (Platform.isWindows) return 'Windows-Setup.exe';
+```
+
+- [ ] **Step 4: Format, analyze, run the module's tests**
+
+Run: `dart format . && flutter analyze && flutter test test/features/auto_update/`
+Expected: no formatting diffs, clean analyze, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/auto_update/presentation/providers/update_providers.dart test/features/auto_update/data/services/github_update_service_test.dart
+git commit -m "fix(auto-update): match the published Windows installer asset name"
+```
+
+---
+
+### Task 2: Set the correct UPDATE_CHANNEL on store builds
+
+Two store artifacts compile with the wrong channel: the Android App Bundle (Play) and the iOS ipa. The Mac App Store lane is already correct (`macos/fastlane/Fastfile:226` passes `UPDATE_CHANNEL=appstore`) — verify, do not change. Wrong channels are currently masked by the iOS/Android early-return in `UpdateChannelConfig.isAutoUpdateEnabled`, but the value must be right before channel-aware UI (Plan C) reads it.
+
+**Files:**
+- Modify: `.github/workflows/release.yml:529`
+- Modify: `ios/fastlane/Fastfile:171`
+
+**Interfaces:**
+- Consumes: `UpdateChannelConfig` reads `String.fromEnvironment('UPDATE_CHANNEL')` (`lib/features/auto_update/domain/entities/update_channel.dart`); recognized values include `playstore` and `appstore`.
+- Produces: correctly-stamped store binaries; no code interface.
+
+- [ ] **Step 1: Fix the App Bundle build**
+
+In `.github/workflows/release.yml`, change line 529:
+
+```yaml
+        run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false
+```
+
+to:
+
+```yaml
+        run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false --dart-define=UPDATE_CHANNEL=playstore
+```
+
+Leave line 526 (`flutter build apk ... UPDATE_CHANNEL=github`) alone — the sideloaded APK is genuinely the github channel.
+
+- [ ] **Step 2: Fix the iOS build lane**
+
+In `ios/fastlane/Fastfile`, inside `lane :build`, change line 171:
+
+```ruby
+    sh("cd ../.. && flutter build ios --release --no-codesign")
+```
+
+to:
+
+```ruby
+    sh("cd ../.. && flutter build ios --release --no-codesign --dart-define=UPDATE_CHANNEL=appstore")
+```
+
+- [ ] **Step 3: Verify all channel stamps across build configs**
+
+Run: `grep -rn "UPDATE_CHANNEL" .github/workflows/release.yml ios/fastlane/Fastfile macos/fastlane/Fastfile`
+Expected: dmg/exe/tar.gz/apk builds say `github`; appbundle says `playstore`; iOS lane and MAS lane (`macos/fastlane/Fastfile:226`) say `appstore`. No other build command lacks a stamp except debug/CI builds in `ci.yaml` (fine — they default to `github`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml ios/fastlane/Fastfile
+git commit -m "fix(release): stamp store builds with their real update channel"
+```
+
+---
+
+### Task 3: Characterization test — pre-migration backup is a no-op for newer databases
+
+`PreMigrationBackupService.backupIfMigrationPending` early-returns when `stored >= target`. For `stored > target` (newer DB, the case the beta channel makes common) this is correct — the version guard throws before anything writes — but it is untested; pin it so a future refactor cannot start "backing up" (and thus touching) files it should leave alone.
+
+**Files:**
+- Test: `test/features/backup/data/services/pre_migration_backup_service_test.dart`
+
+**Interfaces:**
+- Consumes: the file's existing `_makeFixture()` helper and `PreMigrationBackupService` constructor seams (`livePathProvider`, `backupsDirProvider`, `preferences`, `clock`, `idGenerator`).
+- Produces: nothing new — a pinned behavior.
+
+- [ ] **Step 1: Add the test**
+
+In the `PreMigrationBackupService happy path` group, directly after the existing `skips when stored == target (no-op)` test, add:
+
+```dart
+    test('skips when stored > target (newer database, no-op)', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 7, 28),
+        idGenerator: () => 'x',
+      );
+
+      // A database written by a newer app version: the startup version guard
+      // rejects it before Drift opens, so no backup must be taken and the
+      // file must not be touched.
+      await service.backupIfMigrationPending(
+        stored: 137,
+        target: 136,
+        appVersion: '1.8.0.5601',
+      );
+
+      expect(await Directory(f.backupsDir).list().isEmpty, isTrue);
+      expect(f.prefs.getHistory(), isEmpty);
+    });
+```
+
+- [ ] **Step 2: Run the test file**
+
+Run: `flutter test test/features/backup/data/services/pre_migration_backup_service_test.dart`
+Expected: PASS (characterization of existing behavior).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/features/backup/data/services/pre_migration_backup_service_test.dart
+git commit -m "test(backup): pin pre-migration backup no-op for newer databases"
+```
+
+---
+
+### Task 4: Give the "Update Required" startup screen an exit
+
+Today the newer-database screen (`startup_page.dart:692-728`) offers only Close. Add a "Download Latest Version" button and a line telling the user their pre-upgrade backup still exists. This screen will be hit by real users once beta databases circulate (restored backups, iCloud-synced files, channel switchers).
+
+**Files:**
+- Modify: `lib/core/presentation/pages/startup_page.dart` (imports + the `_isVersionMismatch` branch of `_buildErrorContent`)
+- Test: `test/core/presentation/pages/startup_page_test.dart` (group `Error UI - version mismatch`, helper `_buildVersionMismatchError` at line 185)
+
+**Interfaces:**
+- Consumes: `url_launcher` (`pubspec.yaml:86`, `url_launcher: ^6.3.1`) with the codebase's standard call shape `launchUrl(uri, mode: LaunchMode.externalApplication)` (as in `settings_page.dart:66`).
+- Produces: no new public API. New user-visible strings listed below verbatim.
+
+- [ ] **Step 1: Write failing widget tests**
+
+In `test/core/presentation/pages/startup_page_test.dart`, add to the `Error UI - version mismatch` group:
+
+```dart
+    testWidgets('offers a download link for the latest version', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildVersionMismatchError(dbVersion: 137, appVersion: 136),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Download Latest Version'), findsOneWidget);
+    });
+
+    testWidgets('mentions the pre-upgrade backup', (tester) async {
+      await tester.pumpWidget(
+        _buildVersionMismatchError(dbVersion: 137, appVersion: 136),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('backup taken before the upgrade'),
+        findsOneWidget,
+      );
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/core/presentation/pages/startup_page_test.dart`
+Expected: the two new tests FAIL (`Download Latest Version` not found); all others pass.
+
+- [ ] **Step 3: Implement the screen changes**
+
+In `lib/core/presentation/pages/startup_page.dart`:
+
+Add the import (keep the file's import grouping: dart, flutter, packages, local):
+
+```dart
+import 'package:url_launcher/url_launcher.dart';
+```
+
+Add a private helper near `_closeApp`:
+
+```dart
+  static final Uri _latestReleaseUri = Uri.parse(
+    'https://github.com/submersion-app/submersion/releases/latest',
+  );
+
+  Future<void> _openLatestRelease() async {
+    try {
+      await launchUrl(_latestReleaseUri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      // Leaving the user on this screen is the only safe fallback; the URL
+      // is also shown in the surrounding text.
+    }
+  }
+```
+
+Then in the `_isVersionMismatch` branch, replace the block from the second `Text(` (the one that begins `'Please update Submersion to the latest version. '`) through the `FilledButton` with:
+
+```dart
+            Text(
+              'Please update Submersion to the latest version. '
+              'Your data is safe and has not been modified. A backup taken '
+              'before the upgrade is also in your Backups folder and can be '
+              'restored after updating.',
+              style: TextStyle(fontSize: 14, color: subtitleColor),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _openLatestRelease,
+              child: const Text('Download Latest Version'),
+            ),
+            const SizedBox(height: 8),
+            TextButton(onPressed: _closeApp, child: const Text('Close')),
+```
+
+Note the existing test `shows safe data message` asserts `textContaining('Your data is safe and has not been modified')` — the merged sentence above preserves that substring. The existing `close button is tappable` test keeps passing because Close remains, now as a `TextButton`.
+
+- [ ] **Step 4: Run the full startup-page test file**
+
+Run: `flutter test test/core/presentation/pages/startup_page_test.dart`
+Expected: PASS, including the four pre-existing version-mismatch tests.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format . && flutter analyze
+git add lib/core/presentation/pages/startup_page.dart test/core/presentation/pages/startup_page_test.dart
+git commit -m "feat(startup): add download and backup guidance to the update-required screen"
+```
+
+---
+
+### Task 5: Add schemaVersion to SyncManifest
+
+Sync payloads carry no database schema version today (`syncFormatVersion` is a wire-format constant, stuck at 2 across schema changes). The manifest is the gate point: it is read first, per peer, before any base or changeset download. Add an optional `schemaVersion` field. Legacy manifests (absent key) parse as `null`; old apps ignore the new key (their `fromJson` reads named keys only), so this is wire-compatible both directions.
+
+**Files:**
+- Modify: `lib/core/services/sync/changeset_log/sync_manifest.dart`
+- Test: `test/core/services/sync/changeset_log/sync_manifest_test.dart`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `SyncManifest.schemaVersion` (`int?`, constructor named parameter, default absent/null; serialized as JSON key `'schemaVersion'`). Tasks 6-7 depend on this exact name.
+
+- [ ] **Step 1: Write failing round-trip tests**
+
+In `test/core/services/sync/changeset_log/sync_manifest_test.dart`, add (follow the file's existing construction style — it builds manifests with `deviceId`, `provider`, `headSeq`, `updatedAt`):
+
+```dart
+  test('round-trips schemaVersion', () {
+    final manifest = SyncManifest(
+      deviceId: 'dev-1',
+      provider: 'icloud',
+      headSeq: 3,
+      updatedAt: 1234,
+      schemaVersion: 136,
+    );
+
+    final back = SyncManifest.fromJson(manifest.toJson());
+
+    expect(back.schemaVersion, 136);
+  });
+
+  test('legacy manifest without schemaVersion parses as null', () {
+    final back = SyncManifest.fromJson({
+      'deviceId': 'dev-1',
+      'provider': 'icloud',
+      'headSeq': 3,
+      'updatedAt': 1234,
+    });
+
+    expect(back.schemaVersion, isNull);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/core/services/sync/changeset_log/sync_manifest_test.dart`
+Expected: FAIL — `schemaVersion` is not a defined named parameter.
+
+- [ ] **Step 3: Implement the field**
+
+In `lib/core/services/sync/changeset_log/sync_manifest.dart`:
+
+Constructor — add after `this.formatVersion = 1,`:
+
+```dart
+    this.schemaVersion,
+```
+
+Fields — add after `final int formatVersion;`:
+
+```dart
+  /// The database schema version of the publishing device, used by readers to
+  /// hold data from newer-schema peers rather than lossily merging it.
+  /// Null on manifests written before this field existed.
+  final int? schemaVersion;
+```
+
+`toJson()` — add after `'formatVersion': formatVersion,`:
+
+```dart
+    'schemaVersion': schemaVersion,
+```
+
+`fromJson` — add after the `formatVersion:` line:
+
+```dart
+    schemaVersion: json['schemaVersion'] as int?,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/sync_manifest_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/sync/changeset_log/sync_manifest.dart test/core/services/sync/changeset_log/sync_manifest_test.dart
+git commit -m "feat(sync): carry the publisher's schema version in the manifest"
+```
+
+---
+
+### Task 6: Stamp schemaVersion at every manifest write
+
+`ChangesetWriter` constructs manifests at four sites (`changeset_writer.dart:112` base publish, `:170` heartbeat, `:200` changeset publish, `:348` compaction). All four stamp the running app's schema version — including the heartbeat, which rewrites the manifest wholesale and must reflect the device's current schema, not a stale copy.
+
+**Files:**
+- Modify: `lib/core/services/sync/changeset_log/changeset_writer.dart` (4 sites + 1 import)
+- Test: `test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart` (new file, shared with Task 7)
+
+**Interfaces:**
+- Consumes: `SyncManifest.schemaVersion` (Task 5); `AppDatabase.currentSchemaVersion` (`lib/core/database/database.dart:2849`, static const, value 136).
+- Produces: every published manifest carries `'schemaVersion': 136`.
+
+- [ ] **Step 1: Create the failing test file**
+
+Create `test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart`. Copy the setup harness of `test/core/services/sync/changeset_log/changeset_reader_epoch_test.dart` verbatim (imports, `setUp`/`tearDown`, `spyApply`, `publishPeer`, `pull` — including the manifest-rewrite mechanics in `publishPeer`), add `import 'package:submersion/core/database/database.dart';`, then add this first test:
+
+```dart
+  test('published manifests are stamped with the schema version', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publishPeer('peer-1', epochId: 'epoch-A');
+
+    final manifestFile = (await provider.listFiles(
+      folderId: folder,
+      namePattern: ChangesetLogLayout.manifestName('peer-1'),
+    )).single;
+    final manifest = SyncManifest.fromBytes(
+      await provider.downloadFile(manifestFile.id),
+    );
+
+    expect(manifest.schemaVersion, AppDatabase.currentSchemaVersion);
+  });
+```
+
+(Add `import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';` alongside the copied imports.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart`
+Expected: FAIL — `manifest.schemaVersion` is null (writer does not stamp it yet).
+
+- [ ] **Step 3: Stamp all four writer sites**
+
+In `lib/core/services/sync/changeset_log/changeset_writer.dart`:
+
+Add the import:
+
+```dart
+import 'package:submersion/core/database/database.dart';
+```
+
+At each of the four `SyncManifest(` constructions (lines 112, 170, 200, 348 pre-edit), add one argument alongside `updatedAt: now,`:
+
+```dart
+          schemaVersion: AppDatabase.currentSchemaVersion,
+```
+
+All four sites get the same literal line, including the heartbeat at :170 (do not copy `ownManifest.schemaVersion` there).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart`
+Expected: PASS. Also run `flutter test test/core/services/sync/changeset_log/` — the writer/reader/epoch suites must still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/sync/changeset_log/changeset_writer.dart test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart
+git commit -m "feat(sync): stamp manifests with the publishing schema version"
+```
+
+---
+
+### Task 7: Gate ingestion of newer-schema peers in ChangesetReader
+
+The pull loop currently applies any epoch-matching peer. A peer publishing from a newer schema must be held — merging drops its new columns and this device would republish those rows without them. The gate mirrors the stale-epoch filter directly beneath it and reports held peers in a new result set. Placement matters: after `peerManifests.add` (GC still sees the peer) and before the cursor/base/changeset logic (nothing is fetched or advanced).
+
+**Files:**
+- Modify: `lib/core/services/sync/changeset_log/changeset_reader.dart`
+- Test: `test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart` (extends Task 6's file)
+
+**Interfaces:**
+- Consumes: `SyncManifest.schemaVersion` (Task 5); `AppDatabase.currentSchemaVersion`.
+- Produces: `ChangesetReadResult.newerSchemaPeerDeviceIds` (`Set<String>`, default `{}`); `ChangesetReader.pull` gains named parameter `int localSchemaVersion = AppDatabase.currentSchemaVersion`. Task 8 depends on the result-set name.
+
+- [ ] **Step 1: Write the failing gate tests**
+
+Append to `changeset_reader_schema_gate_test.dart`. First extend the copied `publishPeer` helper with a `schemaVersionOverride` parameter, using the same download-mutate-reupload trick the epoch test uses for `manifestUpdatedAt`:
+
+```dart
+    if (schemaVersionOverride != null) {
+      final manifestFile = (await provider.listFiles(
+        folderId: folder,
+        namePattern: ChangesetLogLayout.manifestName(peerId),
+      )).single;
+      final manifest =
+          jsonDecode(utf8.decode(await provider.downloadFile(manifestFile.id)))
+              as Map<String, dynamic>;
+      manifest['schemaVersion'] = schemaVersionOverride;
+      await provider.uploadFile(
+        Uint8List.fromList(utf8.encode(jsonEncode(manifest))),
+        manifestFile.name,
+        folderId: folder,
+      );
+    }
+```
+
+(declared as `int? schemaVersionOverride` in the helper signature). Then add the tests:
+
+```dart
+  test('holds a peer publishing from a newer schema', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publishPeer(
+      'peer-1',
+      epochId: 'epoch-A',
+      schemaVersionOverride: AppDatabase.currentSchemaVersion + 1,
+    );
+
+    final result = await pull(currentEpochId: 'epoch-A');
+
+    expect(result.peersProcessed, 0);
+    expect(result.newerSchemaPeerDeviceIds, {'peer-1'});
+    expect(applied, isEmpty);
+  });
+
+  test('a held peer is fully applied after this device updates', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publishPeer(
+      'peer-1',
+      epochId: 'epoch-A',
+      schemaVersionOverride: AppDatabase.currentSchemaVersion + 1,
+    );
+    await pull(currentEpochId: 'epoch-A'); // held: cursor must not advance
+
+    final result = await reader.pull(
+      provider: provider,
+      selfDeviceId: 'reader-x',
+      folderId: folder,
+      apply: spyApply,
+      applyBaseFile: spyApplyBaseFile(applied),
+      currentEpochId: 'epoch-A',
+      localSchemaVersion: AppDatabase.currentSchemaVersion + 1,
+    );
+
+    expect(result.peersProcessed, 1);
+    expect(result.newerSchemaPeerDeviceIds, isEmpty);
+    expect(applied, isNotEmpty);
+  });
+
+  test('same-schema and legacy (unstamped) peers apply normally', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    // publishPeer without override stamps the current schema version.
+    await publishPeer('peer-same', epochId: 'epoch-A');
+
+    final result = await pull(currentEpochId: 'epoch-A');
+
+    expect(result.peersProcessed, 1);
+    expect(result.newerSchemaPeerDeviceIds, isEmpty);
+  });
+```
+
+The second test is the critical one: it proves the held peer's cursor did not advance, so its data is not lost — merely deferred until the device updates.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart`
+Expected: the new tests FAIL (`newerSchemaPeerDeviceIds`/`localSchemaVersion` undefined).
+
+- [ ] **Step 3: Implement the gate**
+
+In `lib/core/services/sync/changeset_log/changeset_reader.dart`:
+
+Add the import:
+
+```dart
+import 'package:submersion/core/database/database.dart';
+```
+
+Extend `ChangesetReadResult` — constructor gains `this.newerSchemaPeerDeviceIds = const {},` and, after the `skippedPeerDeviceIds` field, add:
+
+```dart
+  /// Peers held because their manifests were published from a newer database
+  /// schema than this build understands. Merging them would silently drop the
+  /// fields this build does not know and republish the rows without them.
+  /// Their cursors are not advanced; the data applies after this device
+  /// updates.
+  final Set<String> newerSchemaPeerDeviceIds;
+```
+
+`pull(...)` signature — add after `String? currentEpochId,`:
+
+```dart
+    int localSchemaVersion = AppDatabase.currentSchemaVersion,
+```
+
+Local state — alongside `final skippedPeerDeviceIds = <String>{};` add:
+
+```dart
+    final newerSchemaPeerDeviceIds = <String>{};
+```
+
+The gate — insert between the stale-epoch filter's closing `}` (line 124 pre-edit) and `peersProcessed++;`:
+
+```dart
+        // Newer-schema filter: hold peers publishing from a newer database
+        // schema. Applying them would silently drop the columns and tables
+        // this build does not know, then republish those rows without them.
+        // The cursor stays put, so the data applies once this device updates.
+        final peerSchema = manifest.schemaVersion;
+        if (peerSchema != null && peerSchema > localSchemaVersion) {
+          newerSchemaPeerDeviceIds.add(peerId);
+          continue;
+        }
+```
+
+Return statement — add `newerSchemaPeerDeviceIds: newerSchemaPeerDeviceIds,` alongside `skippedPeerDeviceIds:`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `flutter test test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart && flutter test test/core/services/sync/changeset_log/`
+Expected: all PASS, including the epoch and verify suites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/sync/changeset_log/changeset_reader.dart test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart
+git commit -m "feat(sync): hold peers publishing from a newer schema version"
+```
+
+---
+
+### Task 8: Surface held peers through SyncResult and the sync message
+
+Copy the `skippedPeerDeviceIds` plumbing one field over: `SyncResult` gains the set, and the user-facing message assembly in `performSync` explains it. To make the message unit-testable, the message-list assembly is extracted into a `@visibleForTesting` static.
+
+**Files:**
+- Modify: `lib/core/services/sync/sync_service.dart` (SyncResult class ~line 55-82; message assembly ~line 607-643)
+- Test: `test/core/services/sync/sync_result_messages_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `ChangesetReadResult.newerSchemaPeerDeviceIds` (Task 7).
+- Produces: `SyncResult.newerSchemaPeerDeviceIds` (`Set<String>`, default `{}`); `SyncService.pullResultMessages({required int recordsFailed, required Set<String> skippedPeerDeviceIds, required Set<String> newerSchemaPeerDeviceIds, required bool adoptedFreshIdentity}) -> List<String>` (static).
+
+- [ ] **Step 1: Write the failing message tests**
+
+Create `test/core/services/sync/sync_result_messages_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+void main() {
+  test('reports peers running a newer version', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 0,
+      skippedPeerDeviceIds: const {},
+      newerSchemaPeerDeviceIds: const {'peer-1', 'peer-2'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages, hasLength(1));
+    expect(messages.single, contains('2 devices run a newer version'));
+    expect(messages.single, contains('Update this device'));
+  });
+
+  test('singular phrasing for one newer peer', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 0,
+      skippedPeerDeviceIds: const {},
+      newerSchemaPeerDeviceIds: const {'peer-1'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages.single, contains('1 device runs a newer version'));
+  });
+
+  test('failed records suppress peer messages (existing precedence)', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 3,
+      skippedPeerDeviceIds: const {'peer-1'},
+      newerSchemaPeerDeviceIds: const {'peer-2'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages.single, '3 records failed to apply');
+  });
+
+  test('stale-epoch and newer-schema peers both reported', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 0,
+      skippedPeerDeviceIds: const {'peer-1'},
+      newerSchemaPeerDeviceIds: const {'peer-2'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages, hasLength(2));
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `flutter test test/core/services/sync/sync_result_messages_test.dart`
+Expected: FAIL — `pullResultMessages` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `lib/core/services/sync/sync_service.dart`:
+
+`SyncResult` — after the `skippedPeerDeviceIds` field's doc comment and declaration, add:
+
+```dart
+  /// Peers held because they publish from a newer database schema than this
+  /// build understands. Their data applies after this device updates.
+  final Set<String> newerSchemaPeerDeviceIds;
+```
+
+and in the constructor, after `this.skippedPeerDeviceIds = const {},`:
+
+```dart
+    this.newerSchemaPeerDeviceIds = const {},
+```
+
+Add the static message builder to `SyncService` (near `performSync`; the file already imports `package:flutter/foundation.dart` — if not, add it for `@visibleForTesting`):
+
+```dart
+  /// Builds the user-facing result messages for a completed pull. Extracted
+  /// so the phrasing and precedence (failures suppress peer notices) are
+  /// unit-testable without a full sync.
+  @visibleForTesting
+  static List<String> pullResultMessages({
+    required int recordsFailed,
+    required Set<String> skippedPeerDeviceIds,
+    required Set<String> newerSchemaPeerDeviceIds,
+    required bool adoptedFreshIdentity,
+  }) {
+    final resultMessages = <String>[];
+    if (recordsFailed > 0) {
+      final recordWord = recordsFailed == 1 ? 'record' : 'records';
+      resultMessages.add('$recordsFailed $recordWord failed to apply');
+      return resultMessages;
+    }
+    final skippedCount = skippedPeerDeviceIds.length;
+    if (skippedCount > 0) {
+      final deviceWord = skippedCount == 1 ? 'device' : 'devices';
+      final verb = skippedCount == 1 ? 'has' : 'have';
+      resultMessages.add(
+        '$skippedCount $deviceWord still $verb an older or unknown '
+        'library version and were not merged. Those devices must adopt '
+        'the current library.',
+      );
+    }
+    final newerCount = newerSchemaPeerDeviceIds.length;
+    if (newerCount > 0) {
+      final phrase = newerCount == 1 ? 'device runs' : 'devices run';
+      resultMessages.add(
+        '$newerCount $phrase a newer version of Submersion; their latest '
+        'changes were not merged. Update this device to receive them.',
+      );
+    }
+    if (adoptedFreshIdentity) {
+      resultMessages.add(
+        'Another device was syncing with this device\'s identity. '
+        'This device adopted a new identity and merged the cloud data.',
+      );
+    }
+    return resultMessages;
+  }
+```
+
+Replace the inline assembly in `performSync` (the block from `final resultMessages = <String>[];` through the `if (adoptedFreshIdentity) { ... }` closing brace, currently lines 607-628) with:
+
+```dart
+      final resultMessages = pullResultMessages(
+        recordsFailed: recordsFailed,
+        skippedPeerDeviceIds: pullResult.skippedPeerDeviceIds,
+        newerSchemaPeerDeviceIds: pullResult.newerSchemaPeerDeviceIds,
+        adoptedFreshIdentity: adoptedFreshIdentity,
+      );
+```
+
+and in the `SyncResult(` construction that follows (line ~632), add:
+
+```dart
+        newerSchemaPeerDeviceIds: pullResult.newerSchemaPeerDeviceIds,
+```
+
+- [ ] **Step 4: Run to verify**
+
+Run: `flutter test test/core/services/sync/sync_result_messages_test.dart && flutter test test/core/services/sync/`
+Expected: all PASS (the broader sync suite guards the refactored inline block).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format . && flutter analyze
+git add lib/core/services/sync/sync_service.dart test/core/services/sync/sync_result_messages_test.dart
+git commit -m "feat(sync): report peers held on a newer schema in sync results"
+```
+
+---
+
+### Task 9: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the complete checks**
+
+Run: `dart format . && flutter analyze && flutter test`
+Expected: no formatting changes, zero analyze issues, full suite green. Known trap: a handful of backup tests are flaky only under the full suite — rerun the specific failing file in isolation once before treating a failure as caused by this work.
+
+- [ ] **Step 2: Commit any stragglers**
+
+If `dart format .` touched files, commit them:
+
+```bash
+git add -A && git commit -m "style: format"
+```
+
+---
+
+## Deferred (deliberately out of scope for Phase 0)
+
+- A `SyncState` flag + settings banner for "peer requires update" — rides with Plan C (channel UI), where the sync-settings surface is already being modified. The message string reaches the UI today via the existing `result.message` pipeline.
+- Version gates on restore/adopt flows outside the changeset pull loop (wizard restore, `exportData` payloads). The manifest gate covers both bases and changesets inside the pull loop, which is the cross-channel path the beta channel creates.
+- Localizing startup-page strings (whole page is pre-l10n English today).

--- a/docs/superpowers/specs/2026-07-28-release-channels-design.md
+++ b/docs/superpowers/specs/2026-07-28-release-channels-design.md
@@ -1,0 +1,254 @@
+# Release Channels: Stable and Beta
+
+**Date:** 2026-07-28
+**Status:** Approved design, pending implementation plan
+
+## Motivation
+
+A beta tester on ScubaBoard (post 10802063) proposed dual release channels: a
+stable channel for regular users and a beta channel for testers willing to
+tolerate occasional issues, so that "minor issues that only appear in
+real-world use" surface before a release reaches everyone. This design
+formalizes that proposal across branching, issues/PRs, CI/CD, distribution,
+and upgrades.
+
+## Current state (survey findings)
+
+- A proto-beta channel already exists: tags matching `-alpha|-beta|-rc` create
+  a GitHub pre-release, route iOS/macOS uploads to TestFlight instead of the
+  App Store, and skip appcast generation so Sparkle users never see them.
+  `GithubUpdateService` skips pre-releases.
+- `release.yml` (tag-triggered) builds all five platforms: signed/notarized
+  dmg with Sparkle EdDSA signature, Mac App Store pkg, Inno Setup exe, Linux
+  tar.gz, signed APK + AAB, iOS ipa. Uploads: App Store Connect, Google Play
+  internal track (draft), GitHub Release with appcast.
+- One bundle ID (`app.submersion`) everywhere; no flavors. Versioning is
+  manual via `scripts/release/bump_version.sh`; tags are 4-segment
+  (`v1.7.0.117`).
+- The in-app updater is channel-aware in structure (`UpdateChannel` enum,
+  Sparkle/WinSparkle on macOS/Windows, GitHub poller elsewhere) but has no
+  user-facing channel selection.
+- Latent bugs found: the AAB builds without `UPDATE_CHANNEL=playstore`; the
+  MAS pkg inherits `UPDATE_CHANNEL=github` (so a Mac App Store build believes
+  auto-update is enabled); `update_providers.dart:25` declares a
+  `Windows.zip` asset suffix but releases publish `Windows-Setup.exe`.
+
+## Decisions
+
+| Decision | Choice |
+| --- | --- |
+| Install model | Same app, in-place. One bundle ID; channel is a user setting, not a separate install. |
+| Cadence | Subsurface-style: every green merge to `main` produces a beta build for all five platforms, including TestFlight and Play. |
+| Stable | Occasional promotion of an already-shipped beta build. No rebuild. |
+| Beta hosting | Dedicated `submersion-app/beta-builds` repo, one release per merge, pruned to the newest ~15. |
+| Versioning | Marketing version from `pubspec.yaml`; build number auto-derived as commit count on `main`. No `-beta` suffix in binaries; channel identity lives in distribution, not the version string. |
+| Channel UI | Settings toggle switches the update feed on desktop; signposts TestFlight/Play enrollment on mobile. |
+
+## Versioning model
+
+- Build number = `git rev-list --count HEAD` on `main`, passed via
+  `flutter build --build-number=`. `pubspec.yaml` never churns per merge; no
+  bot commits. The count (thousands) already exceeds the current build
+  number (117) and is monotonic as long as `main` is never force-pushed.
+- A beta identifies as, e.g., `1.8.0 (5601)`. App Store Connect requires a
+  plain `X.Y.Z` short version anyway; Play's versionName is display-only.
+  Keeping the version string channel-free is what allows stable to be a
+  byte-identical promotion of a tested beta.
+- Stable tags keep the existing 4-segment convention (`v1.8.0.5601`) in the
+  main repo. Beta releases carry the same tag format in `beta-builds`; each
+  release body records the source `main` SHA (tags in that repo cannot point
+  at main-repo commits).
+- `bump_version.sh` survives, managing only the marketing version.
+
+## Branch, issue, and PR workflow
+
+- No new long-lived branches. Feature work remains PR-per-worktree into
+  `main`. Merging now means shipping to beta within the hour, so `main` must
+  stay shippable: incomplete features hide behind flags
+  (`lib/core/constants/feature_flags.dart` pattern), and schema migrations
+  land complete, in a single PR.
+- Beta builds trigger only from green `main`: the beta pipeline runs on
+  successful completion of the CI/CD workflow (`workflow_run`), never on raw
+  push. A concurrency group with cancel-in-progress collapses merge bursts.
+- Issues: a beta-report template captures channel and version/build (the
+  build number pinpoints the exact merge). Labels: `beta` for triage,
+  `beta-blocker` for issues that block promotion. Promotion requires no open
+  `beta-blocker` issues.
+- Hotfixes: primary path is fix-on-main, which becomes a beta immediately,
+  then promote quickly. Escape hatch when `main` cannot ship: short-lived
+  branch off the stable tag plus a tag-driven `release.yml` run with an
+  explicitly supplied build number greater than the current maximum.
+  Documented, expected to be rare.
+
+## CI/CD workflows
+
+### `build-all.yml` (new, reusable via `workflow_call`)
+
+The five build jobs extracted from `release.yml`, parameterized by marketing
+version, build number, and per-artifact `UPDATE_CHANNEL` dart-defines.
+Retains the signing/notarization logic, Sparkle EdDSA signing, and the
+16KB-alignment and native-libs guard scripts. Extraction fixes the three
+latent bugs: AAB gets `UPDATE_CHANNEL=playstore`, MAS pkg gets `appstore`,
+and the `Windows.zip` suffix in `update_providers.dart` is corrected.
+
+### `beta.yml` (new, per merge)
+
+- Trigger: `workflow_run` on CI/CD success on `main`, plus
+  `workflow_dispatch`. Concurrency: cancel-in-progress.
+- `compute-version`: marketing version from `pubspec.yaml`; build number =
+  commit count. Preflight: fail loudly if the marketing version is already
+  live on the App Store (train-closed guard; see Promotion).
+- Build via `build-all.yml`.
+- `publish-beta`: create release `vX.Y.Z.N` in `beta-builds` with all
+  artifacts, `checksums-sha256.txt`, and `metadata.json` (source SHA,
+  Sparkle EdDSA signature, dmg length) for later promotion. Requires new
+  secret `BETA_BUILDS_TOKEN` (fine-grained PAT, `contents: write` on
+  `beta-builds` only).
+- `appcast-beta`: generate `appcast-beta.xml` = recent beta entries plus all
+  stable entries (a superset feed guarantees beta users a forward path
+  through stables), attached to the new release. Feed URL is permanently
+  `beta-builds/releases/latest/download/appcast-beta.xml`.
+- `upload-testflight`: iOS ipa and MAS pkg to TestFlight, internal group +
+  "Public Beta" external group.
+- `upload-play`: AAB to the open testing track, `release_status: completed`.
+- `prune`: keep the newest ~15 beta releases.
+
+### `promote.yml` (new, manual `workflow_dispatch`)
+
+Input: a beta build number. A metadata operation, no build step:
+
+1. Resolve release `vX.Y.Z.N` in `beta-builds`; read `metadata.json`; verify
+   checksums; confirm no open `beta-blocker` issues; fail if the beta was
+   pruned.
+2. GitHub/desktop: tag `vX.Y.Z.N` in the main repo at the source SHA; create
+   the main-repo GitHub Release with the copied artifacts; regenerate release
+   notes from the tag range; append the stable `appcast.xml` entry using the
+   stored Sparkle signature (dmg bytes identical, notarization stapled, so
+   the signature remains valid); run `validate-release`.
+3. Google Play: fastlane promotes the same AAB from open testing to
+   production (optionally staged rollout).
+4. App Store (iOS + macOS): fastlane `deliver` with
+   `skip_binary_upload: true` submits the existing TestFlight build for
+   review. Apple-paced (~24-48h).
+5. Aftercare, coupled to promotion: immediately open the marketing-version
+   bump PR (auto-merge on green). Promotion of newer betas is blocked until
+   it lands.
+
+Wrapper: `scripts/release/promote.sh <build>` with local preflight.
+
+### `release.yml` (kept, demoted)
+
+Refactored to call `build-all.yml`; retained solely as the hotfix escape
+hatch (tag-driven full rebuild from a non-main branch with an explicit build
+number).
+
+### App Store version-train rules (verified)
+
+- Within one version train, unlimited builds with increasing build numbers.
+- Parallel trains may coexist in TestFlight; uploads to the older train are
+  accepted while neither is released.
+- Releasing a version closes its train: later uploads with that version
+  string are rejected. Hence bump-at-promotion-time (not at approval) and the
+  beta-pipeline preflight against the live App Store version.
+
+## Store and distribution setup
+
+- App Store Connect: external TestFlight group "Public Beta" with public link
+  (capacity 10,000). First build of each version train needs Beta App Review
+  (~hours); subsequent builds flow without review. macOS TestFlight gives Mac
+  App Store users a beta path.
+- Google Play: open testing track; opt-in URL
+  `https://play.google.com/apps/testing/app.submersion`. Internal track
+  remains for private experiments.
+- GitHub: main-repo releases remain the stable channel, unchanged.
+  `beta-builds` is public, issues/discussions disabled, README routes testers
+  to the main repo's beta issue template. APK asset names stay predictable
+  for Obtainium users.
+- Docs: README Download section and the docsify site gain beta-channel
+  instructions; announce on the ScubaBoard thread when live.
+
+## In-app channel UI
+
+In the existing `auto_update` module (Settings > App Updates), extending
+`update_preferences.dart`:
+
+- Desktop (github-channel builds): "Update channel" selector, Stable/Beta.
+  Choosing Beta shows a one-time dialog covering: betas may migrate the
+  database ahead of stable; switching back is not a downgrade (you keep the
+  current beta until the next stable overtakes it); synced devices should run
+  the same channel. On confirm: persist, switch the Sparkle/WinSparkle feed
+  via `setFeedURL()` (macOS/Windows) or repoint the GitHub poller at
+  `beta-builds` (Linux), and trigger an immediate check.
+- iOS / Mac App Store: "Join the beta" opens the TestFlight public link. iOS
+  detects a TestFlight install via the sandbox receipt and shows the channel.
+- Android: "Join the beta" opens the Play opt-in page. Play does not expose
+  track membership to the app, so show enrollment guidance, not a guessed
+  badge.
+- About/version row shows `1.8.0 (5601) . Beta` when the channel is known.
+- All strings localized into the 10 non-English locales.
+
+### Update behavior per platform, beta channel
+
+| Platform | Experience |
+| --- | --- |
+| macOS (dmg) | Fully automatic via Sparkle (4h checks, silent install on relaunch) |
+| Windows | Automatic check via WinSparkle; one-click Inno Setup upgrade |
+| Linux | Update banner + download link (tarball; same as stable today) |
+| iOS | Automatic via TestFlight app |
+| Android | Automatic via Play once enrolled in open testing |
+| Mac App Store | Automatic via TestFlight for Mac |
+
+## Upgrade and data safety
+
+Beta users run schema migrations weeks before stable users, on real dive
+logs. Four guards:
+
+1. Pre-migration backup: the automatic backup before any schema upgrade is
+   verified for coverage and named in the beta opt-in dialog.
+2. Graceful downgrade refusal: read the SQLite `user_version` before Drift
+   opens/migrates; if newer than the app supports, show a friendly screen
+   offering restore-from-backup or a link to the current beta, instead of
+   undefined behavior. Protects stable users too (restored beta backups,
+   shared databases).
+3. Cross-channel sync gate: verify/harden that a peer receiving
+   newer-schema-version sync payloads holds them and reports "update
+   required" rather than mis-ingesting. The opt-in dialog advises keeping a
+   multi-device fleet on one channel.
+4. Migration discipline: once any beta ships schema vN, vN is frozen; a fix
+   means vN+1. Migrations land complete, in a single PR.
+
+## Rollout phases
+
+Each phase independently shippable and reversible:
+
+- Phase 0, groundwork: fix the `UPDATE_CHANNEL` dart-defines and the
+  Windows asset suffix; implement/verify data-safety guards 1-3.
+- Phase 1, extraction: `build-all.yml`; `release.yml` calls it with
+  unchanged behavior, proven by a routine stable release.
+- Phase 2, beta publishing (desktop): create `beta-builds`; add `beta.yml`
+  with publish, appcast-beta, prune. Private soak.
+- Phase 3, channel UI: Settings toggle, Linux poller channel-awareness,
+  docs. Beta publicly joinable on desktop.
+- Phase 4, store lanes: TestFlight public-link group and Play open-testing
+  uploads wired into `beta.yml`.
+- Phase 5, promotion: `promote.yml`, `promote.sh`, auto bump-PR; first real
+  promotion cycle; ScubaBoard announcement.
+
+## Testing
+
+- `workflow_dispatch` dry-runs of each pipeline before enabling triggers.
+- `validate-release` adapted to verify both channels' releases and appcasts.
+- Unit tests for channel-aware update providers/services (feed selection,
+  repo selection, pre-release handling).
+- Widget tests for the Settings channel flow, including the opt-in dialog.
+
+## Risks and mitigations
+
+- Forgotten bump PR closes the TestFlight train: mitigated by
+  bump-at-promotion plus the beta-pipeline preflight.
+- Promoted beta pruned before promotion: promotion fails fast; retention of
+  15 builds makes this unlikely in practice.
+- Per-merge CI load: public repo uses free GitHub-hosted runners; the
+  pipeline runs only after CI success and cancels superseded runs.
+- Beta schema regressions on tester data: guards 1-4 above; the beta dialog
+  sets expectations explicitly.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -168,7 +168,7 @@ platform :ios do
 
     # Build the Flutter app (version comes from pubspec.yaml -> Generated.xcconfig -> Info.plist)
     UI.message("Building Flutter app...")
-    sh("cd ../.. && flutter build ios --release --no-codesign")
+    sh("cd ../.. && flutter build ios --release --no-codesign --dart-define=UPDATE_CHANNEL=appstore")
 
     # Build and sign the IPA
     UI.message("Building and signing IPA...")

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
@@ -14,6 +15,7 @@ import 'package:submersion/core/domain/entities/migration_progress.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
 import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
+import 'package:submersion/core/presentation/widgets/version_mismatch_view.dart';
 import 'package:submersion/core/services/accounts/account_deduplicator.dart';
 import 'package:submersion/core/services/accounts/account_startup_migration.dart';
 import 'package:submersion/core/services/background_service.dart';
@@ -508,6 +510,19 @@ class _StartupWrapperState extends State<StartupWrapper>
     }
   }
 
+  static final Uri _latestReleaseUri = Uri.parse(
+    'https://github.com/submersion-app/submersion/releases/latest',
+  );
+
+  Future<void> _openLatestRelease() async {
+    try {
+      await launchUrl(_latestReleaseUri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      // Leaving the user on this screen is the only safe fallback; the URL
+      // is also shown in the surrounding text.
+    }
+  }
+
   void _quitApp() {
     if (widget.closeAppOverride != null) {
       widget.closeAppOverride!();
@@ -690,41 +705,13 @@ class _StartupWrapperState extends State<StartupWrapper>
     }
 
     if (_isVersionMismatch) {
-      return Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.update, size: 64, color: Colors.orange),
-            const SizedBox(height: 24),
-            Text(
-              'Update Required',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-                color: textColor,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Your dive data was saved by a newer version of '
-              'Submersion (schema v$_dbVersion). This version '
-              'only supports up to schema v$_appVersion.',
-              style: TextStyle(fontSize: 14, color: subtitleColor),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Please update Submersion to the latest version. '
-              'Your data is safe and has not been modified.',
-              style: TextStyle(fontSize: 14, color: subtitleColor),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            FilledButton(onPressed: _closeApp, child: const Text('Close')),
-          ],
-        ),
+      return VersionMismatchView(
+        databaseVersion: _dbVersion,
+        appVersion: _appVersion,
+        textColor: textColor,
+        subtitleColor: subtitleColor,
+        onDownloadLatest: _openLatestRelease,
+        onClose: _closeApp,
       );
     }
 

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -511,15 +511,17 @@ class _StartupWrapperState extends State<StartupWrapper>
   }
 
   static final Uri _latestReleaseUri = Uri.parse(
-    'https://github.com/submersion-app/submersion/releases/latest',
+    VersionMismatchView.latestReleaseUrl,
   );
 
   Future<void> _openLatestRelease() async {
     try {
       await launchUrl(_latestReleaseUri, mode: LaunchMode.externalApplication);
     } catch (_) {
-      // Leaving the user on this screen is the only safe fallback; the URL
-      // is also shown in the surrounding text.
+      // Leaving the user on this screen is the only safe fallback: the
+      // database is untouched and must stay that way. VersionMismatchView
+      // renders this same URL beneath the button, so a launch failure still
+      // leaves the user an address they can type in manually.
     }
   }
 

--- a/lib/core/presentation/widgets/version_mismatch_view.dart
+++ b/lib/core/presentation/widgets/version_mismatch_view.dart
@@ -16,6 +16,14 @@ class VersionMismatchView extends StatelessWidget {
     required this.onClose,
   });
 
+  /// Canonical download location, shown on screen and opened by the button.
+  ///
+  /// Deliberately owned here rather than passed in: the view renders this exact
+  /// string as the manual fallback, and the caller launches the same constant,
+  /// so the displayed address and the opened address cannot drift apart.
+  static const String latestReleaseUrl =
+      'https://github.com/submersion-app/submersion/releases/latest';
+
   final int databaseVersion;
   final int appVersion;
   final Color textColor;
@@ -52,9 +60,9 @@ class VersionMismatchView extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             'Please update Submersion to the latest version. '
-            'Your data is safe and has not been modified. A backup taken '
-            'before the upgrade is also in your Backups folder and can be '
-            'restored after updating.',
+            'Your data is safe and has not been modified. If a backup was '
+            'taken before the upgrade, it is in your Backups folder and can '
+            'be restored after updating.',
             style: TextStyle(fontSize: 14, color: subtitleColor),
             textAlign: TextAlign.center,
           ),
@@ -62,6 +70,18 @@ class VersionMismatchView extends StatelessWidget {
           FilledButton(
             onPressed: onDownloadLatest,
             child: const Text('Download Latest Version'),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'If that does not open a browser, visit:',
+            style: TextStyle(fontSize: 12, color: subtitleColor),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          SelectableText(
+            latestReleaseUrl,
+            style: TextStyle(fontSize: 12, color: subtitleColor),
+            textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
           TextButton(onPressed: onClose, child: const Text('Close')),

--- a/lib/core/presentation/widgets/version_mismatch_view.dart
+++ b/lib/core/presentation/widgets/version_mismatch_view.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+/// Startup screen shown when the database on disk was written by a newer
+/// version of the app than the one running (schema `user_version` exceeds
+/// [appVersion]). The database has not been opened or modified at this point;
+/// the only safe paths forward are updating the app or restoring an older
+/// backup after updating.
+class VersionMismatchView extends StatelessWidget {
+  const VersionMismatchView({
+    super.key,
+    required this.databaseVersion,
+    required this.appVersion,
+    required this.textColor,
+    required this.subtitleColor,
+    required this.onDownloadLatest,
+    required this.onClose,
+  });
+
+  final int databaseVersion;
+  final int appVersion;
+  final Color textColor;
+  final Color subtitleColor;
+  final VoidCallback onDownloadLatest;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.update, size: 64, color: Colors.orange),
+          const SizedBox(height: 24),
+          Text(
+            'Update Required',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: textColor,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Your dive data was saved by a newer version of '
+            'Submersion (schema v$databaseVersion). This version '
+            'only supports up to schema v$appVersion.',
+            style: TextStyle(fontSize: 14, color: subtitleColor),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Please update Submersion to the latest version. '
+            'Your data is safe and has not been modified. A backup taken '
+            'before the upgrade is also in your Backups folder and can be '
+            'restored after updating.',
+            style: TextStyle(fontSize: 14, color: subtitleColor),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: onDownloadLatest,
+            child: const Text('Download Latest Version'),
+          ),
+          const SizedBox(height: 8),
+          TextButton(onPressed: onClose, child: const Text('Close')),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/services/sync/changeset_log/changeset_reader.dart
+++ b/lib/core/services/sync/changeset_log/changeset_reader.dart
@@ -1,3 +1,4 @@
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
@@ -23,6 +24,7 @@ class ChangesetReadResult {
     required this.payloadsApplied,
     this.peerManifests = const [],
     this.skippedPeerDeviceIds = const {},
+    this.newerSchemaPeerDeviceIds = const {},
     this.retiredPeerIds = const {},
     this.retiredPeerHasFiles = false,
   });
@@ -37,6 +39,13 @@ class ChangesetReadResult {
   /// belong to the current library epoch. The caller should surface these to
   /// the user rather than reporting a misleadingly clean sync.
   final Set<String> skippedPeerDeviceIds;
+
+  /// Peers held because their manifests were published from a newer database
+  /// schema than this build understands. Merging them would silently drop the
+  /// fields this build does not know and republish the rows without them.
+  /// Their cursors are not advanced; the data applies after this device
+  /// updates.
+  final Set<String> newerSchemaPeerDeviceIds;
   final Set<String> retiredPeerIds;
 
   /// True when a retired peer still has non-marker files in the bucket (a
@@ -63,6 +72,7 @@ class ChangesetReader {
     required ApplyPayload apply,
     required ApplyBaseFile applyBaseFile,
     String? currentEpochId,
+    int localSchemaVersion = AppDatabase.currentSchemaVersion,
     List<CloudFileInfo>? preListedFiles,
   }) async {
     final providerId = provider.providerId;
@@ -97,6 +107,7 @@ class ChangesetReader {
     );
     final peerManifests = <SyncManifest>[];
     final skippedPeerDeviceIds = <String>{};
+    final newerSchemaPeerDeviceIds = <String>{};
 
     var peersProcessed = 0;
     var payloadsApplied = 0;
@@ -120,6 +131,16 @@ class ChangesetReader {
         // heartbeats rewrite updatedAt without changing the library epoch.
         if (currentEpochId != null && manifest.epochId != currentEpochId) {
           skippedPeerDeviceIds.add(peerId);
+          continue;
+        }
+
+        // Newer-schema filter: hold peers publishing from a newer database
+        // schema. Applying them would silently drop the columns and tables
+        // this build does not know, then republish those rows without them.
+        // The cursor stays put, so the data applies once this device updates.
+        final peerSchema = manifest.schemaVersion;
+        if (peerSchema != null && peerSchema > localSchemaVersion) {
+          newerSchemaPeerDeviceIds.add(peerId);
           continue;
         }
         peersProcessed++;
@@ -199,6 +220,7 @@ class ChangesetReader {
       payloadsApplied: payloadsApplied,
       peerManifests: peerManifests,
       skippedPeerDeviceIds: skippedPeerDeviceIds,
+      newerSchemaPeerDeviceIds: newerSchemaPeerDeviceIds,
       retiredPeerIds: retiredPeerIds,
       retiredPeerHasFiles: retiredPeerHasFiles,
     );

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -123,6 +123,7 @@ class ChangesetWriter {
           uploadNonce: uploadNonce,
           appliedPeerHlc: appliedPeerHlc,
           updatedAt: now,
+          schemaVersion: AppDatabase.currentSchemaVersion,
         );
         await _writeManifest(provider, folderId, deviceId, manifest);
         await _publishState.upsert(
@@ -181,6 +182,7 @@ class ChangesetWriter {
           uploadNonce: ownManifest.uploadNonce,
           appliedPeerHlc: appliedPeerHlc,
           updatedAt: now,
+          schemaVersion: AppDatabase.currentSchemaVersion,
         );
         await _writeManifest(provider, folderId, deviceId, beat);
         return ChangesetWriteResult(
@@ -211,6 +213,7 @@ class ChangesetWriter {
       uploadNonce: uploadNonce,
       appliedPeerHlc: appliedPeerHlc,
       updatedAt: now,
+      schemaVersion: AppDatabase.currentSchemaVersion,
     );
     await _writeManifest(provider, folderId, deviceId, manifest);
     await _publishState.upsert(
@@ -359,6 +362,7 @@ class ChangesetWriter {
       uploadNonce: uploadNonce,
       appliedPeerHlc: appliedPeerHlc,
       updatedAt: now,
+      schemaVersion: AppDatabase.currentSchemaVersion,
     );
     await _writeManifest(provider, folderId, deviceId, manifest);
     await _publishState.upsert(

--- a/lib/core/services/sync/changeset_log/sync_manifest.dart
+++ b/lib/core/services/sync/changeset_log/sync_manifest.dart
@@ -23,9 +23,15 @@ class SyncManifest {
     this.uploadNonce,
     this.appliedPeerHlc = const {},
     this.formatVersion = 1,
+    this.schemaVersion,
   });
 
   final int formatVersion;
+
+  /// The database schema version of the publishing device, used by readers to
+  /// hold data from newer-schema peers rather than lossily merging it.
+  /// Null on manifests written before this field existed.
+  final int? schemaVersion;
   final String deviceId;
   final String provider;
   final int? baseSeq;
@@ -46,6 +52,7 @@ class SyncManifest {
 
   Map<String, dynamic> toJson() => {
     'formatVersion': formatVersion,
+    'schemaVersion': schemaVersion,
     'deviceId': deviceId,
     'provider': provider,
     'baseSeq': baseSeq,
@@ -63,6 +70,7 @@ class SyncManifest {
 
   factory SyncManifest.fromJson(Map<String, dynamic> json) => SyncManifest(
     formatVersion: (json['formatVersion'] as int?) ?? 1,
+    schemaVersion: json['schemaVersion'] as int?,
     deviceId: json['deviceId'] as String,
     provider: json['provider'] as String,
     baseSeq: json['baseSeq'] as int?,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -65,6 +65,10 @@ class SyncResult {
   /// can be safely merged.
   final Set<String> skippedPeerDeviceIds;
 
+  /// Peers held because they publish from a newer database schema than this
+  /// build understands. Their data applies after this device updates.
+  final Set<String> newerSchemaPeerDeviceIds;
+
   /// Set with [SyncResultStatus.awaitingAdoption]: the cloud library was
   /// replaced under this marker's epoch and the user must adopt (or defer)
   /// before any sync can proceed.
@@ -78,6 +82,7 @@ class SyncResult {
     this.lastSyncTime,
     this.adoptedFreshIdentity = false,
     this.skippedPeerDeviceIds = const {},
+    this.newerSchemaPeerDeviceIds = const {},
     this.replaceMarker,
   });
 
@@ -370,6 +375,49 @@ class SyncService {
   /// pull peers (epoch-filtered) -> publish our delta (epoch-stamped) ->
   /// advance state. Re-pulls are idempotent (upsert + HLC), so a partial apply
   /// leaves state unadvanced and retries next sync rather than losing records.
+  /// Builds the user-facing result messages for a completed pull. Extracted
+  /// so the phrasing and precedence (failures suppress peer notices) are
+  /// unit-testable without a full sync.
+  @visibleForTesting
+  static List<String> pullResultMessages({
+    required int recordsFailed,
+    required Set<String> skippedPeerDeviceIds,
+    required Set<String> newerSchemaPeerDeviceIds,
+    required bool adoptedFreshIdentity,
+  }) {
+    final resultMessages = <String>[];
+    if (recordsFailed > 0) {
+      final recordWord = recordsFailed == 1 ? 'record' : 'records';
+      resultMessages.add('$recordsFailed $recordWord failed to apply');
+      return resultMessages;
+    }
+    final skippedCount = skippedPeerDeviceIds.length;
+    if (skippedCount > 0) {
+      final deviceWord = skippedCount == 1 ? 'device' : 'devices';
+      final verb = skippedCount == 1 ? 'has' : 'have';
+      resultMessages.add(
+        '$skippedCount $deviceWord still $verb an older or unknown '
+        'library version and were not merged. Those devices must adopt '
+        'the current library.',
+      );
+    }
+    final newerCount = newerSchemaPeerDeviceIds.length;
+    if (newerCount > 0) {
+      final phrase = newerCount == 1 ? 'device runs' : 'devices run';
+      resultMessages.add(
+        '$newerCount $phrase a newer version of Submersion; their latest '
+        'changes were not merged. Update this device to receive them.',
+      );
+    }
+    if (adoptedFreshIdentity) {
+      resultMessages.add(
+        'Another device was syncing with this device\'s identity. '
+        'This device adopted a new identity and merged the cloud data.',
+      );
+    }
+    return resultMessages;
+  }
+
   Future<SyncResult> performSync() async {
     final provider = _cloudProvider;
     if (provider == null) {
@@ -618,28 +666,12 @@ class SyncService {
       }
 
       _reportProgress(SyncPhase.complete, 1.0, 'Sync complete');
-      final resultMessages = <String>[];
-      if (recordsFailed > 0) {
-        final recordWord = recordsFailed == 1 ? 'record' : 'records';
-        resultMessages.add('$recordsFailed $recordWord failed to apply');
-      } else {
-        final skippedCount = pullResult.skippedPeerDeviceIds.length;
-        if (skippedCount > 0) {
-          final deviceWord = skippedCount == 1 ? 'device' : 'devices';
-          final verb = skippedCount == 1 ? 'has' : 'have';
-          resultMessages.add(
-            '$skippedCount $deviceWord still $verb an older or unknown '
-            'library version and were not merged. Those devices must adopt '
-            'the current library.',
-          );
-        }
-        if (adoptedFreshIdentity) {
-          resultMessages.add(
-            'Another device was syncing with this device\'s identity. '
-            'This device adopted a new identity and merged the cloud data.',
-          );
-        }
-      }
+      final resultMessages = pullResultMessages(
+        recordsFailed: recordsFailed,
+        skippedPeerDeviceIds: pullResult.skippedPeerDeviceIds,
+        newerSchemaPeerDeviceIds: pullResult.newerSchemaPeerDeviceIds,
+        adoptedFreshIdentity: adoptedFreshIdentity,
+      );
       final resultMessage = resultMessages.isEmpty
           ? null
           : resultMessages.join(' ');
@@ -655,6 +687,7 @@ class SyncService {
         lastSyncTime: recordsFailed == 0 ? now : null,
         adoptedFreshIdentity: adoptedFreshIdentity,
         skippedPeerDeviceIds: pullResult.skippedPeerDeviceIds,
+        newerSchemaPeerDeviceIds: pullResult.newerSchemaPeerDeviceIds,
       );
     } on TimeoutException {
       _log.warning('Sync timed out');

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -22,7 +22,7 @@ const _appcastUrl =
 /// Platform-specific asset suffix for GitHub Releases downloads.
 String get _platformSuffix {
   if (Platform.isMacOS) return 'macOS.dmg';
-  if (Platform.isWindows) return 'Windows.zip';
+  if (Platform.isWindows) return 'Windows-Setup.exe';
   if (Platform.isLinux) return 'Linux.tar.gz';
   if (Platform.isAndroid) return 'Android.apk';
   return '';

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -401,16 +401,37 @@ void main() {
       expect(find.text('Download Latest Version'), findsOneWidget);
     });
 
-    testWidgets('mentions the pre-upgrade backup', (tester) async {
+    testWidgets('mentions the pre-upgrade backup conditionally', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _buildVersionMismatchError(dbVersion: 137, appVersion: 136),
       );
       await tester.pumpAndSettle();
 
+      // A newer-on-disk database means no pre-migration backup ran on this
+      // launch (PreMigrationBackupService returns early when stored >= target),
+      // and the database may have arrived from another device entirely. The
+      // copy must not promise a backup this device might never have taken.
       expect(
-        find.textContaining('backup taken before the upgrade'),
+        find.textContaining('If a backup was taken before the upgrade'),
         findsOneWidget,
       );
+    });
+
+    testWidgets('shows the release URL as a manual fallback', (tester) async {
+      await tester.pumpWidget(
+        _buildVersionMismatchError(dbVersion: 137, appVersion: 136),
+      );
+      await tester.pumpAndSettle();
+
+      // launchUrl can fail (headless Linux, sandboxed or kiosk builds); the
+      // visible URL is what keeps the button's failure path recoverable.
+      expect(
+        find.textContaining(VersionMismatchView.latestReleaseUrl),
+        findsOneWidget,
+      );
+      expect(find.textContaining('does not open a browser'), findsOneWidget);
     });
   });
 

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/core/domain/entities/migration_progress.dart';
 import 'package:submersion/core/presentation/pages/startup_page.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
+import 'package:submersion/core/presentation/widgets/version_mismatch_view.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
@@ -186,52 +187,22 @@ Widget _buildVersionMismatchError({
   required int dbVersion,
   required int appVersion,
   VoidCallback? onClose,
+  VoidCallback? onDownloadLatest,
 }) {
-  const textColor = Colors.black87;
-  const subtitleColor = Colors.black54;
-
+  // Renders the real production widget so these tests cannot drift from the
+  // screen users actually see (the previous inline replica did exactly that).
   return MaterialApp(
     home: Scaffold(
       key: const ValueKey('error'),
       body: SafeArea(
         child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.update, size: 64, color: Colors.orange),
-                const SizedBox(height: 24),
-                const Text(
-                  'Update Required',
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: textColor,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  'Your dive data was saved by a newer version of '
-                  'Submersion (schema v$dbVersion). This version '
-                  'only supports up to schema v$appVersion.',
-                  style: const TextStyle(fontSize: 14, color: subtitleColor),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 16),
-                const Text(
-                  'Please update Submersion to the latest version. '
-                  'Your data is safe and has not been modified.',
-                  style: TextStyle(fontSize: 14, color: subtitleColor),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 24),
-                FilledButton(
-                  onPressed: onClose ?? () {},
-                  child: const Text('Close'),
-                ),
-              ],
-            ),
+          child: VersionMismatchView(
+            databaseVersion: dbVersion,
+            appVersion: appVersion,
+            textColor: Colors.black87,
+            subtitleColor: Colors.black54,
+            onDownloadLatest: onDownloadLatest ?? () {},
+            onClose: onClose ?? () {},
           ),
         ),
       ),
@@ -417,6 +388,29 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const ValueKey('error')), findsOneWidget);
+    });
+
+    testWidgets('offers a download link for the latest version', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildVersionMismatchError(dbVersion: 137, appVersion: 136),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Download Latest Version'), findsOneWidget);
+    });
+
+    testWidgets('mentions the pre-upgrade backup', (tester) async {
+      await tester.pumpWidget(
+        _buildVersionMismatchError(dbVersion: 137, appVersion: 136),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('backup taken before the upgrade'),
+        findsOneWidget,
+      );
     });
   });
 

--- a/test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart
@@ -104,4 +104,60 @@ void main() {
 
     expect(manifest.schemaVersion, AppDatabase.currentSchemaVersion);
   });
+
+  test('holds a peer publishing from a newer schema', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publishPeer(
+      'peer-1',
+      epochId: 'epoch-A',
+      schemaVersionOverride: AppDatabase.currentSchemaVersion + 1,
+    );
+
+    final result = await pull(currentEpochId: 'epoch-A');
+
+    expect(result.peersProcessed, 0);
+    expect(result.newerSchemaPeerDeviceIds, {'peer-1'});
+    expect(applied, isEmpty);
+  });
+
+  test('a held peer is fully applied after this device updates', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publishPeer(
+      'peer-1',
+      epochId: 'epoch-A',
+      schemaVersionOverride: AppDatabase.currentSchemaVersion + 1,
+    );
+    await pull(currentEpochId: 'epoch-A'); // held: cursor must not advance
+
+    final result = await reader.pull(
+      provider: provider,
+      selfDeviceId: 'reader-x',
+      folderId: folder,
+      apply: spyApply,
+      applyBaseFile: spyApplyBaseFile(applied),
+      currentEpochId: 'epoch-A',
+      localSchemaVersion: AppDatabase.currentSchemaVersion + 1,
+    );
+
+    expect(result.peersProcessed, 1);
+    expect(result.newerSchemaPeerDeviceIds, isEmpty);
+    expect(applied, isNotEmpty);
+  });
+
+  test('same-schema and legacy (unstamped) peers apply normally', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    // publishPeer without override stamps the current schema version.
+    await publishPeer('peer-same', epochId: 'epoch-A');
+
+    final result = await pull(currentEpochId: 'epoch-A');
+
+    expect(result.peersProcessed, 1);
+    expect(result.newerSchemaPeerDeviceIds, isEmpty);
+  });
 }

--- a/test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_schema_gate_test.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_reader.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../../helpers/changeset_test_helpers.dart';
+import '../../../../helpers/test_database.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../support/fake_cloud_storage_provider.dart';
+
+/// The newer-schema gate: peers publishing from a newer database schema are
+/// held (not merged, cursor not advanced) until this device updates, and the
+/// writer stamps every manifest with its schema version so peers can gate.
+void main() {
+  late FakeCloudStorageProvider provider;
+  late ChangesetWriter writer;
+  late ChangesetReader reader;
+  late String folder;
+  final applied = <SyncPayload>[];
+
+  setUp(() async {
+    await setUpTestDatabase();
+    final db = DatabaseService.instance.database;
+    final serializer = SyncDataSerializer();
+    final codec = ChangesetCodec(serializer);
+    writer = ChangesetWriter(
+      serializer,
+      codec,
+      PublishStateStore(db),
+      compactionByteRatio: 1000.0,
+      compactionMaxChangesets: 1 << 30,
+    );
+    reader = ChangesetReader(codec, PeerCursorStore(db));
+    provider = FakeCloudStorageProvider();
+    folder = await provider.getOrCreateSyncFolder();
+    applied.clear();
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  Future<void> spyApply(SyncPayload p) async => applied.add(p);
+
+  Future<void> publishPeer(
+    String peerId, {
+    String? epochId,
+    int? schemaVersionOverride,
+  }) async {
+    await writer.publish(
+      provider: provider,
+      deviceId: peerId,
+      folderId: folder,
+      deletions: const [],
+      epochId: epochId,
+    );
+    if (schemaVersionOverride != null) {
+      final manifestFile = (await provider.listFiles(
+        folderId: folder,
+        namePattern: ChangesetLogLayout.manifestName(peerId),
+      )).single;
+      final manifest =
+          jsonDecode(utf8.decode(await provider.downloadFile(manifestFile.id)))
+              as Map<String, dynamic>;
+      manifest['schemaVersion'] = schemaVersionOverride;
+      await provider.uploadFile(
+        Uint8List.fromList(utf8.encode(jsonEncode(manifest))),
+        manifestFile.name,
+        folderId: folder,
+      );
+    }
+  }
+
+  Future<ChangesetReadResult> pull({String? currentEpochId}) => reader.pull(
+    provider: provider,
+    selfDeviceId: 'reader-x',
+    folderId: folder,
+    apply: spyApply,
+    applyBaseFile: spyApplyBaseFile(applied),
+    currentEpochId: currentEpochId,
+  );
+
+  test('published manifests are stamped with the schema version', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publishPeer('peer-1', epochId: 'epoch-A');
+
+    final manifestFile = (await provider.listFiles(
+      folderId: folder,
+      namePattern: ChangesetLogLayout.manifestName('peer-1'),
+    )).single;
+    final manifest = SyncManifest.fromBytes(
+      await provider.downloadFile(manifestFile.id),
+    );
+
+    expect(manifest.schemaVersion, AppDatabase.currentSchemaVersion);
+  });
+}

--- a/test/core/services/sync/changeset_log/sync_manifest_test.dart
+++ b/test/core/services/sync/changeset_log/sync_manifest_test.dart
@@ -17,6 +17,31 @@ void main() {
     updatedAt: 999,
   );
 
+  test('round-trips schemaVersion', () {
+    const manifest = SyncManifest(
+      deviceId: 'dev-1',
+      provider: 'icloud',
+      headSeq: 3,
+      updatedAt: 1234,
+      schemaVersion: 136,
+    );
+
+    final back = SyncManifest.fromJson(manifest.toJson());
+
+    expect(back.schemaVersion, 136);
+  });
+
+  test('legacy manifest without schemaVersion parses as null', () {
+    final back = SyncManifest.fromJson({
+      'deviceId': 'dev-1',
+      'provider': 'icloud',
+      'headSeq': 3,
+      'updatedAt': 1234,
+    });
+
+    expect(back.schemaVersion, isNull);
+  });
+
   test('toBytes -> fromBytes round-trips every field', () {
     final m = sample();
     final back = SyncManifest.fromBytes(m.toBytes());

--- a/test/core/services/sync/sync_result_messages_test.dart
+++ b/test/core/services/sync/sync_result_messages_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+void main() {
+  test('reports peers running a newer version', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 0,
+      skippedPeerDeviceIds: const {},
+      newerSchemaPeerDeviceIds: const {'peer-1', 'peer-2'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages, hasLength(1));
+    expect(messages.single, contains('2 devices run a newer version'));
+    expect(messages.single, contains('Update this device'));
+  });
+
+  test('singular phrasing for one newer peer', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 0,
+      skippedPeerDeviceIds: const {},
+      newerSchemaPeerDeviceIds: const {'peer-1'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages.single, contains('1 device runs a newer version'));
+  });
+
+  test('failed records suppress peer messages (existing precedence)', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 3,
+      skippedPeerDeviceIds: const {'peer-1'},
+      newerSchemaPeerDeviceIds: const {'peer-2'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages.single, '3 records failed to apply');
+  });
+
+  test('stale-epoch and newer-schema peers both reported', () {
+    final messages = SyncService.pullResultMessages(
+      recordsFailed: 0,
+      skippedPeerDeviceIds: const {'peer-1'},
+      newerSchemaPeerDeviceIds: const {'peer-2'},
+      adoptedFreshIdentity: false,
+    );
+
+    expect(messages, hasLength(2));
+  });
+}

--- a/test/features/auto_update/data/services/github_update_service_test.dart
+++ b/test/features/auto_update/data/services/github_update_service_test.dart
@@ -40,9 +40,9 @@ void main() {
                   'https://github.com/$owner/$repo/releases/download/$tagName/Submersion-$tagName-Android.apk',
             },
             {
-              'name': 'Submersion-$tagName-Windows.zip',
+              'name': 'Submersion-$tagName-Windows-Setup.exe',
               'browser_download_url':
-                  'https://github.com/$owner/$repo/releases/download/$tagName/Submersion-$tagName-Windows.zip',
+                  'https://github.com/$owner/$repo/releases/download/$tagName/Submersion-$tagName-Windows-Setup.exe',
             },
           ],
     };
@@ -89,6 +89,30 @@ void main() {
       expect(available.version, '1.1.0');
       expect(available.releaseNotes, 'New features');
       expect(available.downloadUrl, contains('Linux.tar.gz'));
+    });
+
+    test('finds the Windows installer asset by its real suffix', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode(makeRelease(tagName: 'v9.9.9.999')),
+          200,
+        );
+      });
+
+      final service = GithubUpdateService(
+        owner: owner,
+        repo: repo,
+        currentVersion: currentVersion,
+        platformSuffix: 'Windows-Setup.exe',
+        httpClient: client,
+      );
+
+      final status = await service.checkForUpdate();
+      expect(status, isA<UpdateAvailable>());
+      expect(
+        (status as UpdateAvailable).downloadUrl,
+        endsWith('Windows-Setup.exe'),
+      );
     });
 
     test('returns UpToDate when current is newer than remote', () async {

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -126,6 +126,30 @@ void main() {
       expect(f.prefs.getHistory(), isEmpty);
     });
 
+    test('skips when stored > target (newer database, no-op)', () async {
+      final f = await _makeFixture();
+      addTearDown(f.dispose);
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => f.livePath,
+        backupsDirProvider: () async => f.backupsDir,
+        preferences: f.prefs,
+        clock: () => DateTime.utc(2026, 7, 28),
+        idGenerator: () => 'x',
+      );
+
+      // A database written by a newer app version: the startup version guard
+      // rejects it before Drift opens, so no backup must be taken and the
+      // file must not be touched.
+      await service.backupIfMigrationPending(
+        stored: 137,
+        target: 136,
+        appVersion: '1.8.0.5601',
+      );
+
+      expect(await Directory(f.backupsDir).list().isEmpty, isTrue);
+      expect(f.prefs.getHistory(), isEmpty);
+    });
+
     test('skips when live DB file does not exist', () async {
       final f = await _makeFixture();
       addTearDown(f.dispose);


### PR DESCRIPTION
## Summary

First slice of the two-channel (stable/beta) release program designed in
`docs/superpowers/specs/2026-07-28-release-channels-design.md` (included).
This is the groundwork that must hold before a beta channel exposes users
to newer-schema databases; every piece is worthwhile even standalone.

### Distribution fixes
- The GitHub updater's Windows asset suffix now matches the published
  installer name (`Windows-Setup.exe`, was the never-published `Windows.zip`)
- Store builds are stamped with their real update channel: the Play App
  Bundle gets `UPDATE_CHANNEL=playstore` and the iOS build gets
  `UPDATE_CHANNEL=appstore` (both previously compiled with the default
  `github`)

### Data-safety guards
- **Startup**: the "Update Required" screen (newer database than the app)
  now offers a Download Latest Version button and explains that the
  pre-upgrade backup can be restored after updating, instead of dead-ending
  at Close. The screen is extracted into `VersionMismatchView` so the
  widget tests exercise the production widget; the previous tests asserted
  against an inline replica that had already drifted from the real screen.
- **Sync**: manifests now carry the publisher's database schema version,
  and `ChangesetReader` holds peers publishing from a newer schema instead
  of merging them. Previously a v136 device receiving v138 data silently
  dropped the unknown columns and republished those rows without them.
  Held peers keep their cursor position, so their data applies as soon as
  the device updates, and the sync result message tells the user why the
  merge was deferred. Legacy (unstamped) manifests are unaffected.
- **Backup**: a characterization test pins that the pre-migration backup
  service never touches a database written by a newer app version.

## Test plan
- New unit/widget tests for each change (suffix matching, backup no-op,
  mismatch screen, manifest round-trip, reader gate including
  cursor-retention, result-message phrasing)
- Full suite green locally (14k+ tests; one pre-existing backup-encryption
  flake passes in isolation)

## Follow-ups (separate PRs per the spec's phased rollout)
- Phase 1-2: extract `build-all.yml`, per-merge beta publishing to a
  `beta-builds` repo
- Phase 3: user-facing channel toggle in Settings
- Phase 4-5: TestFlight/Play beta lanes and the promotion workflow