### PR TITLE
fix(sync): stop idle syncs rotting the upload-nonce ring into a false twin (#733)

### DIFF
--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -212,9 +212,20 @@ class SyncInitializer {
   /// install is uploading under this device id (a twin). A null nonce is
   /// never foreign: it was written by a pre-nonce build of this same device,
   /// and flagging it would false-positive every upgrader's first sync.
+  ///
+  /// An empty ring is never foreign either: it means this install has no
+  /// record of ever uploading here -- lost or reset SharedPreferences (a
+  /// reinstall that kept the database, a DB-only restore, OS prefs cleanup)
+  /// rather than evidence of a twin. Adopting on it would mint a fresh
+  /// identity (and re-upload a full base) after every such loss (#733). A
+  /// genuine whole-container clone carries the cloned, non-empty ring, so
+  /// twin detection still fires for it: whichever twin uploads first puts a
+  /// nonce in the manifest that the other's cloned ring does not contain.
   bool isForeignUploadNonce(String? nonce, String providerId) {
     if (nonce == null) return false;
-    return !_recordedUploadNonces(providerId).contains(nonce);
+    final recorded = _recordedUploadNonces(providerId);
+    if (recorded.isEmpty) return false;
+    return !recorded.contains(nonce);
   }
 
   /// Check sync status on app launch

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -531,7 +531,7 @@ class SyncService {
           provider.providerId,
         );
         try {
-          await _changesetWriter.publish(
+          final write = await _changesetWriter.publish(
             provider: provider,
             deviceId: deviceId,
             folderId: folderId,
@@ -540,6 +540,20 @@ class SyncService {
             uploadNonce: uploadNonce,
             appliedPeerHlc: appliedPeerHlc,
           );
+          // A publish that did not stamp this nonce into the manifest -- a
+          // noop (nothing to say) or a heartbeat (which deliberately keeps
+          // the previous nonce) -- must give its speculative ring slot back.
+          // Otherwise every idle sync consumes a slot until the manifest's
+          // live nonce is evicted, and the device reads its own manifest as
+          // a foreign twin: a fresh identity plus a full base re-upload
+          // every ring-length idle syncs (#733).
+          if (write.kind == ChangesetWriteKind.noop ||
+              write.kind == ChangesetWriteKind.heartbeat) {
+            await _syncInitializer?.removeUploadNonce(
+              uploadNonce,
+              provider.providerId,
+            );
+          }
         } catch (e) {
           // Keep the speculative nonce on a timeout (the publish may have
           // landed); remove it only on definite failures, so repeated hard

--- a/test/core/services/sync/sync_twin_identity_test.dart
+++ b/test/core/services/sync/sync_twin_identity_test.dart
@@ -101,6 +101,14 @@ void main() {
       'adopts a fresh identity when own manifest carries a foreign nonce',
       () async {
         final deviceId = await repository.getDeviceId();
+        // A whole-container clone copies the nonce ring along with the DB, so
+        // a real twin scenario always has prior nonces of our own on record.
+        // (An EMPTY ring reads as lost prefs, not as a twin -- see the
+        // dedicated test below.)
+        await initializer.recordUploadNonce(
+          'minted-before-the-clone',
+          cloud.providerId,
+        );
         final twinPayload = await craftPayloadWithDive(deviceId, 'twin-dive-1');
         await seedPeerBaseFromPayload(
           cloud,
@@ -279,6 +287,123 @@ void main() {
       expect(await repository.getDeviceId(), deviceIdBefore);
     });
 
+    test('idle syncs do not rot the nonce ring into a false twin', () async {
+      // Sync 1 publishes a base; its nonce is the one the cloud manifest will
+      // keep carrying through every following idle sync.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd-idle-base'),
+      );
+      final service = buildService();
+      expect((await service.performSync()).isSuccess, isTrue);
+      final deviceId = await repository.getDeviceId();
+
+      // More idle syncs than the ring holds entries. Each publishes nothing,
+      // so the manifest keeps the base upload's nonce; none of them may keep
+      // its speculative ring slot, or that live nonce would be evicted and
+      // the device would read its own manifest as a foreign twin (#733) --
+      // minting a fresh identity and re-uploading a full base every few
+      // idle syncs, forever.
+      for (var i = 1; i <= 9; i++) {
+        final result = await service.performSync();
+        expect(result.isSuccess, isTrue, reason: 'idle sync $i');
+        expect(
+          result.adoptedFreshIdentity,
+          isFalse,
+          reason: 'idle sync $i must not split this device as a twin',
+        );
+      }
+      expect(await repository.getDeviceId(), deviceId);
+    });
+
+    test('a heartbeat rewrite gives its speculative ring slot back', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd-heartbeat'),
+      );
+      final service = buildService();
+      expect((await service.performSync()).isSuccess, isTrue);
+      final deviceId = await repository.getDeviceId();
+      final published = await ownManifest(cloud, deviceId);
+      expect(published, isNotNull);
+
+      // Age the manifest past the heartbeat threshold so the next idle sync
+      // rewrites it -- deliberately preserving the OLD nonce (a heartbeat is
+      // not an upload event). The heartbeat sync's speculative nonce never
+      // reaches the cloud, so it must be un-recorded again.
+      final folder = await cloud.getOrCreateSyncFolder();
+      final aged = SyncManifest(
+        deviceId: published!.deviceId,
+        provider: published.provider,
+        baseSeq: published.baseSeq,
+        basePartCount: published.basePartCount,
+        baseBytes: published.baseBytes,
+        baseChecksum: published.baseChecksum,
+        basePartChecksums: published.basePartChecksums,
+        headSeq: published.headSeq,
+        publishedHlcHigh: published.publishedHlcHigh,
+        epochId: published.epochId,
+        uploadNonce: published.uploadNonce,
+        appliedPeerHlc: published.appliedPeerHlc,
+        updatedAt: 0,
+      );
+      await cloud.uploadFile(
+        aged.toBytes(),
+        ChangesetLogLayout.manifestName(deviceId),
+        folderId: folder,
+      );
+
+      final result = await service.performSync();
+      expect(result.isSuccess, isTrue);
+      expect(result.adoptedFreshIdentity, isFalse);
+
+      final prefs = await SharedPreferences.getInstance();
+      final ring = prefs.getStringList(
+        'sync_upload_nonces_${cloud.providerId}',
+      );
+      expect(
+        ring,
+        [published.uploadNonce],
+        reason:
+            'the heartbeat preserved the previous nonce in the manifest, so '
+            'its own speculative nonce must not stay in the ring',
+      );
+    });
+
+    test('a lost nonce ring reads as lost prefs, not as a twin', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd-prefs-loss'),
+      );
+      expect((await buildService().performSync()).isSuccess, isTrue);
+      final deviceId = await repository.getDeviceId();
+
+      // Simulate SharedPreferences loss while the database (and with it the
+      // device id) survives: reinstall keeping the DB, a DB-only restore, or
+      // the OS clearing app prefs. The manifest's nonce is now unknown, but
+      // an EMPTY ring is evidence of lost prefs, not of a twin.
+      SharedPreferences.setMockInitialValues({});
+      final freshInitializer = SyncInitializer(
+        syncRepository: repository,
+        prefs: await SharedPreferences.getInstance(),
+      );
+      final service = SyncService(
+        syncRepository: repository,
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+        syncInitializer: freshInitializer,
+      );
+
+      final result = await service.performSync();
+      expect(result.isSuccess, isTrue);
+      expect(
+        result.adoptedFreshIdentity,
+        isFalse,
+        reason:
+            'an empty ring means this install has no upload record at all; '
+            'adopting here would mint a new identity (and re-upload a full '
+            'base) after every prefs loss',
+      );
+      expect(await repository.getDeviceId(), deviceId);
+    });
+
     test('the nonce ring keeps the newest entries per provider', () async {
       for (var i = 0; i < 9; i++) {
         await initializer.recordUploadNonce('nonce-$i', 'fake');
@@ -291,6 +416,7 @@ void main() {
       );
       expect(initializer.isForeignUploadNonce('nonce-8', 'fake'), isFalse);
       expect(initializer.isForeignUploadNonce('nonce-1', 'fake'), isFalse);
+      await initializer.recordUploadNonce('other-nonce', 'other-provider');
       expect(
         initializer.isForeignUploadNonce('nonce-8', 'other-provider'),
         isTrue,


### PR DESCRIPTION
Fixes #733.

## Root cause (validated, and different from the issue's initial theory)

The issue attributed the identity churn to SharedPreferences loss. Tracing the code showed prefs loss can only cause a *one-shot* false adopt — it cannot explain an open-ended chain of identities. The actual loop is deterministic and needs no data loss at all:

1. `performSync` records a speculative upload nonce into the ring **before every publish attempt** (deliberate crash-safety: a lost response must not leave an unrecorded nonce in the manifest).
2. But a publish that returns `noop` (nothing to say — the common case for idle auto-sync) or `heartbeat` (manifest rewritten, deliberately preserving the previous nonce) never stamps that nonce into the cloud manifest. The publish result was discarded, so the slot was never given back.
3. After `_maxRecordedNonces` (8) consecutive idle syncs, the manifest's live nonce is evicted from the ring → `_detectTwin` reads the device's **own** manifest as a foreign twin → `adoptFreshIdentity()` → the new id has no manifest → full-base upload. The cycle then restarts: one new identity plus one full base every 8 idle syncs, forever.

A reproducing test against the unmodified code failed at exactly idle sync 9, confirming the mechanism.

## Changes

- **`sync_service.dart`** — capture the publish `ChangesetWriteResult`; when it is `noop` or `heartbeat`, remove the speculative nonce so idle syncs no longer consume ring slots. Real uploads, timeouts (nonce kept — the upload may have landed), and definite failures (nonce removed) are unchanged.
- **`sync_initializer.dart`** — `isForeignUploadNonce` now treats an **empty** ring as lost/reset SharedPreferences (reinstall keeping the DB, DB-only restore, OS prefs cleanup) rather than twin evidence. This closes the issue's secondary trigger. A genuine whole-container clone carries the cloned, non-empty ring, so real twin detection still fires: whichever twin uploads first leaves a nonce the other's cloned ring does not contain.

## Tests

Three new tests in `sync_twin_identity_test.dart`:

- `idle syncs do not rot the nonce ring into a false twin` — 9 idle syncs after a base publish; previously adopted a fresh identity on idle sync 9.
- `a heartbeat rewrite gives its speculative ring slot back` — ages the manifest past the heartbeat threshold and asserts the ring holds only the manifest's real nonce afterwards.
- `a lost nonce ring reads as lost prefs, not as a twin` — wipes prefs while the DB survives; previously minted a fresh identity.

Two existing tests updated to match the new empty-ring semantics (the genuine-twin test now seeds the ring, as a real cloned install would have; the per-provider isolation test seeds the other provider's ring).

Full sync suite green (556 tests), `flutter analyze` clean, `dart format` clean.

## Deliberately out of scope

- **Skipping the full base after a genuine twin adopt** (issue suggestion 3): the base-less adopted-publish mode watermarks at max local HLC, which for a twin split could strand not-yet-published local rows below the watermark. With spurious adopts eliminated, a full base on a rare genuine split is the safe choice.
- **Faster retirement of orphaned identities** (issue suggestion 4): separate design decision; also note that already-orphaned bases in an affected bucket will not self-clean for 365 days — only the newest identity's files are live, so the stale `ssv1.<old-id>.*` files can be deleted manually.