### PR TITLE
fix(dive-detail): don't wrap the dive number badge

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1033,6 +1033,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                         style: TextStyle(
                           color: colorScheme.onPrimaryContainer,
                           fontWeight: FontWeight.bold,
+                          // Pin the pre-scale size (CircleAvatar's implicit
+                          // titleMedium default) so FittedBox scales from a
+                          // theme-independent baseline.
+                          fontSize: 16,
                         ),
                       ),
                     ),

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1016,34 +1016,29 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         children: [
           Row(
             children: [
-              // In the embedded master-detail pane the pinned header already
-              // shows the dive number, so skip it here to avoid repeating it.
-              // On the standalone full page there is no such header, so keep it.
-              if (!widget.embedded) ...[
-                CircleAvatar(
-                  radius: 24,
-                  backgroundColor: colorScheme.primaryContainer,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
-                    child: FittedBox(
-                      fit: BoxFit.scaleDown,
-                      child: Text(
-                        '#${dive.diveNumber ?? '-'}',
-                        maxLines: 1,
-                        style: TextStyle(
-                          color: colorScheme.onPrimaryContainer,
-                          fontWeight: FontWeight.bold,
-                          // Pin the pre-scale size (CircleAvatar's implicit
-                          // titleMedium default) so FittedBox scales from a
-                          // theme-independent baseline.
-                          fontSize: 16,
-                        ),
+              CircleAvatar(
+                radius: 24,
+                backgroundColor: colorScheme.primaryContainer,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      '#${dive.diveNumber ?? '-'}',
+                      maxLines: 1,
+                      style: TextStyle(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.bold,
+                        // Pin the pre-scale size (CircleAvatar's implicit
+                        // titleMedium default) so FittedBox scales from a
+                        // theme-independent baseline.
+                        fontSize: 16,
                       ),
                     ),
                   ),
                 ),
-                const SizedBox(width: 16),
-              ],
+              ),
+              const SizedBox(width: 16),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -836,12 +836,19 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
           CircleAvatar(
             radius: 16,
             backgroundColor: colorScheme.primaryContainer,
-            child: Text(
-              '#${dive.diveNumber ?? '-'}',
-              style: TextStyle(
-                color: colorScheme.onPrimaryContainer,
-                fontWeight: FontWeight.bold,
-                fontSize: 11,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 3),
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  '#${dive.diveNumber ?? '-'}',
+                  maxLines: 1,
+                  style: TextStyle(
+                    color: colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 11,
+                  ),
+                ),
               ),
             ),
           ),
@@ -1009,18 +1016,30 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         children: [
           Row(
             children: [
-              CircleAvatar(
-                radius: 24,
-                backgroundColor: colorScheme.primaryContainer,
-                child: Text(
-                  '#${dive.diveNumber ?? '-'}',
-                  style: TextStyle(
-                    color: colorScheme.onPrimaryContainer,
-                    fontWeight: FontWeight.bold,
+              // In the embedded master-detail pane the pinned header already
+              // shows the dive number, so skip it here to avoid repeating it.
+              // On the standalone full page there is no such header, so keep it.
+              if (!widget.embedded) ...[
+                CircleAvatar(
+                  radius: 24,
+                  backgroundColor: colorScheme.primaryContainer,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        '#${dive.diveNumber ?? '-'}',
+                        maxLines: 1,
+                        style: TextStyle(
+                          color: colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 16),
+                const SizedBox(width: 16),
+              ],
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/features/dive_log/presentation/pages/dive_detail_page_section_config_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_section_config_test.dart
@@ -683,17 +683,18 @@ void main() {
       orderedDiveIdsProvider.overrideWith((ref) async => <String>[]),
     ];
 
-    /// Number of distinct rendered lines for the badge [text].
-    int lineCountOf(WidgetTester tester, String text) {
-      final paragraph = tester.renderObject<RenderParagraph>(find.text(text));
+    /// Number of distinct rendered lines for the badge [text] rendered by
+    /// the paragraph matched by [finder].
+    int lineCountOf(WidgetTester tester, Finder finder, String text) {
+      final paragraph = tester.renderObject<RenderParagraph>(finder);
       final boxes = paragraph.getBoxesForSelection(
         TextSelection(baseOffset: 0, extentOffset: text.length),
       );
       return boxes.map((box) => box.top).toSet().length;
     }
 
-    testWidgets('embedded mode shows the dive number exactly once, '
-        'on a single line', (tester) async {
+    testWidgets('embedded mode shows the dive number in the pinned header '
+        'and the hero card, each on a single line', (tester) async {
       final settings = _settingsWithVisibleSections([]);
 
       await tester.pumpWidget(
@@ -706,9 +707,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Embedded header badge only — the hero card badge is omitted.
-      expect(find.text('#28466'), findsOneWidget);
-      expect(lineCountOf(tester, '#28466'), 1);
+      // Embedded header badge plus the hero card badge.
+      final badges = find.text('#28466');
+      expect(badges, findsNWidgets(2));
+      expect(lineCountOf(tester, badges.at(0), '#28466'), 1);
+      expect(lineCountOf(tester, badges.at(1), '#28466'), 1);
     });
 
     testWidgets('standalone page shows the dive number exactly once, '
@@ -721,8 +724,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Hero card badge only — there is no embedded header here.
-      expect(find.text('#28466'), findsOneWidget);
-      expect(lineCountOf(tester, '#28466'), 1);
+      final badge = find.text('#28466');
+      expect(badge, findsOneWidget);
+      expect(lineCountOf(tester, badge, '#28466'), 1);
     });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_page_section_config_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_section_config_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 // ignore: implementation_imports
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
@@ -72,6 +73,7 @@ Widget _buildTestWidget({
   required Dive dive,
   required AppSettings settings,
   List<Override> extraOverrides = const [],
+  bool embedded = false,
 }) {
   return ProviderScope(
     overrides: [
@@ -85,7 +87,7 @@ Widget _buildTestWidget({
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: DiveDetailPage(diveId: dive.id),
+      home: DiveDetailPage(diveId: dive.id, embedded: embedded),
     ),
   );
 }
@@ -664,6 +666,63 @@ void main() {
 
       expect(find.text('Me'), findsOneWidget);
       expect(find.text('mysterySlug'), findsOneWidget);
+    });
+  });
+
+  group('DiveDetailPage dive number badge', () {
+    /// A dive whose 5-digit number previously wrapped mid-word (#744 / #801).
+    final bigNumberDive = Dive(
+      id: 'test-dive-big-number',
+      dateTime: DateTime(2026, 3, 15, 10, 0),
+      diveNumber: 28466,
+    );
+
+    /// Overrides for the embedded header's nav buttons, which derive
+    /// prev/next from the ordered dive id list.
+    List<Override> embeddedOverrides() => [
+      orderedDiveIdsProvider.overrideWith((ref) async => <String>[]),
+    ];
+
+    /// Number of distinct rendered lines for the badge [text].
+    int lineCountOf(WidgetTester tester, String text) {
+      final paragraph = tester.renderObject<RenderParagraph>(find.text(text));
+      final boxes = paragraph.getBoxesForSelection(
+        TextSelection(baseOffset: 0, extentOffset: text.length),
+      );
+      return boxes.map((box) => box.top).toSet().length;
+    }
+
+    testWidgets('embedded mode shows the dive number exactly once, '
+        'on a single line', (tester) async {
+      final settings = _settingsWithVisibleSections([]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: bigNumberDive,
+          settings: settings,
+          extraOverrides: embeddedOverrides(),
+          embedded: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Embedded header badge only — the hero card badge is omitted.
+      expect(find.text('#28466'), findsOneWidget);
+      expect(lineCountOf(tester, '#28466'), 1);
+    });
+
+    testWidgets('standalone page shows the dive number exactly once, '
+        'on a single line', (tester) async {
+      final settings = _settingsWithVisibleSections([]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(dive: bigNumberDive, settings: settings),
+      );
+      await tester.pumpAndSettle();
+
+      // Hero card badge only — there is no embedded header here.
+      expect(find.text('#28466'), findsOneWidget);
+      expect(lineCountOf(tester, '#28466'), 1);
     });
   });
 }


### PR DESCRIPTION
## Problem

On the dive detail page, the dive number badge **wrapped mid-word** for 4-5 digit numbers — e.g. #2846 rendered as "#284 / 6" — in both the pinned header and the hero card (the same overflow #744 fixed for the list tiles).

## Fix

`dive_detail_page.dart`:

- Scale both the **pinned header** badge and the **hero card** badge to fit with `FittedBox(scaleDown)` + `maxLines: 1`, so long numbers shrink instead of wrapping.
- The hero-card badge pins its pre-scale `fontSize` (CircleAvatar's implicit `titleMedium` default) so the scaling baseline is theme-independent.

The badge intentionally remains in both the pinned header and the hero card in embedded (master-detail) mode — an earlier revision of this PR removed the hero-card badge there, but that was reverted to keep the hero card self-contained.

## Tests

New regression tests in `dive_detail_page_section_config_test.dart` render a 5-digit dive number (#28466) and assert:

- **embedded mode:** the badge appears in both the pinned header and the hero card, each on a single line
- **standalone page:** the badge appears exactly once (hero card), on a single line

Line-wrap detection uses `RenderParagraph.getBoxesForSelection` to count distinct rendered lines.

Verified locally: full `flutter test` suite passes (14,449 tests), `flutter analyze` clean, `dart format` clean.
