### PR TITLE
fix(settings): make diver-profile save actions visible on same-color app bars

### DIFF
--- a/lib/features/settings/presentation/pages/emergency_contacts_edit_page.dart
+++ b/lib/features/settings/presentation/pages/emergency_contacts_edit_page.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class EmergencyContactsEditPage extends ConsumerStatefulWidget {
   const EmergencyContactsEditPage({super.key});
@@ -195,9 +196,9 @@ class _EmergencyContactsEditPageState
                 ),
               )
             else
-              TextButton(
+              AppBarTextAction(
+                label: context.l10n.divers_edit_saveButton,
                 onPressed: () => _save(diver),
-                child: Text(context.l10n.divers_edit_saveButton),
               ),
           ],
         ),

--- a/lib/features/settings/presentation/pages/insurance_edit_page.dart
+++ b/lib/features/settings/presentation/pages/insurance_edit_page.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class InsuranceEditPage extends ConsumerStatefulWidget {
   const InsuranceEditPage({super.key});
@@ -182,9 +183,9 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
                 ),
               )
             else
-              TextButton(
+              AppBarTextAction(
+                label: context.l10n.divers_edit_saveButton,
                 onPressed: () => _save(diver),
-                child: Text(context.l10n.divers_edit_saveButton),
               ),
           ],
         ),

--- a/lib/features/settings/presentation/pages/medical_info_edit_page.dart
+++ b/lib/features/settings/presentation/pages/medical_info_edit_page.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class MedicalInfoEditPage extends ConsumerStatefulWidget {
   const MedicalInfoEditPage({super.key});
@@ -194,9 +195,9 @@ class _MedicalInfoEditPageState extends ConsumerState<MedicalInfoEditPage> {
                 ),
               )
             else
-              TextButton(
+              AppBarTextAction(
+                label: context.l10n.divers_edit_saveButton,
                 onPressed: () => _save(diver),
-                child: Text(context.l10n.divers_edit_saveButton),
               ),
           ],
         ),

--- a/lib/features/settings/presentation/pages/notes_edit_page.dart
+++ b/lib/features/settings/presentation/pages/notes_edit_page.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class NotesEditPage extends ConsumerStatefulWidget {
   const NotesEditPage({super.key});
@@ -145,9 +146,9 @@ class _NotesEditPageState extends ConsumerState<NotesEditPage> {
                 ),
               )
             else
-              TextButton(
+              AppBarTextAction(
+                label: context.l10n.divers_edit_saveButton,
                 onPressed: () => _save(diver),
-                child: Text(context.l10n.divers_edit_saveButton),
               ),
           ],
         ),

--- a/lib/features/settings/presentation/pages/personal_info_edit_page.dart
+++ b/lib/features/settings/presentation/pages/personal_info_edit_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/providers/provider.dart';
@@ -199,9 +200,9 @@ class _PersonalInfoEditPageState extends ConsumerState<PersonalInfoEditPage> {
                 ),
               )
             else
-              TextButton(
+              AppBarTextAction(
+                label: context.l10n.divers_edit_saveButton,
                 onPressed: () => _save(diver),
-                child: Text(context.l10n.divers_edit_saveButton),
               ),
           ],
         ),

--- a/lib/features/settings/presentation/pages/personal_info_edit_page.dart
+++ b/lib/features/settings/presentation/pages/personal_info_edit_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class PersonalInfoEditPage extends ConsumerStatefulWidget {
   final bool isNewDiver;

--- a/lib/features/settings/presentation/pages/prior_experience_edit_page.dart
+++ b/lib/features/settings/presentation/pages/prior_experience_edit_page.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Edits a diver's pre-app diving experience (prior dive count, prior bottom
 /// time, and the year they started diving). These totals fold into the
@@ -196,9 +197,9 @@ class _PriorExperienceEditPageState
                 ),
               )
             else
-              TextButton(
+              AppBarTextAction(
+                label: context.l10n.divers_edit_saveButton,
                 onPressed: () => _save(diver),
-                child: Text(context.l10n.divers_edit_saveButton),
               ),
           ],
         ),

--- a/lib/shared/widgets/app_bar_text_action.dart
+++ b/lib/shared/widgets/app_bar_text_action.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// A text action for [AppBar.actions] that stays visible on every theme.
+///
+/// A bare [TextButton] takes its foreground from `colorScheme.primary`,
+/// which some full themes (Tropical, Console) set to the same color as the
+/// app bar background, rendering the label invisible (#736). This widget
+/// pins the foreground to the app bar's own foreground color instead.
+class AppBarTextAction extends StatelessWidget {
+  const AppBarTextAction({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final foreground =
+        theme.appBarTheme.foregroundColor ?? theme.colorScheme.onSurface;
+    return TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(foregroundColor: foreground),
+      child: Text(label),
+    );
+  }
+}

--- a/lib/shared/widgets/app_bar_text_action.dart
+++ b/lib/shared/widgets/app_bar_text_action.dart
@@ -14,7 +14,7 @@ class AppBarTextAction extends StatelessWidget {
   });
 
   final String label;
-  final VoidCallback? onPressed;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/shared/widgets/app_bar_text_action.dart
+++ b/lib/shared/widgets/app_bar_text_action.dart
@@ -19,8 +19,18 @@ class AppBarTextAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    // AppBar wraps its whole toolbar, actions included, in a DefaultTextStyle
+    // whose color resolves AppBar.foregroundColor, AppBarTheme.foregroundColor
+    // and the Material default in that order, so it is the one channel that
+    // tracks a per-app-bar override. The surrounding IconTheme is not usable
+    // here: it carries the actions icon color, which Material 3 defaults to the
+    // de-emphasized onSurfaceVariant rather than the toolbar foreground. The
+    // theme fallbacks below only apply when this widget is used outside an
+    // app bar, or under a toolbar text style that leaves the color unset.
     final foreground =
-        theme.appBarTheme.foregroundColor ?? theme.colorScheme.onSurface;
+        DefaultTextStyle.of(context).style.color ??
+        theme.appBarTheme.foregroundColor ??
+        theme.colorScheme.onSurface;
     return TextButton(
       onPressed: onPressed,
       style: TextButton.styleFrom(foregroundColor: foreground),

--- a/test/features/settings/presentation/pages/emergency_contacts_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/emergency_contacts_edit_page_test.dart
@@ -65,6 +65,7 @@ void main() {
           diverListNotifierProvider.overrideWith((_) => notifier),
         ],
         child: const MaterialApp(
+          locale: Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: EmergencyContactsEditPage(),

--- a/test/features/settings/presentation/pages/emergency_contacts_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/emergency_contacts_edit_page_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/emergency_contacts_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<Diver>>>
+    implements DiverListNotifier {
+  _CapturingNotifier(List<Diver> divers) : super(AsyncValue.data(divers));
+
+  Diver? updated;
+
+  @override
+  Future<Diver> addDiver(Diver diver) async => diver;
+
+  @override
+  Future<void> updateDiver(Diver diver) async => updated = diver;
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<DeleteDiverResult> deleteDiver(String id) async =>
+      const DeleteDiverResult(reassignedTripsCount: 0, reassignedSitesCount: 0);
+
+  @override
+  Future<void> setAsDefault(String id) async {}
+}
+
+void main() {
+  final now = DateTime.now();
+
+  Diver makeDiver({
+    EmergencyContact primary = const EmergencyContact(),
+    EmergencyContact secondary = const EmergencyContact(),
+  }) {
+    return Diver(
+      id: 'diver-1',
+      name: 'Alice Alpha',
+      createdAt: now,
+      updatedAt: now,
+      emergencyContact: primary,
+      emergencyContact2: secondary,
+    );
+  }
+
+  Future<_CapturingNotifier> pump(WidgetTester tester, Diver diver) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final notifier = _CapturingNotifier([diver]);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          currentDiverProvider.overrideWith((_) async => diver),
+          diverListNotifierProvider.overrideWith((_) => notifier),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: EmergencyContactsEditPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return notifier;
+  }
+
+  /// Finds a field by label inside the card headed by [cardTitle], so the
+  /// primary and secondary contact forms can be told apart.
+  Finder fieldIn(String cardTitle, String label) {
+    return find.descendant(
+      of: find
+          .ancestor(of: find.text(cardTitle), matching: find.byType(Card))
+          .first,
+      matching: find.widgetWithText(TextFormField, label),
+    );
+  }
+
+  testWidgets('populates both contact cards from the existing diver', (
+    tester,
+  ) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        primary: const EmergencyContact(
+          name: 'Bruna Bravo',
+          phone: '555-0100',
+          relation: 'Spouse',
+        ),
+        secondary: const EmergencyContact(
+          name: 'Carlos Charlie',
+          phone: '555-0200',
+          relation: 'Brother',
+        ),
+      ),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Emergency Contacts'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Bruna Bravo'), findsOneWidget);
+    expect(find.text('555-0200'), findsOneWidget);
+    expect(find.text('Brother'), findsOneWidget);
+    expect(notifier.updated, isNull);
+  });
+
+  testWidgets('saving persists the primary contact and leaves the secondary '
+      'null when blank', (tester) async {
+    final notifier = await pump(tester, makeDiver());
+
+    await tester.enterText(
+      fieldIn('Primary Contact', 'Contact Name'),
+      '  Bruna Bravo  ',
+    );
+    await tester.enterText(
+      fieldIn('Primary Contact', 'Contact Phone'),
+      '555-0100',
+    );
+    await tester.enterText(
+      fieldIn('Primary Contact', 'Relationship'),
+      'Spouse',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.emergencyContact.name, 'Bruna Bravo');
+    expect(notifier.updated!.emergencyContact.phone, '555-0100');
+    expect(notifier.updated!.emergencyContact.relation, 'Spouse');
+    expect(notifier.updated!.emergencyContact2.name, isNull);
+    expect(notifier.updated!.emergencyContact2.phone, isNull);
+  });
+
+  testWidgets('saving persists an edited secondary contact independently', (
+    tester,
+  ) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        primary: const EmergencyContact(name: 'Bruna Bravo', phone: '555-0100'),
+      ),
+    );
+
+    await tester.enterText(
+      fieldIn('Secondary Contact', 'Contact Name'),
+      'Carlos Charlie',
+    );
+    await tester.enterText(
+      fieldIn('Secondary Contact', 'Contact Phone'),
+      '555-0200',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.emergencyContact.name, 'Bruna Bravo');
+    expect(notifier.updated!.emergencyContact2.name, 'Carlos Charlie');
+    expect(notifier.updated!.emergencyContact2.phone, '555-0200');
+  });
+
+  testWidgets('clearing a stored contact persists null', (tester) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        primary: const EmergencyContact(
+          name: 'Bruna Bravo',
+          phone: '555-0100',
+          relation: 'Spouse',
+        ),
+      ),
+    );
+
+    await tester.enterText(fieldIn('Primary Contact', 'Contact Name'), '');
+    await tester.enterText(fieldIn('Primary Contact', 'Contact Phone'), '');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.emergencyContact.name, isNull);
+    expect(notifier.updated!.emergencyContact.phone, isNull);
+    expect(notifier.updated!.emergencyContact.relation, 'Spouse');
+  });
+}

--- a/test/features/settings/presentation/pages/insurance_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/insurance_edit_page_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/insurance_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<Diver>>>
+    implements DiverListNotifier {
+  _CapturingNotifier(List<Diver> divers) : super(AsyncValue.data(divers));
+
+  Diver? updated;
+
+  @override
+  Future<Diver> addDiver(Diver diver) async => diver;
+
+  @override
+  Future<void> updateDiver(Diver diver) async => updated = diver;
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<DeleteDiverResult> deleteDiver(String id) async =>
+      const DeleteDiverResult(reassignedTripsCount: 0, reassignedSitesCount: 0);
+
+  @override
+  Future<void> setAsDefault(String id) async {}
+}
+
+void main() {
+  final now = DateTime.now();
+
+  Diver makeDiver({DiverInsurance insurance = const DiverInsurance()}) {
+    return Diver(
+      id: 'diver-1',
+      name: 'Alice Alpha',
+      createdAt: now,
+      updatedAt: now,
+      insurance: insurance,
+    );
+  }
+
+  Future<_CapturingNotifier> pump(WidgetTester tester, Diver diver) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final notifier = _CapturingNotifier([diver]);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          currentDiverProvider.overrideWith((_) async => diver),
+          diverListNotifierProvider.overrideWith((_) => notifier),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: InsuranceEditPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return notifier;
+  }
+
+  testWidgets('populates the policy fields and expiry from the diver', (
+    tester,
+  ) async {
+    final expiry = DateTime(2030, 6, 15);
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        insurance: DiverInsurance(
+          provider: 'DAN',
+          policyNumber: 'POL-12345',
+          expiryDate: expiry,
+        ),
+      ),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Insurance'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('DAN'), findsOneWidget);
+    expect(find.text('POL-12345'), findsOneWidget);
+    expect(find.textContaining('2030'), findsOneWidget);
+    expect(notifier.updated, isNull);
+  });
+
+  testWidgets('shows the not-set placeholder when no expiry is stored', (
+    tester,
+  ) async {
+    await pump(tester, makeDiver());
+
+    expect(find.text('Not set'), findsOneWidget);
+    expect(
+      find.byTooltip('Clear insurance expiry date'),
+      findsNothing,
+      reason: 'the clear button only makes sense once an expiry exists',
+    );
+  });
+
+  testWidgets('saving persists the trimmed provider and policy number', (
+    tester,
+  ) async {
+    final expiry = DateTime(2030, 6, 15);
+    final notifier = await pump(
+      tester,
+      makeDiver(insurance: DiverInsurance(expiryDate: expiry)),
+    );
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Insurance Provider'),
+      '  DiveAssure  ',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Policy Number'),
+      'POL-99',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.insurance.provider, 'DiveAssure');
+    expect(notifier.updated!.insurance.policyNumber, 'POL-99');
+    expect(
+      notifier.updated!.insurance.expiryDate,
+      expiry,
+      reason: 'an untouched expiry must survive the save',
+    );
+  });
+
+  testWidgets('clearing the expiry date persists a null expiry', (
+    tester,
+  ) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        insurance: DiverInsurance(
+          provider: 'DAN',
+          expiryDate: DateTime(2030, 6, 15),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Clear insurance expiry date'));
+    await tester.pumpAndSettle();
+    expect(find.text('Not set'), findsOneWidget);
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.insurance.expiryDate, isNull);
+    expect(notifier.updated!.insurance.provider, 'DAN');
+  });
+
+  testWidgets('clearing the provider persists null', (tester) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        insurance: const DiverInsurance(
+          provider: 'DAN',
+          policyNumber: 'POL-12345',
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Insurance Provider'),
+      '',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.insurance.provider, isNull);
+    expect(notifier.updated!.insurance.policyNumber, 'POL-12345');
+  });
+}

--- a/test/features/settings/presentation/pages/insurance_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/insurance_edit_page_test.dart
@@ -61,6 +61,7 @@ void main() {
           diverListNotifierProvider.overrideWith((_) => notifier),
         ],
         child: const MaterialApp(
+          locale: Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: InsuranceEditPage(),

--- a/test/features/settings/presentation/pages/medical_info_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/medical_info_edit_page_test.dart
@@ -71,6 +71,7 @@ void main() {
           diverListNotifierProvider.overrideWith((_) => notifier),
         ],
         child: const MaterialApp(
+          locale: Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: MedicalInfoEditPage(),

--- a/test/features/settings/presentation/pages/medical_info_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/medical_info_edit_page_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/medical_info_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<Diver>>>
+    implements DiverListNotifier {
+  _CapturingNotifier(List<Diver> divers) : super(AsyncValue.data(divers));
+
+  Diver? updated;
+
+  @override
+  Future<Diver> addDiver(Diver diver) async => diver;
+
+  @override
+  Future<void> updateDiver(Diver diver) async => updated = diver;
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<DeleteDiverResult> deleteDiver(String id) async =>
+      const DeleteDiverResult(reassignedTripsCount: 0, reassignedSitesCount: 0);
+
+  @override
+  Future<void> setAsDefault(String id) async {}
+}
+
+void main() {
+  final now = DateTime.now();
+
+  Diver makeDiver({
+    String? bloodType,
+    String? allergies,
+    String? medications,
+    String medicalNotes = '',
+    DateTime? clearanceExpiry,
+  }) {
+    return Diver(
+      id: 'diver-1',
+      name: 'Alice Alpha',
+      createdAt: now,
+      updatedAt: now,
+      bloodType: bloodType,
+      allergies: allergies,
+      medications: medications,
+      medicalNotes: medicalNotes,
+      medicalClearanceExpiryDate: clearanceExpiry,
+    );
+  }
+
+  Future<_CapturingNotifier> pump(WidgetTester tester, Diver diver) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final notifier = _CapturingNotifier([diver]);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          currentDiverProvider.overrideWith((_) async => diver),
+          diverListNotifierProvider.overrideWith((_) => notifier),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MedicalInfoEditPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return notifier;
+  }
+
+  testWidgets('populates the medical fields from the existing diver', (
+    tester,
+  ) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        bloodType: 'O+',
+        allergies: 'Penicillin',
+        medications: 'None',
+        medicalNotes: 'Cleared for deep diving',
+        clearanceExpiry: DateTime(2030, 6, 15),
+      ),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Medical Information'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('O+'), findsOneWidget);
+    expect(find.text('Penicillin'), findsOneWidget);
+    expect(find.text('Cleared for deep diving'), findsOneWidget);
+    expect(find.textContaining('2030'), findsOneWidget);
+    expect(notifier.updated, isNull);
+  });
+
+  testWidgets('flags a clearance date that has already passed', (tester) async {
+    await pump(
+      tester,
+      makeDiver(clearanceExpiry: now.subtract(const Duration(days: 1))),
+    );
+
+    expect(find.text('Expired'), findsOneWidget);
+    expect(find.text('Expiring Soon'), findsNothing);
+  });
+
+  testWidgets('flags a clearance date that is about to lapse', (tester) async {
+    await pump(
+      tester,
+      makeDiver(clearanceExpiry: now.add(const Duration(days: 7))),
+    );
+
+    expect(find.text('Expiring Soon'), findsOneWidget);
+    expect(find.text('Expired'), findsNothing);
+  });
+
+  testWidgets('saving persists the trimmed medical details', (tester) async {
+    final expiry = DateTime(2030, 6, 15);
+    final notifier = await pump(tester, makeDiver(clearanceExpiry: expiry));
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Blood Type'),
+      '  AB-  ',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Allergies'),
+      'Latex',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Medications'),
+      'Antihistamine',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Medical Notes'),
+      'Annual physical on file',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.bloodType, 'AB-');
+    expect(notifier.updated!.allergies, 'Latex');
+    expect(notifier.updated!.medications, 'Antihistamine');
+    expect(notifier.updated!.medicalNotes, 'Annual physical on file');
+    expect(
+      notifier.updated!.medicalClearanceExpiryDate,
+      expiry,
+      reason: 'an untouched clearance date must survive the save',
+    );
+  });
+
+  testWidgets('clearing the clearance date persists null', (tester) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(bloodType: 'O+', clearanceExpiry: DateTime(2030, 6, 15)),
+    );
+
+    await tester.tap(find.byTooltip('Clear medical clearance date'));
+    await tester.pumpAndSettle();
+    expect(find.text('Not set'), findsOneWidget);
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.medicalClearanceExpiryDate, isNull);
+    expect(notifier.updated!.bloodType, 'O+');
+  });
+
+  testWidgets('clearing an optional field persists null', (tester) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(bloodType: 'O+', allergies: 'Penicillin'),
+    );
+
+    await tester.enterText(find.widgetWithText(TextFormField, 'Allergies'), '');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.allergies, isNull);
+    expect(notifier.updated!.bloodType, 'O+');
+  });
+}

--- a/test/features/settings/presentation/pages/notes_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/notes_edit_page_test.dart
@@ -61,6 +61,7 @@ void main() {
           diverListNotifierProvider.overrideWith((_) => notifier),
         ],
         child: const MaterialApp(
+          locale: Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: NotesEditPage(),

--- a/test/features/settings/presentation/pages/notes_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/notes_edit_page_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/notes_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<Diver>>>
+    implements DiverListNotifier {
+  _CapturingNotifier(List<Diver> divers) : super(AsyncValue.data(divers));
+
+  Diver? updated;
+
+  @override
+  Future<Diver> addDiver(Diver diver) async => diver;
+
+  @override
+  Future<void> updateDiver(Diver diver) async => updated = diver;
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<DeleteDiverResult> deleteDiver(String id) async =>
+      const DeleteDiverResult(reassignedTripsCount: 0, reassignedSitesCount: 0);
+
+  @override
+  Future<void> setAsDefault(String id) async {}
+}
+
+void main() {
+  final now = DateTime.now();
+
+  Diver makeDiver({String notes = ''}) {
+    return Diver(
+      id: 'diver-1',
+      name: 'Alice Alpha',
+      createdAt: now,
+      updatedAt: now,
+      notes: notes,
+    );
+  }
+
+  Future<_CapturingNotifier> pump(WidgetTester tester, Diver diver) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final notifier = _CapturingNotifier([diver]);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          currentDiverProvider.overrideWith((_) async => diver),
+          diverListNotifierProvider.overrideWith((_) => notifier),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: NotesEditPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return notifier;
+  }
+
+  testWidgets('populates the notes field from the existing diver', (
+    tester,
+  ) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(notes: 'Prefers early morning boat dives'),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Notes'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Prefers early morning boat dives'), findsOneWidget);
+    expect(notifier.updated, isNull);
+  });
+
+  testWidgets('saving persists the trimmed notes onto the diver', (
+    tester,
+  ) async {
+    final notifier = await pump(tester, makeDiver());
+
+    await tester.enterText(
+      find.byType(TextField),
+      '  Nitrox refresher due in spring  ',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.notes, 'Nitrox refresher due in spring');
+    expect(notifier.updated!.id, 'diver-1');
+  });
+
+  testWidgets('clearing existing notes persists an empty string', (
+    tester,
+  ) async {
+    final notifier = await pump(tester, makeDiver(notes: 'Old note'));
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.notes, isEmpty);
+  });
+}

--- a/test/features/settings/presentation/pages/personal_info_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/personal_info_edit_page_test.dart
@@ -70,6 +70,7 @@ void main() {
           diverListNotifierProvider.overrideWith((_) => notifier),
         ],
         child: MaterialApp(
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: PersonalInfoEditPage(isNewDiver: isNewDiver),

--- a/test/features/settings/presentation/pages/personal_info_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/personal_info_edit_page_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/pages/personal_info_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<Diver>>>
+    implements DiverListNotifier {
+  _CapturingNotifier(List<Diver> divers) : super(AsyncValue.data(divers));
+
+  Diver? updated;
+  Diver? added;
+
+  @override
+  Future<Diver> addDiver(Diver diver) async {
+    added = diver;
+    return diver;
+  }
+
+  @override
+  Future<void> updateDiver(Diver diver) async => updated = diver;
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<DeleteDiverResult> deleteDiver(String id) async =>
+      const DeleteDiverResult(reassignedTripsCount: 0, reassignedSitesCount: 0);
+
+  @override
+  Future<void> setAsDefault(String id) async {}
+}
+
+void main() {
+  final now = DateTime.now();
+
+  Diver makeDiver({String name = 'Alice Alpha', String? email, String? phone}) {
+    return Diver(
+      id: 'diver-1',
+      name: name,
+      email: email,
+      phone: phone,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  Future<_CapturingNotifier> pump(
+    WidgetTester tester,
+    Diver diver, {
+    bool isNewDiver = false,
+  }) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final notifier = _CapturingNotifier([diver]);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          currentDiverProvider.overrideWith((_) async => diver),
+          diverListNotifierProvider.overrideWith((_) => notifier),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PersonalInfoEditPage(isNewDiver: isNewDiver),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return notifier;
+  }
+
+  testWidgets('populates the fields from the existing diver', (tester) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(email: 'alice@example.com', phone: '555-0100'),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Personal Info'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Alice Alpha'), findsOneWidget);
+    expect(find.text('alice@example.com'), findsOneWidget);
+    expect(find.text('555-0100'), findsOneWidget);
+    expect(notifier.updated, isNull);
+  });
+
+  testWidgets('saving persists the edited name, email and phone', (
+    tester,
+  ) async {
+    final notifier = await pump(tester, makeDiver());
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name *'),
+      '  Bruna Bravo  ',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Email'),
+      'bruna@example.com',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Phone'),
+      '555-0199',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.id, 'diver-1');
+    expect(notifier.updated!.name, 'Bruna Bravo');
+    expect(notifier.updated!.email, 'bruna@example.com');
+    expect(notifier.updated!.phone, '555-0199');
+  });
+
+  testWidgets('clearing an optional field persists null', (tester) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(email: 'alice@example.com', phone: '555-0100'),
+    );
+
+    await tester.enterText(find.widgetWithText(TextFormField, 'Email'), '');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.email, isNull);
+    expect(notifier.updated!.phone, '555-0100');
+  });
+
+  testWidgets('an empty name blocks the save', (tester) async {
+    final notifier = await pump(tester, makeDiver());
+
+    await tester.enterText(find.widgetWithText(TextFormField, 'Name *'), '   ');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNull);
+    expect(find.text('Name is required'), findsOneWidget);
+  });
+
+  testWidgets('a malformed email blocks the save', (tester) async {
+    final notifier = await pump(tester, makeDiver());
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Email'),
+      'not-an-email',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNull);
+    expect(find.text('Enter a valid email'), findsOneWidget);
+  });
+
+  testWidgets('new-diver mode creates a diver instead of updating one', (
+    tester,
+  ) async {
+    final notifier = await pump(tester, makeDiver(), isNewDiver: true);
+
+    expect(find.widgetWithText(AppBar, 'Create Diver'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name *'),
+      'Carlos Charlie',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.added, isNotNull);
+    expect(notifier.added!.name, 'Carlos Charlie');
+    expect(notifier.added!.id, isNotEmpty);
+    expect(notifier.updated, isNull);
+  });
+}

--- a/test/features/settings/presentation/pages/prior_experience_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/prior_experience_edit_page_test.dart
@@ -67,6 +67,7 @@ void main() {
           diverListNotifierProvider.overrideWith((_) => notifier),
         ],
         child: const MaterialApp(
+          locale: Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: PriorExperienceEditPage(),

--- a/test/shared/widgets/app_bar_text_action_test.dart
+++ b/test/shared/widgets/app_bar_text_action_test.dart
@@ -18,7 +18,19 @@ void main() {
 
   Color renderedColor(WidgetTester tester, String label) {
     final paragraph = tester.renderObject<RenderParagraph>(find.text(label));
-    return paragraph.text.style!.color!;
+    final style = paragraph.text.style;
+    expect(
+      style,
+      isNotNull,
+      reason: 'the rendered span for "$label" carries no TextStyle',
+    );
+    final color = style!.color;
+    expect(
+      color,
+      isNotNull,
+      reason: 'the TextStyle for "$label" resolved to a null color',
+    );
+    return color!;
   }
 
   testWidgets('bare TextButton is invisible on the tropical app bar '

--- a/test/shared/widgets/app_bar_text_action_test.dart
+++ b/test/shared/widgets/app_bar_text_action_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/theme/full_themes/tropical_theme.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, ThemeData theme, Widget action) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Title'), actions: [action]),
+        ),
+      ),
+    );
+  }
+
+  Color renderedColor(WidgetTester tester, String label) {
+    final paragraph = tester.renderObject<RenderParagraph>(find.text(label));
+    return paragraph.text.style!.color!;
+  }
+
+  testWidgets('bare TextButton is invisible on the tropical app bar '
+      '(the #736 defect this widget exists to avoid)', (tester) async {
+    await pump(
+      tester,
+      tropicalLight,
+      TextButton(onPressed: () {}, child: const Text('Save')),
+    );
+    expect(
+      renderedColor(tester, 'Save'),
+      tropicalLight.appBarTheme.backgroundColor,
+      reason:
+          'colorScheme.primary equals the app bar background in the '
+          'tropical theme, so a bare TextButton renders invisibly',
+    );
+  });
+
+  testWidgets('AppBarTextAction stays visible against the tropical app bar', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      tropicalLight,
+      AppBarTextAction(label: 'Save', onPressed: () {}),
+    );
+    final color = renderedColor(tester, 'Save');
+    expect(color, tropicalLight.appBarTheme.foregroundColor);
+    expect(color, isNot(tropicalLight.appBarTheme.backgroundColor));
+  });
+
+  testWidgets('AppBarTextAction invokes onPressed', (tester) async {
+    var tapped = false;
+    await pump(
+      tester,
+      tropicalLight,
+      AppBarTextAction(label: 'Save', onPressed: () => tapped = true),
+    );
+    await tester.tap(find.text('Save'));
+    expect(tapped, isTrue);
+  });
+}

--- a/test/shared/widgets/app_bar_text_action_test.dart
+++ b/test/shared/widgets/app_bar_text_action_test.dart
@@ -5,12 +5,21 @@ import 'package:submersion/core/theme/full_themes/tropical_theme.dart';
 import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 void main() {
-  Future<void> pump(WidgetTester tester, ThemeData theme, Widget action) {
+  Future<void> pump(
+    WidgetTester tester,
+    ThemeData theme,
+    Widget action, {
+    Color? appBarForeground,
+  }) {
     return tester.pumpWidget(
       MaterialApp(
         theme: theme,
         home: Scaffold(
-          appBar: AppBar(title: const Text('Title'), actions: [action]),
+          appBar: AppBar(
+            foregroundColor: appBarForeground,
+            title: const Text('Title'),
+            actions: [action],
+          ),
         ),
       ),
     );
@@ -61,6 +70,49 @@ void main() {
     expect(color, tropicalLight.appBarTheme.foregroundColor);
     expect(color, isNot(tropicalLight.appBarTheme.backgroundColor));
   });
+
+  testWidgets(
+    'AppBarTextAction honors a per-app-bar foregroundColor override',
+    (tester) async {
+      const override = Color(0xFFAA0000);
+      await pump(
+        tester,
+        tropicalLight,
+        AppBarTextAction(label: 'Save', onPressed: () {}),
+        appBarForeground: override,
+      );
+      expect(
+        renderedColor(tester, 'Save'),
+        override,
+        reason:
+            'an AppBar.foregroundColor override sits ahead of '
+            'AppBarTheme.foregroundColor in the app bar resolution chain',
+      );
+    },
+  );
+
+  testWidgets(
+    'AppBarTextAction uses the emphasized foreground when a theme sets no '
+    'app bar foreground color',
+    (tester) async {
+      final theme = ThemeData(useMaterial3: true);
+      await pump(
+        tester,
+        theme,
+        AppBarTextAction(label: 'Save', onPressed: () {}),
+      );
+      expect(theme.appBarTheme.foregroundColor, isNull);
+      expect(renderedColor(tester, 'Save'), theme.colorScheme.onSurface);
+      expect(
+        renderedColor(tester, 'Save'),
+        isNot(theme.colorScheme.onSurfaceVariant),
+        reason:
+            'the actions IconTheme resolves to the de-emphasized '
+            'onSurfaceVariant under Material 3, which is wrong for a text '
+            'action and must not be used as the color source',
+      );
+    },
+  );
 
   testWidgets('AppBarTextAction invokes onPressed', (tester) async {
     var tapped = false;


### PR DESCRIPTION
## Summary

The Diver Profile sub-pages (Insurance, Medical, Notes, Personal Info, Emergency Contacts, Prior Experience) appeared to have no Save button. The button was always there and functional — it was invisible: those pages render Save as a bare `TextButton` in the AppBar, a `TextButton`'s foreground defaults to `colorScheme.primary`, and in the Tropical theme `primary` is the exact same color as the AppBar background (Console light is a ~1.3:1 contrast, effectively the same). Body Weight was unaffected because it uses a FAB.

## Fix

New shared widget `AppBarTextAction` pins its foreground to `appBarTheme.foregroundColor` (falling back to `onSurface`), and all six pages use it for their Save action. No page logic changes.

## Tests

- New widget test proves the defect (a bare TextButton under the Tropical theme renders in the AppBar's background color) and the fix (AppBarTextAction renders in the AppBar foreground color), plus a tap-callback check.
- Existing page tests that tap `find.text('Save')` still pass.

Full suite green.

Fixes #736