### PR TITLE
fix(dive-edit): stop segmented-button labels wrapping mid-word on phones

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -3817,19 +3817,38 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
               SegmentedButton<WeightingFeedback>(
                 emptySelectionAllowed: true,
                 segments: [
+                  // Labels like "Overweighted" are wider than a third of the
+                  // row on a phone; scale them down to stay on one line rather
+                  // than wrapping mid-word.
                   ButtonSegment(
                     value: WeightingFeedback.correct,
-                    label: Text(
-                      context.l10n.diveLog_edit_weightFeedback_correct,
+                    label: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        context.l10n.diveLog_edit_weightFeedback_correct,
+                        maxLines: 1,
+                      ),
                     ),
                   ),
                   ButtonSegment(
                     value: WeightingFeedback.overweighted,
-                    label: Text(context.l10n.diveLog_edit_weightFeedback_over),
+                    label: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        context.l10n.diveLog_edit_weightFeedback_over,
+                        maxLines: 1,
+                      ),
+                    ),
                   ),
                   ButtonSegment(
                     value: WeightingFeedback.underweighted,
-                    label: Text(context.l10n.diveLog_edit_weightFeedback_under),
+                    label: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        context.l10n.diveLog_edit_weightFeedback_under,
+                        maxLines: 1,
+                      ),
+                    ),
                   ),
                 ],
                 selected: {?_weightingFeedback},

--- a/lib/features/dive_log/presentation/widgets/dive_mode_selector.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_mode_selector.dart
@@ -50,11 +50,16 @@ class DiveModeSelector extends StatelessWidget {
     final selector = SegmentedButton<DiveMode>(
       style: const ButtonStyle(visualDensity: VisualDensity.compact),
       segments: DiveMode.values.map((mode) {
+        // Text-only: an icon plus a label (up to "GAUGE") does not fit four
+        // segments on a phone and wraps the label mid-word. The caption below
+        // and the tooltip already convey what each mode is.
         return ButtonSegment<DiveMode>(
           value: mode,
-          label: Text(mode.name.toUpperCase()),
+          label: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(mode.name.toUpperCase(), maxLines: 1),
+          ),
           tooltip: mode.displayName,
-          icon: Icon(_getIconForMode(mode), size: 18),
         );
       }).toList(),
       selected: {selectedMode},
@@ -90,18 +95,5 @@ class DiveModeSelector extends StatelessWidget {
         ),
       ],
     );
-  }
-
-  IconData _getIconForMode(DiveMode mode) {
-    switch (mode) {
-      case DiveMode.oc:
-        return Icons.air; // Open circuit - breathing from tanks
-      case DiveMode.ccr:
-        return Icons.loop; // Closed circuit - loop symbol
-      case DiveMode.scr:
-        return Icons.sync_alt; // Semi-closed - partial loop
-      case DiveMode.gauge:
-        return Icons.timer_outlined; // Gauge / bottom timer - depth & time only
-    }
   }
 }

--- a/test/features/dive_log/presentation/widgets/dive_mode_selector_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_mode_selector_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_selector.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: DiveModeSelector(selectedMode: DiveMode.oc, onChanged: (_) {}),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders text-only labels, one line, no per-segment icons', (
+    tester,
+  ) async {
+    await pump(tester);
+
+    for (final label in ['OC', 'CCR', 'SCR', 'GAUGE']) {
+      expect(find.text(label), findsOneWidget);
+    }
+
+    // Longest label stays on a single line, scaled to fit its segment.
+    final gauge = find.text('GAUGE');
+    expect(tester.widget<Text>(gauge).maxLines, 1);
+    expect(
+      find.ancestor(of: gauge, matching: find.byType(FittedBox)),
+      findsOneWidget,
+    );
+
+    // The segments no longer carry icons (they were what overflowed the row).
+    expect(
+      find.descendant(
+        of: find.byType(SegmentedButton<DiveMode>),
+        matching: find.byType(Icon),
+      ),
+      findsNothing,
+    );
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_mode_selector_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_mode_selector_test.dart
@@ -35,12 +35,12 @@ void main() {
     );
 
     // The segments no longer carry icons (they were what overflowed the row).
+    final segmentedButton = tester.widget<SegmentedButton<DiveMode>>(
+      find.byType(SegmentedButton<DiveMode>),
+    );
     expect(
-      find.descendant(
-        of: find.byType(SegmentedButton<DiveMode>),
-        matching: find.byType(Icon),
-      ),
-      findsNothing,
+      segmentedButton.segments.map((segment) => segment.icon),
+      everyElement(isNull),
     );
   });
 }


### PR DESCRIPTION
## Problem

On a phone, two `SegmentedButton`s in the dive editor overflow their labels and wrap mid-word:

- **Dive Mode** (OC / CCR / SCR / **GAUGE**): each segment renders an icon *and* a label, which doesn't fit four segments across a phone — "GAUGE" wraps to "G / AU / GE".
- **Weighting feedback** (Felt right / Overweighted / Underweighted): the long single-word labels are wider than a third of the row, so "Overweighted" / "Underweighted" wrap onto a second line.

## Fix

`dive_mode_selector.dart` + `dive_edit_page.dart`:

- Drop the per-segment icons on Dive Mode (text-only). The caption below the selector and the tooltip already convey what each mode is, and the icons were the extra width that pushed the label into wrapping.
- Wrap the labels of both controls in `FittedBox(fit: BoxFit.scaleDown)` with `maxLines: 1`, so a label that is slightly too wide scales down to fit on one line rather than char-wrapping.

## Tests

- New `dive_mode_selector_test.dart`: the four labels render, the longest stays single-line inside a `FittedBox`, and the segments no longer carry icons.
- The existing `dive_edit_weight_feedback_test.dart` (taps the labels) still passes.

Verified locally against Flutter 3.44.8 / Dart 3.12.2: `flutter test test/features/dive_log/presentation/pages/` (+ the new widget test) passes, `flutter analyze` clean, `dart format` clean.