### PR TITLE
fix(dashboard): pluralize the data-issues chip and link it to the findings

### DIFF
--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -323,7 +323,10 @@ class GaugeStrip extends ConsumerWidget {
           icon: Icons.fact_check_outlined,
           label: l10n.dashboard_gauges_dataIssues(g.dataQualityFindings),
           tone: _Tone.warn,
-          onTap: () => context.push('/settings/data-quality'),
+          // The findings inbox lists the actual issues (with per-dive detail
+          // and repair actions); the settings page only toggles which checks
+          // run.
+          onTap: () => context.push('/dives/quality'),
         ),
       );
     }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "نسخ احتياطي منذ {days} يوم",
   "dashboard_gauges_syncPending": "{count} غير متزامنة",
   "dashboard_gauges_synced": "متزامن",
-  "dashboard_gauges_dataIssues": "{count} مشاكل في البيانات",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{مشكلة واحدة في البيانات} other{{count} مشاكل في البيانات}}",
   "dashboard_gauges_retry": "الحالة غير متاحة - انقر لإعادة المحاولة",
   "dashboard_urgent_title": "يتطلب الانتباه",
   "dashboard_photos_title": "أحدث الصور",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Backup vor {days}T",
   "dashboard_gauges_syncPending": "{count} nicht synchronisiert",
   "dashboard_gauges_synced": "Synchronisiert",
-  "dashboard_gauges_dataIssues": "{count} Datenprobleme",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 Datenproblem} other{{count} Datenprobleme}}",
   "dashboard_gauges_retry": "Status nicht verfügbar - zum Wiederholen tippen",
   "dashboard_urgent_title": "Braucht Aufmerksamkeit",
   "dashboard_photos_title": "Aktuelle Fotos",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2003,7 +2003,7 @@
     }
   },
   "dashboard_gauges_synced": "Synced",
-  "dashboard_gauges_dataIssues": "{count} data issues",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 data issue} other{{count} data issues}}",
   "@dashboard_gauges_dataIssues": {
     "placeholders": {
       "count": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Copia hace {days}d",
   "dashboard_gauges_syncPending": "{count} sin sincronizar",
   "dashboard_gauges_synced": "Sincronizado",
-  "dashboard_gauges_dataIssues": "{count} problemas de datos",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 problema de datos} other{{count} problemas de datos}}",
   "dashboard_gauges_retry": "Estado no disponible - toca para reintentar",
   "dashboard_urgent_title": "Requiere atención",
   "dashboard_photos_title": "Fotos recientes",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Sauvegarde il y a {days}j",
   "dashboard_gauges_syncPending": "{count} non synchronisés",
   "dashboard_gauges_synced": "Synchronisé",
-  "dashboard_gauges_dataIssues": "{count} problèmes de données",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 problème de données} other{{count} problèmes de données}}",
   "dashboard_gauges_retry": "Statut indisponible - touchez pour réessayer",
   "dashboard_urgent_title": "Attention requise",
   "dashboard_photos_title": "Photos récentes",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "גיבוי לפני {days} ימים",
   "dashboard_gauges_syncPending": "{count} לא מסונכרנים",
   "dashboard_gauges_synced": "מסונכרן",
-  "dashboard_gauges_dataIssues": "{count} בעיות נתונים",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{בעיית נתונים אחת} other{{count} בעיות נתונים}}",
   "dashboard_gauges_retry": "הסטטוס אינו זמין - הקש לניסיון חוזר",
   "dashboard_urgent_title": "דורש תשומת לב",
   "dashboard_photos_title": "תמונות אחרונות",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Mentés {days} napja",
   "dashboard_gauges_syncPending": "{count} nem szinkronizált",
   "dashboard_gauges_synced": "Szinkronizálva",
-  "dashboard_gauges_dataIssues": "{count} adatprobléma",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 adatprobléma} other{{count} adatprobléma}}",
   "dashboard_gauges_retry": "Az állapot nem érhető el - koppints az újrapróbáláshoz",
   "dashboard_urgent_title": "Figyelmet igényel",
   "dashboard_photos_title": "Legutóbbi fotók",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Backup {days}g fa",
   "dashboard_gauges_syncPending": "{count} non sincronizzati",
   "dashboard_gauges_synced": "Sincronizzato",
-  "dashboard_gauges_dataIssues": "{count} problemi nei dati",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 problema nei dati} other{{count} problemi nei dati}}",
   "dashboard_gauges_retry": "Stato non disponibile - tocca per riprovare",
   "dashboard_urgent_title": "Richiede attenzione",
   "dashboard_photos_title": "Foto recenti",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -5480,7 +5480,7 @@ abstract class AppLocalizations {
   /// No description provided for @dashboard_gauges_dataIssues.
   ///
   /// In en, this message translates to:
-  /// **'{count} data issues'**
+  /// **'{count, plural, =1{1 data issue} other{{count} data issues}}'**
   String dashboard_gauges_dataIssues(int count);
 
   /// No description provided for @dashboard_gauges_retry.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -3160,7 +3160,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count مشاكل في البيانات';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count مشاكل في البيانات',
+      one: 'مشكلة واحدة في البيانات',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -3236,7 +3236,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count Datenprobleme';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Datenprobleme',
+      one: '1 Datenproblem',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -3168,7 +3168,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count data issues';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count data issues',
+      one: '1 data issue',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -3231,7 +3231,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count problemas de datos';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count problemas de datos',
+      one: '1 problema de datos',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -3240,7 +3240,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count problèmes de données';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count problèmes de données',
+      one: '1 problème de données',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -3137,7 +3137,13 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count בעיות נתונים';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count בעיות נתונים',
+      one: 'בעיית נתונים אחת',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -3211,7 +3211,13 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count adatprobléma';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count adatprobléma',
+      one: '1 adatprobléma',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -3224,7 +3224,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count problemi nei dati';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count problemi nei dati',
+      one: '1 problema nei dati',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -3202,7 +3202,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count dataproblemen';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dataproblemen',
+      one: '1 dataprobleem',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -3231,7 +3231,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count problemas de dados';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count problemas de dados',
+      one: '1 problema de dados',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -3056,7 +3056,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String dashboard_gauges_dataIssues(int count) {
-    return '$count 个数据问题';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 个数据问题',
+      one: '1 个数据问题',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Back-up {days}d geleden",
   "dashboard_gauges_syncPending": "{count} niet gesynchroniseerd",
   "dashboard_gauges_synced": "Gesynchroniseerd",
-  "dashboard_gauges_dataIssues": "{count} dataproblemen",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 dataprobleem} other{{count} dataproblemen}}",
   "dashboard_gauges_retry": "Status niet beschikbaar - tik om opnieuw te proberen",
   "dashboard_urgent_title": "Vereist aandacht",
   "dashboard_photos_title": "Recente foto's",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "Cópia há {days}d",
   "dashboard_gauges_syncPending": "{count} por sincronizar",
   "dashboard_gauges_synced": "Sincronizado",
-  "dashboard_gauges_dataIssues": "{count} problemas de dados",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 problema de dados} other{{count} problemas de dados}}",
   "dashboard_gauges_retry": "Estado indisponível - toque para tentar novamente",
   "dashboard_urgent_title": "Requer atenção",
   "dashboard_photos_title": "Fotos recentes",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5684,7 +5684,7 @@
   "dashboard_gauges_backupDays": "{days} 天前备份",
   "dashboard_gauges_syncPending": "{count} 条未同步",
   "dashboard_gauges_synced": "已同步",
-  "dashboard_gauges_dataIssues": "{count} 个数据问题",
+  "dashboard_gauges_dataIssues": "{count, plural, =1{1 个数据问题} other{{count} 个数据问题}}",
   "dashboard_gauges_retry": "状态不可用 - 点按重试",
   "dashboard_urgent_title": "需要注意",
   "dashboard_photos_title": "最近照片",

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -78,8 +78,8 @@ Future<NavSpy> pumpStrip(
         builder: (_, _) => stub('/settings/backup'),
       ),
       GoRoute(
-        path: '/settings/data-quality',
-        builder: (_, _) => stub('/settings/data-quality'),
+        path: '/dives/quality',
+        builder: (_, _) => stub('/dives/quality'),
       ),
       GoRoute(
         path: '/settings/diver-profile/insurance',
@@ -547,7 +547,25 @@ void main() {
       );
       expect(find.text('4 data issues'), findsOneWidget);
       await tapChip(tester, '4 data issues');
-      expect(spy.location, '/settings/data-quality');
+      expect(spy.location, '/dives/quality');
+    });
+
+    testWidgets('the data-issues chip is singular for a count of one', (
+      tester,
+    ) async {
+      await pumpStrip(
+        tester,
+        const DashboardGauges(
+          gearGauges: [],
+          hasGear: true,
+          insurance: null,
+          noFlyStatus: null,
+          daysSinceLastDive: null,
+          dataQualityFindings: 1,
+        ),
+      );
+      expect(find.text('1 data issue'), findsOneWidget);
+      expect(find.text('1 data issues'), findsNothing);
     });
 
     testWidgets('event chips stay hidden when they have no data', (


### PR DESCRIPTION
## Problem

On the dashboard, the **data issues** chip has two problems:

1. **Bad pluralization.** The label is a plain `"{count} data issues"`, so a single finding renders **"1 data issues"**.
2. **Wrong destination.** Tapping it opens `/settings/data-quality` — the page that only **toggles which checks run** — instead of showing *what* the issue actually is. The user can't get from the chip to the problem.

## Fix

- Make `dashboard_gauges_dataIssues` an **ICU plural** (`=1{1 data issue} other{{count} data issues}`) across all eleven locales.
- Point the chip's `onTap` at **`/dives/quality`**, the findings inbox (`DataQualityInboxPage`) that lists each issue with its per-dive detail, a "Go to dive" action, and repair buttons. This is the same target the dive-detail page, import summary, and dive list already use — the dashboard chip was the outlier still pointing at the settings page.

## Tests

`gauge_strip_test.dart`: updated the tap-target expectation to `/dives/quality`, and added a case asserting the chip reads **"1 data issue"** (singular) for a count of one.

Verified locally (Flutter 3.44.8 / Dart 3.12.2): `flutter analyze lib` clean, `dart format` clean, `flutter gen-l10n` run, dashboard + arb-parity suites green.