### PR TITLE
fix(media): sharing a photo/video can crash on a blank filename or missing temp dir

### DIFF
--- a/lib/features/media/data/services/media_share_temp_file.dart
+++ b/lib/features/media/data/services/media_share_temp_file.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+
+/// Writes [bytes] to a temp file named after [item].shareFilename, suitable
+/// for handing to the OS share sheet.
+///
+/// getTemporaryDirectory() returns where the OS expects the cache directory
+/// to live, but does not guarantee it exists yet. On a long-used install the
+/// directory is already present from other cache writes; on a fresh install
+/// (or a fresh sandboxed container) it may not exist, and opening a file for
+/// write inside a missing directory throws PathNotFoundException. See PR #555
+/// for the same failure mode in the sync temp dir.
+Future<File> writeShareTempFile(MediaItem item, Uint8List bytes) async {
+  final tempDir = await getTemporaryDirectory();
+  final file = File('${tempDir.path}/${item.shareFilename}');
+  await file.parent.create(recursive: true);
+  await file.writeAsBytes(bytes);
+  return file;
+}

--- a/lib/features/media/domain/entities/media_item.dart
+++ b/lib/features/media/domain/entities/media_item.dart
@@ -163,8 +163,41 @@ class MediaItem extends Equatable {
     return isVideo ? 'dive_video.mp4' : 'dive_photo.jpg';
   }
 
-  /// MIME type to advertise when sharing this item, matching [shareFilename].
-  String get shareMimeType => isVideo ? 'video/mp4' : 'image/jpeg';
+  /// MIME type to advertise when sharing this item, derived from
+  /// [shareFilename]'s extension so the advertised type never disagrees with
+  /// the filename (and likely the bytes) some share targets inspect. Falls
+  /// back to a media-type-appropriate default for a missing or unrecognized
+  /// extension.
+  String get shareMimeType {
+    final name = shareFilename;
+    final dot = name.lastIndexOf('.');
+    final ext = dot >= 0 && dot < name.length - 1
+        ? name.substring(dot + 1).toLowerCase()
+        : '';
+    switch (ext) {
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'gif':
+        return 'image/gif';
+      case 'webp':
+        return 'image/webp';
+      case 'heic':
+        return 'image/heic';
+      case 'heif':
+        return 'image/heif';
+      case 'mp4':
+        return 'video/mp4';
+      case 'mov':
+        return 'video/quicktime';
+      case 'm4v':
+        return 'video/x-m4v';
+      default:
+        return isVideo ? 'video/mp4' : 'image/jpeg';
+    }
+  }
 
   /// Returns formatted duration string (e.g., "1:30" for 90 seconds)
   String? get durationString {

--- a/lib/features/media/domain/entities/media_item.dart
+++ b/lib/features/media/domain/entities/media_item.dart
@@ -152,6 +152,20 @@ class MediaItem extends Equatable {
   /// Returns true if this is a video
   bool get isVideo => mediaType == MediaType.video;
 
+  /// Filename to use when writing this item's bytes to a temp file for
+  /// sharing. Falls back to a media-type-appropriate default when
+  /// [originalFilename] is missing or blank -- some import sources (e.g.
+  /// the desktop file picker) report an empty string rather than null,
+  /// which a plain `??` fallback misses and produces an empty path.
+  String get shareFilename {
+    final name = originalFilename;
+    if (name != null && name.isNotEmpty) return name;
+    return isVideo ? 'dive_video.mp4' : 'dive_photo.jpg';
+  }
+
+  /// MIME type to advertise when sharing this item, matching [shareFilename].
+  String get shareMimeType => isVideo ? 'video/mp4' : 'image/jpeg';
+
   /// Returns formatted duration string (e.g., "1:30" for 90 seconds)
   String? get durationString {
     if (durationSeconds == null) return null;

--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:share_plus/share_plus.dart';
@@ -19,6 +18,7 @@ import 'package:submersion/features/dive_log/presentation/providers/active_sourc
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/data/services/metadata_write_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
@@ -390,15 +390,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
         return;
       }
 
-      final bytes = resolvedResult.bytes!;
-
-      // Save to temp file. tempDir.path may not exist yet on a fresh
-      // install -- getTemporaryDirectory() only returns where the OS
-      // expects it, it doesn't create it.
-      final tempDir = await getTemporaryDirectory();
-      final file = File('${tempDir.path}/${item.shareFilename}');
-      await file.parent.create(recursive: true);
-      await file.writeAsBytes(bytes);
+      final file = await writeShareTempFile(item, resolvedResult.bytes!);
 
       // Dismiss loading - use rootNavigator to match where showDialog placed the dialog
       if (mounted) Navigator.of(context, rootNavigator: true).pop();

--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -392,9 +392,12 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
 
       final bytes = resolvedResult.bytes!;
 
-      // Save to temp file
+      // Save to temp file. tempDir.path may not exist yet on a fresh
+      // install -- getTemporaryDirectory() only returns where the OS
+      // expects it, it doesn't create it.
       final tempDir = await getTemporaryDirectory();
       final file = File('${tempDir.path}/${item.shareFilename}');
+      await file.parent.create(recursive: true);
       await file.writeAsBytes(bytes);
 
       // Dismiss loading - use rootNavigator to match where showDialog placed the dialog

--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -394,8 +394,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
 
       // Save to temp file
       final tempDir = await getTemporaryDirectory();
-      final filename = item.originalFilename ?? 'dive_photo.jpg';
-      final file = File('${tempDir.path}/$filename');
+      final file = File('${tempDir.path}/${item.shareFilename}');
       await file.writeAsBytes(bytes);
 
       // Dismiss loading - use rootNavigator to match where showDialog placed the dialog
@@ -403,7 +402,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
 
       // Share
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path, mimeType: 'image/jpeg')]),
+        ShareParams(files: [XFile(file.path, mimeType: item.shareMimeType)]),
       );
     } catch (e) {
       if (mounted) Navigator.of(context, rootNavigator: true).pop();

--- a/lib/features/media/presentation/pages/trip_photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/trip_photo_viewer_page.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:share_plus/share_plus.dart';
@@ -11,6 +8,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
@@ -220,15 +218,7 @@ class _TripPhotoViewerPageState extends ConsumerState<TripPhotoViewerPage> {
         return;
       }
 
-      final bytes = resolvedResult.bytes!;
-
-      // Save to temp file. tempDir.path may not exist yet on a fresh
-      // install -- getTemporaryDirectory() only returns where the OS
-      // expects it, it doesn't create it.
-      final tempDir = await getTemporaryDirectory();
-      final file = File('${tempDir.path}/${item.shareFilename}');
-      await file.parent.create(recursive: true);
-      await file.writeAsBytes(bytes);
+      final file = await writeShareTempFile(item, resolvedResult.bytes!);
 
       // Dismiss loading - use rootNavigator to match where showDialog placed it
       if (mounted) Navigator.of(context, rootNavigator: true).pop();

--- a/lib/features/media/presentation/pages/trip_photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/trip_photo_viewer_page.dart
@@ -222,9 +222,12 @@ class _TripPhotoViewerPageState extends ConsumerState<TripPhotoViewerPage> {
 
       final bytes = resolvedResult.bytes!;
 
-      // Save to temp file
+      // Save to temp file. tempDir.path may not exist yet on a fresh
+      // install -- getTemporaryDirectory() only returns where the OS
+      // expects it, it doesn't create it.
       final tempDir = await getTemporaryDirectory();
       final file = File('${tempDir.path}/${item.shareFilename}');
+      await file.parent.create(recursive: true);
       await file.writeAsBytes(bytes);
 
       // Dismiss loading - use rootNavigator to match where showDialog placed it

--- a/lib/features/media/presentation/pages/trip_photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/trip_photo_viewer_page.dart
@@ -224,8 +224,7 @@ class _TripPhotoViewerPageState extends ConsumerState<TripPhotoViewerPage> {
 
       // Save to temp file
       final tempDir = await getTemporaryDirectory();
-      final filename = item.originalFilename ?? 'dive_photo.jpg';
-      final file = File('${tempDir.path}/$filename');
+      final file = File('${tempDir.path}/${item.shareFilename}');
       await file.writeAsBytes(bytes);
 
       // Dismiss loading - use rootNavigator to match where showDialog placed it
@@ -233,7 +232,7 @@ class _TripPhotoViewerPageState extends ConsumerState<TripPhotoViewerPage> {
 
       // Share
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path, mimeType: 'image/jpeg')]),
+        ShareParams(files: [XFile(file.path, mimeType: item.shareMimeType)]),
       );
     } catch (e) {
       if (mounted) Navigator.of(context, rootNavigator: true).pop();

--- a/test/features/media/data/services/media_share_temp_file_test.dart
+++ b/test/features/media/data/services/media_share_temp_file_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+
+  // Same failure mode as PR #555 (sync_temp_dir_test.dart), reproduced for
+  // the media share flow: getTemporaryDirectory() may hand back a path that
+  // does not exist yet (macOS Library/Caches/<bundle-id>, absent on a fresh
+  // install), and writeAsBytes throws PathNotFoundException when opening a
+  // file for write inside a missing directory.
+  group('writeShareTempFile', () {
+    late Directory parent;
+    late Directory missing;
+    late DateTime now;
+
+    setUp(() async {
+      now = DateTime(2024, 6, 15, 10, 30);
+      parent = await Directory.systemTemp.createTemp(
+        'media_share_temp_file_test_',
+      );
+      missing = Directory('${parent.path}/Library/Caches/app.submersion');
+      expect(
+        missing.existsSync(),
+        isFalse,
+        reason: 'precondition: the resolved dir does not exist yet',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            channel,
+            (call) async =>
+                call.method == 'getTemporaryDirectory' ? missing.path : null,
+          );
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+      if (parent.existsSync()) await parent.delete(recursive: true);
+    });
+
+    test('creates the temp directory when it does not exist yet', () async {
+      final item = MediaItem(
+        id: 'media-1',
+        diveId: 'dive-1',
+        mediaType: MediaType.photo,
+        originalFilename: 'IMG_1234.jpg',
+        takenAt: now,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      final file = await writeShareTempFile(
+        item,
+        Uint8List.fromList([1, 2, 3]),
+      );
+
+      expect(
+        missing.existsSync(),
+        isTrue,
+        reason: 'the missing temp dir must be created before writing',
+      );
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsBytesSync(), [1, 2, 3]);
+    });
+
+    test(
+      'names the file after shareFilename, honoring the blank fallback',
+      () async {
+        final item = MediaItem(
+          id: 'media-1',
+          diveId: 'dive-1',
+          mediaType: MediaType.video,
+          originalFilename: '',
+          takenAt: now,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        final file = await writeShareTempFile(item, Uint8List.fromList([9]));
+
+        expect(file.path, '${missing.path}/dive_video.mp4');
+      },
+    );
+  });
+}

--- a/test/features/media/domain/entities/media_item_test.dart
+++ b/test/features/media/domain/entities/media_item_test.dart
@@ -254,6 +254,35 @@ void main() {
       expect(item.shareMimeType, 'video/mp4');
     });
 
+    // shareFilename preserves the original extension (e.g. HEIC photos,
+    // MOV videos); shareMimeType must agree with it rather than assuming
+    // every photo is a JPEG and every video is an MP4.
+    test('shareMimeType matches a HEIC photo filename', () {
+      final item = baseItem.copyWith(originalFilename: 'IMG_1234.HEIC');
+      expect(item.shareMimeType, 'image/heic');
+    });
+
+    test('shareMimeType matches a PNG photo filename', () {
+      final item = baseItem.copyWith(originalFilename: 'screenshot.png');
+      expect(item.shareMimeType, 'image/png');
+    });
+
+    test('shareMimeType matches a MOV video filename', () {
+      final item = baseItem.copyWith(
+        mediaType: MediaType.video,
+        originalFilename: 'clip.mov',
+      );
+      expect(item.shareMimeType, 'video/quicktime');
+    });
+
+    test(
+      'shareMimeType falls back to the media-type default for an unrecognized extension',
+      () {
+        final item = baseItem.copyWith(originalFilename: 'export.xyz');
+        expect(item.shareMimeType, 'image/jpeg');
+      },
+    );
+
     test('durationString formats seconds correctly', () {
       final video30s = baseItem.copyWith(durationSeconds: 30);
       expect(video30s.durationString, '0:30');

--- a/test/features/media/domain/entities/media_item_test.dart
+++ b/test/features/media/domain/entities/media_item_test.dart
@@ -220,6 +220,40 @@ void main() {
       expect(baseItem.isVideo, false);
     });
 
+    test('shareFilename returns originalFilename when present', () {
+      final item = baseItem.copyWith(originalFilename: 'IMG_1234.jpg');
+      expect(item.shareFilename, 'IMG_1234.jpg');
+    });
+
+    test('shareFilename falls back for a null filename', () {
+      expect(baseItem.originalFilename, isNull);
+      expect(baseItem.shareFilename, 'dive_photo.jpg');
+    });
+
+    test('shareFilename falls back for an empty-string filename', () {
+      // Some import sources (e.g. the desktop file picker) report an
+      // empty string rather than null, which a plain `??` fallback misses.
+      final item = baseItem.copyWith(originalFilename: '');
+      expect(item.shareFilename, 'dive_photo.jpg');
+    });
+
+    test('shareFilename fallback uses a video extension for videos', () {
+      final item = baseItem.copyWith(
+        mediaType: MediaType.video,
+        originalFilename: '',
+      );
+      expect(item.shareFilename, 'dive_video.mp4');
+    });
+
+    test('shareMimeType returns image/jpeg for photos', () {
+      expect(baseItem.shareMimeType, 'image/jpeg');
+    });
+
+    test('shareMimeType returns video/mp4 for videos', () {
+      final item = baseItem.copyWith(mediaType: MediaType.video);
+      expect(item.shareMimeType, 'video/mp4');
+    });
+
     test('durationString formats seconds correctly', () {
       final video30s = baseItem.copyWith(durationSeconds: 30);
       expect(video30s.durationString, '0:30');


### PR DESCRIPTION
## Summary

Sharing a photo or video from the media viewer could fail two different ways, both surfaced by an in-app "Failed to share" error:

- **Blank filename → "Is a directory"**: `item.originalFilename ?? 'dive_photo.jpg'` only guards `null`, not an empty string. Some import sources (e.g. the desktop file picker) report `originalFilename` as `''` rather than `null`, which collapsed the share temp-file path down to the cache directory itself.
- **Missing temp dir → "No such file or directory"**: `getTemporaryDirectory()` returns where the OS expects the cache directory to live, but doesn't guarantee it exists. On a long-used install this was masked by the directory already existing from other cache writes; on a fresh install it doesn't, and writing a file into it throws `PathNotFoundException`. This is the same bug class already fixed for the sync temp dir in #555 and for backup restore in #588 — just never applied to the media share path.

Both were hardcoded to assume JPEG (`mimeType: 'image/jpeg'`) regardless of whether the item was actually a video.

## Changes

- Adds `MediaItem.shareFilename` / `shareMimeType`, which fall back to a media-type-appropriate default (`dive_photo.jpg` / `dive_video.mp4`) when `originalFilename` is missing *or* blank, and pick the right MIME type for videos instead of always assuming JPEG.
- Extracts the duplicated write-temp-file-then-share logic (identical in both `photo_viewer_page.dart` and `trip_photo_viewer_page.dart`) into a shared `writeShareTempFile()`, which creates the temp directory before writing to it.
- Both viewer pages now use these instead of inlining the same (buggy) logic twice.

## Test plan

- [x] Unit tests for `shareFilename`/`shareMimeType` covering null, blank, and present filenames, and photo vs. video.
- [x] Unit test for `writeShareTempFile` mocking `path_provider` to return a directory that doesn't exist yet, mirroring the approach in #555. Confirmed it fails with the exact `PathNotFoundException` from production before the fix, and passes after.
- [x] Manually reproduced and verified both original failure modes on macOS against a real local build, using real dive photos with blank filenames.
- [x] `flutter test`, `flutter analyze`, `dart format` all clean.