### PR TITLE
fix(sync): pin pure-Dart HKDF for data key derivation

### DIFF
--- a/lib/core/services/sync/crypto/keyslots.dart
+++ b/lib/core/services/sync/crypto/keyslots.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:cryptography/dart.dart';
 
 import 'package:submersion/core/services/sync/crypto/recovery_code.dart';
 
@@ -184,7 +185,12 @@ abstract final class Keyslots {
   }
 
   static Future<SecretKey> deriveDataKey(SecretKey mlk) async {
-    final hkdf = Hkdf(hmac: Hmac.sha256(), outputLength: 32);
+    // Pinned to the pure-Dart HKDF: the salt is empty (RFC 5869 default),
+    // HKDF keys its extract HMAC with the salt, and the cryptography_flutter
+    // implementation that auto-registers as Cryptography.instance on Android
+    // rejects empty HMAC keys (SecretKeySpec "Empty key", #737). Output is
+    // byte-identical on every platform either way.
+    const hkdf = DartHkdf(hmac: DartHmac(DartSha256()), outputLength: 32);
     return hkdf.deriveKey(
       secretKey: mlk,
       nonce: const <int>[],

--- a/test/core/services/sync/crypto/keyslots_test.dart
+++ b/test/core/services/sync/crypto/keyslots_test.dart
@@ -2,9 +2,43 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:cryptography/dart.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/core/services/sync/crypto/keyslots.dart';
+
+/// Models cryptography_flutter on Android (#737): the plugin auto-registers
+/// itself as [Cryptography.instance], and its native HMAC rejects empty keys
+/// (javax.crypto SecretKeySpec throws "Empty key"). HKDF keys its extract
+/// HMAC with the salt, and the data-key salt is empty, so any derivation
+/// routed through the registered instance crashes there.
+class _EmptyKeyRejectingCryptography extends DartCryptography {
+  @override
+  Hmac hmac(HashAlgorithm hashAlgorithm) =>
+      _EmptyKeyRejectingHmac(hashAlgorithm);
+}
+
+class _EmptyKeyRejectingHmac extends DartHmac {
+  const _EmptyKeyRejectingHmac(super.hashAlgorithm);
+
+  @override
+  Future<Mac> calculateMac(
+    List<int> bytes, {
+    required SecretKey secretKey,
+    List<int> nonce = const <int>[],
+    List<int> aad = const <int>[],
+  }) async {
+    if ((await secretKey.extractBytes()).isEmpty) {
+      throw ArgumentError('Empty key');
+    }
+    return super.calculateMac(
+      bytes,
+      secretKey: secretKey,
+      nonce: nonce,
+      aad: aad,
+    );
+  }
+}
 
 Map<String, dynamic> _vectors() =>
     jsonDecode(
@@ -29,6 +63,18 @@ void main() {
     });
 
     test('HKDF data key matches python vector (KAT)', () async {
+      final c = v['hkdfData'] as Map<String, dynamic>;
+      final dataKey = await Keyslots.deriveDataKey(
+        SecretKey(base64Decode(c['ikm'] as String)),
+      );
+      expect(await dataKey.extractBytes(), base64Decode(c['output'] as String));
+    });
+
+    test('data key derivation survives an HMAC that rejects empty keys '
+        '(#737 Android)', () async {
+      final previous = Cryptography.instance;
+      Cryptography.instance = _EmptyKeyRejectingCryptography();
+      addTearDown(() => Cryptography.instance = previous);
       final c = v['hkdfData'] as Map<String, dynamic>;
       final dataKey = await Keyslots.deriveDataKey(
         SecretKey(base64Decode(c['ikm'] as String)),


### PR DESCRIPTION
Fixes #737

## Problem

Encrypted cloud sync is broken for **every Android user** — entering the sync passphrase appears to fail, and every `performSync()` dies with an uncaught `PlatformException(CAUGHT_ERROR, ... IllegalArgumentException: Empty key)` from `SecretKeySpec` (see the debug log attached to the issue). Encrypted cloud backups share the same code path. The reporter's passphrase (and its special characters) is unrelated; their unlock actually succeeded ("Unlocked encrypted library" in the log) before sync crashed.

## Root cause

- `Keyslots.deriveDataKey` runs HKDF-SHA256 with an empty salt (valid per RFC 5869, which defaults an absent salt to `HashLen` zeros).
- HKDF's extract step keys an HMAC with that salt. `Hmac.sha256()` resolves through `Cryptography.instance` — and `cryptography_flutter` **auto-registers** itself as that instance via `dartPluginClass`, without any app-side opt-in.
- Android is the only platform where the plugin routes HMAC through native code, and `javax.crypto.SecretKeySpec` rejects zero-length keys with exactly the logged `IllegalArgumentException: Empty key` (`SecretKeySpec.java:96`, matching the user's stack frame).

Unlock works because Argon2id is pure Dart and the AES-GCM key-unwrap uses a real 32-byte KEK; only the data-key derivation ever feeds native code an empty key. This is also why iOS/macOS device verification never caught it.

## Fix

Pin `deriveDataKey` to the pure-Dart implementation: `const DartHkdf(hmac: DartHmac(DartSha256()), outputLength: 32)`. HMAC zero-pads keys shorter than the block size, so empty salt ≡ zero salt — the derived key is **byte-identical**, meaning existing encrypted libraries and backups in the wild keep decrypting. The unchanged Python-generated KAT vector test proves compatibility. Key derivation is a handful of hash calls, so skipping native acceleration costs nothing.

Audited the rest of the Android-native path for adjacent empty-input calls: the wrong-passphrase path is safe (`AEADBadTagException` → `INCORRECT_MAC` → `SecretBoxAuthenticationError`, which `tryUnwrap` catches), and all AES-GCM calls use non-empty 32-byte keys. The empty HKDF salt was the sole landmine.

## Testing

- New regression test models the Android environment by swapping `Cryptography.instance` for one whose HMAC rejects empty keys (as `SecretKeySpec` does): it reproduced the exact `Empty key` failure before the fix and now passes while asserting the KAT output still matches.
- 861 tests green across `test/core/services/sync/` and `test/features/backup/`; `dart format` and `flutter analyze` clean.