### PR TITLE
feat(import): import dives directly from a connected Garmin device (USB)

### DIFF
--- a/lib/features/universal_import/data/services/garmin_device_detector.dart
+++ b/lib/features/universal_import/data/services/garmin_device_detector.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:path/path.dart' as p;
+
+/// A Garmin dive computer mounted as a USB mass-storage volume.
+///
+/// Garmin watches (Descent, etc.) do not use a libdivecomputer download
+/// protocol -- when connected by cable they appear as a plain drive whose
+/// activities live as FIT files under `GARMIN/Activity`.
+class GarminDevice {
+  const GarminDevice({
+    required this.volumeName,
+    required this.volumeRootPath,
+    required this.activityDirPath,
+    required this.fitFileCount,
+  });
+
+  /// Display name of the mounted volume (e.g. "GARMIN").
+  final String volumeName;
+
+  /// Absolute path of the mounted volume root (e.g. `/Volumes/GARMIN`).
+  final String volumeRootPath;
+
+  /// Absolute path of the `GARMIN/Activity` directory holding the FIT files.
+  final String activityDirPath;
+
+  /// Number of `.fit` files found directly under [activityDirPath].
+  final int fitFileCount;
+}
+
+/// Detects Garmin dive computers attached as USB mass-storage volumes.
+///
+/// This is desktop-only: mobile platforms cannot mount a watch as a drive.
+/// Detection is purely filesystem-based (no vendor API, credentials, or
+/// network) -- it looks for the `GARMIN/Activity` folder that every Garmin
+/// device exposes, regardless of the volume's name.
+class GarminDeviceDetector {
+  /// [volumeRoots] overrides the platform mount-point scan; used by tests to
+  /// point detection at a temporary directory tree.
+  const GarminDeviceDetector({List<Directory> Function()? volumeRoots})
+    : _volumeRootsOverride = volumeRoots;
+
+  final List<Directory> Function()? _volumeRootsOverride;
+
+  /// Whether the current platform can mount a Garmin device as a drive.
+  static bool get isSupportedPlatform {
+    if (kIsWeb) return false;
+    final platform = defaultTargetPlatform;
+    return platform == TargetPlatform.macOS ||
+        platform == TargetPlatform.windows ||
+        platform == TargetPlatform.linux;
+  }
+
+  /// Scan mounted volumes and return every one that looks like a Garmin
+  /// device (i.e. contains a non-empty `GARMIN/Activity` folder).
+  Future<List<GarminDevice>> detect() async {
+    final roots = _volumeRootsOverride != null
+        ? _volumeRootsOverride()
+        : _defaultVolumeRoots();
+
+    final devices = <GarminDevice>[];
+    for (final root in roots) {
+      try {
+        final activityDir = Directory(p.join(root.path, 'GARMIN', 'Activity'));
+        if (!await activityDir.exists()) continue;
+        final fitCount = await _countFitFiles(activityDir);
+        if (fitCount == 0) continue;
+        devices.add(
+          GarminDevice(
+            volumeName: p.basename(root.path).isEmpty
+                ? root.path
+                : p.basename(root.path),
+            volumeRootPath: root.path,
+            activityDirPath: activityDir.path,
+            fitFileCount: fitCount,
+          ),
+        );
+      } catch (_) {
+        // A volume can be unmounted mid-scan or be unreadable; skip it.
+      }
+    }
+    return devices;
+  }
+
+  /// All `.fit` file paths directly under [activityDirPath], sorted for a
+  /// stable order. Callers filter dives from non-dive activities.
+  Future<List<String>> listFitFiles(String activityDirPath) async {
+    final paths = <String>[];
+    final dir = Directory(activityDirPath);
+    if (!await dir.exists()) return paths;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is File && _isFit(entity.path)) paths.add(entity.path);
+    }
+    paths.sort();
+    return paths;
+  }
+
+  Future<int> _countFitFiles(Directory dir) async {
+    var count = 0;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is File && _isFit(entity.path)) count++;
+    }
+    return count;
+  }
+
+  static bool _isFit(String path) => p.extension(path).toLowerCase() == '.fit';
+
+  /// Candidate mounted-volume roots per platform.
+  List<Directory> _defaultVolumeRoots() {
+    if (Platform.isMacOS) {
+      return _childDirs('/Volumes');
+    }
+    if (Platform.isLinux) {
+      final user =
+          Platform.environment['USER'] ?? Platform.environment['LOGNAME'];
+      final roots = <Directory>[];
+      if (user != null && user.isNotEmpty) {
+        roots
+          ..addAll(_childDirs('/media/$user'))
+          ..addAll(_childDirs('/run/media/$user'));
+      }
+      roots.addAll(_childDirs('/media'));
+      return roots;
+    }
+    if (Platform.isWindows) {
+      // Removable drives get a letter; skip C: (the system volume).
+      return [
+        for (var c = 'D'.codeUnitAt(0); c <= 'Z'.codeUnitAt(0); c++)
+          Directory('${String.fromCharCode(c)}:\\'),
+      ];
+    }
+    return const [];
+  }
+
+  static List<Directory> _childDirs(String path) {
+    try {
+      final dir = Directory(path);
+      if (!dir.existsSync()) return const [];
+      return dir.listSync(followLinks: false).whereType<Directory>().toList();
+    } catch (_) {
+      return const [];
+    }
+  }
+}

--- a/lib/features/universal_import/presentation/providers/universal_import_providers.dart
+++ b/lib/features/universal_import/presentation/providers/universal_import_providers.dart
@@ -29,7 +29,9 @@ import 'package:submersion/features/universal_import/data/parsers/import_parser.
 import 'package:submersion/features/universal_import/data/services/format_detector.dart';
 import 'package:submersion/features/universal_import/data/models/picked_import_file.dart';
 import 'package:submersion/features/universal_import/data/parsers/parser_registry.dart';
+import 'package:submersion/features/dive_import/data/services/fit_parser_service.dart';
 import 'package:submersion/features/universal_import/data/services/batch_parse_service.dart';
+import 'package:submersion/features/universal_import/data/services/garmin_device_detector.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_db_reader.dart';
 import 'package:submersion/features/universal_import/data/services/payload_merger.dart';
 import 'package:submersion/features/universal_import/data/services/shearwater_db_reader.dart';
@@ -49,8 +51,12 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
     this._ref, {
     BatchParseService batchParseService = const BatchParseService(),
     ZipExpansionService zipExpansionService = const ZipExpansionService(),
+    GarminDeviceDetector garminDeviceDetector = const GarminDeviceDetector(),
+    FitParserService fitParserService = const FitParserService(),
   }) : _batchParseService = batchParseService,
        _zipExpansion = zipExpansionService,
+       _garminDetector = garminDeviceDetector,
+       _fitParser = fitParserService,
        super(const UniversalImportState());
 
   final Ref _ref;
@@ -62,6 +68,14 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
   /// Expands ZIP archives (DiveCloud exports) into their member files at
   /// intake so members flow through normal detection and batching.
   final ZipExpansionService _zipExpansion;
+
+  /// Detects a Garmin dive computer mounted as a USB drive. Injectable so
+  /// tests can point it at a temporary directory tree.
+  final GarminDeviceDetector _garminDetector;
+
+  /// Filters dive FITs from non-dive activities when importing from a Garmin
+  /// device (it returns null for runs/rides/corrupt files).
+  final FitParserService _fitParser;
 
   /// Build a [PresetRegistry] that includes both built-in and user-saved
   /// presets so auto-detection scores against all of them.
@@ -435,6 +449,73 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
         error: 'Failed to scan folder: $e',
       );
     }
+  }
+
+  /// Desktop only: detect a Garmin dive computer connected as a USB drive
+  /// and load its dive activities into the wizard.
+  ///
+  /// Garmin watches expose activities as FIT files under `GARMIN/Activity`,
+  /// a folder that mixes dives with runs/rides; non-dive FITs are filtered
+  /// out before triage. When several Garmin volumes are mounted the first is
+  /// used.
+  Future<void> importFromGarminDevice() async {
+    state = state.copyWith(
+      isLoading: true,
+      clearError: true,
+      currentStep: ImportWizardStep.fileSelection,
+    );
+
+    try {
+      final devices = await _garminDetector.detect();
+      if (devices.isEmpty) {
+        state = state.copyWith(
+          isLoading: false,
+          error:
+              'No connected Garmin device found. Connect it by cable, '
+              "or use Choose Folder to select the device's GARMIN/Activity "
+              'folder.',
+        );
+        return;
+      }
+      await _loadDiveFitsFromFolder(devices.first.activityDirPath);
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Failed to read Garmin device: $e',
+      );
+    }
+  }
+
+  /// Scan [activityDirPath] for FIT files, keep only dive activities, and
+  /// enter the wizard's single/batch flow. Corrupt or non-dive FITs (which
+  /// parse to null) are skipped so triage lists only dives.
+  Future<void> _loadDiveFitsFromFolder(String activityDirPath) async {
+    final fitPaths = await _garminDetector.listFitFiles(activityDirPath);
+    final divePaths = <String>[];
+    for (final path in fitPaths) {
+      try {
+        final bytes = await File(path).readAsBytes();
+        final dive = await _fitParser.parseFitFile(bytes);
+        if (dive != null) divePaths.add(path);
+      } catch (_) {
+        // Unreadable/corrupt FIT: skip it and keep scanning the rest.
+      }
+    }
+
+    if (divePaths.isEmpty) {
+      state = state.copyWith(
+        isLoading: false,
+        error: 'No dives found on the connected Garmin device.',
+      );
+      return;
+    }
+
+    if (divePaths.length == 1) {
+      await _loadSingleFromFilePath(divePaths.first);
+    } else {
+      await _loadBatchFromPaths(divePaths);
+    }
+    state = state.copyWith(wasLoadedExternally: true);
   }
 
   // -- Step 1: Source Confirmation --
@@ -856,3 +937,13 @@ final universalImportNotifierProvider =
     StateNotifierProvider<UniversalImportNotifier, UniversalImportState>((ref) {
       return UniversalImportNotifier(ref);
     });
+
+/// Garmin dive computers currently mounted as USB drives. Empty on mobile or
+/// when none is connected; the import UI shows the Garmin option only when a
+/// device is actually present, so it stays hidden for everyone else.
+final garminDevicesProvider = FutureProvider.autoDispose<List<GarminDevice>>((
+  ref,
+) async {
+  if (!GarminDeviceDetector.isSupportedPlatform) return const [];
+  return const GarminDeviceDetector().detect();
+});

--- a/lib/features/universal_import/presentation/widgets/file_selection_step.dart
+++ b/lib/features/universal_import/presentation/widgets/file_selection_step.dart
@@ -23,6 +23,10 @@ class FileSelectionStep extends ConsumerWidget {
     final theme = Theme.of(context);
 
     final hasFile = state.files.isNotEmpty;
+    // Only offer the Garmin option when a device is actually mounted, so the
+    // import dialog stays clean for everyone who doesn't own one.
+    final hasGarminDevice =
+        ref.watch(garminDevicesProvider).valueOrNull?.isNotEmpty ?? false;
 
     return Padding(
       padding: const EdgeInsets.all(24),
@@ -66,6 +70,23 @@ class FileSelectionStep extends ConsumerWidget {
                           .pickFolder(),
               ),
             ),
+            if (hasGarminDevice) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.watch),
+                  label: Text(
+                    context.l10n.universalImport_action_importFromGarmin,
+                  ),
+                  onPressed: state.isLoading
+                      ? null
+                      : () => ref
+                            .read(universalImportNotifierProvider.notifier)
+                            .importFromGarminDevice(),
+                ),
+              ),
+            ],
           ],
           if (state.error != null) ...[
             const SizedBox(height: 16),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "استيراد من جهاز Garmin",
   "diveLog_tank_saveAsPreset": "حفظ كإعداد مسبق",
   "diveLog_tank_saveAsPreset_needSpecs": "أدخل الحجم وضغط العمل أولاً",
   "diveLog_tank_saveAsPreset_nameTitle": "حفظ إعداد الأسطوانة المسبق",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Von Garmin-Gerät importieren",
   "diveLog_tank_saveAsPreset": "Als Vorlage speichern",
   "diveLog_tank_saveAsPreset_needSpecs": "Zuerst Volumen und Arbeitsdruck eingeben",
   "diveLog_tank_saveAsPreset_nameTitle": "Flaschenvorlage speichern",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Import from Garmin Device",
   "diveLog_edit_flightWindowWarning": "This dive ends after the latest safe surfacing time for your flight ({time})",
   "@diveLog_edit_flightWindowWarning": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Importar desde dispositivo Garmin",
   "diveLog_tank_saveAsPreset": "Guardar como preajuste",
   "diveLog_tank_saveAsPreset_needSpecs": "Introduce primero un volumen y una presión de trabajo",
   "diveLog_tank_saveAsPreset_nameTitle": "Guardar preajuste de tanque",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Importer depuis l'appareil Garmin",
   "diveLog_tank_saveAsPreset": "Enregistrer comme preset",
   "diveLog_tank_saveAsPreset_needSpecs": "Saisissez d'abord un volume et une pression de service",
   "diveLog_tank_saveAsPreset_nameTitle": "Enregistrer le preset de bloc",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "ייבוא מהתקן Garmin",
   "diveLog_tank_saveAsPreset": "שמור כתבנית",
   "diveLog_tank_saveAsPreset_needSpecs": "הזן תחילה נפח ולחץ עבודה",
   "diveLog_tank_saveAsPreset_nameTitle": "שמור תבנית בלון",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Importálás Garmin eszközről",
   "diveLog_tank_saveAsPreset": "Mentés előre beállításként",
   "diveLog_tank_saveAsPreset_needSpecs": "Először adjon meg térfogatot és üzemi nyomást",
   "diveLog_tank_saveAsPreset_nameTitle": "Palack előre beállítás mentése",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Importa da dispositivo Garmin",
   "diveLog_tank_saveAsPreset": "Salva come preset",
   "diveLog_tank_saveAsPreset_needSpecs": "Inserisci prima volume e pressione di esercizio",
   "diveLog_tank_saveAsPreset_nameTitle": "Salva preset bombola",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -116,6 +116,12 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @universalImport_action_importFromGarmin.
+  ///
+  /// In en, this message translates to:
+  /// **'Import from Garmin Device'**
+  String get universalImport_action_importFromGarmin;
+
   /// No description provided for @diveLog_edit_flightWindowWarning.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -9,6 +9,10 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'استيراد من جهاز Garmin';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'ينتهي هذا الغوص بعد آخر وقت آمن للصعود إلى السطح قبل رحلتك ($time)';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -9,6 +9,10 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Von Garmin-Gerät importieren';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Dieser Tauchgang endet nach der letzten sicheren Auftauchzeit für deinen Flug ($time)';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -9,6 +9,10 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Import from Garmin Device';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'This dive ends after the latest safe surfacing time for your flight ($time)';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -9,6 +9,10 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Importar desde dispositivo Garmin';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Esta inmersión termina después de la última hora segura para emerger antes de tu vuelo ($time)';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -9,6 +9,10 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Importer depuis l\'appareil Garmin';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Cette plongée se termine après l\'heure limite de remontée pour votre vol ($time)';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -9,6 +9,9 @@ class AppLocalizationsHe extends AppLocalizations {
   AppLocalizationsHe([String locale = 'he']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin => 'ייבוא מהתקן Garmin';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'הצלילה הזו מסתיימת אחרי הזמן הבטוח האחרון לעלייה לפני הטיסה שלך ($time)';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -9,6 +9,10 @@ class AppLocalizationsHu extends AppLocalizations {
   AppLocalizationsHu([String locale = 'hu']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Importálás Garmin eszközről';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Ez a merülés a járatod előtti utolsó biztonságos felszínre érési idő után ér véget ($time)';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -9,6 +9,10 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Importa da dispositivo Garmin';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Questa immersione termina dopo l\'ultimo orario sicuro di riemersione per il tuo volo ($time)';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -9,6 +9,10 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Importeren vanaf Garmin-apparaat';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Deze duik eindigt na het laatste veilige opstijgmoment voor je vlucht ($time)';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -9,6 +9,10 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin =>
+      'Importar do dispositivo Garmin';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return 'Este mergulho termina depois do último horário seguro para emergir antes do seu voo ($time)';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -9,6 +9,9 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get universalImport_action_importFromGarmin => '从 Garmin 设备导入';
+
+  @override
   String diveLog_edit_flightWindowWarning(String time) {
     return '此次潜水的结束时间晚于您航班的最后安全出水时间($time)';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Importeren vanaf Garmin-apparaat",
   "diveLog_tank_saveAsPreset": "Als voorinstelling opslaan",
   "diveLog_tank_saveAsPreset_needSpecs": "Voer eerst een volume en werkdruk in",
   "diveLog_tank_saveAsPreset_nameTitle": "Flesvoorinstelling opslaan",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "Importar do dispositivo Garmin",
   "diveLog_tank_saveAsPreset": "Guardar como preset",
   "diveLog_tank_saveAsPreset_needSpecs": "Introduza primeiro um volume e uma pressão de trabalho",
   "diveLog_tank_saveAsPreset_nameTitle": "Guardar preset do cilindro",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,4 +1,5 @@
 {
+  "universalImport_action_importFromGarmin": "从 Garmin 设备导入",
   "diveLog_tank_saveAsPreset": "另存为预设",
   "diveLog_tank_saveAsPreset_needSpecs": "请先输入容积和工作压力",
   "diveLog_tank_saveAsPreset_nameTitle": "保存气瓶预设",

--- a/test/features/universal_import/data/services/garmin_device_detector_test.dart
+++ b/test/features/universal_import/data/services/garmin_device_detector_test.dart
@@ -1,0 +1,119 @@
+// Verifies Garmin USB detection against a temporary directory tree that
+// mimics one or more mounted volumes: a device is recognised by a non-empty
+// GARMIN/Activity folder, regardless of the volume's name.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/features/universal_import/data/services/garmin_device_detector.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('garmin_detect_test');
+  });
+
+  tearDown(() async {
+    await tmp.delete(recursive: true);
+  });
+
+  /// Create `<tmp>/<volume>/GARMIN/Activity` and drop [fitNames] into it (plus
+  /// any [otherNames] non-FIT files). Returns the volume root path.
+  Future<String> makeVolume(
+    String volume, {
+    List<String> fitNames = const [],
+    List<String> otherNames = const [],
+  }) async {
+    final activity = Directory(p.join(tmp.path, volume, 'GARMIN', 'Activity'));
+    await activity.create(recursive: true);
+    for (final name in fitNames) {
+      await File(p.join(activity.path, name)).writeAsBytes([0, 1, 2, 3]);
+    }
+    for (final name in otherNames) {
+      await File(p.join(activity.path, name)).writeAsString('x');
+    }
+    return p.join(tmp.path, volume);
+  }
+
+  GarminDeviceDetector detectorFor(List<String> volumeRoots) {
+    return GarminDeviceDetector(
+      volumeRoots: () => [for (final r in volumeRoots) Directory(r)],
+    );
+  }
+
+  test('detects a volume with a non-empty GARMIN/Activity folder', () async {
+    final vol = await makeVolume(
+      'GARMIN',
+      fitNames: ['1.fit', '2.fit'],
+      otherNames: ['notes.txt'],
+    );
+
+    final devices = await detectorFor([vol]).detect();
+
+    expect(devices, hasLength(1));
+    expect(devices.single.volumeName, 'GARMIN');
+    expect(devices.single.fitFileCount, 2);
+    expect(devices.single.activityDirPath, p.join(vol, 'GARMIN', 'Activity'));
+  });
+
+  test('recognises the device regardless of the volume name', () async {
+    final vol = await makeVolume('MY_WATCH', fitNames: ['a.fit']);
+
+    final devices = await detectorFor([vol]).detect();
+
+    expect(devices, hasLength(1));
+    expect(devices.single.volumeName, 'MY_WATCH');
+  });
+
+  test('ignores a volume without a GARMIN/Activity folder', () async {
+    final plainDir = Directory(p.join(tmp.path, 'USB_STICK'));
+    await plainDir.create(recursive: true);
+    await File(p.join(plainDir.path, 'photo.jpg')).writeAsString('x');
+
+    final devices = await detectorFor([plainDir.path]).detect();
+
+    expect(devices, isEmpty);
+  });
+
+  test('ignores a GARMIN/Activity folder with no FIT files', () async {
+    final vol = await makeVolume('EMPTY', otherNames: ['README']);
+
+    final devices = await detectorFor([vol]).detect();
+
+    expect(devices, isEmpty);
+  });
+
+  test('returns every matching volume when several are mounted', () async {
+    final a = await makeVolume('A', fitNames: ['1.fit']);
+    final b = await makeVolume('B', fitNames: ['1.fit', '2.fit']);
+    final plain = Directory(p.join(tmp.path, 'PLAIN'))
+      ..createSync(recursive: true);
+
+    final devices = await detectorFor([a, b, plain.path]).detect();
+
+    expect(devices.map((d) => d.volumeName), containsAll(['A', 'B']));
+    expect(devices, hasLength(2));
+  });
+
+  test('listFitFiles returns only .fit paths, sorted', () async {
+    final vol = await makeVolume(
+      'GARMIN',
+      fitNames: ['b.fit', 'a.fit'],
+      otherNames: ['c.gpx'],
+    );
+    final activity = p.join(vol, 'GARMIN', 'Activity');
+
+    final files = await detectorFor([vol]).listFitFiles(activity);
+
+    expect(files.map(p.basename), ['a.fit', 'b.fit']);
+  });
+
+  test('listFitFiles is empty for a missing directory', () async {
+    final files = await const GarminDeviceDetector().listFitFiles(
+      p.join(tmp.path, 'does', 'not', 'exist'),
+    );
+    expect(files, isEmpty);
+  });
+}

--- a/test/features/universal_import/presentation/providers/universal_import_garmin_test.dart
+++ b/test/features/universal_import/presentation/providers/universal_import_garmin_test.dart
@@ -1,0 +1,120 @@
+// Drives the notifier's Garmin-USB import path: detect the mounted device,
+// keep only dive FITs (skipping non-dive/corrupt files), and hand them to the
+// wizard's single/batch flow. Uses a real Garmin dive FIT fixture and a
+// temporary directory tree standing in for the mounted volume.
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/universal_import/data/services/garmin_device_detector.dart';
+import 'package:submersion/features/universal_import/presentation/providers/universal_import_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+const _diveFixture = 'test/dives/005_oc-trimix-two-deco-gases.fit';
+
+void main() {
+  late ProviderContainer container;
+  late Directory tmp;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    tmp = await Directory.systemTemp.createTemp('garmin_import_test');
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await tearDownTestDatabase();
+    await tmp.delete(recursive: true);
+  });
+
+  /// Build a notifier whose detector points at [volumeRoots].
+  Future<UniversalImportNotifier> notifierFor(List<String> volumeRoots) async {
+    final prefs = await SharedPreferences.getInstance();
+    final detector = GarminDeviceDetector(
+      volumeRoots: () => [for (final r in volumeRoots) Directory(r)],
+    );
+    container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        universalImportNotifierProvider.overrideWith(
+          (ref) => UniversalImportNotifier(ref, garminDeviceDetector: detector),
+        ),
+      ],
+    );
+    return container.read(universalImportNotifierProvider.notifier);
+  }
+
+  /// Create `<tmp>/<volume>/GARMIN/Activity` and populate it. Copies the dive
+  /// fixture [diveCopies] times and writes [corrupt] junk .fit files.
+  Future<String> makeGarminVolume(
+    String volume, {
+    int diveCopies = 0,
+    int corrupt = 0,
+  }) async {
+    final activity = Directory(p.join(tmp.path, volume, 'GARMIN', 'Activity'));
+    await activity.create(recursive: true);
+    final diveBytes = await File(_diveFixture).readAsBytes();
+    for (var i = 0; i < diveCopies; i++) {
+      await File(p.join(activity.path, 'dive_$i.fit')).writeAsBytes(diveBytes);
+    }
+    for (var i = 0; i < corrupt; i++) {
+      await File(
+        p.join(activity.path, 'run_$i.fit'),
+      ).writeAsBytes([0, 1, 2, 3, 4]);
+    }
+    return p.join(tmp.path, volume);
+  }
+
+  test('imports a single dive, skipping a corrupt FIT', () async {
+    final vol = await makeGarminVolume('DESCENT', diveCopies: 1, corrupt: 1);
+    final notifier = await notifierFor([vol]);
+
+    await notifier.importFromGarminDevice();
+
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.files, hasLength(1));
+    expect(notifier.state.isBatch, isFalse);
+    expect(notifier.state.currentStep, ImportWizardStep.sourceConfirmation);
+    expect(notifier.state.fileName, 'dive_0.fit');
+    expect(notifier.state.wasLoadedExternally, isTrue);
+    expect(notifier.state.isLoading, isFalse);
+  });
+
+  test('enters batch triage when several dives are present', () async {
+    final vol = await makeGarminVolume('DESCENT', diveCopies: 2, corrupt: 1);
+    final notifier = await notifierFor([vol]);
+
+    await notifier.importFromGarminDevice();
+
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.isBatch, isTrue);
+    expect(notifier.state.files, hasLength(2));
+    expect(notifier.state.currentStep, ImportWizardStep.sourceConfirmation);
+  });
+
+  test('reports an error when no Garmin device is connected', () async {
+    final notifier = await notifierFor(const []);
+
+    await notifier.importFromGarminDevice();
+
+    expect(notifier.state.files, isEmpty);
+    expect(notifier.state.isLoading, isFalse);
+    expect(notifier.state.error, contains('No connected Garmin device'));
+  });
+
+  test('reports an error when the device holds no dives', () async {
+    final vol = await makeGarminVolume('DESCENT', corrupt: 2);
+    final notifier = await notifierFor([vol]);
+
+    await notifier.importFromGarminDevice();
+
+    expect(notifier.state.files, isEmpty);
+    expect(notifier.state.error, contains('No dives found'));
+  });
+}

--- a/test/features/universal_import/presentation/providers/universal_import_garmin_test.dart
+++ b/test/features/universal_import/presentation/providers/universal_import_garmin_test.dart
@@ -1,10 +1,14 @@
 // Drives the notifier's Garmin-USB import path: detect the mounted device,
 // keep only dive FITs (skipping non-dive/corrupt files), and hand them to the
-// wizard's single/batch flow. Uses a real Garmin dive FIT fixture and a
-// temporary directory tree standing in for the mounted volume.
+// wizard's single/batch flow. A temporary directory tree stands in for the
+// mounted volume, populated from a real Garmin dive FIT fixture, FIT files
+// built in-test for valid non-dive activities, and junk bytes for corrupt
+// ones -- the parser rejects the last two through different branches.
 
 import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:fit_tool/fit_tool.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -17,8 +21,57 @@ import '../../../../helpers/test_database.dart';
 
 const _diveFixture = 'test/dives/005_oc-trimix-two-deco-gases.fit';
 
+/// A structurally valid FIT file for a non-dive activity (a run).
+///
+/// Two properties make this fixture do its job, and both are deliberate:
+///
+/// 1. It is not corrupt. It decodes cleanly and carries a [SessionMessage],
+///    so the parser reaches its sport check instead of bailing on a decode
+///    failure -- a different branch from the junk bytes written by `corrupt:`.
+/// 2. It carries depth records even though a real run would not. The parser
+///    rejects a FIT both for `sport != Sport.diving` and for having no usable
+///    profile samples; without depth here the file would be dropped by the
+///    latter, and these tests would still pass if the sport filter were
+///    deleted. The depth samples make `sport` the only reason it is skipped,
+///    which is what pins the filtering behaviour down.
+Uint8List _runningFitBytes({int serialNumber = 99999}) {
+  final start = DateTime.utc(2025, 6, 1, 7, 0, 0);
+  final builder = FitFileBuilder(autoDefine: true, minStringSize: 50);
+
+  builder.add(
+    FileIdMessage()
+      ..type = FileType.activity
+      ..manufacturer = 1
+      ..serialNumber = serialNumber
+      ..timeCreated = start.millisecondsSinceEpoch,
+  );
+
+  for (var i = 0; i < 5; i++) {
+    builder.add(
+      RecordMessage()
+        ..timestamp = start
+            .add(Duration(seconds: i * 60))
+            .millisecondsSinceEpoch
+        ..depth = 5.0 + i
+        ..heartRate = 140 + i,
+    );
+  }
+
+  builder.add(
+    SessionMessage()
+      ..sport = Sport.running
+      ..startTime = start.millisecondsSinceEpoch
+      ..timestamp = start
+          .add(const Duration(minutes: 30))
+          .millisecondsSinceEpoch
+      ..totalElapsedTime = 1800
+      ..totalTimerTime = 1800,
+  );
+
+  return builder.build().toBytes();
+}
+
 void main() {
-  late ProviderContainer container;
   late Directory tmp;
 
   setUp(() async {
@@ -28,18 +81,19 @@ void main() {
   });
 
   tearDown(() async {
-    container.dispose();
     await tearDownTestDatabase();
     await tmp.delete(recursive: true);
   });
 
-  /// Build a notifier whose detector points at [volumeRoots].
+  /// Build a notifier whose detector points at [volumeRoots]. The container is
+  /// disposed via [addTearDown] so a throw here cannot leave the enclosing
+  /// tearDown disposing an uninitialized field.
   Future<UniversalImportNotifier> notifierFor(List<String> volumeRoots) async {
     final prefs = await SharedPreferences.getInstance();
     final detector = GarminDeviceDetector(
       volumeRoots: () => [for (final r in volumeRoots) Directory(r)],
     );
-    container = ProviderContainer(
+    final container = ProviderContainer(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
         universalImportNotifierProvider.overrideWith(
@@ -47,14 +101,17 @@ void main() {
         ),
       ],
     );
+    addTearDown(container.dispose);
     return container.read(universalImportNotifierProvider.notifier);
   }
 
-  /// Create `<tmp>/<volume>/GARMIN/Activity` and populate it. Copies the dive
-  /// fixture [diveCopies] times and writes [corrupt] junk .fit files.
+  /// Create `<tmp>/<volume>/GARMIN/Activity` and populate it: the dive fixture
+  /// [diveCopies] times, [nonDive] valid running activities, and [corrupt]
+  /// junk .fit files.
   Future<String> makeGarminVolume(
     String volume, {
     int diveCopies = 0,
+    int nonDive = 0,
     int corrupt = 0,
   }) async {
     final activity = Directory(p.join(tmp.path, volume, 'GARMIN', 'Activity'));
@@ -63,9 +120,14 @@ void main() {
     for (var i = 0; i < diveCopies; i++) {
       await File(p.join(activity.path, 'dive_$i.fit')).writeAsBytes(diveBytes);
     }
-    for (var i = 0; i < corrupt; i++) {
+    for (var i = 0; i < nonDive; i++) {
       await File(
         p.join(activity.path, 'run_$i.fit'),
+      ).writeAsBytes(_runningFitBytes(serialNumber: 99999 + i));
+    }
+    for (var i = 0; i < corrupt; i++) {
+      await File(
+        p.join(activity.path, 'corrupt_$i.fit'),
       ).writeAsBytes([0, 1, 2, 3, 4]);
     }
     return p.join(tmp.path, volume);
@@ -86,8 +148,50 @@ void main() {
     expect(notifier.state.isLoading, isFalse);
   });
 
+  test('the non-dive fixture is a valid FIT, not a corrupt one', () {
+    // Guards the tests below: if this ever stopped decoding it would exercise
+    // the corrupt-file branch and silently stop covering the sport filter.
+    final fitFile = FitFile.fromBytes(_runningFitBytes());
+    final session = fitFile.records
+        .map((r) => r.message)
+        .whereType<SessionMessage>()
+        .first;
+    expect(session.sport, Sport.running);
+  });
+
+  test('skips a valid non-dive activity, importing only the dive', () async {
+    final vol = await makeGarminVolume('DESCENT', diveCopies: 1, nonDive: 1);
+    final notifier = await notifierFor([vol]);
+
+    await notifier.importFromGarminDevice();
+
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.files, hasLength(1));
+    expect(notifier.state.isBatch, isFalse);
+    expect(notifier.state.fileName, 'dive_0.fit');
+  });
+
+  test(
+    'reports an error when the device holds only non-dive activities',
+    () async {
+      final vol = await makeGarminVolume('DESCENT', nonDive: 2);
+      final notifier = await notifierFor([vol]);
+
+      await notifier.importFromGarminDevice();
+
+      expect(notifier.state.files, isEmpty);
+      expect(notifier.state.isLoading, isFalse);
+      expect(notifier.state.error, contains('No dives found'));
+    },
+  );
+
   test('enters batch triage when several dives are present', () async {
-    final vol = await makeGarminVolume('DESCENT', diveCopies: 2, corrupt: 1);
+    final vol = await makeGarminVolume(
+      'DESCENT',
+      diveCopies: 2,
+      nonDive: 1,
+      corrupt: 1,
+    );
     final notifier = await notifierFor([vol]);
 
     await notifier.importFromGarminDevice();
@@ -108,7 +212,7 @@ void main() {
     expect(notifier.state.error, contains('No connected Garmin device'));
   });
 
-  test('reports an error when the device holds no dives', () async {
+  test('reports an error when the device holds only corrupt FITs', () async {
     final vol = await makeGarminVolume('DESCENT', corrupt: 2);
     final notifier = await notifierFor([vol]);
 

--- a/test/features/universal_import/presentation/widgets/file_selection_step_test.dart
+++ b/test/features/universal_import/presentation/widgets/file_selection_step_test.dart
@@ -43,6 +43,7 @@ class _CancellingPicker extends FilePickerPlatform
 Widget harness() {
   return const ProviderScope(
     child: MaterialApp(
+      locale: Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(body: FileSelectionStep()),
@@ -57,6 +58,7 @@ Widget harnessWithGarmin(List<GarminDevice> garminDevices) {
       garminDevicesProvider.overrideWith((ref) async => garminDevices),
     ],
     child: const MaterialApp(
+      locale: Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(body: FileSelectionStep()),
@@ -132,6 +134,7 @@ void main() {
       UncontrolledProviderScope(
         container: container,
         child: const MaterialApp(
+          locale: Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(body: FileSelectionStep()),

--- a/test/features/universal_import/presentation/widgets/file_selection_step_test.dart
+++ b/test/features/universal_import/presentation/widgets/file_selection_step_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/universal_import/data/models/detection_result.dart';
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
 import 'package:submersion/features/universal_import/data/models/picked_import_file.dart';
+import 'package:submersion/features/universal_import/data/services/garmin_device_detector.dart';
 import 'package:submersion/features/universal_import/presentation/providers/universal_import_providers.dart';
 import 'package:submersion/features/universal_import/presentation/widgets/file_selection_step.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -49,6 +50,20 @@ Widget harness() {
   );
 }
 
+/// FileSelectionStep under a scope with [garminDevices] as the detected list.
+Widget harnessWithGarmin(List<GarminDevice> garminDevices) {
+  return ProviderScope(
+    overrides: [
+      garminDevicesProvider.overrideWith((ref) async => garminDevices),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: FileSelectionStep()),
+    ),
+  );
+}
+
 PickedImportFile _file(String name) => PickedImportFile(
   name: name,
   path: '/tmp/$name',
@@ -69,6 +84,36 @@ void main() {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     await tester.pumpWidget(harness());
     expect(find.text('Choose Folder'), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('desktop hides the Garmin button when no device is connected', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    await tester.pumpWidget(harnessWithGarmin(const []));
+    await tester.pumpAndSettle();
+    expect(find.text('Choose Folder'), findsOneWidget);
+    expect(find.text('Import from Garmin Device'), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('desktop shows the Garmin button when a device is detected', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    await tester.pumpWidget(
+      harnessWithGarmin(const [
+        GarminDevice(
+          volumeName: 'GARMIN',
+          volumeRootPath: '/Volumes/GARMIN',
+          activityDirPath: '/Volumes/GARMIN/GARMIN/Activity',
+          fitFileCount: 3,
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Import from Garmin Device'), findsOneWidget);
     debugDefaultTargetPlatformOverride = null;
   });
 


### PR DESCRIPTION
## Problem

A Garmin Descent isn't a libdivecomputer serial/BLE device — plugged in by cable it mounts as a **USB mass-storage drive**, and its activities live as FIT files under `GARMIN/Activity`. The FIT import already parses these perfectly, but users had to manually locate that folder and pick the files. There was no "plug in → import" affordance.

This is a no-backend step toward the roadmap's Garmin items (`docs/FEATURE_ROADMAP.md` §"Garmin Dive sync" / "Automatic conversion from Garmin Descent"): it needs no Garmin Connect account, credentials, or network — just the filesystem.

## Changes

- New `GarminDeviceDetector` (`universal_import/data/services/`): scans mounted-volume roots (macOS `/Volumes`, Linux `/media` + `/run/media`, Windows drive letters) for a non-empty `GARMIN/Activity` folder. Recognises the device by that folder, **regardless of volume name**. Mount-point scan is injectable so it's unit-testable against a temp tree.
- New desktop-only **"Import from Garmin Device"** button in the import wizard's file-selection step, beside the existing "Choose Folder".
- `UniversalImportNotifier.importFromGarminDevice()`: detects the device, lists its `.fit` files, and keeps only **dive** activities — non-dive FITs (runs/rides) and corrupt files parse to `null` via the existing `FitParserService` and are skipped — then hands the result to the existing single/batch triage → duplicate-check → import pipeline. Falls back with a clear message pointing at "Choose Folder" when nothing is detected.

No changes to the parse/save path — this only adds a new source into the existing flow.

## Scope / notes

- **Desktop only** (the button is gated behind the same desktop check as "Choose Folder"); phones can't mount a watch as a drive.
- If several Garmin volumes are mounted, the first is used (single device is the norm).
- Filtering parses each FIT once to classify it; FIT files are small and this is desktop, so cost is negligible.

## Tests

- `garmin_device_detector_test.dart`: name-agnostic detection, empty/absent `GARMIN/Activity` ignored, multi-volume, `.fit`-only listing.
- `universal_import_garmin_test.dart`: single- and multi-dive import from a real dive FIT fixture, corrupt-file skipping, and the no-device / no-dives error states.

Verified locally (Flutter 3.44.8 / Dart 3.12.2): `flutter analyze lib` clean, `dart format` clean, full `test/features/universal_import` suite green.