### PR TITLE
fix(dive-log): match buddy filter against the buddies junction table

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1940,7 +1940,14 @@ class DiveRepository {
       }
     }
     if (filter.buddyNameFilter != null && filter.buddyNameFilter!.isNotEmpty) {
-      clauses.add('d.buddy LIKE ?');
+      // The dive editor writes buddies only to the dive_buddies junction;
+      // d.buddy is a legacy text column kept for old data (#757).
+      clauses.add(
+        '(d.buddy LIKE ? OR EXISTS (SELECT 1 FROM dive_buddies db '
+        'JOIN buddies b ON b.id = db.buddy_id '
+        'WHERE db.dive_id = d.id AND LOWER(b.name) LIKE LOWER(?)))',
+      );
+      args.add(Variable('%${filter.buddyNameFilter}%'));
       args.add(Variable('%${filter.buddyNameFilter}%'));
     }
     if (filter.buddyId != null) {

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1943,7 +1943,7 @@ class DiveRepository {
       // The dive editor writes buddies only to the dive_buddies junction;
       // d.buddy is a legacy text column kept for old data (#757).
       clauses.add(
-        '(d.buddy LIKE ? OR EXISTS (SELECT 1 FROM dive_buddies db '
+        '(LOWER(d.buddy) LIKE LOWER(?) OR EXISTS (SELECT 1 FROM dive_buddies db '
         'JOIN buddies b ON b.id = db.buddy_id '
         'WHERE db.dive_id = d.id AND LOWER(b.name) LIKE LOWER(?)))',
       );

--- a/lib/features/dive_log/domain/models/dive_filter_state.dart
+++ b/lib/features/dive_log/domain/models/dive_filter_state.dart
@@ -256,8 +256,12 @@ class DiveFilterState {
         }
       }
       if (buddyNameFilter != null && buddyNameFilter!.isNotEmpty) {
-        final buddyLower = dive.buddy?.toLowerCase() ?? '';
-        if (!buddyLower.contains(buddyNameFilter!.toLowerCase())) {
+        final query = buddyNameFilter!.toLowerCase();
+        final matchesLegacy = (dive.buddy?.toLowerCase() ?? '').contains(query);
+        final matchesJunction = dive.buddies.any(
+          (b) => b.buddy.name.toLowerCase().contains(query),
+        );
+        if (!matchesLegacy && !matchesJunction) {
           return false;
         }
       }

--- a/lib/features/statistics/data/dive_filter_sql.dart
+++ b/lib/features/statistics/data/dive_filter_sql.dart
@@ -116,11 +116,17 @@ import 'package:submersion/features/equipment/domain/constants/equipment_attribu
     conditions.add('is_favorite = 1');
   }
 
-  // Buddy free-text: case-insensitive substring.
+  // Buddy free-text: case-insensitive substring against the legacy scalar
+  // column OR any junction-linked buddy's name. The dive editor writes only
+  // the dive_buddies junction; the scalar covers old data (#757).
   if (filter.buddyNameFilter != null && filter.buddyNameFilter!.isNotEmpty) {
     conditions.add(
-      "buddy IS NOT NULL AND LOWER(buddy) LIKE '%' || LOWER(?) || '%'",
+      "((buddy IS NOT NULL AND LOWER(buddy) LIKE '%' || LOWER(?) || '%') "
+      'OR id IN (SELECT db.dive_id FROM dive_buddies db '
+      'JOIN buddies b ON b.id = db.buddy_id '
+      "WHERE LOWER(b.name) LIKE '%' || LOWER(?) || '%'))",
     );
+    params.add(filter.buddyNameFilter);
     params.add(filter.buddyNameFilter);
   }
 

--- a/test/features/statistics/data/dive_filter_sql_test.dart
+++ b/test/features/statistics/data/dive_filter_sql_test.dart
@@ -96,6 +96,32 @@ void main() {
         );
   }
 
+  Future<void> insertBuddy(String id, String name) async {
+    await db
+        .into(db.buddies)
+        .insert(
+          BuddiesCompanion(
+            id: Value(id),
+            name: Value(name),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> linkBuddy(String diveId, String buddyId) async {
+    await db
+        .into(db.diveBuddies)
+        .insert(
+          DiveBuddiesCompanion(
+            id: Value('$diveId-$buddyId'),
+            diveId: Value(diveId),
+            buddyId: Value(buddyId),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
   Future<void> insertDiveCenter(String id) async {
     await db
         .into(db.diveCenters)
@@ -446,6 +472,13 @@ void main() {
     await linkTag('d5', 'dry');
     await linkTag('d7', 'night');
 
+    // buddies: d6 has NO legacy dives.buddy text, only a junction-table
+    // buddy whose name matches the 'alice' filter. The modern dive editor
+    // writes only the junction, so the buddy filter must match through it
+    // (#757); d1 covers the legacy scalar column.
+    await insertBuddy('b1', 'Alice Junction');
+    await linkBuddy('d6', 'b1');
+
     // equipment: ANY-match axis.
     await linkEquipment('d1', 'eq1');
     await linkEquipment('d2', 'eq1');
@@ -561,6 +594,27 @@ void main() {
       reason: 'ANY-tank semantics: d5 matches via its second (100%) tank',
     );
     expect(await idsMatching(battery['computerSerial']!), {'d4'});
+    expect(
+      await idsMatching(battery['buddyNameFilter']!),
+      {'d1', 'd6'},
+      reason:
+          'buddy filter must match junction-table buddies (d6, no legacy '
+          'scalar) as well as the legacy dives.buddy column (d1) -- #757',
+    );
+    expect(
+      battery['buddyNameFilter']!.apply(domainDives).map((d) => d.id).toSet(),
+      {'d1', 'd6'},
+      reason: 'apply() must consult dive.buddies, not only dive.buddy',
+    );
+    expect(
+      (await DiveRepository().getDiveSummaries(
+        filter: battery['buddyNameFilter']!,
+      )).map((s) => s.id).toSet(),
+      {'d1', 'd6'},
+      reason:
+          'repository SQL filter (getDiveSummaries) must match junction '
+          'buddies too',
+    );
     expect(
       await idsMatching(battery['customFieldKey + value substring']!),
       {'d6'},


### PR DESCRIPTION
## Summary

The dive-list buddy filter matched only the legacy `dives.buddy` text column. The modern dive editor never writes that column — buddies are persisted exclusively through the `dive_buddies` junction — so filtering by any buddy added through the picker returned zero dives.

## Fix

All three filter implementations now match the legacy scalar OR the junction:

- `dive_repository_impl.dart` (`_buildFilterWhereClauses`, used by the paginated dive list): added an EXISTS subquery joining `dive_buddies` to `buddies` on name.
- `dive_filter_sql.dart` (statistics subquery builder): same clause in its bare-column style.
- `DiveFilterState.apply()` (in-memory fallback for export/table/map views): also checks `dive.buddies` names.

Matching is case-insensitive substring in all three, mirroring the previous scalar semantics.

## Tests

Extended the SQL/apply parity battery with a junction-only buddy (no scalar) plus hand-verified absolute expectations across all three paths — the absolute assertions fail without the fix (the old test seeded the legacy column, which is why this shipped).

Full suite: 14,346 tests passing.

Fixes #757