### PR TITLE
fix(dive-log): keep pushed dive details on the stack instead of master-detail redirect

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -215,8 +215,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     // On desktop, redirect standalone detail pages to master-detail view.
     // Skip in table mode -- table view has no master-detail split to redirect into.
+    // Skip when this page was PUSHED (trip/buddy/site drill-through): the
+    // redirect uses go(), which would wipe the stack and lose the browse
+    // context and back button (#764). Only redirect root-level details
+    // (deep links, tab navigation).
     if (!widget.embedded &&
         !_hasRedirected &&
+        !(GoRouter.maybeOf(context)?.canPop() ?? false) &&
         ResponsiveBreakpoints.isMasterDetail(context)) {
       final viewMode = ref.read(diveListViewModeProvider);
       if (viewMode != ListViewMode.table) {

--- a/test/features/dive_log/presentation/pages/dive_detail_pushed_context_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_pushed_context_test.dart
@@ -58,6 +58,9 @@ void main() {
       if (d.toString().contains('overflowed')) return;
       originalOnError?.call(d);
     };
+    // Restore via tearDown so a throw from pumpWidget/pump below cannot leak
+    // the override into subsequent tests.
+    addTearDown(() => FlutterError.onError = originalOnError);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -81,7 +84,6 @@ void main() {
     );
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    FlutterError.onError = originalOnError;
     return router;
   }
 
@@ -96,7 +98,9 @@ void main() {
       locations: locations,
     );
 
-    router.push('/dives/b');
+    // push() completes only when the pushed route is popped; hold the future
+    // and await it after the pop so it is never left dangling.
+    final pushed = router.push('/dives/b');
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
@@ -112,6 +116,7 @@ void main() {
     router.pop();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
+    await pushed;
     expect(find.text('TRIP PAGE'), findsOneWidget);
   });
 

--- a/test/features/dive_log/presentation/pages/dive_detail_pushed_context_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_pushed_context_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Regression coverage for #764: drilling from a browse context (trip, buddy,
+/// site) into a dive PUSHES /dives/:id; the page's desktop master-detail
+/// redirect must not wipe that stack, or the browse context and back button
+/// are lost.
+void main() {
+  const desktop = Size(1200, 800);
+
+  Future<GoRouter> pumpWithRouter(
+    WidgetTester tester, {
+    required String initialLocation,
+    required Size size,
+    required List<String> locations,
+  }) async {
+    final dive = createTestDiveWithBottomTime(id: 'b');
+    final overrides = await getBaseOverrides();
+
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: '/trip',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('TRIP PAGE'))),
+        ),
+        GoRoute(
+          path: '/dives',
+          builder: (context, state) {
+            locations.add(state.uri.toString());
+            return const Scaffold(body: Center(child: Text('DIVE LIST')));
+          },
+        ),
+        GoRoute(
+          path: '/dives/:id',
+          builder: (context, state) {
+            locations.add(state.uri.toString());
+            return DiveDetailPage(
+              diveId: state.pathParameters['id']!,
+              embedded: false,
+            );
+          },
+        ),
+      ],
+    );
+
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (d) {
+      if (d.toString().contains('overflowed')) return;
+      originalOnError?.call(d);
+    };
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          orderedDiveIdsProvider.overrideWith((ref) async => ['a', 'b', 'c']),
+        ],
+        child: MediaQuery(
+          data: MediaQueryData(size: size),
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    FlutterError.onError = originalOnError;
+    return router;
+  }
+
+  testWidgets('pushed dive detail on desktop stays on the stack (#764)', (
+    tester,
+  ) async {
+    final locations = <String>[];
+    final router = await pumpWithRouter(
+      tester,
+      initialLocation: '/trip',
+      size: desktop,
+      locations: locations,
+    );
+
+    router.push('/dives/b');
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      locations.last,
+      '/dives/b',
+      reason:
+          'a pushed detail page must not self-redirect to the '
+          'master-detail list and destroy the browse context',
+    );
+    expect(router.canPop(), isTrue);
+
+    router.pop();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('TRIP PAGE'), findsOneWidget);
+  });
+
+  testWidgets('root-level dive detail on desktop still redirects to '
+      'master-detail', (tester) async {
+    final locations = <String>[];
+    await pumpWithRouter(
+      tester,
+      initialLocation: '/dives/b',
+      size: desktop,
+      locations: locations,
+    );
+
+    expect(
+      locations.last,
+      '/dives?selected=b',
+      reason:
+          'deep-linked standalone detail (nothing to pop) keeps the '
+          'desktop master-detail redirect',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

On desktop, drilling from a browse context (Trips, Buddies, Sites) into a dive lost the browse context: the trip page pushed `/dives/:id` correctly, but `DiveDetailPage` then self-redirected with `context.go('/dives?selected=...')` one frame later. `go()` replaces the whole navigation stack, so the trip page vanished, the back button disappeared, and the master pane became the Dives list with its own filters — exactly as reported in #764.

## Fix

The desktop master-detail redirect now fires only when the detail page is the stack root (`!context.canPop()`). A pushed detail page stays standalone with a working back button; deep links and tab navigation keep the redirect.

## Tests

New router-based test proves both behaviors: a pushed detail no longer relocates to `/dives?selected=` and pops back to the trip page (fails before the fix with the exact redirect location), while a root-level detail still redirects to master-detail. Existing dive-detail nav tests unaffected.

Full suite green.

Fixes #764