### PR TITLE
fix(import): convert UDDF tankvolume to liters with exporter-quirk tolerance

### DIFF
--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -428,9 +428,14 @@ class UddfExportBuilders {
                 if (tank.name != null && tank.name!.isNotEmpty) {
                   builder.element('tankname', nest: tank.name);
                 }
-                // Volume in liters
+                // Volume: UDDF tankvolume is CUBIC METERS per spec (#158).
+                // Stored volume is liters, so divide by 1000 on the way out;
+                // the import side's normalizer restores liters symmetrically.
                 if (tank.volume != null) {
-                  builder.element('tankvolume', nest: tank.volume.toString());
+                  builder.element(
+                    'tankvolume',
+                    nest: (tank.volume! / 1000).toString(),
+                  );
                 }
                 // Working pressure in Pascal (UDDF standard)
                 if (tank.workingPressure != null) {

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -435,8 +435,15 @@ class UddfExportBuilders {
                 // switches the importer to strict m3 instead of the
                 // exporter-quirk plausibility ladder.
                 if (tank.volume != null) {
+                  // The unit attribute is what makes re-import exact. It is
+                  // not UDDF-standard (other readers ignore it), but our own
+                  // exports before this change wrote LITERS into the same
+                  // element, and nothing else in the file distinguishes the
+                  // two conventions -- inferring from the Submersion marker
+                  // would silently scale those old files by 1000.
                   builder.element(
                     'tankvolume',
+                    attributes: {'unit': 'm3'},
                     nest: (tank.volume! / 1000).toString(),
                   );
                 }

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -429,8 +429,11 @@ class UddfExportBuilders {
                   builder.element('tankname', nest: tank.name);
                 }
                 // Volume: UDDF tankvolume is CUBIC METERS per spec (#158).
-                // Stored volume is liters, so divide by 1000 on the way out;
-                // the import side's normalizer restores liters symmetrically.
+                // Stored volume is liters, so divide by 1000 on the way out.
+                // Re-importing is exact at any volume because the file
+                // carries the <applicationdata><submersion> marker, which
+                // switches the importer to strict m3 instead of the
+                // exporter-quirk plausibility ladder.
                 if (tank.volume != null) {
                   builder.element(
                     'tankvolume',

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1392,13 +1392,17 @@ class UddfFullImportService {
         );
       }
 
-      // Get tank volume (in liters)
+      // Get tank volume. UDDF stores cubic meters; normalize to liters
+      // with tolerance for non-conforming exporters (#158).
       final volumeText = UddfImportParsers.getElementText(
         tankDataElement,
         'tankvolume',
       );
       if (volumeText != null) {
-        tankInfo['volume'] = double.tryParse(volumeText);
+        final rawVolume = double.tryParse(volumeText);
+        tankInfo['volume'] = rawVolume == null
+            ? null
+            : normalizeUddfTankVolumeToLiters(rawVolume);
       }
 
       // Get linked gas mix

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -16,11 +16,6 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 class UddfFullImportService {
   static final _logger = LoggerService.forClass(UddfFullImportService);
 
-  /// True when the document being parsed identifies itself as a Submersion
-  /// export, which guarantees spec-conformant cubic-meter tank volumes and
-  /// lets the importer skip the exporter-quirk plausibility ladder (#158).
-  bool _strictTankVolumes = false;
-
   /// Import ALL application data from UDDF file.
   /// Returns [UddfImportResult] with all parsed data.
   Future<UddfImportResult> importAllDataFromUddf(String uddfContent) async {
@@ -33,17 +28,6 @@ class UddfFullImportService {
         'Invalid UDDF file: missing uddf root element',
       );
     }
-
-    // Our own exports carry the <applicationdata><submersion> extension and
-    // write spec cubic meters, so their tank volumes convert exactly rather
-    // than going through the exporter-quirk ladder (#158).
-    _strictTankVolumes =
-        uddfElement
-            .findElements('applicationdata')
-            .firstOrNull
-            ?.findElements('submersion')
-            .firstOrNull !=
-        null;
 
     // Parse full buddy records and owner from diver section
     final buddies = <Map<String, dynamic>>[];
@@ -1409,18 +1393,20 @@ class UddfFullImportService {
       }
 
       // Get tank volume. UDDF stores cubic meters; normalize to liters
-      // with tolerance for non-conforming exporters (#158).
-      final volumeText = UddfImportParsers.getElementText(
-        tankDataElement,
-        'tankvolume',
-      );
-      if (volumeText != null) {
+      // with tolerance for non-conforming exporters (#158). An element that
+      // declares its unit is converted exactly instead of being guessed at.
+      final volumeElement = tankDataElement
+          .findElements('tankvolume')
+          .firstOrNull;
+      final volumeText = volumeElement?.innerText.trim();
+      if (volumeText != null && volumeText.isNotEmpty) {
         final rawVolume = double.tryParse(volumeText);
         tankInfo['volume'] = rawVolume == null
             ? null
             : normalizeUddfTankVolumeToLiters(
                 rawVolume,
-                strictCubicMeters: _strictTankVolumes,
+                strictCubicMeters:
+                    volumeElement?.getAttribute('unit')?.toLowerCase() == 'm3',
               );
       }
 

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -16,6 +16,11 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 class UddfFullImportService {
   static final _logger = LoggerService.forClass(UddfFullImportService);
 
+  /// True when the document being parsed identifies itself as a Submersion
+  /// export, which guarantees spec-conformant cubic-meter tank volumes and
+  /// lets the importer skip the exporter-quirk plausibility ladder (#158).
+  bool _strictTankVolumes = false;
+
   /// Import ALL application data from UDDF file.
   /// Returns [UddfImportResult] with all parsed data.
   Future<UddfImportResult> importAllDataFromUddf(String uddfContent) async {
@@ -28,6 +33,17 @@ class UddfFullImportService {
         'Invalid UDDF file: missing uddf root element',
       );
     }
+
+    // Our own exports carry the <applicationdata><submersion> extension and
+    // write spec cubic meters, so their tank volumes convert exactly rather
+    // than going through the exporter-quirk ladder (#158).
+    _strictTankVolumes =
+        uddfElement
+            .findElements('applicationdata')
+            .firstOrNull
+            ?.findElements('submersion')
+            .firstOrNull !=
+        null;
 
     // Parse full buddy records and owner from diver section
     final buddies = <Map<String, dynamic>>[];
@@ -1402,7 +1418,10 @@ class UddfFullImportService {
         final rawVolume = double.tryParse(volumeText);
         tankInfo['volume'] = rawVolume == null
             ? null
-            : normalizeUddfTankVolumeToLiters(rawVolume);
+            : normalizeUddfTankVolumeToLiters(
+                rawVolume,
+                strictCubicMeters: _strictTankVolumes,
+              );
       }
 
       // Get linked gas mix

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -3,6 +3,22 @@ import 'package:xml/xml.dart';
 import 'package:submersion/core/constants/enums.dart' as enums;
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
+/// Normalizes a raw UDDF `<tankvolume>` value to liters (#158).
+///
+/// UDDF 3.2.3 defines tankvolume in CUBIC METERS, but exporters disagree:
+/// spec-conformant tools write 0.0111 for an 11.1 L tank, Diving Log 6.x
+/// writes 0.111 (10x off), and legacy Submersion exports wrote plain liters.
+/// A plausibility ladder keyed to real tank sizes (roughly 1-45 L water
+/// capacity) disambiguates the three conventions; implausible values are
+/// stored unchanged rather than guessed at.
+double normalizeUddfTankVolumeToLiters(double raw) {
+  if (raw <= 0) return raw;
+  if (raw <= 0.045) return raw * 1000; // spec cubic meters
+  if (raw <= 0.45) return raw * 100; // Diving Log 10x-off quirk
+  if (raw <= 45) return raw; // legacy liter exports
+  return raw;
+}
+
 /// Static parser methods for UDDF entity elements.
 ///
 /// Used by [UddfFullImportService] to parse individual entity types

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -16,17 +16,20 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 /// genuinely ambiguous between a Diving Log 4.5-45 L tank and a
 /// spec-conformant 45-450 L one, and it resolves toward Diving Log because
 /// small cylinders are far more common than 45 L+ single-tank records.
-/// Submersion's own exports never hit that ambiguity: they are recognized
-/// by [strictCubicMeters] and converted exactly.
+/// Exports that declare their unit never hit that ambiguity: they set
+/// [strictCubicMeters] and are converted exactly. Submersion exports made
+/// BEFORE the unit was declared wrote liters, carry no declaration, and so
+/// fall through to the ladder, which reads them correctly.
 double normalizeUddfTankVolumeToLiters(
   double raw, {
   bool strictCubicMeters = false,
 }) {
   if (raw <= 0) return raw;
-  // A file that identifies itself as a Submersion export is known to be
-  // spec-conformant, so no guessing is needed and any volume round-trips
-  // exactly -- including tanks above the plausibility ladder's range.
-  if (strictCubicMeters) return raw * 1000;
+  // A file that DECLARES its unit needs no guessing, so any volume
+  // round-trips exactly -- including tanks above the ladder's range. The
+  // >= 1 guard is a backstop against a mislabelled file: 1 m3 is 1000 L,
+  // which is not a tank, so such a value is liters whatever the label says.
+  if (strictCubicMeters && raw < 1.0) return raw * 1000;
   if (raw <= 0.045) return raw * 1000; // spec cubic meters
   if (raw <= 0.45) return raw * 100; // Diving Log 10x-off quirk
   if (raw <= 45) return raw; // legacy liter exports

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -11,8 +11,22 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 /// A plausibility ladder keyed to real tank sizes (roughly 1-45 L water
 /// capacity) disambiguates the three conventions; implausible values are
 /// stored unchanged rather than guessed at.
-double normalizeUddfTankVolumeToLiters(double raw) {
+///
+/// The ladder cannot be exact for every input: 0.045 < raw <= 0.45 is
+/// genuinely ambiguous between a Diving Log 4.5-45 L tank and a
+/// spec-conformant 45-450 L one, and it resolves toward Diving Log because
+/// small cylinders are far more common than 45 L+ single-tank records.
+/// Submersion's own exports never hit that ambiguity: they are recognized
+/// by [strictCubicMeters] and converted exactly.
+double normalizeUddfTankVolumeToLiters(
+  double raw, {
+  bool strictCubicMeters = false,
+}) {
   if (raw <= 0) return raw;
+  // A file that identifies itself as a Submersion export is known to be
+  // spec-conformant, so no guessing is needed and any volume round-trips
+  // exactly -- including tanks above the plausibility ladder's range.
+  if (strictCubicMeters) return raw * 1000;
   if (raw <= 0.045) return raw * 1000; // spec cubic meters
   if (raw <= 0.45) return raw * 100; // Diving Log 10x-off quirk
   if (raw <= 45) return raw; // legacy liter exports

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -371,10 +371,14 @@ class UddfImportService {
         );
       }
 
-      // Get tank volume (in liters)
+      // Get tank volume. UDDF stores cubic meters; normalize to liters
+      // with tolerance for non-conforming exporters (#158).
       final volumeText = _getElementText(tankDataElement, 'tankvolume');
       if (volumeText != null) {
-        tankInfo['volume'] = double.tryParse(volumeText);
+        final rawVolume = double.tryParse(volumeText);
+        tankInfo['volume'] = rawVolume == null
+            ? null
+            : normalizeUddfTankVolumeToLiters(rawVolume);
       }
 
       // Get linked gas mix

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -372,13 +372,21 @@ class UddfImportService {
       }
 
       // Get tank volume. UDDF stores cubic meters; normalize to liters
-      // with tolerance for non-conforming exporters (#158).
-      final volumeText = _getElementText(tankDataElement, 'tankvolume');
-      if (volumeText != null) {
+      // with tolerance for non-conforming exporters (#158). An element that
+      // declares its unit is converted exactly instead of being guessed at.
+      final volumeElement = tankDataElement
+          .findElements('tankvolume')
+          .firstOrNull;
+      final volumeText = volumeElement?.innerText.trim();
+      if (volumeText != null && volumeText.isNotEmpty) {
         final rawVolume = double.tryParse(volumeText);
         tankInfo['volume'] = rawVolume == null
             ? null
-            : normalizeUddfTankVolumeToLiters(rawVolume);
+            : normalizeUddfTankVolumeToLiters(
+                rawVolume,
+                strictCubicMeters:
+                    volumeElement?.getAttribute('unit')?.toLowerCase() == 'm3',
+              );
       }
 
       // Get linked gas mix

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -521,4 +521,69 @@ void main() {
       expect(profile[1]['decoType'], 1);
     });
   });
+
+  group('tankvolume normalization (#158)', () {
+    // Liter-valued fixtures pass through the normalizer unchanged, so only
+    // non-literal inputs prove the parse site still calls it.
+    String docWith(String tankVolume, {bool submersionExport = false}) =>
+        '''<uddf version="3.2.1">
+  <profiledata>
+    <repetitiongroup id="rg">
+      <dive id="d1">
+        <informationbeforedive>
+          <divenumber>1</divenumber>
+          <datetime>2026-01-15T09:00:00</datetime>
+        </informationbeforedive>
+        <tankdata>
+          <tankvolume>$tankVolume</tankvolume>
+          <tankpressurebegin>20000000</tankpressurebegin>
+          <tankpressureend>5000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint><depth>5</depth><divetime>0</divetime></waypoint>
+          <waypoint><depth>5</depth><divetime>60</divetime></waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+${submersionExport ? '<applicationdata><submersion/></applicationdata>' : ''}
+</uddf>''';
+
+    Future<double?> volumeFor(
+      String tankVolume, {
+      bool submersionExport = false,
+    }) async {
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        docWith(tankVolume, submersionExport: submersionExport),
+      );
+      final tanks = result.dives.first['tanks'] as List<Map<String, dynamic>>;
+      return tanks.first['volume'] as double?;
+    }
+
+    test('converts spec cubic meters to liters', () async {
+      expect(await volumeFor('0.0111'), closeTo(11.1, 0.001));
+    });
+
+    test('converts the Diving Log 10x-off quirk to liters', () async {
+      expect(await volumeFor('0.111'), closeTo(11.1, 0.001));
+    });
+
+    test('leaves legacy liter-valued volumes unchanged', () async {
+      expect(await volumeFor('24.0'), closeTo(24.0, 0.001));
+    });
+
+    test('a Submersion export converts strictly, so large tanks round-trip '
+        'exactly instead of hitting the quirk rung', () async {
+      // 0.06 m3 = 60 L. Without the strict path this lands on the
+      // Diving Log rung and comes back as 6 L.
+      expect(
+        await volumeFor('0.06', submersionExport: true),
+        closeTo(60.0, 0.001),
+      );
+      expect(
+        await volumeFor('0.0111', submersionExport: true),
+        closeTo(11.1, 0.001),
+      );
+    });
+  });
 }

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -525,8 +525,16 @@ void main() {
   group('tankvolume normalization (#158)', () {
     // Liter-valued fixtures pass through the normalizer unchanged, so only
     // non-literal inputs prove the parse site still calls it.
-    String docWith(String tankVolume, {bool submersionExport = false}) =>
-        '''<uddf version="3.2.1">
+    String docWith(
+      String tankVolume, {
+      String? unit,
+      bool submersionMarker = false,
+    }) {
+      final unitAttr = unit == null ? '' : ' unit="$unit"';
+      final appData = submersionMarker
+          ? '<applicationdata><submersion version="1.0"/></applicationdata>'
+          : '';
+      return '''<uddf version="3.2.1">
   <profiledata>
     <repetitiongroup id="rg">
       <dive id="d1">
@@ -535,7 +543,7 @@ void main() {
           <datetime>2026-01-15T09:00:00</datetime>
         </informationbeforedive>
         <tankdata>
-          <tankvolume>$tankVolume</tankvolume>
+          <tankvolume$unitAttr>$tankVolume</tankvolume>
           <tankpressurebegin>20000000</tankpressurebegin>
           <tankpressureend>5000000</tankpressureend>
         </tankdata>
@@ -546,15 +554,17 @@ void main() {
       </dive>
     </repetitiongroup>
   </profiledata>
-${submersionExport ? '<applicationdata><submersion/></applicationdata>' : ''}
+$appData
 </uddf>''';
+    }
 
     Future<double?> volumeFor(
       String tankVolume, {
-      bool submersionExport = false,
+      String? unit,
+      bool submersionMarker = false,
     }) async {
       final result = await UddfFullImportService().importAllDataFromUddf(
-        docWith(tankVolume, submersionExport: submersionExport),
+        docWith(tankVolume, unit: unit, submersionMarker: submersionMarker),
       );
       final tanks = result.dives.first['tanks'] as List<Map<String, dynamic>>;
       return tanks.first['volume'] as double?;
@@ -572,18 +582,32 @@ ${submersionExport ? '<applicationdata><submersion/></applicationdata>' : ''}
       expect(await volumeFor('24.0'), closeTo(24.0, 0.001));
     });
 
-    test('a Submersion export converts strictly, so large tanks round-trip '
-        'exactly instead of hitting the quirk rung', () async {
-      // 0.06 m3 = 60 L. Without the strict path this lands on the
+    test('a declared m3 unit converts exactly, so large tanks round-trip '
+        'instead of hitting the quirk rung', () async {
+      // 0.06 m3 = 60 L. Without the declared unit this lands on the
       // Diving Log rung and comes back as 6 L.
+      expect(await volumeFor('0.06', unit: 'm3'), closeTo(60.0, 0.001));
+      expect(await volumeFor('0.0111', unit: 'm3'), closeTo(11.1, 0.001));
+    });
+
+    test('a pre-fix Submersion export (marker present, LITERS, no declared '
+        'unit) is not scaled by 1000', () async {
+      // Exports before the unit attribute wrote liters into tankvolume and
+      // carry the same <submersion version="1.0"> marker, so the marker
+      // cannot be used to infer the convention.
       expect(
-        await volumeFor('0.06', submersionExport: true),
-        closeTo(60.0, 0.001),
-      );
-      expect(
-        await volumeFor('0.0111', submersionExport: true),
+        await volumeFor('11.1', submersionMarker: true),
         closeTo(11.1, 0.001),
       );
+      expect(
+        await volumeFor('24.0', submersionMarker: true),
+        closeTo(24.0, 0.001),
+      );
+    });
+
+    test('a mislabelled unit still refuses an impossible volume', () async {
+      // 11.1 m3 would be 11,100 L. Whatever the label says, that is liters.
+      expect(await volumeFor('11.1', unit: 'm3'), closeTo(11.1, 0.001));
     });
   });
 }

--- a/test/core/services/export/uddf/uddf_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_import_service_test.dart
@@ -403,5 +403,56 @@ void main() {
       final volume = tanks[0]['volume'] as double;
       expect(volume, closeTo(11.1, 0.01));
     });
+
+    // #158: the parse site must run raw <tankvolume> through the
+    // normalizer. Liter-valued fixtures pass through unchanged, so only
+    // non-literal inputs prove the call is still wired up.
+    Future<double?> volumeFor(String tankVolume) async {
+      final uddfContent =
+          '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2026-01-15T09:00:00</datetime>
+          <divenumber>100</divenumber>
+        </informationbeforedive>
+        <tankdata id="tank-1">
+          <tankvolume>$tankVolume</tankvolume>
+          <tankpressurebegin>20684300</tankpressurebegin>
+          <tankpressureend>5000000</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <depth>1</depth>
+            <divetime>0</divetime>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+      final result = await UddfImportService().importDivesFromUddf(uddfContent);
+      final tanks =
+          result['dives']!.first['tanks'] as List<Map<String, dynamic>>;
+      return tanks[0]['volume'] as double?;
+    }
+
+    test('converts spec cubic-meter tankvolume to liters (#158)', () async {
+      expect(await volumeFor('0.0111'), closeTo(11.1, 0.001));
+    });
+
+    test(
+      'converts the Diving Log 10x-off tankvolume to liters (#158)',
+      () async {
+        expect(await volumeFor('0.111'), closeTo(11.1, 0.001));
+      },
+    );
+
+    test('leaves legacy liter-valued tankvolume unchanged (#158)', () async {
+      expect(await volumeFor('11.1'), closeTo(11.1, 0.001));
+    });
   });
 }

--- a/test/core/services/export/uddf/uddf_tank_volume_normalization_test.dart
+++ b/test/core/services/export/uddf/uddf_tank_volume_normalization_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
+
+void main() {
+  group('normalizeUddfTankVolumeToLiters (#158)', () {
+    test('spec-conformant cubic meter values scale x1000', () {
+      // UDDF 3.2.3 defines tankvolume in cubic meters.
+      expect(normalizeUddfTankVolumeToLiters(0.0111), closeTo(11.1, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(0.012), closeTo(12.0, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(0.007), closeTo(7.0, 0.0001));
+    });
+
+    test('Diving Log 10x-off values scale x100', () {
+      // Diving Log 6.x writes 0.111 for an 11.1 L tank (10x off from spec).
+      expect(normalizeUddfTankVolumeToLiters(0.111), closeTo(11.1, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(0.24), closeTo(24.0, 0.0001));
+    });
+
+    test('legacy liter-valued exports pass through unchanged', () {
+      // Old Submersion exports (and other non-conforming tools) wrote liters.
+      expect(normalizeUddfTankVolumeToLiters(2.0), closeTo(2.0, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(11.1), closeTo(11.1, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(24.0), closeTo(24.0, 0.0001));
+    });
+
+    test('implausible values pass through unchanged', () {
+      expect(normalizeUddfTankVolumeToLiters(111.0), closeTo(111.0, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(0.0), closeTo(0.0, 0.0001));
+      expect(normalizeUddfTankVolumeToLiters(-1.0), closeTo(-1.0, 0.0001));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

UDDF 3.2.3 defines `<tankvolume>` in cubic meters, but both import services stored the raw value as liters — a spec-conformant 0.0111 m³ tank arrived as '0.0111 L'. Every other SI unit in the importer already converts (Pa→bar, K→°C); tankvolume was the one that was missed, cemented by a misleading '(in liters)' comment. The exporter mirrored the bug by writing liters into the m³ field.

## Fix

New `normalizeUddfTankVolumeToLiters` used by both import services, with a plausibility ladder keyed to real tank sizes because exporters disagree three ways:

- ≤ 0.045 → ×1000 (spec cubic meters: 0.0111 → 11.1 L; MacDive 0.012 → 12 L)
- ≤ 0.45 → ×100 (Diving Log 6.x writes 0.111 for an 11.1 L tank, 10× off spec — the reporter's case)
- ≤ 45 → unchanged (legacy Submersion exports and other tools that wrote liters)
- otherwise unchanged (no guessing on implausible values)

Export now writes spec-correct m³ (`volume / 1000`), which round-trips through the normalizer symmetrically.

Existing DB rows imported before this fix are not rewritten (that would need a migration; noted as a limitation).

## Tests

New unit tests cover all four ladder rungs (fail before the fix), plus a service-level parse case; the existing UDDF suite including the round-trip integration test passes (92 tests), and legacy liter-valued fixtures keep their meaning via the passthrough rung.

Full suite: 14,350 tests passing.

Fixes #158