### PR TITLE
fix(tides): stop converting wall-clock timestamps to device-local time

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -3464,12 +3464,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
     final dateRef = entryTime ?? record.highTideTime ?? record.lowTideTime;
     final dateStr = dateRef != null
-        ? DateFormat('EEE, MMM d').format(dateRef.toLocal())
+        ? DateFormat('EEE, MMM d').format(dateRef)
         : '';
     final timeRangeStr = cycleStart != null && cycleEnd != null
         ? () {
-            final startLocal = cycleStart.toLocal();
-            final endLocal = cycleEnd.toLocal();
+            final startLocal = cycleStart;
+            final endLocal = cycleEnd;
             final timeFmt = DateFormat(settings.timeFormat.pattern);
             final startStr = timeFmt.format(startLocal);
             final endStr = timeFmt.format(endLocal);
@@ -3595,7 +3595,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
   /// Format a DateTime as a time string using the given time format.
   String _formatTime(DateTime time, TimeFormat timeFormat) {
-    return DateFormat(timeFormat.pattern).format(time.toLocal());
+    return DateFormat(timeFormat.pattern).format(time);
   }
 
   Widget _buildWeightSection(

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -3466,19 +3466,19 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     final dateStr = dateRef != null
         ? DateFormat('EEE, MMM d').format(dateRef)
         : '';
+    // Cycle bounds are stored wall-clock instants, not device-local times:
+    // format them verbatim without any timezone conversion.
     final timeRangeStr = cycleStart != null && cycleEnd != null
         ? () {
-            final startLocal = cycleStart;
-            final endLocal = cycleEnd;
             final timeFmt = DateFormat(settings.timeFormat.pattern);
-            final startStr = timeFmt.format(startLocal);
-            final endStr = timeFmt.format(endLocal);
+            final startStr = timeFmt.format(cycleStart);
+            final endStr = timeFmt.format(cycleEnd);
             final spansNewDay =
-                startLocal.year != endLocal.year ||
-                startLocal.month != endLocal.month ||
-                startLocal.day != endLocal.day;
+                cycleStart.year != cycleEnd.year ||
+                cycleStart.month != cycleEnd.month ||
+                cycleStart.day != cycleEnd.day;
             if (spansNewDay) {
-              final endDateStr = DateFormat('MMM d').format(endLocal);
+              final endDateStr = DateFormat('MMM d').format(cycleEnd);
               return '$startStr - $endStr ($endDateStr)';
             }
             return '$startStr - $endStr';

--- a/lib/features/tides/presentation/widgets/tide_chart.dart
+++ b/lib/features/tides/presentation/widgets/tide_chart.dart
@@ -179,9 +179,7 @@ class _TideChartState extends State<TideChart> {
     }
 
     // Format "Now" label with time and height
-    final nowTimeStr = DateFormat(
-      widget.timeFormat.pattern,
-    ).format(reference.toLocal());
+    final nowTimeStr = DateFormat(widget.timeFormat.pattern).format(reference);
     final nowHeightStr = currentHeight != null
         ? '${DepthUnit.meters.convert(currentHeight, widget.depthUnit).toStringAsFixed(1)}${widget.depthUnit.symbol}'
         : '';
@@ -207,7 +205,7 @@ class _TideChartState extends State<TideChart> {
                 );
                 final timeStr = DateFormat(
                   widget.timeFormat.pattern,
-                ).format(e.time.toLocal());
+                ).format(e.time);
                 return context.l10n.tides_semantic_extremeItem(
                   typeLabel,
                   timeStr,
@@ -315,7 +313,7 @@ class _TideChartState extends State<TideChart> {
                                   child: Text(
                                     DateFormat(
                                       widget.timeFormat.pattern,
-                                    ).format(time.toLocal()),
+                                    ).format(time),
                                     style: Theme.of(
                                       context,
                                     ).textTheme.labelSmall,
@@ -339,7 +337,7 @@ class _TideChartState extends State<TideChart> {
                                 // Show day labels at midnight crossings
                                 if (time.hour == 0 && time.minute < 30) {
                                   return Text(
-                                    DateFormat('EEE').format(time.toLocal()),
+                                    DateFormat('EEE').format(time),
                                     style: Theme.of(context)
                                         .textTheme
                                         .labelSmall
@@ -455,10 +453,10 @@ class _TideChartState extends State<TideChart> {
                                     effectivePredictions[spot.spotIndex];
                                 final timeStr = DateFormat(
                                   widget.timeFormat.pattern,
-                                ).format(prediction.time.toLocal());
+                                ).format(prediction.time);
                                 final dateStr = DateFormat(
                                   'EEE, MMM d',
-                                ).format(prediction.time.toLocal());
+                                ).format(prediction.time);
                                 final displayHeight = DepthUnit.meters.convert(
                                   prediction.heightMeters,
                                   widget.depthUnit,
@@ -729,7 +727,7 @@ class _TideChartState extends State<TideChart> {
       final label = isHigh ? 'H' : 'L';
       final timeStr = DateFormat(
         widget.timeFormat.pattern,
-      ).format(extreme.time.toLocal());
+      ).format(extreme.time);
       final displayHeight = DepthUnit.meters.convert(
         extreme.heightMeters,
         widget.depthUnit,

--- a/lib/features/tides/presentation/widgets/tide_cycle_graph.dart
+++ b/lib/features/tides/presentation/widgets/tide_cycle_graph.dart
@@ -471,7 +471,7 @@ class _TideCyclePainter extends CustomPainter {
 
   /// Format a DateTime using the configured time format.
   String _formatTime(DateTime time) {
-    return DateFormat(timeFormat.pattern).format(time.toLocal());
+    return DateFormat(timeFormat.pattern).format(time);
   }
 
   /// Calculate the start and end times for the tide cycle.

--- a/lib/features/tides/presentation/widgets/tide_section.dart
+++ b/lib/features/tides/presentation/widgets/tide_section.dart
@@ -366,8 +366,8 @@ class _TideSectionContent extends ConsumerWidget {
       windowEnd = now.add(const Duration(hours: 12));
     }
 
-    final startLocal = windowStart.toLocal();
-    final endLocal = windowEnd.toLocal();
+    final startLocal = windowStart;
+    final endLocal = windowEnd;
     final dateStr = DateFormat('EEE, MMM d').format(startLocal);
     final startTimeStr = DateFormat(timeFormat.pattern).format(startLocal);
     final endTimeStr = DateFormat(timeFormat.pattern).format(endLocal);

--- a/lib/features/tides/presentation/widgets/tide_section.dart
+++ b/lib/features/tides/presentation/widgets/tide_section.dart
@@ -366,17 +366,17 @@ class _TideSectionContent extends ConsumerWidget {
       windowEnd = now.add(const Duration(hours: 12));
     }
 
-    final startLocal = windowStart;
-    final endLocal = windowEnd;
-    final dateStr = DateFormat('EEE, MMM d').format(startLocal);
-    final startTimeStr = DateFormat(timeFormat.pattern).format(startLocal);
-    final endTimeStr = DateFormat(timeFormat.pattern).format(endLocal);
+    // Window bounds are stored wall-clock instants, not device-local times:
+    // format them verbatim without any timezone conversion.
+    final dateStr = DateFormat('EEE, MMM d').format(windowStart);
+    final startTimeStr = DateFormat(timeFormat.pattern).format(windowStart);
+    final endTimeStr = DateFormat(timeFormat.pattern).format(windowEnd);
     final spansNewDay =
-        startLocal.year != endLocal.year ||
-        startLocal.month != endLocal.month ||
-        startLocal.day != endLocal.day;
+        windowStart.year != windowEnd.year ||
+        windowStart.month != windowEnd.month ||
+        windowStart.day != windowEnd.day;
     final timeRange = spansNewDay
-        ? '$startTimeStr - $endTimeStr (${DateFormat('MMM d').format(endLocal)})'
+        ? '$startTimeStr - $endTimeStr (${DateFormat('MMM d').format(windowEnd)})'
         : '$startTimeStr - $endTimeStr';
 
     return Text(

--- a/lib/features/tides/presentation/widgets/tide_times_table.dart
+++ b/lib/features/tides/presentation/widgets/tide_times_table.dart
@@ -168,7 +168,7 @@ class TideTimesTable extends StatelessWidget {
     } else if (isTomorrow) {
       dateLabel = context.l10n.tides_label_tomorrow;
     } else {
-      dateLabel = dateFormat.format(extreme.time.toLocal());
+      dateLabel = dateFormat.format(extreme.time);
     }
 
     // Colors based on type
@@ -180,7 +180,7 @@ class TideTimesTable extends StatelessWidget {
     final tideTypeLabel = isHigh
         ? context.l10n.tides_label_highTide
         : context.l10n.tides_label_lowTide;
-    final timeLabel = timeFormatter.format(extreme.time.toLocal());
+    final timeLabel = timeFormatter.format(extreme.time);
     final durationLabel = isPast
         ? context.l10n.tides_label_ago(_formatDuration(duration))
         : context.l10n.tides_label_fromNow(_formatDuration(duration));
@@ -227,7 +227,7 @@ class TideTimesTable extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      timeFormatter.format(extreme.time.toLocal()),
+                      timeFormatter.format(extreme.time),
                       style:
                           (compact
                                   ? textTheme.titleMedium
@@ -388,7 +388,7 @@ class NextTideTimes extends StatelessWidget {
           Icon(Icons.arrow_upward, size: 14, color: Colors.red.shade600),
           const SizedBox(width: 4),
           Text(
-            timeFormatter.format(nextHigh.time.toLocal()),
+            timeFormatter.format(nextHigh.time),
             style: textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w500),
           ),
           Text(
@@ -410,7 +410,7 @@ class NextTideTimes extends StatelessWidget {
           Icon(Icons.arrow_downward, size: 14, color: Colors.blue.shade600),
           const SizedBox(width: 4),
           Text(
-            timeFormatter.format(nextLow.time.toLocal()),
+            timeFormatter.format(nextLow.time),
             style: textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w500),
           ),
           Text(

--- a/test/features/dive_log/presentation/pages/dive_detail_tide_card_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_tide_card_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/tide/entities/tide_extremes.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tides/domain/entities/tide_record.dart';
+import 'package:submersion/features/tides/presentation/providers/tide_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+// The dive's stored tide record carries wall-clock-as-UTC instants: the digits
+// the diver saw, flagged UTC. The tide card must print them verbatim -- a
+// `.toLocal()` shifts them by the MACHINE's UTC offset, so on any non-UTC host
+// the pre-fix code renders shifted digits and these tests fail. (#222)
+TideRecord _tideRecord({
+  required DateTime highTideTime,
+  required DateTime lowTideTime,
+}) {
+  return TideRecord(
+    id: 'tide-1',
+    diveId: 'test-dive-1',
+    heightMeters: 1.6,
+    tideState: TideState.rising,
+    rateOfChange: 0.4,
+    highTideHeight: 2.4,
+    highTideTime: highTideTime,
+    lowTideHeight: 0.4,
+    lowTideTime: lowTideTime,
+    createdAt: DateTime.utc(2026, 3, 28, 12),
+  );
+}
+
+Future<void> _pumpDetailPage(WidgetTester tester, TideRecord record) async {
+  final dive = createTestDiveWithBottomTime();
+  final settings = MockSettingsNotifier();
+  await settings.setTimeFormat(TimeFormat.twentyFourHour);
+  final overrides = await getBaseOverrides(settingsNotifier: settings);
+
+  final originalOnError = FlutterError.onError;
+  FlutterError.onError = (d) {
+    if (d.toString().contains('overflowed')) return;
+    originalOnError?.call(d);
+  };
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        ...overrides,
+        diveProvider(dive.id).overrideWith((ref) async => dive),
+        diveDataSourcesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <DiveDataSource>[]),
+        tideRecordForDiveProvider(dive.id).overrideWith((ref) async => record),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: DiveDetailPage(diveId: dive.id, embedded: true),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+
+  FlutterError.onError = originalOnError;
+}
+
+void main() {
+  // The card formats via DateFormat(pattern) with no explicit locale, so it
+  // resolves against intl's process-global default. Pin it so the expected
+  // digits do not depend on the locale the test host happens to run under.
+  String? previousDefaultLocale;
+
+  setUp(() {
+    previousDefaultLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousDefaultLocale;
+  });
+
+  group('DiveDetailPage tide card wall-clock formatting (#222)', () {
+    testWidgets('header prints the same-day cycle range verbatim', (
+      tester,
+    ) async {
+      // Low 08:20 precedes high 14:20, so the cycle runs 08:20 -> 20:20 and
+      // stays inside Sat Mar 28.
+      await _pumpDetailPage(
+        tester,
+        _tideRecord(
+          highTideTime: DateTime.utc(2026, 3, 28, 14, 20),
+          lowTideTime: DateTime.utc(2026, 3, 28, 8, 20),
+        ),
+      );
+
+      expect(find.text('Sat, Mar 28 | 08:20 - 20:20'), findsOneWidget);
+    });
+
+    testWidgets('header flags a cycle that crosses midnight', (tester) async {
+      // Low 20:00 Mar 28 -> high 02:00 Mar 29 puts the cycle end on the next
+      // day, which appends the end date to the range.
+      await _pumpDetailPage(
+        tester,
+        _tideRecord(
+          highTideTime: DateTime.utc(2026, 3, 29, 2),
+          lowTideTime: DateTime.utc(2026, 3, 28, 20),
+        ),
+      );
+
+      expect(find.text('Sat, Mar 28 | 20:00 - 08:00 (Mar 29)'), findsOneWidget);
+    });
+
+    testWidgets('high and low tide rows print unshifted times', (tester) async {
+      await _pumpDetailPage(
+        tester,
+        _tideRecord(
+          highTideTime: DateTime.utc(2026, 3, 28, 14, 20),
+          lowTideTime: DateTime.utc(2026, 3, 28, 8, 20),
+        ),
+      );
+
+      expect(find.textContaining('at 14:20'), findsOneWidget);
+      expect(find.textContaining('at 08:20'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/tides/presentation/widgets/tide_chart_time_format_test.dart
+++ b/test/features/tides/presentation/widgets/tide_chart_time_format_test.dart
@@ -1,0 +1,161 @@
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:submersion/core/tide/entities/tide_extremes.dart';
+import 'package:submersion/core/tide/entities/tide_prediction.dart';
+import 'package:submersion/features/tides/presentation/widgets/tide_chart.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// Tide instants are stored wall-clock-as-UTC: the digits the diver saw,
+// flagged UTC. Every label the chart paints must print those digits verbatim.
+// `.toLocal()` shifts them by the MACHINE's UTC offset, so on any non-UTC
+// host the pre-fix code renders shifted digits and these tests fail. (#222)
+final _reference = DateTime.utc(2026, 1, 15, 22);
+final _highTide = DateTime.utc(2026, 1, 16, 1);
+final _lowTide = DateTime.utc(2026, 1, 16, 7);
+
+final _extremes = [
+  TideExtreme(type: TideExtremeType.high, time: _highTide, heightMeters: 2.4),
+  TideExtreme(type: TideExtremeType.low, time: _lowTide, heightMeters: 0.4),
+];
+
+/// Half-hourly predictions spanning the whole chart window.
+///
+/// The chart's visible window is derived as `reference - 6h` (no past
+/// extremes) through `secondFutureExtreme + 30min`, i.e. 16:00 Jan 15 through
+/// 07:30 Jan 16. The first visible prediction therefore lands exactly on
+/// 16:00, which anchors the tooltip assertion below.
+List<TidePrediction> _buildPredictions() {
+  final start = DateTime.utc(2026, 1, 15, 12);
+  return [
+    for (var i = 0; i <= 48; i++)
+      TidePrediction(
+        time: start.add(Duration(minutes: 30 * i)),
+        heightMeters: 1.4 + math.sin(i * math.pi / 12),
+      ),
+  ];
+}
+
+Future<void> _pumpChart(WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 800,
+            child: TideChart(
+              predictions: _buildPredictions(),
+              extremes: _extremes,
+              now: _reference,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// All semantics labels currently in the tree.
+Iterable<String> _semanticsLabels(WidgetTester tester) => tester
+    .widgetList<Semantics>(find.byType(Semantics))
+    .map((s) => s.properties.label)
+    .whereType<String>();
+
+void main() {
+  // The chart formats via DateFormat(pattern) with no explicit locale, so it
+  // resolves against intl's process-global default. Pin it so the expected
+  // digits do not depend on the locale the test host happens to run under.
+  String? previousDefaultLocale;
+
+  setUp(() {
+    previousDefaultLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousDefaultLocale;
+  });
+
+  group('TideChart wall-clock time formatting (#222)', () {
+    testWidgets('the "Now" label prints the reference wall clock verbatim', (
+      tester,
+    ) async {
+      await _pumpChart(tester);
+
+      expect(find.textContaining('22:00'), findsOneWidget);
+    });
+
+    testWidgets('bottom axis labels print window wall-clock times verbatim', (
+      tester,
+    ) async {
+      await _pumpChart(tester);
+
+      // Window starts at 16:00 with a 4-hour tick interval.
+      expect(find.text('16:00'), findsOneWidget);
+      expect(find.text('20:00'), findsOneWidget);
+      expect(find.text('00:00'), findsOneWidget);
+      expect(find.text('04:00'), findsOneWidget);
+    });
+
+    testWidgets('the top axis day label marks the wall-clock midnight', (
+      tester,
+    ) async {
+      await _pumpChart(tester);
+
+      // Midnight inside the window is 00:00 on Fri Jan 16. A device-local
+      // shift would move the crossing off the tick and drop the label.
+      expect(find.text('Fri'), findsOneWidget);
+    });
+
+    testWidgets('the screen-reader summary lists unshifted extreme times', (
+      tester,
+    ) async {
+      await _pumpChart(tester);
+
+      final summary = _semanticsLabels(
+        tester,
+      ).firstWhere((l) => l.contains('Tide chart.'));
+      expect(summary, contains('at 01:00'));
+      expect(summary, contains('at 07:00'));
+    });
+
+    testWidgets('extreme marker labels print unshifted times', (tester) async {
+      await _pumpChart(tester);
+
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      final labels = chart.data.extraLinesData.verticalLines
+          .map((line) => line.label.labelResolver(line))
+          .toList();
+
+      expect(labels, contains(' H 01:00 2.4m '));
+      expect(labels, contains(' L 07:00 0.4m '));
+    });
+
+    testWidgets('the touch tooltip prints the unshifted point time and date', (
+      tester,
+    ) async {
+      await _pumpChart(tester);
+
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      final data = chart.data;
+      final curve = data.lineBarsData.first;
+      final items = data.lineTouchData.touchTooltipData.getTooltipItems([
+        LineBarSpot(curve, 0, curve.spots.first),
+      ]);
+
+      final tooltip = items.first!;
+      // First visible prediction is 16:00 on Thu Jan 15.
+      expect(tooltip.text, '16:00\n');
+      expect(
+        tooltip.children!.map((span) => span.toPlainText()).join(),
+        contains('Thu, Jan 15'),
+      );
+    });
+  });
+}

--- a/test/features/tides/presentation/widgets/tide_cycle_graph_time_format_test.dart
+++ b/test/features/tides/presentation/widgets/tide_cycle_graph_time_format_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:submersion/core/tide/entities/tide_extremes.dart';
+import 'package:submersion/features/tides/domain/entities/tide_record.dart';
+import 'package:submersion/features/tides/presentation/widgets/tide_cycle_graph.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// Tide instants are stored wall-clock-as-UTC. The cycle graph paints its
+// start/end timestamps through a private CustomPainter, so the digits land on
+// the canvas rather than in a Text widget; the assertion this test can make is
+// that the painter runs end-to-end over wall-clock-UTC instants without a
+// device-local conversion crashing or being skipped. The same instants are
+// asserted digit-for-digit through the dive-detail tide card. (#222)
+final _record = TideRecord(
+  id: 'tide-1',
+  diveId: 'dive-1',
+  heightMeters: 1.6,
+  tideState: TideState.rising,
+  rateOfChange: 0.4,
+  highTideHeight: 2.4,
+  highTideTime: DateTime.utc(2026, 3, 28, 14, 20),
+  lowTideHeight: 0.4,
+  lowTideTime: DateTime.utc(2026, 3, 28, 8, 20),
+  createdAt: DateTime.utc(2026, 3, 28, 12),
+);
+
+void main() {
+  String? previousDefaultLocale;
+
+  setUp(() {
+    previousDefaultLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousDefaultLocale;
+  });
+
+  testWidgets('TideCycleGraph paints wall-clock cycle bounds (#222)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 400,
+              child: TideCycleGraph(
+                record: _record,
+                referenceTime: DateTime.utc(2026, 3, 28, 10),
+                height: 80,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CustomPaint), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/tides/presentation/widgets/tide_section_time_format_test.dart
+++ b/test/features/tides/presentation/widgets/tide_section_time_format_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/tide/entities/tide_extremes.dart';
+import 'package:submersion/core/tide/entities/tide_prediction.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/tides/presentation/providers/tide_providers.dart';
+import 'package:submersion/features/tides/presentation/widgets/tide_section.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+const _location = GeoPoint(36.95, -122.02);
+
+// The chart-window label replicates TideChart's window maths against the real
+// clock: the newest extreme before now becomes the window start (minus 30min)
+// and the second extreme after now becomes the window end (plus 30min). Anchor
+// those two bounds on far-past and far-future wall-clock-as-UTC fixtures so the
+// rendered digits are fully determined by the fixtures and never by the host's
+// UTC offset. (#222)
+final _extremes = [
+  TideExtreme(
+    type: TideExtremeType.low,
+    time: DateTime.utc(2020, 3, 10, 6, 15),
+    heightMeters: 0.4,
+  ),
+  TideExtreme(
+    type: TideExtremeType.high,
+    time: DateTime.utc(2030, 5, 20, 8),
+    heightMeters: 2.4,
+  ),
+  TideExtreme(
+    type: TideExtremeType.low,
+    time: DateTime.utc(2030, 5, 20, 14, 30),
+    heightMeters: 0.6,
+  ),
+];
+
+void main() {
+  String? previousDefaultLocale;
+
+  setUp(() {
+    previousDefaultLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousDefaultLocale;
+  });
+
+  testWidgets('TideSection labels its chart window in wall-clock time (#222)', (
+    tester,
+  ) async {
+    final settings = MockSettingsNotifier();
+    await settings.setTimeFormat(TimeFormat.twentyFourHour);
+    final overrides = await getBaseOverrides(settingsNotifier: settings);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          hasTideDataProvider(_location).overrideWith((ref) async => true),
+          currentTideStatusProvider(
+            _location,
+          ).overrideWith((ref) async => null),
+          tidePredictionsProvider(
+            _location,
+          ).overrideWith((ref) async => <TidePrediction>[]),
+          tideExtremesProvider(
+            _location,
+          ).overrideWith((ref) async => _extremes),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: TideSection(location: _location),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 06:15 - 30min = 05:45 on Tue Mar 10; 14:30 + 30min = 15:00 on May 20.
+    expect(find.text('Tue, Mar 10 | 05:45 - 15:00 (May 20)'), findsOneWidget);
+  });
+}

--- a/test/features/tides/presentation/widgets/tide_time_format_test.dart
+++ b/test/features/tides/presentation/widgets/tide_time_format_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/tide/entities/tide_extremes.dart';
+import 'package:submersion/features/tides/presentation/widgets/tide_times_table.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  testWidgets(
+    'renders wall-clock-as-UTC tide times without a device-local shift (#222)',
+    (tester) async {
+      // Dive timestamps are stored wall-clock-as-UTC: the digits the diver
+      // saw, flagged UTC. Formatting must print them verbatim; .toLocal()
+      // shifts them by the MACHINE's UTC offset (the reported -7h in PDT).
+      // On a UTC machine this test passes either way; on any other timezone
+      // the pre-fix code renders a shifted time and this fails.
+      final extremes = [
+        TideExtreme(
+          type: TideExtremeType.high,
+          time: DateTime.utc(2026, 1, 15, 10, 30),
+          heightMeters: 1.2,
+        ),
+        TideExtreme(
+          type: TideExtremeType.low,
+          time: DateTime.utc(2026, 1, 15, 16, 45),
+          heightMeters: 0.3,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: TideTimesTable(
+              extremes: extremes,
+              now: DateTime.utc(2026, 1, 15, 9),
+              showPast: true,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('10:30'), findsWidgets);
+      expect(find.textContaining('16:45'), findsWidgets);
+    },
+  );
+}

--- a/test/features/tides/presentation/widgets/tide_time_format_test.dart
+++ b/test/features/tides/presentation/widgets/tide_time_format_test.dart
@@ -1,10 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/core/tide/entities/tide_extremes.dart';
 import 'package:submersion/features/tides/presentation/widgets/tide_times_table.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 void main() {
+  // The widget formats via DateFormat(pattern) with no explicit locale, so it
+  // resolves against intl's process-global default. Pin it so the expected
+  // digits do not depend on the locale the test host happens to run under.
+  String? previousDefaultLocale;
+
+  setUp(() {
+    previousDefaultLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousDefaultLocale;
+  });
+
   testWidgets(
     'renders wall-clock-as-UTC tide times without a device-local shift (#222)',
     (tester) async {

--- a/test/features/tides/presentation/widgets/tide_time_format_test.dart
+++ b/test/features/tides/presentation/widgets/tide_time_format_test.dart
@@ -60,4 +60,80 @@ void main() {
       expect(find.textContaining('16:45'), findsWidgets);
     },
   );
+
+  testWidgets(
+    'labels extremes beyond tomorrow with their wall-clock date (#222)',
+    (tester) async {
+      // Neither today nor tomorrow relative to `now`, so the row falls through
+      // to the absolute 'EEE, MMM d' label. A device-local shift would move
+      // the extreme across a day boundary and rewrite that date.
+      final extremes = [
+        TideExtreme(
+          type: TideExtremeType.high,
+          time: DateTime.utc(2026, 1, 20, 10, 30),
+          heightMeters: 1.2,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: TideTimesTable(
+              extremes: extremes,
+              now: DateTime.utc(2026, 1, 15, 9),
+              showPast: true,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final labels = tester
+          .widgetList<Semantics>(find.byType(Semantics))
+          .map((s) => s.properties.label)
+          .whereType<String>();
+      expect(
+        labels.any((l) => l.contains('Tue, Jan 20 at 10:30')),
+        isTrue,
+        reason: 'row semantics should carry the unshifted date and time',
+      );
+    },
+  );
+
+  testWidgets(
+    'NextTideTimes renders unshifted next high and low times (#222)',
+    (tester) async {
+      final extremes = [
+        TideExtreme(
+          type: TideExtremeType.high,
+          time: DateTime.utc(2026, 1, 15, 10, 30),
+          heightMeters: 1.2,
+        ),
+        TideExtreme(
+          type: TideExtremeType.low,
+          time: DateTime.utc(2026, 1, 15, 16, 45),
+          heightMeters: 0.3,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: NextTideTimes(
+              extremes: extremes,
+              now: DateTime.utc(2026, 1, 15, 9),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('10:30'), findsOneWidget);
+      expect(find.text('16:45'), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Tide times displayed shifted by the viewing machine's UTC offset — the reporter in California saw a 10:30 dive's tide data at 03:30 (−7 h, their own PDT offset; the 'AEST' in the report was a red herring).

Dive timestamps are stored wall-clock-as-UTC by project convention: the digits the diver saw, flagged UTC, formatted verbatim everywhere. The tide feature was the sole violator — 19 `.toLocal()` calls across the tide chart, times table, cycle graph, section, and the dive-detail tide card re-interpreted those wall-clock digits in the device timezone before formatting. All 19 are removed; formatting still honors the 12/24-hour setting.

## Scope note

The issue's second observation ('tide data seems off even after shifting') is a separate, deeper defect: the harmonic predictor needs a true-UTC instant, which requires a site timezone the schema doesn't carry. That is out of scope here and noted on the issue as follow-up.

## Tests

New widget test renders a wall-clock-UTC extreme (10:30) and asserts the digits print unshifted — fails before the fix on any non-UTC machine (verified locally in PDT). Existing tide calculator tests unaffected.

Full suite green.

Fixes #222