### PR TITLE
fix(dc): resolve suffixed HW OSTC BLE names to the right descriptor

### DIFF
--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -107,6 +107,38 @@ static int strcasecmp_nospace(const char *a, const char *b) {
     return 0;
 }
 
+// Number of characters of `product` matched as a space/case-insensitive
+// PREFIX of `name`, or 0 when `name` does not start with the whole product
+// (or the match ends mid-word in `name`). Some vendors append a serial to
+// the advertised BLE name (e.g. an OSTC4 advertising "OSTC4 12345"):
+// dc_filter_hw accepts any "OSTC*" name for EVERY hw_ostc3-family
+// descriptor and the exact-name tiebreaker cannot bridge the suffix, so
+// the first family row ("OSTC 2") used to win. Issue #590.
+static size_t product_prefix_len(const char *name, const char *product) {
+    const char *a = name;
+    const char *b = product;
+    size_t matched = 0;
+    while (1) {
+        while (*a == ' ') a++;
+        while (*b == ' ') b++;
+        if (*b == '\0') break;
+        if (*a == '\0' ||
+            tolower((unsigned char)*a) != tolower((unsigned char)*b)) {
+            return 0;
+        }
+        a++;
+        b++;
+        matched++;
+    }
+    // The name must not continue with a letter: "OSTC 2 TR..." is not a
+    // prefix match for "OSTC 2" (the longer product row should win).
+    while (*a == ' ') a++;
+    if (isalpha((unsigned char)*a)) {
+        return 0;
+    }
+    return matched;
+}
+
 // Some Scubapro/Uwatec dive computers advertise a short BLE name that differs
 // from the libdivecomputer product string. dc_filter_uwatec matches each such
 // alias against EVERY Uwatec/Scubapro descriptor, so the family-level fallback
@@ -196,6 +228,7 @@ int libdc_descriptor_match(const char *name, unsigned int transport,
 
     dc_descriptor_t *desc = NULL;
     int found = 0;
+    size_t best_prefix_len = 0;
     while (dc_iterator_next(iter, &desc) == DC_STATUS_SUCCESS) {
         if (dc_descriptor_filter(desc, (dc_transport_t)transport, name)) {
             // Keep first family-level match as fallback.
@@ -229,6 +262,23 @@ int libdc_descriptor_match(const char *name, unsigned int transport,
                     info->transports = dc_descriptor_get_transports(desc);
                     dc_descriptor_free(desc);
                     break;
+                }
+
+                // No exact match: prefer the descriptor whose product is
+                // the LONGEST prefix of the advertised name, so a
+                // serial-suffixed name resolves to its own model instead
+                // of the first family row (issue #590). The descriptor
+                // table's strings are static, so the pointers stay valid
+                // after dc_descriptor_free.
+                if (product) {
+                    size_t plen = product_prefix_len(name, product);
+                    if (plen > best_prefix_len) {
+                        best_prefix_len = plen;
+                        info->vendor = dc_descriptor_get_vendor(desc);
+                        info->product = product;
+                        info->model = dc_descriptor_get_model(desc);
+                        info->transports = dc_descriptor_get_transports(desc);
+                    }
                 }
             }
         }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -107,9 +107,12 @@ static int strcasecmp_nospace(const char *a, const char *b) {
     return 0;
 }
 
-// Number of characters of `product` matched as a space/case-insensitive
-// PREFIX of `name`, or 0 when `name` does not start with the whole product
-// (or the match ends mid-word in `name`). Some vendors append a serial to
+// Number of NON-SPACE characters of `product` matched as a space/case-
+// insensitive PREFIX of `name`, or 0 when `name` does not start with the
+// whole product (or the match ends mid-word in `name`). Spaces are skipped
+// in both strings and do not count, so the score compares like for like
+// across spacing variants ("OSTC 4" and "OSTC4" both score 5) and stays
+// usable as a longest-match tiebreaker. Some vendors append a serial to
 // the advertised BLE name (e.g. an OSTC4 advertising "OSTC4 12345"):
 // dc_filter_hw accepts any "OSTC*" name for EVERY hw_ostc3-family
 // descriptor and the exact-name tiebreaker cannot bridge the suffix, so

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -97,6 +97,16 @@ static void test_non_uwatec_device_unaffected(void) {
 // numbering (Petrel 3 = 10, Perdix 2 = 11, Tern = 12, Peregrine TX = 13).
 static void test_perdix_3_resolves(void) {
     expect_ble_match("Perdix 3", "Perdix 3", 14);
+
+    // Issue #590: HW OSTC BLE names can carry a serial suffix; the prefix
+    // tiebreaker must resolve them to their own descriptor instead of the
+    // first hw_ostc3 family row ("OSTC 2").
+    expect_ble_match("OSTC4", "OSTC 4", 0x43);
+    expect_ble_match("OSTC4 12345", "OSTC 4", 0x43);
+    expect_ble_match("OSTC 4 12345", "OSTC 4", 0x43);
+    expect_ble_match("OSTC5-9876", "OSTC 5", 0x44);
+    expect_ble_match("OSTC 2", "OSTC 2", 0);
+    expect_ble_match("OSTC Plus 321", "OSTC Plus", 0);
     expect_ble_match("perdix 3", "Perdix 3", 14);
     printf("PASS: test_perdix_3_resolves\n");
 }

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -97,18 +97,21 @@ static void test_non_uwatec_device_unaffected(void) {
 // numbering (Petrel 3 = 10, Perdix 2 = 11, Tern = 12, Peregrine TX = 13).
 static void test_perdix_3_resolves(void) {
     expect_ble_match("Perdix 3", "Perdix 3", 14);
+    expect_ble_match("perdix 3", "Perdix 3", 14);
+    printf("PASS: test_perdix_3_resolves\n");
+}
 
-    // Issue #590: HW OSTC BLE names can carry a serial suffix; the prefix
-    // tiebreaker must resolve them to their own descriptor instead of the
-    // first hw_ostc3 family row ("OSTC 2").
+// Issue #590: HW OSTC BLE names can carry a serial suffix; the prefix
+// tiebreaker must resolve them to their own descriptor instead of the first
+// hw_ostc3 family row ("OSTC 2"). Unsuffixed names must stay put.
+static void test_hw_ostc_suffixed_names_resolve(void) {
     expect_ble_match("OSTC4", "OSTC 4", 0x43);
     expect_ble_match("OSTC4 12345", "OSTC 4", 0x43);
     expect_ble_match("OSTC 4 12345", "OSTC 4", 0x43);
     expect_ble_match("OSTC5-9876", "OSTC 5", 0x44);
     expect_ble_match("OSTC 2", "OSTC 2", 0);
     expect_ble_match("OSTC Plus 321", "OSTC Plus", 0);
-    expect_ble_match("perdix 3", "Perdix 3", 14);
-    printf("PASS: test_perdix_3_resolves\n");
+    printf("PASS: test_hw_ostc_suffixed_names_resolve\n");
 }
 
 // Issue #483 regression guard: dc_filter_shearwater passes a whitelisted name
@@ -145,6 +148,7 @@ int main(void) {
     test_exact_product_names_unchanged();
     test_non_uwatec_device_unaffected();
     test_perdix_3_resolves();
+    test_hw_ostc_suffixed_names_resolve();
     test_other_perdix_models_unchanged();
     test_symbios_handset_resolves_to_handset();
     test_symbios_hud_resolves_to_hud();


### PR DESCRIPTION
## Summary

An OSTC4 was detected as 'OSTC 2' during BLE discovery (#590). libdivecomputer's `dc_filter_hw` accepts any name starting with 'OSTC' for every hw_ostc3-family descriptor, and our matcher's exact-name tiebreaker can't bridge a serial suffix — so an OSTC4 advertising 'OSTC4 12345' fell through to the first family row in the table, which is 'OSTC 2'. Same defect class as the fixed Scubapro 'HUD' (#285) and 'Perdix 3' (#483) cases.

## Fix

`libdc_descriptor_match` (shared by all five platforms) gains a longest-product-prefix tiebreaker for non-exact matches: a name that starts with a full product string (space/case-insensitive, and not continuing into a letter, so 'OSTC 2 TR...' never matches the shorter 'OSTC 2' row) resolves to that descriptor. 'OSTC4 12345' → OSTC 4 (0x43); bare and exact names behave as before; the Pelagic/Uwatec paths are untouched.

## Scope note

This fixes identification/labeling. The reported download failure may be separate — the hw_ostc3 backend detects the real model from the device at connect time — so if download still fails after correct identification, that's a distinct transport issue (asked on the issue).

## Tests

Six new cases in the native descriptor-match integration test, including the exact reported shape; verified failing pre-fix ('OSTC4 12345' resolved to OSTC 2/0x00). All 7 native suites pass.

Fixes #590