### PR TITLE
feat(settings): add DD.MM.YYYY dot-separated date format

### DIFF
--- a/lib/core/constants/units.dart
+++ b/lib/core/constants/units.dart
@@ -128,7 +128,8 @@ enum DateFormatPreference {
   ddmmyyyy('DD/MM/YYYY', 'dd/MM/yyyy'),
   yyyymmdd('YYYY-MM-DD', 'yyyy-MM-dd'),
   mmmDYYYY('MMM D, YYYY', 'MMM d, yyyy'),
-  dMMMYYYY('D MMM YYYY', 'd MMM yyyy');
+  dMMMYYYY('D MMM YYYY', 'd MMM yyyy'),
+  ddmmyyyyDots('DD.MM.YYYY', 'dd.MM.yyyy');
 
   final String displayName;
   final String pattern;
@@ -142,5 +143,8 @@ enum DateFormatPreference {
 
   /// Whether this format puts day before month
   bool get isDayFirst =>
-      this == ddmmyyyy || this == dMMMYYYY || this == yyyymmdd;
+      this == ddmmyyyy ||
+      this == dMMMYYYY ||
+      this == yyyymmdd ||
+      this == ddmmyyyyDots;
 }

--- a/lib/core/services/export/shared/unit_converters.dart
+++ b/lib/core/services/export/shared/unit_converters.dart
@@ -15,6 +15,8 @@ String formatDateForExport(DateTime date, DateFormatPreference format) {
       return DateFormat('MMM d, yyyy').format(date);
     case DateFormatPreference.dMMMYYYY:
       return DateFormat('d MMM yyyy').format(date);
+    case DateFormatPreference.ddmmyyyyDots:
+      return DateFormat('dd.MM.yyyy').format(date);
   }
 }
 

--- a/test/core/constants/date_format_preference_test.dart
+++ b/test/core/constants/date_format_preference_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+
+void main() {
+  group('DateFormatPreference', () {
+    test('ddmmyyyyDots renders a dot-separated example', () {
+      expect(DateFormatPreference.ddmmyyyyDots.example, '15.01.2024');
+    });
+
+    test(
+      'ddmmyyyyDots uses the DD.MM.YYYY display name and dd.MM.yyyy pattern',
+      () {
+        expect(DateFormatPreference.ddmmyyyyDots.displayName, 'DD.MM.YYYY');
+        expect(DateFormatPreference.ddmmyyyyDots.pattern, 'dd.MM.yyyy');
+      },
+    );
+
+    test('ddmmyyyyDots is day-first', () {
+      expect(DateFormatPreference.ddmmyyyyDots.isDayFirst, isTrue);
+    });
+
+    test('ddmmyyyyDots round-trips through name-based serialization', () {
+      final name = DateFormatPreference.ddmmyyyyDots.name;
+      final restored = DateFormatPreference.values.firstWhere(
+        (e) => e.name == name,
+      );
+      expect(restored, DateFormatPreference.ddmmyyyyDots);
+    });
+  });
+}

--- a/test/core/services/export/shared/unit_converters_test.dart
+++ b/test/core/services/export/shared/unit_converters_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/services/export/shared/unit_converters.dart';
+
+void main() {
+  group('formatDateForExport', () {
+    final date = DateTime(2024, 1, 15);
+
+    test('renders the dot-separated DD.MM.YYYY format', () {
+      expect(
+        formatDateForExport(date, DateFormatPreference.ddmmyyyyDots),
+        '15.01.2024',
+      );
+    });
+
+    test('renders every date format preference without throwing', () {
+      for (final format in DateFormatPreference.values) {
+        expect(
+          () => formatDateForExport(date, format),
+          returnsNormally,
+          reason: 'format $format should be handled by the export switch',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a dot-separated `DD.MM.YYYY` date format option (standard in Germany and much of Central Europe), which was missing from the date-format picker in both the setup wizard and Settings. Closes #752.

## Changes

- Add `ddmmyyyyDots('DD.MM.YYYY', 'dd.MM.yyyy')` to `DateFormatPreference` (`lib/core/constants/units.dart`). Both pickers iterate `.values`, so the option surfaces automatically with no UI changes.
- Include the new value in the `isDayFirst` getter (it is day-first).
- Handle the new value in the export date formatter switch (`formatDateForExport` in `unit_converters.dart`), which is an exhaustive `switch` and would otherwise fail to compile.

## Backward compatibility

`diver_settings.date_format` stores the enum by `.name` (read and write are both name-based), so existing rows keep their current values and no migration is required.

## Tests

- `DateFormatPreference.ddmmyyyyDots` renders `15.01.2024`, uses the expected display name/pattern, is day-first, and round-trips through name-based serialization.
- `formatDateForExport` renders the new dot format as `15.01.2024`, plus an exhaustiveness guard that every `DateFormatPreference` value formats without throwing.

Note: an unrelated pre-existing test failure (`setup_apply_service_test.dart: settings-mode draft seeds live backup state`) exists on `main` and is not affected by this change.