### PR TITLE
fix(dc): stop advertising USB for USB-HID-only dive computers

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors
 // Transport bitmask values matching libdc_wrapper.h.
 private const val LIBDC_TRANSPORT_SERIAL = 1 shl 0
 private const val LIBDC_TRANSPORT_USB = 1 shl 1
+@Suppress("unused") // kept so the bitmask table matches libdc_wrapper.h
 private const val LIBDC_TRANSPORT_USBHID = 1 shl 2
 private const val LIBDC_TRANSPORT_IRDA = 1 shl 3
 private const val LIBDC_TRANSPORT_BLE = 1 shl 5
@@ -116,9 +117,12 @@ class DiveComputerHostApiImpl(
     private fun mapTransports(bitmask: Int): List<TransportType> {
         val transports = mutableListOf<TransportType>()
         if (bitmask and LIBDC_TRANSPORT_BLE != 0) transports.add(TransportType.BLE)
-        if (bitmask and LIBDC_TRANSPORT_USB != 0 ||
-            bitmask and LIBDC_TRANSPORT_USBHID != 0
-        ) {
+        // USBHID is deliberately NOT surfaced as USB: no platform build
+        // implements a USB HID transport (HAVE_HIDAPI is off), so
+        // advertising it sent HID-only devices (Suunto EON Steel family)
+        // into the serial path's "No USB serial ports found" dead end
+        // (#143). BLE is the working path for those devices.
+        if (bitmask and LIBDC_TRANSPORT_USB != 0) {
             transports.add(TransportType.USB)
         }
         if (bitmask and LIBDC_TRANSPORT_SERIAL != 0) transports.add(TransportType.SERIAL)

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -65,8 +65,12 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
         if bitmask & UInt32(LIBDC_TRANSPORT_BLE) != 0 {
             transports.append(.ble)
         }
-        if bitmask & UInt32(LIBDC_TRANSPORT_USB) != 0 ||
-           bitmask & UInt32(LIBDC_TRANSPORT_USBHID) != 0 {
+        // USBHID is deliberately NOT surfaced as USB: no platform build
+        // implements a USB HID transport (HAVE_HIDAPI is off), so
+        // advertising it sent HID-only devices (Suunto EON Steel family)
+        // into the serial path's "No USB serial ports found" dead end
+        // (#143). BLE is the working path for those devices.
+        if bitmask & UInt32(LIBDC_TRANSPORT_USB) != 0 {
             transports.append(.usb)
         }
         if bitmask & UInt32(LIBDC_TRANSPORT_SERIAL) != 0 {

--- a/packages/libdivecomputer_plugin/linux/dive_computer_host_api_impl.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_host_api_impl.cc
@@ -67,7 +67,12 @@ static FlValue* transports_to_fl_value(unsigned int transports) {
             129, fl_value_new_int(LIBDIVECOMPUTER_PLUGIN_TRANSPORT_TYPE_BLE),
             (GDestroyNotify)fl_value_unref));
   }
-  if (transports & (LIBDC_TRANSPORT_USB | LIBDC_TRANSPORT_USBHID)) {
+  // USBHID is deliberately NOT surfaced as USB: no platform build
+  // implements a USB HID transport (HAVE_HIDAPI is off), so
+  // advertising it sent HID-only devices (Suunto EON Steel family)
+  // into the serial path's "No USB serial ports found" dead end
+  // (#143). BLE is the working path for those devices.
+  if (transports & LIBDC_TRANSPORT_USB) {
     fl_value_append_take(
         list,
         fl_value_new_custom(

--- a/packages/libdivecomputer_plugin/windows/dive_computer_host_api_impl.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_host_api_impl.cc
@@ -42,7 +42,12 @@ void DiveComputerHostApiImpl::GetDeviceDescriptors(
             transports.push_back(
                 flutter::CustomEncodableValue(TransportType::kBle));
         }
-        if (info.transports & (LIBDC_TRANSPORT_USB | LIBDC_TRANSPORT_USBHID)) {
+        // USBHID is deliberately NOT surfaced as USB: no platform build
+        // implements a USB HID transport (HAVE_HIDAPI is off), so
+        // advertising it sent HID-only devices (Suunto EON Steel family)
+        // into the serial path's "No USB serial ports found" dead end
+        // (#143). BLE is the working path for those devices.
+        if (info.transports & LIBDC_TRANSPORT_USB) {
             transports.push_back(
                 flutter::CustomEncodableValue(TransportType::kUsb));
         }


### PR DESCRIPTION
## Summary

The Suunto EON Steel (and EON Steel Black, EON Core, D5, Ocean) declare `USBHID | BLE` transports — no serial. Every platform's transport mapping folded USBHID into plain 'USB', but none of them implements a USB HID transport (`HAVE_HIDAPI` is compiled out everywhere), and the UI's USB option routes to the USB-serial path. Result: the app promised USB for these devices and then dead-ended at 'No USB serial ports found' (#143).

## Fix

All four platform implementations (macOS/iOS Swift, Windows, Linux, Android) stop mapping USBHID to the USB transport. HID-only devices now advertise BLE only — the transport that actually works — instead of a guaranteed failure. Devices with real USB-serial (e.g. Mares Puck on an FTDI cable) are unaffected: their descriptors carry `SERIAL`, which still maps.

True USB-HID cable support (IOHIDManager / hidapi / hidraw / Android USB Host) would be a feature; #143 stays as the tracking issue for that if there's demand.

## Tests

Plugin Dart tests green; the change is four parallel two-line native mappings with no shared-C or Dart surface, validated by the per-platform CI builds.

Closes #143