### PR TITLE
fix(equipment): hide retired gear from pickers and default equipment list

### DIFF
--- a/lib/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet.dart
@@ -22,7 +22,9 @@ class EquipmentPickerSheet extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final equipmentAsync = ref.watch(allEquipmentProvider);
+    // Only active gear belongs in the dive-edit picker; retired items are
+    // reachable from the Equipment page's Retired filter (#636).
+    final equipmentAsync = ref.watch(activeEquipmentProvider);
 
     return Column(
       children: [

--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -24,7 +24,13 @@ class EquipmentRepository {
   Future<List<EquipmentItem>> getActiveEquipment({String? diverId}) async {
     try {
       final query = _db.select(_db.equipment)
-        ..where((t) => t.isActive.equals(true))
+        // status is the user-visible retirement flag; legacy rows can carry
+        // status=retired with isActive still true, so filter on both (#636).
+        ..where(
+          (t) =>
+              t.isActive.equals(true) &
+              t.status.isNotValue(EquipmentStatus.retired.name),
+        )
         ..orderBy([
           (t) => OrderingTerm.asc(t.type),
           (t) => OrderingTerm.asc(t.name),

--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -55,8 +55,14 @@ class EquipmentRepository {
   /// Get all retired equipment
   Future<List<EquipmentItem>> getRetiredEquipment({String? diverId}) async {
     try {
+      // Either retirement marker counts, so items retired before the two
+      // fields were kept in sync are still listed (#636).
       final query = _db.select(_db.equipment)
-        ..where((t) => t.isActive.equals(false))
+        ..where(
+          (t) =>
+              t.isActive.equals(false) |
+              t.status.equals(EquipmentStatus.retired.name),
+        )
         ..orderBy([(t) => OrderingTerm.asc(t.name)]);
 
       if (diverId != null) {
@@ -111,8 +117,14 @@ class EquipmentRepository {
     String? diverId,
   }) async {
     try {
+      // The Retired filter also matches legacy rows that only ever had
+      // isActive flipped, so nothing becomes unreachable in the UI (#636).
       final query = _db.select(_db.equipment)
-        ..where((t) => t.status.equals(status.name))
+        ..where(
+          (t) => status == EquipmentStatus.retired
+              ? t.status.equals(status.name) | t.isActive.equals(false)
+              : t.status.equals(status.name),
+        )
         ..orderBy([
           (t) => OrderingTerm.asc(t.type),
           (t) => OrderingTerm.asc(t.name),
@@ -381,8 +393,16 @@ class EquipmentRepository {
   Future<void> retireEquipment(String id) async {
     try {
       final now = DateTime.now().millisecondsSinceEpoch;
+      // Write BOTH retirement fields: status is the user-visible flag and
+      // what the Retired filter and getActiveEquipment read, isActive is
+      // the legacy one. Flipping only isActive left items invisible under
+      // the Retired filter (#636).
       await (_db.update(_db.equipment)..where((t) => t.id.equals(id))).write(
-        EquipmentCompanion(isActive: const Value(false), updatedAt: Value(now)),
+        EquipmentCompanion(
+          isActive: const Value(false),
+          status: Value(EquipmentStatus.retired.name),
+          updatedAt: Value(now),
+        ),
       );
     } catch (e, stackTrace) {
       _log.error(
@@ -398,8 +418,22 @@ class EquipmentRepository {
   Future<void> reactivateEquipment(String id) async {
     try {
       final now = DateTime.now().millisecondsSinceEpoch;
+      // Clear a retired status on the way back in, but leave any other
+      // status (needsService, inService, loaned) alone -- reactivating is
+      // not the same as declaring the item serviceable (#636).
+      final current = await (_db.select(
+        _db.equipment,
+      )..where((t) => t.id.equals(id))).getSingleOrNull();
+      final clearsRetiredStatus =
+          current?.status == EquipmentStatus.retired.name;
       await (_db.update(_db.equipment)..where((t) => t.id.equals(id))).write(
-        EquipmentCompanion(isActive: const Value(true), updatedAt: Value(now)),
+        EquipmentCompanion(
+          isActive: const Value(true),
+          status: clearsRetiredStatus
+              ? Value(EquipmentStatus.active.name)
+              : const Value.absent(),
+          updatedAt: Value(now),
+        ),
       );
     } catch (e, stackTrace) {
       _log.error(

--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -404,6 +404,15 @@ class EquipmentRepository {
           updatedAt: Value(now),
         ),
       );
+      // Retiring is a real edit to the row, so it has to be staged for sync
+      // like create/update -- otherwise the item stays active on every other
+      // device, which now also hides it from the active-gear queries.
+      await _syncRepository.markRecordPending(
+        entityType: 'equipment',
+        recordId: id,
+        localUpdatedAt: now,
+      );
+      SyncEventBus.notifyLocalChange();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to retire equipment: $id',
@@ -435,6 +444,12 @@ class EquipmentRepository {
           updatedAt: Value(now),
         ),
       );
+      await _syncRepository.markRecordPending(
+        entityType: 'equipment',
+        recordId: id,
+        localUpdatedAt: now,
+      );
+      SyncEventBus.notifyLocalChange();
     } catch (e, stackTrace) {
       _log.error(
         'Failed to reactivate equipment: $id',

--- a/lib/features/equipment/presentation/pages/equipment_edit_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_edit_page.dart
@@ -781,7 +781,9 @@ class _EquipmentEditPageState extends ConsumerState<EquipmentEditPage> {
         lastServiceDate: existingEquipment?.lastServiceDate,
         serviceIntervalDays: existingEquipment?.serviceIntervalDays,
         notes: _notesController.text.trim(),
-        isActive: existingEquipment?.isActive ?? true,
+        // Retiring via the status dropdown must deactivate the item, or it
+        // keeps appearing in active-gear pickers (#636).
+        isActive: _selectedStatus != EquipmentStatus.retired,
         // Only attributes in the SELECTED type's catalog are kept: switching
         // type drops out-of-catalog values at save time (form = source of
         // truth), plus non-empty custom fields with re-packed sort order.

--- a/lib/features/equipment/presentation/pages/equipment_edit_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_edit_page.dart
@@ -108,7 +108,12 @@ class _EquipmentEditPageState extends ConsumerState<EquipmentEditPage> {
     _purchaseCurrencyController.text = equipment.purchaseCurrency;
     _notesController.text = equipment.notes;
     _selectedType = equipment.type;
-    _selectedStatus = equipment.status;
+    // A legacy row can carry isActive=false with a non-retired status.
+    // Show it as Retired so the form states the item's real condition --
+    // otherwise saving would silently reactivate it (#636).
+    _selectedStatus = !equipment.isActive
+        ? EquipmentStatus.retired
+        : equipment.status;
     _purchaseDate = equipment.purchaseDate;
     _customReminderEnabled = equipment.customReminderEnabled;
     _customReminderDays = equipment.customReminderDays ?? const [7, 14, 30];

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -131,8 +131,12 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
     final AsyncValue<List<EquipmentItem>> equipmentAsync;
     if (_selectedFilter == _serviceDueFilter) {
       equipmentAsync = ref.watch(serviceDueEquipmentProvider);
+    } else if (_selectedFilter == null) {
+      // The default view hides retired gear; the Retired status filter is
+      // the way to see it (#636).
+      equipmentAsync = ref.watch(activeEquipmentProvider);
     } else {
-      final status = _selectedFilter as EquipmentStatus?;
+      final status = _selectedFilter as EquipmentStatus;
       equipmentAsync = ref.watch(equipmentByStatusProvider(status));
     }
 

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -104,12 +104,19 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
     }
   }
 
+  /// Invalidate whatever provider the visible list is actually reading.
+  /// Must mirror the selection in [build]: the default (no filter) view
+  /// reads activeEquipmentProvider, so invalidating only the status family
+  /// would leave pull-to-refresh and error-retry showing stale rows.
   void _invalidateCurrentProvider(WidgetRef ref) {
     if (_selectedFilter == _serviceDueFilter) {
       ref.invalidate(serviceDueEquipmentProvider);
+    } else if (_selectedFilter == null) {
+      ref.invalidate(activeEquipmentProvider);
     } else {
-      final status = _selectedFilter as EquipmentStatus?;
-      ref.invalidate(equipmentByStatusProvider(status));
+      ref.invalidate(
+        equipmentByStatusProvider(_selectedFilter as EquipmentStatus),
+      );
     }
   }
 

--- a/test/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet_test.dart
+++ b/test/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet_test.dart
@@ -21,7 +21,9 @@ Future<void> _pump(
   addTearDown(tester.view.reset);
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [allEquipmentProvider.overrideWith((ref) async => equipment)],
+      overrides: [
+        activeEquipmentProvider.overrideWith((ref) async => equipment),
+      ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,

--- a/test/features/dive_planner/presentation/plan_gear_weights_section_test.dart
+++ b/test/features/dive_planner/presentation/plan_gear_weights_section_test.dart
@@ -61,6 +61,7 @@ void main() {
       ...base,
       weightObservationsProvider.overrideWith((ref) async => observations),
       allEquipmentProvider.overrideWith((ref) async => const [suitItem]),
+      activeEquipmentProvider.overrideWith((ref) async => const [suitItem]),
       latestDiverWeightProvider.overrideWith((ref) async => entry),
     ];
 
@@ -115,6 +116,7 @@ void main() {
           ...base,
           weightObservationsProvider.overrideWith((ref) async => const []),
           allEquipmentProvider.overrideWith((ref) async => const [suitItem]),
+          activeEquipmentProvider.overrideWith((ref) async => const [suitItem]),
           latestDiverWeightProvider.overrideWith((ref) async => null),
           equipmentSetsProvider.overrideWith((ref) async => [set]),
           equipmentSetWithItemsProvider(
@@ -156,6 +158,7 @@ void main() {
           ...base,
           weightObservationsProvider.overrideWith((ref) async => const []),
           allEquipmentProvider.overrideWith((ref) async => const []),
+          activeEquipmentProvider.overrideWith((ref) async => const []),
           latestDiverWeightProvider.overrideWith((ref) async => null),
         ],
         child: const PlanGearWeightsSection(),

--- a/test/features/equipment/data/repositories/equipment_repository_test.dart
+++ b/test/features/equipment/data/repositories/equipment_repository_test.dart
@@ -186,6 +186,26 @@ void main() {
         expect(result.length, equals(1));
         expect(result[0].name, equals('Active Reg'));
       });
+
+      test('excludes status-retired gear even when isActive was never flipped '
+          '(#636)', () async {
+        await repository.createEquipment(
+          createTestEquipment(name: 'Active Reg'),
+        );
+        // Legacy inconsistency: the edit page used to set status=retired
+        // while leaving isActive=true, so existing rows can carry both.
+        await repository.createEquipment(
+          createTestEquipment(
+            name: 'Status-Retired Reg',
+            status: EquipmentStatus.retired,
+            isActive: true,
+          ),
+        );
+
+        final result = await repository.getActiveEquipment();
+
+        expect(result.map((e) => e.name).toList(), ['Active Reg']);
+      });
     });
 
     group('getRetiredEquipment', () {

--- a/test/features/equipment/data/repositories/equipment_repository_test.dart
+++ b/test/features/equipment/data/repositories/equipment_repository_test.dart
@@ -208,6 +208,80 @@ void main() {
       });
     });
 
+    group('retirement keeps status and isActive in sync (#636)', () {
+      test('retireEquipment writes the retired status too', () async {
+        final item = await repository.createEquipment(
+          createTestEquipment(name: 'Old Reg'),
+        );
+
+        await repository.retireEquipment(item.id);
+
+        final stored = await repository.getEquipmentById(item.id);
+        expect(stored!.isActive, isFalse);
+        expect(stored.status, EquipmentStatus.retired);
+        expect(await repository.getActiveEquipment(), isEmpty);
+        expect((await repository.getRetiredEquipment()).map((e) => e.name), [
+          'Old Reg',
+        ]);
+      });
+
+      test('reactivateEquipment clears a retired status', () async {
+        final item = await repository.createEquipment(
+          createTestEquipment(name: 'Back In Service'),
+        );
+        await repository.retireEquipment(item.id);
+
+        await repository.reactivateEquipment(item.id);
+
+        final stored = await repository.getEquipmentById(item.id);
+        expect(stored!.isActive, isTrue);
+        expect(stored.status, EquipmentStatus.active);
+        expect((await repository.getActiveEquipment()).map((e) => e.name), [
+          'Back In Service',
+        ]);
+      });
+
+      test('reactivateEquipment leaves a non-retired status alone', () async {
+        final item = await repository.createEquipment(
+          createTestEquipment(
+            name: 'Needs Service Reg',
+            status: EquipmentStatus.needsService,
+            isActive: false,
+          ),
+        );
+
+        await repository.reactivateEquipment(item.id);
+
+        final stored = await repository.getEquipmentById(item.id);
+        expect(stored!.isActive, isTrue);
+        expect(
+          stored.status,
+          EquipmentStatus.needsService,
+          reason: 'reactivating is not a declaration that the item is fit',
+        );
+      });
+
+      test('legacy isActive-only retirements still list as retired', () async {
+        // Written by the pre-fix retire path: isActive false, status active.
+        await repository.createEquipment(
+          createTestEquipment(name: 'Legacy Retired', isActive: false),
+        );
+
+        expect((await repository.getRetiredEquipment()).map((e) => e.name), [
+          'Legacy Retired',
+        ]);
+        expect(
+          (await repository.getEquipmentByStatus(
+            EquipmentStatus.retired,
+          )).map((e) => e.name),
+          ['Legacy Retired'],
+          reason:
+              'the Retired filter must not hide items that only ever had '
+              'isActive flipped',
+        );
+      });
+    });
+
     group('getRetiredEquipment', () {
       test('should return only retired equipment', () async {
         await repository.createEquipment(

--- a/test/features/equipment/data/repositories/equipment_repository_test.dart
+++ b/test/features/equipment/data/repositories/equipment_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
@@ -284,6 +285,40 @@ void main() {
               'only the Retired filter widens to the legacy isActive flag; '
               'other statuses match on status alone',
         );
+      });
+
+      test('retiring and reactivating stage the row for sync', () async {
+        final item = await repository.createEquipment(
+          createTestEquipment(name: 'Synced Reg'),
+        );
+        final db = DatabaseService.instance.database;
+
+        Future<int> pendingCount() async {
+          final rows = await db.select(db.syncRecords).get();
+          return rows
+              .where(
+                (r) => r.entityType == 'equipment' && r.recordId == item.id,
+              )
+              .length;
+        }
+
+        // createEquipment already staged it; clear so the assertion is about
+        // retire/reactivate rather than the create.
+        await db.delete(db.syncRecords).go();
+        expect(await pendingCount(), 0);
+
+        await repository.retireEquipment(item.id);
+        expect(
+          await pendingCount(),
+          1,
+          reason:
+              'an unsynced retirement leaves the item active on every other '
+              'device, which now also keeps it in the active-gear queries',
+        );
+
+        await db.delete(db.syncRecords).go();
+        await repository.reactivateEquipment(item.id);
+        expect(await pendingCount(), 1);
       });
 
       test('legacy isActive-only retirements still list as retired', () async {

--- a/test/features/equipment/data/repositories/equipment_repository_test.dart
+++ b/test/features/equipment/data/repositories/equipment_repository_test.dart
@@ -261,6 +261,31 @@ void main() {
         );
       });
 
+      test('a non-retired status filter matches only that status', () async {
+        await repository.createEquipment(
+          createTestEquipment(name: 'Active Reg'),
+        );
+        await repository.createEquipment(
+          createTestEquipment(
+            name: 'Loaned Reg',
+            status: EquipmentStatus.loaned,
+          ),
+        );
+        await repository.createEquipment(
+          createTestEquipment(name: 'Retired Reg', isActive: false),
+        );
+
+        expect(
+          (await repository.getEquipmentByStatus(
+            EquipmentStatus.loaned,
+          )).map((e) => e.name),
+          ['Loaned Reg'],
+          reason:
+              'only the Retired filter widens to the legacy isActive flag; '
+              'other statuses match on status alone',
+        );
+      });
+
       test('legacy isActive-only retirements still list as retired', () async {
         // Written by the pre-fix retire path: isActive false, status active.
         await repository.createEquipment(

--- a/test/features/equipment/presentation/pages/equipment_list_page_test.dart
+++ b/test/features/equipment/presentation/pages/equipment_list_page_test.dart
@@ -100,6 +100,7 @@ Future<List<Override>> _buildOverrides({
     settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
     currentDiverIdProvider.overrideWith((ref) => MockCurrentDiverIdNotifier()),
     equipmentByStatusProvider.overrideWith((ref, status) => <EquipmentItem>[]),
+    activeEquipmentProvider.overrideWith((ref) async => <EquipmentItem>[]),
     equipmentListNotifierProvider.overrideWith((ref) => _MockEquipNotifier()),
     equipmentListViewModeProvider.overrideWith((ref) => viewMode),
     equipmentTableConfigProvider.overrideWith(

--- a/test/features/equipment/presentation/widgets/equipment_list_content_test.dart
+++ b/test/features/equipment/presentation/widgets/equipment_list_content_test.dart
@@ -72,6 +72,7 @@ Future<List<Override>> _buildOverrides({
     // The equipment list content watches equipmentByStatusProvider(null) for
     // all equipment when no filter is selected, so we override that.
     equipmentByStatusProvider.overrideWith((ref, status) => equipment),
+    activeEquipmentProvider.overrideWith((ref) async => equipment),
     equipmentListViewModeProvider.overrideWith((ref) => ListViewMode.table),
     equipmentTableConfigProvider.overrideWith(
       (ref) => _TestEquipTableConfigNotifier(_testConfig),
@@ -92,6 +93,7 @@ Future<List<Override>> _buildPhoneOverrides({
     settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
     currentDiverIdProvider.overrideWith((ref) => MockCurrentDiverIdNotifier()),
     equipmentByStatusProvider.overrideWith((ref, status) => items),
+    activeEquipmentProvider.overrideWith((ref) async => items),
     equipmentListViewModeProvider.overrideWith((ref) => viewMode),
     equipmentTableConfigProvider.overrideWith(
       (ref) => _TestEquipTableConfigNotifier(_testConfig),

--- a/test/features/equipment/presentation/widgets/equipment_list_content_test.dart
+++ b/test/features/equipment/presentation/widgets/equipment_list_content_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -497,5 +498,176 @@ void main() {
         expect(bravo.isSelected, isTrue);
       },
     );
+  });
+
+  group('filter selection and refresh target the right provider (#636)', () {
+    Future<void> pumpPhoneList(
+      WidgetTester tester,
+      List<EquipmentItem> items,
+    ) async {
+      final overrides = await _buildPhoneOverrides(
+        items: items,
+        viewMode: ListViewMode.detailed,
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const EquipmentListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('selecting a status filter switches to the status provider', (
+      tester,
+    ) async {
+      await pumpPhoneList(tester, [
+        _makeEquipment(id: 'e1', name: 'Alpha Reg'),
+        _makeEquipment(
+          id: 'e2',
+          name: 'Old BCD',
+          status: EquipmentStatus.retired,
+        ),
+      ]);
+
+      await tester.tap(find.byType(DropdownButton<Object?>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(EquipmentStatus.retired.displayName).last);
+      await tester.pumpAndSettle();
+
+      // The status branch of build() is now live; both fixtures come back
+      // because the status provider is overridden to return the full list.
+      expect(find.byType(EquipmentListTile), findsNWidgets(2));
+      expect(tester.takeException(), isNull);
+    });
+
+    /// Drives the RefreshIndicator directly: the list is short, so its
+    /// default physics do not permit the overscroll a drag would need.
+    Future<void> pullToRefresh(WidgetTester tester) async {
+      final state = tester.state<RefreshIndicatorState>(
+        find.byType(RefreshIndicator),
+      );
+      unawaited(state.show());
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('refreshing the default view rebuilds the active provider', (
+      tester,
+    ) async {
+      var activeBuilds = 0;
+      var statusBuilds = 0;
+      final items = [_makeEquipment(id: 'e1', name: 'Alpha Reg')];
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+            currentDiverIdProvider.overrideWith(
+              (ref) => MockCurrentDiverIdNotifier(),
+            ),
+            activeEquipmentProvider.overrideWith((ref) async {
+              activeBuilds++;
+              return items;
+            }),
+            equipmentByStatusProvider.overrideWith((ref, status) {
+              statusBuilds++;
+              return items;
+            }),
+            equipmentListViewModeProvider.overrideWith(
+              (ref) => ListViewMode.detailed,
+            ),
+            equipmentTableConfigProvider.overrideWith(
+              (ref) => _TestEquipTableConfigNotifier(_testConfig),
+            ),
+          ],
+          child: const EquipmentListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final activeBefore = activeBuilds;
+      final statusBefore = statusBuilds;
+
+      await pullToRefresh(tester);
+
+      expect(
+        activeBuilds,
+        greaterThan(activeBefore),
+        reason:
+            'the default view reads activeEquipmentProvider, so refresh must '
+            'invalidate that one or the list stays stale (#636)',
+      );
+      expect(
+        statusBuilds,
+        statusBefore,
+        reason: 'the status family is not what the default view is showing',
+      );
+    });
+
+    testWidgets('refreshing under a status filter rebuilds that status', (
+      tester,
+    ) async {
+      var activeBuilds = 0;
+      var statusBuilds = 0;
+      final items = [
+        _makeEquipment(
+          id: 'e2',
+          name: 'Old BCD',
+          status: EquipmentStatus.retired,
+        ),
+      ];
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+            currentDiverIdProvider.overrideWith(
+              (ref) => MockCurrentDiverIdNotifier(),
+            ),
+            activeEquipmentProvider.overrideWith((ref) async {
+              activeBuilds++;
+              return items;
+            }),
+            equipmentByStatusProvider.overrideWith((ref, status) {
+              statusBuilds++;
+              return items;
+            }),
+            equipmentListViewModeProvider.overrideWith(
+              (ref) => ListViewMode.detailed,
+            ),
+            equipmentTableConfigProvider.overrideWith(
+              (ref) => _TestEquipTableConfigNotifier(_testConfig),
+            ),
+          ],
+          child: const EquipmentListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(DropdownButton<Object?>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(EquipmentStatus.retired.displayName).last);
+      await tester.pumpAndSettle();
+
+      final activeBefore = activeBuilds;
+      final statusBefore = statusBuilds;
+
+      await pullToRefresh(tester);
+
+      expect(
+        statusBuilds,
+        greaterThan(statusBefore),
+        reason:
+            'the filtered view reads the status family, so refresh must '
+            'invalidate that family',
+      );
+      expect(activeBuilds, activeBefore);
+    });
   });
 }

--- a/test/features/weight_planner/presentation/weight_planner_page_test.dart
+++ b/test/features/weight_planner/presentation/weight_planner_page_test.dart
@@ -78,6 +78,10 @@ void main() {
           allEquipmentProvider.overrideWith(
             (ref) async => const [suitItem, bcdItem],
           ),
+
+          activeEquipmentProvider.overrideWith(
+            (ref) async => const [suitItem, bcdItem],
+          ),
           latestDiverWeightProvider.overrideWith(
             (ref) async => latestWeight ?? entry,
           ),


### PR DESCRIPTION
## Summary

Retired equipment kept appearing when logging a dive and in the equipment list (#636). Root cause: two unsynced 'retired' concepts. The edit page's status dropdown wrote `status: retired` but explicitly preserved `isActive: true`, while the active-gear query filtered only on `isActive` — and the dive-edit picker used the unfiltered all-equipment provider anyway.

## Fix

- Retiring via the status dropdown now derives `isActive` (`status != retired`), and un-retiring restores it.
- `getActiveEquipment` additionally excludes `status = retired`, which also covers legacy rows that carry the old inconsistency — no data migration needed.
- The dive-edit equipment picker watches `activeEquipmentProvider` (the precedent already used by equipment-set editing).
- The equipment list's default view hides retired gear; the existing Retired filter is the way to see it.

## Tests

New repository test seeds the legacy inconsistency (status retired, isActive true) and asserts `getActiveEquipment` excludes it (fails pre-fix). Picker, list, and planner-picker tests updated for the provider change; full suite green.

Fixes #636