### PR TITLE
fix(export): honor PDF detail level on save and print total runtime

### DIFF
--- a/lib/core/services/export/export_service.dart
+++ b/lib/core/services/export/export_service.dart
@@ -116,6 +116,9 @@ class ExportService {
   }) =>
       _pdf.saveDivesToPdfFile(dives, title: title, allSightings: allSightings);
 
+  Future<String?> savePdfBytesToFile(List<int> bytes, String fileName) =>
+      _pdf.savePdfBytesToFile(bytes, fileName);
+
   // ==================== PDF Course Export ====================
 
   Future<String> exportCourseTrainingLogToPdf(

--- a/lib/core/services/export/pdf/pdf_course_export_service.dart
+++ b/lib/core/services/export/pdf/pdf_course_export_service.dart
@@ -3,6 +3,7 @@ import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/core/services/pdf_templates/pdf_shared_components.dart';
 import 'package:submersion/features/courses/domain/entities/course.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/signatures/data/services/signature_storage_service.dart';
@@ -36,10 +37,7 @@ class PdfCourseExportService {
     }
 
     // Calculate summary statistics
-    final totalBottomTime = trainingDives.fold<Duration>(
-      Duration.zero,
-      (sum, dive) => sum + (dive.bottomTime ?? Duration.zero),
-    );
+    final totalRuntime = pdfTotalRuntime(trainingDives);
     final maxDepth = trainingDives.fold<double?>(
       null,
       (max, dive) => dive.maxDepth != null
@@ -119,10 +117,7 @@ class PdfCourseExportService {
                 children: [
                   _buildStatBox('${trainingDives.length}', 'Training Dives'),
                   pw.SizedBox(width: 30),
-                  _buildStatBox(
-                    '${totalBottomTime.inMinutes}',
-                    'Total Minutes',
-                  ),
+                  _buildStatBox('${totalRuntime.inMinutes}', 'Total Minutes'),
                   if (maxDepth != null) ...[
                     pw.SizedBox(width: 30),
                     _buildStatBox(
@@ -298,9 +293,12 @@ class PdfCourseExportService {
                   'Max Depth',
                   '${dive.maxDepth!.toStringAsFixed(1)} m',
                 ),
-              if (dive.bottomTime != null) ...[
+              if (dive.effectiveRuntime != null) ...[
                 pw.SizedBox(width: 20),
-                _buildInfoChip('Duration', '${dive.bottomTime!.inMinutes} min'),
+                _buildInfoChip(
+                  'Duration',
+                  '${pdfDiveDurationMinutes(dive)} min',
+                ),
               ],
               if (dive.waterTemp != null) ...[
                 pw.SizedBox(width: 20),

--- a/lib/core/services/export/pdf/pdf_export_service.dart
+++ b/lib/core/services/export/pdf/pdf_export_service.dart
@@ -116,8 +116,10 @@ class PdfExportService {
                     pw.Text(
                       'Max Depth: ${dive.maxDepth!.toStringAsFixed(1)} m',
                     ),
-                  if (dive.bottomTime != null)
-                    pw.Text('Duration: ${dive.bottomTime!.inMinutes} min'),
+                  if (dive.effectiveRuntime != null)
+                    pw.Text(
+                      'Duration: ${dive.effectiveRuntime!.inMinutes} min',
+                    ),
                 ],
               ),
               if (dive.waterTemp != null)
@@ -197,20 +199,28 @@ class PdfExportService {
       title: title,
       allSightings: allSightings,
     );
+    return savePdfBytesToFile(result.bytes, result.fileName);
+  }
 
+  /// Save already-built PDF bytes to a user-selected location.
+  ///
+  /// Used by the template-aware export path so the save-to-file flow honors
+  /// the selected detail level instead of falling back to the legacy
+  /// single-layout builder (#644).
+  Future<String?> savePdfBytesToFile(List<int> bytes, String fileName) async {
     final saveResult = await FilePicker.saveFile(
       dialogTitle: 'Save PDF File',
-      fileName: result.fileName,
+      fileName: fileName,
       type: FileType.custom,
       allowedExtensions: ['pdf'],
-      bytes: Uint8List.fromList(result.bytes),
+      bytes: Uint8List.fromList(bytes),
     );
 
     if (saveResult == null) return null;
 
     if (!Platform.isAndroid) {
       final file = File(saveResult);
-      await file.writeAsBytes(result.bytes);
+      await file.writeAsBytes(bytes);
     }
 
     return saveResult;
@@ -270,8 +280,8 @@ class PdfExportService {
     // Summary page
     if (dives.isNotEmpty) {
       final totalDiveTime = dives
-          .where((d) => d.bottomTime != null)
-          .fold<Duration>(Duration.zero, (sum, d) => sum + d.bottomTime!);
+          .where((d) => d.effectiveRuntime != null)
+          .fold<Duration>(Duration.zero, (sum, d) => sum + d.effectiveRuntime!);
       final maxDepth = dives
           .where((d) => d.maxDepth != null)
           .map((d) => d.maxDepth!)
@@ -414,7 +424,7 @@ class PdfExportService {
               pw.SizedBox(width: 16),
               _buildPdfInfoChip(
                 'Duration',
-                '${dive.bottomTime?.inMinutes ?? '-'} min',
+                '${dive.effectiveRuntime?.inMinutes ?? '-'} min',
               ),
               pw.SizedBox(width: 16),
               _buildPdfInfoChip(

--- a/lib/core/services/pdf_templates/pdf_shared_components.dart
+++ b/lib/core/services/pdf_templates/pdf_shared_components.dart
@@ -7,6 +7,19 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/signatures/domain/entities/signature.dart';
 
+/// Minutes string for a logbook Duration field (#644).
+///
+/// Uses [Dive.effectiveRuntime] (runtime, then exit-entry, then profile,
+/// then bottomTime), never bottomTime directly: the logbook Duration must
+/// show the total dive duration, which bottom time understates.
+String pdfDiveDurationMinutes(Dive dive) =>
+    '${dive.effectiveRuntime?.inMinutes ?? '-'}';
+
+/// Sum of effective runtimes for summary and total rows (#644).
+Duration pdfTotalRuntime(List<Dive> dives) => dives
+    .where((d) => d.effectiveRuntime != null)
+    .fold<Duration>(Duration.zero, (sum, d) => sum + d.effectiveRuntime!);
+
 /// Shared PDF components used across multiple templates.
 ///
 /// These helper methods provide consistent styling and layout for
@@ -504,9 +517,7 @@ class PdfSharedComponents {
       return pw.Center(child: pw.Text('No dives to summarize'));
     }
 
-    final totalDiveTime = dives
-        .where((d) => d.bottomTime != null)
-        .fold<Duration>(Duration.zero, (sum, d) => sum + d.bottomTime!);
+    final totalDiveTime = pdfTotalRuntime(dives);
     final maxDepth = dives
         .where((d) => d.maxDepth != null)
         .map((d) => d.maxDepth!)

--- a/lib/core/services/pdf_templates/pdf_template_detailed.dart
+++ b/lib/core/services/pdf_templates/pdf_template_detailed.dart
@@ -143,7 +143,7 @@ class PdfTemplateDetailed extends PdfTemplateBuilder {
               pw.SizedBox(width: 16),
               PdfSharedComponents.buildInfoChip(
                 'Duration',
-                '${dive.bottomTime?.inMinutes ?? '-'} min',
+                '${pdfDiveDurationMinutes(dive)} min',
               ),
               pw.SizedBox(width: 16),
               PdfSharedComponents.buildInfoChip(

--- a/lib/core/services/pdf_templates/pdf_template_naui.dart
+++ b/lib/core/services/pdf_templates/pdf_template_naui.dart
@@ -104,9 +104,7 @@ class PdfTemplateNaui extends PdfTemplateBuilder {
     required List<Dive> dives,
   }) {
     // Calculate summary stats
-    final totalBottomTime = dives
-        .where((d) => d.bottomTime != null)
-        .fold<Duration>(Duration.zero, (sum, d) => sum + d.bottomTime!);
+    final totalBottomTime = pdfTotalRuntime(dives);
     final maxDepth = dives
         .where((d) => d.maxDepth != null)
         .map((d) => d.maxDepth!)
@@ -319,7 +317,7 @@ class PdfTemplateNaui extends PdfTemplateBuilder {
                                 ),
                                 _buildNauiField(
                                   'Time',
-                                  '${dive.bottomTime?.inMinutes ?? '-'}min',
+                                  '${pdfDiveDurationMinutes(dive)}min',
                                 ),
                               ],
                             ),

--- a/lib/core/services/pdf_templates/pdf_template_naui.dart
+++ b/lib/core/services/pdf_templates/pdf_template_naui.dart
@@ -104,7 +104,7 @@ class PdfTemplateNaui extends PdfTemplateBuilder {
     required List<Dive> dives,
   }) {
     // Calculate summary stats
-    final totalBottomTime = pdfTotalRuntime(dives);
+    final totalRuntime = pdfTotalRuntime(dives);
     final maxDepth = dives
         .where((d) => d.maxDepth != null)
         .map((d) => d.maxDepth!)
@@ -160,7 +160,7 @@ class PdfTemplateNaui extends PdfTemplateBuilder {
               _buildStatBox('$diveCount', 'Dives'),
               pw.SizedBox(width: 20),
               _buildStatBox(
-                '${totalBottomTime.inHours}:${(totalBottomTime.inMinutes % 60).toString().padLeft(2, '0')}',
+                '${totalRuntime.inHours}:${(totalRuntime.inMinutes % 60).toString().padLeft(2, '0')}',
                 'Hours',
               ),
               pw.SizedBox(width: 20),

--- a/lib/core/services/pdf_templates/pdf_template_padi.dart
+++ b/lib/core/services/pdf_templates/pdf_template_padi.dart
@@ -306,7 +306,7 @@ class PdfTemplatePadi extends PdfTemplateBuilder {
                     ),
                     _buildPadiField(
                       'Time',
-                      '${dive.bottomTime?.inMinutes ?? '-'}min',
+                      '${pdfDiveDurationMinutes(dive)}min',
                     ),
                     _buildPadiField(
                       'Temp',

--- a/lib/core/services/pdf_templates/pdf_template_professional.dart
+++ b/lib/core/services/pdf_templates/pdf_template_professional.dart
@@ -389,8 +389,8 @@ class PdfTemplateProfessional extends PdfTemplateBuilder {
                     ),
                     _buildMetricRow(
                       'Duration',
-                      dive.bottomTime != null
-                          ? '${dive.bottomTime!.inMinutes} min'
+                      dive.effectiveRuntime != null
+                          ? '${dive.effectiveRuntime!.inMinutes} min'
                           : '-',
                     ),
                   ],

--- a/lib/core/services/pdf_templates/pdf_template_simple.dart
+++ b/lib/core/services/pdf_templates/pdf_template_simple.dart
@@ -156,8 +156,8 @@ class PdfTemplateSimple extends PdfTemplateBuilder {
                           cellStyle,
                         ),
                         _buildCell(
-                          dive.bottomTime != null
-                              ? '${dive.bottomTime!.inMinutes}min'
+                          dive.effectiveRuntime != null
+                              ? '${dive.effectiveRuntime!.inMinutes}min'
                               : '-',
                           cellStyle,
                         ),

--- a/lib/features/settings/presentation/providers/export_providers.dart
+++ b/lib/features/settings/presentation/providers/export_providers.dart
@@ -254,47 +254,7 @@ class ExportNotifier extends StateNotifier<ExportState> {
         return;
       }
 
-      // Load signatures for all dives
-      state = state.copyWith(message: 'Loading signatures...');
-      final signatureService = SignatureStorageService();
-      final diveSignatures = <String, List<Signature>>{};
-      for (final dive in dives) {
-        final sigs = await signatureService.getAllSignaturesForDive(dive.id);
-        if (sigs.isNotEmpty) {
-          diveSignatures[dive.id] = sigs;
-        }
-      }
-
-      // Load certifications if requested
-      List<Certification>? certifications;
-      if (exportOptions.includeCertificationCards) {
-        state = state.copyWith(message: 'Loading certifications...');
-        certifications = await _ref.read(allCertificationsProvider.future);
-      }
-
-      // Get current diver for personalization
-      final diver = await _ref.read(currentDiverProvider.future);
-
-      // Initialize fonts for proper Unicode support
-      state = state.copyWith(message: 'Loading fonts...');
-      await PdfFonts.instance.initialize();
-
-      // Get the appropriate template builder
-      state = state.copyWith(
-        message: 'Generating ${exportOptions.template.displayName} PDF...',
-      );
-      final factory = PdfTemplateFactory();
-      final builder = factory.getBuilder(exportOptions.template);
-
-      // Build the PDF
-      final pdfBytes = await builder.buildPdf(
-        dives: dives,
-        pageSize: exportOptions.pageSize,
-        title: 'Dive Logbook',
-        diveSignatures: diveSignatures.isNotEmpty ? diveSignatures : null,
-        certifications: certifications,
-        diver: diver,
-      );
+      final pdfBytes = await _buildLogbookPdfBytes(exportOptions, dives);
 
       // Save and share the PDF
       final path = await _exportService.sharePdfBytes(
@@ -313,6 +273,55 @@ class ExportNotifier extends StateNotifier<ExportState> {
         message: 'Export failed: $e',
       );
     }
+  }
+
+  /// Build logbook PDF bytes honoring [exportOptions] (template, page size,
+  /// certification cards, diver personalization). Shared by the share and
+  /// save-to-file paths so both respect the selected detail level (#644).
+  Future<List<int>> _buildLogbookPdfBytes(
+    PdfExportOptions exportOptions,
+    List<Dive> dives,
+  ) async {
+    // Load signatures for all dives
+    state = state.copyWith(message: 'Loading signatures...');
+    final signatureService = SignatureStorageService();
+    final diveSignatures = <String, List<Signature>>{};
+    for (final dive in dives) {
+      final sigs = await signatureService.getAllSignaturesForDive(dive.id);
+      if (sigs.isNotEmpty) {
+        diveSignatures[dive.id] = sigs;
+      }
+    }
+
+    // Load certifications if requested
+    List<Certification>? certifications;
+    if (exportOptions.includeCertificationCards) {
+      state = state.copyWith(message: 'Loading certifications...');
+      certifications = await _ref.read(allCertificationsProvider.future);
+    }
+
+    // Get current diver for personalization
+    final diver = await _ref.read(currentDiverProvider.future);
+
+    // Initialize fonts for proper Unicode support
+    state = state.copyWith(message: 'Loading fonts...');
+    await PdfFonts.instance.initialize();
+
+    // Get the appropriate template builder
+    state = state.copyWith(
+      message: 'Generating ${exportOptions.template.displayName} PDF...',
+    );
+    final factory = PdfTemplateFactory();
+    final builder = factory.getBuilder(exportOptions.template);
+
+    return builder.buildPdf(
+      dives: dives,
+      pageSize: exportOptions.pageSize,
+      title: 'Dive Logbook',
+      diveSignatures: diveSignatures.isNotEmpty ? diveSignatures : null,
+      certifications: certifications,
+      diver: diver,
+    );
   }
 
   Future<void> exportDivesToUddf() async {
@@ -957,11 +966,16 @@ class ExportNotifier extends StateNotifier<ExportState> {
         return;
       }
 
+      // Build with the SAME template-aware path as the share flow, so the
+      // selected detail level, page size, and diver personalization are
+      // honored (#644: options were previously dropped here and the legacy
+      // single-layout builder produced identical PDFs for every level).
+      final pdfBytes = await _buildLogbookPdfBytes(options, dives);
+
       state = state.copyWith(message: 'Choose save location...');
-      final path = await _exportService.saveDivesToPdfFile(
-        dives,
-        title: 'Dive Logbook',
-      );
+      final fileName =
+          'dive_logbook_${options.template.name}_${DateFormat('yyyy-MM-dd').format(DateTime.now())}.pdf';
+      final path = await _exportService.savePdfBytesToFile(pdfBytes, fileName);
 
       if (path == null) {
         state = state.copyWith(

--- a/test/core/services/export/pdf/pdf_course_export_service_test.dart
+++ b/test/core/services/export/pdf/pdf_course_export_service_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/services/export/pdf/pdf_course_export_service.dart';
+import 'package:submersion/features/courses/domain/entities/course.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+import '../../../../helpers/pdf_text.dart';
+import '../../../../helpers/test_database.dart';
+
+/// The course training log must report total *runtime*, not bottom time (#644).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory shareDir;
+  late PdfCourseExportService service;
+
+  setUpAll(() async {
+    shareDir = await Directory.systemTemp.createTemp('course_pdf_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => call.method == 'getApplicationDocumentsDirectory'
+              ? shareDir.path
+              : null,
+        );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('dev.fluttercommunity.plus/share'),
+          (call) async => null,
+        );
+  });
+
+  tearDownAll(() async {
+    if (await shareDir.exists()) await shareDir.delete(recursive: true);
+  });
+
+  setUp(() async {
+    await setUpTestDatabase();
+    service = PdfCourseExportService();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final course = Course(
+    id: 'course-1',
+    diverId: 'diver-1',
+    name: 'Advanced Open Water',
+    agency: CertificationAgency.padi,
+    startDate: DateTime(2026, 5, 27),
+    completionDate: DateTime(2026, 5, 29),
+    instructorName: 'Jane Instructor',
+    createdAt: DateTime(2026, 5, 27),
+    updatedAt: DateTime(2026, 5, 29),
+  );
+
+  Dive trainingDive({
+    required String id,
+    required int number,
+    Duration? runtime,
+    Duration? bottomTime,
+    double? maxDepth,
+  }) => Dive(
+    id: id,
+    diveNumber: number,
+    dateTime: DateTime(2026, 5, 27 + number, 9),
+    runtime: runtime,
+    bottomTime: bottomTime,
+    maxDepth: maxDepth,
+  );
+
+  /// Runs the export and returns the visible text of the generated PDF.
+  Future<String> exportText(List<Dive> dives) async {
+    final path = await service.exportCourseTrainingLogToPdf(course, dives);
+    final bytes = await File(path).readAsBytes();
+    expect(String.fromCharCodes(bytes.take(4)), '%PDF');
+    return pdfVisibleText(bytes);
+  }
+
+  test('Total Minutes sums runtime, not bottom time', () async {
+    final text = await exportText([
+      trainingDive(
+        id: 'd1',
+        number: 1,
+        runtime: const Duration(minutes: 62),
+        bottomTime: const Duration(minutes: 50),
+        maxDepth: 25.0,
+      ),
+      trainingDive(
+        id: 'd2',
+        number: 2,
+        bottomTime: const Duration(minutes: 40),
+        maxDepth: 18.0,
+      ),
+    ]);
+
+    expect(
+      text,
+      contains('102 Total Minutes'),
+      reason:
+          'runtime 62 + bottomTime fallback 40 = 102; bottom time alone '
+          'would understate the training log at 90 (#644)',
+    );
+    expect(text, contains('2 Training Dives'));
+    expect(text, contains('25.0m Max Depth'));
+  });
+
+  test('per-dive Duration chip prints runtime, not bottom time', () async {
+    final text = await exportText([
+      trainingDive(
+        id: 'd1',
+        number: 1,
+        runtime: const Duration(minutes: 62),
+        bottomTime: const Duration(minutes: 50),
+        maxDepth: 25.0,
+      ),
+    ]);
+
+    expect(text, contains('Duration 62 min'));
+    expect(text, isNot(contains('50 min')));
+  });
+
+  test('a runtime-only dive still gets a Duration chip', () async {
+    // Before #644 the chip was gated on bottomTime, so a dive logged with only
+    // a runtime rendered no duration at all.
+    final text = await exportText([
+      trainingDive(id: 'd1', number: 1, runtime: const Duration(minutes: 47)),
+    ]);
+
+    expect(text, contains('Duration 47 min'));
+    expect(text, contains('47 Total Minutes'));
+  });
+
+  test('a dive with no duration at all renders no Duration chip', () async {
+    final text = await exportText([
+      trainingDive(id: 'd1', number: 1, maxDepth: 12.0),
+    ]);
+
+    expect(text, isNot(contains('Duration')));
+    expect(text, contains('0 Total Minutes'));
+  });
+}

--- a/test/core/services/export/pdf/pdf_save_bytes_test.dart
+++ b/test/core/services/export/pdf/pdf_save_bytes_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/core/services/export/pdf/pdf_export_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+import '../../../../helpers/mock_file_picker_platform.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Records what the save dialog was asked for so tests can assert the file
+/// name reaching the picker, not just the value handed back.
+class _RecordingPicker extends MockFilePickerPlatform {
+  String? requestedFileName;
+  List<String>? requestedExtensions;
+  Uint8List? offeredBytes;
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) async {
+    requestedFileName = fileName;
+    requestedExtensions = allowedExtensions;
+    offeredBytes = bytes;
+    return saveFileResult;
+  }
+}
+
+/// [PdfExportService.savePdfBytesToFile] is the seam the template-aware save
+/// flow uses so the selected detail level survives to disk (#644).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _RecordingPicker picker;
+  late FilePickerPlatform originalPicker;
+  late Directory workDir;
+  late PdfExportService service;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    originalPicker = FilePickerPlatform.instance;
+    picker = _RecordingPicker();
+    FilePickerPlatform.instance = picker;
+    workDir = await Directory.systemTemp.createTemp('pdf_save_bytes_test_');
+    service = PdfExportService();
+  });
+
+  tearDown(() async {
+    FilePickerPlatform.instance = originalPicker;
+    if (await workDir.exists()) await workDir.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  final pdfBytes = <int>[...'%PDF-1.4'.codeUnits, 0x0A, 0x25, 0xE2, 0x0A];
+
+  test('writes the supplied bytes to the chosen path', () async {
+    final target = '${workDir.path}/dive_logbook_padiStyle_2026-01-15.pdf';
+    picker.saveFileResult = target;
+
+    final path = await service.savePdfBytesToFile(
+      pdfBytes,
+      'dive_logbook_padiStyle_2026-01-15.pdf',
+    );
+
+    expect(path, target);
+    expect(await File(target).readAsBytes(), pdfBytes);
+  });
+
+  test('offers the caller file name and a .pdf filter to the picker', () async {
+    picker.saveFileResult = '${workDir.path}/out.pdf';
+
+    await service.savePdfBytesToFile(
+      pdfBytes,
+      'dive_logbook_nauiStyle_2026-01-15.pdf',
+    );
+
+    expect(
+      picker.requestedFileName,
+      'dive_logbook_nauiStyle_2026-01-15.pdf',
+      reason: 'the template name must survive into the suggested file name',
+    );
+    expect(picker.requestedExtensions, ['pdf']);
+    expect(picker.offeredBytes, pdfBytes);
+  });
+
+  test('returns null and writes nothing when the user cancels', () async {
+    picker.saveFileResult = null;
+
+    expect(await service.savePdfBytesToFile(pdfBytes, 'cancelled.pdf'), isNull);
+    expect(workDir.listSync(), isEmpty);
+  });
+
+  test('saveDivesToPdfFile routes the generated logbook through it', () async {
+    final target = '${workDir.path}/logbook.pdf';
+    picker.saveFileResult = target;
+
+    final path = await service.saveDivesToPdfFile([
+      Dive(
+        id: 'd1',
+        diveNumber: 1,
+        dateTime: DateTime(2026, 1, 15, 9),
+        runtime: const Duration(minutes: 62),
+        maxDepth: 25.0,
+      ),
+    ]);
+
+    expect(path, target);
+    expect(picker.requestedFileName, startsWith('dive_logbook_'));
+    expect(picker.requestedFileName, endsWith('.pdf'));
+    final written = await File(target).readAsBytes();
+    expect(String.fromCharCodes(written.take(4)), '%PDF');
+  });
+
+  test(
+    'ExportService.savePdfBytesToFile delegates to the PDF service',
+    () async {
+      final target = '${workDir.path}/facade.pdf';
+      picker.saveFileResult = target;
+
+      final path = await ExportService().savePdfBytesToFile(
+        pdfBytes,
+        'facade.pdf',
+      );
+
+      expect(path, target);
+      expect(picker.requestedFileName, 'facade.pdf');
+      expect(await File(target).readAsBytes(), pdfBytes);
+    },
+  );
+}

--- a/test/core/services/export/pdf/pdf_trip_export_test.dart
+++ b/test/core/services/export/pdf/pdf_trip_export_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/pdf/pdf_export_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
+
+import '../../../../helpers/pdf_text.dart';
+
+/// The trip report's per-dive Duration line must print total runtime rather
+/// than bottom time, matching the rest of the PDF exports (#644).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory shareDir;
+  late PdfExportService service;
+
+  setUpAll(() async {
+    shareDir = await Directory.systemTemp.createTemp('trip_pdf_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => call.method == 'getApplicationDocumentsDirectory'
+              ? shareDir.path
+              : null,
+        );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('dev.fluttercommunity.plus/share'),
+          (call) async => null,
+        );
+  });
+
+  tearDownAll(() async {
+    if (await shareDir.exists()) await shareDir.delete(recursive: true);
+  });
+
+  setUp(() => service = PdfExportService());
+
+  final trip = Trip(
+    id: 'trip-1',
+    name: 'Red Sea 2026',
+    startDate: DateTime(2026, 5, 1),
+    endDate: DateTime(2026, 5, 8),
+    location: 'Hurghada',
+    createdAt: DateTime(2026, 4, 1),
+    updatedAt: DateTime(2026, 5, 9),
+  );
+
+  Future<String> exportText(List<Dive> dives) async {
+    final path = await service.exportTripToPdf(trip, dives);
+    final bytes = await File(path).readAsBytes();
+    expect(String.fromCharCodes(bytes.take(4)), '%PDF');
+    return pdfVisibleText(bytes);
+  }
+
+  test('per-dive Duration prints runtime, not bottom time', () async {
+    final text = await exportText([
+      Dive(
+        id: 'd1',
+        diveNumber: 1,
+        dateTime: DateTime(2026, 5, 2, 9),
+        runtime: const Duration(minutes: 62),
+        bottomTime: const Duration(minutes: 50),
+        maxDepth: 25.0,
+      ),
+    ]);
+
+    expect(text, contains('Duration: 62 min'));
+    expect(text, isNot(contains('50 min')));
+  });
+
+  test('a runtime-only dive still prints a Duration line', () async {
+    // The line used to be gated on bottomTime, so runtime-only dives showed
+    // no duration in the trip report at all.
+    final text = await exportText([
+      Dive(
+        id: 'd1',
+        diveNumber: 1,
+        dateTime: DateTime(2026, 5, 2, 9),
+        entryTime: DateTime(2026, 5, 2, 9),
+        exitTime: DateTime(2026, 5, 2, 9, 47),
+        maxDepth: 18.0,
+      ),
+    ]);
+
+    expect(text, contains('Duration: 47 min'));
+  });
+
+  test('a dive with no duration prints no Duration line', () async {
+    final text = await exportText([
+      Dive(
+        id: 'd1',
+        diveNumber: 1,
+        dateTime: DateTime(2026, 5, 2, 9),
+        maxDepth: 18.0,
+      ),
+    ]);
+
+    expect(text, isNot(contains('Duration:')));
+    expect(text, contains('Max Depth: 18.0 m'));
+  });
+}

--- a/test/core/services/pdf_templates/pdf_dive_duration_test.dart
+++ b/test/core/services/pdf_templates/pdf_dive_duration_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/pdf_templates/pdf_shared_components.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+void main() {
+  group('pdfDiveDuration (#644)', () {
+    Dive dive({Duration? runtime, Duration? bottomTime}) => Dive(
+      id: 'd1',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 1, 15, 9),
+      runtime: runtime,
+      bottomTime: bottomTime,
+    );
+
+    test('prints total runtime, not bottom time', () {
+      final d = dive(
+        runtime: const Duration(minutes: 62),
+        bottomTime: const Duration(minutes: 50),
+      );
+      expect(
+        pdfDiveDurationMinutes(d),
+        '62',
+        reason:
+            'the logbook Duration field must show the dive runtime; bottom '
+            'time understates it (#644)',
+      );
+    });
+
+    test('falls back to bottom time when nothing better exists', () {
+      expect(
+        pdfDiveDurationMinutes(dive(bottomTime: const Duration(minutes: 50))),
+        '50',
+      );
+    });
+
+    test('prints a dash when no duration is known', () {
+      expect(pdfDiveDurationMinutes(dive()), '-');
+    });
+  });
+
+  group('pdfTotalRuntime (#644)', () {
+    test('sums effective runtimes across dives', () {
+      final dives = [
+        Dive(
+          id: 'a',
+          diveNumber: 1,
+          dateTime: DateTime(2026, 1, 15),
+          runtime: const Duration(minutes: 62),
+          bottomTime: const Duration(minutes: 50),
+        ),
+        Dive(
+          id: 'b',
+          diveNumber: 2,
+          dateTime: DateTime(2026, 1, 16),
+          bottomTime: const Duration(minutes: 40),
+        ),
+      ];
+      expect(
+        pdfTotalRuntime(dives),
+        const Duration(minutes: 102),
+        reason: 'runtime (62) + bottomTime fallback (40), not 50 + 40',
+      );
+    });
+  });
+}

--- a/test/features/settings/presentation/providers/export_pdf_logbook_test.dart
+++ b/test/features/settings/presentation/providers/export_pdf_logbook_test.dart
@@ -1,0 +1,361 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/pdf_templates.dart';
+import 'package:submersion/features/certifications/domain/entities/certification.dart';
+import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:submersion/core/database/database.dart'
+    show AppDatabase, DivesCompanion, MediaCompanion;
+
+import '../../../../helpers/mock_file_picker_platform.dart';
+import '../../../../helpers/pdf_text.dart';
+import '../../../../helpers/test_database.dart';
+
+/// A valid 1x1 transparent PNG, so the PDF image decoder has real bytes.
+final _onePixelPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGA'
+  'hKmMIQAAAABJRU5ErkJggg==',
+);
+
+/// Writes an instructor-signature media row the way a signed dive carries one.
+///
+/// Inserted directly rather than through `SignatureStorageService.saveSignature`
+/// because that method omits the non-nullable `media.filePath` column and
+/// throws before it ever reaches the database.
+Future<void> _storeSignature(
+  AppDatabase db, {
+  required String diveId,
+  required String signerName,
+}) async {
+  final now = DateTime(2026, 1, 20).millisecondsSinceEpoch;
+  // media.diveId is a foreign key, so the dive row has to exist first.
+  await db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(diveId),
+          diveDateTime: Value(now),
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+  await db
+      .into(db.media)
+      .insert(
+        MediaCompanion(
+          id: Value('sig-$diveId'),
+          diveId: Value(diveId),
+          filePath: const Value(''),
+          fileType: const Value('instructor_signature'),
+          imageData: Value(_onePixelPng),
+          signerName: Value(signerName),
+          takenAt: Value(now),
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+}
+
+/// Records the name the save dialog was offered so tests can prove the
+/// selected template reaches the suggested file name.
+class _RecordingPicker extends MockFilePickerPlatform {
+  String? requestedFileName;
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) async {
+    requestedFileName = fileName;
+    return saveFileResult;
+  }
+}
+
+/// Both PDF logbook paths - share and save-to-file - must run through the same
+/// template-aware builder, so the chosen detail level, page size, certification
+/// cards and diver personalization survive (#644).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory workDir;
+  late _RecordingPicker picker;
+  late FilePickerPlatform originalPicker;
+  late AppDatabase db;
+
+  setUpAll(() async {
+    workDir = await Directory.systemTemp.createTemp('export_pdf_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => call.method == 'getApplicationDocumentsDirectory'
+              ? workDir.path
+              : null,
+        );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('dev.fluttercommunity.plus/share'),
+          (call) async => null,
+        );
+  });
+
+  tearDownAll(() async {
+    if (await workDir.exists()) await workDir.delete(recursive: true);
+  });
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    originalPicker = FilePickerPlatform.instance;
+    picker = _RecordingPicker();
+    FilePickerPlatform.instance = picker;
+  });
+
+  tearDown(() async {
+    FilePickerPlatform.instance = originalPicker;
+    await tearDownTestDatabase();
+  });
+
+  final diver = Diver(
+    id: 'diver-1',
+    name: 'Nauticus Testerson',
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  final certifications = [
+    Certification(
+      id: 'cert-1',
+      diverId: 'diver-1',
+      name: 'Rescue Diver',
+      agency: CertificationAgency.padi,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    ),
+  ];
+
+  final dives = [
+    Dive(
+      id: 'd1',
+      diveNumber: 2,
+      dateTime: DateTime(2026, 1, 16, 9),
+      runtime: const Duration(minutes: 62),
+      bottomTime: const Duration(minutes: 50),
+      maxDepth: 25.0,
+      avgDepth: 18.0,
+      waterTemp: 22.0,
+    ),
+    Dive(
+      id: 'd2',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 1, 15, 9),
+      bottomTime: const Duration(minutes: 40),
+      maxDepth: 18.0,
+      avgDepth: 12.0,
+      waterTemp: 24.0,
+    ),
+  ];
+
+  ProviderContainer makeContainer({List<Dive>? divesOverride}) {
+    final container = ProviderContainer(
+      overrides: [
+        divesProvider.overrideWith((ref) async => divesOverride ?? dives),
+        currentDiverProvider.overrideWith((ref) async => diver),
+        allCertificationsProvider.overrideWith((ref) async => certifications),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  ExportNotifier notifierOf(ProviderContainer c) =>
+      c.read(exportNotifierProvider.notifier);
+
+  Future<String> textAt(String path) async =>
+      pdfVisibleText(await File(path).readAsBytes());
+
+  group('exportDivesToPdf (share)', () {
+    test(
+      'honors the selected template and personalizes with the diver',
+      () async {
+        final container = makeContainer();
+        await notifierOf(container).exportDivesToPdf(
+          const PdfExportOptions(template: PdfTemplate.detailed),
+        );
+
+        final state = container.read(exportNotifierProvider);
+        expect(state.status, ExportStatus.success);
+        expect(state.filePath, isNotNull);
+        expect(
+          state.filePath,
+          contains('dive_logbook_detailed_'),
+          reason: 'the shared file name must carry the chosen template',
+        );
+
+        final text = await textAt(state.filePath!);
+        expect(text, contains('Nauticus Testerson'));
+        expect(text, contains('Summary'));
+        expect(
+          text,
+          contains('Total Dive Time 1h 42m'),
+          reason: 'runtime 62 + bottomTime fallback 40 = 102 minutes (#644)',
+        );
+      },
+    );
+
+    test(
+      'the simple template produces a different, table-only layout',
+      () async {
+        final container = makeContainer();
+        await notifierOf(container).exportDivesToPdf(
+          const PdfExportOptions(template: PdfTemplate.simple),
+        );
+
+        final state = container.read(exportNotifierProvider);
+        expect(state.status, ExportStatus.success);
+        expect(state.filePath, contains('dive_logbook_simple_'));
+
+        final text = await textAt(state.filePath!);
+        expect(text, contains('Nauticus Testerson'));
+        expect(text, contains('2 dives'));
+        expect(
+          text,
+          isNot(contains('Summary')),
+          reason: 'the simple template is a compact table with no summary page',
+        );
+      },
+    );
+
+    test('includeCertificationCards adds the certifications page', () async {
+      final container = makeContainer();
+      await notifierOf(container).exportDivesToPdf(
+        const PdfExportOptions(includeCertificationCards: true),
+      );
+
+      final withCards = await textAt(
+        container.read(exportNotifierProvider).filePath!,
+      );
+      expect(withCards, contains('Certifications'));
+      expect(withCards, contains('Rescue Diver'));
+
+      final plain = makeContainer();
+      await notifierOf(plain).exportDivesToPdf(const PdfExportOptions());
+      final withoutCards = await textAt(
+        plain.read(exportNotifierProvider).filePath!,
+      );
+      expect(withoutCards, isNot(contains('Rescue Diver')));
+    });
+
+    test('carries a captured signature into the logbook', () async {
+      await _storeSignature(db, diveId: 'd1', signerName: 'Ida Instructor');
+
+      final container = makeContainer();
+      await notifierOf(container).exportDivesToPdf(
+        const PdfExportOptions(template: PdfTemplate.detailed),
+      );
+
+      final text = await textAt(
+        container.read(exportNotifierProvider).filePath!,
+      );
+      expect(
+        text,
+        contains('Ida Instructor'),
+        reason: 'signatures stored for a dive must reach the exported PDF',
+      );
+    });
+
+    test('reports an error when there is nothing to export', () async {
+      final container = makeContainer(divesOverride: const []);
+      await notifierOf(container).exportDivesToPdf();
+
+      final state = container.read(exportNotifierProvider);
+      expect(state.status, ExportStatus.error);
+      expect(state.message, 'No dives to export');
+    });
+  });
+
+  group('savePdfToFile', () {
+    test('saves the template the user picked, not the legacy layout', () async {
+      final target = '${workDir.path}/saved_simple.pdf';
+      picker.saveFileResult = target;
+
+      final container = makeContainer();
+      await notifierOf(
+        container,
+      ).savePdfToFile(const PdfExportOptions(template: PdfTemplate.simple));
+
+      final state = container.read(exportNotifierProvider);
+      expect(state.status, ExportStatus.success);
+      expect(state.filePath, target);
+      expect(
+        picker.requestedFileName,
+        startsWith('dive_logbook_simple_'),
+        reason: 'the suggested save name must carry the chosen template',
+      );
+
+      final text = await textAt(target);
+      expect(text, contains('Nauticus Testerson'));
+      expect(text, contains('2 dives'));
+      expect(
+        text,
+        isNot(contains('Summary')),
+        reason:
+            'the legacy single-layout builder always emitted a summary page; '
+            'saving must use the selected simple template instead (#644)',
+      );
+    });
+
+    test('the detailed template saves a different document', () async {
+      final target = '${workDir.path}/saved_detailed.pdf';
+      picker.saveFileResult = target;
+
+      final container = makeContainer();
+      await notifierOf(
+        container,
+      ).savePdfToFile(const PdfExportOptions(template: PdfTemplate.detailed));
+
+      expect(picker.requestedFileName, startsWith('dive_logbook_detailed_'));
+      final text = await textAt(target);
+      expect(text, contains('Summary'));
+      expect(text, contains('Total Dive Time 1h 42m'));
+    });
+
+    test(
+      'goes idle with a cancel message when the picker is dismissed',
+      () async {
+        picker.saveFileResult = null;
+
+        final container = makeContainer();
+        await notifierOf(container).savePdfToFile(const PdfExportOptions());
+
+        final state = container.read(exportNotifierProvider);
+        expect(state.status, ExportStatus.idle);
+        expect(state.message, 'Save cancelled');
+      },
+    );
+
+    test('reports an error when there is nothing to save', () async {
+      final container = makeContainer(divesOverride: const []);
+      await notifierOf(container).savePdfToFile(const PdfExportOptions());
+
+      final state = container.read(exportNotifierProvider);
+      expect(state.status, ExportStatus.error);
+      expect(state.message, 'No dives to export');
+    });
+  });
+}

--- a/test/helpers/pdf_text.dart
+++ b/test/helpers/pdf_text.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Extracts the visible text of a generated PDF so tests can assert on what a
+/// diver actually reads, not just on "some bytes came back".
+///
+/// The `pdf` package writes each page's content stream Flate-compressed, with
+/// one text-showing operator per word:
+///
+/// ```
+/// BT /F9 14 Tf 0 Tc 0 3.388 Td [(Total)]TJ ET
+/// ```
+///
+/// [pdfVisibleText] inflates every stream object, pulls the literal strings out
+/// of the `[...]TJ` operators in document order, and joins them with single
+/// spaces. Word-level tokens mean a phrase such as `Total Dive Time` reassembles
+/// exactly, while glyph positioning is ignored.
+String pdfVisibleText(List<int> bytes) => pdfTextTokens(bytes).join(' ');
+
+/// The individual text tokens of [bytes], in document order.
+List<String> pdfTextTokens(List<int> bytes) {
+  final tokens = <String>[];
+  for (final stream in _streamPayloads(bytes)) {
+    for (final match in _showTextArray.allMatches(stream)) {
+      for (final literal in _literal.allMatches(match.group(1)!)) {
+        final text = _unescape(literal.group(1)!);
+        if (text.isNotEmpty) tokens.add(text);
+      }
+    }
+  }
+  return tokens;
+}
+
+/// `[(word)]TJ` / `[(a) -20 (b)] TJ` text-showing operators.
+final _showTextArray = RegExp(r'\[(.*?)\]\s*TJ', dotAll: true);
+
+/// A PDF literal string, honoring backslash escapes.
+final _literal = RegExp(r'\(((?:[^()\\]|\\.)*)\)');
+
+String _unescape(String raw) =>
+    raw.replaceAll(r'\(', '(').replaceAll(r'\)', ')').replaceAll(r'\\', r'\');
+
+/// Inflates every `stream ... endstream` object, skipping the ones that are not
+/// zlib-compressed (images, embedded fonts) rather than failing on them.
+Iterable<String> _streamPayloads(List<int> bytes) sync* {
+  const begin = [0x73, 0x74, 0x72, 0x65, 0x61, 0x6D]; // 'stream'
+  const end = [
+    0x65, 0x6E, 0x64, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6D, // 'endstream'
+  ];
+
+  var cursor = 0;
+  while (true) {
+    final open = _indexOf(bytes, begin, cursor);
+    if (open < 0) return;
+    var start = open + begin.length;
+    if (start < bytes.length && bytes[start] == 0x0D) start++;
+    if (start < bytes.length && bytes[start] == 0x0A) start++;
+    final close = _indexOf(bytes, end, start);
+    if (close < 0) return;
+    cursor = close + end.length;
+
+    try {
+      yield latin1.decode(zlib.decode(bytes.sublist(start, close)));
+    } catch (_) {
+      // Not a zlib payload (raw image data, an embedded font); nothing to read.
+      continue;
+    }
+  }
+}
+
+int _indexOf(List<int> haystack, List<int> needle, int from) {
+  outer:
+  for (var i = from; i <= haystack.length - needle.length; i++) {
+    for (var j = 0; j < needle.length; j++) {
+      if (haystack[i + j] != needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}


### PR DESCRIPTION
## Summary

Two defects in the PDF logbook export, matching the two complaints in #644:

1. **Every detail level produced the same PDF (when saving to a file).** The share flow correctly dispatched to the selected template builder, but `savePdfToFile` ignored its `PdfExportOptions` entirely and called the legacy single-layout generator — so Basic/Detailed/Professional all produced identical files. Both paths now share one template-aware byte builder (`_buildLogbookPdfBytes`), with a new `savePdfBytesToFile` on the export service/facade; ignoring the options is no longer structurally possible.

2. **Duration printed bottom time, not runtime.** Every PDF surface (all five templates, the legacy layout, and the summary totals) printed `dive.bottomTime`, understating dive duration. All nine sites now use `Dive.effectiveRuntime` (runtime → exit−entry → profile → bottomTime) via shared `pdfDiveDurationMinutes`/`pdfTotalRuntime` helpers.

## Tests

New unit tests for the helpers (runtime 62 min / bottom 50 min must print 62; totals sum effective runtimes) — these encode the defect and fail against the old bottomTime code. Existing PDF template and export-service tests pass.

Full suite green.

Fixes #644