### PR TITLE
fix(analysis): prorate segment SAC fallback against dive duration, per-segment tank volume

### DIFF
--- a/lib/features/dive_log/data/services/gas_analysis_service.dart
+++ b/lib/features/dive_log/data/services/gas_analysis_service.dart
@@ -81,6 +81,8 @@ class GasAnalysisService {
         tankPressures: resolvedPressures[tank.id],
         startTime: startTime,
         endTime: endTime,
+        diveStartTimestamp: profile.first.timestamp,
+        diveEndTimestamp: profile.last.timestamp,
       );
 
       if (sacRate == null) continue;
@@ -196,6 +198,8 @@ class GasAnalysisService {
         tankPressures: resolvedPressures[tank.id],
         startTime: seg.start,
         endTime: seg.end,
+        diveStartTimestamp: profile.first.timestamp,
+        diveEndTimestamp: profile.last.timestamp,
       );
 
       if (sacRate == null) continue;
@@ -656,6 +660,8 @@ class GasAnalysisService {
     List<TankPressurePoint>? tankPressures,
     required int startTime,
     required int endTime,
+    required int diveStartTimestamp,
+    required int diveEndTimestamp,
   }) {
     if (profile.isEmpty) return null;
 
@@ -683,8 +689,10 @@ class GasAnalysisService {
     // Fallback: estimate from tank start/end (less accurate for segments)
     if (pressureUsed == null || pressureUsed <= 0) {
       if (tank.startPressure != null && tank.endPressure != null) {
-        // Estimate proportionally based on segment duration
-        final totalDuration = profile.last.timestamp - profile.first.timestamp;
+        // Prorate against the WHOLE DIVE: the profile passed in is the
+        // SEGMENT's own slice, so dividing by its span made proportion ~1.0
+        // and charged every segment the entire cylinder (#110).
+        final totalDuration = diveEndTimestamp - diveStartTimestamp;
         if (totalDuration > 0) {
           final tankPressureUsed = tank.startPressure! - tank.endPressure!;
           final proportion = durationSec / totalDuration;
@@ -693,7 +701,7 @@ class GasAnalysisService {
           startPressure =
               tank.startPressure! -
               (tankPressureUsed *
-                  (startTime - profile.first.timestamp) /
+                  (startTime - diveStartTimestamp) /
                   totalDuration);
           endPressure = startPressure - pressureUsed;
         }

--- a/lib/features/dive_log/data/services/gas_analysis_service.dart
+++ b/lib/features/dive_log/data/services/gas_analysis_service.dart
@@ -75,14 +75,24 @@ class GasAnalysisService {
       final maxDepth = depths.reduce(math.max);
 
       // Calculate SAC for this segment
+      // Window to prorate a pressure-series-less tank across: its own
+      // usage range when the gas switches identify one, else the dive.
+      final usageRange = _getTankUsageRange(
+        tank: tank,
+        gasSwitches: sortedSwitches,
+        diveStart: profile.first.timestamp,
+        diveEnd: diveEndTimestamp,
+        tanks: tanks,
+      );
+
       final sacRate = _calculateSegmentSac(
         profile: segmentProfile,
         tank: tank,
         tankPressures: resolvedPressures[tank.id],
         startTime: startTime,
         endTime: endTime,
-        diveStartTimestamp: profile.first.timestamp,
-        diveEndTimestamp: profile.last.timestamp,
+        prorationStart: usageRange?.start ?? profile.first.timestamp,
+        prorationEnd: usageRange?.end ?? profile.last.timestamp,
       );
 
       if (sacRate == null) continue;
@@ -192,14 +202,25 @@ class GasAnalysisService {
       final maxD = depths.reduce(math.max);
 
       // Calculate SAC
+      // Same proration window as the gas-switch path: a tank that was only
+      // breathed for part of the dive must not have its drop spread across
+      // the whole of it.
+      final usageRange = _getTankUsageRange(
+        tank: tank,
+        gasSwitches: gasSwitches,
+        diveStart: profile.first.timestamp,
+        diveEnd: profile.last.timestamp,
+        tanks: tanks,
+      );
+
       final sacRate = _calculateSegmentSac(
         profile: segmentProfile,
         tank: tank,
         tankPressures: resolvedPressures[tank.id],
         startTime: seg.start,
         endTime: seg.end,
-        diveStartTimestamp: profile.first.timestamp,
-        diveEndTimestamp: profile.last.timestamp,
+        prorationStart: usageRange?.start ?? profile.first.timestamp,
+        prorationEnd: usageRange?.end ?? profile.last.timestamp,
       );
 
       if (sacRate == null) continue;
@@ -660,8 +681,8 @@ class GasAnalysisService {
     List<TankPressurePoint>? tankPressures,
     required int startTime,
     required int endTime,
-    required int diveStartTimestamp,
-    required int diveEndTimestamp,
+    required int prorationStart,
+    required int prorationEnd,
   }) {
     if (profile.isEmpty) return null;
 
@@ -689,10 +710,14 @@ class GasAnalysisService {
     // Fallback: estimate from tank start/end (less accurate for segments)
     if (pressureUsed == null || pressureUsed <= 0) {
       if (tank.startPressure != null && tank.endPressure != null) {
-        // Prorate against the WHOLE DIVE: the profile passed in is the
-        // SEGMENT's own slice, so dividing by its span made proportion ~1.0
-        // and charged every segment the entire cylinder (#110).
-        final totalDuration = diveEndTimestamp - diveStartTimestamp;
+        // Prorate across the window the tank was actually breathed, NOT the
+        // segment's own span: the profile passed in is the segment slice, so
+        // dividing by it made proportion ~1.0 and charged every segment the
+        // entire cylinder (#110). The window is the tank's usage range when
+        // gas switches identify it -- spreading a stage/deco tank's drop over
+        // the whole dive would understate its SAC by the ratio of its stint
+        // to the dive, and calculateCylinderSac already prorates this way.
+        final totalDuration = prorationEnd - prorationStart;
         if (totalDuration > 0) {
           final tankPressureUsed = tank.startPressure! - tank.endPressure!;
           final proportion = durationSec / totalDuration;
@@ -700,9 +725,7 @@ class GasAnalysisService {
           // Estimate absolute pressures for this segment
           startPressure =
               tank.startPressure! -
-              (tankPressureUsed *
-                  (startTime - diveStartTimestamp) /
-                  totalDuration);
+              (tankPressureUsed * (startTime - prorationStart) / totalDuration);
           endPressure = startPressure - pressureUsed;
         }
       }

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -2048,21 +2048,34 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         .map((t) => t.volume!)
         .firstOrNull;
 
-    // Determine if we can show L/min (need tank volume)
-    final showLitersPerMin =
-        sacUnit == SacUnit.litersPerMin && tankVolume != null;
-
     // Use the top-level normalization function
     final normalizationFactor = calculateSacNormalizationFactor(dive, analysis);
 
-    // Format SAC value based on unit setting, applying normalization
-    String formatSacValue(double sacBarPerMin) {
+    // Format SAC value based on unit setting, applying normalization.
+    // [segmentTankId] selects that segment's own cylinder volume for the
+    // L/min conversion -- sidemount tanks can differ in size, so one shared
+    // volume misconverts half the segments (#110). Falls back to the first
+    // tank with a volume when the segment carries no attribution.
+    String formatSacValue(double sacBarPerMin, {String? segmentTankId}) {
       // Apply normalization to align with overall dive SAC
       final normalizedSac = sacBarPerMin * normalizationFactor;
 
-      if (showLitersPerMin) {
+      final segmentVolume = segmentTankId == null
+          ? null
+          : dive.tanks
+                .where(
+                  (t) =>
+                      t.id == segmentTankId &&
+                      t.volume != null &&
+                      t.volume! > 0,
+                )
+                .map((t) => t.volume!)
+                .firstOrNull;
+      final effectiveVolume = segmentVolume ?? tankVolume;
+
+      if (sacUnit == SacUnit.litersPerMin && effectiveVolume != null) {
         // Convert bar/min to L/min: sacLPerMin = sacBarPerMin * tankVolume
-        final sacLPerMin = normalizedSac * tankVolume;
+        final sacLPerMin = normalizedSac * effectiveVolume;
         return '${units.convertVolume(sacLPerMin).toStringAsFixed(1)} ${units.volumeSymbol}/min';
       } else {
         // Convert to user's pressure unit (bar or psi)
@@ -2208,7 +2221,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                         SizedBox(
                           width: 90,
                           child: Text(
-                            formatSacValue(segment.sacRate),
+                            formatSacValue(
+                              segment.sacRate,
+                              segmentTankId: segment.tankId,
+                            ),
                             style: Theme.of(context).textTheme.bodySmall
                                 ?.copyWith(fontWeight: FontWeight.bold),
                             textAlign: TextAlign.end,

--- a/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
+++ b/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
@@ -42,6 +42,55 @@ void main() {
   }
 
   group('calculateGasSwitchSegments', () {
+    test('fallback prorates against the whole dive, not the segment '
+        '(#110)', () {
+      // No per-sample pressure series (common on sidemount, where the
+      // attributed tank's series is flat while the diver breathes the
+      // other cylinder): the start/end-pressure fallback applies.
+      const tank = DiveTank(
+        id: 't1',
+        name: 'Sidemount L',
+        startPressure: 200,
+        endPressure: 100,
+        gasMix: GasMix(o2: 21, he: 0),
+      );
+      final profile = flatProfile(30 * 60, 20.0);
+      GasSwitchWithTank sw(String id, int ts) => GasSwitchWithTank(
+        gasSwitch: GasSwitch(
+          id: id,
+          diveId: 'dive-1',
+          timestamp: ts,
+          tankId: 't1',
+          createdAt: DateTime(2026),
+        ),
+        tankName: 'Sidemount L',
+        gasMix: 'Air',
+        o2Fraction: 0.21,
+      );
+
+      final segments = service.calculateGasSwitchSegments(
+        profile: profile,
+        tanks: [tank],
+        gasSwitches: [sw('gs1', 0), sw('gs2', 600), sw('gs3', 1200)],
+        tankPressures: const {},
+      );
+
+      expect(segments, isNotNull);
+      expect(segments!.length, 3);
+      // Each 10-minute third gets one third of the 100 bar drop:
+      // 33.33 bar / 10 min / 3.0 atm. The old fallback divided the segment
+      // by ITS OWN duration, charging every segment the whole cylinder and
+      // inflating segment SAC by the number of segments.
+      for (final s in segments) {
+        expect(s.sacRate, closeTo(100 / 3 / 10 / 3.0, 0.02));
+      }
+      final totalConsumed = segments.fold<double>(
+        0,
+        (sum, s) => sum + s.gasConsumed,
+      );
+      expect(totalConsumed, closeTo(100, 1.0));
+    });
+
     test('computes SAC with Z-factor for segments with tank volume', () {
       const tank = DiveTank(
         id: 't1',

--- a/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
+++ b/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/utils/gas_compressibility.dart';
 import 'package:submersion/features/dive_log/data/services/gas_analysis_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -42,6 +43,65 @@ void main() {
   }
 
   group('calculateGasSwitchSegments', () {
+    test('a stage tank prorates over its own stint, not the whole dive '
+        '(#110)', () {
+      // 60-minute dive: back gas for 50 minutes, then a deco tank for the
+      // last 10. Neither has a pressure series, so both fall back to
+      // start/end pressures. The deco tank's whole 50 bar drop belongs to
+      // its 10-minute stint -- spreading it across the full dive would
+      // understate its SAC six-fold, and would disagree with
+      // calculateCylinderSac, which prorates over the usage range.
+      const backGas = DiveTank(
+        id: 't1',
+        name: 'Back gas',
+        role: TankRole.backGas,
+        startPressure: 200,
+        endPressure: 100,
+        gasMix: GasMix(o2: 21, he: 0),
+      );
+      const decoTank = DiveTank(
+        id: 't2',
+        name: 'Deco 50',
+        role: TankRole.deco,
+        startPressure: 200,
+        endPressure: 150,
+        gasMix: GasMix(o2: 50, he: 0),
+      );
+      final profile = flatProfile(60 * 60, 20.0);
+      GasSwitchWithTank sw(String id, int ts, String tankId) =>
+          GasSwitchWithTank(
+            gasSwitch: GasSwitch(
+              id: id,
+              diveId: 'dive-1',
+              timestamp: ts,
+              tankId: tankId,
+              createdAt: DateTime(2026),
+            ),
+            tankName: tankId,
+            gasMix: 'mix',
+            o2Fraction: 0.21,
+          );
+
+      final segments = service.calculateGasSwitchSegments(
+        profile: profile,
+        tanks: [backGas, decoTank],
+        gasSwitches: [sw('gs1', 0, 't1'), sw('gs2', 50 * 60, 't2')],
+        tankPressures: const {},
+      );
+
+      expect(segments, isNotNull);
+      expect(segments!.length, 2);
+
+      final deco = segments.last;
+      expect(deco.tankId, 't2');
+      // Full 50 bar over the 10-minute stint at 3.0 ata.
+      expect(
+        deco.sacRate,
+        closeTo(50 / 10 / 3.0, 0.02),
+        reason: 'whole-dive proration would charge only 50 * (10/60) bar here',
+      );
+    });
+
     test('fallback prorates against the whole dive, not the segment '
         '(#110)', () {
       // No per-sample pressure series (common on sidemount, where the

--- a/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
+++ b/test/features/dive_log/data/services/gas_analysis_service_segment_sac_test.dart
@@ -151,6 +151,56 @@ void main() {
       expect(totalConsumed, closeTo(100, 1.0));
     });
 
+    test('falls back to whole-dive proration when the gas switches name no '
+        'known cylinder (#110)', () {
+      // Every gas switch points at a tank id absent from the dive's tank list
+      // (stale ids survive a re-import), so each segment resolves to the first
+      // cylinder through the orElse fallback and no switch identifies that
+      // cylinder's usage window. Proration must then widen to the whole dive
+      // instead of collapsing onto the segment.
+      const tank = DiveTank(
+        id: 't1',
+        name: 'Back gas',
+        startPressure: 200,
+        endPressure: 100,
+        gasMix: GasMix(o2: 21, he: 0),
+      );
+      final profile = flatProfile(30 * 60, 20.0);
+      GasSwitchWithTank sw(String id, int ts, String tankId) =>
+          GasSwitchWithTank(
+            gasSwitch: GasSwitch(
+              id: id,
+              diveId: 'dive-1',
+              timestamp: ts,
+              tankId: tankId,
+              createdAt: DateTime(2026),
+            ),
+            tankName: tankId,
+            gasMix: 'Air',
+            o2Fraction: 0.21,
+          );
+
+      final segments = service.calculateGasSwitchSegments(
+        profile: profile,
+        tanks: [tank],
+        gasSwitches: [sw('gs1', 0, 'orphan-a'), sw('gs2', 15 * 60, 'orphan-b')],
+        tankPressures: const {},
+      );
+
+      expect(segments, isNotNull);
+      expect(segments!.length, 2);
+      // Whole-dive window: each 15-minute half carries half of the 100 bar
+      // drop, i.e. 50 bar / 15 min / 3.0 ata.
+      for (final s in segments) {
+        expect(s.sacRate, closeTo(50 / 15 / 3.0, 0.02));
+      }
+      // The cylinder is charged exactly once across the dive.
+      expect(
+        segments.fold<double>(0, (sum, s) => sum + s.gasConsumed),
+        closeTo(100, 1.0),
+      );
+    });
+
     test('computes SAC with Z-factor for segments with tank volume', () {
       const tank = DiveTank(
         id: 't1',
@@ -310,6 +360,64 @@ void main() {
       // All segment SAC rates should be positive
       for (final seg in segments) {
         expect(seg.sacRate, greaterThan(0));
+      }
+    });
+
+    test('falls back to whole-dive proration when no gas switches identify '
+        'the active cylinder (#110)', () {
+      // A sidemount pair with no gas switches logged: neither cylinder is back
+      // gas, so the usage window is indeterminate and every segment must
+      // prorate against the whole dive.
+      const left = DiveTank(
+        id: 't1',
+        name: 'Sidemount L',
+        role: TankRole.sidemountLeft,
+        startPressure: 200,
+        endPressure: 80,
+        gasMix: GasMix(o2: 21, he: 0),
+      );
+      const right = DiveTank(
+        id: 't2',
+        name: 'Sidemount R',
+        role: TankRole.sidemountRight,
+        startPressure: 200,
+        endPressure: 90,
+        gasMix: GasMix(o2: 21, he: 0),
+      );
+      final profile = <DiveProfilePoint>[];
+      for (int t = 0; t <= 120; t += 10) {
+        profile.add(DiveProfilePoint(timestamp: t, depth: t / 120 * 25));
+      }
+      for (int t = 130; t <= 2220; t += 10) {
+        profile.add(DiveProfilePoint(timestamp: t, depth: 25.0));
+      }
+      for (int t = 2230; t <= 2520; t += 10) {
+        profile.add(
+          DiveProfilePoint(timestamp: t, depth: 25.0 * (1 - (t - 2220) / 300)),
+        );
+      }
+
+      // No gasSwitches: the active-tank lookup falls through to the first
+      // cylinder, which is not back gas, so the usage range is unknowable.
+      final segments = service.calculatePhaseSegments(
+        profile: profile,
+        tanks: [left, right],
+      );
+
+      expect(segments, isNotNull);
+      expect(segments!, isNotEmpty);
+      const diveDurationSec = 2520;
+      for (final seg in segments) {
+        expect(seg.tankId, 't1');
+        expect(seg.sacRate, greaterThan(0));
+        // The 120 bar drop is spread across the whole dive, not the segment,
+        // so each segment's share is strictly proportional to its length.
+        final durationSec = seg.endTimestamp - seg.startTimestamp;
+        expect(
+          seg.gasConsumed,
+          closeTo(120 * durationSec / diveDurationSec, 0.01),
+          reason: 'segment must carry only its whole-dive share of the drop',
+        );
       }
     });
 

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
 import 'package:submersion/core/deco/entities/deco_status.dart';
 import 'package:submersion/core/deco/entities/tissue_compartment.dart';
@@ -1245,5 +1246,97 @@ void main() {
         );
       },
     );
+
+    testWidgets('converts each segment with its own cylinder volume (#110)', (
+      tester,
+    ) async {
+      // Sidemount: two cylinders of different sizes. Both segments carry the
+      // same bar/min rate, so any difference between the rendered L/min values
+      // can only come from the per-segment volume lookup. Before #110 every
+      // segment reused the first tank with a volume, printing 8.8 L/min twice.
+      final dive = diveWithProfile().copyWith(
+        tanks: const [
+          // No start/end pressures: dive.sacPressure stays null, so the SAC
+          // normalization factor is exactly 1.0 and the expected value is just
+          // sacRate * volume.
+          DiveTank(id: 'tank-a', name: 'Left', volume: 11.0),
+          DiveTank(id: 'tank-b', name: 'Right', volume: 7.0),
+        ],
+      );
+      final analysis = ProfileAnalysis.empty().copyWith(
+        sacSegments: const [
+          SacSegment(
+            startTimestamp: 0,
+            endTimestamp: 300,
+            avgDepth: 18.0,
+            minDepth: 0.0,
+            maxDepth: 24.0,
+            sacRate: 0.8,
+            gasConsumed: 4.0,
+            tankId: 'tank-a',
+            segmentationType: SacSegmentationType.timeInterval,
+          ),
+          SacSegment(
+            startTimestamp: 300,
+            endTimestamp: 600,
+            avgDepth: 18.0,
+            minDepth: 0.0,
+            maxDepth: 24.0,
+            sacRate: 0.8,
+            gasConsumed: 4.0,
+            tankId: 'tank-b',
+            segmentationType: SacSegmentationType.timeInterval,
+          ),
+        ],
+      );
+
+      // The L/min display is what exercises the volume conversion at all; the
+      // default pressurePerMin renders bar/min and ignores tank volume.
+      final settings = MockSettingsNotifier();
+      await settings.setSacUnit(SacUnit.litersPerMin);
+      final base = await getBaseOverrides(settingsNotifier: settings);
+      final originalOnError = FlutterError.onError;
+      addTearDown(() => FlutterError.onError = originalOnError);
+      FlutterError.onError = (d) {
+        if (d.toString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...base,
+            ...sacOverrides(
+              dive,
+              profileAnalysisProvider(
+                dive.id,
+              ).overrideWith((ref) async => analysis),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: DiveDetailPage(diveId: dive.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      final card = sacCardFinder(tester);
+      expect(card, findsOneWidget);
+      expect(
+        find.descendant(of: card, matching: find.text('8.8 L/min')),
+        findsOneWidget,
+        reason: '0.8 bar/min converted on the 11.0 L cylinder',
+      );
+      expect(
+        find.descendant(of: card, matching: find.text('5.6 L/min')),
+        findsOneWidget,
+        reason:
+            '0.8 bar/min converted on the 7.0 L cylinder -- a single shared '
+            'volume would print 8.8 L/min here too',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Per-segment SAC on Dive Details was wrong while the overall SAC was right (#110), worst on sidemount. Two defects:

1. **The no-pressure-data fallback charged every segment the whole cylinder.** `_calculateSegmentSac` receives the SEGMENT's own profile slice, but its start/end-pressure fallback prorated against that slice's span — so `proportion = segmentDuration / segmentDuration ≈ 1.0` and each segment was billed the tank's entire pressure drop, inflating segment SAC by the number of segments. Sidemount hits this constantly: with no recorded gas switches all segments attribute to one tank whose pressure series is flat during the other cylinder's stints, forcing the fallback. The fallback now prorates against the whole dive's duration (both segmentation paths).

2. **L/min conversion used one tank volume for every segment.** The display converted with 'first tank with a volume', wrong when sidemount cylinders differ in size. It now resolves each segment's own `tankId` volume, falling back to the old behavior for unattributed segments.

Overall SAC was never affected (it uses the volume-weighted combined-series path).

## Tests

New service test: 200→100 bar tank, no pressure series, three equal segments — each must get one third of the drop (fails pre-fix with each segment charged the full 100 bar; observed 3.39 vs expected 1.11 bar/min). Full suite green.

Fixes #110