### PR TITLE
fix(media): don't cache a long backoff for a permission-blocked gallery photo lookup

### DIFF
--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -130,6 +130,22 @@ class AssetResolutionService {
       );
     }
 
+    // A gallery query against a library the app cannot access yet returns
+    // zero candidates -- indistinguishable from "genuinely no matching
+    // photo" unless permission is checked directly. Skip the query (and,
+    // critically, skip caching an unresolved result) when permission isn't
+    // in place: caching would apply the 24h+ backoff to a transient,
+    // user-recoverable condition, leaving the item stuck as unavailable
+    // long after permission is granted.
+    final permission = await _photoPickerService.checkPermission();
+    if (permission != PhotoPermissionStatus.authorized &&
+        permission != PhotoPermissionStatus.limited) {
+      _log.info(
+        'Skipping gallery search for media ${item.id}: permission is $permission',
+      );
+      return const ResolutionResult(status: ResolutionStatus.unavailable);
+    }
+
     // Step 3: Search gallery by metadata (with query coalescing)
     const timeWindow = Duration(seconds: 5);
     final start = item.takenAt.subtract(timeWindow);

--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -137,7 +137,17 @@ class AssetResolutionService {
     // in place: caching would apply the 24h+ backoff to a transient,
     // user-recoverable condition, leaving the item stuck as unavailable
     // long after permission is granted.
-    final permission = await _photoPickerService.checkPermission();
+    final PhotoPermissionStatus permission;
+    try {
+      permission = await _photoPickerService.checkPermission();
+    } catch (e) {
+      // checkPermission() ultimately hits platform code; treat a
+      // platform-channel failure like any other gallery failure rather than
+      // letting it bubble out of resolveAssetId() and break a Riverpod
+      // provider watching it.
+      _log.error('Permission check failed for media ${item.id}', error: e);
+      return const ResolutionResult(status: ResolutionStatus.unavailable);
+    }
     if (permission != PhotoPermissionStatus.authorized &&
         permission != PhotoPermissionStatus.limited) {
       _log.info(

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -83,6 +83,9 @@ void main() {
         when(
           mockPicker.getThumbnail('original-asset-id', size: 50),
         ).thenAnswer((_) async => null);
+        when(
+          mockPicker.checkPermission(),
+        ).thenAnswer((_) async => PhotoPermissionStatus.authorized);
         // Gallery search returns a match
         when(mockPicker.getAssetsInDateRange(any, any)).thenAnswer(
           (_) async => [
@@ -151,6 +154,93 @@ void main() {
     });
   });
 
+  // A gallery query against a library the app cannot access yet returns
+  // zero candidates -- indistinguishable from "genuinely no matching
+  // photo" unless permission is checked directly. Caching that as a long
+  // (24h+) backoff means granting permission moments later doesn't help:
+  // the item stays stuck showing unavailable until the backoff expires.
+  // Permission is a transient, user-recoverable condition, so a resolution
+  // attempt blocked by it must not be cached at all.
+  group('resolveAssetId permission handling', () {
+    void stubMissingPermission(PhotoPermissionStatus status) {
+      when(mockPicker.supportsGalleryBrowsing).thenReturn(true);
+      when(mockCache.getCachedAssetId('media-1')).thenAnswer((_) async => null);
+      when(mockCache.getCacheEntry('media-1')).thenAnswer((_) async => null);
+      when(
+        mockPicker.getThumbnail('original-asset-id', size: 50),
+      ).thenAnswer((_) async => null);
+      when(mockPicker.checkPermission()).thenAnswer((_) async => status);
+    }
+
+    test(
+      'does not cache or query the gallery when permission is not determined',
+      () async {
+        stubMissingPermission(PhotoPermissionStatus.notDetermined);
+
+        final result = await service.resolveAssetId(createTestItem());
+
+        expect(result.status, equals(ResolutionStatus.unavailable));
+        expect(result.localAssetId, isNull);
+        verifyNever(mockPicker.getAssetsInDateRange(any, any));
+        verifyNever(
+          mockCache.cacheResolution(
+            mediaId: anyNamed('mediaId'),
+            localAssetId: anyNamed('localAssetId'),
+            method: anyNamed('method'),
+          ),
+        );
+        verifyNever(mockCache.incrementAttempt(any));
+      },
+    );
+
+    test('does not cache when permission is denied', () async {
+      stubMissingPermission(PhotoPermissionStatus.denied);
+
+      final result = await service.resolveAssetId(createTestItem());
+
+      expect(result.status, equals(ResolutionStatus.unavailable));
+      verifyNever(mockPicker.getAssetsInDateRange(any, any));
+      verifyNever(
+        mockCache.cacheResolution(
+          mediaId: anyNamed('mediaId'),
+          localAssetId: anyNamed('localAssetId'),
+          method: anyNamed('method'),
+        ),
+      );
+    });
+
+    test(
+      'still searches the gallery when permission is only limited',
+      () async {
+        stubMissingPermission(PhotoPermissionStatus.limited);
+        when(mockPicker.getAssetsInDateRange(any, any)).thenAnswer(
+          (_) async => [
+            AssetInfo(
+              id: 'matched-id',
+              type: AssetType.image,
+              createDateTime: DateTime(2025, 6, 15, 10, 30, 1),
+              width: 4032,
+              height: 3024,
+              filename: 'IMG_001.jpg',
+            ),
+          ],
+        );
+        when(
+          mockCache.cacheResolution(
+            mediaId: anyNamed('mediaId'),
+            localAssetId: anyNamed('localAssetId'),
+            method: anyNamed('method'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final result = await service.resolveAssetId(createTestItem());
+
+        expect(result.status, equals(ResolutionStatus.resolved));
+        expect(result.localAssetId, equals('matched-id'));
+      },
+    );
+  });
+
   /// Drives the full tier ladder rather than the matchers in isolation, so
   /// the order the tiers run in is pinned: the exact-second tier must be
   /// reached before the fuzzy window, which is the whole point of adding it.
@@ -164,6 +254,9 @@ void main() {
       when(
         mockPicker.getThumbnail('original-asset-id', size: 50),
       ).thenAnswer((_) async => null);
+      when(
+        mockPicker.checkPermission(),
+      ).thenAnswer((_) async => PhotoPermissionStatus.authorized);
       when(
         mockPicker.getAssetsInDateRange(any, any),
       ).thenAnswer((_) async => candidates);

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -1,5 +1,4 @@
-import 'dart:typed_data';
-
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -237,6 +236,41 @@ void main() {
 
         expect(result.status, equals(ResolutionStatus.resolved));
         expect(result.localAssetId, equals('matched-id'));
+      },
+    );
+
+    // checkPermission() ultimately hits platform code (see
+    // PhotoPickerServiceMobile.checkPermission()); a platform-channel
+    // exception must not bubble out of resolveAssetId() and break a
+    // Riverpod provider watching it. It should be treated like any other
+    // gallery failure: log and report unavailable without caching.
+    test(
+      'returns unavailable without caching when checkPermission throws',
+      () async {
+        when(mockPicker.supportsGalleryBrowsing).thenReturn(true);
+        when(
+          mockCache.getCachedAssetId('media-1'),
+        ).thenAnswer((_) async => null);
+        when(mockCache.getCacheEntry('media-1')).thenAnswer((_) async => null);
+        when(
+          mockPicker.getThumbnail('original-asset-id', size: 50),
+        ).thenAnswer((_) async => null);
+        when(
+          mockPicker.checkPermission(),
+        ).thenThrow(PlatformException(code: 'permission_check_failed'));
+
+        final result = await service.resolveAssetId(createTestItem());
+
+        expect(result.status, equals(ResolutionStatus.unavailable));
+        expect(result.localAssetId, isNull);
+        verifyNever(mockPicker.getAssetsInDateRange(any, any));
+        verifyNever(
+          mockCache.cacheResolution(
+            mediaId: anyNamed('mediaId'),
+            localAssetId: anyNamed('localAssetId'),
+            method: anyNamed('method'),
+          ),
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary

A gallery-synced photo (imported on another device, e.g. an iPhone, then synced to this device via the app's own sync) can permanently show "File not found" on desktop even after the user grants Photos access, because a resolution failure caused by *missing permission* was being cached exactly like a resolution failure caused by *the photo genuinely being gone*.

`AssetResolutionService._resolveFromGallery()` falls back to a metadata-based gallery search (filename+timestamp, then timestamp+dimensions) when the item's stored `platformAssetId` doesn't load directly on this device -- expected, since that ID came from wherever the photo was originally imported. That search calls `PhotoPickerService.getAssetsInDateRange()`, which silently returns an empty list when gallery permission isn't authorized yet -- indistinguishable from "no matching photo exists here" without checking permission directly.

An empty candidate list gets cached as `unresolved` with an escalating backoff (24h → 3d → 7d). That's correct behavior for a photo that's actually gone, but wrong for permission not yet being granted: if the very first resolution attempt for an item races photo-library authorization (plausible on a fresh install, or a fresh sandboxed app identity), it gets stuck showing "File not found" for a full day even though later attempts would succeed immediately.

Confirmed directly by reading a real `local_asset_cache` table: 7 media items were all marked `unresolved` in a single batch moments before Photos permission was granted, while an 8th item resolved fine (via `original_id`) 22 minutes later once permission was in place. No code change to the matching tiers themselves -- they already work correctly once given real candidates.

## Changes

- `AssetResolutionService._resolveFromGallery()` checks `PhotoPickerService.checkPermission()` before running the gallery search. If permission isn't `authorized` or `limited`, it returns `unavailable` *without writing a cache entry*, so the next resolution attempt (e.g. right after the user grants access) retries immediately instead of waiting out the backoff.

## Test plan

- [x] New unit tests: no cache write and no gallery query when permission is `notDetermined` or `denied`; gallery search still runs normally when permission is `limited`.
- [x] Manually reproduced against a real local `local_asset_cache` table showing the stuck-unresolved state, cleared the stale entries, and confirmed the same items resolved correctly after this fix on rebuild.
- [x] Re-verified against a full restore of real production data (977 dives, 828 media items) -- gallery-synced photos from real dives now render correctly instead of showing "File not found".
- [x] `flutter test`, `flutter analyze`, `dart format` all clean.