### PR TITLE
fix(import): parse LF/BOM CSVs correctly and add MySSI preset

### DIFF
--- a/lib/features/universal_import/data/csv/presets/built_in_presets.dart
+++ b/lib/features/universal_import/data/csv/presets/built_in_presets.dart
@@ -14,7 +14,51 @@ const List<CsvPreset> builtInCsvPresets = [
   _garminConnect,
   _shearwater,
   _submersionNative,
+  _myssi,
 ];
+
+// ======================== 8. MySSI (SSI website export) ========================
+
+/// The CSV downloadable from my.divessi.com (#190). Country, Dive Activity,
+/// Specialty Dive, and Dive type have no import target field and stay
+/// unmapped.
+const _myssi = CsvPreset(
+  id: 'myssi',
+  name: 'MySSI',
+  source: PresetSource.builtIn,
+  sourceApp: SourceApp.ssiMyDiveGuide,
+  signatureHeaders: [
+    'dive #',
+    'dive site',
+    'country',
+    'date / time',
+    'dive activity',
+    'specialty dive',
+    'dive type',
+    'duration',
+    'depth',
+    'dive buddy / instructor / center',
+  ],
+  matchThreshold: 0.6,
+  mappings: {
+    'primary': FieldMapping(
+      name: 'MySSI Default',
+      sourceApp: SourceApp.ssiMyDiveGuide,
+      columns: [
+        ColumnMapping(sourceColumn: 'dive #', targetField: 'diveNumber'),
+        ColumnMapping(sourceColumn: 'Dive Site', targetField: 'siteName'),
+        ColumnMapping(sourceColumn: 'Date / Time', targetField: 'dateTime'),
+        ColumnMapping(sourceColumn: 'Duration', targetField: 'duration'),
+        ColumnMapping(sourceColumn: 'Depth', targetField: 'maxDepth'),
+        ColumnMapping(
+          sourceColumn: 'Dive Buddy / Instructor / Center',
+          targetField: 'buddy',
+        ),
+      ],
+    ),
+  },
+  supportedEntities: {ImportEntityType.dives},
+);
 
 // ======================== 1. Subsurface (multi-file) ========================
 

--- a/lib/features/universal_import/data/services/format_detector.dart
+++ b/lib/features/universal_import/data/services/format_detector.dart
@@ -257,10 +257,19 @@ class FormatDetector {
   // ======================== CSV Detection ========================
 
   DetectionResult? _detectCsv(String content, Uint8List bytes) {
-    // Try to parse first line as CSV headers
+    // Normalize line endings and strip the UTF-8 BOM before parsing: the
+    // csv package's default eol is '\r\n' matched literally, so an LF-only
+    // file (e.g. the MySSI web export) would otherwise parse as ONE giant
+    // row and every cell would be reported as a header (#190).
+    var normalized = content;
+    if (normalized.startsWith('﻿')) {
+      normalized = normalized.substring(1);
+    }
+    normalized = normalized.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+
     List<List<dynamic>> rows;
     try {
-      rows = const CsvToListConverter().convert(content);
+      rows = const CsvToListConverter(eol: '\n').convert(normalized);
     } catch (_) {
       return null;
     }
@@ -369,6 +378,15 @@ class FormatDetector {
   double _scoreSsi(List<String> headers) {
     final joined = headers.join(' ');
     if (joined.contains('ssi') || joined.contains('mydiveguide')) return 0.85;
+    // The MySSI website CSV export carries no 'ssi' branding anywhere; match
+    // its distinctive column set instead (#190).
+    const myssiSignature = [
+      'dive activity',
+      'specialty dive',
+      'dive buddy / instructor / center',
+    ];
+    final hits = myssiSignature.where(headers.contains).length;
+    if (hits >= 2) return 0.8;
     return 0.0;
   }
 

--- a/lib/features/universal_import/data/services/format_detector.dart
+++ b/lib/features/universal_import/data/services/format_detector.dart
@@ -20,6 +20,10 @@ class FormatDetector {
   /// Maximum bytes to read for detection purposes.
   static const _peekSize = 8192;
 
+  /// The UTF-8 byte order mark as decoded text (U+FEFF). Written as an escape
+  /// because the literal character is invisible in source.
+  static const _bom = '\u{FEFF}';
+
   /// Detect the format and source app of the given file bytes.
   DetectionResult detect(Uint8List bytes) {
     if (bytes.isEmpty) {
@@ -242,7 +246,7 @@ class FormatDetector {
   /// remove (it is not Unicode White_Space), so it is stripped explicitly.
   DetectionResult? _detectDl7(String content) {
     var trimmed = content.trimLeft();
-    if (trimmed.startsWith('﻿')) {
+    if (trimmed.startsWith(_bom)) {
       trimmed = trimmed.substring(1).trimLeft();
     }
     if (!trimmed.startsWith('FSH|')) return null;
@@ -262,7 +266,7 @@ class FormatDetector {
     // file (e.g. the MySSI web export) would otherwise parse as ONE giant
     // row and every cell would be reported as a header (#190).
     var normalized = content;
-    if (normalized.startsWith('﻿')) {
+    if (normalized.startsWith(_bom)) {
       normalized = normalized.substring(1);
     }
     normalized = normalized.replaceAll('\r\n', '\n').replaceAll('\r', '\n');

--- a/lib/features/universal_import/data/services/format_detector.dart
+++ b/lib/features/universal_import/data/services/format_detector.dart
@@ -261,15 +261,14 @@ class FormatDetector {
   // ======================== CSV Detection ========================
 
   DetectionResult? _detectCsv(String content, Uint8List bytes) {
-    // Normalize line endings and strip the UTF-8 BOM before parsing: the
-    // csv package's default eol is '\r\n' matched literally, so an LF-only
-    // file (e.g. the MySSI web export) would otherwise parse as ONE giant
-    // row and every cell would be reported as a header (#190).
-    var normalized = content;
-    if (normalized.startsWith(_bom)) {
-      normalized = normalized.substring(1);
-    }
-    normalized = normalized.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    // Normalize line endings before parsing: the csv package's default eol
+    // is '\r\n' matched literally, so an LF-only file (e.g. the MySSI web
+    // export) would otherwise parse as ONE giant row and every cell would
+    // be reported as a header (#190).
+    //
+    // A UTF-8 BOM needs no handling here: utf8.decode in [detect] already
+    // consumes it, so `content` never starts with U+FEFF.
+    final normalized = content.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
 
     List<List<dynamic>> rows;
     try {

--- a/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
+++ b/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
@@ -8,8 +8,8 @@ import 'package:submersion/features/universal_import/data/models/import_enums.da
 
 void main() {
   group('built-in presets', () {
-    test('contains exactly 7 presets', () {
-      expect(builtInCsvPresets.length, 7);
+    test('contains exactly 8 presets', () {
+      expect(builtInCsvPresets.length, 8);
     });
 
     test('all presets have unique IDs', () {

--- a/test/features/universal_import/data/csv/presets/preset_registry_test.dart
+++ b/test/features/universal_import/data/csv/presets/preset_registry_test.dart
@@ -54,6 +54,33 @@ void main() {
       },
     );
 
+    test('detects MySSI from its export headers (#190)', () {
+      const myssiHeaders = [
+        'dive #',
+        'Dive Site',
+        'Country',
+        'Date / Time',
+        'Dive Activity',
+        'Specialty Dive',
+        'Dive type',
+        'Duration',
+        'Depth',
+        'Dive Buddy / Instructor / Center',
+      ];
+
+      final matches = registry.detectPreset(myssiHeaders);
+
+      expect(matches, isNotEmpty);
+      expect(matches.first.preset.id, 'myssi');
+      expect(
+        matches.first.preset.primaryMapping!.columns,
+        hasLength(6),
+        reason:
+            'dive #, Dive Site, Date / Time, Duration, Depth, and Buddy map; '
+            'Country/Activity/Specialty/Dive type have no target field',
+      );
+    });
+
     test('detects MacDive from its headers', () {
       const macdiveHeaders = [
         'Dive No',

--- a/test/features/universal_import/data/services/format_detector_test.dart
+++ b/test/features/universal_import/data/services/format_detector_test.dart
@@ -260,7 +260,7 @@ void main() {
 
     test('strips the UTF-8 BOM from the first CSV header (#190)', () {
       const csv =
-          '﻿dive #,Dive Site,Country,Date / Time,Dive Activity,'
+          '\u{FEFF}dive #,Dive Site,Country,Date / Time,Dive Activity,'
           'Specialty Dive,Dive type,Duration,Depth,'
           'Dive Buddy / Instructor / Center\n'
           '1,Reef,Egypt,2026-01-15 09:00,Fun Dive,,Open Water,45,18,Bob\n';
@@ -324,7 +324,7 @@ void main() {
 
     test('a BOM before FSH still detects', () {
       final result = detector.detect(
-        _toBytes('﻿FSH|^~<>{}|X^^|ZXU|20240101120000|\n'),
+        _toBytes('\u{FEFF}FSH|^~<>{}|X^^|ZXU|20240101120000|\n'),
       );
       expect(result.format, ImportFormat.danDl7);
     });

--- a/test/features/universal_import/data/services/format_detector_test.dart
+++ b/test/features/universal_import/data/services/format_detector_test.dart
@@ -214,13 +214,59 @@ void main() {
     });
 
     test('returns headers in csvHeaders field', () {
+      // Five dive-ish columns so the generic score clears its 0.3 gate --
+      // the old 3-column sample scored below it and the assertion never ran.
       const csv =
-          'Date,Depth,Duration\n'
-          '2024-01-15,25,45\n';
+          'date,depth,duration,location,temperature\n'
+          '2024-01-15,25,45,Reef,28\n';
       final result = detector.detect(_toBytes(csv));
-      if (result.format == ImportFormat.csv) {
-        expect(result.csvHeaders, ['Date', 'Depth', 'Duration']);
-      }
+      expect(result.format, ImportFormat.csv);
+      expect(result.csvHeaders, [
+        'date',
+        'depth',
+        'duration',
+        'location',
+        'temperature',
+      ]);
+    });
+
+    test('parses LF-only CSV into a real header row, not one giant row '
+        '(#190)', () {
+      // MySSI web export: LF line endings, 10 columns, 28 dive rows. The
+      // csv package's default eol is CRLF matched literally, so without
+      // normalization the whole file becomes ONE row and every cell is
+      // reported as a header (9 commas x 29 lines + 1 = 262).
+      final rows = List.generate(
+        28,
+        (i) =>
+            '${i + 1},Coral Garden,Egypt,2026-01-15 09:00,'
+            'Fun Dive,,Open Water,45,18.5,Alice',
+      );
+      final csv =
+          'dive #,Dive Site,Country,Date / Time,Dive Activity,'
+          'Specialty Dive,Dive type,Duration,Depth,'
+          'Dive Buddy / Instructor / Center\n'
+          '${rows.join('\n')}\n';
+      final result = detector.detect(_toBytes(csv));
+      expect(result.format, ImportFormat.csv);
+      expect(
+        result.csvHeaders,
+        hasLength(10),
+        reason: 'LF-only files must not merge every cell into the header row',
+      );
+      expect(result.csvHeaders!.first, 'dive #');
+      expect(result.sourceApp, SourceApp.ssiMyDiveGuide);
+    });
+
+    test('strips the UTF-8 BOM from the first CSV header (#190)', () {
+      const csv =
+          '﻿dive #,Dive Site,Country,Date / Time,Dive Activity,'
+          'Specialty Dive,Dive type,Duration,Depth,'
+          'Dive Buddy / Instructor / Center\n'
+          '1,Reef,Egypt,2026-01-15 09:00,Fun Dive,,Open Water,45,18,Bob\n';
+      final result = detector.detect(_toBytes(csv));
+      expect(result.format, ImportFormat.csv);
+      expect(result.csvHeaders!.first, 'dive #');
     });
 
     test('does not detect non-dive CSV', () {


### PR DESCRIPTION
## Summary

Importing the MySSI website CSV reported '0 of 262 columns mapped'. Three stacked defects:

1. **LF-only files parsed as one giant row.** The csv package's default record delimiter is a literal CRLF; the MySSI export is LF-terminated, so the whole (8 KB-truncated) file became a single row and every cell was reported as a header — 9 commas x 29 lines + 1 = exactly the 262 'columns' from the report. The detector now strips the UTF-8 BOM and normalizes line endings before parsing (the real import pipeline already did; the detector didn't).
2. **No SSI detection without branding.** The SSI scorer only fired when a header literally contained 'ssi'/'mydiveguide' — the export contains neither. It now also matches the export's distinctive column set.
3. **No MySSI preset.** Added a built-in preset mapping dive #, Dive Site, Date / Time, Duration, Depth, and Dive Buddy / Instructor / Center (6 of 10 columns; Country/Activity/Specialty/Dive type have no import target).

## Tests

- New detector tests: a 29-line LF-only MySSI file yields 10 headers (fails before with 262) and detects as SSI; BOM variant yields a clean first header.
- New registry test: MySSI headers resolve to the new preset with 6 mapped columns.
- Fixed a vacuous existing test whose assertion was gated behind an if that never fired.

Full suite green except one OCR page test that is a known concurrency flake (passes standalone).

Fixes #190