### PR TITLE
fix(settings): push section detail so system back returns to settings

### DIFF
--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -228,7 +228,15 @@ class _SettingsSectionDetailPage extends ConsumerWidget {
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           tooltip: context.l10n.settings_backToSettings_tooltip,
-          onPressed: () => context.go('/settings'),
+          // Pop the pushed section route; fall back to go() for deep links
+          // where the detail page is the root of the stack.
+          onPressed: () {
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go('/settings');
+            }
+          },
         ),
       ),
       body: _buildContent(context, ref),
@@ -365,11 +373,13 @@ class _MobileSettingsTile extends StatelessWidget {
         context.push('/settings/appearance');
         break;
       default:
-        // For sections that don't have dedicated pages,
-        // show them in a detail page using query params
+        // For sections that don't have dedicated pages, show them in a
+        // detail page using query params. PUSH (not go): go() replaces the
+        // location in place, leaving nothing on the stack for the system
+        // back gesture to pop, so Android closed the whole app (#647).
         final state = GoRouterState.of(context);
         final currentPath = state.uri.path;
-        context.go('$currentPath?selected=$sectionId');
+        context.push('$currentPath?selected=$sectionId');
     }
   }
 }

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -1027,4 +1027,77 @@ void main() {
       expect(find.byType(DropdownButton<int>), findsOneWidget);
     });
   });
+
+  group('Section navigation stack (#647)', () {
+    Future<GoRouter> pumpSettingsList(WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final router = GoRouter(
+        initialLocation: '/settings',
+        routes: [
+          GoRoute(
+            path: '/settings',
+            builder: (context, state) => const SettingsPage(),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: getOverrides(),
+          child: MaterialApp.router(
+            locale: const Locale('en'),
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return router;
+    }
+
+    testWidgets('opening a query-param section pushes a poppable route so the '
+        'system back gesture returns to Settings instead of closing the app', (
+      tester,
+    ) async {
+      final router = await pumpSettingsList(tester);
+
+      await tester.scrollUntilVisible(find.text('Data'), 100);
+      await tester.tap(find.text('Data'));
+      await tester.pumpAndSettle();
+
+      expect(
+        router.canPop(),
+        isTrue,
+        reason:
+            'the section detail must be a pushed route; with nothing to '
+            'pop, the Android back gesture closes the whole app (#647)',
+      );
+
+      router.pop();
+      await tester.pumpAndSettle();
+
+      // Back on the section list.
+      expect(find.text('Units'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('detail app-bar back returns to the settings list', (
+      tester,
+    ) async {
+      await pumpSettingsList(tester);
+
+      await tester.scrollUntilVisible(find.text('Data'), 100);
+      await tester.tap(find.text('Data'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Units'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
 }

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -1029,12 +1029,15 @@ void main() {
   });
 
   group('Section navigation stack (#647)', () {
-    Future<GoRouter> pumpSettingsList(WidgetTester tester) async {
+    Future<GoRouter> pumpSettingsList(
+      WidgetTester tester, {
+      String initialLocation = '/settings',
+    }) async {
       await tester.binding.setSurfaceSize(const Size(400, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
       final router = GoRouter(
-        initialLocation: '/settings',
+        initialLocation: initialLocation,
         routes: [
           GoRoute(
             path: '/settings',
@@ -1080,6 +1083,30 @@ void main() {
       await tester.pumpAndSettle();
 
       // Back on the section list.
+      expect(find.text('Units'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('deep-linked section detail falls back to go() because there '
+        'is nothing on the stack to pop', (tester) async {
+      // Opening ?selected= directly (a deep link or a restored location)
+      // makes the detail page the stack root, so the app-bar back button
+      // cannot pop and must navigate to the section list instead.
+      final router = await pumpSettingsList(
+        tester,
+        initialLocation: '/settings?selected=data',
+      );
+
+      expect(router.canPop(), isFalse);
+
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pumpAndSettle();
+
+      expect(
+        router.state.uri.toString(),
+        '/settings',
+        reason: 'the fallback clears the selected-section query parameter',
+      );
       expect(find.text('Units'), findsOneWidget);
       expect(tester.takeException(), isNull);
     });


### PR DESCRIPTION
## Summary

On Android, opening most Settings sections (Data, Units, Manage, About, ...) and then using the system back gesture closed the whole app. Only Appearance and Diver Profile behaved, which was the tell: those two are real pushed child routes, while every other section was a query-param mutation of `/settings` via `context.go()` — same path, nothing pushed, nothing for predictive back to pop.

## Fix

- `_navigateToSection`'s default branch now uses `context.push('/settings?selected=...')`, so each section detail is a real stack entry the system back gesture pops.
- The detail page's manual back arrow pops when possible and falls back to `go('/settings')` for deep links where the detail is the stack root.

Deep links to `/settings?selected=x` render exactly as before.

## Tests

New test group: selecting the Data section must leave the router with something to pop (fails before the fix), popping returns to the section list, and the app-bar back arrow still works.

Full suite: 14,348 tests passing.

Fixes #647